### PR TITLE
Cython: add __init__.py to load atomspace.pxd from external

### DIFF
--- a/opencog/cython/opencog/CMakeLists.txt
+++ b/opencog/cython/opencog/CMakeLists.txt
@@ -93,8 +93,9 @@ SET_TARGET_PROPERTIES(atomspace_cython PROPERTIES
 # The cogserver needs the atomspace pxd file to get the Handle, Atom and
 # AtomSpace defintions.
 INSTALL (FILES
+	__init__.py
 	atomspace.pxd
-   DESTINATION "include/${PROJECT_NAME}/cython/opencog"
+	DESTINATION "include/${PROJECT_NAME}/cython/opencog"
 )
 
 ############################## type constructors #####################


### PR DESCRIPTION
This commit attempt to fix issue https://github.com/opencog/opencog/issues/1614, some part of https://github.com/opencog/opencog/issues/1625, and the problem encountered to YiShan(https://groups.google.com/forum/#!topic/opencog/IxQQJajw2gc).

This fix makes `__init__.py` in ${ATOMSPACE_INCLUDE_DIR}/opencog/cython/opencog/atomspace.pxd during build project.

It would be needed by external project. (e.g. agent_finder module, cogserver module, etc.)