### PR TITLE
fix for get_tv function bug in python binding

### DIFF
--- a/opencog/cython/opencog/atomspace_details.pyx
+++ b/opencog/cython/opencog/atomspace_details.pyx
@@ -192,7 +192,7 @@ cdef class AtomSpace:
             pytv = TruthValue()
             pytv.cobj = new tv_ptr(tv) # make copy of smart pointer
             return pytv
-        return TruthValue(tv.get().getMean(),tv.get().getCount())
+        return TruthValue(tv.get().getMean(), tv.get().getConfidence())
 
     def set_tv(self, Handle h, TruthValue tv):
         """ Set the TruthValue of an Atom in the AtomSpace """


### PR DESCRIPTION
When I create any kind of atom in python and request the truth value explicitly to them, It always returns wrong confidence value.

Execute log:
```python
$ l1 = MemberLink(a1, a2, TruthValue(0.8, 0.7))

$ print l1 #Correct value
(MemberLink (stv 0.800000 0.700000)
  (ConceptNode "123") ; [3]
  (ConceptNode "456") ; [6]
) ; [7]

$ print l1.tv #Wrong value
(stv 0.800000 1.000000)
```

C++ class 'SimpleTruthValue' constructor needs parameter (strength_t, count_t), but Python class 'TruthValue' constructor needs parameter (self, strength, confidence). Due to this bug, C++ class always return 1.0 because result of converting confidence value is bigger than 1.0.

Execute log after fix:
```python
$ l1 = MemberLink(a1, a2, TruthValue(0.8, 0.7))

$ print l1 #Correct value
(MemberLink (stv 0.800000 0.700000)
  (ConceptNode "123") ; [3]
  (ConceptNode "456") ; [6]
) ; [7]

$ print l1.tv #Correct value
(stv 0.800000 0.700000)
```