### PR TITLE
ChoiceLink unneeded special case

### DIFF
--- a/opencog/query/InitiateSearchCB.h
+++ b/opencog/query/InitiateSearchCB.h
@@ -72,7 +72,6 @@ class InitiateSearchCB : public virtual PatternMatchCallback
 
 		bool _search_fail;
 		virtual bool neighbor_search(PatternMatchEngine *);
-		virtual bool disjunct_search(PatternMatchEngine *);
 		virtual bool link_type_search(PatternMatchEngine *);
 		virtual bool variable_search(PatternMatchEngine *);
 		virtual bool no_search(PatternMatchEngine *);


### PR DESCRIPTION
At the present implementation of PatternMatchEngine this piece of code is not needed any more. The case described in the comment is covered by ChoiceLinkUTest - top-disco test. After removing the code it works fine and it is easier to introduce next changes.

```
100% tests passed, 0 tests failed out of 81
```