### PR TITLE
Rule substitution implementation

### DIFF
--- a/opencog/rule-engine/forwardchainer/DefaultForwardChainerCB.cc
+++ b/opencog/rule-engine/forwardchainer/DefaultForwardChainerCB.cc
@@ -33,6 +33,7 @@
 #include <opencog/guile/SchemeSmob.h>
 #include <opencog/rule-engine/URECommons.h>
 
+#include "VarGroundingPMCB.h"
 #include "DefaultForwardChainerCB.h"
 
 using namespace opencog;
@@ -81,15 +82,14 @@ vector<Rule*> DefaultForwardChainerCB::choose_rules(FCMemory& fcmem)
                     gen_sub_varlist(h, rule->get_vardecl()));
             Handle sourcecpy = temp_pm_as.add_atom(source);
 
-            BindLinkPtr bl = createBindLink(HandleSeq { implicant_vardecl, hcpy,
-                                                        hcpy });
-            DefaultImplicator imp(&temp_pm_as);
-            imp.implicand = bl->get_implicand();
-            PMCGroundings gcb(imp);
+            BindLinkPtr bl = createBindLink(HandleSeq { implicant_vardecl,
+                                                         hcpy,hcpy });
+            VarGroundingPMCB gcb(&temp_pm_as);
+            gcb.implicand = bl->get_implicand();
             bl->imply(gcb);
 
             FindAtoms fv(VARIABLE_NODE);
-            for (const auto& termg_map : gcb._term_groundings) {
+            for (const auto& termg_map : gcb.term_groundings) {
                 for (const auto& it : termg_map) {
                     if (it.second == sourcecpy) {
                         match = true;
@@ -98,11 +98,10 @@ vector<Rule*> DefaultForwardChainerCB::choose_rules(FCMemory& fcmem)
                         HandleSeq new_rules = substitute_rule_part(
                                 temp_pm_as,
                                 temp_pm_as.add_atom(rule->get_handle()),
-                                fv.varset, gcb._var_groundings);
+                                fv.varset, gcb.var_groundings);
                         for (const auto& nr : new_rules)
                             if (find(new_rules.begin(), new_rules.end(),
-                                     nr)
-                                == new_rules.end())
+                                     nr) == new_rules.end())
                                 new_rules.push_back(nr);
                     }
                 }

--- a/opencog/rule-engine/forwardchainer/DefaultForwardChainerCB.cc
+++ b/opencog/rule-engine/forwardchainer/DefaultForwardChainerCB.cc
@@ -262,9 +262,7 @@ HandleSeq DefaultForwardChainerCB::substitute_rule_part(
     for (const auto& varg_map : var_groundings) {
         std::map<Handle, Handle> filtered_vgmap;
         for (const auto& iv : varg_map) {
-            //Should also be var node
-            if (find(vars.begin(), vars.end(), iv.first) != vars.end()
-                and (NodeCast(iv.first)))
+            if (find(vars.begin(), vars.end(), iv.first) != vars.end())
                      filtered_vgmap[iv.first] = iv.second;
         }
         filtered_vgmap_list.push_back(filtered_vgmap);

--- a/opencog/rule-engine/forwardchainer/DefaultForwardChainerCB.cc
+++ b/opencog/rule-engine/forwardchainer/DefaultForwardChainerCB.cc
@@ -248,7 +248,7 @@ Handle DefaultForwardChainerCB::gen_sub_varlist(const Handle& parent,
  * @param as             The Atomspace where all the atoms are dwelling
  * @param hrule          A handle to BindLink instance
  * @param vars           The grounded var list in @param hrule
- * @param var_groundings the set of groundings to each var in @param vars
+ * @param var_groundings The set of groundings to each var in @param vars
  *
  * @return A HandleSeq of all possible derived rules
  */
@@ -260,19 +260,17 @@ HandleSeq DefaultForwardChainerCB::substitute_rule_part(
 
     //Filter out variables not listed in vars from var-groundings
     for (const auto& varg_map : var_groundings) {
-        std::map<Handle, Handle> filtered_vgmap;
-        for (const auto& iv : varg_map) {
+        for (const auto& iv : varg_map)
             if (find(vars.begin(), vars.end(), iv.first) != vars.end())
-                     filtered_vgmap[iv.first] = iv.second;
-        }
-        filtered_vgmap_list.push_back(filtered_vgmap);
+                filtered_vgmap_list.push_back(
+                        std::map<Handle, Handle> { { iv.first, iv.second } });
     }
 
     HandleSeq derived_rules;
     BindLinkPtr blptr = BindLinkCast(hrule);
+    Substitutor st(&as);
 
     for (auto& vgmap : filtered_vgmap_list) {
-        Substitutor st(&as);
         Handle himplicand = st.substitute(blptr->get_implicand(), vgmap);
 
         //Create the BindLink/Rule by substituting vars with groundings

--- a/opencog/rule-engine/forwardchainer/DefaultForwardChainerCB.cc
+++ b/opencog/rule-engine/forwardchainer/DefaultForwardChainerCB.cc
@@ -95,11 +95,11 @@ vector<Rule*> DefaultForwardChainerCB::choose_rules(FCMemory& fcmem)
                         match = true;
                         fv.search_set(it.first);
 
-                        HandleSeq new_rules = substitute_rule_part(
+                        HandleSeq new_candidate_rules = substitute_rule_part(
                                 temp_pm_as,
                                 temp_pm_as.add_atom(rule->get_handle()),
                                 fv.varset, gcb.var_groundings);
-                        for (const auto& nr : new_rules)
+                        for (const auto& nr : new_candidate_rules)
                             if (find(new_rules.begin(), new_rules.end(),
                                      nr) == new_rules.end())
                                 new_rules.push_back(nr);

--- a/opencog/rule-engine/forwardchainer/DefaultForwardChainerCB.h
+++ b/opencog/rule-engine/forwardchainer/DefaultForwardChainerCB.h
@@ -40,7 +40,6 @@ private:
     source_selection_mode _ts_mode;
 
     Handle gen_sub_varlist(const Handle& parent, const Handle& parent_varlist);
-    Handle create_varlist(AtomSpace& as,HandleSeq& varseq,VariableTypeMap& vtype_map);
     HandleSeq substitute_rule_part(AtomSpace& as, Handle hrule,const std::set<Handle>& vars,const std::vector<std::map<Handle,Handle>>& var_groundings);
 
 

--- a/opencog/rule-engine/forwardchainer/DefaultForwardChainerCB.h
+++ b/opencog/rule-engine/forwardchainer/DefaultForwardChainerCB.h
@@ -40,6 +40,9 @@ private:
     source_selection_mode _ts_mode;
 
     Handle gen_sub_varlist(const Handle& parent, const Handle& parent_varlist);
+    Handle create_varlist(AtomSpace& as,HandleSeq& varseq,VariableTypeMap& vtype_map);
+    HandleSeq substitute_rule_part(AtomSpace& as, Handle hrule,const std::set<Handle>& vars,const std::vector<std::map<Handle,Handle>>& var_groundings);
+
 
 public:
     DefaultForwardChainerCB(AtomSpace& as, source_selection_mode ts_mode =
@@ -50,6 +53,8 @@ public:
     virtual HandleSeq choose_premises(FCMemory& fcmem);
     virtual Handle choose_next_source(FCMemory& fcmem);
     virtual HandleSeq apply_rule(FCMemory& fcmem);
+
+    HandleSeq new_rules; // new_rules formed substituting source to matching implicant
 };
 
 } // ~namespace opencog

--- a/opencog/rule-engine/forwardchainer/VarGroundingPMCB.h
+++ b/opencog/rule-engine/forwardchainer/VarGroundingPMCB.h
@@ -1,0 +1,64 @@
+/*
+ * VarGroundingPMCB.h
+ *
+ * Copyright (C) 2015 Misgana Bayetta
+ *
+ * Author: Misgana Bayetta <misgana.bayetta@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef VARGROUNDINGPMCB_H_
+#define VARGROUNDINGPMCB_H_
+
+#include <opencog/query/DefaultImplicator.h>
+
+namespace opencog
+{
+/**
+ * It just holds all var_grounding and term_grounding maps
+ * of the entire PM process.
+ */
+class VarGroundingPMCB: public virtual DefaultImplicator {
+public:
+    VarGroundingPMCB(AtomSpace * as) :
+            Implicator(as), InitiateSearchCB(as),
+            DefaultPatternMatchCB(as),DefaultImplicator(as)
+
+    {
+    }
+    virtual ~VarGroundingPMCB(){}
+
+    virtual bool grounding(const std::map<Handle, Handle> &var_soln,
+                           const std::map<Handle, Handle> &term_soln)
+    {
+
+        var_groundings.push_back(var_soln);
+        term_groundings.push_back(term_soln);
+        // If we found as many as we want, then stop looking for more.
+        if (result_list.size() < max_results)
+            return false;
+
+        return true;
+    }
+
+    std::vector<std::map<Handle, Handle>> var_groundings;
+    std::vector<std::map<Handle, Handle>> term_groundings;
+};
+
+} /* namespace opencog */
+
+#endif /* VARGROUNDINGPMCB_H_ */


### PR DESCRIPTION
I have implemented part of rule substitution by source when there is matching rule found. Previously, it
only finds a rule that matches and passes it to the rule selection phase. Now, it also derives a new BindLink/Rule by substituting part of the matched rule with the source. This will boost the efficiency of pattern matching since fewer variables are searched for.  

**Next tasks:**

  -Unit test for substitute_rule_part method.

  -Refactor rule_match method since now its also handling grounding i.e making it more elegant.

  -Execute if implicant is fully grounded and is executable.

  -Store to result list if implicant is fully grounded while rule matching.
   
 **Test report**

100% tests passed, 0 tests failed out of 78

Total Test time (real) =  85.48 sec
[100%] Built target test