### PR TITLE
__path__ code to address "opencog" python module now being in multiple directories

### DIFF
--- a/opencog/cython/opencog/__init__.py
+++ b/opencog/cython/opencog/__init__.py
@@ -1,0 +1,2 @@
+from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)


### PR DESCRIPTION
This is a parallel pull request with opencog/opencog#1606
It addresses #20 