### PR TITLE
Python parenthesis matching

### DIFF
--- a/opencog/cython/PythonEval.cc
+++ b/opencog/cython/PythonEval.cc
@@ -1185,6 +1185,7 @@ void PythonEval::eval_expr(const std::string& partial_expr)
 
         // Add this expression to our evaluation buffer.
         _input_line += part;
+        _input_line += '\n';  // we stripped this off, above
     }
 
     // If there are more closes than opens, then fail.

--- a/opencog/cython/PythonEval.h
+++ b/opencog/cython/PythonEval.h
@@ -117,6 +117,7 @@ class PythonEval : public GenericEval
         std::map <std::string, PyObject*> _modules;
 
         std::string _result;
+        int _paren_count;
 
     public:
         PythonEval(AtomSpace* atomspace);


### PR DESCRIPTION
In python, an open paren allows a long line to continue to the next line, so don't throw any error unless the matching paren count is zero or negative.