### PR TITLE
Evaluatable variables support

### DIFF
--- a/opencog/atoms/bind/ConcreteLink.cc
+++ b/opencog/atoms/bind/ConcreteLink.cc
@@ -479,6 +479,7 @@ void ConcreteLink::trace_connectives(const std::set<Type>& connectives,
 		Type t = term->getType();
 		if (connectives.find(t) == connectives.end()) continue;
 		_pat.evaluatable_holders.insert(term);
+		add_to_map(_pat.in_evaluatable, term, term);
 		LinkPtr lp(LinkCast(term));
 		if (lp)
 			trace_connectives(connectives, lp->getOutgoingSet());

--- a/opencog/atoms/bind/ConcreteLink.cc
+++ b/opencog/atoms/bind/ConcreteLink.cc
@@ -470,6 +470,23 @@ void ConcreteLink::unbundle_virtual(const std::set<Handle>& vars,
 }
 
 /* ================================================================= */
+
+void ConcreteLink::trace_connectives(const std::set<Type>& connectives,
+                                     const HandleSeq& oset)
+{
+	for (const Handle& term: oset)
+	{
+		Type t = term->getType();
+		if (connectives.find(t) == connectives.end()) continue;
+		_pat.evaluatable_holders.insert(term);
+		LinkPtr lp(LinkCast(term));
+		if (lp)
+			trace_connectives(connectives, lp->getOutgoingSet());
+		// XXX insert var into in_evaluatable...
+	}
+}
+
+/* ================================================================= */
 /**
  * Create a map that holds all of the clauses that a given atom
  * participates in.  In other words, it indicates all the places

--- a/opencog/atoms/bind/ConcreteLink.cc
+++ b/opencog/atoms/bind/ConcreteLink.cc
@@ -358,13 +358,13 @@ static void add_to_map(std::unordered_multimap<Handle, Handle>& map,
 /// enough, expect when an entire term is a variable.  Thus, for
 /// example, a term such as (NotLink (VariableNode $x)) needs to be
 /// evaluated at grounding-time, even though it does not currently
-/// cotnain a GPN or a VirtualLink: the grounding might contain it;
+/// contain a GPN or a VirtualLink: the grounding might contain it;
 /// We don't know yet.  However, there's a gotcha: we don't yet know
 /// what the connectives are. The actual connectives depend on the
 /// callback; the default callback uses AndLink, OrLink, NotLink, but
-/// other callbacks may pick something else.  Thus, the callback is
-/// given a chance to modify the evaluatable_holders before the pattern
-/// search starts.
+/// other callbacks may pick something else.  Thus, we cannot do this
+/// here. By contrast, SatisfactionLink and BindLink explicitly assume
+/// the default callback, so they do the additional unbundling there.
 ///
 /// A term is "executable" if it is an ExecutionOutputLink
 /// or if it inherits from one (such as PlusLink, TimesLink).
@@ -387,21 +387,6 @@ static void add_to_map(std::unordered_multimap<Handle, Handle>& map,
 /// arises when a virtual clause has two or more variables in it, and
 /// those variables are grounded by different disconnected graph
 /// components; the combinatoric explosino has to be handled...
-///
-/// If the evaluatable_holders combine multiple variables using
-/// connectives, then the entire clause can become virtual. Because we
-/// do not yet know what the connectives are (they are
-/// callback-dependent), the callback myst also modify the virtuals, as
-/// well.
-///
-/// XXX FIXME: the above design, where the callback is twerking the
-/// evaluatable_holders, seems mildly broken, to me.  It seems to me
-/// that we should assume a specific callback, and unbundle as
-/// approrpriate, for that callback. Easy to say, but hard to do:
-/// The various different users of the pattern matcher call this code
-/// to perform the unbundling, but then use thier own callbacks on it.
-/// Thus, we still need a layer of generic unbundling, somewhere, and
-/// here seems to be a good a spot as any...
 ///
 void ConcreteLink::unbundle_virtual(const std::set<Handle>& vars,
                                     const HandleSeq& clauses,

--- a/opencog/atoms/bind/ConcreteLink.h
+++ b/opencog/atoms/bind/ConcreteLink.h
@@ -89,6 +89,9 @@ protected:
 	                      HandleSeq& virtual_clauses,
 	                      std::set<Handle>& black_clauses);
 
+	void trace_connectives(const std::set<Type>&,
+	                       const HandleSeq& clauses);
+
 	void check_connectivity(const std::vector<HandleSeq>&);
 
 	void make_connectivity_map(const HandleSeq&);

--- a/opencog/atoms/bind/README.md
+++ b/opencog/atoms/bind/README.md
@@ -7,6 +7,13 @@ the SatisfactionLink and the BindLink.  This helps avoid having to
 unpack these links every time a pattern search is performed. It also
 verifies that the syntax is correct; that the links are well-formed.
 
+The SatisfactionLink and BindLink implicitly assume (have to assume)
+that they will run with the DefaultPatternMatchCB, or variants thereof.
+However, the current implementation does allow them to actually run
+with other callbacks as well, so weird stuff may happen due to this
+implicit assumption. By contrast, the ConcreteLink tries not to make
+such assumptions, or, at least, to make fewer of them.
+
 
 Basic Intro
 -----------
@@ -105,7 +112,7 @@ TO-DO List
 
 Type Restrictions
 -----------------
-It couold make sense to store type restrictions with a new VariableNode
+It could make sense to store type restrictions with a new VariableNode
 class. This would offer a minor performance improvement: type
 restrictions would not have to be looked up in a mp, as currently
 implemented.  On the other hand, this could e a major headache: every

--- a/opencog/atoms/bind/SatisfactionLink.cc
+++ b/opencog/atoms/bind/SatisfactionLink.cc
@@ -51,6 +51,8 @@ void SatisfactionLink::setup_sat_body(void)
 	// we are being run with the DefaultPatternMatchCB, and so we assume
 	// that the logical connectives are AndLink, OrLink and NotLink.
 	// Tweak the evaluatable_holders to reflect this.
+	std::set<Type> connectives({AND_LINK, OR_LINK, NOT_LINK});
+	trace_connectives(connectives, _pat.clauses);
 
 	// Split the non-virtual clauses into connected components
 	std::vector<HandleSeq> comps;

--- a/opencog/atoms/bind/SatisfactionLink.cc
+++ b/opencog/atoms/bind/SatisfactionLink.cc
@@ -47,6 +47,11 @@ void SatisfactionLink::setup_sat_body(void)
 	unbundle_virtual(_varlist.varset, _pat.cnf_clauses,
                     _fixed, _virtual, _pat.black);
 
+	// unbundle_virtual does not handle connectives. Here, we assume that
+	// we are being run with the DefaultPatternMatchCB, and so we assume
+	// that the logical connectives are AndLink, OrLink and NotLink.
+	// Tweak the evaluatable_holders to reflect this.
+
 	// Split the non-virtual clauses into connected components
 	std::vector<HandleSeq> comps;
 	std::vector<std::set<Handle>> comp_vars;

--- a/opencog/query/DefaultPatternMatchCB.cc
+++ b/opencog/query/DefaultPatternMatchCB.cc
@@ -27,7 +27,6 @@
 
 #include "DefaultPatternMatchCB.h"
 #include "Instantiator.h"
-#include "PatternMatchEngine.h"
 
 using namespace opencog;
 

--- a/opencog/query/DefaultPatternMatchCB.cc
+++ b/opencog/query/DefaultPatternMatchCB.cc
@@ -294,6 +294,11 @@ bool DefaultPatternMatchCB::eval_sentence(const Handle& top,
 	dbgprt("Enter eval_sentence CB with top=\n%s\n",
 	        top->toShortString().c_str());
 
+	if (top->getType() == VARIABLE_NODE)
+	{
+		return eval_term(top, gnds);
+	}
+
 	LinkPtr ltop(LinkCast(top));
 	if (NULL == ltop)
 		throw InvalidParamException(TRACE_INFO,

--- a/tests/query/EvaluationUTest.cxxtest
+++ b/tests/query/EvaluationUTest.cxxtest
@@ -67,8 +67,8 @@ public:
 	void setUp(void);
 	void tearDown(void);
 
-	void test_eval(void);
-	void test_logic(void);
+	void ytest_eval(void);
+	void ytest_logic(void);
 	void test_varval(void);
 };
 
@@ -91,7 +91,7 @@ void EvaluationUTest::setUp(void)
 /*
  * Evaluation most basic unit test.
  */
-void EvaluationUTest::test_eval(void)
+void EvaluationUTest::ytest_eval(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
@@ -128,7 +128,7 @@ void EvaluationUTest::test_eval(void)
 /*
  * Evaluation boolean logic unit test.
  */
-void EvaluationUTest::test_logic(void)
+void EvaluationUTest::ytest_logic(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
@@ -168,6 +168,7 @@ void EvaluationUTest::test_varval(void)
 	config().set("SCM_PRELOAD", "tests/query/eval-var.scm");
 	load_scm_files_from_config(*as);
 
+/****
 	Handle dostuff = eval->eval_h("(cog-bind (do-things))");
 	printf ("do-things: \n%s\n", dostuff->toShortString().c_str());
 
@@ -176,6 +177,10 @@ void EvaluationUTest::test_varval(void)
 		"(SetLink (ImplicationLink (ConceptNode \"acceptance\")))");
 
 	TS_ASSERT_EQUALS(expected, dostuff);
+****/
+
+	Handle ndostuff = eval->eval_h("(cog-bind (do-nthings))");
+	printf ("do-nthings: \n%s\n", ndostuff->toShortString().c_str());
 
 	logger().debug("END TEST: %s", __FUNCTION__);
 }

--- a/tests/query/EvaluationUTest.cxxtest
+++ b/tests/query/EvaluationUTest.cxxtest
@@ -168,7 +168,6 @@ void EvaluationUTest::test_varval(void)
 	config().set("SCM_PRELOAD", "tests/query/eval-var.scm");
 	load_scm_files_from_config(*as);
 
-/****
 	Handle dostuff = eval->eval_h("(cog-bind (do-things))");
 	printf ("do-things: \n%s\n", dostuff->toShortString().c_str());
 
@@ -177,10 +176,21 @@ void EvaluationUTest::test_varval(void)
 		"(SetLink (ImplicationLink (ConceptNode \"acceptance\")))");
 
 	TS_ASSERT_EQUALS(expected, dostuff);
-****/
 
 	Handle ndostuff = eval->eval_h("(cog-bind (do-nthings))");
 	printf ("do-nthings: \n%s\n", ndostuff->toShortString().c_str());
+
+	// Of the two possibilities, we only expect one to pass.
+	Handle rejected = eval->eval_h(
+		"(SetLink (ImplicationLink (ConceptNode \"rejection\")))");
+
+	TS_ASSERT_EQUALS(rejected, ndostuff);
+
+	Handle nndostuff = eval->eval_h("(cog-bind (do-nnthings))");
+	printf ("do-nnthings: \n%s\n", nndostuff->toShortString().c_str());
+
+	// Of the two possibilities, we only expect one to pass.
+	TS_ASSERT_EQUALS(expected, nndostuff);
 
 	logger().debug("END TEST: %s", __FUNCTION__);
 }

--- a/tests/query/EvaluationUTest.cxxtest
+++ b/tests/query/EvaluationUTest.cxxtest
@@ -67,8 +67,8 @@ public:
 	void setUp(void);
 	void tearDown(void);
 
-	void ytest_eval(void);
-	void ytest_logic(void);
+	void test_eval(void);
+	void test_logic(void);
 	void test_varval(void);
 };
 
@@ -91,7 +91,7 @@ void EvaluationUTest::setUp(void)
 /*
  * Evaluation most basic unit test.
  */
-void EvaluationUTest::ytest_eval(void)
+void EvaluationUTest::test_eval(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
@@ -128,7 +128,7 @@ void EvaluationUTest::ytest_eval(void)
 /*
  * Evaluation boolean logic unit test.
  */
-void EvaluationUTest::ytest_logic(void)
+void EvaluationUTest::test_logic(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 

--- a/tests/query/eval-var.scm
+++ b/tests/query/eval-var.scm
@@ -43,7 +43,7 @@
 )
 
 ; This pattern will accept one of the two above, reject the other.
-(define (do-things)
+(define (do-cond condi)
 	(BindLink
 		(VariableList
 			(VariableNode "$cxt")
@@ -59,10 +59,15 @@
 					(VariableNode "$action")
 				)
 				; ... and the precondition holds true ...
-				(VariableNode "$condition")
+				condi
 			)
 			; ...  then perform the action.
 			(VariableNode "$action")
 		)
 	)
 )
+
+; This pattern will accept one of the two above, reject the other.
+(define (do-things) (do-cond (VariableNode "$condition")))
+(define (do-nthings) (do-cond (NotLink (VariableNode "$condition"))))
+(define (do-nnthings) (do-cond (NotLink (NotLink (VariableNode "$condition")))))


### PR DESCRIPTION
Part two of adding/fixing support for evaluatable variables.

If a variable is grounded by an EvaluationLink that contains a GroundedPredicateNode in it, then be sure to evaluate it it before deciding if its a match or not. This handles a few more of the corner cases that were missed by previous fixes.