### PR TITLE
move back scm nlp module to opencog repository

### DIFF
--- a/opencog/scm/opencog/nlp/lg-dict.scm
+++ b/opencog/scm/opencog/nlp/lg-dict.scm
@@ -1,7 +1,0 @@
-;
-; OpenCog NLP lg-dict module
-;
-
-(define-module (opencog nlp lg-dict))
-
-(load-extension "liblg-dict" "opencog_nlp_lgdict_init")

--- a/opencog/scm/opencog/nlp/sureal.scm
+++ b/opencog/scm/opencog/nlp/sureal.scm
@@ -1,7 +1,0 @@
-;
-; OpenCog NLP SuReal module
-;
-
-(define-module (opencog nlp sureal))
-
-(load-extension "libsureal" "opencog_nlp_sureal_init")


### PR DESCRIPTION
since there isn't any nlp code here
## Unit Test Result
after disabling BasicSaveUTest and PersistUTest b/c of https://github.com/opencog/atomspace/issues/164#issuecomment-124470493
```
99% tests passed, 1 tests failed out of 77

Total Test time (real) =  49.23 sec

The following tests FAILED:
	 70 - PythonEvalUTest (Failed)
```