### PR TITLE
Fix for loading a link with empty outgoing set from backing store

### DIFF
--- a/opencog/persist/sql/AtomStorage.cc
+++ b/opencog/persist/sql/AtomStorage.cc
@@ -1312,7 +1312,9 @@ AtomPtr AtomStorage::makeAtom(Response &rp, Handle h)
 			char *p = (char *) rp.outlist;
 			while (p)
 			{
-				if (*p == '}') break;
+				// Break if there is no more atom in the outgoing set
+				// or the outgoing set is empty in the first place
+				if (*p == '}' or *p == '\0') break;
 				Handle hout = (Handle) strtoul(p+1, &p, 10);
 				outvec.push_back(hout);
 			}


### PR DESCRIPTION
I got an error `AtomTable - Atom in outgoing set isn't known!` while loading a link with empty outgoing set. Check if the outgoing set is empty before creating the handle would fix this problem.