### PR TITLE
Avoid creating BindLink using AbsentLinks as an Implicant

### DIFF
--- a/opencog/rule-engine/forwardchainer/DefaultForwardChainerCB.cc
+++ b/opencog/rule-engine/forwardchainer/DefaultForwardChainerCB.cc
@@ -67,6 +67,9 @@ vector<Rule*> DefaultForwardChainerCB::choose_rules(FCMemory& fcmem)
         bool match = false;
 
         for (Handle h : impl_members) {
+            //exceptions
+            if(h->getType() == ABSENT_LINK) continue;
+
             AtomSpace rule_atomspace;
             Handle hcpy = rule_atomspace.add_atom(h);
             Handle implicant_vardecl = rule_atomspace.add_atom(


### PR DESCRIPTION
This fixes https://github.com/opencog/atomspace/issues/159 . The issue was the Pattern matcher doesn't like premises which contain only  AbsentLinks.  
 