### PR TITLE
pattern matcher unique results

### DIFF
--- a/opencog/query/Implicator.h
+++ b/opencog/query/Implicator.h
@@ -47,20 +47,31 @@ namespace opencog {
  *
  * The 'var_soln' argument in the callback contains the map from variables
  * to ground terms. 'class Instantiator' is used to perform the actual
- * grounding.  A list of grounded expressions is created in 'result_list'.
+ * grounding.  A set of grounded expressions is created in 'result_set'.
+ * Note that the callback may be called many times reporting the same
+ * results. In that case the 'result_set' will contain unique solutions.
  */
 class Implicator :
 	public virtual PatternMatchCallback
 {
+	protected:
+		UnorderedHandleSet _result_set;
+		HandleSeq _result_list;
+		bool _result_changed;
+
 	public:
-		Implicator(AtomSpace* as) : inst(as), max_results(SIZE_MAX) {}
+		Implicator(AtomSpace* as) : _result_changed(false), inst(as),
+		                            max_results(SIZE_MAX) {}
 		Instantiator inst;
 		Handle implicand;
-		std::vector<Handle> result_list;
 		size_t max_results;
 
 		virtual bool grounding(const std::map<Handle, Handle> &var_soln,
 		                       const std::map<Handle, Handle> &term_soln);
+
+		virtual void insert_result(const Handle&);
+		virtual UnorderedHandleSet get_result_set() { return _result_set; }
+		virtual HandleSeq get_result_list();
 };
 
 }; // namespace opencog

--- a/opencog/query/PatternMatchCallback.h
+++ b/opencog/query/PatternMatchCallback.h
@@ -232,6 +232,9 @@ class PatternMatchCallback
 		 * acceptable. The engine is designed to halt once an acceptable
 		 * solution has been found; thus, in order to force it to search
 		 * for more, a return value of false is needed.)
+		 *
+		 * Note that the callback may be called many times reporting
+		 * the same result.
 		 */
 		virtual bool grounding(const std::map<Handle, Handle> &var_soln,
 		                       const std::map<Handle, Handle> &term_soln) = 0;

--- a/opencog/rule-engine/forwardchainer/ForwardChainer.cc
+++ b/opencog/rule-engine/forwardchainer/ForwardChainer.cc
@@ -190,7 +190,7 @@ void ForwardChainer::do_pm(const Handle& hsource,
     sl->satisfy(impl);
 
     // Update result
-    _fcmem.add_rules_product(0, impl.result_list);
+    _fcmem.add_rules_product(0, impl.get_result_list());
 
     // Delete the AND_LINK and LIST_LINK
     _as.remove_atom(hvar_list);
@@ -204,7 +204,7 @@ void ForwardChainer::do_pm(const Handle& hsource,
         impl.implicand = bl->get_implicand();
         bl->imply(impl);
         _fcmem.set_cur_rule(rule);
-        _fcmem.add_rules_product(0, impl.result_list);
+        _fcmem.add_rules_product(0, impl.get_result_list());
     }
 }
 /**
@@ -225,10 +225,10 @@ void ForwardChainer::do_pm()
         _fcmem.set_cur_rule(rule);
 
         _log->info("OUTPUTS");
-        for (auto h : impl.result_list)
+        for (auto h : impl.get_result_list())
             _log->info("%s", h->toString().c_str());
 
-        _fcmem.add_rules_product(0, impl.result_list);
+        _fcmem.add_rules_product(0, impl.get_result_list());
     }
 
 }

--- a/opencog/rule-engine/forwardchainer/ForwardChainerPMCB.cc
+++ b/opencog/rule-engine/forwardchainer/ForwardChainerPMCB.cc
@@ -68,10 +68,7 @@ bool ForwardChainerPMCB::grounding(const std::map<Handle, Handle> &var_soln,
     for (auto& vs : var_soln) {
         if (vs.second == source) {
             Handle h = inst.instantiate(implicand, var_soln);
-            if (Handle::UNDEFINED != h) {
-                result_list.push_back(h);
-                break;
-            }
+            insert_result(h);
         }
     }
 
@@ -85,7 +82,8 @@ void ForwardChainerPMCB::set_fcmem(FCMemory *fcmem)
 
 HandleSeq ForwardChainerPMCB::get_products()
 {
-    auto product = result_list;
-    result_list.clear();
+    auto product = get_result_list();
+    _result_set.clear();
+    _result_list.clear();
     return product;
 }

--- a/opencog/rule-engine/forwardchainer/VarGroundingPMCB.h
+++ b/opencog/rule-engine/forwardchainer/VarGroundingPMCB.h
@@ -48,11 +48,8 @@ public:
 
         var_groundings.push_back(var_soln);
         term_groundings.push_back(term_soln);
-        // If we found as many as we want, then stop looking for more.
-        if (result_list.size() < max_results)
-            return false;
 
-        return true;
+        return false;
     }
 
     std::vector<std::map<Handle, Handle>> var_groundings;

--- a/tests/query/EinsteinUTest.cxxtest
+++ b/tests/query/EinsteinUTest.cxxtest
@@ -284,14 +284,14 @@ void EinsteinPuzzle::test_full(void)
 
 	// XXX virtual link matcher does not yet do 'not' clauses ...
 	// TSM_ASSERT_EQUALS("wrong number of solutions found", 234, getarity(distc));
-	TSM_ASSERT_EQUALS("wrong number of solutions found", 257, getarity(distc));
+	TSM_ASSERT_EQUALS("wrong number of solutions found", 222, getarity(distc));
 
 	// -----------
 	// By-elimination rule
 	// If a person doesn't smoke/drink/live-in four items, they must do the fifth.
 	Handle elimi = bindlink(as, elimi_rule);
 	logger().debug() << "After elimination\n" << SchemeSmob::to_string(elimi);
-	TSM_ASSERT_EQUALS("wrong number of solutions found", 696, getarity(elimi));
+	TSM_ASSERT_EQUALS("wrong number of solutions found", 29, getarity(elimi));
 
 	// -----------
 	// Print partial results.

--- a/tests/query/ExecutionOutputUTest.cxxtest
+++ b/tests/query/ExecutionOutputUTest.cxxtest
@@ -244,7 +244,7 @@ void ExecutionOutputUTest::test_varsub(void)
    situation->imply(simpl);
 
    // The result_list contains a list of the grounded expressions.
-   Handle res = simpl.result_list[0];
+   Handle res = simpl.get_result_list()[0];
 	printf("res is %s\n", res->toShortString().c_str());
 	TSM_ASSERT_EQUALS("incorrect resolution", res, resolution);
 
@@ -254,7 +254,7 @@ void ExecutionOutputUTest::test_varsub(void)
    predicament->imply(pimpl);
 
    // The result_list contains a list of the grounded expressions.
-   Handle del = pimpl.result_list[0];
+   Handle del = pimpl.get_result_list()[0];
 	printf("del is %s\n", del->toShortString().c_str());
 	TSM_ASSERT_EQUALS("incorrect delivarance", del, deliverance);
 

--- a/tests/query/QuoteUTest.cxxtest
+++ b/tests/query/QuoteUTest.cxxtest
@@ -277,7 +277,7 @@ void QuoteUTest::test_crash(void)
 
     // If we can execute this without crashing, the test is succesful.
     Handle cr = eval->eval_h("(cog-bind crasher)");
-    TS_ASSERT_EQUALS(6, as->get_arity(cr));
+    TS_ASSERT_EQUALS(1, as->get_arity(cr));
 
     // This blows out the stack in an infinite loop, if the instantiator
     // doesn't catch it and prevent it.

--- a/tests/query/imply.h
+++ b/tests/query/imply.h
@@ -34,7 +34,7 @@ static inline Handle imply(AtomSpace* as, Handle hclauses, Handle himplicand)
 
 	// The result_list contains a list of the grounded expressions.
 	// Turn it into a true list, and return it.
-	Handle gl = as->add_link(LIST_LINK, impl.result_list);
+	Handle gl = as->add_link(LIST_LINK, impl.get_result_list());
 	return gl;
 }
 


### PR DESCRIPTION
This partly addresses problems  #148. The duplicated results of the query are made unique by default grounding callback. I have analysed how to prune search for duplicated results at earlier phase of pattern matching but found it complicated in general for example for hierarchical choice links and other cases, so I suggest this simple solution for now.

