### PR TITLE
Fix ure example part i

### DIFF
--- a/examples/rule-engine/README.md
+++ b/examples/rule-engine/README.md
@@ -4,15 +4,19 @@ Unified Rule Engine examples
 Overview
 --------
 
-Here is a collection of examples (for now one) using the unified rule
-engine.
+Collection of examples (for now one) using the unified rule engine.
 
 Usage
 -----
 
-TODO: Something that looks like what is described in examples/guile or
-examples/pattern-matcher. Unfortunately I wasn't able to run any so I
-can't provide specific instructions yet.
+First, you need to be able to run the examples in examples/guile and
+examples/pattern-matcher. Have a look at examples/guile/README.md and
+then examples/pattern-matcher/simple.scm.
+
+The first set of demos provide a basic introduction to various main
+features.
+
+* simple-deduction.scm: Example of a simple URE based crisp deduction.
 
 Crisp deduction and modus ponens chainer
 ----------------------------------------

--- a/examples/rule-engine/simple-deduction.scm
+++ b/examples/rule-engine/simple-deduction.scm
@@ -23,7 +23,7 @@
 (define AB (ImplicationLink (stv 1 1) A B))
 (define BC (ImplicationLink (stv 1 1) B C))
 
-; (cog-fc AB)
+; (cog-fc AB "examples/rule-engine/cpolicy.json")
 
 ; Expected output should be
 ; TODO

--- a/examples/rule-engine/simple-deduction.scm
+++ b/examples/rule-engine/simple-deduction.scm
@@ -1,0 +1,29 @@
+;
+; Simple crisp deduction example
+;
+; 1. Launch guile under this directory (see examples/guile/README.md
+; for prerequisite if you haven't already)
+;
+; $ guile
+;
+; 2. The load this file
+;
+; scheme@(guile-user)> (load-from-path "simple-deduction.scm")
+;
+; 3. Scroll to the bottom, and run some of the commented-out examples.
+
+(use-modules (opencog))
+(use-modules (opencog rule-engine))
+
+(load-from-path "utilities.scm")
+
+(define A (ConceptNode "A"))
+(define B (ConceptNode "B"))
+(define C (ConceptNode "C"))
+(define AB (ImplicationLink (stv 1 1) A B))
+(define BC (ImplicationLink (stv 1 1) B C))
+
+; (cog-fc AB)
+
+; Expected output should be
+; TODO

--- a/opencog/atoms/execution/ExecutionOutputLink.cc
+++ b/opencog/atoms/execution/ExecutionOutputLink.cc
@@ -146,14 +146,14 @@ static inline double get_double(AtomSpace *as, const Handle& ha)
 
 /// do_execute -- execute the GroundedSchemaNode of the ExecutionOutputLink
 ///
-/// If the type t is an EXECUTION_OUTPUTLINK, then:
+/// If the type t is an EXECUTION_OUTPUT_LINK, then:
 /// Expects the sequence to be exactly two atoms long.
 /// Expects the first handle of the sequence to be a GroundedSchemaNode
 /// Expects the second handle of the sequence to be a ListLink
 /// Executes the GroundedSchemaNode, supplying the second handle as argument
 ///
 /// If the type t is either PLUS_LINK or TIMES_LINK, then:
-/// Exepects the atoms to be either NumberNodes, or executable links
+/// Expects the atoms to be either NumberNodes, or executable links
 /// that end up being valued as NumberNodes.
 ///
 Handle ExecutionOutputLink::do_execute(AtomSpace* as, Type t,

--- a/opencog/guile/SchemePrimitive.h
+++ b/opencog/guile/SchemePrimitive.h
@@ -93,6 +93,7 @@ class SchemePrimitive : public PrimitiveEnviron
 			double (T::*d_hhtb)(Handle, Handle, Type, bool);
 			Handle (T::*h_h)(Handle);
 			Handle (T::*h_hi)(Handle, int);
+			Handle (T::*h_hs)(Handle, const std::string&);
 			Handle (T::*h_sq)(const std::string&, const HandleSeq&);
 			Handle (T::*h_sqq)(const std::string&,
 			                   const HandleSeq&, const HandleSeq&);
@@ -130,6 +131,7 @@ class SchemePrimitive : public PrimitiveEnviron
 			D_HHTB,// return double, take handle, handle, and type
 			H_H,   // return handle, take handle
 			H_HI,  // return handle, take handle and int
+			H_HS,  // return handle, take handle and string
 			H_SQ,  // return handle, take string and HandleSeq
 			H_SQQ, // return handle, take string, HandleSeq and HandleSeq
 			Q_H,   // return HandleSeq, take handle
@@ -209,6 +211,16 @@ class SchemePrimitive : public PrimitiveEnviron
 					Handle h(SchemeSmob::verify_handle(scm_car(args), scheme_name));
 					int i = SchemeSmob::verify_int(scm_cadr(args), scheme_name, 2);
 					Handle rh((that->*method.h_hi)(h,i));
+					rc = SchemeSmob::handle_to_scm(rh);
+					break;
+				}
+				case H_HS:
+				{
+					Handle h(SchemeSmob::verify_handle(scm_car(args),
+					                                   scheme_name));
+					std::string s(SchemeSmob::verify_string(scm_cadr(args),
+					                                        scheme_name, 2));
+					Handle rh((that->*method.h_hs)(h,s));
 					rc = SchemeSmob::handle_to_scm(rh);
 					break;
 				}
@@ -519,6 +531,7 @@ class SchemePrimitive : public PrimitiveEnviron
 		DECLARE_CONSTR_4(D_HHTB, d_hhtb, double, Handle, Handle, Type, bool)
 		DECLARE_CONSTR_1(H_H,  h_h,  Handle, Handle)
 		DECLARE_CONSTR_2(H_HI, h_hi, Handle, Handle, int)
+		DECLARE_CONSTR_2(H_HS, h_hs, Handle, Handle, const std::string&)
 		DECLARE_CONSTR_2(H_SQ, h_sq, Handle, const std::string&, const HandleSeq&)
 		DECLARE_CONSTR_3(H_SQQ, h_sqq, Handle, const std::string&, const HandleSeq&, const HandleSeq&)
 		DECLARE_CONSTR_1(Q_H, q_h, HandleSeq, Handle)
@@ -601,6 +614,7 @@ DECLARE_DECLARE_1(void, void)
 DECLARE_DECLARE_2(bool, Handle, int)
 DECLARE_DECLARE_2(bool, Handle, Handle)
 DECLARE_DECLARE_2(Handle, Handle, int)
+DECLARE_DECLARE_2(Handle, Handle, const std::string&)
 DECLARE_DECLARE_2(Handle, const std::string&, const HandleSeq&)
 DECLARE_DECLARE_2(const std::string&, const std::string&, const std::string&)
 DECLARE_DECLARE_2(void, const std::string&, const std::string&)

--- a/opencog/query/DefaultPatternMatchCB.cc
+++ b/opencog/query/DefaultPatternMatchCB.cc
@@ -566,7 +566,7 @@ void DefaultPatternMatchCB::init(const Variables& vars,
  * some other clause, thus establishing connectivity from that clause to
  * the subgraphs of the ChoiceLink.
  *
- * The practical side-effect, here, with regards to satsifcation, is
+ * The practical side-effect, here, with regards to satisfaction, is
  * this: if both groundings are to be found in the above example, then
  * two efforts must be made: One effort, with the initial grounding
  * starting at `Hunt`, and a second, starting at `Zebra`.  So... that
@@ -675,7 +675,7 @@ bool DefaultPatternMatchCB::link_type_search(PatternMatchEngine *pme,
 	for (const Handle& cl: clauses)
 	{
 		// Evaluatables don't exist in the atomspace, in general.
-		// Cannot start a search wtih them.
+		// Cannot start a search with them.
 		if (0 < pat.evaluatable_holders.count(cl)) continue;
 		size_t prev = count;
 		find_rarest(cl, _starter_term, count);

--- a/opencog/query/PatternMatch.cc
+++ b/opencog/query/PatternMatch.cc
@@ -327,7 +327,7 @@ bool BindLink::imply(PatternMatchCallback& pmc, bool check_conn)
 // All clauses of the Concrete link are connected, so this is easy.
 bool ConcreteLink::satisfy(PatternMatchCallback& pmcb) const
 {
-   PatternMatchEngine pme(pmcb, _varlist, _pat);
+	PatternMatchEngine pme(pmcb, _varlist, _pat);
 
 #ifdef DEBUG
 	debug_print();

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -44,7 +44,12 @@ using namespace opencog;
  */
 /* ======================================================== */
 
-// Uncomment below to enable debug print
+// To enable debug print you must
+//
+// 1. Uncomment #define DEBUG below
+//
+// 2. Comment out #ifdef DEBUG and #endif in PatternMatchEngine.h in
+// order to have perm_count and perm_count_stack defined.
 // #define DEBUG
 #ifdef WIN32
 #ifdef DEBUG
@@ -900,8 +905,8 @@ bool PatternMatchEngine::explore_up_branches(const Handle& hp,
 ///
 /// There are two ways to understand this method. In the "simple" case,
 /// where there are no unordered links, and no ChoiceLinks, this becomes
-/// a simple wrapper around tree_compare(), and it just returns true of
-/// false to indicate if the suggested grounding `hsoln` actually is a
+/// a simple wrapper around tree_compare(), and it just returns true or
+/// false to indicate if the suggested grounding `hg` actually is a
 /// match for the current term being grounded. Before calling
 /// tree_compare(), it pushes all current state, and then pops it upon
 /// return. In other words, this encapsulates a single up-branch
@@ -918,7 +923,7 @@ bool PatternMatchEngine::explore_up_branches(const Handle& hp,
 /// possible permuations, each of which must be explored. This method
 /// controls the exploration of these different branches. For each
 /// possible branch, it saves state, explores the branch, and pops the
-/// state. If the exploration yielded nothing, then the next bracnh is
+/// state. If the exploration yielded nothing, then the next branch is
 /// explored, until exhaustion of the possibilities.  Upon exhaustion, it
 /// returns to the caller.
 ///
@@ -963,7 +968,7 @@ bool PatternMatchEngine::explore_link_branches(const Handle& hp,
 
 /// See explore_link_branches() for a general explanation. This method
 /// handles the ChoiceLink branch alternatives only.  It assumes
-/// that the caller had handles the unordered-link alternative branches.
+/// that the caller had handled the unordered-link alternative branches.
 bool PatternMatchEngine::explore_choice_branches(const Handle& hp,
                                                  const Handle& hg,
                                                  const Handle& clause_root)

--- a/opencog/rule-engine/InferenceSCM.cc
+++ b/opencog/rule-engine/InferenceSCM.cc
@@ -71,7 +71,8 @@ void InferenceSCM::init_in_module(void* data)
 void InferenceSCM::init(void)
 {
 #ifdef HAVE_GUILE
-    //all commands for invoking the rule engine from scm shell should be declared here
+    // All commands for invoking the rule engine from scm shell should
+    // be declared here
     define_scheme_primitive("cog-fc", &InferenceSCM::do_forward_chaining,
                             this, "rule-engine");
     define_scheme_primitive("cog-bc", &InferenceSCM::do_backward_chaining,
@@ -79,16 +80,17 @@ void InferenceSCM::init(void)
 #endif
 }
 
-Handle InferenceSCM::do_forward_chaining(Handle h)
+Handle InferenceSCM::do_forward_chaining(Handle h, const string& conf_path)
 {
 #ifdef HAVE_GUILE
     AtomSpace *as = SchemeSmob::ss_get_env_as("cog-fc");
     DefaultForwardChainerCB dfc(as);
-    ForwardChainer fc(as);
+    ForwardChainer fc(as, conf_path);
     /**
-     * Parse (cog-fc ListLink()) as forward chaining with Handle::UNDEFINED which  does
-     * pattern matching on the atomspace using the rules declared in the config.A similar
-     * functionality with the python version of the  forward chainer.
+     * Parse (cog-fc ListLink()) as forward chaining with
+     * Handle::UNDEFINED which does pattern matching on the atomspace
+     * using the rules declared in the config. A similar functionality
+     * with the python version of the forward chainer.
      */
     if (h->getType() == LIST_LINK and as->getIncoming(h).empty())
         fc.do_chain(dfc, Handle::UNDEFINED);

--- a/opencog/rule-engine/InferenceSCM.h
+++ b/opencog/rule-engine/InferenceSCM.h
@@ -35,9 +35,12 @@ private:
 	static void* init_in_guile(void*);
 	static void init_in_module(void*);
 
+	static const std::string default_cpolicy_path;
+
 	void init(void);
 
-	Handle do_forward_chaining(Handle h);
+	Handle do_forward_chaining(Handle h,
+		const std::string& conf_path = default_cpolicy_path);
 	/**
 	 * @return a handle to a ListLink  of ListLinks holding a variable followed by all grounding nodes.
 	 */
@@ -45,6 +48,9 @@ private:
 public:
 	InferenceSCM();
 };
+
+const std::string InferenceSCM::default_cpolicy_path =
+	"reasoning/default_cpolicy.json";
 
 } /*end of namespace opencog*/
 

--- a/opencog/rule-engine/forwardchainer/ForwardChainer.cc
+++ b/opencog/rule-engine/forwardchainer/ForwardChainer.cc
@@ -32,11 +32,9 @@
 
 using namespace opencog;
 
-ForwardChainer::ForwardChainer(AtomSpace * as, string conf_path /*=""*/) :
+ForwardChainer::ForwardChainer(AtomSpace * as, const string& conf_path) :
         _as(as), _rec(_as), _fcmem(_as)
 {
-    if (conf_path != "")
-        _conf_path = conf_path;
     init();
 }
 

--- a/opencog/rule-engine/forwardchainer/ForwardChainer.cc
+++ b/opencog/rule-engine/forwardchainer/ForwardChainer.cc
@@ -33,7 +33,7 @@
 using namespace opencog;
 
 ForwardChainer::ForwardChainer(AtomSpace * as, const string& conf_path) :
-        _as(as), _rec(_as), _fcmem(_as)
+	_as(as), _rec(_as), _conf_path(conf_path), _fcmem(_as)
 {
     init();
 }

--- a/opencog/rule-engine/forwardchainer/ForwardChainer.h
+++ b/opencog/rule-engine/forwardchainer/ForwardChainer.h
@@ -44,8 +44,7 @@ private:
 
     JsonicControlPolicyParamLoader* _cpolicy_loader;
 
-	// TODO: this is wrong, we need a more flexible way to define that
-    string _conf_path = "examples/rule-engine/cpolicy.json";
+	string _conf_path;
 
     FCMemory _fcmem; //Stores history
     Logger * _log;

--- a/opencog/rule-engine/forwardchainer/ForwardChainer.h
+++ b/opencog/rule-engine/forwardchainer/ForwardChainer.h
@@ -65,7 +65,7 @@ protected:
         TV_FITNESS_BASED, STI_BASED
     };
 public:
-    ForwardChainer(AtomSpace * as, string conf_path = "");
+    ForwardChainer(AtomSpace * as, const string& conf_path);
     virtual ~ForwardChainer();
     bool step(ForwardChainerCallBack& fcb);
     void do_chain(ForwardChainerCallBack& fcb, Handle hsource =

--- a/tests/rule-engine/ForwardChainerUTest.cxxtest
+++ b/tests/rule-engine/ForwardChainerUTest.cxxtest
@@ -37,7 +37,7 @@ public:
 		             "opencog/scm/utilities.scm, "
 		             "opencog/scm/av-tv.scm");
 		load_scm_files_from_config(*as_);
-		fc_ = new ForwardChainer(as_);
+		fc_ = new ForwardChainer(as_, "examples/rule-engine/cpolicy.json");
 	}
 	~ForwardChainerUTest() {
 		delete as_;

--- a/tests/rule-engine/JsonicControlPolicyParamLoaderUTest.cxxtest
+++ b/tests/rule-engine/JsonicControlPolicyParamLoaderUTest.cxxtest
@@ -37,7 +37,7 @@ void JsonicControlPolicyParamLoaderUTest::test_load_config() {
 	jcpl.load_config();
 	vector<Rule*> rules = jcpl.get_rules();
 	TS_ASSERT_EQUALS(1, rules.size());
-	TS_ASSERT_EQUALS(rules[0]->get_name(), "pln-rule-deduction");
+	TS_ASSERT_EQUALS(rules[0]->get_name(), "pln-rule-modus-ponens");
 	TS_ASSERT_EQUALS(false, jcpl.get_attention_alloc());
 	TS_ASSERT_EQUALS(20, jcpl.get_max_iter());
 }

--- a/tests/rule-engine/test_cpolicy.json
+++ b/tests/rule-engine/test_cpolicy.json
@@ -2,8 +2,8 @@
 	"rules": 
 	[
 		{
-			"name": "pln-rule-deduction",
-			"file_path": "reasoning/pln/rules/deduction.scm",
+			"name": "pln-rule-modus-ponens",
+			"file_path": "tests/rule-engine/bc-modus-ponens.scm",
 			"priority": 1,
 			"mutex": 
 			[


### PR DESCRIPTION
The rule-engine example isn't fixed yet (I'm still having an error, ERROR: In procedure module-lookup: Unbound variable: cog-stv-strength, but it's kind of a pain to debug given guile messing completely up the exception message [I had to hack the C++ code to print that one in order to see the message]).

I'm merging already anyway as we're a bunch working on the URE/PLN as to not drift too much from each others.

Note that now cog-fc takes the JSON file in second argument (beside the source). I know we're gonna get rid of JSON soon but till then that's just makes more sense.