### PR TITLE
Removed assertion for not empty variables list in PM

### DIFF
--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1529,8 +1529,6 @@ bool PatternMatchEngine::get_next_thinnest_clause(bool search_virtual,
 		catch(...) { ungrounded_vars.insert(v); }
 	}
 
-	OC_ASSERT(0 < thick_vars.size(), "Empty set of grounded variables");
-
 	// We are looking for a joining atom, one that is shared in common
 	// with the a fully grounded clause, and an as-yet ungrounded clause.
 	// The joint is called "pursue", and the unsolved clause that it


### PR DESCRIPTION
Yeah, I see it now. The empty variables list assertion should be removed.
```
[100%] Running tests...
Test project /home/jacek/github/atomspace/build/tests
      Start  1: AtomTableUTest
 1/77 Test  #1: AtomTableUTest ...................   Passed    1.28 sec
      Start  2: ClassServerUTest
 2/77 Test  #2: ClassServerUTest .................   Passed    0.07 sec
      Start  3: AtomUTest
 3/77 Test  #3: AtomUTest ........................   Passed    0.07 sec
      Start  4: NodeUTest
 4/77 Test  #4: NodeUTest ........................   Passed    0.07 sec
      Start  5: LinkUTest
 5/77 Test  #5: LinkUTest ........................   Passed    0.06 sec
      Start  6: SimpleTruthValueUTest
 6/77 Test  #6: SimpleTruthValueUTest ............   Passed    0.07 sec
      Start  7: IndefiniteTruthValueUTest
 7/77 Test  #7: IndefiniteTruthValueUTest ........   Passed    0.10 sec
      Start  8: TVMergeUTest
 8/77 Test  #8: TVMergeUTest .....................   Passed    0.06 sec
      Start  9: AttentionValueUTest
 9/77 Test  #9: AttentionValueUTest ..............   Passed    0.07 sec
      Start 10: TLBUTest
10/77 Test #10: TLBUTest .........................   Passed    0.06 sec
      Start 11: AtomSpaceUTest
11/77 Test #11: AtomSpaceUTest ...................   Passed    0.08 sec
      Start 12: AtomSpaceImplUTest
12/77 Test #12: AtomSpaceImplUTest ...............   Passed    0.08 sec
      Start 13: AtomSpaceAsyncUTest
13/77 Test #13: AtomSpaceAsyncUTest ..............   Passed   14.74 sec
      Start 14: UseCountUTest
14/77 Test #14: UseCountUTest ....................   Passed   20.89 sec
      Start 15: MultiSpaceUTest
15/77 Test #15: MultiSpaceUTest ..................   Passed    0.09 sec
      Start 16: RemoveUTest
16/77 Test #16: RemoveUTest ......................   Passed    0.08 sec
      Start 17: HandleMapUTest
17/77 Test #17: HandleMapUTest ...................   Passed    0.55 sec
      Start 18: AssignUTest
18/77 Test #18: AssignUTest ......................   Passed    0.11 sec
      Start 19: ReductUTest
19/77 Test #19: ReductUTest ......................   Passed    0.61 sec
      Start 20: AtomUtilsUTest
20/77 Test #20: AtomUtilsUTest ...................   Passed    0.07 sec
      Start 21: BasicSCMUTest
21/77 Test #21: BasicSCMUTest ....................   Passed    0.21 sec
      Start 22: SCMPrimitiveUTest
22/77 Test #22: SCMPrimitiveUTest ................   Passed    1.46 sec
      Start 23: MultiAtomSpaceUTest
23/77 Test #23: MultiAtomSpaceUTest ..............   Passed    0.49 sec
      Start 24: MultiThreadUTest
24/77 Test #24: MultiThreadUTest .................   Passed   25.38 sec
      Start 25: SCMUtilsUTest
25/77 Test #25: SCMUtilsUTest ....................   Passed    0.19 sec
      Start 26: SCMExecutionOutputUTest
26/77 Test #26: SCMExecutionOutputUTest ..........   Passed    0.60 sec
      Start 27: PatternUTest
27/77 Test #27: PatternUTest .....................   Passed    0.08 sec
      Start 28: PatternCrashUTest
28/77 Test #28: PatternCrashUTest ................   Passed    0.21 sec
      Start 29: StackUTest
29/77 Test #29: StackUTest .......................   Passed    0.05 sec
      Start 30: BigPatternUTest
30/77 Test #30: BigPatternUTest ..................   Passed    0.06 sec
      Start 31: BiggerPatternUTest
31/77 Test #31: BiggerPatternUTest ...............   Passed    0.06 sec
      Start 32: LoopPatternUTest
32/77 Test #32: LoopPatternUTest .................   Passed    0.07 sec
      Start 33: BooleanUTest
33/77 Test #33: BooleanUTest .....................   Passed    0.06 sec
      Start 34: Boolean2NotUTest
34/77 Test #34: Boolean2NotUTest .................   Passed    0.07 sec
      Start 35: FuzzyPatternUTest
35/77 Test #35: FuzzyPatternUTest ................   Passed    0.06 sec
      Start 36: DisconnectedUTest
36/77 Test #36: DisconnectedUTest ................   Passed    0.16 sec
      Start 37: ImplicationUTest
37/77 Test #37: ImplicationUTest .................   Passed    0.11 sec
      Start 38: ExecutionOutputUTest
38/77 Test #38: ExecutionOutputUTest .............   Passed    0.11 sec
      Start 39: BuggyStackUTest
39/77 Test #39: BuggyStackUTest ..................   Passed    0.15 sec
      Start 40: VarTypeNotUTest
40/77 Test #40: VarTypeNotUTest ..................   Passed    0.13 sec
      Start 41: BuggyNotUTest
41/77 Test #41: BuggyNotUTest ....................   Passed    0.13 sec
      Start 42: MatchLinkUTest
42/77 Test #42: MatchLinkUTest ...................   Passed    0.12 sec
      Start 43: UnorderedUTest
43/77 Test #43: UnorderedUTest ...................   Passed    0.27 sec
      Start 44: StackMoreUTest
44/77 Test #44: StackMoreUTest ...................   Passed    0.59 sec
      Start 45: ArcanaUTest
45/77 Test #45: ArcanaUTest ......................   Passed    0.19 sec
      Start 46: SubstitutionUTest
46/77 Test #46: SubstitutionUTest ................   Passed    0.22 sec
      Start 47: GetLinkUTest
47/77 Test #47: GetLinkUTest .....................   Passed    0.21 sec
      Start 48: GreaterThanUTest
48/77 Test #48: GreaterThanUTest .................   Passed    0.26 sec
      Start 49: GreaterComputeUTest
49/77 Test #49: GreaterComputeUTest ..............   Passed    0.17 sec
      Start 50: SequenceUTest
50/77 Test #50: SequenceUTest ....................   Passed    0.21 sec
      Start 51: EvaluationUTest
51/77 Test #51: EvaluationUTest ..................   Passed    0.32 sec
      Start 52: QuoteUTest
52/77 Test #52: QuoteUTest .......................   Passed    0.59 sec
      Start 53: BuggyLinkUTest
53/77 Test #53: BuggyLinkUTest ...................   Passed    0.22 sec
      Start 54: BuggyQuoteUTest
54/77 Test #54: BuggyQuoteUTest ..................   Passed    0.23 sec
      Start 55: BuggyEqualUTest
55/77 Test #55: BuggyEqualUTest ..................   Passed    0.25 sec
      Start 56: ChoiceLinkUTest
56/77 Test #56: ChoiceLinkUTest ..................   Passed    0.66 sec
      Start 57: FiniteStateMachineUTest
57/77 Test #57: FiniteStateMachineUTest ..........   Passed    0.23 sec
      Start 58: AbsentUTest
58/77 Test #58: AbsentUTest ......................   Passed    0.38 sec
      Start 59: SingleUTest
59/77 Test #59: SingleUTest ......................   Passed    0.18 sec
      Start 60: AttentionalFocusCBUTest
60/77 Test #60: AttentionalFocusCBUTest ..........   Passed    0.17 sec
      Start 61: SudokuUTest
61/77 Test #61: SudokuUTest ......................   Passed    0.30 sec
      Start 62: EinsteinUTest
62/77 Test #62: EinsteinUTest ....................   Passed    5.44 sec
      Start 63: ForwardChainerUTest
63/77 Test #63: ForwardChainerUTest ..............***Exception: Other  1.78 sec
      Start 64: BackwardChainerUTest
64/77 Test #64: BackwardChainerUTest .............   Passed    9.42 sec
      Start 65: URECommonsUTest
65/77 Test #65: URECommonsUTest ..................   Passed    0.31 sec
      Start 66: UREConfigReaderUTest
66/77 Test #66: UREConfigReaderUTest .............   Passed    0.24 sec
      Start 67: DefaultForwardChainerCBUTest
67/77 Test #67: DefaultForwardChainerCBUTest .....   Passed    0.23 sec
      Start 68: FCMemoryUTest
68/77 Test #68: FCMemoryUTest ....................   Passed    0.16 sec
      Start 69: PythonPLNTest
69/77 Test #69: PythonPLNTest ....................   Passed    1.24 sec
      Start 70: PythonEvalUTest
70/77 Test #70: PythonEvalUTest ..................   Passed    0.95 sec
      Start 71: PythonUtilitiesUTest
71/77 Test #71: PythonUtilitiesUTest .............   Passed    0.10 sec
      Start 72: Cython
72/77 Test #72: Cython ...........................   Passed    1.94 sec
      Start 73: CythonAtomSpace
73/77 Test #73: CythonAtomSpace ..................   Passed    0.25 sec
      Start 74: CythonUtilities
74/77 Test #74: CythonUtilities ..................   Passed    0.24 sec
      Start 75: CythonBindlink
75/77 Test #75: CythonBindlink ...................   Passed    0.27 sec
      Start 76: CythonGuile
76/77 Test #76: CythonGuile ......................   Passed    0.38 sec
      Start 77: RestApiTest
77/77 Test #77: RestApiTest ......................   Passed    0.30 sec

99% tests passed, 1 tests failed out of 77

Total Test time (real) =  98.29 sec

The following tests FAILED:
	 63 - ForwardChainerUTest (OTHER_FAULT)
Errors while running CTest
```