### PR TITLE
Backward Chainer: improve unify, rule outputs

### DIFF
--- a/opencog/rule-engine/Rule.cc
+++ b/opencog/rule-engine/Rule.cc
@@ -119,9 +119,9 @@ Handle Rule::get_implicant()
  * This function does extra processing to find the real output over an
  * ExecutionOutputLink.  ie, skip to the ListLink under the ExLink.
  *
- * @return the Handle of the implicand
+ * @return the HandleSeq of the implicand
  */
-HandleSeq Rule::get_implicand()
+HandleSeq Rule::get_implicand_seq()
 {
 	// if the rule's handle has not been set yet
 	if (rule_handle_ == Handle::UNDEFINED)

--- a/opencog/rule-engine/Rule.cc
+++ b/opencog/rule-engine/Rule.cc
@@ -116,6 +116,22 @@ Handle Rule::get_implicant()
 /**
  * Get the implicand (output) of the rule defined in a BindLink.
  *
+ * @return the Handle of the implicand
+ */
+Handle Rule::get_implicand()
+{
+	// if the rule's handle has not been set yet
+	if (rule_handle_ == Handle::UNDEFINED)
+		return Handle::UNDEFINED;
+
+	HandleSeq outgoing = LinkCast(rule_handle_)->getOutgoingSet();
+
+	return LinkCast(outgoing[1])->getOutgoingSet()[1];
+}
+
+/**
+ * Get the implicand (output) of the rule defined in a BindLink.
+ *
  * This function does extra processing to find the real output over an
  * ExecutionOutputLink.  ie, skip to the ListLink under the ExLink.
  *

--- a/opencog/rule-engine/Rule.h
+++ b/opencog/rule-engine/Rule.h
@@ -65,6 +65,7 @@ public:
 	Handle get_handle();
 	Handle get_vardecl();
 	Handle get_implicant();
+	Handle get_implicand();
 	HandleSeq get_implicand_seq();
 	int get_cost();
 

--- a/opencog/rule-engine/Rule.h
+++ b/opencog/rule-engine/Rule.h
@@ -65,7 +65,7 @@ public:
 	Handle get_handle();
 	Handle get_vardecl();
 	Handle get_implicant();
-	HandleSeq get_implicand();
+	HandleSeq get_implicand_seq();
 	int get_cost();
 
 	Rule gen_standardize_apart(AtomSpace* as);

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.cc
@@ -306,13 +306,10 @@ VarMultimap BackwardChainer::process_target(Handle& htarget)
 		// and we will be matching the variables in there as well
 		vm.insert(implicand_normal_mapping.begin(), implicand_normal_mapping.end());
 
-		HandleSeq outputs_grounded;
-
 		// reverse ground the rule's outputs the mapping to the premise
 		// so that when we ground the premise, we know how to generate
 		// the final output
-		for (const Handle& ho : outputs)
-			outputs_grounded.push_back(inst.instantiate(ho, vm));
+		Handle output_grounded = inst.instantiate(standardized_rule.get_implicand(), vm);
 
 		logger().debug("Checking permises " + hp->toShortString());
 
@@ -350,12 +347,9 @@ VarMultimap BackwardChainer::process_target(Handle& htarget)
 			// This is a premise grounding that can solve the target, so
 			// apply it by using the mapping to ground the target, and add
 			// it to _as since this is not garbage; this should generate
-			// all the outputs of the rule
-			for (const Handle& ho : outputs_grounded)
-			{
-				Instantiator inst(_as);
-				inst.instantiate(ho, m);
-			}
+			// all the outputs of the rule, and execute any evaluatable
+			Instantiator inst(_as);
+			inst.instantiate(output_grounded, m);
 
 			// Add the grounding to the return results
 			for (Handle& h : free_vars)

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.cc
@@ -208,7 +208,7 @@ VarMultimap BackwardChainer::process_target(Handle& htarget)
 
 	Handle himplicant = standardized_rule.get_implicant();
 	Handle hvardecl = standardized_rule.get_vardecl();
-	HandleSeq outputs = standardized_rule.get_implicand();
+	HandleSeq outputs = standardized_rule.get_implicand_seq();
 
 	std::vector<VarMap> all_mappings;
 
@@ -279,7 +279,7 @@ VarMultimap BackwardChainer::process_target(Handle& htarget)
 	// Reverse ground 2nd version, try it with QuoteLink around variables
 	Handle himplicant_quoted = inst.instantiate(himplicant, implicand_quoted_mapping);
 
-	logger().debug("[BackwardChainer] Alternative everse grounded as "
+	logger().debug("[BackwardChainer] Alternative reverse grounded as "
 				   + himplicant_quoted->toShortString());
 
 	HandleSeq possible_premises_alt =
@@ -402,7 +402,7 @@ std::vector<Rule> BackwardChainer::filter_rules(Handle htarget)
 	for (Rule& r : _rules_set)
 	{
 		Handle vardecl = r.get_vardecl();
-		HandleSeq output = r.get_implicand();
+		HandleSeq output = r.get_implicand_seq();
 		bool unifiable = false;
 
 		// check if any of the implicand's output can be unified to target

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.cc
@@ -635,31 +635,31 @@ HandleSeq BackwardChainer::ground_premises(const Handle& hpremise,
  * XXX Should (Link (Node A)) be unifiable to (Node A))?  BC literature never
  * unify this way, but in AtomSpace context, (Link (Node A)) does contain (Node A)
  *
- * @param htarget          the target with variable nodes
- * @param hmatch           a fully grounded matching handle with @param htarget
- * @param htarget_vardecl  the typed VariableList of the variables in htarget
- * @param result           an output VarMap mapping varibles from target to match
+ * @param hsource          the atom from which to unify
+ * @param hmatch           the atom to which hsource will be unified to
+ * @param htarget_vardecl  the typed VariableList of the variables in hsource
+ * @param result           an output VarMap mapping varibles from hsource to hmatch
  * @return                 true if the two atoms can be unified
  */
-bool BackwardChainer::unify(const Handle& htarget,
+bool BackwardChainer::unify(const Handle& hsource,
                             const Handle& hmatch,
-                            Handle htarget_vardecl,
+                            Handle hsource_vardecl,
                             VarMap& result)
 {
-	logger().debug("[BackwardChainer] starting unify " + htarget->toShortString()
+	logger().debug("[BackwardChainer] starting unify " + hsource->toShortString()
 	               + " to " + hmatch->toShortString());
 
 	// lazy way of restricting PM to be between two atoms
 	AtomSpace temp_space;
 
-	Handle temp_htarget = temp_space.addAtom(htarget);
+	Handle temp_hsource = temp_space.addAtom(hsource);
 	Handle temp_hmatch = temp_space.addAtom(hmatch);
 	Handle temp_vardecl;
 
 	FindAtoms fv(VARIABLE_NODE);
-	fv.search_set(htarget);
+	fv.search_set(hsource);
 
-	if (htarget_vardecl == Handle::UNDEFINED)
+	if (hsource_vardecl == Handle::UNDEFINED)
 	{
 		HandleSeq vars;
 		for (const Handle& h : fv.varset)
@@ -668,10 +668,10 @@ bool BackwardChainer::unify(const Handle& htarget,
 		temp_vardecl = temp_space.addAtom(createVariableList(vars));
 	}
 	else
-		temp_vardecl = temp_space.addAtom(gen_sub_varlist(htarget_vardecl,
+		temp_vardecl = temp_space.addAtom(gen_sub_varlist(hsource_vardecl,
 		                                                  fv.varset));
 
-	SatisfactionLinkPtr sl(createSatisfactionLink(temp_vardecl, temp_htarget));
+	SatisfactionLinkPtr sl(createSatisfactionLink(temp_vardecl, temp_hsource));
 	UnifyPMCB pmcb(&temp_space);
 
 	sl->satisfy(pmcb);

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.cc
@@ -218,7 +218,9 @@ VarMultimap BackwardChainer::process_target(Handle& htarget)
 	{
 		VarMap temp_mapping;
 
-		if (not unify(h, htarget, hvardecl, temp_mapping))
+		// try unify in both direction
+		if (not unify(h, htarget, hvardecl, temp_mapping)
+		    && not unify(htarget, h, Handle::UNDEFINED, temp_mapping))
 			continue;
 
 		all_mappings.push_back(temp_mapping);
@@ -410,7 +412,9 @@ std::vector<Rule> BackwardChainer::filter_rules(Handle htarget)
 		{
 			VarMap mapping;
 
-			if (not unify(h, htarget, vardecl, mapping))
+			// try unify in both direction
+			if (not unify(h, htarget, vardecl, mapping)
+			    && not unify(htarget, h, Handle::UNDEFINED, mapping))
 				continue;
 
 			unifiable = true;
@@ -670,7 +674,7 @@ bool BackwardChainer::unify(const Handle& htarget,
 		                                                  fv.varset));
 
 	SatisfactionLinkPtr sl(createSatisfactionLink(temp_vardecl, temp_htarget));
-	UnifyPMCB pmcb(&temp_space);
+	BackwardChainerPMCB pmcb(&temp_space);
 
 	sl->satisfy(pmcb);
 

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.cc
@@ -218,9 +218,7 @@ VarMultimap BackwardChainer::process_target(Handle& htarget)
 	{
 		VarMap temp_mapping;
 
-		// try unify in both direction
-		if (not unify(h, htarget, hvardecl, temp_mapping)
-		    && not unify(htarget, h, Handle::UNDEFINED, temp_mapping))
+		if (not unify(h, htarget, hvardecl, temp_mapping))
 			continue;
 
 		all_mappings.push_back(temp_mapping);
@@ -412,9 +410,7 @@ std::vector<Rule> BackwardChainer::filter_rules(Handle htarget)
 		{
 			VarMap mapping;
 
-			// try unify in both direction
-			if (not unify(h, htarget, vardecl, mapping)
-			    && not unify(htarget, h, Handle::UNDEFINED, mapping))
+			if (not unify(h, htarget, vardecl, mapping))
 				continue;
 
 			unifiable = true;
@@ -632,8 +628,10 @@ HandleSeq BackwardChainer::ground_premises(const Handle& hpremise,
  * specific atom to another, let it handles UnorderedLink, VariableNode in
  * QuoteLink, etc.
  *
- * XXX TODO check if the UnifyPMCB solution is correct
- * XXX TODO unify in both direction? (maybe not)
+ * This will in general unify htarget to hmatch in one direction.  However, it
+ * allows a typed variable A in htarget to map to another variable B in hmatch,
+ * in which case the mapping will be returned reverse (as B->A).
+ *
  * XXX Should (Link (Node A)) be unifiable to (Node A))?  BC literature never
  * unify this way, but in AtomSpace context, (Link (Node A)) does contain (Node A)
  *
@@ -674,7 +672,7 @@ bool BackwardChainer::unify(const Handle& htarget,
 		                                                  fv.varset));
 
 	SatisfactionLinkPtr sl(createSatisfactionLink(temp_vardecl, temp_htarget));
-	BackwardChainerPMCB pmcb(&temp_space);
+	UnifyPMCB pmcb(&temp_space);
 
 	sl->satisfy(pmcb);
 

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.h
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.h
@@ -128,8 +128,8 @@ private:
 	                               bool check_history,
 	                               std::vector<VarMap>& vmap);
 	HandleSeq ground_premises(const Handle& htarget, const VarMap& vmap, std::vector<VarMap>& vmap_list);
-	bool unify(const Handle& htarget, const Handle& hmatch,
-	           Handle htarget_vardecl, VarMap& result);
+	bool unify(const Handle& hsource, const Handle& hmatch,
+	           Handle hsource_vardecl, VarMap& result);
 
 	Handle gen_sub_varlist(const Handle& parent_varlist,
 	                       std::set<Handle> varset);

--- a/opencog/rule-engine/backwardchainer/BackwardChainerPMCB.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainerPMCB.cc
@@ -36,18 +36,6 @@ BackwardChainerPMCB::~BackwardChainerPMCB()
 {
 }
 
-bool BackwardChainerPMCB::node_match(Handle& node1, Handle& node2)
-{
-	return DefaultPatternMatchCB::node_match(node1, node2);
-	//return AttentionalFocusCB::node_match(node1, node2);
-}
-
-bool BackwardChainerPMCB::link_match(LinkPtr& lpat, LinkPtr& lsoln)
-{
-	return DefaultPatternMatchCB::link_match(lpat, lsoln);
-	//return AttentionalFocusCB::link_match(lpat, lsoln);
-}
-
 bool BackwardChainerPMCB::grounding(const std::map<Handle, Handle> &var_soln,
                                const std::map<Handle, Handle> &pred_soln)
 {

--- a/opencog/rule-engine/backwardchainer/BackwardChainerPMCB.h
+++ b/opencog/rule-engine/backwardchainer/BackwardChainerPMCB.h
@@ -34,7 +34,7 @@ class BackwardChainerPMCB :
 	public InitiateSearchCB,
 	public DefaultPatternMatchCB // : public virtual PLNImplicator
 {
-private:
+protected:
 	AtomSpace* as_;
 
 	std::vector<std::map<Handle, Handle>> var_solns_;
@@ -51,8 +51,6 @@ public:
 		DefaultPatternMatchCB::set_pattern(vars, pat);
 	}
 
-	virtual bool node_match(Handle& node1, Handle& node2);
-	virtual bool link_match(LinkPtr& lpat, LinkPtr& lsoln);
 	virtual bool grounding(const std::map<Handle, Handle> &var_soln,
 			const std::map<Handle, Handle> &pred_soln);
 

--- a/opencog/rule-engine/backwardchainer/UnifyPMCB.cc
+++ b/opencog/rule-engine/backwardchainer/UnifyPMCB.cc
@@ -35,7 +35,6 @@ UnifyPMCB::~UnifyPMCB()
 
 }
 
-
 bool UnifyPMCB::variable_match(const Handle& npat_h,
                                const Handle& nsoln_h)
 {
@@ -45,4 +44,31 @@ bool UnifyPMCB::variable_match(const Handle& npat_h,
 	if (soltype == VARIABLE_NODE) return true;
 
 	return BackwardChainerPMCB::variable_match(npat_h, nsoln_h);
+}
+
+bool UnifyPMCB::grounding(const std::map<Handle, Handle> &var_soln,
+                          const std::map<Handle, Handle> &pred_soln)
+{
+	std::map<Handle, Handle> true_var_soln;
+
+	// get rid of non-var mapping
+	for (auto& p : var_soln)
+	{
+		if (p.first->getType() == VARIABLE_NODE)
+		{
+			// check if any typed variable map to a variable, and if so,
+			// store the reverse mapping
+			if (DefaultPatternMatchCB::_type_restrictions->count(p.first) == 1
+			    && DefaultPatternMatchCB::_type_restrictions->at(p.first).count(p.second->getType()) == 0)
+				true_var_soln[p.second] = p.first;
+			else
+				true_var_soln[p.first] = p.second;
+		}
+	}
+
+	// store the variable solution
+	var_solns_.push_back(true_var_soln);
+	pred_solns_.push_back(pred_soln);
+
+	return false;
 }

--- a/opencog/rule-engine/backwardchainer/UnifyPMCB.h
+++ b/opencog/rule-engine/backwardchainer/UnifyPMCB.h
@@ -36,6 +36,9 @@ public:
 	virtual ~UnifyPMCB();
 
 	virtual bool variable_match(const Handle&, const Handle&);
+	virtual bool grounding(const std::map<Handle, Handle> &var_soln,
+			const std::map<Handle, Handle> &pred_soln);
+
 };
 
 }

--- a/tests/rule-engine/BackwardChainerUTest.cxxtest
+++ b/tests/rule-engine/BackwardChainerUTest.cxxtest
@@ -67,8 +67,6 @@ void BackwardChainerUTest::setUp()
 	             "opencog/atomspace/core_types.scm, "
 	             "opencog/scm/utilities.scm, "
 	             "opencog/scm/av-tv.scm"
-//	             "opencog/python/pln_old/examples/backward_chaining/criminal.scm, "
-//	             "tests/rule-engine/bc-example.scm"
 	             );
 	load_scm_files_from_config(*as_);
 }
@@ -226,7 +224,7 @@ void BackwardChainerUTest::test_2rules_bc()
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
 	config().set("SCM_PRELOAD",
-	             "opencog/python/pln_old/examples/backward_chaining/criminal.scm");
+	             "tests/rule-engine/bc-criminal.scm");
 	load_scm_files_from_config(*as_);
 
 	// load modus ponens & deduction rules

--- a/tests/rule-engine/BackwardChainerUTest.cxxtest
+++ b/tests/rule-engine/BackwardChainerUTest.cxxtest
@@ -51,7 +51,8 @@ public:
 	void test_unify();
 	void test_filter_rules();
 
-	void test_basic_bc();
+	void test_1rule_bc();
+	void test_2rules_bc();
 
 	// void test_match_knowledge_base();
 	// void test_simple_deduction_bc();
@@ -64,7 +65,8 @@ void BackwardChainerUTest::setUp()
 {
 	config().set("SCM_PRELOAD",
 	             "opencog/atomspace/core_types.scm, "
-	             "opencog/scm/utilities.scm"
+	             "opencog/scm/utilities.scm, "
+	             "opencog/scm/av-tv.scm"
 //	             "opencog/python/pln_old/examples/backward_chaining/criminal.scm, "
 //	             "tests/rule-engine/bc-example.scm"
 	             );
@@ -183,7 +185,7 @@ void BackwardChainerUTest::test_filter_rules()
 	logger().debug("END TEST: %s", __FUNCTION__);
 }
 
-void BackwardChainerUTest::test_basic_bc()
+void BackwardChainerUTest::test_1rule_bc()
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
@@ -196,7 +198,6 @@ void BackwardChainerUTest::test_basic_bc()
 	cpolicy_loader.load_config();
 
 	std::vector<Rule> rules;
-
 	for (Rule* pr : cpolicy_loader.get_rules())
 		rules.push_back(*pr);
 
@@ -211,6 +212,42 @@ void BackwardChainerUTest::test_basic_bc()
 
 	bc.set_target(target);
 	bc.do_until(10);
+
+	VarMultimap results = bc.get_chaining_result();
+
+	TSM_ASSERT("Incorrect number of solution found!", results[target_var].size() == 1);
+	TSM_ASSERT("Getting incorrect solution!", results[target_var].count(soln) == 1);
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+void BackwardChainerUTest::test_2rules_bc()
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	config().set("SCM_PRELOAD",
+	             "opencog/python/pln_old/examples/backward_chaining/criminal.scm");
+	load_scm_files_from_config(*as_);
+
+	// load modus ponens & deduction rules
+	JsonicControlPolicyParamLoader cpolicy_loader(JsonicControlPolicyParamLoader(as_, "tests/rule-engine/bc_cpolicy_2.json"));
+	cpolicy_loader.load_config();
+
+	std::vector<Rule> rules;
+	for (Rule* pr : cpolicy_loader.get_rules())
+		rules.push_back(*pr);
+
+	BackwardChainer bc(as_, rules);
+
+	Handle target_var = eval_->eval_h("(VariableNode \"$x\")");
+	Handle target =
+	    eval_->eval_h("(InheritanceLink"
+	                  "   (VariableNode \"$x\")"
+					  "   (ConceptNode \"criminal\"))");
+	Handle soln = eval_->eval_h("(ConceptNode \"West\")");
+
+	bc.set_target(target);
+	bc.do_until(100);
 
 	VarMultimap results = bc.get_chaining_result();
 

--- a/tests/rule-engine/bc-criminal.scm
+++ b/tests/rule-engine/bc-criminal.scm
@@ -1,0 +1,94 @@
+; Example taken from "Artifical Intelligence - A Modern Approach"
+
+; "The law says that it is a crime for an American to sell weapons to hostile
+; nations. The country Nono, an enemy of America, has some missiles, and all
+; of its missiles were sold to it by ColonelWest, who is American."
+
+; "... it is a crime for an American to sell weapons to hostile nations":
+; American(x) ∧ Weapon(y) ∧ Sells(x, y, z) ∧ Hostile(z) ⇒ Criminal (x).
+(ImplicationLink (stv .99 .99)
+    (AndLink
+        (InheritanceLink
+            (VariableNode "$x")
+            (ConceptNode "American"))
+        (InheritanceLink
+            (VariableNode "$y")
+            (ConceptNode "weapon"))
+        (EvaluationLink
+            (PredicateNode "sell")
+            (ListLink
+                (VariableNode "$x")
+                (VariableNode "$y")
+                (VariableNode "$z")))
+        (InheritanceLink
+            (VariableNode "$z")
+            (ConceptNode "hostile")))
+    (InheritanceLink
+        (VariableNode "$x")
+        (ConceptNode "criminal")))
+
+; "Nono ... has some missiles."
+; ∃x Owns(Nono, x) ∧ Missile(x) is transformed by Existential Instantiation to
+; Owns(Nono,M1), Missile(M1)
+(AndLink (stv .99 .99)
+    (InheritanceLink (stv .99 .99)
+        (ConceptNode "missile@123")
+        (ConceptNode "missile"))
+    (EvaluationLink (stv .99 .99)
+        (PredicateNode "own")
+        (ListLink
+            (ConceptNode "Nono")
+            (ConceptNode "missile@123"))))
+
+; "All of its missiles were sold to it by Colonel West":
+; Missile(x) ∧ Owns(Nono, x) ⇒ Sells(West, x, Nono) .
+(ImplicationLink (stv .99 .99)
+    (AndLink
+        (InheritanceLink
+            (VariableNode "$a")
+            (ConceptNode "missile"))
+        (EvaluationLink
+            (PredicateNode "own")
+            (ListLink
+                (ConceptNode "Nono")
+                (VariableNode "$a"))))
+    (EvaluationLink
+        (PredicateNode "sell")
+        (ListLink
+            (ConceptNode "West")
+            (VariableNode "$a")
+            (ConceptNode "Nono"))))
+
+; Missiles are weapons: Missile(x) ⇒ Weapon(x)
+(InheritanceLink (stv .99 .99)
+    (ConceptNode "missile")
+    (ConceptNode "weapon"))
+
+; An enemy of America is "hostile": Enemy(x,America) ⇒ Hostile(x) .
+(ImplicationLink (stv .99 .99)
+    (EvaluationLink
+        (PredicateNode "enemy_of")
+        (ListLink
+            (VariableNode "$b")
+            (ConceptNode "America")))
+    (InheritanceLink
+        (VariableNode "$b")
+        (ConceptNode "hostile")))
+
+; "West, who is American ...": American(West).
+(InheritanceLink (stv .99 .99)
+    (ConceptNode "West")
+    (ConceptNode "American"))
+
+; "The country Nono, an enemy of America ...": Enemy(Nono,America).
+(EvaluationLink (stv .99 .99)
+    (PredicateNode "enemy_of")
+    (ListLink
+        (ConceptNode "Nono")
+        (ConceptNode "America")))
+
+; example query: "Who is a criminal?"; query is checked in backward_agent
+;(define isCriminal
+;    (InheritanceLink
+;        (VariableNode "$isCriminal")
+;        (ConceptNode "criminal")))

--- a/tests/rule-engine/bc-deduction.scm
+++ b/tests/rule-engine/bc-deduction.scm
@@ -66,6 +66,7 @@
          (sBC (cog-stv-strength BC))
          (cBC (cog-stv-confidence BC)))
       (if (and (>= sAB 0.5) (>= cAB 0.5) (>= sBC 0.5) (>= cBC 0.5))
-          (cog-set-tv! AC (stv 1 1)))))
+          (cog-set-tv! AC (stv 1 1)))
+    )
 )
 

--- a/tests/rule-engine/bc-deduction.scm
+++ b/tests/rule-engine/bc-deduction.scm
@@ -1,0 +1,71 @@
+; =============================================================================
+; Deduction Rule
+; TODO The rule must be applicable to ImplicationLink, SubsetLink and PartOfLink
+;
+; AND(Inheritance A B, Inheritance B C) entails Inheritance A C
+; -----------------------------------------------------------------------------
+(define pln-rule-deduction
+    (BindLink
+        (VariableList
+                (TypedVariableLink
+                   (VariableNode "$A")
+                   (TypeNode "ConceptNode"))
+                (TypedVariableLink
+                   (VariableNode "$B")
+                   (TypeNode "ConceptNode"))
+                (TypedVariableLink
+                   (VariableNode "$C")
+                   (TypeNode "ConceptNode")))
+        (ImplicationLink
+            (AndLink
+                (InheritanceLink
+                    (VariableNode "$A")
+                    (VariableNode "$B")
+                )
+                (InheritanceLink
+                    (VariableNode "$B")
+                    (VariableNode "$C")
+                )
+                ; To avoid matching (Inheritance A B) and (Inheritance B A)
+                (NotLink
+                    (EqualLink
+                        (VariableNode "$A")
+                        (VariableNode "$C")
+                    )
+                )
+            )
+            (ExecutionOutputLink
+                (GroundedSchemaNode "scm: pln-formula-simple-deduction")
+                (ListLink
+                    (InheritanceLink
+                        (VariableNode "$A")
+                        (VariableNode "$B"))
+                    (InheritanceLink
+                        (VariableNode "$B")
+                        (VariableNode "$C")
+                    )
+                    (InheritanceLink
+                        (VariableNode "$A")
+                        (VariableNode "$C")
+                    )
+                )
+            )
+        )
+    )
+)
+
+
+; -----------------------------------------------------------------------------
+; Deduction Formula
+; -----------------------------------------------------------------------------
+
+(define (pln-formula-simple-deduction AB BC AC)
+    (let
+        ((sAB (cog-stv-strength AB))
+         (cAB (cog-stv-confidence AB))
+         (sBC (cog-stv-strength BC))
+         (cBC (cog-stv-confidence BC)))
+      (if (and (>= sAB 0.5) (>= cAB 0.5) (>= sBC 0.5) (>= cBC 0.5))
+          (cog-set-tv! AC (stv 1 1)))))
+)
+

--- a/tests/rule-engine/bc_cpolicy_2.json
+++ b/tests/rule-engine/bc_cpolicy_2.json
@@ -12,7 +12,7 @@
 
 			"category": "PLN"
 		},
-		
+
 		{
 			"name": "pln-rule-deduction",
 			"file_path": "tests/rule-engine/bc-deduction.scm",

--- a/tests/rule-engine/bc_cpolicy_2.json
+++ b/tests/rule-engine/bc_cpolicy_2.json
@@ -2,27 +2,27 @@
 	"rules": 
 	[
 		{
-			"name": "crisp-deduction",
-			"file_path": "rules/crisp-deduction.scm",
+			"name": "pln-rule-modus-ponens",
+			"file_path": "tests/rule-engine/bc-modus-ponens.scm",
 			"priority": 1,
 			"mutex": 
 			[
 				
 			],
 
-			"category": "crisp-deduction-modus-ponens-example"
+			"category": "PLN"
 		},
-
+		
 		{
-			"name": "crisp-modus-ponens",
-			"file_path": "rules/crisp-modus-ponens.scm",
+			"name": "pln-rule-deduction",
+			"file_path": "tests/rule-engine/bc-deduction.scm",
 			"priority": 1,
 			"mutex": 
 			[
 				
 			],
 
-			"category": "crisp-deduction-modus-ponens-example"
+			"category": "PLN"
 		}
 	],
 


### PR DESCRIPTION
- Better handling of unification for typed rules
- Rule outputs with executable will be properly executed
- Added criminal example to unit test, using a typed deduction rule and a normal modus ponens rule

The criminal example will fail until https://github.com/opencog/atomspace/issues/46 is fixed.  I fixed it on my local copy by over-riding the clause_match callback, but I don't think that's a long term solution.
