### PR TITLE
Fix define link

### DIFF
--- a/opencog/atoms/bind/BetaRedex.cc
+++ b/opencog/atoms/bind/BetaRedex.cc
@@ -98,18 +98,7 @@ const Variables& BetaRedex::get_local_args(void) const
 /// variables).
 ScopeLinkPtr BetaRedex::get_definition(void) const
 {
-	// Is the defined link actually defined?
-	// We cannot do this check when the ctor runs, since it might
-	// not yet be defined (or the definition may have changed!!)
-   HandleSeq ename;
-   _outgoing[0]->getIncomingSetByType(std::back_inserter(ename), DEFINE_LINK);
-   if (1 != ename.size())
-      throw InvalidParamException(TRACE_INFO,
-         "Cannot find defined function!");
-
-	// Get the the defined function
-	DefineLinkPtr ldefun(DefineLinkCast(ename[0]));
-	return ldefun->get_definition();
+	return ScopeLinkCast(DefineLink::get_definition(_outgoing[0]));
 }
 
 /// Compose this link with the defined link, and return the result.

--- a/opencog/atoms/bind/CMakeLists.txt
+++ b/opencog/atoms/bind/CMakeLists.txt
@@ -33,6 +33,8 @@ ENDIF (CYGWIN)
 
 INSTALL (FILES
 	BindLink.h
+	ScopeLink.h
+	DefineLink.h
 	PatternLink.h
 	PatternUtils.h
 	VariableList.h

--- a/opencog/atoms/bind/DefineLink.cc
+++ b/opencog/atoms/bind/DefineLink.cc
@@ -36,23 +36,17 @@ void DefineLink::init(const HandleSeq& oset)
 		throw InvalidParamException(TRACE_INFO,
 			"Expecting name and definition, got size %d", oset.size());
 
-	// The name must not have been previously defined before.
-	HandleSeq ename;
-	oset[0]->getIncomingSetByType(std::back_inserter(ename), DEFINE_LINK);
-	if (0 < ename.size())
-		throw InvalidParamException(TRACE_INFO,
-			"This is already defined; remove before redfining!");
+	_alias = oset[0];
 
-	_definition = ScopeLinkCast(oset[1]);
-	if (NULL == _definition)
-		_definition = createScopeLink(*LinkCast(oset[1]));
-	if (NULL == _definition)
-	{
-		Type t = oset[1]->getType();
-		const std::string& tname = classserver().getTypeName(t);
-		throw InvalidParamException(TRACE_INFO,
-			"Expecting a ScopeLink, got %s", tname.c_str());
-	}
+	// The name must not have been previously defined before.
+	IncomingSet defs = _alias->getIncomingSetByType(DEFINE_LINK);
+	for (LinkPtr def : defs)
+        if (def->isSource(_alias))
+	        throw InvalidParamException(TRACE_INFO,
+	                                    "This is already defined; "
+	                                    "remove before redfining!");
+
+	_definition = oset[1];
 }
 
 DefineLink::DefineLink(const HandleSeq& oset,
@@ -82,6 +76,25 @@ DefineLink::DefineLink(Link &l)
 	}
 
 	init(l.getOutgoingSet());
+}
+
+Handle DefineLink::get_definition(const Handle& alias) {
+	// Get all DefineLinks associated with that alias, beware that it
+	// will also return DefineLink with that alias as definition body.
+    IncomingSet defs = alias->getIncomingSetByType(DEFINE_LINK);
+
+    // Return the first (supposedly unique) definition
+    for (LinkPtr defl : defs) {
+	    DefineLinkPtr def(DefineLinkCast(def->getHandle()));
+	    if (def->get_alias() == alias)
+		    return def->get_definition();
+    }
+
+    // There is no definition for that alias
+    throw InvalidParamException(TRACE_INFO,
+                                "Cannot find defined hypergraph for atom %s",
+                                alias->toString().c_str());
+    return Handle::UNDEFINED;
 }
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/bind/DefineLink.cc
+++ b/opencog/atoms/bind/DefineLink.cc
@@ -85,7 +85,7 @@ Handle DefineLink::get_definition(const Handle& alias) {
 
     // Return the first (supposedly unique) definition
     for (LinkPtr defl : defs) {
-	    DefineLinkPtr def(DefineLinkCast(def->getHandle()));
+	    DefineLinkPtr def(DefineLinkCast(defl->getHandle()));
 	    if (def->get_alias() == alias)
 		    return def->get_definition();
     }

--- a/opencog/atoms/bind/DefineLink.h
+++ b/opencog/atoms/bind/DefineLink.h
@@ -39,11 +39,11 @@ namespace opencog
  * be replaced by something completely different, someday ...
  */
 
-/// The DefineLink is used to give a name to a pattern, typically to
-/// a ScopeLink, a SatisfactionLink or a BindLink.  The DefineLink is
-/// unique, in that, if any other atoms exists with this same name, it
-/// will throw an error!  Thus, only ONE DefineLink with a given name
-/// can exist at a time.
+/// The DefineLink is used to give a name to a hypergraph (schema,
+/// pattern, concept, predicate, etc).  The DefineLink is unique, in
+/// that, if any other atoms exists with this same name, it will throw
+/// an error!  Thus, only ONE DefineLink with a given name can exist
+/// at a time.
 ///
 /// This class is intended to be used for anything that needs to be
 /// accessed by name: for, if there were two things with the same name,
@@ -67,8 +67,11 @@ namespace opencog
 class DefineLink : public Link
 {
 protected:
-	// The definition is the named object that this link is defining.
-	ScopeLinkPtr _definition;
+	// Reference to the definition body (typically a node)
+	Handle _alias;
+	// Definition body that this link is defining.
+	Handle _definition;
+
 	void init(const HandleSeq&);
 public:
 	DefineLink(const HandleSeq&,
@@ -80,7 +83,19 @@ public:
 	           AttentionValuePtr av = AttentionValue::DEFAULT_AV());
 
 	DefineLink(Link &l);
-	ScopeLinkPtr get_definition(void) { return _definition; }
+	Handle get_alias(void) { return _alias; }
+	Handle get_definition(void) { return _definition; }
+
+	/**
+	 * Given a Handle pointing to <name> in
+	 *
+	 * DefineLink
+	 *    <name>
+	 *    <body>
+	 *
+	 * return <body>
+	 */
+	static Handle get_definition(const Handle& alias);
 };
 
 typedef std::shared_ptr<DefineLink> DefineLinkPtr;

--- a/opencog/atomspace/Link.h
+++ b/opencog/atomspace/Link.h
@@ -206,7 +206,8 @@ public:
     std::string toShortString(std::string indent = "");
 
     /**
-     * Returns whether a given handle is a source of this link.
+     * Returns whether a given handle is a source (the first outgoing
+     * if the link is ordered) of this link.
      *
      * @param Handle to be checked for being a link source.
      * @return Whether a given handle is a source of this link.
@@ -215,7 +216,8 @@ public:
 
     /**
      * Returns whether the element in a given position in the
-     * outgoing set of this link is a source.
+     * outgoing set of this link is a source (the first outgoing
+     * if the link is ordered).
      *
      * @param Position in the outgoing set.
      * @return Whether the element in a given position in the
@@ -224,7 +226,8 @@ public:
     bool isSource(size_t) const throw (IndexErrorException, InvalidParamException);
 
     /**
-     * Returns whether a given handle is a target of this link.
+     * Returns whether a given handle is a target (any but the first
+     * if the link is ordered) of this link.
      *
      * @param Handle to be checked for being a link target.
      * @return Whether a given handle is a target of this link.
@@ -233,7 +236,8 @@ public:
 
     /**
      * Returns whether the element in a given position in the
-     * outgoing set of this link is a target.
+     * outgoing set of this link is a target (any but the first
+     * if the link is ordered).
      *
      * @param Position in the outgoing set.
      * @return Whether the element in a given position in the

--- a/opencog/atomutils/AtomUtils.cc
+++ b/opencog/atomutils/AtomUtils.cc
@@ -305,19 +305,4 @@ HandleSeq get_predicates_for(const Handle& target,
     return answer;
 }
 
-Handle get_definition(const Handle& alias) {
-    IncomingSet defs = alias->getIncomingSetByType(DEFINE_LINK);
-
-    // Return the first (supposedly unique) definition
-    for (LinkPtr def : defs)
-        if (def->isSource(alias))
-            return DefineLinkCast(def->getHandle())->get_definition();
-
-    // There is no definition for that alias
-    throw InvalidParamException(TRACE_INFO,
-                                "Cannot find defined hypergraph for atom %s",
-                                alias->toString().c_str());
-    return Handle::UNDEFINED;
-}
-
 } // namespace OpenCog

--- a/opencog/atomutils/AtomUtils.cc
+++ b/opencog/atomutils/AtomUtils.cc
@@ -25,6 +25,7 @@
 
 #include <opencog/atomspace/Link.h>
 #include <opencog/atomspace/Node.h>
+#include <opencog/atoms/bind/DefineLink.h>
 #include "AtomUtils.h"
 
 namespace opencog
@@ -304,8 +305,19 @@ HandleSeq get_predicates_for(const Handle& target,
     return answer;
 }
 
-Handle get_definition(const Handle& name) {
-	return Handle::UNDEFINED;
+Handle get_definition(const Handle& alias) {
+    IncomingSet defs = alias->getIncomingSetByType(DEFINE_LINK);
+
+    // Return the first (supposedly unique) definition
+    for (LinkPtr def : defs)
+        if (def->isSource(alias))
+            return DefineLinkCast(def->getHandle())->get_definition();
+
+    // There is no definition for that alias
+    throw InvalidParamException(TRACE_INFO,
+                                "Cannot find defined hypergraph for atom %s",
+                                alias->toString().c_str());
+    return Handle::UNDEFINED;
 }
 
 } // namespace OpenCog

--- a/opencog/atomutils/AtomUtils.cc
+++ b/opencog/atomutils/AtomUtils.cc
@@ -304,4 +304,8 @@ HandleSeq get_predicates_for(const Handle& target,
     return answer;
 }
 
+Handle get_definition(const Handle& name) {
+	return Handle::UNDEFINED;
+}
+
 } // namespace OpenCog

--- a/opencog/atomutils/AtomUtils.h
+++ b/opencog/atomutils/AtomUtils.h
@@ -181,17 +181,6 @@ HandleSeq get_predicates(const Handle& target,
 HandleSeq get_predicates_for(const Handle& target, 
                              const Handle& predicate);
 
-/**
- * Given a Handle pointing to <name> in
- *
- * DefineLink
- *    <name>
- *    <body>
- *
- * return <body>
- */
-Handle get_definition(const Handle& name);
-
 /** @}*/
 }
 

--- a/opencog/atomutils/AtomUtils.h
+++ b/opencog/atomutils/AtomUtils.h
@@ -181,6 +181,17 @@ HandleSeq get_predicates(const Handle& target,
 HandleSeq get_predicates_for(const Handle& target, 
                              const Handle& predicate);
 
+/**
+ * Given a Handle pointing to <name> in
+ *
+ * DefineLink
+ *    <name>
+ *    <body>
+ *
+ * return <body>
+ */
+Handle get_definition(const Handle& name);
+
 /** @}*/
 }
 

--- a/opencog/query/Composition.cc
+++ b/opencog/query/Composition.cc
@@ -105,7 +105,7 @@ bool PatternMatchEngine::redex_compare(const LinkPtr& lp,
 	// grounds. So, for these two reasons, the simple, "obvious" method
 	// A is out. Instead, we implement method B: we rename the variables
 	// that the match engine is carrying, to correspond with the variable
-	// names that are native to the definition. This way, insde the body
+	// names that are native to the definition. This way, inside the body
 	// of the definition, everything looks "normal", and should thus
 	// proceed as formal.  Of course, on exit, we have to unmasquerade.
 	//
@@ -114,7 +114,7 @@ bool PatternMatchEngine::redex_compare(const LinkPtr& lp,
 	// empting to just create a new PME, and let it run. The problem with
 	// that is that we have no particularly good way of integrating the
 	// new pme state, with the existing pme state. So we don't.  Instead,
-	// we push all pme state, clear the decks, (almost as if strting from
+	// we push all pme state, clear the decks, (almost as if starting from
 	// scratch) and then pop all pme state when we are done.
 
 	BetaRedexPtr cpl(BetaRedexCast(lp));

--- a/tests/atoms/CMakeLists.txt
+++ b/tests/atoms/CMakeLists.txt
@@ -6,3 +6,6 @@ IF(HAVE_GUILE)
 	ADD_CXXTEST(ReductUTest)
 	TARGET_LINK_LIBRARIES(ReductUTest atomspace smob clearbox execution)
 ENDIF(HAVE_GUILE)
+
+ADD_CXXTEST(DefineLinkUTest)
+TARGET_LINK_LIBRARIES(DefineLinkUTest atomspace)

--- a/tests/atoms/DefineLinkUTest.cxxtest
+++ b/tests/atoms/DefineLinkUTest.cxxtest
@@ -1,0 +1,65 @@
+/*
+ * tests/atomspace/DefineUTest.cxxtest
+ *
+ * Copyright (C) 2015 Nil Geisweiller
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/atomspace/Atom.h>
+#include <opencog/atomspace/AtomSpace.h>
+#include <opencog/atoms/bind/DefineLink.h>
+
+using namespace opencog;
+
+// Test the DefineLink.
+//
+class DefineLinkUTest :  public CxxTest::TestSuite
+{
+private:
+	AtomSpace _as;
+
+public:
+	DefineLinkUTest()
+	{
+		logger().setPrintToStdoutFlag(true);
+	}
+
+	void setUp() {}
+
+	void tearDown() {}
+
+	void test_define_concept();
+	// void test_define_pattern();
+	// void test_define_function();
+};
+
+// Test DefineLink over a ConceptNode
+void DefineLinkUTest::test_define_concept()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Create DefineLink over a concept node
+	// Handle define_concept =
+	// 	_as.add_link(DEFINE_LINK,
+	// 	             _as.add_node(CONCEPT_NODE, "new-alias-for-A"),
+	// 	             _as.add_node(CONCEPT_NODE, "A"));
+
+	TS_ASSERT(true);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}

--- a/tests/atoms/DefineLinkUTest.cxxtest
+++ b/tests/atoms/DefineLinkUTest.cxxtest
@@ -23,6 +23,7 @@
 #include <opencog/atomspace/Atom.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/atoms/bind/DefineLink.h>
+#include <opencog/atomutils/AtomUtils.h>
 
 using namespace opencog;
 
@@ -54,12 +55,13 @@ void DefineLinkUTest::test_define_concept()
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
 	// Create DefineLink over a concept node
-	// Handle define_concept =
-	// 	_as.add_link(DEFINE_LINK,
-	// 	             _as.add_node(CONCEPT_NODE, "new-alias-for-A"),
-	// 	             _as.add_node(CONCEPT_NODE, "A"));
+	Handle A = _as.add_node(CONCEPT_NODE, "A"),
+		aliasA = _as.add_node(CONCEPT_NODE, "alias-A"),
+		def_concept = _as.add_link(DEFINE_LINK, aliasA, A);
 
-	TS_ASSERT(true);
+	// Test that aliasA returns A as definition
+	Handle body = get_definition(aliasA);
+	TS_ASSERT_EQUALS(A, body);
 
 	logger().info("END TEST: %s", __FUNCTION__);
 }

--- a/tests/atoms/DefineLinkUTest.cxxtest
+++ b/tests/atoms/DefineLinkUTest.cxxtest
@@ -56,11 +56,11 @@ void DefineLinkUTest::test_define_concept()
 
 	// Create DefineLink over a concept node
 	Handle A = _as.add_node(CONCEPT_NODE, "A"),
-		aliasA = _as.add_node(CONCEPT_NODE, "alias-A"),
+		alias = _as.add_node(CONCEPT_NODE, "alias-of-A"),
 		def_concept = _as.add_link(DEFINE_LINK, aliasA, A);
 
 	// Test that aliasA returns A as definition
-	Handle body = get_definition(aliasA);
+	Handle body = DefineLink::get_definition(alias);
 	TS_ASSERT_EQUALS(A, body);
 
 	logger().info("END TEST: %s", __FUNCTION__);

--- a/tests/atoms/DefineLinkUTest.cxxtest
+++ b/tests/atoms/DefineLinkUTest.cxxtest
@@ -57,7 +57,7 @@ void DefineLinkUTest::test_define_concept()
 	// Create DefineLink over a concept node
 	Handle A = _as.add_node(CONCEPT_NODE, "A"),
 		alias = _as.add_node(CONCEPT_NODE, "alias-of-A"),
-		def_concept = _as.add_link(DEFINE_LINK, aliasA, A);
+		def_concept = _as.add_link(DEFINE_LINK, alias, A);
 
 	// Test that aliasA returns A as definition
 	Handle body = DefineLink::get_definition(alias);


### PR DESCRIPTION
## Description
Attempt to generalize DefineLink so that it can be used for anything not just in the context of the pattern matcher. It is still under the directory `opencog/atoms/bind`, maybe it should be moved elsewhere (like in `opencog/atoms/core`)

* Modify DefineLink class so that the definition body can be anything (not only a ScopeLink)
* Add a static method DefinieLink::get_definition(const Handle& alias) that return the definition body given a definition alias as in (DefineLink alias body)
* Simplify BetaRedexLink. Warning it assumes the definition body is a ScopeLink, I didn't change that, ultimately I guess it should be able to handle non ScopeLink (constants).

I strongly suspect BetaRedexLink and ExecutionOutputLink (or ApplyLink/ApplicationLink as we might soon rename it) are the same thing and should be unified.

## UTest Results
```
100% tests passed, 0 tests failed out of 79
```
