### PR TITLE
infinite recursion bugfix.

### DIFF
--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -89,7 +89,7 @@ AtomTable::~AtomTable()
     // No one who shall look at these atoms ahall ever again
     // find a reference to this atomtable.
     UUID undef = Handle::UNDEFINED.value();
-    for (Handle h : _atom_set) {
+    for (const Handle& h : _atom_set) {
         h->_atomTable = NULL;
         h->_uuid = undef;
     }

--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -100,7 +100,7 @@ private:
     // the only index that actually holds the atom shared_ptr, and thus
     // increments the atom use count in a guaranteed fashion.  This is
     // the one true guaranteee that the atom will not be deleted while
-    // it s in the atom table.
+    // it is in the atom table.
     std::unordered_set<Handle, handle_hash> _atom_set;
 
     //!@{

--- a/opencog/query/DefaultPatternMatchCB.cc
+++ b/opencog/query/DefaultPatternMatchCB.cc
@@ -192,6 +192,7 @@ bool DefaultPatternMatchCB::clause_match(const Handle& ptrn,
 		// which seems reasonable, except that everything else in the
 		// default callback ignores the TV on EvaluationLinks. So this
 		// is kind-of schizophrenic here.  Not sure what else to do.
+		_temp_aspace.clear();
 		TruthValuePtr tvp(EvaluationLink::do_evaluate(&_temp_aspace, grnd));
 
 		dbgprt("clause_match evaluation yeilded tv=%s\n", tvp->toString().c_str());
@@ -268,6 +269,7 @@ bool DefaultPatternMatchCB::eval_term(const Handle& virt,
 	// do_evaluate callback.  Alternately, perhaps the
 	// EvaluationLink::do_evaluate() method should do this ??? Its a toss-up.
 
+	_temp_aspace.clear();
 	TruthValuePtr tvp(EvaluationLink::do_evaluate(&_temp_aspace, gvirt));
 
 	dbgprt("eval_term evaluation yeilded tv=%s\n", tvp->toString().c_str());

--- a/opencog/query/Instantiator.cc
+++ b/opencog/query/Instantiator.cc
@@ -30,6 +30,10 @@ using namespace opencog;
 
 Handle Instantiator::walk_tree(const Handle& expr)
 {
+	// halt infinite regress
+	if (_halt)
+		return Handle(expr);
+
 	Type t = expr->getType();
 
 	// Must not explore the insides of a QuoteLink.
@@ -52,7 +56,10 @@ Handle Instantiator::walk_tree(const Handle& expr)
 		// Not so fast, pardner. VariableNodes can be grounded by
 		// links, and those links may be executable. In that case,
 		// we have to execute them.
-		return walk_tree(it->second);
+		_halt = true;
+		Handle hgnd(walk_tree(it->second));
+		_halt = false;
+		return hgnd;
 	}
 
 	// If we are here, then we have a link. Walk it.

--- a/opencog/query/Instantiator.cc
+++ b/opencog/query/Instantiator.cc
@@ -31,6 +31,11 @@ using namespace opencog;
 Handle Instantiator::walk_tree(const Handle& expr)
 {
 	Type t = expr->getType();
+
+	// Must not explore the insides of a QuoteLink.
+	if (QUOTE_LINK == t)
+		return Handle(expr);
+
 	LinkPtr lexpr(LinkCast(expr));
 	if (not lexpr)
 	{
@@ -54,7 +59,7 @@ Handle Instantiator::walk_tree(const Handle& expr)
 
 	// Walk the subtree, substituting values for variables.
 	HandleSeq oset_results;
-	for (Handle h : lexpr->getOutgoingSet())
+	for (const Handle& h : lexpr->getOutgoingSet())
 	{
 		Handle hg = walk_tree(h);
 		// It would be a NULL handle if it's deleted... Just skip

--- a/opencog/query/Instantiator.h
+++ b/opencog/query/Instantiator.h
@@ -39,6 +39,7 @@ class Instantiator
 private:
 		AtomSpace *_as;
 		const std::map<Handle, Handle> *_vmap;
+		bool _halt = false;
 
 		/**
 		 * Recursively walk a tree starting with the root of the

--- a/tests/query/QuoteUTest.cxxtest
+++ b/tests/query/QuoteUTest.cxxtest
@@ -74,6 +74,7 @@ public:
     void test_double_quote(void);
     void test_impossible(void);
     void test_numeric_greater(void);
+    void test_crash(void);
 };
 
 void QuoteUTest::tearDown(void)
@@ -131,6 +132,8 @@ void QuoteUTest::test_quoted_variable(void)
     banana = as->getOutgoing(banana, 0);
     TS_ASSERT_EQUALS(CONCEPT_NODE, banana->getType());
     TS_ASSERT_EQUALS(0, strcmp("banana", as->getName(banana).c_str()));
+
+    logger().debug("END TEST: %s", __FUNCTION__);
 }
 
 /*
@@ -151,6 +154,8 @@ void QuoteUTest::test_nest(void)
     allstar = as->getOutgoing(allstar, 0);
     TS_ASSERT_EQUALS(PREDICATE_NODE, allstar->getType());
     TS_ASSERT_EQUALS(0, strcmp("all-var", as->getName(allstar).c_str()));
+
+    logger().debug("END TEST: %s", __FUNCTION__);
 }
 
 void QuoteUTest::test_throw(void)
@@ -172,6 +177,8 @@ void QuoteUTest::test_throw(void)
         did_throw = true;
     }
     TS_ASSERT_EQUALS(true, did_throw);
+
+    logger().debug("END TEST: %s", __FUNCTION__);
 }
 
 /*
@@ -192,6 +199,8 @@ void QuoteUTest::test_gpn(void)
     allstar = as->getOutgoing(allstar, 0);
     TS_ASSERT_EQUALS(LIST_LINK, allstar->getType());
     TS_ASSERT_EQUALS(2, as->getArity(allstar));
+
+    logger().debug("END TEST: %s", __FUNCTION__);
 }
 
 /*
@@ -212,6 +221,8 @@ void QuoteUTest::test_double_quote(void)
     banana = as->getOutgoing(banana, 0);
     TS_ASSERT_EQUALS(CONCEPT_NODE, banana->getType());
     TS_ASSERT_EQUALS(0, strcmp("banana", as->getName(banana).c_str()));
+
+    logger().debug("END TEST: %s", __FUNCTION__);
 }
 
 // Test bug bug #1531
@@ -229,6 +240,8 @@ void QuoteUTest::test_impossible(void)
     // Mostly we expect the above to not throw or assert.
     // Getting back false tv (no groundings at all) is a bonus.
     TS_ASSERT_EQUALS(TruthValue::FALSE_TV(), tv);
+
+    logger().debug("END TEST: %s", __FUNCTION__);
 }
 
 /*
@@ -258,4 +271,22 @@ void QuoteUTest::test_numeric_greater(void)
     TS_ASSERT_EQUALS(0, as->getArity(people_richer_than_obama));
     TS_ASSERT_EQUALS(1, as->getArity(people_richer_than_george));
     TS_ASSERT_EQUALS(2, as->getArity(people_richer_than_susan));
+
+    logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+void QuoteUTest::test_crash(void)
+{
+    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+    config().set("SCM_PRELOAD", "opencog/scm/opencog/query.scm, "
+                                "tests/query/quote-crash.scm");
+
+    load_scm_files_from_config(*as);
+
+    // If we can execute this without crashing, the test is suecesful.
+    Handle cr = eval->eval_h("(cog-bind crasher)");
+    printf("crasher is %s\n", cr->toShortString().c_str());
+
+    logger().debug("END TEST: %s", __FUNCTION__);
 }

--- a/tests/query/QuoteUTest.cxxtest
+++ b/tests/query/QuoteUTest.cxxtest
@@ -286,7 +286,9 @@ void QuoteUTest::test_crash(void)
 
     // If we can execute this without crashing, the test is suecesful.
     Handle cr = eval->eval_h("(cog-bind crasher)");
-    printf("crasher is %s\n", cr->toShortString().c_str());
+
+    Handle inf = eval->eval_h("(cog-bind infloop)");
+    printf("infloop is %s\n", inf->toShortString().c_str());
 
     logger().debug("END TEST: %s", __FUNCTION__);
 }

--- a/tests/query/QuoteUTest.cxxtest
+++ b/tests/query/QuoteUTest.cxxtest
@@ -284,11 +284,15 @@ void QuoteUTest::test_crash(void)
 
     load_scm_files_from_config(*as);
 
-    // If we can execute this without crashing, the test is suecesful.
+    // If we can execute this without crashing, the test is succesful.
     Handle cr = eval->eval_h("(cog-bind crasher)");
+    TS_ASSERT_EQUALS(8, as->getArity(cr));
 
+    // This blows out the stack in an infinite loop, if the instantiator
+    // doesn't catch it and prevent it.
     Handle inf = eval->eval_h("(cog-bind infloop)");
     printf("infloop is %s\n", inf->toShortString().c_str());
+    TS_ASSERT_EQUALS(9, as->getArity(inf));
 
     logger().debug("END TEST: %s", __FUNCTION__);
 }

--- a/tests/query/quote-crash.scm
+++ b/tests/query/quote-crash.scm
@@ -2,11 +2,22 @@
 (use-modules (opencog))
 (use-modules (opencog query))
 
+; This is an infinite loop, except that the QuoteLink is supposed
+; to stop the recursion.
 (define crasher
 	(BindLink
-   	(ImplicationLink
-      	(VariableNode "$x")
-      	(ListLink
-         	(ConceptNode "And the answer is ...")
-         	(VariableNode "$x")
-         	(QuoteLink (VariableNode "$x"))))))
+		(ImplicationLink
+			(VariableNode "$x")
+			(ListLink
+				(ConceptNode "And the answer is ...")
+				(QuoteLink (VariableNode "$x"))))))
+
+;; This is an infinite loop, because there are no type restrictions on
+;; the variable, and the instantiaotor can get confused.
+(define infloop
+	(BindLink
+		(ImplicationLink
+			(VariableNode "$x")
+			(ListLink
+				(ConceptNode "And the answer is ...")
+				(VariableNode "$x")))))

--- a/tests/query/quote-crash.scm
+++ b/tests/query/quote-crash.scm
@@ -1,0 +1,12 @@
+
+(use-modules (opencog))
+(use-modules (opencog query))
+
+(define crasher
+	(BindLink
+   	(ImplicationLink
+      	(VariableNode "$x")
+      	(ListLink
+         	(ConceptNode "And the answer is ...")
+         	(VariableNode "$x")
+         	(QuoteLink (VariableNode "$x"))))))

--- a/tests/rule-engine/CMakeLists.txt
+++ b/tests/rule-engine/CMakeLists.txt
@@ -7,9 +7,7 @@ LINK_LIBRARIES(
 ADD_CXXTEST(RuleUTest)
 ADD_CXXTEST(ForwardChainerUTest)
 
-# Currently, BackwardChainer its up all possible RAM.
-# Disabling un til this is fixed.
-# ADD_CXXTEST(BackwardChainerUTest)
+ADD_CXXTEST(BackwardChainerUTest)
 ADD_CXXTEST(URECommonsUTest)
 ADD_CXXTEST(JsonicControlPolicyParamLoaderUTest)
 ADD_CXXTEST(DefaultForwardChainerCBUTest)


### PR DESCRIPTION
This fixes an infinite recursion bug discussed in bug #41.

-- BackwardChainerUTet now works and passes
-- Horrid EinsteinUTest performance now fixed.
-- QuoteLinkUTest expanded to make sure quotes are handled correctly during instantiation (they were not, that was one of the two different infinite regressions)