### PR TITLE
use include/opencog/* as install path

### DIFF
--- a/opencog/atoms/CMakeLists.txt
+++ b/opencog/atoms/CMakeLists.txt
@@ -7,5 +7,5 @@ ADD_SUBDIRECTORY (reduct)
 INSTALL (FILES
 	NumberNode.h
 	TypeNode.h
-	DESTINATION "include/${PROJECT_NAME}/atoms"
+	DESTINATION "include/opencog/atoms"
 )

--- a/opencog/atoms/bind/CMakeLists.txt
+++ b/opencog/atoms/bind/CMakeLists.txt
@@ -38,5 +38,5 @@ INSTALL (FILES
 	PatternLink.h
 	PatternUtils.h
 	VariableList.h
-	DESTINATION "include/${PROJECT_NAME}/atoms/bind"
+	DESTINATION "include/opencog/atoms/bind"
 )

--- a/opencog/atoms/core/CMakeLists.txt
+++ b/opencog/atoms/core/CMakeLists.txt
@@ -21,5 +21,5 @@ INSTALL (TARGETS atomcore
 INSTALL (FILES
 	FreeLink.h
 	PutLink.h
-	DESTINATION "include/${PROJECT_NAME}/atoms/core"
+	DESTINATION "include/opencog/atoms/core"
 )

--- a/opencog/atoms/execution/CMakeLists.txt
+++ b/opencog/atoms/execution/CMakeLists.txt
@@ -34,5 +34,5 @@ INSTALL (FILES
 	EvaluationLink.h
 	ExecutionOutputLink.h
 	Instantiator.h
-	DESTINATION "include/${PROJECT_NAME}/atoms/execution"
+	DESTINATION "include/opencog/atoms/execution"
 )

--- a/opencog/atoms/reduct/CMakeLists.txt
+++ b/opencog/atoms/reduct/CMakeLists.txt
@@ -32,5 +32,5 @@ INSTALL (FILES
 	FunctionLink.h
 	PlusLink.h
 	TimesLink.h
-	DESTINATION "include/${PROJECT_NAME}/atoms/reduct"
+	DESTINATION "include/opencog/atoms/reduct"
 )

--- a/opencog/atomspace/CMakeLists.txt
+++ b/opencog/atomspace/CMakeLists.txt
@@ -91,7 +91,7 @@ INSTALL (FILES
 	TypeIndex.h
 	types.h
 	version.h
-	DESTINATION "include/${PROJECT_NAME}/atomspace"
+	DESTINATION "include/opencog/atomspace"
 )
 
 # Install the auto-genned atom types as well

--- a/opencog/atomspaceutils/CMakeLists.txt
+++ b/opencog/atomspaceutils/CMakeLists.txt
@@ -22,5 +22,5 @@ ENDIF (CYGWIN)
 
 INSTALL (FILES
 	AtomSpaceUtils.h
-	DESTINATION "include/${PROJECT_NAME}/atomspaceutils"
+	DESTINATION "include/opencog/atomspaceutils"
 )

--- a/opencog/atomutils/CMakeLists.txt
+++ b/opencog/atomutils/CMakeLists.txt
@@ -26,5 +26,5 @@ INSTALL (FILES
     ForeachChaseLink.h
     HandleMap.h
     Substitutor.h
-    DESTINATION "include/${PROJECT_NAME}/atomutils"
+    DESTINATION "include/opencog/atomutils"
 )

--- a/opencog/cython/CMakeLists.txt
+++ b/opencog/cython/CMakeLists.txt
@@ -44,7 +44,7 @@ INSTALL (TARGETS PythonEval DESTINATION "lib${LIB_DIR_SUFFIX}/opencog")
 INSTALL (FILES
 	PythonEval.h
 	PyIncludeWrapper.h
-	DESTINATION "include/${PROJECT_NAME}/cython"
+	DESTINATION "include/opencog/cython"
 )
 
 INSTALL (FILES 

--- a/opencog/cython/opencog/CMakeLists.txt
+++ b/opencog/cython/opencog/CMakeLists.txt
@@ -98,7 +98,7 @@ SET_TARGET_PROPERTIES(atomspace_cython PROPERTIES
 INSTALL (FILES
 	__init__.py
 	atomspace.pxd
-	DESTINATION "include/${PROJECT_NAME}/cython/opencog"
+	DESTINATION "include/opencog/cython/opencog"
 )
 
 ############################## type constructors #####################

--- a/opencog/guile/CMakeLists.txt
+++ b/opencog/guile/CMakeLists.txt
@@ -31,5 +31,5 @@ INSTALL (FILES
 	SchemePrimitive.h
 	SchemeSmob.h
 	load-file.h
-	DESTINATION "include/${PROJECT_NAME}/guile"
+	DESTINATION "include/opencog/guile"
 )

--- a/opencog/persist/guile/CMakeLists.txt
+++ b/opencog/persist/guile/CMakeLists.txt
@@ -14,5 +14,5 @@ INSTALL (TARGETS persist
 
 INSTALL (FILES
 	PersistSCM.h
-	DESTINATION "include/${PROJECT_NAME}/persist/guile"
+	DESTINATION "include/opencog/persist/guile"
 )

--- a/opencog/persist/sql/CMakeLists.txt
+++ b/opencog/persist/sql/CMakeLists.txt
@@ -44,5 +44,5 @@ INSTALL (FILES
 	AtomStorage.h
 	odbcxx.h
 	SQLPersistSCM.h
-	DESTINATION "include/${PROJECT_NAME}/persist/sql"
+	DESTINATION "include/opencog/persist/sql"
 )

--- a/opencog/query/CMakeLists.txt
+++ b/opencog/query/CMakeLists.txt
@@ -46,5 +46,5 @@ INSTALL (FILES
 	PatternMatchCallback.h
 	PatternMatchEngine.h
 	Satisfier.h
-	DESTINATION "include/${PROJECT_NAME}/query"
+	DESTINATION "include/opencog/query"
 )

--- a/opencog/rule-engine/CMakeLists.txt
+++ b/opencog/rule-engine/CMakeLists.txt
@@ -39,7 +39,7 @@ INSTALL (FILES
 	URECommons.h
 	Rule.h
 	UREConfigReader.h
-	DESTINATION "include/${PROJECT_NAME}/rule-engine"
+	DESTINATION "include/opencog/rule-engine"
 )
 
 ADD_SUBDIRECTORY(forwardchainer)

--- a/opencog/rule-engine/backwardchainer/CMakeLists.txt
+++ b/opencog/rule-engine/backwardchainer/CMakeLists.txt
@@ -1,4 +1,4 @@
 INSTALL (FILES
 	BackwardChainerPMCB.h
-	DESTINATION "include/${PROJECT_NAME}/rule-engine/backwardchainer"
+	DESTINATION "include/opencog/rule-engine/backwardchainer"
 )

--- a/opencog/rule-engine/forwardchainer/CMakeLists.txt
+++ b/opencog/rule-engine/forwardchainer/CMakeLists.txt
@@ -4,5 +4,5 @@ INSTALL (FILES
 	ForwardChainer.h
 	ForwardChainerCallBack.h
 	ForwardChainerPMCB.h
-	DESTINATION "include/${PROJECT_NAME}/rule-engine/forwardchainer"
+	DESTINATION "include/opencog/rule-engine/forwardchainer"
 )


### PR DESCRIPTION
The other option, that I know of, is to refactor all dependent project's preprocessor declarations. That maybe the 'right' thing to do, I don't know, or revert the project name change.