### PR TITLE
Backward Chainer: change from unordered_map to map

### DIFF
--- a/opencog/rule-engine/backwardchainer/Target.h
+++ b/opencog/rule-engine/backwardchainer/Target.h
@@ -137,7 +137,7 @@ public:
 	Target& get(Handle& h);
 
 private:
-	std::unordered_map<Handle, Target> _targets_map;
+	std::map<Handle, Target> _targets_map;
 	AtomSpace _history_space;
 	unsigned int _total_selection;
 };


### PR DESCRIPTION
Haven't figured out why yet, but this makes the unit test more deterministic.