### PR TITLE
Fix for loading certain types of atoms from backing store

### DIFF
--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -267,7 +267,7 @@ bool AtomTable::inEnviron(AtomPtr atom)
 
 // Experimental C++ atom types support code
 // Try to cast, if possible.
-static AtomPtr factory(Type atom_type, AtomPtr atom)
+AtomPtr AtomTable::factory(Type atom_type, AtomPtr atom)
 {
     // Nodes of various kinds -----------
     if (NUMBER_NODE == atom_type) {

--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -190,6 +190,8 @@ public:
     Handle getHandle(const AtomPtr&) const;
     Handle getHandle(Handle&) const;
 
+    static AtomPtr factory(Type atom_type, AtomPtr atom);
+
 public:
     /**
      * Returns the set of atoms of a given type (subclasses optionally).

--- a/opencog/persist/sql/AtomStorage.cc
+++ b/opencog/persist/sql/AtomStorage.cc
@@ -1319,6 +1319,19 @@ AtomPtr AtomStorage::makeAtom(Response &rp, Handle h)
 #endif /* USE_INLINE_EDGES */
 			atom = createLink(realtype, outvec);
 		}
+
+		// Create via the factory for specific types of atom
+		// Otherwise at the later stage of the sql-load process when the
+		// same atom is being added to the AtomTable (which will also call
+		// the same factory function), the dynamic-casting of any atom of
+		// one of these types will fail, resulting a new atom being created.
+		// But the new atom is having a different UUID, if there exist another
+		// link connecting to this atom, the system will fail to find the
+		// correct handle of this atom (because it is using the original
+		// UUID, as retrieve from the SQL database). Since each of the atoms
+		// in the outgoing set of a link needs to be valid, we will get
+		// an "Atom in outgoing set isn't known!" error as a result
+		atom = AtomTable::factory(realtype, atom);
 	}
 	else
 	{


### PR DESCRIPTION
While loading certain types of atoms from the backing store, for example, a NumberNode in this form
```
(ListLink
    (NumberNode "1.000000")
)
```
will return an error `AtomTable - Atom in outgoing set isn't known!`.

To solve this problem, we need to explicitly create these types of atoms.