### PR TITLE
Backward Chainer: added UnifyPMCB

### DIFF
--- a/opencog/rule-engine/CMakeLists.txt
+++ b/opencog/rule-engine/CMakeLists.txt
@@ -3,9 +3,9 @@
 #
 ADD_LIBRARY(ruleengine SHARED
 	backwardchainer/BackwardChainer.cc
+	backwardchainer/BackwardChainerPMCB.cc
 	URECommons.cc
 	forwardchainer/ForwardChainer.cc
-	backwardchainer/BCPatternMatch.cc
 	forwardchainer/ForwardChainInputMatchCB.cc
 	forwardchainer/ForwardChainPatternMatchCB.cc
 	forwardchainer/ForwardChainerCallBack.h

--- a/opencog/rule-engine/CMakeLists.txt
+++ b/opencog/rule-engine/CMakeLists.txt
@@ -4,6 +4,7 @@
 ADD_LIBRARY(ruleengine SHARED
 	backwardchainer/BackwardChainer.cc
 	backwardchainer/BackwardChainerPMCB.cc
+	backwardchainer/UnifyPMCB.cc
 	URECommons.cc
 	forwardchainer/ForwardChainer.cc
 	forwardchainer/ForwardChainInputMatchCB.cc

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.cc
@@ -25,6 +25,7 @@
 
 #include "BackwardChainer.h"
 #include "BackwardChainerPMCB.h"
+#include "UnifyPMCB.h"
 
 #include <opencog/util/random.h>
 
@@ -627,7 +628,7 @@ HandleSeq BackwardChainer::ground_premises(const Handle& hpremise,
  * specific atom to another, let it handles UnorderedLink, VariableNode in
  * QuoteLink, etc.
  *
- * XXX TODO allow typed variable to unify to a variable
+ * XXX TODO check if the UnifyPMCB solution is correct
  * XXX TODO unify in both direction? (maybe not)
  * XXX Should (Link (Node A)) be unifiable to (Node A))?  BC literature never
  * unify this way, but in AtomSpace context, (Link (Node A)) does contain (Node A)
@@ -669,7 +670,7 @@ bool BackwardChainer::unify(const Handle& htarget,
 		                                                  fv.varset));
 
 	SatisfactionLinkPtr sl(createSatisfactionLink(temp_vardecl, temp_htarget));
-	BackwardChainerPMCB pmcb(&temp_space);
+	UnifyPMCB pmcb(&temp_space);
 
 	sl->satisfy(pmcb);
 

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.h
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.h
@@ -2,8 +2,10 @@
  * BackwardChainer.h
  *
  * Copyright (C) 2014 Misgana Bayetta
+ * Copyright (C) 2015 OpenCog Foundation
  *
  * Author: Misgana Bayetta <misgana.bayetta@gmail.com>  October 2014
+ *         William Ma <https://github.com/williampma>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License v3 as

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.h
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.h
@@ -116,7 +116,7 @@ public:
 
 private:
 
-	VarMultimap do_bc(Handle& htarget);
+	VarMultimap process_target(Handle& htarget);
 
 	std::vector<Rule> filter_rules(Handle htarget);
 	Rule select_rule(const std::vector<Rule>& rules);

--- a/opencog/rule-engine/backwardchainer/BackwardChainerPMCB.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainerPMCB.cc
@@ -28,7 +28,7 @@ using namespace opencog;
 
 BackwardChainerPMCB::BackwardChainerPMCB(AtomSpace * as)
     : InitiateSearchCB(as), DefaultPatternMatchCB(as), as_(as)
- //       : Implicator(as), DefaultPatternMatchCB(as), AttentionalFocusCB(as), PLNImplicator(as), as_(as)
+ // : Implicator(as), DefaultPatternMatchCB(as), AttentionalFocusCB(as), PLNImplicator(as), as_(as)
 {
 }
 
@@ -39,14 +39,12 @@ BackwardChainerPMCB::~BackwardChainerPMCB()
 bool BackwardChainerPMCB::node_match(Handle& node1, Handle& node2)
 {
 	return DefaultPatternMatchCB::node_match(node1, node2);
-
 	//return AttentionalFocusCB::node_match(node1, node2);
 }
 
 bool BackwardChainerPMCB::link_match(LinkPtr& lpat, LinkPtr& lsoln)
 {
 	return DefaultPatternMatchCB::link_match(lpat, lsoln);
-
 	//return AttentionalFocusCB::link_match(lpat, lsoln);
 }
 

--- a/opencog/rule-engine/backwardchainer/BackwardChainerPMCB.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainerPMCB.cc
@@ -1,7 +1,8 @@
 /*
- * BCPatternMatch.cc
+ * BackwardChainerPMCB.cc
  *
  * Copyright (C) 2014 Misgana Bayetta
+ * Copyright (C) 2015 OpenCog Foundation
  *
  * Author: Misgana Bayetta <misgana.bayetta@gmail.com>  October 2014
  *
@@ -21,54 +22,45 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include "BCPatternMatch.h"
+#include "BackwardChainerPMCB.h"
 
 using namespace opencog;
 
-BCPatternMatch::BCPatternMatch(AtomSpace * as)
+BackwardChainerPMCB::BackwardChainerPMCB(AtomSpace * as)
     : InitiateSearchCB(as), DefaultPatternMatchCB(as), as_(as)
  //       : Implicator(as), DefaultPatternMatchCB(as), AttentionalFocusCB(as), PLNImplicator(as), as_(as)
 {
 }
 
-BCPatternMatch::~BCPatternMatch()
+BackwardChainerPMCB::~BackwardChainerPMCB()
 {
 }
 
-bool BCPatternMatch::node_match(Handle& node1, Handle& node2)
+bool BackwardChainerPMCB::node_match(Handle& node1, Handle& node2)
 {
 	return DefaultPatternMatchCB::node_match(node1, node2);
 
 	//return AttentionalFocusCB::node_match(node1, node2);
 }
 
-bool BCPatternMatch::link_match(LinkPtr& lpat, LinkPtr& lsoln)
+bool BackwardChainerPMCB::link_match(LinkPtr& lpat, LinkPtr& lsoln)
 {
 	return DefaultPatternMatchCB::link_match(lpat, lsoln);
 
 	//return AttentionalFocusCB::link_match(lpat, lsoln);
 }
 
-bool BCPatternMatch::grounding(const std::map<Handle, Handle> &var_soln,
+bool BackwardChainerPMCB::grounding(const std::map<Handle, Handle> &var_soln,
                                const std::map<Handle, Handle> &pred_soln)
 {
-//	for (auto& p : pred_soln)
-//		logger().debug("PM pred: " + p.first->toShortString()
-//		               + " map to " + p.second->toShortString());
-
 	std::map<Handle, Handle> true_var_soln;
 
 	// get rid of non-var mapping
 	for (auto& p : var_soln)
 	{
 		if (p.first->getType() == VARIABLE_NODE)
-		{
 			true_var_soln[p.first] = p.second;
-//			logger().debug("PM var: " + p.first->toShortString()
-//			               + " map to " + p.second->toShortString());
-		}
 	}
-
 
 	// XXX TODO if a variable match to itself, reject?
 
@@ -79,11 +71,11 @@ bool BCPatternMatch::grounding(const std::map<Handle, Handle> &var_soln,
 	return false;
 }
 
-std::vector<std::map<Handle, Handle>> BCPatternMatch::get_var_list()
+std::vector<std::map<Handle, Handle>> BackwardChainerPMCB::get_var_list()
 {
 	return var_solns_;
 }
-std::vector<std::map<Handle, Handle>> BCPatternMatch::get_pred_list()
+std::vector<std::map<Handle, Handle>> BackwardChainerPMCB::get_pred_list()
 {
 	return pred_solns_;
 }

--- a/opencog/rule-engine/backwardchainer/BackwardChainerPMCB.h
+++ b/opencog/rule-engine/backwardchainer/BackwardChainerPMCB.h
@@ -51,9 +51,9 @@ public:
 		DefaultPatternMatchCB::set_pattern(vars, pat);
 	}
 
-	bool node_match(Handle& node1, Handle& node2);
-	bool link_match(LinkPtr& lpat, LinkPtr& lsoln);
-	bool grounding(const std::map<Handle, Handle> &var_soln,
+	virtual bool node_match(Handle& node1, Handle& node2);
+	virtual bool link_match(LinkPtr& lpat, LinkPtr& lsoln);
+	virtual bool grounding(const std::map<Handle, Handle> &var_soln,
 			const std::map<Handle, Handle> &pred_soln);
 
     /**

--- a/opencog/rule-engine/backwardchainer/BackwardChainerPMCB.h
+++ b/opencog/rule-engine/backwardchainer/BackwardChainerPMCB.h
@@ -1,7 +1,8 @@
 /*
- * BCPatternMatch.h
+ * BackwardChainerPMCB.h
  *
  * Copyright (C) 2014 Misgana Bayetta
+ * Copyright (C) 2015 OpenCog Foundation
  *
  * Author: Misgana Bayetta <misgana.bayetta@gmail.com>  October 2014
  *
@@ -20,19 +21,16 @@
  * Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-#ifndef BCPATTERNMATCH_H_
-#define BCPATTERNMATCH_H_
+
+#ifndef _OPENCOG_BACKWARDCHAINERPMCB_H_
+#define _OPENCOG_BACKWARDCHAINERPMCB_H_
 
 #include <opencog/query/DefaultImplicator.h>
 
 namespace opencog
 {
 
-/**
- * Given a rule(i.e a bindLink handle), find all the premises that
- * satisfy the rule.  by pattern matching.
- */
-class BCPatternMatch :
+class BackwardChainerPMCB :
 	public InitiateSearchCB,
 	public DefaultPatternMatchCB // : public virtual PLNImplicator
 {
@@ -43,8 +41,8 @@ private:
 	std::vector<std::map<Handle, Handle>> pred_solns_;
 
 public:
-	BCPatternMatch(AtomSpace*);
-	virtual ~BCPatternMatch();
+	BackwardChainerPMCB(AtomSpace*);
+	virtual ~BackwardChainerPMCB();
 
 	virtual void set_pattern(const Variables& vars,
 	                         const Pattern& pat)
@@ -53,16 +51,8 @@ public:
 		DefaultPatternMatchCB::set_pattern(vars, pat);
 	}
 
-	// The following callbacks are used for guiding the PM to look
-	// only the target list based on step 3 of
-	// http://wiki.opencog.org/w/New_PLN_Chainer_Design#Overall_Forward_Chaining_Process
 	bool node_match(Handle& node1, Handle& node2);
 	bool link_match(LinkPtr& lpat, LinkPtr& lsoln);
-
-	/**
-	 * A callback handler of the Pattern matcher used to store
-	 * references to new conclusion the target list
-	 */
 	bool grounding(const std::map<Handle, Handle> &var_soln,
 			const std::map<Handle, Handle> &pred_soln);
 
@@ -76,4 +66,4 @@ public:
 
 } // ~namespace opencog
 
-#endif /* BCPATTERNMATCH_H_ */
+#endif /* _OPENCOG_BACKWARDCHAINERPMCB_H_ */

--- a/opencog/rule-engine/backwardchainer/CMakeLists.txt
+++ b/opencog/rule-engine/backwardchainer/CMakeLists.txt
@@ -1,4 +1,4 @@
 INSTALL (FILES
-	BCPatternMatch.h
+	BackwardChainerPMCB.h
 	DESTINATION "include/${PROJECT_NAME}/rule-engine/backwardchainer"
 )

--- a/opencog/rule-engine/backwardchainer/UnifyPMCB.cc
+++ b/opencog/rule-engine/backwardchainer/UnifyPMCB.cc
@@ -1,0 +1,48 @@
+/*
+ * UnifyPMCB.cc
+ *
+ * Copyright (C) 2015 OpenCog Foundation
+ *
+ * Author: William Ma <https://github.com/williampma>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "UnifyPMCB.h"
+
+using namespace opencog;
+
+UnifyPMCB::UnifyPMCB(AtomSpace* as) : BackwardChainerPMCB(as)
+{
+
+}
+
+UnifyPMCB::~UnifyPMCB()
+{
+
+}
+
+
+bool UnifyPMCB::variable_match(const Handle& npat_h,
+                               const Handle& nsoln_h)
+{
+	Type soltype = nsoln_h->getType();
+
+	// special case to allow any typed variable to match to a variable
+	if (soltype == VARIABLE_NODE) return true;
+
+	return BackwardChainerPMCB::variable_match(npat_h, nsoln_h);
+}

--- a/opencog/rule-engine/backwardchainer/UnifyPMCB.h
+++ b/opencog/rule-engine/backwardchainer/UnifyPMCB.h
@@ -1,0 +1,43 @@
+/*
+ * UnifyPMCB.h
+ *
+ * Copyright (C) 2015 OpenCog Foundation
+ *
+ * Author: William Ma <https://github.com/williampma>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef _OPENCOG_UNIFYPMCB_H
+#define _OPENCOG_UNIFYPMCB_H
+
+#include "BackwardChainerPMCB.h"
+
+namespace opencog
+{
+
+class UnifyPMCB : public BackwardChainerPMCB
+{
+public:
+	UnifyPMCB(AtomSpace*);
+	virtual ~UnifyPMCB();
+
+	virtual bool variable_match(const Handle&, const Handle&);
+};
+
+}
+
+#endif // _OPENCOG_UNIFYPMCB_H


### PR DESCRIPTION
To handle rules with typed variable node.  Allowing them to unify to another variable.

## TODO

Wrap a "target" in custom object to store information like
* what rules were applied
* how many time the target has been selected
* etc

which could maybe used for target selection in the future?