### PR TITLE
EinsteinUTest optimisation by thinnest clause selection in pattern matcher (#86)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,8 +214,8 @@ FIND_LIBRARY(GMP_LIBRARY gmp)
 FIND_PATH(GMP_INCLUDE_DIR gmp.h)
 
 # Gnu Guile scheme interpreter
-# Version 2.0.0 is needed for mrs io ports, compilation, etc.
-FIND_PACKAGE(Guile 2.0.0)
+# Version 2.0.9 is needed for mrs io ports, compilation, etc.
+FIND_PACKAGE(Guile 2.0.9)
 IF (GUILE_FOUND AND GMP_LIBRARY AND GMP_INCLUDE_DIR)
 	ADD_DEFINITIONS(-DHAVE_GUILE)
 	SET(HAVE_GUILE 1)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ be built and run.
 > http://cxxtest.sourceforge.net/ | https://launchpad.net/~opencog-dev/+archive/ppa
 
 ###### guile
-> Embedded scheme interpreter (version 2.0.0 or newer is required)
+> Embedded scheme interpreter (version 2.0.9 or newer is required)
 > http://www.gnu.org/software/guile/guile.html | guile-2.0-dev
 
 ###### libgsl

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -850,7 +850,7 @@ bool PatternMatchEngine::tree_compare(const Handle& hp,
 
 	// If the two links are both ordered, its enough to compare
 	// them "side-by-side".
-	if (_classserver.isA(tp, ORDERED_LINK))
+	if (2 > lp->getArity() || _classserver.isA(tp, ORDERED_LINK))
 		return ordered_compare(hp, hg, lp, lg);
 
 	// If we are here, we are dealing with an unordered link.

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -353,7 +353,7 @@ bool PatternMatchEngine::choice_compare(const Handle& hp,
 			if (match)
 			{
 				// Even the stack, *without* erasing the discovered grounding.
-				var_solutn_stack.pop();
+				solution_drop();
 
 				// If the grounding is accepted, record it.
 				if (hp != hg) var_grounding[hp] = hg;
@@ -632,7 +632,7 @@ bool PatternMatchEngine::unorder_compare(const Handle& hp,
 			if (match)
 			{
 				// Even the stack, *without* erasing the discovered grounding.
-				var_solutn_stack.pop();
+				solution_drop();
 
 				// If the grounding is accepted, record it.
 				if (hp != hg) var_grounding[hp] = hg;
@@ -1341,7 +1341,10 @@ bool PatternMatchEngine::do_next_clause(void)
 			Handle undef(Handle::UNDEFINED);
 			bool match = _pmc.optional_clause_match(joiner, undef);
 			dbgprt ("Exhausted search for optional clause, cb=%d\n", match);
-			if (not match) return false;
+			if (not match) {
+				clause_stacks_pop();
+				return false;
+			}
 
 			// XXX Maybe should push n pop here? No, maybe not ...
 			clause_grounding[curr_root] = Handle::UNDEFINED;
@@ -1673,6 +1676,12 @@ void PatternMatchEngine::solution_pop(void)
 {
 	POPSTK(var_solutn_stack, var_grounding);
 	POPSTK(term_solutn_stack, clause_grounding);
+}
+
+void PatternMatchEngine::solution_drop(void)
+{
+	var_solutn_stack.pop();
+	term_solutn_stack.pop();
 }
 
 /* ======================================================== */

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1416,15 +1416,15 @@ void PatternMatchEngine::get_next_untried_clause(void)
 {
 	// First, try to ground all the mandatory clauses, only.
 	// no virtuals, no black boxes, no optionals.
-	if (get_next_untried_helper(false, false, false)) return;
+	if (gen_next_thinnest_clause(false, false, false)) return;
 
 	// Don't bother looking for evaluatables if they are not there.
 	if (not _pat->evaluatable_holders.empty())
 	{
-		if (get_next_untried_helper(true, false, false)) return;
+		if (gen_next_thinnest_clause(true, false, false)) return;
 		if (not _pat->black.empty())
 		{
-			if (get_next_untried_helper(true, true, false)) return;
+			if (gen_next_thinnest_clause(true, true, false)) return;
 		}
 	}
 
@@ -1438,13 +1438,13 @@ void PatternMatchEngine::get_next_untried_clause(void)
 	}
 
 	// Try again, this time, considering the optional clauses.
-	if (get_next_untried_helper(false, false, true)) return;
+	if (gen_next_thinnest_clause(false, false, true)) return;
 	if (not _pat->evaluatable_holders.empty())
 	{
-		if (get_next_untried_helper(true, false, true)) return;
+		if (gen_next_thinnest_clause(true, false, true)) return;
 		if (not _pat->black.empty())
 		{
-			if (get_next_untried_helper(true, true, true)) return;
+			if (gen_next_thinnest_clause(true, true, true)) return;
 		}
 	}
 
@@ -1494,9 +1494,9 @@ unsigned int PatternMatchEngine::thickness(const Handle& clause,
 /// clauses are considered.
 ///
 /// Return true if we found the next ungrounded clause.
-bool PatternMatchEngine::get_next_untried_helper(bool search_virtual,
-                                                 bool search_black,
-                                                 bool search_optionals)
+bool PatternMatchEngine::gen_next_thinnest_clause(bool search_virtual,
+                                                  bool search_black,
+                                                  bool search_optionals)
 {
 	// Search for an as-yet ungrounded clause. Search for required
 	// clauses first; then, only if none of those are left, move on
@@ -1505,43 +1505,49 @@ bool PatternMatchEngine::get_next_untried_helper(bool search_virtual,
 	// the root is grounded.  If its not, start working on that.
 	Handle joint(Handle::UNDEFINED);
 	Handle unsolved_clause(Handle::UNDEFINED);
+	unsigned int thinnest_joint = UINT_MAX;
+	unsigned int thinnest_clause = UINT_MAX;
 	bool unsolved = false;
-	unsigned int thinnest = UINT_MAX;
 
 	// Make a list of the as-yet ungrounded variables.
-	std::set<Handle> undead;
-	for (const Handle &v : _varlist->varseq)
+	std::set<Handle> ungrounded_vars;
+
+	// Grounded variables ordered by the size of their grounding incoming set
+	std::multimap<std::size_t, Handle> thick_vars;
+
+	for (const Handle &v : _varlist->varset)
 	{
-		try { var_grounding.at(v); }
-		catch(...) { undead.insert(v); }
+		try {
+			const Handle& gnd = var_grounding.at(v);
+			if (Handle::UNDEFINED != gnd)
+			{
+				std::size_t incoming_set_size = gnd->getIncomingSetSize();
+				thick_vars.insert(std::make_pair(incoming_set_size, v));
+			}
+			else ungrounded_vars.insert(v);
+		}
+		catch(...) { ungrounded_vars.insert(v); }
 	}
+
+	OC_ASSERT(0 < thick_vars.size(), "Empty set of grounded variables");
 
 	// We are looking for a joining atom, one that is shared in common
 	// with the a fully grounded clause, and an as-yet ungrounded clause.
 	// The joint is called "pursue", and the unsolved clause that it
-	// joins will become our next untried clause.  Note that the join
-	// is not necessarily a variable; it could be a constant atom.
-	// (wouldn't things be faster if they were variables only, that
-	// joined?) the problem is that var_grounding stores both grounded
-	// variables and "grounded" constants.
-#define OLD_LOOP
-#ifdef OLD_LOOP
-	for (const Pattern::ConnectPair& vk : _pat->connectivity_map)
+	// joins will become our next untried clause. We choose joining atom
+	// with smallest size of its incoming set. If there are many such
+	// atoms we choose one from clauses with minimal number of ungrounded
+	// yet variables.
+	for (auto tckvar : thick_vars)
 	{
-		const Pattern::RootList& rl(vk.second);
-		const Handle& pursue = vk.first;
-		try { var_grounding.at(pursue); }
-		catch (...) { continue; }
-#else // OLD_LOOP
-	// Newloop might be slightly faster than old loop.
-	// ... but maybe not...
-	for (auto gndpair : var_grounding)
-	{
-		const Handle& pursue = gndpair.first;
+		std::size_t pursue_thickness = tckvar.first;
+		const Handle& pursue = tckvar.second;
+
+		if (pursue_thickness > thinnest_joint) break;
+
 		try { _pat->connectivity_map.at(pursue); }
 		catch(...) { continue; }
-		const RootList& rl(_pat->connectivity_map.at(pursue));
-#endif
+		const Pattern::RootList& rl(_pat->connectivity_map.at(pursue));
 
 		for (const Handle& root : rl)
 		{
@@ -1550,19 +1556,17 @@ bool PatternMatchEngine::get_next_untried_helper(bool search_virtual,
 			        and (search_black or not is_black(root))
 			        and (search_optionals or not is_optional(root)))
 			{
-				unsigned int th = thickness(root, undead);
-				if (th < thinnest)
+				unsigned int root_thickness = thickness(root, ungrounded_vars);
+				if (root_thickness < thinnest_clause)
 				{
-					thinnest = th;
+					thinnest_clause = root_thickness;
+					thinnest_joint = pursue_thickness;
 					unsolved_clause = root;
 					joint = pursue;
 					unsolved = true;
 				}
 			}
-			if (unsolved and thinnest < 2) break;
 		}
-
-		if (unsolved and thinnest < 2) break;
 	}
 
 	if (unsolved)

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1416,15 +1416,15 @@ void PatternMatchEngine::get_next_untried_clause(void)
 {
 	// First, try to ground all the mandatory clauses, only.
 	// no virtuals, no black boxes, no optionals.
-	if (gen_next_thinnest_clause(false, false, false)) return;
+	if (get_next_thinnest_clause(false, false, false)) return;
 
 	// Don't bother looking for evaluatables if they are not there.
 	if (not _pat->evaluatable_holders.empty())
 	{
-		if (gen_next_thinnest_clause(true, false, false)) return;
+		if (get_next_thinnest_clause(true, false, false)) return;
 		if (not _pat->black.empty())
 		{
-			if (gen_next_thinnest_clause(true, true, false)) return;
+			if (get_next_thinnest_clause(true, true, false)) return;
 		}
 	}
 
@@ -1438,13 +1438,13 @@ void PatternMatchEngine::get_next_untried_clause(void)
 	}
 
 	// Try again, this time, considering the optional clauses.
-	if (gen_next_thinnest_clause(false, false, true)) return;
+	if (get_next_thinnest_clause(false, false, true)) return;
 	if (not _pat->evaluatable_holders.empty())
 	{
-		if (gen_next_thinnest_clause(true, false, true)) return;
+		if (get_next_thinnest_clause(true, false, true)) return;
 		if (not _pat->black.empty())
 		{
-			if (gen_next_thinnest_clause(true, true, true)) return;
+			if (get_next_thinnest_clause(true, true, true)) return;
 		}
 	}
 
@@ -1494,7 +1494,7 @@ unsigned int PatternMatchEngine::thickness(const Handle& clause,
 /// clauses are considered.
 ///
 /// Return true if we found the next ungrounded clause.
-bool PatternMatchEngine::gen_next_thinnest_clause(bool search_virtual,
+bool PatternMatchEngine::get_next_thinnest_clause(bool search_virtual,
                                                   bool search_black,
                                                   bool search_optionals)
 {

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -132,7 +132,7 @@ class PatternMatchEngine
 		bool do_next_clause(void);
 		bool clause_accepted;
 		void get_next_untried_clause(void);
-		bool gen_next_thinnest_clause(bool, bool, bool);
+		bool get_next_thinnest_clause(bool, bool, bool);
 		unsigned int thickness(const Handle&, const std::set<Handle>&);
 		Handle next_clause;
 		Handle next_joint;

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -148,6 +148,7 @@ class PatternMatchEngine
 		// traversal of that clause, where it was last left off.
 		void solution_push(void);
 		void solution_pop(void);
+		void solution_drop(void);
 
 		// Stacks containing partial groundings.
 		typedef std::map<Handle, Handle> SolnMap;

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -132,7 +132,7 @@ class PatternMatchEngine
 		bool do_next_clause(void);
 		bool clause_accepted;
 		void get_next_untried_clause(void);
-		bool get_next_untried_helper(bool, bool, bool);
+		bool gen_next_thinnest_clause(bool, bool, bool);
 		unsigned int thickness(const Handle&, const std::set<Handle>&);
 		Handle next_clause;
 		Handle next_joint;


### PR DESCRIPTION
I have added the first optimization discussed here (#86). Pattern matcher chooses the next joint of clauses as the one with smallest incoming set. If there are many clauses for the same joint then the clause with minimal number of ungrounded variables is selected. This solves the problem with EinsteinUTest running time as well as speeds up other unit tests a little.

I have also found and "fixed" following problems.

1. Weird behaviour of guile 2.0.5, that seemed like concurrent changes in PatternLink/BindLink object constructors. When I changed to guile 2.0.9 it all disappeared. There is also similar comment in the code:
https://github.com/opencog/atomspace/blob/master/opencog/guile/SchemeEval.cc#L239.
So I think it is better to increase required guile versions in CMakeLists to help next persons avoid
such issues.

2. A bug in matching NotLink. This kind of link is unordered but it has only one outgoing atom. There is something wrong in the procedure comparing unordered links. It is randomly missing some search branches. Randomly because incoming sets are ordered by pointers. I have changed comparison of single arity links to work as simple ordered links. I am not sure if it fixes other cases but it solves EinsteinUTest.
