### PR TITLE
PythonEval: allow multiple atomspaces

### DIFF
--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -236,10 +236,12 @@ TruthValuePtr EvaluationLink::do_evaluate(AtomSpace* as, Handle gsn, Handle args
 		size_t pos = 3;
 		while (' ' == schema[pos]) pos++;
 
+		// Save and restore the evaluators atomspace!
 		PythonEval &applier = PythonEval::instance(as);
-		// std::string rc = applier.apply(schema.substr(pos), args);
-		// if (rc.compare("None") or rc.compare("False")) return false;
-		return applier.apply_tv(schema.substr(pos), args);
+		AtomSpace* save_as = applier.get_current_atomspace();
+		TruthValuePtr tv = applier.apply_tv(schema.substr(pos), args);
+		PythonEval::instance(save_as);
+		return tv;
 #else
 		throw RuntimeException(TRACE_INFO,
 			 "Cannot evaluate python GroundedPredicateNode!");

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -236,12 +236,9 @@ TruthValuePtr EvaluationLink::do_evaluate(AtomSpace* as, Handle gsn, Handle args
 		size_t pos = 3;
 		while (' ' == schema[pos]) pos++;
 
-		// Save and restore the evaluators atomspace!
-		PythonEval &applier = PythonEval::instance(as);
-		AtomSpace* save_as = applier.get_current_atomspace();
-		TruthValuePtr tv = applier.apply_tv(schema.substr(pos), args);
-		PythonEval::instance(save_as);
-		return tv;
+		// Be sure to specify the atomspace in which to work!
+		PythonEval &applier = PythonEval::instance();
+		return applier.apply_tv(as, schema.substr(pos), args);
 #else
 		throw RuntimeException(TRACE_INFO,
 			 "Cannot evaluate python GroundedPredicateNode!");

--- a/opencog/atoms/execution/ExecutionOutputLink.cc
+++ b/opencog/atoms/execution/ExecutionOutputLink.cc
@@ -162,15 +162,11 @@ Handle ExecutionOutputLink::do_execute(AtomSpace* as,
 		size_t pos = 3;
 		while (' ' == schema[pos]) pos++;
 
-		// Get a reference to the python evaluator. We have to
-		// save and restore the python evaluators atomspace, just
-		// in case the execution is happening in a different
-		// atomspace, than what the singleton was created with.
-		PythonEval &applier = PythonEval::instance(as);
-		AtomSpace* save_as = applier.get_current_atomspace();
-
-		Handle h = applier.apply(schema.substr(pos), args);
-		PythonEval::instance(save_as);
+		// Get a reference to the python evaluator. 
+		// Be sure to specify the atomspace in which the
+		// evaluation is to be performed.
+		PythonEval &applier = PythonEval::instance();
+		Handle h = applier.apply(as, schema.substr(pos), args);
 
 		// Return the handle
 		return h;

--- a/opencog/atoms/execution/ExecutionOutputLink.cc
+++ b/opencog/atoms/execution/ExecutionOutputLink.cc
@@ -162,13 +162,15 @@ Handle ExecutionOutputLink::do_execute(AtomSpace* as,
 		size_t pos = 3;
 		while (' ' == schema[pos]) pos++;
 
-		// Get a reference to the python evaluator. NOTE: We are
-		// passing in a reference to our atom space to invoke
-		// the safety checking to make sure the singleton instance
-		// is using the same atom space.
+		// Get a reference to the python evaluator. We have to
+		// save and restore the python evaluators atomspace, just
+		// in case the execution is happening in a different
+		// atomspace, than what the singleton was created with.
 		PythonEval &applier = PythonEval::instance(as);
+		AtomSpace* save_as = applier.get_current_atomspace();
 
 		Handle h = applier.apply(schema.substr(pos), args);
+		PythonEval::instance(save_as);
 
 		// Return the handle
 		return h;

--- a/opencog/cython/PythonEval.cc
+++ b/opencog/cython/PythonEval.cc
@@ -668,6 +668,8 @@ PyObject* PythonEval::module_for_function(  const std::string& moduleFunction,
 PyObject* PythonEval::call_user_function(   const std::string& moduleFunction,
                                             Handle arguments)
 {
+    std::lock_guard<std::recursive_mutex> lck(_mtx);
+
     PyObject *pyError, *pyModule, *pyUserFunc, *pyReturnValue = NULL;
     PyObject *pyDict;
     std::string functionName;
@@ -899,6 +901,8 @@ TruthValuePtr PythonEval::apply_tv(AtomSpace *as, const std::string& func, Handl
 
 std::string PythonEval::apply_script(const std::string& script)
 {
+    std::lock_guard<std::recursive_mutex> lck(_mtx);
+
     PyObject* pyError = NULL;
     PyObject *pyCatcher = NULL;
     PyObject *pyOutput = NULL;

--- a/opencog/cython/PythonEval.cc
+++ b/opencog/cython/PythonEval.cc
@@ -421,6 +421,7 @@ PythonEval& PythonEval::instance(AtomSpace* atomspace)
     // Make sure the atom space is the same as the one in the singleton.
     if (atomspace and singletonInstance->_atomspace != atomspace) {
 
+#define CHECK_SINGLETON
 #ifdef CHECK_SINGLETON
         // Someone is trying to initialize the Python interpreter on a
         // different AtomSpace.  Because of the singleton design of the
@@ -792,7 +793,7 @@ PyObject* PythonEval::call_user_function(   const std::string& moduleFunction,
     return pyReturnValue;
 }
 
-Handle PythonEval::apply(const std::string& func, Handle varargs)
+Handle PythonEval::apply(AtomSpace* as, const std::string& func, Handle varargs)
 {
     PyObject *pyReturnAtom = NULL;
     PyObject *pyError, *pyAtomUUID = NULL;
@@ -843,7 +844,7 @@ Handle PythonEval::apply(const std::string& func, Handle varargs)
  * Apply the user function to the arguments passed in varargs and return
  * the extracted truth value.
  */
-TruthValuePtr PythonEval::apply_tv(const std::string& func, Handle varargs)
+TruthValuePtr PythonEval::apply_tv(AtomSpace *as, const std::string& func, Handle varargs)
 {
     // Get the python truth value object returned by this user function.
     PyObject *pyTruthValue = call_user_function(func, varargs);

--- a/opencog/cython/PythonEval.cc
+++ b/opencog/cython/PythonEval.cc
@@ -453,7 +453,7 @@ void PythonEval::initialize_python_objects_and_imports(void)
 
     // Add ATOMSPACE to __main__ module.
     PyObject* pyRootDictionary = PyModule_GetDict(_pyRootModule);
-    PyObject* pyAtomSpaceObject = this->atomspace_py_object();
+    PyObject* pyAtomSpaceObject = this->atomspace_py_object(_atomspace);
     PyDict_SetItemString(pyRootDictionary, "ATOMSPACE", pyAtomSpaceObject);
     Py_DECREF(pyAtomSpaceObject);
 
@@ -484,11 +484,16 @@ PyObject* PythonEval::atomspace_py_object(AtomSpace* atomspace)
         return NULL;
     }
 
-    PyObject * pyAtomSpace;
-    if (atomspace)
-        pyAtomSpace = py_atomspace(atomspace);
-    else
-        pyAtomSpace = py_atomspace(this->_atomspace);
+/***********
+    Weird ... I guess NULL atomspaces are OK!?
+    if (NULL == atomspace) {
+        logger().error("PythonEval::%s No atomspace specified!",
+                        __FUNCTION__);
+        return NULL;
+    }
+************/
+
+    PyObject * pyAtomSpace = py_atomspace(atomspace);
 
     if (!pyAtomSpace) {
         if (PyErr_Occurred())
@@ -727,7 +732,7 @@ PyObject* PythonEval::call_user_function(   const std::string& moduleFunction,
     // Create the Python tuple for the function call with python
     // atoms for each of the atoms in the link arguments.
     PyObject* pyArguments = PyTuple_New(actualArgumentCount);
-    PyObject* pyAtomSpace = this->atomspace_py_object();
+    PyObject* pyAtomSpace = this->atomspace_py_object(_atomspace);
     const HandleSeq& argumentHandles = linkArguments->getOutgoingSet();
     int tupleItem = 0;
     for (HandleSeq::const_iterator it = argumentHandles.begin();
@@ -991,7 +996,7 @@ void PythonEval::import_module( const boost::filesystem::path &file,
         PyObject* pyModuleDictionary = PyModule_GetDict(pyModule);
 
         // Add the ATOMSPACE object to this module
-        PyObject* pyAtomSpaceObject = this->atomspace_py_object();
+        PyObject* pyAtomSpaceObject = this->atomspace_py_object(_atomspace);
         PyDict_SetItemString(pyModuleDictionary,"ATOMSPACE",
                 pyAtomSpaceObject);
 

--- a/opencog/cython/PythonEval.cc
+++ b/opencog/cython/PythonEval.cc
@@ -421,6 +421,7 @@ PythonEval& PythonEval::instance(AtomSpace* atomspace)
     // Make sure the atom space is the same as the one in the singleton.
     if (atomspace and singletonInstance->_atomspace != atomspace) {
 
+#ifdef CHECK_SINGLETON
         // Someone is trying to initialize the Python interpreter on a
         // different AtomSpace.  Because of the singleton design of the
         // the CosgServer+AtomSpace, there is no easy way to support this...
@@ -428,6 +429,19 @@ PythonEval& PythonEval::instance(AtomSpace* atomspace)
             "Trying to re-initialize python interpreter with different\n"
             "AtomSpace ptr! Current ptr=%p New ptr=%p\n",
             singletonInstance->_atomspace, atomspace);
+#else
+        // We need to be able to call the python interpreter with
+        // different atomspaces; for example, we need to use temporary
+        // atomspaces when evaluating virtual links.  So, just set it
+        // here.  Hopefully the user will set it back, after using the
+        // temp atomspace.   Cleary, this is not thread-safe, and will
+        // bust with multiple threads. But the whole singleton-instance
+        // design is fundamentally flawed, so there is not much we can
+        // do about it until someone takes the time to fix this class
+        // to allow multiple instances.
+        //
+        singletonInstance->_atomspace = atomspace;
+#endif
     }
     return *singletonInstance;
 }

--- a/opencog/cython/PythonEval.h
+++ b/opencog/cython/PythonEval.h
@@ -108,7 +108,9 @@ class PythonEval : public GenericEval
         static PythonEval* singletonInstance;
 
         AtomSpace* _atomspace;
-        // Resource Acquisition is Allocatino, for the current AtomSpace.
+        // Resource Acquisition is Allocation, for the current AtomSpace.
+        // If anything throws an exception, then dtor runs and restores
+        // the old atomspace.
         struct RAII {
             RAII(PythonEval* pev, AtomSpace* as) : _pev(pev)
                { _save_as = pev->_atomspace; pev->_atomspace = as; }

--- a/opencog/cython/PythonEval.h
+++ b/opencog/cython/PythonEval.h
@@ -126,7 +126,7 @@ class PythonEval : public GenericEval
         /**
          * Create the singleton instance with the supplied atomspace.
          */
-        static void create_singleton_instance(AtomSpace *);
+        static void create_singleton_instance(AtomSpace*);
 
         /**
          * Delete the singleton instance.
@@ -136,7 +136,8 @@ class PythonEval : public GenericEval
         /**
          * Get a reference to the singleton instance.
          */
-        static PythonEval & instance(AtomSpace * atomspace = NULL);
+        static PythonEval & instance(AtomSpace* atomspace = NULL);
+        AtomSpace* get_current_atomspace(void) { return _atomspace; }
 
         // The async-output interface.
         virtual void begin_eval() {}

--- a/opencog/cython/PythonEval.h
+++ b/opencog/cython/PythonEval.h
@@ -97,12 +97,12 @@ class PythonEval : public GenericEval
         void build_python_error_message(const char* function_name,
                                         std::string& errorMessage);
         void add_to_sys_path(std::string path);
-        PyObject * atomspace_py_object(AtomSpace * atomspace = NULL);
-        void print_dictionary(PyObject* obj);
+        PyObject * atomspace_py_object(AtomSpace *);
+        void print_dictionary(PyObject*);
         void execute_string(const char* command);
         int argument_count(PyObject* pyFunction);
-        PyObject* module_for_function(  const std::string& moduleFunction,
-                                        std::string& functionName);
+        PyObject* module_for_function(const std::string& moduleFunction,
+                                      std::string& functionName);
 
         static PythonEval* singletonInstance;
 
@@ -120,13 +120,13 @@ class PythonEval : public GenericEval
         int _paren_count;
 
     public:
-        PythonEval(AtomSpace* atomspace);
+        PythonEval(AtomSpace*);
         ~PythonEval();
 
         /**
          * Create the singleton instance with the supplied atomspace.
          */
-        static void create_singleton_instance(AtomSpace * atomspace);
+        static void create_singleton_instance(AtomSpace *);
 
         /**
          * Delete the singleton instance.

--- a/opencog/cython/PythonEval.h
+++ b/opencog/cython/PythonEval.h
@@ -108,6 +108,14 @@ class PythonEval : public GenericEval
         static PythonEval* singletonInstance;
 
         AtomSpace* _atomspace;
+        // Resource Acquisition is Allocatino, for the current AtomSpace.
+        struct RAII {
+            RAII(PythonEval* pev, AtomSpace* as) : _pev(pev)
+               { _save_as = pev->_atomspace; pev->_atomspace = as; }
+            ~RAII() {_pev->_atomspace = _save_as; }
+            AtomSpace* _save_as;
+            PythonEval* _pev;
+        };
 
         // Single, global mutex for serializing access to the atomspace.
         // The singleton-instance design of this class forces us to


### PR DESCRIPTION
Some quick-n-dirty code to allow multiple atomspaces in python, while also introducing some minimal thread-safety, too.  I'm hoping this fixes/works-around Yi-Shan's MineCraft scripting issues.