### PR TITLE
fix for examples build failure

### DIFF
--- a/examples/c++-guile/CMakeLists.txt
+++ b/examples/c++-guile/CMakeLists.txt
@@ -1,3 +1,4 @@
+INCLUDE_DIRECTORIES(${CMAKE_BINARY_DIR})
 
 ADD_EXECUTABLE(PrimitiveExample
 	PrimitiveExample.cc


### PR DESCRIPTION
Detail on failure:
http://buildbot.opencog.org:8010/builders/atomspace_master_trusty/builds/0/steps/compile_1/logs/stdio

## Unit Test Result
after disabling BasicSaveUTest and PersistUTest b/c of https://github.com/opencog/atomspace/issues/164#issuecomment-124470493
```
99% tests passed, 1 tests failed out of 77

Total Test time (real) =  49.23 sec

The following tests FAILED:
	 70 - PythonEvalUTest (Failed)
```