### PR TITLE
Backward Chainer: rule's input as premise

### DIFF
--- a/opencog/rule-engine/Rule.cc
+++ b/opencog/rule-engine/Rule.cc
@@ -258,9 +258,10 @@ Handle Rule::standardize_helper(AtomSpace* as, const Handle h, std::map<Handle, 
 	if (dict.count(h) == 1)
 		return dict[h];
 
-	std::string new_name = NodeCast(h)->getName() + "-standardize_apart-" + to_string(boost::uuids::random_generator()());
+	std::stringstream ss;
+	ss << NodeCast(h)->getName() << "-" << rule_handle_ << "-standardize_apart";
 
-	Handle hcpy = as->add_atom(createNode(h->getType(), new_name, h->getTruthValue()));
+	Handle hcpy = as->add_atom(createNode(h->getType(), ss.str(), h->getTruthValue()));
 	dict[h] = hcpy;
 
 	return hcpy;

--- a/opencog/rule-engine/Rule.cc
+++ b/opencog/rule-engine/Rule.cc
@@ -259,7 +259,7 @@ Handle Rule::standardize_helper(AtomSpace* as, const Handle h, std::map<Handle, 
 		return dict[h];
 
 	std::stringstream ss;
-	ss << NodeCast(h)->getName() << "-" << rule_handle_ << "-standardize_apart";
+	ss << NodeCast(h)->getName() << "-rule_uuid_" << rule_handle_ << "-standardize_apart";
 
 	Handle hcpy = as->add_atom(createNode(h->getType(), ss.str(), h->getTruthValue()));
 	dict[h] = hcpy;

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.cc
@@ -823,17 +823,13 @@ bool BackwardChainer::unify(const Handle& hsource,
 Rule BackwardChainer::select_rule(Target& target, const std::vector<Rule>& rules)
 {
 	// store how many times each rule has been used for the target
-	std::vector<unsigned int> weights;
+	std::vector<double> weights;
 	std::for_each(rules.begin(), rules.end(),
 	              [&](const Rule& r)
 	              { weights.push_back(target.get_selection_count() - target.rule_count(r) + 1); });
 
 	// Select the rule that has been applied least
-	// XXX use cogutil MT19937RandGen's internal randomGen member possible?
-	std::mt19937 generator(std::chrono::system_clock::now().time_since_epoch().count());
-	std::discrete_distribution<int> distribution(weights.begin(), weights.end());
-
-	return rules[distribution(generator)];
+	return rules[randGen().randDiscrete(weights)];
 }
 
 /**

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.cc
@@ -851,8 +851,8 @@ Handle BackwardChainer::gen_sub_varlist(const Handle& parent,
                                         const Handle& parent_varlist,
                                         std::set<Handle> additional_free_varset)
 {
-	HandleSeq varseq = get_free_vars_in_tree(parent);
-	std::set<Handle> varset(varseq.begin(), varseq.end());
+	FindAtoms fv(VARIABLE_NODE);
+	fv.search_set(parent);
 
 	HandleSeq oset = LinkCast(parent_varlist)->getOutgoingSet();
 	HandleSeq final_oset;
@@ -861,13 +861,13 @@ Handle BackwardChainer::gen_sub_varlist(const Handle& parent,
 	for (const Handle& h : oset)
 	{
 		Type t = h->getType();
-		if (VARIABLE_NODE == t && varset.count(h) == 1)
+		if (VARIABLE_NODE == t && fv.varset.count(h) == 1)
 		{
 			final_oset.push_back(h);
 			additional_free_varset.erase(h);
 		}
 		else if (TYPED_VARIABLE_LINK == t
-			     and varset.count(LinkCast(h)->getOutgoingSet()[0]) == 1)
+			     and fv.varset.count(LinkCast(h)->getOutgoingSet()[0]) == 1)
 		{
 			final_oset.push_back(h);
 			additional_free_varset.erase(LinkCast(h)->getOutgoingSet()[0]);
@@ -878,7 +878,7 @@ Handle BackwardChainer::gen_sub_varlist(const Handle& parent,
 	// if it is used in parent
 	for (const Handle& h : additional_free_varset)
 	{
-		if (varset.count(h) == 1)
+		if (fv.varset.count(h) == 1)
 			final_oset.push_back(h);
 	}
 

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.cc
@@ -333,10 +333,22 @@ void BackwardChainer::process_target(Target& target)
 		                          premises_vmap_list_alt.end());
 	}
 
-	// XXX TODO what to do when no possible premise?  shouldn't we then backward chain
-	// to the reverse grounded rule implicant?  but they contain standardized variables...
-
 	logger().debug("[BackwardChainer] %d possible permises", possible_premises.size());
+
+	// If no possible premises, then the reverse grounded rule's implicant
+	// could be added as potential target.  Note that however, such target are
+	// not yet in the main atomspace, since whatever the grounded implicant
+	// is, it is possible that it is not valid (like the reverse of if-then
+	// is not always true).  It will require some future steps to see if
+	// another rule will generate the target and add it to the main atomspace.
+	// Also note that these targets could contain variables from standardized
+	// apart version of the rule, and should not be added to the main space.
+	if (possible_premises.size() == 0)
+	{
+		target.store_step(selected_rule, { hrule_implicant_normal_grounded });
+		_targets_set.emplace(hrule_implicant_normal_grounded);
+		return;
+	}
 
 	// For each set of possible premises, check if they already satisfy the
 	// target, so that we can apply the rule while we are looking at it in the

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.cc
@@ -54,7 +54,7 @@ void BackwardChainer::set_target(Handle init_target)
 	_init_target = init_target;
 
 	_targets_set.clear();
-	_targets_set.emplace(_init_target);
+	_targets_set.emplace(_init_target, Handle::UNDEFINED);
 }
 
 UREConfigReader& BackwardChainer::get_config()
@@ -149,7 +149,7 @@ void BackwardChainer::process_target(Target& target)
 	{
 		std::vector<VarMap> kb_vmap;
 
-		HandleSeq kb_match = match_knowledge_base(htarget, Handle::UNDEFINED,
+		HandleSeq kb_match = match_knowledge_base(htarget, target.get_vardecl(),
 		                                          false, kb_vmap);
 
 		// Matched something in the knowledge base? Then need to store
@@ -172,7 +172,7 @@ void BackwardChainer::process_target(Target& target)
 
 				// If there are free variables, add this soln as new target
 				if (not free_vars.empty())
-					_targets_set.emplace(soln);
+					_targets_set.emplace(soln, Handle::UNDEFINED);
 
 				target.store_varmap(vgm);
 			}
@@ -187,7 +187,7 @@ void BackwardChainer::process_target(Target& target)
 		HandleSeq sub_premises = LinkCast(htarget)->getOutgoingSet();
 
 		for (Handle& h : sub_premises)
-			_targets_set.emplace(h);
+			_targets_set.emplace(h, Handle::UNDEFINED);
 
 		return;
 	}
@@ -346,7 +346,8 @@ void BackwardChainer::process_target(Target& target)
 	if (possible_premises.size() == 0)
 	{
 		target.store_step(selected_rule, { hrule_implicant_normal_grounded });
-		_targets_set.emplace(hrule_implicant_normal_grounded);
+		_targets_set.emplace(hrule_implicant_normal_grounded,
+		                     _garbage_superspace.add_atom(gen_sub_varlist(hrule_implicant_normal_grounded, hrule_vardecl, target.get_varset())));
 		return;
 	}
 
@@ -445,7 +446,7 @@ void BackwardChainer::process_target(Target& target)
 		if (_logical_link_types.count(hp->getType()) == 0)
 		{			
 			target.store_step(selected_rule, { hp });
-			_targets_set.emplace(hp);
+			_targets_set.emplace(hp, Handle::UNDEFINED);
 			continue;
 		}
 
@@ -456,7 +457,7 @@ void BackwardChainer::process_target(Target& target)
 		target.store_step(selected_rule, sub_premises);
 
 		for (Handle& s : sub_premises)
-			_targets_set.emplace(s);
+			_targets_set.emplace(s, Handle::UNDEFINED);
 	}
 
 	return;

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.h
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.h
@@ -113,7 +113,6 @@ private:
 
 	HandleSeq match_knowledge_base(const Handle& htarget,
 	                               Handle htarget_vardecl,
-	                               bool check_history,
 	                               std::vector<VarMap>& vmap);
 	HandleSeq ground_premises(const Handle& htarget, const VarMap& vmap,
 	                          std::vector<VarMap>& vmap_list);

--- a/opencog/rule-engine/backwardchainer/BackwardChainerPMCB.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainerPMCB.cc
@@ -26,114 +26,16 @@
 
 using namespace opencog;
 
-BackwardChainerPMCB::BackwardChainerPMCB(AtomSpace* as, VariableListPtr int_vars, bool reverse)
+BackwardChainerPMCB::BackwardChainerPMCB(AtomSpace* as, VariableListPtr int_vars)
     : InitiateSearchCB(as),
       DefaultPatternMatchCB(as),
       _as(as),
-      _int_vars(int_vars),
-      _reverse_enabled(reverse)
+      _int_vars(int_vars)
 {
 }
 
 BackwardChainerPMCB::~BackwardChainerPMCB()
 {
-}
-
-/**
- * Override the initiate_search method.
- *
- * Because if _reverse is enabled, but any nodes & links can be
- * matched to a VariableNode, and the default neighbor_search will
- * put too much restriction for such cases.
- *
- * @param pme   same as default
- * @return      true to stop search for more
- */
-bool BackwardChainerPMCB::initiate_search(PatternMatchEngine* pme)
-{
-	// use the default starter if _reverse is not enabled
-	if (not _reverse_enabled)
-		return InitiateSearchCB::initiate_search(pme);
-
-	// else skip over neighbor_search since that does not apply
-
-	_search_fail = false;
-	bool found = link_type_search(pme);
-	if (found) return true;
-	if (not _search_fail) return false;
-
-	_search_fail = false;
-	found = variable_search(pme);
-	return found;
-}
-
-/**
- * Override the node_match method.
- *
- * This is needed so that something like
- *
- *   InheritanceLink
- *     ConceptNode "Fritz"
- *     ConceptNode "green"
- *
- * can be matched to
- *
- *   InheritanceLink
- *     VariableNode "$X"
- *     ConceptNode "green"
- *
- * so that Truth Value Query can generate additional targets that are
- * themselves Variable Fullfillment Query.
- *
- * @param npat_h   same as default
- * @param nsoln_h  same as default
- * @return         true if matched
- */
-bool BackwardChainerPMCB::node_match(const Handle& npat_h, const Handle& nsoln_h)
-{
-	if (npat_h == nsoln_h)
-		return true;
-
-	if (not _reverse_enabled)
-		return false;
-
-	// if npat_h itself is a VariableNode, then this means it is QuoteLink-ed
-	// in this case we don't want other VariableNode to map to it, since
-	// the purpose was for npat_h to match to itself
-	if (npat_h->getType() == VARIABLE_NODE)
-		return false;
-
-	// allows any normal node to map to a VariableNode (assume untyped)
-	// XXX will it ever map to a typed VariableNode?  What would that mean?
-	if (nsoln_h->getType() == VARIABLE_NODE)
-		return true;
-
-	return false;
-}
-
-/**
- * Override the fuzzy_match callback.
- *
- * This is for matching any link to an external VariableNode.
- *
- * @param ph  same as default
- * @param gh  same as default
- * @return    true if matched
- */
-bool BackwardChainerPMCB::fuzzy_match(const Handle& ph, const Handle& gh)
-{
-	if (not _reverse_enabled)
-		return false;
-
-	// avoid Handle::UNDEFINED
-	if (ph == Handle::UNDEFINED || gh == Handle::UNDEFINED)
-		return false;
-
-	// if the proposed grounding is not a link but is a VariableNode
-	if (gh->getType() == VARIABLE_NODE)
-		return true;
-
-	return false;
 }
 
 bool BackwardChainerPMCB::grounding(const std::map<Handle, Handle> &var_soln,
@@ -145,8 +47,6 @@ bool BackwardChainerPMCB::grounding(const std::map<Handle, Handle> &var_soln,
 	for (auto& p : var_soln)
 	{
 		if (_int_vars->get_variables().varset.count(p.first) == 1)
-			true_var_soln[p.first] = p.second;
-		else if (p.second->getType() == VARIABLE_NODE)
 			true_var_soln[p.first] = p.second;
 	}
 

--- a/opencog/rule-engine/backwardchainer/BackwardChainerPMCB.h
+++ b/opencog/rule-engine/backwardchainer/BackwardChainerPMCB.h
@@ -37,16 +37,14 @@ class BackwardChainerPMCB :
 protected:
 	AtomSpace* _as;
 	VariableListPtr _int_vars;
-	bool _reverse_enabled;
 
 	std::vector<std::map<Handle, Handle>> var_solns_;
 	std::vector<std::map<Handle, Handle>> pred_solns_;
 
 public:
-	BackwardChainerPMCB(AtomSpace*, VariableListPtr, bool reverse = false);
+	BackwardChainerPMCB(AtomSpace*, VariableListPtr);
 	virtual ~BackwardChainerPMCB();
 
-	virtual bool initiate_search(PatternMatchEngine*);
 	virtual void set_pattern(const Variables& vars,
 	                         const Pattern& pat)
 	{
@@ -54,8 +52,6 @@ public:
 		DefaultPatternMatchCB::set_pattern(vars, pat);
 	}
 
-	virtual bool node_match(const Handle&, const Handle&);
-	virtual bool fuzzy_match(const Handle&, const Handle&);
 	virtual bool grounding(const std::map<Handle, Handle> &var_soln,
 			const std::map<Handle, Handle> &pred_soln);
 

--- a/opencog/rule-engine/backwardchainer/Target.cc
+++ b/opencog/rule-engine/backwardchainer/Target.cc
@@ -43,11 +43,12 @@ Target::Target(AtomSpace& as, const Handle& h, const Handle& hvardecl) : _as(as)
 	_htarget_internal = _as.add_atom(h);
 	_selection_count = 0;
 
-	_vars = get_free_vars_in_tree(h);
 	_vardecl = hvardecl;
 
+	HandleSeq vars = VariableListCast(_vardecl)->get_variables().varseq;
+
 	// _varmap is a map that bases on the external space
-	for (auto& hv : _vars)
+	for (auto& hv : vars)
 		_varmap[hv] = UnorderedHandleSet();
 }
 

--- a/opencog/rule-engine/backwardchainer/Target.cc
+++ b/opencog/rule-engine/backwardchainer/Target.cc
@@ -37,13 +37,14 @@ using namespace opencog;
  * @param as  the AtomSpace in which to store temporary information
  * @param h   the original external Handle of the Target
  */
-Target::Target(AtomSpace& as, const Handle& h) : _as(as)
+Target::Target(AtomSpace& as, const Handle& h, const Handle& hvardecl) : _as(as)
 {
 	_htarget_external = h;
 	_htarget_internal = _as.add_atom(h);
 	_selection_count = 0;
 
 	_vars = get_free_vars_in_tree(h);
+	_vardecl = hvardecl;
 
 	// _varmap is a map that bases on the external space
 	for (auto& hv : _vars)
@@ -145,12 +146,12 @@ void TargetSet::clear()
  *
  * @param h  the atom to which the Target will be created
  */
-void TargetSet::emplace(Handle& h)
+void TargetSet::emplace(Handle h, Handle hvardecl)
 {
 	if (_targets_map.count(h) == 1)
 		return;
 
-	_targets_map.insert(std::pair<Handle, Target>(h, Target(_history_space, h)));
+	_targets_map.insert(std::pair<Handle, Target>(h, Target(_history_space, h, hvardecl)));
 }
 
 /**

--- a/opencog/rule-engine/backwardchainer/Target.cc
+++ b/opencog/rule-engine/backwardchainer/Target.cc
@@ -178,7 +178,7 @@ unsigned int TargetSet::size()
 Target& TargetSet::select()
 {
 	HandleSeq handles;
-	std::vector<unsigned int> weights;
+	std::vector<double> weights;
 	for (auto& p : _targets_map)
 	{
 		handles.push_back(p.first);
@@ -187,11 +187,7 @@ Target& TargetSet::select()
 		weights.push_back(_total_selection - p.second.get_selection_count() + 1);
 	}
 
-	// XXX use cogutil MT19937RandGen's intenal randomGen member possible?
-	std::mt19937 generator(std::chrono::system_clock::now().time_since_epoch().count());
-	std::discrete_distribution<int> distribution(weights.begin(), weights.end());
-
-	Target& t = _targets_map.at(handles[distribution(generator)]);
+	Target& t = _targets_map.at(handles[randGen().randDiscrete(weights)]);
 	t.increment_selection_count();
 
 	_total_selection++;

--- a/opencog/rule-engine/backwardchainer/Target.h
+++ b/opencog/rule-engine/backwardchainer/Target.h
@@ -74,7 +74,10 @@ public:
 	 *
 	 * @return the HandleSeq
 	 */
-	HandleSeq get_varseq() const { return _vars; }
+	HandleSeq get_varseq() const
+	{
+		return VariableListCast(_vardecl)->get_variables().varseq;
+	}
 
 	/**
 	 * Get the "free" variables list in set<Handle>
@@ -83,7 +86,7 @@ public:
 	 */
 	std::set<Handle> get_varset() const
 	{
-		return std::set<Handle>(_vars.begin(), _vars.end());
+		return VariableListCast(_vardecl)->get_variables().varset;
 	}
 
 	Handle get_vardecl() const { return _vardecl; }
@@ -114,7 +117,6 @@ private:
 	Handle _htarget_internal;
 	unsigned int _selection_count;
 
-	HandleSeq _vars;
 	Handle _vardecl;
 	VarMultimap _varmap;
 

--- a/opencog/rule-engine/backwardchainer/Target.h
+++ b/opencog/rule-engine/backwardchainer/Target.h
@@ -81,9 +81,12 @@ public:
 	 *
 	 * @return the std::set<Handle>
 	 */
-	std::set<Handle> get_varset() const {
+	std::set<Handle> get_varset() const
+	{
 		return std::set<Handle>(_vars.begin(), _vars.end());
 	}
+
+	Handle get_vardecl() const { return _vardecl; }
 
 	/**
 	 * Get the stored free variable mappings.
@@ -105,13 +108,14 @@ public:
 	float get_weight() { return 1.0f; }
 
 private:
-	Target(AtomSpace& as, const Handle& h);
+	Target(AtomSpace& as, const Handle& h, const Handle& hvardecl);
 
 	Handle _htarget_external;
 	Handle _htarget_internal;
 	unsigned int _selection_count;
 
 	HandleSeq _vars;
+	Handle _vardecl;
 	VarMultimap _varmap;
 
 	AtomSpace& _as;
@@ -125,7 +129,7 @@ public:
 	~TargetSet();
 
 	void clear();
-	void emplace(Handle& h);
+	void emplace(Handle h, Handle hvardecl);
 	unsigned int size();
 	Target& select();
 	Target& get(Handle& h);

--- a/opencog/rule-engine/backwardchainer/UnifyPMCB.cc
+++ b/opencog/rule-engine/backwardchainer/UnifyPMCB.cc
@@ -48,7 +48,20 @@ bool UnifyPMCB::variable_match(const Handle& npat_h,
 	Type soltype = nsoln_h->getType();
 
 	// special case to allow any typed variable to match to a variable
-	if (soltype == VARIABLE_NODE && _ext_vars->get_variables().varset.count(nsoln_h) == 1) return true;
+	if (soltype == VARIABLE_NODE && _ext_vars->get_variables().varset.count(nsoln_h) == 1)
+	{
+		// if the variable is untyped, match immediately
+		if (_ext_vars->get_variables().typemap.count(nsoln_h) == 0
+		    || _int_vars->get_variables().typemap.count(npat_h) == 0)
+			return true;
+
+		// otherwise the two variables type need to match
+		if (_int_vars->get_variables().typemap.at(npat_h)
+		    == _ext_vars->get_variables().typemap.at(nsoln_h))
+			return true;
+
+		return false;
+	}
 
 	return BackwardChainerPMCB::variable_match(npat_h, nsoln_h);
 }

--- a/opencog/rule-engine/backwardchainer/UnifyPMCB.cc
+++ b/opencog/rule-engine/backwardchainer/UnifyPMCB.cc
@@ -32,7 +32,7 @@ using namespace opencog;
  * @param ext_vars  a VariableList of external variables that typed variables can map to
  */
 UnifyPMCB::UnifyPMCB(AtomSpace* as, VariableListPtr int_vars, VariableListPtr ext_vars)
-    : BackwardChainerPMCB(as, int_vars, false), _ext_vars(ext_vars)
+    : BackwardChainerPMCB(as, int_vars), _ext_vars(ext_vars)
 {
 
 }

--- a/tests/rule-engine/BackwardChainerUTest.cxxtest
+++ b/tests/rule-engine/BackwardChainerUTest.cxxtest
@@ -34,6 +34,7 @@ public:
 	//void test_filter_rules();
 
 	void test_1rule_bc();
+	void test_1rule_impossible_bc();
 	void test_2rules_bc();
 
 	void test_tvq_bc();
@@ -189,6 +190,40 @@ void BackwardChainerUTest::test_1rule_bc()
 	logger().debug("END TEST: %s", __FUNCTION__);
 }
 
+void BackwardChainerUTest::test_1rule_impossible_bc()
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	config().set("SCM_PRELOAD",
+	             "tests/rule-engine/bc-config-1.scm,"
+	             "tests/rule-engine/bc-criminal.scm");
+	load_scm_files_from_config(as_);
+
+	// load modus ponens rule
+	Handle top_rbs = as_.get_node(CONCEPT_NODE, UREConfigReader::top_rbs_name);
+	BackwardChainer bc(as_, top_rbs);
+
+	Handle target_var = eval_.eval_h("(VariableNode \"$x\")");
+	Handle target =
+	    eval_.eval_h("(InheritanceLink"
+	                  "   (VariableNode \"$x\")"
+					  "   (ConceptNode \"criminal\"))");
+	Handle soln = eval_.eval_h("(ConceptNode \"West\")");
+
+	bc.set_target(target);
+	bc.get_config().set_maximum_iterations(300);
+	bc.do_chain();
+
+	VarMultimap results = bc.get_chaining_result();
+
+	TSM_ASSERT("Incorrect number of solution found!",
+	           results[target_var].size() == 0);
+	TSM_ASSERT("Getting incorrect solution!",
+	           results[target_var].count(soln) == 0);
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
 void BackwardChainerUTest::test_2rules_bc()
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
@@ -278,7 +313,7 @@ void BackwardChainerUTest::test_tvq_impossible_bc()
 	                             "   (ConceptNode \"Frog\"))");
 
 	bc.set_target(target);
-	bc.get_config().set_maximum_iterations(300);
+	bc.get_config().set_maximum_iterations(100);
 	bc.do_chain();
 
 	TSM_ASSERT("Incorrect strength of target after BC!", target->getTruthValue()->getMean() < 0.1f);

--- a/tests/rule-engine/BackwardChainerUTest.cxxtest
+++ b/tests/rule-engine/BackwardChainerUTest.cxxtest
@@ -9,6 +9,7 @@
 #include <opencog/guile/SchemeSmob.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/util/Config.h>
+#include <opencog/util/mt19937ar.h>
 #include <opencog/guile/load-file.h>
 
 using namespace opencog;
@@ -25,6 +26,7 @@ public:
 	{
 		logger().setLevel(Logger::DEBUG);
 		logger().setPrintToStdoutFlag(true);
+		randGen().seed(0);
 	}
 
 	void setUp();
@@ -48,6 +50,8 @@ void BackwardChainerUTest::setUp()
 	             "opencog/scm/utilities.scm, "
 	             "opencog/scm/av-tv.scm");
 	load_scm_files_from_config(as_);
+
+	randGen().seed(0);
 }
 
 void BackwardChainerUTest::tearDown()

--- a/tests/rule-engine/BackwardChainerUTest.cxxtest
+++ b/tests/rule-engine/BackwardChainerUTest.cxxtest
@@ -206,10 +206,11 @@ void BackwardChainerUTest::test_1rule_impossible_bc()
 	Handle target_var = eval_.eval_h("(VariableNode \"$x\")");
 	Handle target =
 	    eval_.eval_h("(InheritanceLink"
-	                  "   (VariableNode \"$x\")"
-					  "   (ConceptNode \"criminal\"))");
+	                 "   (VariableNode \"$x\")"
+	                 "   (ConceptNode \"criminal\"))");
 	Handle soln = eval_.eval_h("(ConceptNode \"West\")");
 
+	// should NOT be possible to find the solution without deduction rule
 	bc.set_target(target);
 	bc.get_config().set_maximum_iterations(300);
 	bc.do_chain();
@@ -218,7 +219,7 @@ void BackwardChainerUTest::test_1rule_impossible_bc()
 
 	TSM_ASSERT("Incorrect number of solution found!",
 	           results[target_var].size() == 0);
-	TSM_ASSERT("Getting incorrect solution!",
+	TSM_ASSERT("Getting impossible solution!",
 	           results[target_var].count(soln) == 0);
 
 	logger().debug("END TEST: %s", __FUNCTION__);


### PR DESCRIPTION
Added the missing step in the Backward Chainer design:

* when no premise matches the input of a rule, add the partially grounded rule's input as potential target

Contains some basic temporary work-around for some unsolved issue, like #46, #132 