### PR TITLE
Fix finding starter_term when clause is a Node (#75)

### DIFF
--- a/opencog/query/InitiateSearchCB.cc
+++ b/opencog/query/InitiateSearchCB.cc
@@ -97,9 +97,29 @@ InitiateSearchCB::InitiateSearchCB(AtomSpace* as) :
 // If no constant is found, then the returned value is the undefnied
 // handle.
 //
+
 Handle
 InitiateSearchCB::find_starter(const Handle& h, size_t& depth,
-                               Handle& start, size_t& width)
+                                     Handle& start, size_t& width)
+{
+	// If its a node, then we are done.
+	Type t = h->getType();
+	if (_classserver.isNode(t)) {
+		if (t != VARIABLE_NODE) {
+			width = h->getIncomingSetSize();
+			start = h;
+			return h;
+		}
+		return Handle::UNDEFINED;
+	}
+
+	// If its a link, then find recursively
+	return find_starter_recursive(h, depth, start, width);
+}
+
+Handle
+InitiateSearchCB::find_starter_recursive(const Handle& h, size_t& depth,
+                                         Handle& start, size_t& width)
 {
 	// If its a node, then we are done. Don't modify either depth or
 	// start.
@@ -149,7 +169,7 @@ InitiateSearchCB::find_starter(const Handle& h, size_t& depth,
 		if (QUOTE_LINK == hunt->getType())
 			hunt = LinkCast(hunt)->getOutgoingAtom(0);
 
-		Handle s(find_starter(hunt, brdepth, sbr, brwid));
+		Handle s(find_starter_recursive(hunt, brdepth, sbr, brwid));
 
 		if (s != Handle::UNDEFINED
 		    and (brwid < thinnest
@@ -206,7 +226,7 @@ Handle InitiateSearchCB::find_thinnest(const HandleSeq& clauses,
 		}
 	}
 
-    return best_start;
+	return best_start;
 }
 
 /* ======================================================== */

--- a/opencog/query/InitiateSearchCB.h
+++ b/opencog/query/InitiateSearchCB.h
@@ -65,6 +65,8 @@ class InitiateSearchCB : public virtual PatternMatchCallback
 		Handle _starter_term;
 
 		virtual Handle find_starter(const Handle&, size_t&, Handle&, size_t&);
+		virtual Handle find_starter_recursive(const Handle&, size_t&, Handle&,
+		                                      size_t&);
 		virtual Handle find_thinnest(const HandleSeq&,
 		                             const std::set<Handle>&,
 		                             Handle&, size_t&);


### PR DESCRIPTION
This is continuation of #168 which @linas merged already just while I was writing this message.

@williampma: The _starter_term should not be passed UNDEFINED to PatternMatchEngine in my opinion. It does not make sense for me. Why do I need to ask PME to match UNDEFINED clause/term when it is obvious that the answer is "it matches nothing and there is nothing to search". That is why I added protection in PME but not assertion.

I have checked your suggestion deeper and found out that the only case when the starter becomes
UNDEFINED is for clauses being simple nodes. InitiateSearchCB::find_starter was missing that case.
I think this was wrong. It should just find the node as starter and pass it down to PME. It is justified
because then PME calls PatternMatchCallback::match_node and this callback has a chance to accept the node or not. So I have added a fix to find_starter method in this commit.
