### PR TITLE
Fix python doc

### DIFF
--- a/opencog/cython/README.md
+++ b/opencog/cython/README.md
@@ -58,7 +58,7 @@ Here's how to add a node:
 To make things more succinct when referring to types, you can
 alias stuff:
 
-```
+```python
 >>> t=types
 >>> a.add_node(t.ConceptNode, "Ah, more concise")
 >>> ConceptNode = t.ConceptNode
@@ -69,18 +69,18 @@ You'll notice these return opencog.atomspace.Atom objects, which
 internally store a Handle with a UUID and the AtomSpace it's
 connected to:
 
-<source lang="python">
+```python
 >>> atom = a.add_node(ConceptNode, "handle bar")
 >>> str(atom.h)
 '<UUID:4>'
 >>> atom.atomspace
 <opencog.atomspace.AtomSpace object at 0x203220a>
-</source>
+```
 
 Or you may get a different UUID. The atom will fetch and cache information
 about itself behind the scenes.
 
-<source lang="python">
+```python
 >>> str(an_atom)
 'node[ConceptNode:handle bar]'
 >>> an_atom.long_string()
@@ -91,51 +91,51 @@ about itself behind the scenes.
 '3'
 >>> an_atom.type_name
 'ConceptNode'
-</source>
+```
 
 Note that on the second reference to an_atom.t, it won't recheck the
 AtomSpace for the atom type because it's immutable and gets cached
 internally. If you try to set an immutable property of an Atom, you
 get an AttributeError exception:
 
-<source lang="python">
+```python
 >>> an_atom.name = 'change your name man, it sucks.'
 AttributeError: attribute 'name' of 'opencog.atomspace.Atom' objects is not writable
-</source>
+```
 
 I guess the 'handle bar' Atom is stuck with it's amusing but
 unfortunate name.
 
 Lets create our first link:
 
-<source lang="python">
+```python
 >>> n1 = a.add_node(t.ConceptNode, "I can refer to this atom now")
 >>> n2 = a.add_node(t.ConceptNode, "this one too")
 >>> l = a.add_link(t.SimilarityLink, [n1,n2])
 >>> l.out
 [Atom(Handle(5),<opencog.atomspace.AtomSpace object at 0x203220a>),
  Atom(Handle(6),<opencog.atomspace.AtomSpace object at 0x203220a>)]
-</source>
+```
 
 Up until now we've ignored [[Truthvalues]]. The TruthValue
 implementation is not entirely complete. Currently the bindings only
 support "[[SimpleTruthValues]]", since these are the most frequently used.
 
-<source lang="python">
+```python
 >>> from opencog.atomspace import TruthValue
 >>> alink.tv
 '[0.000000,0.000000=0.000000]'
 >>> alink.tv = TruthValue(0.5,0.1)
 >>> alink
 '[SimilarityLink <I can refer to this atom now,this one too> 0.500000 0.200000]'
-</source>
+```
 
 Next up is queries to the AtomSpace. What if we want to iterate over
 all the ConceptNodes we've added so far? Most of the AtomSpace
 getHandleSet methods have been wrapped and also have more descriptive
 names for each variant.
 
-<source lang="python">
+```python
 >>> my_nodes = a.get_atoms_by_type(t.ConceptNode)
 >>> my_nodes
 [Atom(Handle(6),<opencog.atomspace.AtomSpace object at 0x203220a>),
@@ -144,18 +144,18 @@ names for each variant.
  Atom(Handle(3),<opencog.atomspace.AtomSpace object at 0x203220a>),
  Atom(Handle(2),<opencog.atomspace.AtomSpace object at 0x203220a>),
  Atom(Handle(1),<opencog.atomspace.AtomSpace object at 0x203220a>)]
-</source>
+```
 
 By default, subtypes are also retrieved, but we can exclude subtypes
 if we want to be specific.
 
-<source lang="python">
+```python
 >>> a.add_node(t.Node, "I am the one true Node")
 >>> a.get_atoms_by_type(t.Node,subtype=False)
 [Atom(Handle(8),<opencog.atomspace.AtomSpace object at 0x203220a>)]
 >>> print my_specific_nodes[0]
 node[Node:I am the one true Node]
-</source>
+```
 
 There are other queries by type, outgoing set, name etc. See
 `tests/opencog/cython/test_atomspace.py` for the complete picture.
@@ -163,19 +163,19 @@ There are other queries by type, outgoing set, name etc. See
 Note: You can also now use the AtomSpace.add() method which automatically
 determines and checks the required arguments for the type:
 
-<source lang="python">
+```python
 >>> a1 = a.add(t.Node, name="Easier this way")
 >>> a2 = a.add(t.Node, name=".. much easier")
 >>> a.add(t.Link, out=[a1,a2])
 Atom(Handle(11),<opencog.atomspace.AtomSpace object at 0x203220a>)
-</source>
+```
 
 #### The AtomSpace as a container ####
 
 The AtomSpace supports the container methods Python expects for
 a container-like object:
 
-<source lang="python">
+```python
 >>> alink in a    # is this atom in this atomspace
 True
 >>> h in a        # works for handles too
@@ -185,4 +185,4 @@ True
 >>> a[h]          # using [] notation, returns the Atom, or IndexError exception
                   # if handle not in AtomSpace
 Atom(Handle(4),<opencog.atomspace.AtomSpace object at 0x14b2918>)
-</source>
+```

--- a/opencog/cython/README.md
+++ b/opencog/cython/README.md
@@ -1,7 +1,7 @@
 Python bindings for OpenCog
 ---------------------------
 
-== Requirements ==
+## Requirements ##
 
 * Python 2.7 - these bindings may work with earlier versions, but they have not been tested at all.
 * Cython 0.14 or later. http://www.cython.org/
@@ -22,13 +22,13 @@ Currently the package structure looks like this:
  opencog.atomspace.types
  opencog.scheme_wrapper
 
-== Tutorial ==
+## Tutorial ##
 
 This tutorial is a first look at the Python bindings. It assumes that
 you've got a good grasp on the concept of the AtomSpace and the
 CogServer. Oh, and it helps to know a bit of Python too!
 
-=== Setting up ===
+### Setting up ###
 
 Go through the normal process of [[building OpenCog]]. Then ensure that
 the OpenCog data directory is in your Python `sys.path`. By
@@ -40,7 +40,7 @@ just want to use your build dir you can use something like:
 
  $ export PYTHONPATH=$PYTHONPATH:/usr/local/share/opencog/python
 
-=== AtomSpace API ===
+### AtomSpace API ###
 
 These bindings let you interact and instantiate [[Atom]]s interactively.
 The [http://ipython.scipy.org/ IPython] shell is recommended.
@@ -170,7 +170,7 @@ determines and checks the required arguments for the type:
 Atom(Handle(11),<opencog.atomspace.AtomSpace object at 0x203220a>)
 </source>
 
-==== The AtomSpace as a container ====
+#### The AtomSpace as a container ####
 
 The AtomSpace supports the container methods Python expects for
 a container-like object:

--- a/opencog/cython/README.md
+++ b/opencog/cython/README.md
@@ -47,23 +47,23 @@ The [http://ipython.scipy.org/ IPython] shell is recommended.
 
 Here's how to add a node:
 
-<source lang="python">
+```python
 >>> from opencog.atomspace import AtomSpace, types
 
 >>> a = AtomSpace()
 >>> a.add_node(types.ConceptNode, "My first python created node")
 <opencog.atomspace.Atom object at 0x203fa80>
-</source>
+```
 
 To make things more succinct when referring to types, you can
 alias stuff:
 
-<source lang="python">
+```
 >>> t=types
 >>> a.add_node(t.ConceptNode, "Ah, more concise")
 >>> ConceptNode = t.ConceptNode
 >>> a.add_node(ConceptNode, "Ah, a bit more concise")
-</source>
+```
 
 You'll notice these return opencog.atomspace.Atom objects, which
 internally store a Handle with a UUID and the AtomSpace it's

--- a/opencog/python/README.md
+++ b/opencog/python/README.md
@@ -1,19 +1,14 @@
 Using Python with the AtomSpace
 ===============================
 
-Add these lines to the end of your ~/.bashrc file:
-```
-PYTHONPATH="$PYTHONPATH:/usr/local/share/opencog/python"
-export PYTHONPATH
-```
+#### Installation and Usage
 
-Install the required dependencies:
-```
-cd ~/opencog/opencog/python
-sudo pip install -r requirements.txt --upgrade
-```
+See [Python's Cython Bindings](../cython/README.md) for detailed
+instructions.
 
 #### Client API
 
-Once the instructions above have been performed, you can run Python scripts found in the ```~/opencog/opencog/python``` folder, and you can also download and use the Python Client API available here:
+Once the instructions above have been performed, you can run Python
+scripts found in the ```~/opencog/opencog/python``` folder, and you
+can also download and use the Python Client API available here:
 https://github.com/opencog/python-client

--- a/opencog/python/README.md
+++ b/opencog/python/README.md
@@ -3,7 +3,7 @@ Using Python with the AtomSpace
 
 Add these lines to the end of your ~/.bashrc file:
 ```
-PYTHONPATH="$PYTHONPATH:/usr/local/share/opencog/python
+PYTHONPATH="$PYTHONPATH:/usr/local/share/opencog/python"
 export PYTHONPATH
 ```
 


### PR DESCRIPTION
Partially addresses issue #137 

I'm think my changes are consistent with the state of the code. However I don't know if the requirements.txt file should be moved from the opencog repo to the atomspace repo (and the pip install instruction put back) instead.