### PR TITLE
add function to refresh non-core types in py

### DIFF
--- a/opencog/cython/opencog/classserver.pyx
+++ b/opencog/cython/opencog/classserver.pyx
@@ -53,5 +53,11 @@ cdef generate_type_module():
         types[s.c_str()] = i
     types["NO_TYPE"] = NOTYPE
     return types
-
 types = type('atom_types', (), generate_type_module())
+
+#This function is for refreshing new types
+#ex. When you import a cython module which include non-core atom types in C++ 
+#And you can refresh these new types by this function
+
+def get_refreshed_types():    
+    return type('atom_types', (), generate_type_module())


### PR DESCRIPTION
the get_refreshed_types() is for such a situation: We import a cython module which invokes atom_types.inheritance to call classserver to add atom types. Then we want to use atom types in these modules(ex.spacetime/nlp/...). At this time we can use this function to call the type generator again and get new types object.