### PR TITLE
BackwardChainer: minor update

### DIFF
--- a/opencog/rule-engine/backwardchainer/BackwardChainer.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.cc
@@ -37,7 +37,7 @@
 using namespace opencog;
 
 BackwardChainer::BackwardChainer(AtomSpace& as, Handle rbs)
-	: _as(as), _rbs(rbs), _configReader(as, rbs),
+	: _as(as), _configReader(as, rbs),
 	  // create a garbage superspace with _as as parent, so codes acting on
 	  // _garbage will see stuff in _as, but codes acting on _as will not
 	  // see stuff in _garbage
@@ -371,7 +371,7 @@ void BackwardChainer::process_target(Target& target)
 			VarMap& m = vm_list.at(i);
 
 			logger().debug("[BackwardChainer] Checking possible permises grounding "
-						   + g->toShortString());
+			               + g->toShortString());
 
 			FindAtoms fv(VARIABLE_NODE);
 			fv.search_set(g);

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.h
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.h
@@ -124,7 +124,6 @@ private:
 	                       std::set<Handle> additional_free_varset);
 
 	AtomSpace& _as;
-	Handle _rbs;                // rule-based system
 	UREConfigReader _configReader;
 	AtomSpace _garbage_superspace;
 	Handle _init_target;

--- a/opencog/rule-engine/backwardchainer/BackwardChainerPMCB.h
+++ b/opencog/rule-engine/backwardchainer/BackwardChainerPMCB.h
@@ -37,7 +37,7 @@ class BackwardChainerPMCB :
 protected:
 	AtomSpace* _as;
 	VariableListPtr _int_vars;
-	bool _reverse_node_match;
+	bool _reverse_enabled;
 
 	std::vector<std::map<Handle, Handle>> var_solns_;
 	std::vector<std::map<Handle, Handle>> pred_solns_;
@@ -46,6 +46,7 @@ public:
 	BackwardChainerPMCB(AtomSpace*, VariableListPtr, bool reverse = false);
 	virtual ~BackwardChainerPMCB();
 
+	virtual bool initiate_search(PatternMatchEngine*);
 	virtual void set_pattern(const Variables& vars,
 	                         const Pattern& pat)
 	{
@@ -54,6 +55,7 @@ public:
 	}
 
 	virtual bool node_match(const Handle&, const Handle&);
+	virtual bool fuzzy_match(const Handle&, const Handle&);
 	virtual bool grounding(const std::map<Handle, Handle> &var_soln,
 			const std::map<Handle, Handle> &pred_soln);
 

--- a/opencog/rule-engine/backwardchainer/Target.cc
+++ b/opencog/rule-engine/backwardchainer/Target.cc
@@ -46,7 +46,8 @@ Target::Target(AtomSpace* as, const Handle& h)
 
 	_vars = get_free_vars_in_tree(h);
 
-	for (auto hv : _vars)
+	// _varmap is a map that bases on the external space
+	for (auto& hv : _vars)
 		_varmap[hv] = UnorderedHandleSet();
 }
 

--- a/tests/rule-engine/BackwardChainerUTest.cxxtest
+++ b/tests/rule-engine/BackwardChainerUTest.cxxtest
@@ -263,7 +263,7 @@ void BackwardChainerUTest::test_tvq_impossible_bc()
 	load_scm_files_from_config(as_);
 
 	// load modus ponens
-	Handle top_rbs = as_.addNode(CONCEPT_NODE, UREConfigReader::URE_top_name);
+	Handle top_rbs = as_.addNode(CONCEPT_NODE, UREConfigReader::top_rbs_name);
 	BackwardChainer bc(as_, top_rbs);
 
 	// negative test, BC should not modify the TV of this impossible target
@@ -275,7 +275,7 @@ void BackwardChainerUTest::test_tvq_impossible_bc()
 	// modify the TV
 	Handle hidden = eval_.eval_h("(InheritanceLink (stv 0.0 0.0)"
 	                             "   (ConceptNode \"Fritz\")"
-	                             "   (ConceptNode \"green\"))");
+	                             "   (ConceptNode \"Frog\"))");
 
 	bc.set_target(target);
 	bc.get_config().set_maximum_iterations(300);

--- a/tests/rule-engine/BackwardChainerUTest.cxxtest
+++ b/tests/rule-engine/BackwardChainerUTest.cxxtest
@@ -264,9 +264,7 @@ void BackwardChainerUTest::test_tvq_impossible_bc()
 
 	// load modus ponens
 	Handle top_rbs = as_.addNode(CONCEPT_NODE, UREConfigReader::URE_top_name);
-	UREConfigReader config_reader(as_, top_rbs);
-
-	BackwardChainer bc(&as_, config_reader.get_rules());
+	BackwardChainer bc(as_, top_rbs);
 
 	// negative test, BC should not modify the TV of this impossible target
 	Handle target = eval_.eval_h("(InheritanceLink (stv 0.0 0.0)"
@@ -280,7 +278,8 @@ void BackwardChainerUTest::test_tvq_impossible_bc()
 	                             "   (ConceptNode \"green\"))");
 
 	bc.set_target(target);
-	bc.do_until(100);
+	bc.get_config().set_maximum_iterations(300);
+	bc.do_chain();
 
 	TSM_ASSERT("Incorrect strength of target after BC!", target->getTruthValue()->getMean() < 0.1f);
 	TSM_ASSERT("Incorrect confidence of target after BC!", target->getTruthValue()->getConfidence() < 0.1f);

--- a/tests/rule-engine/BackwardChainerUTest.cxxtest
+++ b/tests/rule-engine/BackwardChainerUTest.cxxtest
@@ -260,24 +260,24 @@ void BackwardChainerUTest::test_tvq_impossible_bc()
 	config().set("SCM_PRELOAD",
 	             "tests/rule-engine/bc-config-1.scm,"
 	             "tests/rule-engine/bc-example.scm");
-	load_scm_files_from_config(*as_);
+	load_scm_files_from_config(as_);
 
 	// load modus ponens
-	Handle top_rbs = as_->addNode(CONCEPT_NODE, UREConfigReader::URE_top_name);
-	UREConfigReader config_reader(*as_, top_rbs);
+	Handle top_rbs = as_.addNode(CONCEPT_NODE, UREConfigReader::URE_top_name);
+	UREConfigReader config_reader(as_, top_rbs);
 
-	BackwardChainer bc(as_, config_reader.get_rules());
+	BackwardChainer bc(&as_, config_reader.get_rules());
 
 	// negative test, BC should not modify the TV of this impossible target
-	Handle target = eval_->eval_h("(InheritanceLink (stv 0.0 0.0)"
-	                              "   (ConceptNode \"RandomName\")"
-	                              "   (ConceptNode \"green\"))");
+	Handle target = eval_.eval_h("(InheritanceLink (stv 0.0 0.0)"
+	                             "   (ConceptNode \"RandomName\")"
+	                             "   (ConceptNode \"green\"))");
 
 	// this is not the target, but the inference path should still actually
 	// modify the TV
-	Handle hidden = eval_->eval_h("(InheritanceLink (stv 0.0 0.0)"
-	                              "   (ConceptNode \"Fritz\")"
-	                              "   (ConceptNode \"green\"))");
+	Handle hidden = eval_.eval_h("(InheritanceLink (stv 0.0 0.0)"
+	                             "   (ConceptNode \"Fritz\")"
+	                             "   (ConceptNode \"green\"))");
 
 	bc.set_target(target);
 	bc.do_until(100);

--- a/tests/rule-engine/BackwardChainerUTest.cxxtest
+++ b/tests/rule-engine/BackwardChainerUTest.cxxtest
@@ -37,6 +37,7 @@ public:
 	void test_2rules_bc();
 
 	void test_tvq_bc();
+	void test_tvq_impossible_bc();
 };
 
 void BackwardChainerUTest::setUp()
@@ -251,3 +252,41 @@ void BackwardChainerUTest::test_tvq_bc()
 
 	logger().debug("END TEST: %s", __FUNCTION__);
 }
+
+void BackwardChainerUTest::test_tvq_impossible_bc()
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	config().set("SCM_PRELOAD",
+	             "tests/rule-engine/bc-config-1.scm,"
+	             "tests/rule-engine/bc-example.scm");
+	load_scm_files_from_config(*as_);
+
+	// load modus ponens
+	Handle top_rbs = as_->addNode(CONCEPT_NODE, UREConfigReader::URE_top_name);
+	UREConfigReader config_reader(*as_, top_rbs);
+
+	BackwardChainer bc(as_, config_reader.get_rules());
+
+	// negative test, BC should not modify the TV of this impossible target
+	Handle target = eval_->eval_h("(InheritanceLink (stv 0.0 0.0)"
+	                              "   (ConceptNode \"RandomName\")"
+	                              "   (ConceptNode \"green\"))");
+
+	// this is not the target, but the inference path should still actually
+	// modify the TV
+	Handle hidden = eval_->eval_h("(InheritanceLink (stv 0.0 0.0)"
+	                              "   (ConceptNode \"Fritz\")"
+	                              "   (ConceptNode \"green\"))");
+
+	bc.set_target(target);
+	bc.do_until(100);
+
+	TSM_ASSERT("Incorrect strength of target after BC!", target->getTruthValue()->getMean() < 0.1f);
+	TSM_ASSERT("Incorrect confidence of target after BC!", target->getTruthValue()->getConfidence() < 0.1f);
+	TSM_ASSERT("Incorrect strength of sub-target after BC!", hidden->getTruthValue()->getMean() > 0.9f);
+	TSM_ASSERT("Incorrect confidence of sub-target after BC!", hidden->getTruthValue()->getConfidence() > 0.9f);
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+


### PR DESCRIPTION
* changed the initiate_search to skip neighbor_search in some case, to allow any link/node to match to VariableNode
* added a unit test that needed the above

I could think of an alternative solution where instead of allowing link/node to match to VariableNode so that Truth Value Query will get to additional Variable Fullfillment Query, allow an additional missing step in the backward chainer design:
* when no premise can be found to match a rule's modified input (modified to partially grounded to target output), make the modified rule's input new targets