### PR TITLE
Add missing install for cogserver

### DIFF
--- a/opencog/rule-engine/CMakeLists.txt
+++ b/opencog/rule-engine/CMakeLists.txt
@@ -37,6 +37,7 @@ INSTALL (FILES
 	JsonicControlPolicyParamLoader.h
 	URECommons.h
 	Rule.h
+	UREConfigReader.h
 	DESTINATION "include/${PROJECT_NAME}/rule-engine"
 )
 


### PR DESCRIPTION
Fix one compile error.

Though now it is complaining about the PLNModule, since the ForwardChainer usage is different from the new one.