### PR TITLE
Change satisfying_set to return singleton instead of element if one m…

### DIFF
--- a/opencog/query/Satisfier.cc
+++ b/opencog/query/Satisfier.cc
@@ -99,11 +99,6 @@ Handle opencog::satisfying_set(AtomSpace* as, const Handle& hlink)
 	SatisfyingSet sater(as);
 	bl->satisfy(sater);
 
-	// If there is only one item in the satisfying set, return
-	// that one item. Otherwise, wrap multiple items in a SetLink.
-	if (1 == sater._satisfying_set.size())
-		return sater._satisfying_set[0];
-
 	return as->addLink(SET_LINK, sater._satisfying_set);
 }
 

--- a/tests/query/GetLinkUTest.cxxtest
+++ b/tests/query/GetLinkUTest.cxxtest
@@ -135,9 +135,6 @@ void GetLinkUTest::test_free_bound(void)
 
 	Handle hgnd = eval->eval_h("(cog-satisfying-set is-query)");
 
-	// XXX for better or for worse, satisfying-set skips using the
-	// Setlink if the Setlink only has one element in it.
-	// Handle hans = eval->eval_h("(SetLink (ConceptNode \"human\"))");
 	Handle hans = eval->eval_h("(SetLink (ConceptNode \"human\"))");
 
 	printf("Expected this: %s\n", hans->toString().c_str());

--- a/tests/query/GetLinkUTest.cxxtest
+++ b/tests/query/GetLinkUTest.cxxtest
@@ -138,7 +138,7 @@ void GetLinkUTest::test_free_bound(void)
 	// XXX for better or for worse, satisfying-set skips using the
 	// Setlink if the Setlink only has one element in it.
 	// Handle hans = eval->eval_h("(SetLink (ConceptNode \"human\"))");
-	Handle hans = eval->eval_h("(ConceptNode \"human\")");
+	Handle hans = eval->eval_h("(SetLink (ConceptNode \"human\"))");
 
 	printf("Expected this: %s\n", hans->toString().c_str());
 	printf("Found this answer: %s\n", hgnd->toString().c_str());


### PR DESCRIPTION
…atch

I think it complicates the user's life to silently replace the
singleton by its element when there is only one match. It is also
inconsistent with bindlink behavior.