### PR TITLE
Backward Chainer: implement random target selection

### DIFF
--- a/opencog/rule-engine/backwardchainer/BackwardChainer.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.cc
@@ -60,8 +60,6 @@ void BackwardChainer::set_target(Handle init_target)
 
 	_inference_history.clear();
 
-	_targets_stack = std::stack<Handle>();
-	_targets_stack.push(_init_target);
 	_targets_set = UnorderedHandleSet();
 	_targets_set.insert(_init_target);
 }
@@ -73,10 +71,13 @@ void BackwardChainer::do_full_chain(uint max_steps)
 {
 	uint i = 0;
 
-	while (not _targets_stack.empty())
+	while (not _targets_set.empty())
 	{
 		if (max_steps != 0 && i >= max_steps)
+		{
+			logger().debug("[BackwardChainer] Stopping from reaching max steps");
 			break;
+		}
 
 		do_step();
 		i++;
@@ -88,16 +89,14 @@ void BackwardChainer::do_full_chain(uint max_steps)
  */
 void BackwardChainer::do_step()
 {
-	// XXX TODO targets selection should be done here, by first changing
-	// the stack to other data types
-
-	Handle top = _targets_stack.top();
-	_targets_stack.pop();
+	// XXX TODO do proper target selection here using some fitness function
+	Handle selected_target = rand_element(_targets_set);
+	_targets_set.erase(selected_target);
 
 	logger().debug("[BackwardChainer] Before do_step_bc");
 
-	VarMultimap subt = do_bc(top);
-	VarMultimap& old_subt = _inference_history[top];
+	VarMultimap subt = do_bc(selected_target);
+	VarMultimap& old_subt = _inference_history[selected_target];
 
 	logger().debug("[BackwardChainer] After do_step_bc");
 
@@ -149,7 +148,7 @@ VarMultimap BackwardChainer::do_bc(Handle& hgoal)
 			HandleSeq sub_premises = LinkCast(hgoal)->getOutgoingSet();
 
 			for (Handle& h : sub_premises)
-				_targets_stack.push(h);
+				_targets_set.insert(h);
 
 			return VarMultimap();
 		}
@@ -303,11 +302,11 @@ VarMultimap BackwardChainer::do_bc(Handle& hgoal)
 		if (not to_be_added_to_targets.empty())
 		{
 			// Add itself back to target, since this is not completely solved
-			_targets_stack.push(hgoal);
+			_targets_set.insert(hgoal);
 
 			while (not to_be_added_to_targets.empty())
 			{
-				_targets_stack.push(to_be_added_to_targets.top());
+				_targets_set.insert(to_be_added_to_targets.top());
 				to_be_added_to_targets.pop();
 			}
 		}
@@ -340,11 +339,11 @@ VarMultimap BackwardChainer::do_bc(Handle& hgoal)
 				// solution has variables inside
 				if (not goal_readded)
 				{
-					_targets_stack.push(hgoal);
+					_targets_set.insert(hgoal);
 					goal_readded = true;
 				}
 
-				_targets_stack.push(soln);
+				_targets_set.insert(soln);
 			}
 
 			// Construct the hgoal to all mappings here to be returned
@@ -478,8 +477,9 @@ HandleSeq BackwardChainer::match_knowledge_base(const Handle& htarget,
 				break;
 			}
 
-			// XXX don't want clause that are already in _targets_stack?
-			// no need? since things on targets stack are in inference history
+			// XXX don't want clause that are already in _targets_set?
+			// no need? since things on targets set are in inference history
+			// but only if the target is been inferenced upon...
 
 			i_pred_soln.push_back(p.second);
 		}

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.cc
@@ -62,6 +62,8 @@ void BackwardChainer::set_target(Handle init_target)
 
 	_targets_stack = std::stack<Handle>();
 	_targets_stack.push(_init_target);
+	_targets_set = UnorderedHandleSet();
+	_targets_set.insert(_init_target);
 }
 
 /**

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.h
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.h
@@ -141,6 +141,7 @@ private:
 
 	// XXX TODO will want a list to allow target selection in the future
 	std::stack<Handle> _targets_stack;
+	UnorderedHandleSet _targets_set;
 	std::vector<Rule> _rules_set;
 
 	// XXX any additional link should be reflected

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.h
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.h
@@ -140,12 +140,11 @@ private:
 	map<Handle, VarMultimap> _inference_history;
 
 	// XXX TODO will want a list to allow target selection in the future
-	std::stack<Handle> _targets_stack;
 	UnorderedHandleSet _targets_set;
 	std::vector<Rule> _rules_set;
 
 	// XXX any additional link should be reflected
-	unordered_set<Type> _logical_link_types = { AND_LINK, OR_LINK };
+	unordered_set<Type> _logical_link_types = { AND_LINK, OR_LINK, NOT_LINK };
 
 };
 


### PR DESCRIPTION
Get some sort of target selection going.

Even with this, the criminal example is still not solvable, because there's no backward chaining path that will generate the necessary

```
InheritanceLink
    missile@123
    weapon
```
since
```
InheritanceLink
    $y
    weapon
```
always get immediately satisfied by
```
InheritanceLink
    missile
    weapon
```

To solve this, might need one of the following
 1.  Change the backward chainer so that it doesn't start off with trying to solve the variable, but instead backward chain with a rule immediately... a.k.a changing the "stopping criteria" that determines when a target is done and no longer need to be added back to the potential targets list.
 2.  the mixed forward/backward chainer that will allow the forward chainer to randomly forward chain on the atom.

Anyway...

## TODO ##
* Handle "evaluatable terms" where an "input" of a rule is not an actual input atom, but just a True/False of some EqualLink and stuff...  like the new deduction rule!!!!
 
 Probably need to implement the `evaluate_sentence` callback?  Not sure.  My guess is that `grounding` will not get called when all the inputs are "evaluatable terms"??
