### PR TITLE
atom.sql fixed

### DIFF
--- a/opencog/persist/sql/atom.sql
+++ b/opencog/persist/sql/atom.sql
@@ -1,3 +1,15 @@
+-- -----------------------------------------------------------
+-- Table showing inheritance relationship between atomspaces.
+-- Atomspaces have UUID's identifying them. Top-level atomspaces have
+-- a UUID of zero.  Otherwise, all atomspaces have some (other)
+-- atomspace as a parent.
+
+CREATE TABLE Spaces (
+	space  BIGINT PRIMARY KEY,
+	parent BIGINT
+);
+
+INSERT INTO Spaces VALUES (1,1); -- default root
 
 --
 -- Create a table representation for an opencog Atom
@@ -82,19 +94,6 @@ CREATE TABLE TypeCodes (
 	type SMALLINT UNIQUE,
 	typename TEXT UNIQUE
 );
-
--- -----------------------------------------------------------
--- Table showing inheritance relationship between atomspaces.
--- Atomspaces have UUID's identifying them. Top-level atomspaces have
--- a UUID of zero.  Otherwise, all atomspaces have some (other)
--- atomspace as a parent.
-
-CREATE TABLE Spaces (
-	space  BIGINT PRIMARY KEY,
-	parent BIGINT
-);
-
-INSERT INTO Spaces VALUES (1,1); -- default root
 
 -- -----------------------------------------------------------
 -- Global state


### PR DESCRIPTION
Running the queries of the atom.sql file failed because the table "Atoms" references to "Spaces" before "Spaces" is being created.