### PR TITLE
Improve Haskell Api.

### DIFF
--- a/examples/haskell/README.md
+++ b/examples/haskell/README.md
@@ -1,0 +1,21 @@
+Haskell Examples:
+================
+
+To run these examples you have to previously
+[build](https://github.com/opencog/atomspace#building-atomspace) and
+[install](https://github.com/opencog/atomspace#install) the AtomSpace.
+
+Then you can just compile them with:
+```
+ghc example.hs
+```
+
+If when running an example you get an error: "...cannont open shared object
+file: No such file or directory ...":
+  - Remember to add: "/usr/local/lib/opencog" to your */etc/ld.so.conf* file.
+  - Check if the file: */usr/local/lib/opencog/libhaskell-atomspace.so* exists.
+  - To update loader's cache, run:
+    ```
+       ldconfig /usr/local/lib/opencog/
+    ```
+

--- a/examples/haskell/example.hs
+++ b/examples/haskell/example.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE GADTs #-}
 
 import OpenCog.AtomSpace        (AtomSpace,insert,get,remove,
-                                 debug,runOnNewAtomSpace,
+                                 debug,runOnNewAtomSpace,showAtom,
                                  Atom(..),TruthVal(..),AtomGen(..))
 import Control.Monad.IO.Class   (liftIO)
 
@@ -9,30 +9,34 @@ main :: IO ()
 main = runOnNewAtomSpace program
 
 program :: AtomSpace ()
-program = let andLink = AndLink (ConceptNode "John" Nothing)
-                                (ConceptNode "Carlos" Nothing)
-                                (Just $ SimpleTV 0.5 0.5)
+program = let a = AndLink (ConceptNode "John" Nothing)
+                          (ConceptNode "Carlos" Nothing)
+                          (Just $ SimpleTV 0.5 0.5)
            in do
         liftIO $ putStrLn "Let's insert some new nodes:"
+        liftIO $ showAtom $ ConceptNode "Tall" Nothing
         insert $ ConceptNode "Tall" Nothing
-        insert andLink
+        insert a
+        liftIO $ showAtom a
         liftIO $ putStrLn "-----------After Insert:----------------"
         debug
         liftIO $ putStrLn "----------------------------------------"
-        n <- get andLink
+        n <- get a
         case n of
-          Just (AndLink _ _ _) -> liftIO $ putStrLn $ (show n) ++ " found."
-          Nothing              -> liftIO $ putStrLn "No AndLink found."
-        remove andLink
+          Just at -> liftIO $ putStrLn "AndLink found:" >> showAtom at
+          Nothing -> liftIO $ putStrLn "No AndLink found."
+        remove a
         liftIO $ putStrLn "-----------After Remove:----------------"
         debug
         liftIO $ putStrLn "----------------------------------------"
-        n <- get andLink
+        n <- get a
         case n of
-          Just (AndLink _ _ _) -> liftIO $ putStrLn $ (show n) ++ " found."
+          Just (AndLink _ _ _) -> liftIO $ putStrLn "AndLink found:"
           Nothing              -> liftIO $ putStrLn "No AndLink found."
-        insert $ ListLink [ AtomGen $ NumberNode 4
-                          , AtomGen $ ConceptNode "hello" Nothing
-                          , AtomGen $ NumberNode 4]
-
+        let list = ListLink [ AtomGen $ NumberNode 4
+                            , AtomGen $ ConceptNode "hello" Nothing
+                            , AtomGen $ NumberNode 4]
+        insert list
+        liftIO $ putStrLn "Inserted:"
+        liftIO $ showAtom list
 

--- a/examples/haskell/example.hs
+++ b/examples/haskell/example.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE GADTs #-}
 
 import OpenCog.AtomSpace        (AtomSpace,insert,get,remove,
-                                 debug,runOnNewAtomSpace,showAtom,
+                                 debug,runOnNewAtomSpace,printAtom,
                                  Atom(..),TruthVal(..),AtomGen(..))
 import Control.Monad.IO.Class   (liftIO)
 
@@ -14,16 +14,16 @@ program = let a = AndLink (ConceptNode "John" Nothing)
                           (Just $ SimpleTV 0.5 0.5)
            in do
         liftIO $ putStrLn "Let's insert some new nodes:"
-        liftIO $ showAtom $ ConceptNode "Tall" Nothing
+        liftIO $ printAtom $ ConceptNode "Tall" Nothing
         insert $ ConceptNode "Tall" Nothing
         insert a
-        liftIO $ showAtom a
+        liftIO $ printAtom a
         liftIO $ putStrLn "-----------After Insert:----------------"
         debug
         liftIO $ putStrLn "----------------------------------------"
         n <- get a
         case n of
-          Just at -> liftIO $ putStrLn "AndLink found:" >> showAtom at
+          Just at -> liftIO $ putStrLn "AndLink found:" >> printAtom at
           Nothing -> liftIO $ putStrLn "No AndLink found."
         remove a
         liftIO $ putStrLn "-----------After Remove:----------------"
@@ -38,5 +38,5 @@ program = let a = AndLink (ConceptNode "John" Nothing)
                             , AtomGen $ NumberNode 4]
         insert list
         liftIO $ putStrLn "Inserted:"
-        liftIO $ showAtom list
+        liftIO $ printAtom list
 

--- a/examples/haskell/example.hs
+++ b/examples/haskell/example.hs
@@ -11,7 +11,7 @@ main = runOnNewAtomSpace program
 program :: AtomSpace ()
 program = let andLink = And (Concept "John")
                             (Concept "Carlos")
-                            (Just $ SimpleTruthVal 0.5 0.5)
+                            (Just $ SimpleTV 0.5 0.5)
            in do
         liftIO $ putStrLn "Let's insert some new nodes:"
         insert $ Concept "Tall"
@@ -21,7 +21,7 @@ program = let andLink = And (Concept "John")
         liftIO $ putStrLn "----------------------------------------"
         n <- get andLink
         case n of
-          Just (And _ _ _) -> liftIO $ putStrLn "AndLink found."
+          Just (And _ _ _) -> liftIO $ putStrLn $ (show n) ++ " found."
           Nothing          -> liftIO $ putStrLn "No AndLink found."
         remove andLink
         liftIO $ putStrLn "-----------After Remove:----------------"
@@ -29,7 +29,7 @@ program = let andLink = And (Concept "John")
         liftIO $ putStrLn "----------------------------------------"
         n <- get andLink
         case n of
-          Just (And _ _ _) -> liftIO $ putStrLn "AndLink found."
+          Just (And _ _ _) -> liftIO $ putStrLn $ (show n) ++ " found."
           Nothing          -> liftIO $ putStrLn "No AndLink found."
         insert $ List [ AtomGen $ Number 4
                       , AtomGen $ Concept "hello"

--- a/examples/haskell/example.hs
+++ b/examples/haskell/example.hs
@@ -9,9 +9,9 @@ main :: IO ()
 main = runOnNewAtomSpace program
 
 program :: AtomSpace ()
-program = let andLink = And (Concept "John")
-                            (Concept "Carlos")
-                            (Just $ SimpleTV 0.5 0.5)
+program = let andLink = AndLink (ConceptNode "John")
+                                (ConceptNode "Carlos")
+                                (Just $ SimpleTV 0.5 0.5)
            in do
         liftIO $ putStrLn "Let's insert some new nodes:"
         insert $ Concept "Tall"
@@ -21,18 +21,18 @@ program = let andLink = And (Concept "John")
         liftIO $ putStrLn "----------------------------------------"
         n <- get andLink
         case n of
-          Just (And _ _ _) -> liftIO $ putStrLn $ (show n) ++ " found."
-          Nothing          -> liftIO $ putStrLn "No AndLink found."
+          Just (AndLink _ _ _) -> liftIO $ putStrLn $ (show n) ++ " found."
+          Nothing              -> liftIO $ putStrLn "No AndLink found."
         remove andLink
         liftIO $ putStrLn "-----------After Remove:----------------"
         debug
         liftIO $ putStrLn "----------------------------------------"
         n <- get andLink
         case n of
-          Just (And _ _ _) -> liftIO $ putStrLn $ (show n) ++ " found."
-          Nothing          -> liftIO $ putStrLn "No AndLink found."
-        insert $ List [ AtomGen $ Number 4
-                      , AtomGen $ Concept "hello"
-                      , AtomGen $ Number 4]
+          Just (AndLink _ _ _) -> liftIO $ putStrLn $ (show n) ++ " found."
+          Nothing              -> liftIO $ putStrLn "No AndLink found."
+        insert $ ListLink [ AtomGen $ NumberNode 4
+                          , AtomGen $ ConceptNode "hello"
+                          , AtomGen $ NumberNode 4]
 
 

--- a/examples/haskell/example.hs
+++ b/examples/haskell/example.hs
@@ -9,12 +9,12 @@ main :: IO ()
 main = runOnNewAtomSpace program
 
 program :: AtomSpace ()
-program = let andLink = AndLink (ConceptNode "John")
-                                (ConceptNode "Carlos")
+program = let andLink = AndLink (ConceptNode "John" Nothing)
+                                (ConceptNode "Carlos" Nothing)
                                 (Just $ SimpleTV 0.5 0.5)
            in do
         liftIO $ putStrLn "Let's insert some new nodes:"
-        insert $ Concept "Tall"
+        insert $ ConceptNode "Tall" Nothing
         insert andLink
         liftIO $ putStrLn "-----------After Insert:----------------"
         debug
@@ -32,7 +32,7 @@ program = let andLink = AndLink (ConceptNode "John")
           Just (AndLink _ _ _) -> liftIO $ putStrLn $ (show n) ++ " found."
           Nothing              -> liftIO $ putStrLn "No AndLink found."
         insert $ ListLink [ AtomGen $ NumberNode 4
-                          , AtomGen $ ConceptNode "hello"
+                          , AtomGen $ ConceptNode "hello" Nothing
                           , AtomGen $ NumberNode 4]
 
 

--- a/examples/haskell/example.hs
+++ b/examples/haskell/example.hs
@@ -2,7 +2,7 @@
 
 import OpenCog.AtomSpace.Api   (AtomSpace,insert,get,remove,
                                 debug,runOnNewAtomSpace)
-import OpenCog.AtomSpace.Types (Atom(..),TruthVal(..))
+import OpenCog.AtomSpace.Types (Atom(..),TruthVal(..),AtomGen(..))
 import Control.Monad.IO.Class  (liftIO)
 
 main :: IO ()
@@ -21,14 +21,18 @@ program = let andLink = And (Concept "John")
         liftIO $ putStrLn "----------------------------------------"
         n <- get andLink
         case n of
-          Just (And _ _ _) -> liftIO $ print "AndLink found."
-          Nothing          -> liftIO $ print "No AndLink found."
+          Just (And _ _ _) -> liftIO $ putStrLn "AndLink found."
+          Nothing          -> liftIO $ putStrLn "No AndLink found."
         remove andLink
         liftIO $ putStrLn "-----------After Remove:----------------"
         debug
         liftIO $ putStrLn "----------------------------------------"
         n <- get andLink
         case n of
-          Just (And _ _ tv) -> liftIO $ print "AndLink found."
-          Nothing           -> liftIO $ print "No AndLink found."
+          Just (And _ _ _) -> liftIO $ putStrLn "AndLink found."
+          Nothing          -> liftIO $ putStrLn "No AndLink found."
+        insert $ List [ AtomGen $ Number 4
+                      , AtomGen $ Concept "hello"
+                      , AtomGen $ Number 4]
+
 

--- a/examples/haskell/example.hs
+++ b/examples/haskell/example.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE GADTs #-}
 
-import OpenCog.AtomSpace.Api   (AtomSpace,insert,get,remove,
-                                debug,runOnNewAtomSpace)
-import OpenCog.AtomSpace.Types (Atom(..),TruthVal(..),AtomGen(..))
-import Control.Monad.IO.Class  (liftIO)
+import OpenCog.AtomSpace        (AtomSpace,insert,get,remove,
+                                 debug,runOnNewAtomSpace,
+                                 Atom(..),TruthVal(..),AtomGen(..))
+import Control.Monad.IO.Class   (liftIO)
 
 main :: IO ()
 main = runOnNewAtomSpace program

--- a/examples/haskell/example.hs
+++ b/examples/haskell/example.hs
@@ -1,19 +1,34 @@
+{-# LANGUAGE GADTs #-}
 
-import OpenCog.AtomSpace.Api    (AtomSpace,asAddNode,runOnNewAtomSpace)
-import OpenCog.AtomSpace.Types  (Node(..),NodeType(..))
-import Control.Monad.IO.Class   (liftIO)
-import Data.Default             (Default(..))
+import OpenCog.AtomSpace.Api   (AtomSpace,insert,get,remove,
+                                debug,runOnNewAtomSpace)
+import OpenCog.AtomSpace.Types (Atom(..),TruthVal(..))
+import Control.Monad.IO.Class  (liftIO)
 
 main :: IO ()
 main = runOnNewAtomSpace program
 
 program :: AtomSpace ()
-program = do
-              liftIO $ putStrLn "Let's add some new nodes:"
-              h1 <- asAddNode def{ nodeName = "NewNode"
-                                 , nodeType = ConceptNode }
-              h2 <- asAddNode def{ nodeName = "AnotherNewNode"
-                                 , nodeType = ConceptNode}
-              liftIO $ putStrLn $ "Added with handles "
-                                  ++ show(h1) ++ " and " ++ show(h2)
+program = let andLink = And (Concept "John")
+                            (Concept "Carlos")
+                            (Just $ SimpleTruthVal 0.5 0.5)
+           in do
+        liftIO $ putStrLn "Let's insert some new nodes:"
+        insert $ Concept "Tall"
+        insert andLink
+        liftIO $ putStrLn "-----------After Insert:----------------"
+        debug
+        liftIO $ putStrLn "----------------------------------------"
+        n <- get andLink
+        case n of
+          Just (And _ _ _) -> liftIO $ print "AndLink found."
+          Nothing          -> liftIO $ print "No AndLink found."
+        remove andLink
+        liftIO $ putStrLn "-----------After Remove:----------------"
+        debug
+        liftIO $ putStrLn "----------------------------------------"
+        n <- get andLink
+        case n of
+          Just (And _ _ tv) -> liftIO $ print "AndLink found."
+          Nothing           -> liftIO $ print "No AndLink found."
 

--- a/examples/haskell/example_data_types.hs
+++ b/examples/haskell/example_data_types.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE GADTs #-}
+
+import OpenCog.AtomSpace            (TruthVal(..),Atom(..),AtomGen(..),
+                                     runOnNewAtomSpace,get,insert,remove,
+                                     printAtom)
+import Control.Monad.IO.Class       (liftIO)
+
+someTv :: Maybe TruthVal
+someTv = Just $ SimpleTV 0.4 0.5
+
+n = ConceptNode "Animal" someTv
+l = ListLink [AtomGen n]
+
+e = EvaluationLink
+   (PredicateNode "isFriend")
+   (ListLink [ AtomGen $ ConceptNode "Alan" Nothing
+             , AtomGen $ ConceptNode "Robert" Nothing
+             ])
+   someTv
+
+li = (ListLink [ AtomGen $ ConceptNode "SomeConcept" someTv
+               , AtomGen $ PredicateNode "SomePredicate"
+               ])
+
+main :: IO ()
+main = runOnNewAtomSpace $ do
+         p <- get $ PredicateNode "Pred"
+         case p of
+            Just (PredicateNode _) -> liftIO $ print "Predicate found."
+            _                      -> liftIO $ print "No Predicate found."
+         liftIO $ printAtom li
+         () <- case li of
+           ListLink (x:_) -> case x of
+               AtomGen (ConceptNode c _)  -> liftIO $ print "First is Concept"
+               AtomGen (PredicateNode p ) -> liftIO $ print "First is Predicate"
+               _                          -> liftIO $ print "First is other type"
+         insert e
+         get e
+         remove e
+         return ()
+

--- a/lib/FindCabal.cmake
+++ b/lib/FindCabal.cmake
@@ -3,7 +3,7 @@ FIND_PROGRAM(CABAL_EXECUTABLE cabal)
 
 IF (CABAL_EXECUTABLE)
     EXECUTE_PROCESS(
-        COMMAND cabal list
+        COMMAND cabal list nothing
         OUTPUT_QUIET
         ERROR_VARIABLE out
     )

--- a/opencog/haskell/AtomSpace_CWrapper.cpp
+++ b/opencog/haskell/AtomSpace_CWrapper.cpp
@@ -1,6 +1,12 @@
 
 #include "AtomSpace_CWrapper.h"
 #include <opencog/atomspace/ClassServer.h>
+#include <opencog/atomspace/TruthValue.h>
+#include <opencog/atomspace/SimpleTruthValue.h>
+#include <opencog/atomspace/CountTruthValue.h>
+#include <opencog/atomspace/IndefiniteTruthValue.h>
+#include <opencog/atomspace/FuzzyTruthValue.h>
+#include <opencog/atomspace/ProbabilisticTruthValue.h>
 
 AtomSpace* AtomSpace_new()
 {
@@ -69,3 +75,43 @@ void AtomSpace_debug( AtomSpace* this_ptr )
     std::cerr<<(*this_ptr);
 }
 
+int AtomSpace_getTruthValue( AtomSpace* this_ptr
+                           , long handle
+                           , double *parameters )
+{
+    Handle h(handle);
+    TruthValuePtr tv = h->getTruthValue();
+    switch(tv->getType())
+    {
+        case SIMPLE_TRUTH_VALUE: {
+            parameters[0]=tv->getMean();
+            parameters[1]=tv->getConfidence();
+            break; }
+        case COUNT_TRUTH_VALUE: {
+            parameters[0]=tv->getMean();
+            parameters[1]=tv->getCount();
+            parameters[2]=tv->getConfidence();
+            break; }
+        case INDEFINITE_TRUTH_VALUE: {
+            IndefiniteTruthValuePtr itv =
+                std::dynamic_pointer_cast<IndefiniteTruthValue>(tv);
+            parameters[0]=itv->getMean();
+            parameters[1]=itv->getL();
+            parameters[2]=itv->getU();
+            parameters[3]=itv->getConfidenceLevel();
+            parameters[4]=itv->getDiff();
+            break; }
+        case FUZZY_TRUTH_VALUE: {
+            parameters[0]=tv->getMean();
+            parameters[1]=tv->getConfidence();
+            break; }
+        case PROBABILISTIC_TRUTH_VALUE: {
+            parameters[0]=tv->getMean();
+            parameters[1]=tv->getCount();
+            parameters[2]=tv->getConfidence();
+            break; }
+        default:
+            break;
+    }
+    return tv->getType();
+}

--- a/opencog/haskell/AtomSpace_CWrapper.cpp
+++ b/opencog/haskell/AtomSpace_CWrapper.cpp
@@ -1,43 +1,71 @@
 
 #include "AtomSpace_CWrapper.h"
+#include <opencog/atomspace/ClassServer.h>
 
 AtomSpace* AtomSpace_new()
 {
     return new AtomSpace();
 }
 
-void AtomSpace_delete(AtomSpace* this_ptr)
+void AtomSpace_delete( AtomSpace* this_ptr )
 {
     delete this_ptr;
 }
 
-long AtomSpace_addNode(AtomSpace* this_ptr, Type t, const char* name)
+long AtomSpace_addNode( AtomSpace* this_ptr
+                      , const char* type
+                      , const char* name )
 {
+    Type t = classserver().getType(std::string(type));
     return this_ptr->addNode(t,std::string(name)).value();
 }
 
-/*
-int AtomSpace_getSize(AtomSpace* this_ptr)
+long AtomSpace_addLink( AtomSpace* this_ptr
+                      , const char* type
+                      , const long* outgoing
+                      , int size )
 {
-    this_ptr->getSize();
+    Type t = classserver().getType(std::string(type));
+    HandleSeq oset;
+    for(int i=0;i<size;i++)
+        oset.push_back(Handle(outgoing[i]));
+    return this_ptr->addLink(t,oset).value();
 }
 
-int AtomSpace_getNumNodes(AtomSpace* this_ptr)
+long AtomSpace_getNode( AtomSpace* this_ptr
+                      , const char* type
+                      , const char* name
+                      , int* found )
 {
-    this_ptr->getNumNodes();
+    Type t = classserver().getType(std::string(type));
+    Handle h = this_ptr->getNode(t,std::string(name));
+    *found = h != Handle::UNDEFINED;
+    return h.value();
 }
 
-int AtomSpace_getNumLinks(AtomSpace* this_ptr)
+long AtomSpace_getLink( AtomSpace* this_ptr
+                      , const char* type
+                      , const long* outgoing
+                      , int size
+                      , int* found )
 {
-    this_ptr->getNumLinks();
+    Type t = classserver().getType(std::string(type));
+    HandleSeq oset;
+    for(int i=0;i<size;i++)
+        oset.push_back(Handle(outgoing[i]));
+    Handle h = this_ptr->getLink(t,oset);
+    *found = h != Handle::UNDEFINED;
+    return h.value();
 }
 
-void AtomSpace_addAtom(AtomSpace* this_ptr, AtomPtr atom)
+int AtomSpace_removeAtom( AtomSpace* this_ptr
+                        , long handle )
 {
-    this_ptr->addAtom(atom);
+    return this_ptr->removeAtom(Handle(handle));
 }
-bool AtomSpace_removeAtom(AtomSpace* this_ptr, Handle h)
+
+void AtomSpace_debug( AtomSpace* this_ptr )
 {
-    this_ptr->removeAtom(h);
+    std::cerr<<(*this_ptr);
 }
-*/
+

--- a/opencog/haskell/AtomSpace_CWrapper.cpp
+++ b/opencog/haskell/AtomSpace_CWrapper.cpp
@@ -94,7 +94,7 @@ int AtomSpace_getTruthValue( AtomSpace* this_ptr
             break; }
         case INDEFINITE_TRUTH_VALUE: {
             IndefiniteTruthValuePtr itv =
-                std::dynamic_pointer_cast<IndefiniteTruthValue>(tv);
+                std::static_pointer_cast<IndefiniteTruthValue>(tv);
             parameters[0]=itv->getMean();
             parameters[1]=itv->getL();
             parameters[2]=itv->getU();
@@ -114,4 +114,44 @@ int AtomSpace_getTruthValue( AtomSpace* this_ptr
             break;
     }
     return tv->getType();
+}
+
+void AtomSpace_setTruthValue( AtomSpace* this_ptr
+                            , long handle
+                            , int type
+                            , double *parameters )
+{
+    Handle h(handle);
+    switch(type)
+    {
+        case SIMPLE_TRUTH_VALUE: {
+            double count = SimpleTruthValue::confidenceToCount(parameters[1]);
+            h->setTruthValue(SimpleTruthValue::createTV(parameters[0],count));
+            break; }
+        case COUNT_TRUTH_VALUE: {
+            h->setTruthValue(CountTruthValue::createTV(parameters[0]
+                                                      ,parameters[2]
+                                                      ,parameters[1]));
+            break; }
+        case INDEFINITE_TRUTH_VALUE: {
+            IndefiniteTruthValuePtr iptr =
+                IndefiniteTruthValue::createITV(parameters[1]
+                                               ,parameters[2]
+                                               ,parameters[3]);
+            iptr->setMean(parameters[0]);
+            iptr->setDiff(parameters[4]);
+            h->setTruthValue(std::static_pointer_cast<TruthValue>(iptr));
+            break; }
+        case FUZZY_TRUTH_VALUE: {
+            double count = FuzzyTruthValue::confidenceToCount(parameters[1]);
+            h->setTruthValue(FuzzyTruthValue::createTV(parameters[0],count));
+            break; }
+        case PROBABILISTIC_TRUTH_VALUE: {
+            h->setTruthValue(ProbabilisticTruthValue::createTV(parameters[0]
+                                                              ,parameters[2]
+                                                              ,parameters[1]));
+            break; }
+        default:
+            break;
+    }
 }

--- a/opencog/haskell/AtomSpace_CWrapper.h
+++ b/opencog/haskell/AtomSpace_CWrapper.h
@@ -6,16 +6,26 @@ extern "C"
     using namespace opencog;
 
     AtomSpace* AtomSpace_new();
-    void AtomSpace_delete(AtomSpace* this_ptr);
-    long AtomSpace_addNode(AtomSpace* this_ptr, Type t, const char* name);
-/*
-    int AtomSpace_getSize(AtomSpace* this_ptr);
-    int AtomSpace_getNumNodes(AtomSpace* this_ptr);
-    int AtomSpace_getNumLinks(AtomSpace* this_ptr);
-    void AtomSpace_addAtom(AtomSpace* this_ptr, AtomPtr atom);
-    Handle AtomSpace_addLink(AtomSpace* this_ptr, Type t,
-                             const HandleSeq& outgoing);
-    bool AtomSpace_removeAtom(AtomSpace* this_ptr, Handle h);
-*/
+    void AtomSpace_delete( AtomSpace* this_ptr );
+
+    long AtomSpace_addNode( AtomSpace* this_ptr
+                          , const char* type
+                          , const char* name);
+    long AtomSpace_addLink( AtomSpace* this_ptr
+                          , const char* type
+                          , const long* outgoing
+                          , int size );
+    long AtomSpace_getNode( AtomSpace* this_ptr
+                          , const char* type
+                          , const char* name
+                          , int* found );
+    long AtomSpace_getLink( AtomSpace* this_ptr
+                          , const char* type
+                          , const long* outgoing
+                          , int size
+                          , int* found );
+    int AtomSpace_removeAtom( AtomSpace* this_ptr
+                            , long handle );
+    void AtomSpace_debug( AtomSpace* this_ptr );
 }
 

--- a/opencog/haskell/AtomSpace_CWrapper.h
+++ b/opencog/haskell/AtomSpace_CWrapper.h
@@ -27,5 +27,9 @@ extern "C"
     int AtomSpace_removeAtom( AtomSpace* this_ptr
                             , long handle );
     void AtomSpace_debug( AtomSpace* this_ptr );
+
+    int AtomSpace_getTruthValue( AtomSpace* this_ptr
+                                , long handle
+                                , double* parameters );
 }
 

--- a/opencog/haskell/AtomSpace_CWrapper.h
+++ b/opencog/haskell/AtomSpace_CWrapper.h
@@ -1,42 +1,136 @@
 
 #include <opencog/atomspace/AtomSpace.h>
 
+/**
+ * C wrapper of the AtomSpace:
+ * It was developed as an interface necessary for haskell bindings.
+ * (ghc supports FFI for c libraries)
+ * Now, it doesn't have specific code related to Haskell, so this library
+ * could be used by another application with same requirements.
+ */
+
 extern "C"
 {
     using namespace opencog;
 
+    /**
+     * AtomSpace_new Creates a new instance of the AtomSpace class.
+     *
+     * @return  Pointer to the AtomSpace instance created.
+     */
     AtomSpace* AtomSpace_new();
+
+    /**
+     * AtomSpace_delete Deletes an AtomSpace object.
+     *
+     * @param this_ptr  Pointer to object.
+     */
     void AtomSpace_delete( AtomSpace* this_ptr );
 
+    /**
+     * AtomSpace_addNode Inserts a new node to the atomspace, or
+     *                   updates it if exists.
+     *
+     * @param  this_ptr  Pointer to AtomSpace instance.
+     * @param  type      String representation of a node type.
+     * @param  name      Node name.
+     *
+     * @return Handle id of the node inserted.
+     */
     UUID AtomSpace_addNode( AtomSpace* this_ptr
                           , const char* type
                           , const char* name);
 
+    /**
+     * AtomSpace_addLink Inserts a new link to the atomspace, or
+     *                   updates it if exists.
+     *
+     * @param  this_ptr  Pointer to AtomSpace instance.
+     * @param  type      String representation of a link type.
+     * @param  outgoing  List of UUID of the outgoing set.
+     * @param  size      Size of the outgoing list.
+     *
+     * @return Handle id of the link inserted.
+     */
     UUID AtomSpace_addLink( AtomSpace* this_ptr
                           , const char* type
                           , const UUID* outgoing
                           , int size );
 
+    /**
+     * AtomSpace_getNode Gets a node back from the atomspace.
+     *
+     * @param      this_ptr  Pointer to AtomSpace instance.
+     * @param      type      String representation of a node type.
+     * @param      name      Node name.
+     * @param[out] found     Flag to know if the node was found.
+     *
+     * @return     Handle id of the node.
+     */
     UUID AtomSpace_getNode( AtomSpace* this_ptr
                           , const char* type
                           , const char* name
                           , int* found );
 
+    /**
+     * AtomSpace_getLink     Gets a link back from the atomspace.
+     *
+     * @param      this_ptr  Pointer to AtomSpace instance.
+     * @param      type      String representation of a link type.
+     * @param      outgoing  List of UUID of the outgoing set.
+     * @param      size      Size of the outgoing list.
+     * @param[out] found     Flag to know if the link was found.
+     *
+     * @return     Handle id of the link.
+     */
     UUID AtomSpace_getLink( AtomSpace* this_ptr
                           , const char* type
                           , const UUID* outgoing
                           , int size
                           , int* found );
 
+    /**
+     * AtomSpace_removeAtom  Removes an atom from the atomspace.
+     *
+     * @param      this_ptr  Pointer to AtomSpace instance.
+     * @param      handle    Handle id of the atom to be removed.
+     *
+     * @return     Flag to know if the atom has been removed.
+     */
     int AtomSpace_removeAtom( AtomSpace* this_ptr
                             , UUID handle );
 
+    /**
+     * AtomSpace_debug  Debug function to print the state
+     *                  of the atomspace on stderr.
+     *
+     * @param      this_ptr  Pointer to AtomSpace instance.
+     */
     void AtomSpace_debug( AtomSpace* this_ptr );
 
+    /**
+     * AtomSpace_getTruthValue  Gets the truthvalue of
+     *                          an atom on the atomspace.
+     *
+     * @param      this_ptr    Pointer to AtomSpace instance.
+     * @param      handle      Handle id of target atom.
+     * @param[out] parameters  List of parameters of TruthValue result instance.
+     *
+     * @return     TruthValue type.
+     */
     TruthValueType AtomSpace_getTruthValue( AtomSpace* this_ptr
                                           , UUID handle
                                           , double* parameters );
 
+    /**
+     * AtomSpace_setTruthValue  Sets the truthvalue of
+     *                          an atom on the atomspace.
+     *
+     * @param      this_ptr    Pointer to AtomSpace instance.
+     * @param      handle      Handle id of target atom.
+     * @param      type        TruthValue type to be set.
+     * @param      parameters  List of parameters of TruthValue to be set.
+     */
     void AtomSpace_setTruthValue( AtomSpace* this_ptr
                                 , UUID handle
                                 , TruthValueType type

--- a/opencog/haskell/AtomSpace_CWrapper.h
+++ b/opencog/haskell/AtomSpace_CWrapper.h
@@ -11,25 +11,35 @@ extern "C"
     long AtomSpace_addNode( AtomSpace* this_ptr
                           , const char* type
                           , const char* name);
+
     long AtomSpace_addLink( AtomSpace* this_ptr
                           , const char* type
                           , const long* outgoing
                           , int size );
+
     long AtomSpace_getNode( AtomSpace* this_ptr
                           , const char* type
                           , const char* name
                           , int* found );
+
     long AtomSpace_getLink( AtomSpace* this_ptr
                           , const char* type
                           , const long* outgoing
                           , int size
                           , int* found );
+
     int AtomSpace_removeAtom( AtomSpace* this_ptr
                             , long handle );
+
     void AtomSpace_debug( AtomSpace* this_ptr );
 
     int AtomSpace_getTruthValue( AtomSpace* this_ptr
-                                , long handle
-                                , double* parameters );
+                               , long handle
+                               , double* parameters );
+
+    void AtomSpace_setTruthValue( AtomSpace* this_ptr
+                               , long handle
+                               , int type
+                               , double* parameters );
 }
 

--- a/opencog/haskell/AtomSpace_CWrapper.h
+++ b/opencog/haskell/AtomSpace_CWrapper.h
@@ -8,38 +8,38 @@ extern "C"
     AtomSpace* AtomSpace_new();
     void AtomSpace_delete( AtomSpace* this_ptr );
 
-    long AtomSpace_addNode( AtomSpace* this_ptr
+    UUID AtomSpace_addNode( AtomSpace* this_ptr
                           , const char* type
                           , const char* name);
 
-    long AtomSpace_addLink( AtomSpace* this_ptr
+    UUID AtomSpace_addLink( AtomSpace* this_ptr
                           , const char* type
-                          , const long* outgoing
+                          , const UUID* outgoing
                           , int size );
 
-    long AtomSpace_getNode( AtomSpace* this_ptr
+    UUID AtomSpace_getNode( AtomSpace* this_ptr
                           , const char* type
                           , const char* name
                           , int* found );
 
-    long AtomSpace_getLink( AtomSpace* this_ptr
+    UUID AtomSpace_getLink( AtomSpace* this_ptr
                           , const char* type
-                          , const long* outgoing
+                          , const UUID* outgoing
                           , int size
                           , int* found );
 
     int AtomSpace_removeAtom( AtomSpace* this_ptr
-                            , long handle );
+                            , UUID handle );
 
     void AtomSpace_debug( AtomSpace* this_ptr );
 
-    int AtomSpace_getTruthValue( AtomSpace* this_ptr
-                               , long handle
-                               , double* parameters );
+    TruthValueType AtomSpace_getTruthValue( AtomSpace* this_ptr
+                                          , UUID handle
+                                          , double* parameters );
 
     void AtomSpace_setTruthValue( AtomSpace* this_ptr
-                               , long handle
-                               , int type
-                               , double* parameters );
+                                , UUID handle
+                                , TruthValueType type
+                                , double* parameters );
 }
 

--- a/opencog/haskell/OpenCog/AtomSpace.hs
+++ b/opencog/haskell/OpenCog/AtomSpace.hs
@@ -6,6 +6,8 @@ module OpenCog.AtomSpace
     , remove
     , get
     , debug
+    , showAtom
+    , drawAtom
     , TruthVal (..)
     , AtomName (..)
     , Atom (..)
@@ -15,5 +17,6 @@ module OpenCog.AtomSpace
 
 import OpenCog.AtomSpace.Api
 import OpenCog.AtomSpace.Types
-import OpenCog.AtomSpace.Env    (AtomSpace,runOnNewAtomSpace)
+import OpenCog.AtomSpace.Env        (AtomSpace,runOnNewAtomSpace)
+import OpenCog.AtomSpace.Utils      (showAtom,drawAtom)
 

--- a/opencog/haskell/OpenCog/AtomSpace.hs
+++ b/opencog/haskell/OpenCog/AtomSpace.hs
@@ -1,0 +1,19 @@
+
+module OpenCog.AtomSpace
+    ( AtomSpace
+    , runOnNewAtomSpace
+    , insert
+    , remove
+    , get
+    , debug
+    , TruthVal (..)
+    , AtomName (..)
+    , Atom (..)
+    , AtomGen (..)
+    , appAtomGen
+    ) where
+
+import OpenCog.AtomSpace.Api
+import OpenCog.AtomSpace.Types
+import OpenCog.AtomSpace.Env    (AtomSpace,runOnNewAtomSpace)
+

--- a/opencog/haskell/OpenCog/AtomSpace.hs
+++ b/opencog/haskell/OpenCog/AtomSpace.hs
@@ -6,8 +6,8 @@ module OpenCog.AtomSpace
     , remove
     , get
     , debug
+    , printAtom
     , showAtom
-    , drawAtom
     , TruthVal (..)
     , AtomName (..)
     , Atom (..)
@@ -18,5 +18,5 @@ module OpenCog.AtomSpace
 import OpenCog.AtomSpace.Api
 import OpenCog.AtomSpace.Types
 import OpenCog.AtomSpace.Env        (AtomSpace,runOnNewAtomSpace)
-import OpenCog.AtomSpace.Utils      (showAtom,drawAtom)
+import OpenCog.AtomSpace.Utils      (printAtom,showAtom)
 

--- a/opencog/haskell/OpenCog/AtomSpace.hs
+++ b/opencog/haskell/OpenCog/AtomSpace.hs
@@ -1,13 +1,20 @@
+-- GSoC 2015 - Haskell bindings for OpenCog.
 
+-- | This library defines Haskell Bindings for the AtomSpace.
 module OpenCog.AtomSpace
-    ( AtomSpace
+    (
+    -- * AtomSpace Environment
+      AtomSpace
     , runOnNewAtomSpace
+    -- * AtomSpace Interaction
     , insert
     , remove
     , get
     , debug
+    -- * AtomSpace Printing
     , printAtom
     , showAtom
+    -- * AtomSpace Main Data Types
     , TruthVal (..)
     , AtomName (..)
     , Atom (..)

--- a/opencog/haskell/OpenCog/AtomSpace/Api.hs
+++ b/opencog/haskell/OpenCog/AtomSpace/Api.hs
@@ -1,5 +1,8 @@
+-- GSoC 2015 - Haskell bindings for OpenCog.
 {-# LANGUAGE ForeignFunctionInterface #-}
 
+-- | This Module defines the main functions to interact with the AtomSpace
+-- creating/removing/modifying atoms.
 module OpenCog.AtomSpace.Api (
       insert
     , remove
@@ -23,10 +26,11 @@ import OpenCog.AtomSpace.Types      (Atom(..),AtomName(..),TruthVal(..))
 
 --------------------------------------------------------------------------------
 
--- Debug function to print the atomspace on stderr.
 foreign import ccall "AtomSpace_debug"
   c_atomspace_debug :: AtomSpaceRef -> IO ()
 
+-- | 'debug' prints the state of the AtomSpace on stderr.
+-- (only for debugging purposes)
 debug :: AtomSpace ()
 debug = do
     asRef <- getAtomSpace
@@ -77,7 +81,7 @@ insertAndGetHandle i = case i of
             Nothing -> return ()
         return h
 
--- Function to insert an atom to the atomspace.
+-- | 'insert' creates a new atom on the atomspace or updates the existing one.
 insert :: Atom a -> AtomSpace ()
 insert i = insertAndGetHandle (toRaw i) >> return ()
 
@@ -88,7 +92,8 @@ foreign import ccall "AtomSpace_removeAtom"
                      -> Handle
                      -> IO CInt
 
--- Function to remove an atom from the atomspace.
+-- | 'remove' deletes an atom from the atomspace.
+-- Returns True in success or False if it couldn't locate the specified atom.
 remove :: Atom a -> AtomSpace Bool
 remove i = do
     asRef <- getAtomSpace
@@ -188,7 +193,8 @@ getWithHandle i = do
              Just (tv,h,newOutgoing) -> Just $ (Link aType newOutgoing (Just tv), h)
              _                       -> Nothing
 
--- Function to get an atom from the atomspace.
+-- | 'get' looks for an atom in the atomspace and returns it.
+-- (With updated mutable information)
 get :: Atom a -> AtomSpace (Maybe (Atom a))
 get i = do
     m <- getWithHandle $ toRaw i
@@ -204,6 +210,7 @@ foreign import ccall "AtomSpace_getTruthValue"
                             -> Ptr CDouble
                             -> IO CInt
 
+-- Internal function to get an atom's truth value.
 getTruthValue :: Handle -> AtomSpace TVRaw
 getTruthValue handle = do
     asRef <- getAtomSpace
@@ -220,6 +227,7 @@ foreign import ccall "AtomSpace_setTruthValue"
                             -> Ptr CDouble
                             -> IO ()
 
+-- Internal function to set an atom's truth value.
 setTruthValue :: Handle -> TVRaw -> AtomSpace ()
 setTruthValue handle (TVRaw tvtype list) = do
     asRef <- getAtomSpace

--- a/opencog/haskell/OpenCog/AtomSpace/Api.hs
+++ b/opencog/haskell/OpenCog/AtomSpace/Api.hs
@@ -92,7 +92,7 @@ foreign import ccall "AtomSpace_removeAtom"
 remove :: Atom a -> AtomSpace Bool
 remove i = do
     asRef <- getAtomSpace
-    m <- getWithHandle $ toRaw i -- TODO: Make more efficiently this
+    m <- getWithHandle $ toRaw i
     case m of
       Just (_,handle) -> liftIO $ toBool <$> c_atomspace_remove asRef handle
       _               -> return False
@@ -222,7 +222,7 @@ foreign import ccall "AtomSpace_setTruthValue"
 
 setTruthValue :: Handle -> TVRaw -> AtomSpace ()
 setTruthValue handle (TVRaw tvtype list) = do
-    asRef <- getAtomSpace            
+    asRef <- getAtomSpace
     liftIO $ withArray (map realToFrac list) $
       \lptr -> do
           c_atomspace_setTruthValue asRef handle (fromIntegral $ fromEnum tvtype) lptr

--- a/opencog/haskell/OpenCog/AtomSpace/Api.hs
+++ b/opencog/haskell/OpenCog/AtomSpace/Api.hs
@@ -1,7 +1,10 @@
-{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE ForeignFunctionInterface , GADTs #-}
 
 module OpenCog.AtomSpace.Api (
-      asAddNode
+      insert
+    , remove
+    , get
+    , debug
     , runOnNewAtomSpace
     , AtomSpace
     ) where
@@ -10,13 +13,17 @@ module OpenCog.AtomSpace.Api (
 -- asDelete/asNew functions.
 
 import Foreign                      (Ptr)
-import Foreign.C.Types              (CShort(..),CLong(..))
+import Foreign.C.Types              (CULong(..),CInt(..))
 import Foreign.C.String             (CString,withCString)
+import Foreign.Marshal.Array        (withArray)
+import Foreign.Marshal.Utils        (toBool)
+import Foreign.Marshal.Alloc        (alloca)
+import Foreign.Storable             (peek)
 import Control.Exception            (bracket)
 import Control.Monad.IO.Class       (liftIO)
 import Control.Monad.Trans.Reader   (ReaderT,runReaderT,ask)
 import Data.Functor                 ((<$>))
-import OpenCog.AtomSpace.Types      (Node(..),Handle)
+import OpenCog.AtomSpace.Types      (Atom(..),AtomName(..),TruthVal(..))
 
 -- Internal AtomSpace reference to a mutable C++ instance
 -- of the AtomSpace class.
@@ -39,21 +46,6 @@ foreign import ccall "AtomSpace_delete"
 asDelete :: AtomSpaceRef -> IO ()
 asDelete = c_atomspace_delete
 
--- Internal function getAtomSpace.
-getAtomSpace :: AtomSpace AtomSpaceRef
-getAtomSpace = ask
-
--- 'asAddNode' calls to the addNode method of the AtomSpace C++ class.
-foreign import ccall "AtomSpace_addNode"
-  c_atomspace_addnode :: AtomSpaceRef -> CShort -> CString -> IO CLong
-asAddNode :: Node -> AtomSpace Handle
-asAddNode nod = do
-                  asRef <- getAtomSpace
-                  let ntype = fromIntegral $ fromEnum $ nodeType nod
-                      fun = \str -> fromIntegral <$>
-                                    c_atomspace_addnode asRef ntype str
-                   in liftIO $ withCString (nodeName nod) fun
-
 -- 'runOnNewAtomSpace' creates a new AtomSpace (C++ object), does some
 -- computation over it, and then deletes it.
 -- By using bracket, I ensure properly freeing memory in case of exceptions
@@ -61,3 +53,193 @@ asAddNode nod = do
 runOnNewAtomSpace :: AtomSpace a -> IO a
 runOnNewAtomSpace as = bracket asNew asDelete $ runReaderT as
 
+-- Internal function getAtomSpace, to get the actual reference to the atomspace.
+getAtomSpace :: AtomSpace AtomSpaceRef
+getAtomSpace = ask
+
+type Handle = CULong
+type AtomType = String
+data AtomGen a = Link AtomType [a] (Maybe TruthVal) a
+               | Node AtomType AtomName (Maybe TruthVal) a
+
+toAtomGen :: Atom a -> AtomGen (Atom a)
+toAtomGen i = case i of
+    Predicate n  -> Node "PredicateNode" n Nothing i
+    And a1 a2 tv -> Link "AndLink" [a1,a2] tv i
+    Concept n    -> Node "ConceptNode" n Nothing i
+    _            -> undefined
+
+fromAtomGen :: AtomGen (Atom a) -> Atom a
+fromAtomGen i = case i of
+    Node "ConceptNode" n _ (Concept _)     -> Concept n
+    Node "PredicateNode" n _ (Predicate _) -> Predicate n
+    Link "AndLink" [a1,a2] tv (And _ _ _)  -> And a1 a2 tv
+    _                                      -> undefined
+
+--------------------------------------------------------------------------------
+
+-- Debug function to print the atomspace on stderr.
+foreign import ccall "AtomSpace_debug"
+  c_atomspace_debug :: AtomSpaceRef -> IO ()
+
+debug :: AtomSpace ()
+debug = do
+    asRef <- getAtomSpace
+    liftIO $ c_atomspace_debug asRef
+
+--------------------------------------------------------------------------------
+
+foreign import ccall "AtomSpace_addNode"
+  c_atomspace_addnode :: AtomSpaceRef
+                      -> CString
+                      -> CString
+                      -> IO Handle
+
+insertNode :: AtomType -> AtomName -> AtomSpace Handle
+insertNode aType aName = do
+    asRef <- getAtomSpace
+    liftIO $ withCString aType $
+       \atype -> withCString aName $
+       \aname -> c_atomspace_addnode asRef atype aname
+
+foreign import ccall "AtomSpace_addLink"
+  c_atomspace_addlink :: AtomSpaceRef
+                      -> CString
+                      -> Ptr Handle
+                      -> CInt
+                      -> IO Handle
+
+insertLink :: AtomType -> [Atom a] -> AtomSpace Handle
+insertLink aType aOutgoing = do
+    list <- mapM insertAndGetHandle aOutgoing
+    asRef <- getAtomSpace
+    liftIO $ withCString aType $
+      \atype -> withArray list $
+      \lptr -> c_atomspace_addlink asRef atype lptr (fromIntegral $ length list)
+
+insertAndGetHandle :: Atom a -> AtomSpace Handle
+insertAndGetHandle i = case toAtomGen i of
+    Node aType aName tv _     -> insertNode aType aName
+                                 -- TODO: After getting handler set truthvalue!
+    Link aType aOutgoing tv _ -> insertLink aType aOutgoing
+                                 -- TODO: After getting handler set truthvalue!
+
+-- Function to insert an atom to the atomspace.
+insert :: Atom a -> AtomSpace ()
+insert i = insertAndGetHandle i >> return ()
+
+--------------------------------------------------------------------------------
+
+foreign import ccall "AtomSpace_removeAtom"
+  c_atomspace_remove :: AtomSpaceRef
+                     -> Handle
+                     -> IO CInt
+
+-- Function to remove an atom from the atomspace.
+remove :: Atom a -> AtomSpace Bool
+remove i = do
+    asRef <- getAtomSpace
+    m <- getWithHandle i -- TODO: Make more efficiently this
+    case m of
+      Just (_,handle) -> liftIO $ toBool <$> c_atomspace_remove asRef handle
+      _               -> return False
+
+--------------------------------------------------------------------------------
+
+foreign import ccall "AtomSpace_getNode"
+  c_atomspace_getnode :: AtomSpaceRef
+                      -> CString
+                      -> CString
+                      -> Ptr CInt
+                      -> IO Handle
+
+getNodeHandle :: AtomType -> AtomName -> AtomSpace (Maybe Handle)
+getNodeHandle aType aName = do
+    asRef <- getAtomSpace
+    liftIO $ withCString aType $
+      \atype -> withCString aName $
+      \aname -> alloca $
+      \iptr -> do
+          h <- c_atomspace_getnode asRef atype aname iptr
+          found <- toBool <$> peek iptr
+          return $ if found
+                     then Just h
+                     else Nothing
+
+getNode :: AtomType -> AtomName -> AtomSpace (Maybe (TruthVal,Handle))
+getNode aType aName = do
+    m <- getNodeHandle aType aName
+    return $ case m of
+      Nothing -> Nothing
+      Just h  -> Just (undefined,h)
+              -- TODO: After getting handler, get actual truthvalue!
+
+
+foreign import ccall "AtomSpace_getLink"
+  c_atomspace_getlink :: AtomSpaceRef
+                      -> CString
+                      -> Ptr Handle
+                      -> CInt
+                      -> Ptr CInt
+                      -> IO Handle
+
+getLinkHandle :: AtomType -> [Handle] -> AtomSpace (Maybe Handle)
+getLinkHandle aType aOutgoing = do
+    asRef <- getAtomSpace
+    liftIO $ withCString aType $
+      \atype -> withArray aOutgoing $
+      \lptr -> alloca $
+      \iptr -> do
+          h <- c_atomspace_getlink asRef atype lptr
+                 (fromIntegral $ length aOutgoing) iptr
+          found <- toBool <$> peek iptr
+          return $ if found
+                     then Just h
+                     else Nothing
+
+getLink :: AtomType -> [Handle] -> AtomSpace (Maybe (TruthVal,Handle))
+getLink aType aOutgoing = do
+    m <- getLinkHandle aType aOutgoing
+    return $ case m of
+      Nothing -> Nothing
+      Just h  -> Just (undefined,h)
+              -- TODO: After getting handler, get actual truthvalue!
+
+getWithHandle :: Atom a -> AtomSpace (Maybe (Atom a,Handle))
+getWithHandle i = do
+    let onLink :: AtomType
+               -> [Atom a]
+               -> AtomSpace (Maybe (TruthVal,Handle,[Atom a]))
+        onLink aType aOutgoing = do
+            list <- mapM getWithHandle aOutgoing -- :: [Maybe (Atom a,Handle)]
+            case sequence list of -- :: Maybe [(Atom a,Handle)]
+              Nothing -> return Nothing
+              Just l  -> do
+                res <- getLink aType $ map snd l
+                case res of
+                  Just (tv,h) -> return $ Just (tv,h,map fst l)
+                  _           -> return Nothing
+     in
+        case toAtomGen i of
+          Node aType aName _ n -> do
+           m <- getNode aType aName
+           return $ case m of
+             Just (tv,h) -> Just (fromAtomGen (Node aType aName (Just tv) n),h)
+             _           -> Nothing
+
+          Link aType aOutgoing _ n -> do
+           m <- onLink aType aOutgoing
+           return $ case m of
+             Just (tv,h,newOutgoing) -> Just (fromAtomGen
+                                         (Link aType newOutgoing (Just tv) n),h)
+             _                       -> Nothing
+
+-- Function to get an atom from the atomspace.
+get :: Atom a -> AtomSpace (Maybe (Atom a))
+get i = do
+    m <- getWithHandle i
+    return $ case m of
+      Just (at,_) -> Just at
+      _           -> Nothing
+
+--------------------------------------------------------------------------------

--- a/opencog/haskell/OpenCog/AtomSpace/Env.hs
+++ b/opencog/haskell/OpenCog/AtomSpace/Env.hs
@@ -1,5 +1,7 @@
+-- GSoC 2015 - Haskell bindings for OpenCog.
 {-# LANGUAGE ForeignFunctionInterface #-}
 
+-- | This Module defines the main environment for the AtomSpace bindings.
 module OpenCog.AtomSpace.Env (
       AtomSpace
     , AtomSpaceRef(..)
@@ -18,7 +20,7 @@ import Control.Monad.Trans.Reader   (ReaderT,runReaderT,ask)
 -- of the AtomSpace class.
 newtype AtomSpaceRef = AtomSpaceRef (Ptr AtomSpaceRef)
 
--- Main Data Type for representing programs working on an AtomSpace.
+-- | Main Data Type for representing programs working on an AtomSpace.
 -- We have to use the IO monad because of the use of FFI for calling c functions
 -- for working on a mutable instance of the atomspace, so we have side effects.
 type AtomSpace = ReaderT AtomSpaceRef IO
@@ -35,7 +37,7 @@ foreign import ccall "AtomSpace_delete"
 asDelete :: AtomSpaceRef -> IO ()
 asDelete = c_atomspace_delete
 
--- 'runOnNewAtomSpace' creates a new AtomSpace (C++ object), does some
+-- | 'runOnNewAtomSpace' creates a new AtomSpace (C++ object), does some
 -- computation over it, and then deletes it.
 -- By using bracket, I ensure properly freeing memory in case of exceptions
 -- during the computation.

--- a/opencog/haskell/OpenCog/AtomSpace/Env.hs
+++ b/opencog/haskell/OpenCog/AtomSpace/Env.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+module OpenCog.AtomSpace.Env (
+      AtomSpace
+    , AtomSpaceRef(..)
+    , getAtomSpace
+    , runOnNewAtomSpace
+    ) where
+
+-- Note that I don't export the AtomSpace data constructor nor the
+-- asDelete/asNew functions.
+
+import Foreign                      (Ptr)
+import Control.Exception            (bracket)
+import Control.Monad.Trans.Reader   (ReaderT,runReaderT,ask)
+
+-- Internal AtomSpace reference to a mutable C++ instance
+-- of the AtomSpace class.
+newtype AtomSpaceRef = AtomSpaceRef (Ptr AtomSpaceRef)
+
+-- Main Data Type for representing programs working on an AtomSpace.
+-- We have to use the IO monad because of the use of FFI for calling c functions
+-- for working on a mutable instance of the atomspace, so we have side effects.
+type AtomSpace = ReaderT AtomSpaceRef IO
+
+-- Internal functions new and delete, to create and delete C++ instances
+-- of the AtomSpace class.
+foreign import ccall "AtomSpace_new"
+  c_atomspace_new :: IO AtomSpaceRef
+asNew :: IO AtomSpaceRef
+asNew = c_atomspace_new
+
+foreign import ccall "AtomSpace_delete"
+  c_atomspace_delete :: AtomSpaceRef -> IO ()
+asDelete :: AtomSpaceRef -> IO ()
+asDelete = c_atomspace_delete
+
+-- 'runOnNewAtomSpace' creates a new AtomSpace (C++ object), does some
+-- computation over it, and then deletes it.
+-- By using bracket, I ensure properly freeing memory in case of exceptions
+-- during the computation.
+runOnNewAtomSpace :: AtomSpace a -> IO a
+runOnNewAtomSpace as = bracket asNew asDelete $ runReaderT as
+
+-- Internal function getAtomSpace, to get the actual reference to the atomspace.
+getAtomSpace :: AtomSpace AtomSpaceRef
+getAtomSpace = ask
+

--- a/opencog/haskell/OpenCog/AtomSpace/Internal.hs
+++ b/opencog/haskell/OpenCog/AtomSpace/Internal.hs
@@ -6,6 +6,8 @@ module OpenCog.AtomSpace.Internal (
     , AtomRaw(..)
     , toRaw
     , fromRaw
+    , TVTypeEnum(..)
+    , tvMAX_PARAMS
     ) where
 
 import Foreign.C.Types              (CULong(..))
@@ -44,3 +46,16 @@ fromRaw raw orig = case (raw,orig) of
         Just $ List lnew
     _                                               -> Nothing -- undefined
 
+--Constant with the maximum number of parameters in any type of TV.
+tvMAX_PARAMS :: Int
+tvMAX_PARAMS = 5
+
+--TV enum type to work with TruthValueTypes from
+-- <opencog/atomspace/TruthValue.h> definition.
+data TVTypeEnum = NULL_TRUTH_VALUE
+                | SIMPLE_TRUTH_VALUE
+                | COUNT_TRUTH_VALUE
+                | INDEFINITE_TRUTH_VALUE
+                | FUZZY_TRUTH_VALUE
+                | PROBABILISTIC_TRUTH_VALUE
+    deriving Enum

--- a/opencog/haskell/OpenCog/AtomSpace/Internal.hs
+++ b/opencog/haskell/OpenCog/AtomSpace/Internal.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE GADTs #-}
+
+module OpenCog.AtomSpace.Internal (
+      Handle(..)
+    , AtomType(..)
+    , AtomRaw(..)
+    , toRaw
+    , fromRaw
+    ) where
+
+import Foreign.C.Types              (CULong(..))
+import Data.Functor                 ((<$>))
+import OpenCog.AtomSpace.Types      (Atom(..),AtomName(..),TruthVal(..),
+                                     appAtomGen,AtomGen(..))
+
+type Handle = CULong
+type AtomType = String
+data AtomRaw = Link AtomType [AtomRaw] (Maybe TruthVal)
+             | Node AtomType AtomName  (Maybe TruthVal)
+
+toRaw :: Atom a -> AtomRaw
+toRaw i = case i of
+    Predicate n  -> Node "PredicateNode" n Nothing
+    And a1 a2 tv -> Link "AndLink" [toRaw a1,toRaw a2] tv
+    Concept n    -> Node "ConceptNode" n Nothing
+    List list    -> Link "ListLink" (map (appAtomGen toRaw) list) Nothing
+    _            -> undefined
+
+fromRaw :: AtomRaw -> Atom a -> Maybe (Atom a)
+fromRaw raw orig = case (raw,orig) of
+    (Node "ConceptNode" n _    , Concept _   ) -> Just $ Concept n
+    (Node "PredicateNode" n _  , Predicate _ ) -> Just $ Predicate n
+    (Link "AndLink" [ar,br] tv , And ao bo _ ) -> do
+        a <- fromRaw ar ao
+        b <- fromRaw br bo
+        Just $ And a b tv
+    (Link "ListLink" lraw _    , List lorig  ) -> do
+        lnew <- if length lraw == length lorig
+                 then sequence $ zipWith (\raw orig -> 
+                                    appAtomGen
+                                    ((<$>) AtomGen . fromRaw raw) orig)
+                                    lraw lorig
+                 else Nothing
+        Just $ List lnew
+    _                                               -> Nothing -- undefined
+

--- a/opencog/haskell/OpenCog/AtomSpace/Internal.hs
+++ b/opencog/haskell/OpenCog/AtomSpace/Internal.hs
@@ -7,6 +7,8 @@ module OpenCog.AtomSpace.Internal (
     , toRaw
     , fromRaw
     , TVRaw(..)
+    , fromTVRaw
+    , toTVRaw
     , TVTypeEnum(..)
     , tvMAX_PARAMS
     ) where

--- a/opencog/haskell/OpenCog/AtomSpace/Types.hs
+++ b/opencog/haskell/OpenCog/AtomSpace/Types.hs
@@ -45,44 +45,44 @@ appAtomGen f (AtomGen at) = f at
 
 data Atom a where -- TODO: Review the types constraints, add Attention Values, etc.
     -- Predicate
-    Predicate   :: AtomName -> Atom (Atom a -> TruthVal)
-    And         :: Atom a -> Atom a -> (Maybe TruthVal) -> Atom a
-    Or          :: Atom a -> Atom a -> (Maybe TruthVal) -> Atom a
-    Implication :: Atom a -> Atom a -> (Maybe TruthVal) -> Atom a
-    Equivalence :: Atom a -> Atom a -> (Maybe TruthVal) -> Atom a
-    Evaluation  :: (Atom (Atom a -> TruthVal))  ->
+    PredicateNode   :: AtomName -> Atom (Atom a -> TruthVal)
+    AndLink         :: Atom a -> Atom a -> (Maybe TruthVal) -> Atom a
+    OrLink          :: Atom a -> Atom a -> (Maybe TruthVal) -> Atom a
+    ImplicationLink :: Atom a -> Atom a -> (Maybe TruthVal) -> Atom a
+    EquivalenceLink :: Atom a -> Atom a -> (Maybe TruthVal) -> Atom a
+    EvaluationLink  :: (Atom (Atom a -> TruthVal))  ->
                       Atom [AtomGen] -> (Maybe TruthVal) -> Atom a
 
     -- Concept
-    Concept       :: AtomName -> Atom TConceptNode
-    Inheritance   :: Atom TConceptNode -> Atom TConceptNode -> (Maybe TruthVal) -> Atom a
-    Similarity    :: Atom TConceptNode -> Atom TConceptNode -> (Maybe TruthVal) -> Atom a
-    Member        :: Atom TConceptNode -> Atom TConceptNode -> (Maybe TruthVal) -> Atom a
-    SatisfyingSet :: Atom (Atom a -> TruthVal) -> Atom TConceptNode
+    ConceptNode       :: AtomName -> (Maybe TruthVal) -> Atom TConceptNode
+    InheritanceLink   :: Atom TConceptNode -> Atom TConceptNode -> (Maybe TruthVal) -> Atom a
+    SimilarityLink    :: Atom TConceptNode -> Atom TConceptNode -> (Maybe TruthVal) -> Atom a
+    MemberLink        :: Atom TConceptNode -> Atom TConceptNode -> (Maybe TruthVal) -> Atom a
+    SatisfyingSetLink :: Atom (Atom a -> TruthVal) -> Atom TConceptNode
 
     -- Number
-    Number :: (Num a,Show a) => a -> Atom TNumberNode
+    NumberNode :: (Num a,Show a) => a -> Atom TNumberNode
 
     -- List
-    List :: [AtomGen] -> Atom [AtomGen]
+    ListLink :: [AtomGen] -> Atom [AtomGen]
 
 instance Show AtomGen where
     show (AtomGen at) = concat' ["AtomGen",show at]
 
 instance Show (Atom a) where
-    show (Predicate n)         = concat' ["Predicate",show n]
-    show (And a1 a2 m)         = concat' ["And",show a1,show a2,show m]
-    show (Or a1 a2 m)          = concat' ["Or",show a1,show a2,show m]
-    show (Implication a1 a2 m) = concat' ["Implication",show a1,show a2,show m]
-    show (Equivalence a1 a2 m) = concat' ["Equivalence",show a1,show a2,show m]
-    show (Evaluation a1 a2 m)  = concat' ["Evaluation",show a1,show a2,show m]
-    show (Concept n)           = concat' ["Concept",show n]
-    show (Inheritance a1 a2 m) = concat' ["Inheritance",show a1,show a2,show m]
-    show (Similarity a1 a2 m)  = concat' ["Similarity",show a1,show a2,show m]
-    show (Member a1 a2 m)      = concat' ["Member",show a1,show a2,show m]
-    show (SatisfyingSet a)     = concat' ["SatisfyingSet",show a]
-    show (Number n)            = concat' ["Number",show n]
-    show (List l)              = concat' ["List",show l]
+    show (PredicateNode n)         = concat' ["Predicate",show n]
+    show (AndLink a1 a2 m)         = concat' ["And",show a1,show a2,show m]
+    show (OrLink a1 a2 m)          = concat' ["Or",show a1,show a2,show m]
+    show (ImplicationLink a1 a2 m) = concat' ["Implication",show a1,show a2,show m]
+    show (EquivalenceLink a1 a2 m) = concat' ["Equivalence",show a1,show a2,show m]
+    show (EvaluationLink a1 a2 m)  = concat' ["Evaluation",show a1,show a2,show m]
+    show (ConceptNode n)           = concat' ["Concept",show n]
+    show (InheritanceLink a1 a2 m) = concat' ["Inheritance",show a1,show a2,show m]
+    show (SimilarityLink a1 a2 m)  = concat' ["Similarity",show a1,show a2,show m]
+    show (MemberLink a1 a2 m)      = concat' ["Member",show a1,show a2,show m]
+    show (SatisfyingSetLink a)     = concat' ["SatisfyingSet",show a]
+    show (NumberNode n)            = concat' ["Number",show n]
+    show (ListLink l)              = concat' ["List",show l]
 
 concat' (a:b:xs) = a ++ " " ++ concat' (b:xs)
 concat' (b:[])   = b

--- a/opencog/haskell/OpenCog/AtomSpace/Types.hs
+++ b/opencog/haskell/OpenCog/AtomSpace/Types.hs
@@ -12,9 +12,26 @@ module OpenCog.AtomSpace.Types (
 
 type AtomName = String
 
-data TruthVal = SimpleTruthVal Double Double
-              | CountTruthVal Double Double Double
-              | IndefiniteTruthVal Double Double Double Double
+data TruthVal = SimpleTV { tvMean       :: Double
+                         , tvConfidence :: Double
+                         }
+              | CountTV { tvMean       :: Double
+                        , tvCount      :: Double
+                        , tvConfidence :: Double
+                        }
+              | IndefTV { tvMean      :: Double
+                        , tvL         :: Double
+                        , tvU         :: Double
+                        , tvConfLevel :: Double
+                        , tvDiff      :: Double
+                        }
+              | FuzzyTV { tvMean       :: Double
+                        , tvConfidence :: Double
+                        }
+              | ProbTV { tvMean       :: Double
+                       , tvCount      :: Double
+                       , tvConfidence :: Double
+                       }
     deriving Show
 
 data TConceptNode

--- a/opencog/haskell/OpenCog/AtomSpace/Types.hs
+++ b/opencog/haskell/OpenCog/AtomSpace/Types.hs
@@ -1,5 +1,7 @@
+-- GSoC 2015 - Haskell bindings for OpenCog.
 {-# LANGUAGE GADTs , EmptyDataDecls , ExistentialQuantification , RankNTypes #-}
 
+-- | This Module defines the main data types for Haskell bindings.
 module OpenCog.AtomSpace.Types (
     TruthVal (..)
   , AtomName (..)
@@ -10,8 +12,10 @@ module OpenCog.AtomSpace.Types (
   , TConceptNode
   ) where
 
+-- | Atom name type.
 type AtomName = String
 
+-- | 'TruthVal' represent the different types of TruthValues.
 data TruthVal = SimpleTV { tvMean       :: Double
                          , tvConfidence :: Double
                          }
@@ -37,12 +41,18 @@ data TruthVal = SimpleTV { tvMean       :: Double
 data TConceptNode
 data TNumberNode
 
+-- | 'AtomGen' is a general atom type hiding the type variables.
+-- (necessary when working with many instances of different atoms,
+-- for example, for lists of atoms)
 data AtomGen where
     AtomGen :: Atom a -> AtomGen
 
+-- | 'appAtomGen' evaluates a given function with the atom instance
+-- wrapped inside the 'AtomGen' type.
 appAtomGen :: (forall a. Atom a -> b) -> AtomGen -> b
 appAtomGen f (AtomGen at) = f at
 
+-- | 'Atom' is the main data type to represent the different types of atoms.
 data Atom a where
     PredicateNode   :: AtomName -> Atom (Atom a -> TruthVal)
     AndLink         :: Atom a -> Atom b -> (Maybe TruthVal) -> Atom c

--- a/opencog/haskell/OpenCog/AtomSpace/Types.hs
+++ b/opencog/haskell/OpenCog/AtomSpace/Types.hs
@@ -43,47 +43,47 @@ data AtomGen where
 appAtomGen :: (forall a. Atom a -> b) -> AtomGen -> b
 appAtomGen f (AtomGen at) = f at
 
-data Atom a where -- TODO: Review the types constraints, add Attention Values, etc.
-    -- Predicate
+data Atom a where
     PredicateNode   :: AtomName -> Atom (Atom a -> TruthVal)
-    AndLink         :: Atom a -> Atom a -> (Maybe TruthVal) -> Atom a
-    OrLink          :: Atom a -> Atom a -> (Maybe TruthVal) -> Atom a
-    ImplicationLink :: Atom a -> Atom a -> (Maybe TruthVal) -> Atom a
-    EquivalenceLink :: Atom a -> Atom a -> (Maybe TruthVal) -> Atom a
+    AndLink         :: Atom a -> Atom b -> (Maybe TruthVal) -> Atom c
+    OrLink          :: Atom a -> Atom b -> (Maybe TruthVal) -> Atom c
+    ImplicationLink :: Atom a -> Atom b -> (Maybe TruthVal) -> Atom c
+    EquivalenceLink :: Atom a -> Atom b -> (Maybe TruthVal) -> Atom c
     EvaluationLink  :: (Atom (Atom a -> TruthVal))  ->
-                      Atom [AtomGen] -> (Maybe TruthVal) -> Atom a
+                      Atom [AtomGen] -> (Maybe TruthVal) -> Atom b
 
-    -- Concept
     ConceptNode       :: AtomName -> (Maybe TruthVal) -> Atom TConceptNode
     InheritanceLink   :: Atom TConceptNode -> Atom TConceptNode -> (Maybe TruthVal) -> Atom a
     SimilarityLink    :: Atom TConceptNode -> Atom TConceptNode -> (Maybe TruthVal) -> Atom a
     MemberLink        :: Atom TConceptNode -> Atom TConceptNode -> (Maybe TruthVal) -> Atom a
     SatisfyingSetLink :: Atom (Atom a -> TruthVal) -> Atom TConceptNode
 
-    -- Number
     NumberNode :: (Num a,Show a) => a -> Atom TNumberNode
 
-    -- List
     ListLink :: [AtomGen] -> Atom [AtomGen]
 
+
 instance Show AtomGen where
-    show (AtomGen at) = concat' ["AtomGen",show at]
+    show (AtomGen at) = concatWSpaces ["AtomGen",show at]
 
 instance Show (Atom a) where
-    show (PredicateNode n)         = concat' ["Predicate",show n]
-    show (AndLink a1 a2 m)         = concat' ["And",show a1,show a2,show m]
-    show (OrLink a1 a2 m)          = concat' ["Or",show a1,show a2,show m]
-    show (ImplicationLink a1 a2 m) = concat' ["Implication",show a1,show a2,show m]
-    show (EquivalenceLink a1 a2 m) = concat' ["Equivalence",show a1,show a2,show m]
-    show (EvaluationLink a1 a2 m)  = concat' ["Evaluation",show a1,show a2,show m]
-    show (ConceptNode n m)         = concat' ["Concept",show n,show m]
-    show (InheritanceLink a1 a2 m) = concat' ["Inheritance",show a1,show a2,show m]
-    show (SimilarityLink a1 a2 m)  = concat' ["Similarity",show a1,show a2,show m]
-    show (MemberLink a1 a2 m)      = concat' ["Member",show a1,show a2,show m]
-    show (SatisfyingSetLink a)     = concat' ["SatisfyingSet",show a]
-    show (NumberNode n)            = concat' ["Number",show n]
-    show (ListLink l)              = concat' ["List",show l]
+    show (PredicateNode n)         = mix ["PredicateNode",show n]
+    show (AndLink a1 a2 m)         = mix ["AndLink",show a1,show a2,show m]
+    show (OrLink a1 a2 m)          = mix ["OrLink",show a1,show a2,show m]
+    show (ImplicationLink a1 a2 m) = mix ["ImplicationLink",show a1,show a2,show m]
+    show (EquivalenceLink a1 a2 m) = mix ["EquivalenceLink",show a1,show a2,show m]
+    show (EvaluationLink a1 a2 m)  = mix ["EvaluationLink",show a1,show a2,show m]
+    show (ConceptNode n m)         = mix ["ConceptNode",show n,show m]
+    show (InheritanceLink a1 a2 m) = mix ["InheritanceLink",show a1,show a2,show m]
+    show (SimilarityLink a1 a2 m)  = mix ["SimilarityLink",show a1,show a2,show m]
+    show (MemberLink a1 a2 m)      = mix ["MemberLink",show a1,show a2,show m]
+    show (SatisfyingSetLink a)     = mix ["SatisfyingSetLink",show a]
+    show (NumberNode n)            = mix ["NumberNode",show n]
+    show (ListLink l)              = mix ["ListLink",show l]
 
-concat' (a:b:xs) = a ++ " " ++ concat' (b:xs)
-concat' (b:[])   = b
-concat' []       = ""
+mix :: [String] -> String
+mix xs = "( "++concatWSpaces xs++")"
+
+concatWSpaces :: [String] -> String
+concatWSpaces = foldr (\a b -> a++" "++b) []
+

--- a/opencog/haskell/OpenCog/AtomSpace/Types.hs
+++ b/opencog/haskell/OpenCog/AtomSpace/Types.hs
@@ -1,9 +1,11 @@
-{-# LANGUAGE GADTs , EmptyDataDecls #-}
+{-# LANGUAGE GADTs , EmptyDataDecls , ExistentialQuantification , RankNTypes #-}
 
 module OpenCog.AtomSpace.Types (
     TruthVal (..)
   , AtomName (..)
   , Atom (..)
+  , AtomGen (..)
+  , appAtomGen
   , TNumberNode
   , TConceptNode
   ) where
@@ -18,6 +20,12 @@ data TruthVal = SimpleTruthVal Double Double
 data TConceptNode
 data TNumberNode
 
+data AtomGen where
+    AtomGen :: Atom a -> AtomGen
+
+appAtomGen :: (forall a. Atom a -> b) -> AtomGen -> b
+appAtomGen f (AtomGen at) = f at
+
 data Atom a where -- TODO: Review the types constraints, add Attention Values, etc.
     -- Predicate
     Predicate   :: AtomName -> Atom (Atom a -> TruthVal)
@@ -26,7 +34,7 @@ data Atom a where -- TODO: Review the types constraints, add Attention Values, e
     Implication :: Atom a -> Atom a -> (Maybe TruthVal) -> Atom a
     Equivalence :: Atom a -> Atom a -> (Maybe TruthVal) -> Atom a
     Evaluation  :: (Atom (Atom a -> TruthVal))  ->
-                      Atom [Atom a] -> (Maybe TruthVal) -> Atom a
+                      Atom [AtomGen] -> (Maybe TruthVal) -> Atom a
 
     -- Concept
     Concept       :: AtomName -> Atom TConceptNode
@@ -39,4 +47,5 @@ data Atom a where -- TODO: Review the types constraints, add Attention Values, e
     Number :: (Num a) => a -> Atom TNumberNode
 
     -- List
-    List :: [Atom a] -> Atom [Atom a]
+    List :: [AtomGen] -> Atom [AtomGen]
+

--- a/opencog/haskell/OpenCog/AtomSpace/Types.hs
+++ b/opencog/haskell/OpenCog/AtomSpace/Types.hs
@@ -15,23 +15,23 @@ type AtomName = String
 data TruthVal = SimpleTV { tvMean       :: Double
                          , tvConfidence :: Double
                          }
-              | CountTV { tvMean       :: Double
-                        , tvCount      :: Double
-                        , tvConfidence :: Double
-                        }
-              | IndefTV { tvMean      :: Double
-                        , tvL         :: Double
-                        , tvU         :: Double
-                        , tvConfLevel :: Double
-                        , tvDiff      :: Double
-                        }
-              | FuzzyTV { tvMean       :: Double
-                        , tvConfidence :: Double
-                        }
-              | ProbTV { tvMean       :: Double
-                       , tvCount      :: Double
-                       , tvConfidence :: Double
-                       }
+              | CountTV  { tvMean       :: Double
+                         , tvCount      :: Double
+                         , tvConfidence :: Double
+                         }
+              | IndefTV  { tvMean      :: Double
+                         , tvL         :: Double
+                         , tvU         :: Double
+                         , tvConfLevel :: Double
+                         , tvDiff      :: Double
+                         }
+              | FuzzyTV  { tvMean       :: Double
+                         , tvConfidence :: Double
+                         }
+              | ProbTV   { tvMean       :: Double
+                         , tvCount      :: Double
+                         , tvConfidence :: Double
+                         }
     deriving Show
 
 data TConceptNode
@@ -76,7 +76,7 @@ instance Show (Atom a) where
     show (ImplicationLink a1 a2 m) = concat' ["Implication",show a1,show a2,show m]
     show (EquivalenceLink a1 a2 m) = concat' ["Equivalence",show a1,show a2,show m]
     show (EvaluationLink a1 a2 m)  = concat' ["Evaluation",show a1,show a2,show m]
-    show (ConceptNode n)           = concat' ["Concept",show n]
+    show (ConceptNode n m)         = concat' ["Concept",show n,show m]
     show (InheritanceLink a1 a2 m) = concat' ["Inheritance",show a1,show a2,show m]
     show (SimilarityLink a1 a2 m)  = concat' ["Similarity",show a1,show a2,show m]
     show (MemberLink a1 a2 m)      = concat' ["Member",show a1,show a2,show m]

--- a/opencog/haskell/OpenCog/AtomSpace/Types.hs
+++ b/opencog/haskell/OpenCog/AtomSpace/Types.hs
@@ -1,53 +1,42 @@
+{-# LANGUAGE GADTs , EmptyDataDecls #-}
 
-module OpenCog.AtomSpace.Types(
-    NodeType (..)
-  , LinkType (..)
-  , TruthValue (..)
+module OpenCog.AtomSpace.Types (
+    TruthVal (..)
+  , AtomName (..)
   , Atom (..)
-  , Link (..)
-  , Node (..)
-  , Handle (..)
+  , TNumberNode
+  , TConceptNode
   ) where
 
-import Data.Default     (Default(..))
+type AtomName = String
 
--- I should add more options here, this is just an example.
-data NodeType = NodeType1 | ConceptNode
-    deriving (Enum,Show)
-
--- I should add more options here, this is just an example.
-data LinkType = LinkType1 | LinkType2
-    deriving (Enum,Show)
-
-data TruthValue = SimpleTruthValue Double Double
-                | CountTruthValue Double Double Double
-                | IndefiniteTruthValue Double Double Double Double
+data TruthVal = SimpleTruthVal Double Double
+              | CountTruthVal Double Double Double
+              | IndefiniteTruthVal Double Double Double Double
     deriving Show
 
-instance Default TruthValue where
-    def = SimpleTruthValue 1 0
+data TConceptNode
+data TNumberNode
 
-type Handle = Int
+data Atom a where -- TODO: Review the types constraints, add Attention Values, etc.
+    -- Predicate
+    Predicate   :: AtomName -> Atom (Atom a -> TruthVal)
+    And         :: Atom a -> Atom a -> (Maybe TruthVal) -> Atom a
+    Or          :: Atom a -> Atom a -> (Maybe TruthVal) -> Atom a
+    Implication :: Atom a -> Atom a -> (Maybe TruthVal) -> Atom a
+    Equivalence :: Atom a -> Atom a -> (Maybe TruthVal) -> Atom a
+    Evaluation  :: (Atom (Atom a -> TruthVal))  ->
+                      Atom [Atom a] -> (Maybe TruthVal) -> Atom a
 
-data Atom = CLink Link | CNode Node
-    deriving Show
+    -- Concept
+    Concept       :: AtomName -> Atom TConceptNode
+    Inheritance   :: Atom TConceptNode -> Atom TConceptNode -> (Maybe TruthVal) -> Atom a
+    Similarity    :: Atom TConceptNode -> Atom TConceptNode -> (Maybe TruthVal) -> Atom a
+    Member        :: Atom TConceptNode -> Atom TConceptNode -> (Maybe TruthVal) -> Atom a
+    SatisfyingSet :: Atom (Atom a -> TruthVal) -> Atom TConceptNode
 
-data Link = Link{
-    linkType  :: LinkType
-,   linkName  :: String
-,   linkTv    :: TruthValue
-,   linkAtoms :: [Atom]
-}   deriving Show
+    -- Number
+    Number :: (Num a) => a -> Atom TNumberNode
 
-instance Default Link where
-    def = Link LinkType1 "" def []
-
-data Node = Node{
-    nodeType  :: NodeType
-,   nodeName  :: String
-,   nodeTv    :: TruthValue
-}   deriving Show
-
-instance Default Node where
-    def = Node ConceptNode "" def
-
+    -- List
+    List :: [Atom a] -> Atom [Atom a]

--- a/opencog/haskell/OpenCog/AtomSpace/Types.hs
+++ b/opencog/haskell/OpenCog/AtomSpace/Types.hs
@@ -44,8 +44,29 @@ data Atom a where -- TODO: Review the types constraints, add Attention Values, e
     SatisfyingSet :: Atom (Atom a -> TruthVal) -> Atom TConceptNode
 
     -- Number
-    Number :: (Num a) => a -> Atom TNumberNode
+    Number :: (Num a,Show a) => a -> Atom TNumberNode
 
     -- List
     List :: [AtomGen] -> Atom [AtomGen]
 
+instance Show AtomGen where
+    show (AtomGen at) = concat' ["AtomGen",show at]
+
+instance Show (Atom a) where
+    show (Predicate n)         = concat' ["Predicate",show n]
+    show (And a1 a2 m)         = concat' ["And",show a1,show a2,show m]
+    show (Or a1 a2 m)          = concat' ["Or",show a1,show a2,show m]
+    show (Implication a1 a2 m) = concat' ["Implication",show a1,show a2,show m]
+    show (Equivalence a1 a2 m) = concat' ["Equivalence",show a1,show a2,show m]
+    show (Evaluation a1 a2 m)  = concat' ["Evaluation",show a1,show a2,show m]
+    show (Concept n)           = concat' ["Concept",show n]
+    show (Inheritance a1 a2 m) = concat' ["Inheritance",show a1,show a2,show m]
+    show (Similarity a1 a2 m)  = concat' ["Similarity",show a1,show a2,show m]
+    show (Member a1 a2 m)      = concat' ["Member",show a1,show a2,show m]
+    show (SatisfyingSet a)     = concat' ["SatisfyingSet",show a]
+    show (Number n)            = concat' ["Number",show n]
+    show (List l)              = concat' ["List",show l]
+
+concat' (a:b:xs) = a ++ " " ++ concat' (b:xs)
+concat' (b:[])   = b
+concat' []       = ""

--- a/opencog/haskell/OpenCog/AtomSpace/Utils.hs
+++ b/opencog/haskell/OpenCog/AtomSpace/Utils.hs
@@ -1,6 +1,6 @@
 module OpenCog.AtomSpace.Utils (
-      drawAtom
-    , showAtom
+      showAtom
+    , printAtom
     ) where
 
 import OpenCog.AtomSpace.Types      (Atom(..),TruthVal(..))
@@ -20,9 +20,9 @@ showTV' :: Maybe TruthVal -> String
 showTV' (Just tv) = showTV tv
 showTV' Nothing   = ""
 
--- Function to draw an atom in opencog notation (indented notation).
-drawAtom :: Atom a -> String
-drawAtom at = concatWNewline $ list 0 $ toRaw at
+-- Function to show an atom in opencog notation (indented notation).
+showAtom :: Atom a -> String
+showAtom at = concatWNewline $ list 0 $ toRaw at
   where
     list :: Int -> AtomRaw -> [String]
     list lv at = case at of
@@ -47,6 +47,6 @@ drawAtom at = concatWNewline $ list 0 $ toRaw at
     tab 0 s  = s
     tab lv s = "  "++ tab (lv-1) s
 
-showAtom :: Atom a -> IO ()
-showAtom at = putStrLn $ drawAtom at
+printAtom :: Atom a -> IO ()
+printAtom at = putStrLn $ showAtom at
 

--- a/opencog/haskell/OpenCog/AtomSpace/Utils.hs
+++ b/opencog/haskell/OpenCog/AtomSpace/Utils.hs
@@ -1,0 +1,52 @@
+module OpenCog.AtomSpace.Utils (
+      drawAtom
+    , showAtom
+    ) where
+
+import OpenCog.AtomSpace.Types      (Atom(..),TruthVal(..))
+import OpenCog.AtomSpace.Internal   (fromTVRaw,toRaw,AtomRaw(..))
+import Data.Functor                 ((<$>))
+
+showTV :: TruthVal -> String
+showTV (SimpleTV a b     ) = "(stv "++show a++" "++show b++")"
+showTV (CountTV a b c    ) = "(ctv "++show a++" "++show b++" "++show c++")"
+showTV (IndefTV a b c d e) = "(itv "++show a++" "++show b++" "
+                                    ++show c++" "++show d++" "
+                                    ++show e++")"
+showTV (FuzzyTV a b      ) = "(ftv "++show a++" "++show b++")"
+showTV (ProbTV a b c     ) = "(ptv "++show a++" "++show b++" "++show c++")"
+
+showTV' :: Maybe TruthVal -> String
+showTV' (Just tv) = showTV tv
+showTV' Nothing   = ""
+
+-- Function to draw an atom in opencog notation (indented notation).
+drawAtom :: Atom a -> String
+drawAtom at = concatWNewline $ list 0 $ toRaw at
+  where
+    list :: Int -> AtomRaw -> [String]
+    list lv at = case at of
+      Link atype lraw  tv -> let showtv = showTV' $ fromTVRaw <$> tv
+                              in [tab lv $ concatWSpaces [atype,showtv]]
+                                 ++ concat (map (list (lv+1)) lraw)
+      Node atype aname tv -> let showtv = showTV' $ fromTVRaw <$> tv
+                              in [tab lv $ concatWSpaces [atype,showtv
+                                                         ,"\""++aname++"\""]]
+
+    concatWNewline :: [String] -> String
+    concatWNewline []     = []
+    concatWNewline (x:xs) = foldr1 (\a b -> a++"\n"++b) (x:xs)
+
+    concatWSpaces :: [String] -> String
+    concatWSpaces []     = []
+    concatWSpaces (x:xs) = foldr1 (\a b -> if a /= ""
+                                            then a++" "++b
+                                            else b) (x:xs)
+
+    tab :: Int -> String -> String
+    tab 0 s  = s
+    tab lv s = "  "++ tab (lv-1) s
+
+showAtom :: Atom a -> IO ()
+showAtom at = putStrLn $ drawAtom at
+

--- a/opencog/haskell/OpenCog/AtomSpace/Utils.hs
+++ b/opencog/haskell/OpenCog/AtomSpace/Utils.hs
@@ -1,3 +1,6 @@
+-- GSoC 2015 - Haskell bindings for OpenCog.
+
+-- | This Module offers useful functions for working on an AtomSpace.
 module OpenCog.AtomSpace.Utils (
       showAtom
     , printAtom
@@ -7,6 +10,7 @@ import OpenCog.AtomSpace.Types      (Atom(..),TruthVal(..))
 import OpenCog.AtomSpace.Internal   (fromTVRaw,toRaw,AtomRaw(..))
 import Data.Functor                 ((<$>))
 
+-- Function to show a truth value in opencog notation.
 showTV :: TruthVal -> String
 showTV (SimpleTV a b     ) = "(stv "++show a++" "++show b++")"
 showTV (CountTV a b c    ) = "(ctv "++show a++" "++show b++" "++show c++")"
@@ -20,7 +24,7 @@ showTV' :: Maybe TruthVal -> String
 showTV' (Just tv) = showTV tv
 showTV' Nothing   = ""
 
--- Function to show an atom in opencog notation (indented notation).
+-- | 'showAtom' shows an atom in opencog notation (indented notation).
 showAtom :: Atom a -> String
 showAtom at = concatWNewline $ list 0 $ toRaw at
   where
@@ -47,6 +51,7 @@ showAtom at = concatWNewline $ list 0 $ toRaw at
     tab 0 s  = s
     tab lv s = "  "++ tab (lv-1) s
 
+-- | 'printAtom' prints the given atom on stdout.
 printAtom :: Atom a -> IO ()
 printAtom at = putStrLn $ showAtom at
 

--- a/opencog/haskell/README.md
+++ b/opencog/haskell/README.md
@@ -18,8 +18,12 @@ Go through the normal process of
 [building](https://github.com/opencog/atomspace#building-atomspace) and
 [installing](https://github.com/opencog/atomspace#install) the AtomSpace.
 
-Then move to this directory (/opencog/haskell) and build and install the
-opencog-atomspace haskell library:
+This will install automatically the haskell library.
+
+If you want to install only the haskell library, for example a new version,
+move to this directory (/opencog/haskell), remove the dist folder, and 
+build and install the
+opencog-atomspace haskell library with these commands:
 
 ```
  cabal configure
@@ -84,3 +88,26 @@ main = runOnNewAtomSpace prog
 
 ```
 
+###Main functions:
+
+####insert:
+Function to insert atoms to the atomspace. To create new atoms or just to
+update the mutable information of a specific atom.
+```haskell
+insert :: Atom a -> AtomSpace ()
+```
+####get:
+Function to get an atom back from the atomspace.
+```haskell
+get :: Atom a -> AtomSpace (Maybe (Atom a))
+```
+####remove:
+Function to remove atoms from the atomspace.
+```haskell
+remove :: Atom a -> AtomSpace Bool
+```
+####debug:
+Debug function to print the state of the atomspace.
+```haskell
+debug :: AtomSpace ()
+```

--- a/opencog/haskell/README.md
+++ b/opencog/haskell/README.md
@@ -1,6 +1,20 @@
 Haskell Bindings for OpenCog:
 ============================
 
+This directory contains the implementation of Haskell bindings for the AtomSpace.
+
+GSoC 2015 - Haskell Bindings.
+
+**Student:** Marcos Pividori
+
+**Mentor:** Nil Geisweiller
+
+For general information on haskell bindings you can visit the wiki page:
+[Haskell](http://wiki.opencog.org/w/Haskell)
+
+For in depth information on the implementation and project details:
+[Haskell Bindings - GSoC 2015](http://wiki.opencog.org/w/Haskell_Bindings_-_GSoC_2015)
+
 ### Requirements
 
 To use the Haskell bindings, it is necessary to have installed:
@@ -14,26 +28,23 @@ which includes the most important tools for Haskell environment.
 
 ### Installation
 
-Go through the normal process of 
+Go through the normal process of
 [building](https://github.com/opencog/atomspace#building-atomspace) and
 [installing](https://github.com/opencog/atomspace#install) the AtomSpace.
 
-This will install automatically the haskell library.
+This will automatically install the haskell library.
 
 If you want to install only the haskell library, for example a new version,
-move to this directory (/opencog/haskell), remove the dist folder, and 
-build and install the
-opencog-atomspace haskell library with these commands:
+move to this directory (/opencog/haskell), build and install the
+opencog-atomspace haskell library with this command:
 
 ```
- cabal configure
- cabal build
  cabal install
 ```
 
 (It is necessary to previously build and install the AtomSpace, because the
 opencog-atomspace haskell library
-depends on the atomspace_wrapper library)
+depends on the haskell-atomspace C wrapper library)
 
 ### Usage
 
@@ -43,7 +54,10 @@ import OpenCog.AtomSpace
 ...
 ```
 
-### AtomSpace API
+You can find many examples on the [examples/haskell](../../examples/haskell)
+directory.
+
+### AtomSpace Environment
 
 The main idea is to build programs that work on an AtomSpace on the
 Monad 'AtomSpace'.
@@ -65,7 +79,7 @@ type AtomSpace = ReaderT AtomSpaceRef IO
 ReaderT is a monad transformer, so in fact:
 
 ```haskell
-AtomSpace a = ReaderT { runReaderT :: AtomSpaceRef -> IO a }	 
+AtomSpace a = ReaderT { runReaderT :: AtomSpaceRef -> IO a }
 ```
 
 The interpretation of runReaderT in this case is:  "given an atomspace in
@@ -106,8 +120,14 @@ Function to remove atoms from the atomspace.
 ```haskell
 remove :: Atom a -> AtomSpace Bool
 ```
+####printAtom
+Function to show the given atom in opencog notation.
+```haskell
+printAtom :: Atom a -> IO ()
+```
 ####debug:
-Debug function to print the state of the atomspace.
+Debug function to print the state of the atomspace on stderr.
 ```haskell
 debug :: AtomSpace ()
 ```
+

--- a/opencog/haskell/opencog-atomspace.cabal
+++ b/opencog/haskell/opencog-atomspace.cabal
@@ -23,5 +23,3 @@ library
 
   extra-libraries:   haskell-atomspace
 
-  extra-lib-dirs:    /usr/local/lib/opencog
-

--- a/opencog/haskell/opencog-atomspace.cabal
+++ b/opencog/haskell/opencog-atomspace.cabal
@@ -10,7 +10,11 @@ build-type:          Simple
 cabal-version:       >=1.8
 
 library
-  exposed-modules:   OpenCog.AtomSpace.Api
+  exposed-modules:   OpenCog.AtomSpace
+
+  other-modules:     OpenCog.AtomSpace.Env
+                   , OpenCog.AtomSpace.Internal
+                   , OpenCog.AtomSpace.Api
                    , OpenCog.AtomSpace.Types
 
   build-depends:     base         >=4.5

--- a/opencog/haskell/opencog-atomspace.cabal
+++ b/opencog/haskell/opencog-atomspace.cabal
@@ -15,7 +15,6 @@ library
 
   build-depends:     base         >=4.5
                    , transformers >=0.4
-                   , data-default >=0.5
 
   extra-libraries:   haskell-atomspace
 

--- a/opencog/haskell/opencog-atomspace.cabal
+++ b/opencog/haskell/opencog-atomspace.cabal
@@ -14,6 +14,7 @@ library
 
   other-modules:     OpenCog.AtomSpace.Env
                    , OpenCog.AtomSpace.Internal
+                   , OpenCog.AtomSpace.Utils
                    , OpenCog.AtomSpace.Api
                    , OpenCog.AtomSpace.Types
 


### PR DESCRIPTION
Hi,
I have been working on Haskell bindings. I want to make this pull request before going too far.
First, I focused on the Atom data type representation. I have gone in depth in this topic and I have written a summary on the project wiki page with the main ideas: [1](http://wiki.opencog.org/w/Haskell_Bindings_-_GSoC_2015#Atoms_Data)
As I far as I understand, we want to have simple bindings, as similar as possible to the Atom notation described on the OpenCog documents. Also we want to take advantage of Haskell type system to impose type restrictions in how atoms relates between them, implemented as an EDSL.
I investigated the main design options available, their advantages/disadvantages, in order to have a clear idea about which is the best. On the wiki page, I explain more on this, the posibility of using template haskell, etc.
On the branch: [data-options](https://github.com/MarcosPividori/atomspace/tree/data-options/opencog/haskell/api_options) I implement 4 different options for the data type representation and I explain their advantage/disadvantages. It looks like the best option is to work with GADTs, so I went in that direction.
On the other hand, I also worked improving the API, with 3 new main functions to interact with the atomspace: insert, remove and get (and a debug function to print the atomspace on stderr). Also, I offer a util function printAtom to show a given atom in opencog notation. I updated the examples with this new interface.
Every comment/ review is welcome!
Thanks,
Marcos