### PR TITLE
Backward Chainer: a version that can solve the criminal problem

### DIFF
--- a/opencog/rule-engine/InferenceSCM.cc
+++ b/opencog/rule-engine/InferenceSCM.cc
@@ -127,7 +127,7 @@ Handle InferenceSCM::do_backward_chaining(Handle h)
 
 	logger().debug("[BackwardChainer] Before do_chain");
 
-    bc.do_full_chain();
+    bc.do_until(cpolicy_loader.get_max_iter());
 
 	logger().debug("[BackwardChainer] After do_chain");
     map<Handle, UnorderedHandleSet> soln = bc.get_chaining_result();

--- a/opencog/rule-engine/backwardchainer/BCPatternMatch.cc
+++ b/opencog/rule-engine/backwardchainer/BCPatternMatch.cc
@@ -37,9 +37,6 @@ BCPatternMatch::~BCPatternMatch()
 
 bool BCPatternMatch::node_match(Handle& node1, Handle& node2)
 {
-	logger().debug("[BackwardChainer] In node_match looking at %s and %s",
-	               node1->toShortString().c_str(),
-	               node2->toShortString().c_str());
 	return DefaultPatternMatchCB::node_match(node1, node2);
 
 	//return AttentionalFocusCB::node_match(node1, node2);
@@ -47,9 +44,6 @@ bool BCPatternMatch::node_match(Handle& node1, Handle& node2)
 
 bool BCPatternMatch::link_match(LinkPtr& lpat, LinkPtr& lsoln)
 {
-	logger().debug("[BackwardChainer] In link_match looking at %s and %s",
-	               lpat->toShortString().c_str(),
-	               lsoln->toShortString().c_str());
 	return DefaultPatternMatchCB::link_match(lpat, lsoln);
 
 	//return AttentionalFocusCB::link_match(lpat, lsoln);
@@ -58,9 +52,9 @@ bool BCPatternMatch::link_match(LinkPtr& lpat, LinkPtr& lsoln)
 bool BCPatternMatch::grounding(const std::map<Handle, Handle> &var_soln,
                                const std::map<Handle, Handle> &pred_soln)
 {
-	for (auto& p : pred_soln)
-		logger().debug("PM pred: " + p.first->toShortString()
-		               + " map to " + p.second->toShortString());
+//	for (auto& p : pred_soln)
+//		logger().debug("PM pred: " + p.first->toShortString()
+//		               + " map to " + p.second->toShortString());
 
 	std::map<Handle, Handle> true_var_soln;
 
@@ -70,8 +64,8 @@ bool BCPatternMatch::grounding(const std::map<Handle, Handle> &var_soln,
 		if (p.first->getType() == VARIABLE_NODE)
 		{
 			true_var_soln[p.first] = p.second;
-			logger().debug("PM var: " + p.first->toShortString()
-			               + " map to " + p.second->toShortString());
+//			logger().debug("PM var: " + p.first->toShortString()
+//			               + " map to " + p.second->toShortString());
 		}
 	}
 

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.cc
@@ -86,16 +86,18 @@ void BackwardChainer::do_until(uint max_steps)
  * Do a single step of backward chaining.
  */
 void BackwardChainer::do_step()
-{
+{	
+	logger().debug("[BackwardChainer] ==========================================");
+	logger().debug("[BackwardChainer] Start of a single BC step");
+	logger().debug("[BackwardChainer] %d potential targets", _targets_set.size());
+
 	// XXX TODO do proper target selection here using some fitness function
 	Handle selected_target = rand_element(_targets_set);
-
-	logger().debug("[BackwardChainer] Before do_step_bc");
 
 	VarMultimap subt = do_bc(selected_target);
 	VarMultimap& old_subt = _inference_history[selected_target];
 
-	logger().debug("[BackwardChainer] After do_step_bc");
+	logger().debug("[BackwardChainer] End of a single BC step");
 
 	// add the substitution to inference history
 	for (auto& p : subt)
@@ -327,8 +329,8 @@ VarMultimap BackwardChainer::do_bc(Handle& hgoal)
 		// Break out any logical link and add to targets
 		HandleSeq sub_premises = LinkCast(h)->getOutgoingSet();
 
-		for (Handle& h : sub_premises)
-			_targets_set.insert(h);
+		for (Handle& s : sub_premises)
+			_targets_set.insert(s);
 	}
 
 	return results;
@@ -413,7 +415,7 @@ HandleSeq BackwardChainer::match_knowledge_base(const Handle& htarget,
 	SatisfactionLinkPtr sl(createSatisfactionLink(htarget_vardecl, htarget));
 	BCPatternMatch bcpm(_garbage_superspace);
 
-	logger().debug("[BackwardChainer] Before satisfy");
+	logger().debug("[BackwardChainer] Before patterm matcher");
 
 	sl->satisfy(bcpm);
 

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.cc
@@ -302,10 +302,7 @@ VarMultimap BackwardChainer::do_bc(Handle& hgoal)
 		for (const Handle& ho : outputs)
 			outputs_grounded.push_back(inst.instantiate(ho, vm));
 
-
 		logger().debug("Checking permises " + h->toShortString());
-
-
 
 		bool need_bc = false;
 		std::vector<VarMap> vm_list;
@@ -339,32 +336,13 @@ VarMultimap BackwardChainer::do_bc(Handle& hgoal)
 
 			// This is a grounding that can solve the goal, so apply it
 			// by using the mapping to ground the goal target, and add
-			// it to _as since this is not garbage
-			//
-			// XXX TODO this is not really applying the rule since other
-			// unrelated output of the rule are not added to the
-			// atomspace; might need to do something with "HandleSeq outputs"
+			// it to _as since this is not garbage; this should generate
+			// all the outputs of the rule
 			for (const Handle& ho : outputs_grounded)
 			{
-				// XXX TODO check! ho is not in _as, can Instantiator handle this?
-
 				Instantiator inst(_as);
-				Handle hho = inst.instantiate(ho, m);
-
-				logger().debug("[BackwardChainer] Instantiated " + ho->toShortString() + " to " + hho->toShortString());
+				inst.instantiate(ho, m);
 			}
-
-			for (const Handle& ho : outputs)
-				logger().debug("[BackwardChainer] rule output include " + ho->toShortString());
-
-			for (const Handle& ho : outputs_grounded)
-				logger().debug("[BackwardChainer] grounded rule output include " + ho->toShortString());
-
-			for (auto& p : vm)
-				logger().debug("[BackwardChainer] original mapping here is " + p.first->toShortString() + " to " + p.second->toShortString());
-
-			for (auto& p : m)
-				logger().debug("[BackwardChainer] the mapping here is " + p.first->toShortString() + " to " + p.second->toShortString());
 
 			// Add the grounding to the return results
 			for (Handle& h : free_vars)

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.cc
@@ -307,7 +307,7 @@ VarMultimap BackwardChainer::do_bc(Handle& hgoal)
 		logger().debug("[BackwardChainer] %d new targets to be added",
 		               to_be_added_to_targets.size());
 
-		if (not to_be_added_to_targets.empty())
+		if (possible_premises.size() == 0 || not to_be_added_to_targets.empty())
 		{
 			// Add itself back to target, since this is not completely solved
 			_targets_set.insert(hgoal);

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.h
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.h
@@ -130,7 +130,7 @@ private:
 	           Handle htarget_vardecl, VarMap& result);
 
 	Handle gen_sub_varlist(const Handle& parent_varlist,
-	                       const std::set<Handle>& varset);
+	                       std::set<Handle> varset);
 
 	AtomSpace* _as;
 	AtomSpace* _garbage_superspace;

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.h
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.h
@@ -125,7 +125,7 @@ private:
 	                               Handle htarget_vardecl,
 	                               bool check_history,
 	                               std::vector<VarMap>& vmap);
-	HandleSeq ground_premises(const Handle& htarget, std::vector<VarMap>& vmap);
+	HandleSeq ground_premises(const Handle& htarget, const VarMap& vmap, std::vector<VarMap>& vmap_list);
 	bool unify(const Handle& htarget, const Handle& hmatch,
 	           Handle htarget_vardecl, VarMap& result);
 

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.h
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.h
@@ -109,7 +109,7 @@ public:
 
 	void set_target(Handle init_target);
 
-	void do_full_chain(uint max_steps = 0);
+	void do_until(uint max_steps);
 	void do_step();
 
 	VarMultimap& get_chaining_result();

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.h
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.h
@@ -139,7 +139,8 @@ private:
 	// a map of a premise, to a map of its variables mapping
 	map<Handle, VarMultimap> _inference_history;
 
-	// XXX TODO will want a list to allow target selection in the future
+	// XXX TODO add information to each target stating what rules were applied
+	// and how often the target was chosen?
 	UnorderedHandleSet _targets_set;
 	std::vector<Rule> _rules_set;
 

--- a/tests/rule-engine/BackwardChainerUTest.cxxtest
+++ b/tests/rule-engine/BackwardChainerUTest.cxxtest
@@ -210,7 +210,7 @@ void BackwardChainerUTest::test_basic_bc()
 	Handle soln = eval_->eval_h("(ConceptNode \"Fritz\")");
 
 	bc.set_target(target);
-	bc.do_full_chain(10);
+	bc.do_until(10);
 
 	VarMultimap results = bc.get_chaining_result();
 


### PR DESCRIPTION
This version solves the criminal problem using a combination of deduction rule and modus ponens rule.  This has been tested with about 100 steps of chaining.

100 steps because target selection, rule selection, etc are still random (so the same target and same useless rule will keep getting selected in many of the steps).  Might be less if there's some intelligence selection algorithm is implemented.  I don't really get the fitness function mentioned on the wiki yet.

A target will no longer be removed from the potential targets list once added.  Previously the target is removed if the variables in the target can be grounded to non-variables.  Now, instead it stays in targets list.  This is needed to backward chain
```
        (InheritanceLink
            (VariableNode "$y")
            (ConceptNode "weapon"))
```
of the criminal problem so that the deduction rule can get selected.

As a result, there's no deterministic way to tell if a backward chainer is "done" on variable fullfillment query.  Right now it can only be stopped by reaching max-iter on the json policy file.  The other stopping criteria mentioned on the wiki might need to be implemented in the future.

## TODO

* override pattern matcher's default callback to allow a typed variable to get unified to a variable (this is needed to properly backward chain on rules with typed variables)
