### PR TITLE
Fix include from BindLink.h to BindLinkAPI.h

### DIFF
--- a/opencog/rule-engine/UREConfigReader.cc
+++ b/opencog/rule-engine/UREConfigReader.cc
@@ -26,7 +26,7 @@
 #include <opencog/atoms/bind/BindLink.h>
 #include <opencog/atoms/bind/DefineLink.h>
 #include <opencog/atoms/NumberNode.h>
-#include <opencog/query/BindLink.h>
+#include <opencog/query/BindLinkAPI.h>
 
 using namespace opencog;
 


### PR DESCRIPTION
Fixing this error: http://i.gyazo.com/c65c3fd6d34a874037d59bffab4d8e80.png

     fatal error: opencog/query/BindLink.h: No such file or directory