### PR TITLE
Forgot to load av-tv.scm

### DIFF
--- a/examples/rule-engine/simple-deduction.scm
+++ b/examples/rule-engine/simple-deduction.scm
@@ -16,6 +16,7 @@
 (use-modules (opencog rule-engine))
 
 (load-from-path "utilities.scm")
+(load-from-path "av-tv.scm")
 
 (define A (ConceptNode "A"))
 (define B (ConceptNode "B"))


### PR DESCRIPTION
It still doesn't work out of the box. You'd need to specify the absolute paths. I could fix the JSON parser and whatnot but since I'm gonna get rid of JSON there isn't much point.