### PR TITLE
AtomTable: allow _environ's typeIndex to go thru

### DIFF
--- a/opencog/atomspace/AtomSpace.cc
+++ b/opencog/atomspace/AtomSpace.cc
@@ -356,7 +356,7 @@ void AtomSpace::clear()
 {
     std::vector<Handle> allAtoms;
 
-    atomTable.getHandlesByType(back_inserter(allAtoms), ATOM, true);
+    atomTable.getHandlesByType(back_inserter(allAtoms), ATOM, true, false);
 
     DPRINTF("atoms in allAtoms: %lu\n", allAtoms.size());
 
@@ -371,7 +371,7 @@ void AtomSpace::clear()
     }
 
     allAtoms.clear();
-    atomTable.getHandlesByType(back_inserter(allAtoms), ATOM, true);
+    atomTable.getHandlesByType(back_inserter(allAtoms), ATOM, true, false);
     assert(allAtoms.size() == 0);
 
     logger().setLevel(save);

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -99,6 +99,10 @@ AtomTable::~AtomTable()
 
 bool AtomTable::isCleared(void) const
 {
+    // XXX Currently only check if stuff in derived space is gone. No
+    // checking is done on the parent. This is inline with how clear()
+    // is expected to work.
+
     if (size != 0) {
         DPRINTF("AtomTable::size is not 0\n");
         return false;
@@ -626,7 +630,12 @@ size_t AtomTable::getNumLinks() const
 size_t AtomTable::getNumAtomsOfType(Type type, bool subclass) const
 {
     std::lock_guard<std::recursive_mutex> lck(_mtx);
-    return typeIndex.getNumAtomsOfType(type, subclass);
+    size_t result = typeIndex.getNumAtomsOfType(type, subclass);
+
+    if (_environ)
+        result += _environ->getNumAtomsOfType(type, subclass);
+
+    return result;
 }
 
 Handle AtomTable::getRandom(RandGen *rng) const

--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -200,10 +200,13 @@ public:
      */
     template <typename OutputIterator> OutputIterator
     getHandlesByType(OutputIterator result,
-                       Type type,
-                       bool subclass = false) const
+                     Type type,
+                     bool subclass = false,
+                     bool parent = true) const
     {
         std::lock_guard<std::recursive_mutex> lck(_mtx);
+        if (parent && _environ)
+            _environ->getHandlesByType(result, type, subclass, parent);
         return std::copy(typeIndex.begin(type, subclass),
                          typeIndex.end(),
                          result);
@@ -213,9 +216,12 @@ public:
     template <typename Function> void
     foreachHandleByType(Function func,
                         Type type,
-                        bool subclass = false) const
+                        bool subclass = false,
+                        bool parent = true) const
     {
         std::lock_guard<std::recursive_mutex> lck(_mtx);
+        if (parent && _environ)
+            _environ->foreachHandleByType(func, type, subclass);
         std::for_each(typeIndex.begin(type, subclass),
                       typeIndex.end(),
              [&](Handle h)->void {

--- a/tests/atomspace/MultiSpaceUTest.cxxtest
+++ b/tests/atomspace/MultiSpaceUTest.cxxtest
@@ -528,5 +528,31 @@ public:
 		as1.getHandlesByType(back_inserter(handle_set), ATOM, false);
 		// cogserver crashes at this point; no crash == pass
 	}
+
+	// This tests bug report #97
+	void testGetType()
+	{
+		AtomSpace as;
+		AtomSpace ex(&as);
+
+		// Add nodes of same typ.
+		as.addNode(CONCEPT_NODE, "aaa");
+		ex.addNode(CONCEPT_NODE, "bbb");
+
+		HandleSeq handle_set;
+		ex.getHandlesByType(handle_set, CONCEPT_NODE);
+
+		TS_ASSERT(handle_set.size() == 2);
+
+		ex.clear();
+
+		TS_ASSERT(as.getSize() == 1);
+		TS_ASSERT(ex.getSize() == 0);
+
+		handle_set.clear();
+		ex.getHandlesByType(handle_set, CONCEPT_NODE);
+
+		TS_ASSERT(handle_set.size() == 1);
+	}
 };
 


### PR DESCRIPTION
For https://github.com/opencog/atomspace/issues/97

I did the same thing with nodeIndex, linkIndex, and importanceIndex (specifically getNumNodes, getNumLinks, etc) at https://github.com/williampma/atomspace/tree/ATIndex .  However, apparently the assumption in the scheme version of MultiAtomSpaceUTest (https://github.com/opencog/atomspace/blob/master/tests/scm/MultiAtomSpaceUTest.cxxtest) is different (ie, only the nodes/links in the derived space are counted).  So I ended up not touching them.

It's hard to tell which assumption is correct.