### PR TITLE
Pattern matcher term tree traversing

### DIFF
--- a/opencog/atoms/bind/PatternLink.h
+++ b/opencog/atoms/bind/PatternLink.h
@@ -119,6 +119,10 @@ protected:
 	void check_connectivity(const std::vector<HandleSeq>&);
 	void make_map_recursive(const Handle&, const Handle&);
 
+	void make_term_trees();
+	void make_term_tree_recursive(const Handle&, const Handle&,
+	                              PatternTermPtr&);
+
 	void init(void);
 	void common_init(void);
 	void setup_components(void);

--- a/opencog/query/CMakeLists.txt
+++ b/opencog/query/CMakeLists.txt
@@ -42,6 +42,7 @@ INSTALL (FILES
 	Implicator.h
 	InitiateSearchCB.h
 	Pattern.h
+	PatternTerm.h
 	PatternSCM.h
 	PatternMatchCallback.h
 	PatternMatchEngine.h

--- a/opencog/query/Composition.cc
+++ b/opencog/query/Composition.cc
@@ -163,7 +163,10 @@ bool PatternMatchEngine::redex_compare(const LinkPtr& lp,
 	clause_accepted = false;
 
 	Handle hp(_pat->cnf_clauses[0]);
-	bool found = tree_compare(hp, Handle(lg), CALL_COMP);
+	throw RuntimeException(TRACE_INFO, "Unimplemented yet");
+	// TODO: wrap by PatternTermPtr
+	// bool found = tree_compare(hp, Handle(lg), CALL_COMP);
+	bool found = false;
 #endif
 
 #if 0

--- a/opencog/query/Pattern.h
+++ b/opencog/query/Pattern.h
@@ -30,6 +30,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include <opencog/query/PatternTerm.h>
 #include <opencog/atomspace/Handle.h>
 #include <opencog/atomspace/types.h>  // for typedef Type
 
@@ -79,6 +80,15 @@ struct Pattern
 	typedef std::map<Handle, RootList> ConnectMap;
 	typedef std::pair<Handle, RootList> ConnectPair;
 
+	// Each atom of the pattern as well as their corresponding pattern terms
+	// may appear in many clauses. Moreover the same atom may be replicated
+	// under the same clause root in many instances. Each occurence has its
+	// own unique PatternTermPtr. We need to keep the mapping beetwen atoms
+	// and clause roots to the list of atoms occurences. Typically the list
+	// of PatternTermPtr has single element, but as said above when given atom
+	// is replicated under one root then the list has many elements.
+	typedef std::map<std::pair<Handle,Handle>, PatternTermSeq> ConnectTermMap;
+
 	// -------------------------------------------
 	// The current set of clauses (beta redex context) being grounded.
 	std::string redex_name;  // for debugging only!
@@ -127,6 +137,8 @@ struct Pattern
 	// after one clause is solved, we know what parts of the unsolved
 	// clauses already have a solution.
 	ConnectMap       connectivity_map;     // setup by make_connectivity_map()
+
+	ConnectTermMap   connected_terms_map;  // setup by make_term_trees()
 };
 
 /** @}*/

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -114,15 +114,15 @@ static inline void prtmsg(const char * msg, const Handle& h)
 /// contents. This is done recursively, of course.  The QuoteLink
 /// must have only one child; anything else beyond that is ignored
 /// (as its not clear what else could possibly be done).
-bool PatternMatchEngine::quote_compare(const Handle& hp,
+bool PatternMatchEngine::quote_compare(const PatternTermPtr& ptm,
                                        const Handle& hg)
 {
 	in_quote = true;
-	LinkPtr lp(LinkCast(hp));
+	LinkPtr lp(LinkCast(ptm->getHandle()));
 	if (1 != lp->getArity())
 		throw InvalidParamException(TRACE_INFO,
 		            "QuoteLink has unexpected arity!");
-	bool ma = tree_compare(lp->getOutgoingAtom(0), hg, CALL_QUOTE);
+	bool ma = tree_compare(ptm->getOutgoingTerm(0), hg, CALL_QUOTE);
 	in_quote = false;
 	return ma;
 }
@@ -238,12 +238,12 @@ bool PatternMatchEngine::node_compare(const Handle& hp,
 
 /// If the two links are both ordered, its enough to compare
 /// them "side-by-side".
-bool PatternMatchEngine::ordered_compare(const Handle& hp,
+bool PatternMatchEngine::ordered_compare(const PatternTermPtr& ptm,
                                          const Handle& hg,
                                          const LinkPtr& lp,
                                          const LinkPtr& lg)
 {
-	const HandleSeq &osp = lp->getOutgoingSet();
+	const PatternTermSeq &osp = ptm->getOutgoingSet();
 	const HandleSeq &osg = lg->getOutgoingSet();
 
 //	size_t oset_sz = osp.size();
@@ -277,7 +277,7 @@ bool PatternMatchEngine::ordered_compare(const Handle& hp,
 		else if (i < osp_size)
 			tc = tree_compare(osp[i], Handle::UNDEFINED, CALL_UNORDER);
 
-		else tc = tree_compare(Handle::UNDEFINED, osg[i], CALL_UNORDER);
+		else tc = tree_compare(PatternTerm::UNDEFINED, osg[i], CALL_UNORDER);
 
 		if (not tc)
 		{
@@ -297,6 +297,7 @@ bool PatternMatchEngine::ordered_compare(const Handle& hp,
 	if (not match) return false;
 
 	// If we've found a grounding, record it.
+	const Handle &hp = ptm->getHandle();
 	if (hp != hg) var_grounding[hp] = hg;
 
 	return true;
@@ -311,17 +312,18 @@ bool PatternMatchEngine::ordered_compare(const Handle& hp,
 /// can match one of the sub-expressions of the ChoiceLink, then
 /// the ChoiceLink as a whole can be considered to be grounded.
 ///
-bool PatternMatchEngine::choice_compare(const Handle& hp,
+bool PatternMatchEngine::choice_compare(const PatternTermPtr& ptm,
                                         const Handle& hg,
                                         const LinkPtr& lp,
                                         const LinkPtr& lg)
 {
-	const std::vector<Handle> &osp = lp->getOutgoingSet();
+	const Handle& hp = ptm->getHandle();
+	const PatternTermSeq &osp = ptm->getOutgoingSet();
 
 	// _choice_state lets use resume where we last left off.
 	size_t iend = osp.size();
 	bool fresh = false;
-	size_t icurr = curr_choice(hp, hg, fresh);
+	size_t icurr = curr_choice(ptm, hg, fresh);
 	if (fresh) choose_next = false; // took a step, clear the flag
 
 	dbgprt("tree_comp resume choice search at %zu of %zu of UUID=%lu "
@@ -340,7 +342,7 @@ bool PatternMatchEngine::choice_compare(const Handle& hp,
 	while (icurr<iend)
 	{
 		solution_push();
-		const Handle& hop = osp[icurr];
+		const PatternTermPtr& hop = osp[icurr];
 
 		dbgprt("tree_comp or_link choice %zu of %zu\n", icurr, iend);
 
@@ -358,7 +360,7 @@ bool PatternMatchEngine::choice_compare(const Handle& hp,
 				// If the grounding is accepted, record it.
 				if (hp != hg) var_grounding[hp] = hg;
 
-				_choice_state[Choice(hp, hg)] = icurr;
+				_choice_state[Choice(ptm, hg)] = icurr;
 				return true;
 			}
 		}
@@ -368,32 +370,32 @@ bool PatternMatchEngine::choice_compare(const Handle& hp,
 	}
 
 	// If we are here, we've explored all the possibilities already
-	_choice_state.erase(Choice(hp, hg));
+	_choice_state.erase(Choice(ptm, hg));
 	return false;
 }
 
 /// Return the current choice state for the given pattern & ground
 /// combination.
-size_t PatternMatchEngine::curr_choice(const Handle& hp,
+size_t PatternMatchEngine::curr_choice(const PatternTermPtr& ptm,
                                        const Handle& hg,
                                        bool& fresh)
 {
 	size_t istart;
-	try { istart = _choice_state.at(Choice(hp, hg)); }
+	try { istart = _choice_state.at(Choice(ptm, hg)); }
 	catch(...) { istart = 0; fresh = true; }
 	return istart;
 }
 
-bool PatternMatchEngine::have_choice(const Handle& hp,
+bool PatternMatchEngine::have_choice(const PatternTermPtr& ptm,
                                      const Handle& hg)
 {
 #if USE_AT
 	bool have = true;
-	try { _choice_state.at(Choice(hp, hg)); }
+	try { _choice_state.at(Choice(ptm, hg)); }
 	catch(...) { have = false;}
 	return have;
 #else
-	return 0 < _choice_state.count(Choice(hp, hg));
+	return 0 < _choice_state.count(Choice(ptm, hg));
 #endif
 }
 
@@ -544,13 +546,14 @@ they call compare_tree.
 
 ******************************************************************/
 
-bool PatternMatchEngine::unorder_compare(const Handle& hp,
+bool PatternMatchEngine::unorder_compare(const PatternTermPtr& ptm,
                                          const Handle& hg,
                                          const LinkPtr& lp,
                                          const LinkPtr& lg)
 {
+	const Handle& hp = ptm->getHandle();
 	const HandleSeq& osg = lg->getOutgoingSet();
-	const HandleSeq& osp = lp->getOutgoingSet();
+	const PatternTermSeq& osp = ptm->getOutgoingSet();
 //	size_t arity = osp.size();
 	size_t osg_size = osg.size();
 	size_t osp_size = osp.size();
@@ -565,7 +568,7 @@ bool PatternMatchEngine::unorder_compare(const Handle& hp,
 
 	// _perm_state lets use resume where we last left off.
 	bool fresh = false;
-	Permutation mutation = curr_perm(hp, hg, fresh);
+	Permutation mutation = curr_perm(ptm, hg, fresh);
 	if (fresh) take_step = false; // took a step, clear the flag.
 
 	// Cases C and D fall through.
@@ -574,13 +577,13 @@ bool PatternMatchEngine::unorder_compare(const Handle& hp,
 	int num_perms = facto(mutation.size());
 	dbgprt("tree_comp resume unordered search at %d of %d of UUID=%lu "
 	       "take_step=%d have_more=%d\n",
-	       perm_count[Unorder(hp, hg)], num_perms, hp.value(),
+	       perm_count[Unorder(ptm, hg)], num_perms, hp.value(),
 	       take_step, have_more);
 #endif
 	do
 	{
 		dbgprt("tree_comp explore unordered perm %d of %d of UUID=%lu\n",
-		       perm_count[Unorder(hp, hg)], num_perms, hp.value());
+		       perm_count[Unorder(ptm, hg)], num_perms, hp.value());
 
 		solution_push();
 		bool match = true;
@@ -593,7 +596,7 @@ bool PatternMatchEngine::unorder_compare(const Handle& hp,
 			else if (i < osp_size)
 				tc = tree_compare(mutation[i], Handle::UNDEFINED, CALL_UNORDER);
 
-			else tc = tree_compare(Handle::UNDEFINED, osg[i], CALL_UNORDER);
+			else tc = tree_compare(PatternTerm::UNDEFINED, osg[i], CALL_UNORDER);
 
 			if (not tc)
 			{
@@ -640,27 +643,27 @@ bool PatternMatchEngine::unorder_compare(const Handle& hp,
 				// Handle case 5&7 of description above.
 				have_more = true;
 				dbgprt("Good permutation %d for UUID=%lu have_more=%d\n",
-				       perm_count[Unorder(hp, hg)], hp.value(), have_more);
-				_perm_state[Unorder(hp, hg)] = mutation;
+				       perm_count[Unorder(ptm, hg)], hp.value(), have_more);
+				_perm_state[Unorder(ptm, hg)] = mutation;
 				return true;
 			}
 		}
 		// If we are here, we are handling case 8.
 		dbgprt("Above permuation %d failed UUID=%lu\n",
-		       perm_count[Unorder(hp, hg)], hp.value());
+		       perm_count[Unorder(ptm, hg)], hp.value());
 
 take_next_step:
 		take_step = false; // we are taking a step, so clear the flag.
 		have_more = false; // start with a clean slate...
 		solution_pop();
 #ifdef DEBUG
-		perm_count[Unorder(hp, hg)] ++;
+		perm_count[Unorder(ptm, hg)] ++;
 #endif
 	} while (std::next_permutation(mutation.begin(), mutation.end()));
 
 	// If we are here, we've explored all the possibilities already
 	dbgprt("Exhausted all permuations of UUID=%lu\n", hp.value());
-	_perm_state.erase(Unorder(hp, hg));
+	_perm_state.erase(Unorder(ptm, hg));
 	have_more = false;
 	return false;
 }
@@ -669,20 +672,20 @@ take_next_step:
 /// particular point in the tree comparison (i.e. for the
 /// particular unordered link hp in the pattern.)
 PatternMatchEngine::Permutation
-PatternMatchEngine::curr_perm(const Handle& hp,
+PatternMatchEngine::curr_perm(const PatternTermPtr& ptm,
                               const Handle& hg,
                               bool& fresh)
 {
 	Permutation perm;
-	try { perm = _perm_state.at(Unorder(hp, hg)); }
+	try { perm = _perm_state.at(Unorder(ptm, hg)); }
 	catch(...)
 	{
 #ifdef DEBUG
+		const Handle &hp = ptm->getHandle();
 		dbgprt("tree_comp fresh start unordered link UUID=%lu\n", hp.value());
-		perm_count[Unorder(hp, hg)] = 0;
+		perm_count[Unorder(ptm, hg)] = 0;
 #endif
-		LinkPtr lp(LinkCast(hp));
-		perm = lp->getOutgoingSet();
+		perm = ptm->getOutgoingSet();
 		sort(perm.begin(), perm.end());
 		fresh = true;
 	}
@@ -691,10 +694,10 @@ PatternMatchEngine::curr_perm(const Handle& hp,
 
 /// Return true if there are more permutations to explore.
 /// Else return false.
-bool PatternMatchEngine::have_perm(const Handle& hp,
+bool PatternMatchEngine::have_perm(const PatternTermPtr& ptm,
                                    const Handle& hg)
 {
-	try { _perm_state.at(Unorder(hp, hg)); }
+	try { _perm_state.at(Unorder(ptm, hg)); }
 	catch(...) { return false; }
 	return true;
 }
@@ -752,10 +755,12 @@ void PatternMatchEngine::perm_pop(void)
  * var_grounding when encountering variables (and sub-clauses) in the
  * pattern.
  */
-bool PatternMatchEngine::tree_compare(const Handle& hp,
+bool PatternMatchEngine::tree_compare(const PatternTermPtr& ptm,
                                       const Handle& hg,
                                       Caller caller)
 {
+	const Handle& hp = ptm->getHandle();
+
 	// This could happen when the arity of the two hypergraphs are different.
 	// It's clearly a mismatch so we should always return false here unless
 	// we are looking for a non-exact match
@@ -768,7 +773,7 @@ bool PatternMatchEngine::tree_compare(const Handle& hp,
 	// (as its not clear what else could possibly be done).
 	Type tp = hp->getType();
 	if (not in_quote and QUOTE_LINK == tp)
-		return quote_compare(hp, hg);
+		return quote_compare(ptm, hg);
 
 	// Handle hp is from the pattern clause, and it might be one
 	// of the bound variables. If so, then declare a match.
@@ -842,18 +847,40 @@ bool PatternMatchEngine::tree_compare(const Handle& hp,
 	// the ChoiceLink as a whole can be considered to be grounded.
 	//
 	if (CHOICE_LINK == tp)
-		return choice_compare(hp, hg, lp, lg);
+		return choice_compare(ptm, hg, lp, lg);
 
 	// If the two links are both ordered, its enough to compare
 	// them "side-by-side".
 	if (2 > lp->getArity() || _classserver.isA(tp, ORDERED_LINK))
-		return ordered_compare(hp, hg, lp, lg);
+		return ordered_compare(ptm, hg, lp, lg);
 
 	// If we are here, we are dealing with an unordered link.
-	return unorder_compare(hp, hg, lp, lg);
+	return unorder_compare(ptm, hg, lp, lg);
 }
 
 /* ======================================================== */
+
+bool PatternMatchEngine::explore_term_branches(const Handle& hp,
+                                               const Handle& hg,
+                                               const Handle& clause_root)
+{
+	try
+	{
+		// The term may appear in the clause in many places.
+		// Start exploration at each occurence
+		for (const PatternTermPtr &ptm :
+			_pat->connected_terms_map.at({hp, clause_root}))
+		{
+			if (explore_link_branches(ptm, hg, clause_root))
+				return true;
+		}
+	} catch (...) {
+		dbgprt("Term not found for hp=%s, clause=%s\n",
+		        hp->toShortString().c_str(),
+		        clause_root->toShortString().c_str());
+	}
+	return false;
+}
 
 /// explore_up_branches -- look for groundings for the given term.
 ///
@@ -879,7 +906,7 @@ bool PatternMatchEngine::tree_compare(const Handle& hp,
 /// explored.  Thus, this returns true only if entire pattern was
 /// grounded.
 ///
-bool PatternMatchEngine::explore_up_branches(const Handle& hp,
+bool PatternMatchEngine::explore_up_branches(const PatternTermPtr& ptm,
                                              const Handle& hg,
                                              const Handle& clause_root)
 {
@@ -887,12 +914,12 @@ bool PatternMatchEngine::explore_up_branches(const Handle& hp,
 	IncomingSet iset = _pmc.get_incoming_set(hg);
 	size_t sz = iset.size();
 	dbgprt("Looking upward for pat-UUID=%lu have %zu branches\n",
-	        hp.value(), sz);
+	        ptm->getHandle().value(), sz);
 	bool found = false;
 	for (size_t i = 0; i < sz; i++) {
 		dbgprt("Try upward branch %zu of %zu for pat-UUID=%lu propose=%lu\n",
-		       i, sz, hp.value(), Handle(iset[i]).value());
-		found = explore_link_branches(hp, Handle(iset[i]), clause_root);
+		       i, sz, ptm->getHandle().value(), Handle(iset[i]).value());
+		found = explore_link_branches(ptm, Handle(iset[i]), clause_root);
 		if (found) break;
 	}
 
@@ -932,10 +959,11 @@ bool PatternMatchEngine::explore_up_branches(const Handle& hp,
 /// explored.  Thus, this returns true only if entire pattern was
 /// grounded.
 ///
-bool PatternMatchEngine::explore_link_branches(const Handle& hp,
+bool PatternMatchEngine::explore_link_branches(const PatternTermPtr& ptm,
                                                const Handle& hg,
                                                const Handle& clause_root)
 {
+	const Handle& hp = ptm->getHandle();
 	// Let's not stare at our own navel. ... Unless the current
 	// clause has GroundedPredicateNodes in it. In that case, we
 	// have to make sure that they get evaluated.
@@ -946,11 +974,11 @@ bool PatternMatchEngine::explore_link_branches(const Handle& hp,
 	// If its not an unordered link, then don't try to iterate.
 	Type tp = hp->getType();
 	if (not _classserver.isA(tp, UNORDERED_LINK))
-		return explore_choice_branches(hp, hg, clause_root);
+		return explore_choice_branches(ptm, hg, clause_root);
 
 	do {
 		// If the pattern was satisfied, then we are done for good.
-		if (explore_choice_branches(hp, hg, clause_root))
+		if (explore_choice_branches(ptm, hg, clause_root))
 			return true;
 
 		dbgprt("Step to next permuation\n");
@@ -958,7 +986,7 @@ bool PatternMatchEngine::explore_link_branches(const Handle& hp,
 		// On the next go-around, take a step.
 		take_step = true;
 		have_more = false;
-	} while (have_perm(hp, hg));
+	} while (have_perm(ptm, hg));
 
 	dbgprt("No more unordered permutations\n");
 
@@ -968,13 +996,14 @@ bool PatternMatchEngine::explore_link_branches(const Handle& hp,
 /// See explore_link_branches() for a general explanation. This method
 /// handles the ChoiceLink branch alternatives only.  It assumes
 /// that the caller had handled the unordered-link alternative branches.
-bool PatternMatchEngine::explore_choice_branches(const Handle& hp,
+bool PatternMatchEngine::explore_choice_branches(const PatternTermPtr& ptm,
                                                  const Handle& hg,
                                                  const Handle& clause_root)
 {
+	const Handle& hp = ptm->getHandle();
 	// If its not an choice link, then don't try to iterate.
 	if (CHOICE_LINK != hp->getType())
-		return explore_single_branch(hp, hg, clause_root);
+		return explore_single_branch(ptm, hg, clause_root);
 
 	dbgprt("Begin choice branchpoint iteration loop\n");
 	do {
@@ -983,7 +1012,7 @@ bool PatternMatchEngine::explore_choice_branches(const Handle& hp,
 		// However, currently, no test case trips this up. so .. OK.
 		// whatever. This still probably needs fixing.
 		if (_need_choice_push) choice_stack.push(_choice_state);
-		bool match = explore_single_branch(hp, hg, clause_root);
+		bool match = explore_single_branch(ptm, hg, clause_root);
 		if (_need_choice_push) POPSTK(choice_stack, _choice_state);
 		_need_choice_push = false;
 
@@ -995,7 +1024,7 @@ bool PatternMatchEngine::explore_choice_branches(const Handle& hp,
 		// If we are here, there was no match.
 		// On the next go-around, take a step.
 		choose_next = true;
-	} while (have_choice(hp, hg));
+	} while (have_choice(ptm, hg));
 
 	dbgprt("Exhausted all choice possibilities\n");
 
@@ -1018,32 +1047,32 @@ bool PatternMatchEngine::explore_choice_branches(const Handle& hp,
 /// term. Thus, this method will return true ONLY if ALL OF the terms
 /// and clauses in the pattern are satisfiable (are accepted matches).
 ///
-bool PatternMatchEngine::explore_single_branch(const Handle& hp,
+bool PatternMatchEngine::explore_single_branch(const PatternTermPtr& ptm,
                                                const Handle& hg,
                                                const Handle& clause_root)
 {
 	solution_push();
 
 	dbgprt("Checking pattern UUID=%lu for soln by %lu\n",
-	       hp.value(), hg.value());
+	       ptm->getHandle().value(), hg.value());
 
-	bool match = tree_compare(hp, hg, CALL_SOLN);
+	bool match = tree_compare(ptm, hg, CALL_SOLN);
 
 	if (not match)
 	{
 		dbgprt("Pattern UUID=%lu NOT solved by %lu\n",
-		       hp.value(), hg.value());
+		       ptm->getHandle().value(), hg.value());
 		solution_pop();
 		return false;
 	}
 
 	dbgprt("UUID=%lu solved by %lu move up\n",
-          hp.value(), hg.value());
+          ptm->getHandle().value(), hg.value());
 
 	// XXX should not do perm_push every time... only selectively.
 	// But when? This is very confusing ...
 	perm_push();
-	bool found = do_term_up(hp, hg, clause_root);
+	bool found = do_term_up(ptm, hg, clause_root);
 	perm_pop();
 
 	solution_pop();
@@ -1089,7 +1118,7 @@ bool PatternMatchEngine::explore_single_branch(const Handle& hp,
 ///
 /// Returns true if a grounding for the term's parent was found.
 ///
-bool PatternMatchEngine::do_term_up(const Handle& hp,
+bool PatternMatchEngine::do_term_up(const PatternTermPtr& ptm,
                                     const Handle& hg,
                                     const Handle& clause_root)
 {
@@ -1099,6 +1128,7 @@ bool PatternMatchEngine::do_term_up(const Handle& hp,
 	// at the top of the clause, move on to the next clause. Else,
 	// we are working on a term somewhere in the middle of a clause
 	// and need to walk upwards.
+	const Handle& hp = ptm->getHandle();
 	if (hp == clause_root)
 		return clause_accept(clause_root, hg);
 
@@ -1175,67 +1205,42 @@ bool PatternMatchEngine::do_term_up(const Handle& hp,
 		}
 	}
 
-	FindAtoms fa(hp);
-	fa.stop_at_quote = false;
-	fa.search_set(clause_root);
+	PatternTermPtr parent = ptm->getParent();
+	OC_ASSERT(PatternTerm::UNDEFINED != parent, "Unknown term parent");
 
-	// It is almost always the case, but not necessarily, that
-	// least_holders contains one atom. (i.e. the one atom that
-	// is the parent of `hp` that is within clause_root.
-	// If `hp` appears twice (or N times) in a clause_root,
-	// then it will show up twice (or N times) in least_holders.
-	// As far as I can tell, it is sufficient to examine only the
-	// first appearance in almost all cases, unless the holders
-	// lie below an ChoiceLink.  For ChoiceLinks, we really have to
-	// examine all the different holders, they correspond to the
-	// different choices.
-	//
-	// least_holders could be empty if hp is inside a quote link.
-	// This can happen if the explore callback gives us a bad
-	// starting point.
-	OC_ASSERT(0 < fa.least_holders.size(), "Impossible situation");
+	const Handle& hi = parent->getHandle();
 
+	// Do the simple case first, ChoiceLinks are harder.
 	bool found = false;
-	for (const Handle& hi : fa.least_holders)
+	if (CHOICE_LINK != hi->getType())
 	{
-		// Do the simple case first, ChoiceLinks are harder.
-		if (CHOICE_LINK != hi->getType())
-		{
-			dbgprt("Exploring one possible embedding out of %zu\n",
-			       fa.least_holders.size());
-
-			if (explore_up_branches(hi, hg, clause_root)) found = true;
-
-			dbgprt("After moving up the clause, found = %d\n", found);
-		}
-		else
-		if (hi == clause_root)
-		{
-			dbgprt("Exploring one possible ChoiceLink at root out of %zu\n",
-			       fa.least_holders.size());
-			if (clause_accept(clause_root, hg)) found = true;
-		}
-		else
-		{
-			// If we are here, we have an embedded ChoiceLink, i.e. a
-			// ChoiceLink that is not at the clause root. It's contained
-			// in some other link, and we have to get that link and
-			// perform comparisons on it. i.e. we have to "hop over"
-			// (hop up) past the ChoiceLink, before resuming the search.
-			// The easiest way to hop is to do it recursively... i.e.
-			// call ourselves again.
-			dbgprt("Exploring one possible ChoiceLink in clause out of %zu\n",
-			       fa.least_holders.size());
-
-			OC_ASSERT(not have_choice(hi, hg),
-			          "Something is wrong with the ChoiceLink code");
-
-			_need_choice_push = true;
-			if (do_term_up(hi, hg, clause_root)) found = true;
-		}
+		if (explore_up_branches(parent, hg, clause_root)) found = true;
+		dbgprt("After moving up the clause, found = %d\n", found);
 	}
-	dbgprt("Done exploring %zu choices, found %d\n",
-	       fa.least_holders.size(), found);
+	else
+	if (hi == clause_root)
+	{
+		dbgprt("Exploring ChoiceLink at root\n");
+		if (clause_accept(clause_root, hg)) found = true;
+	}
+	else
+	{
+		// If we are here, we have an embedded ChoiceLink, i.e. a
+		// ChoiceLink that is not at the clause root. It's contained
+		// in some other link, and we have to get that link and
+		// perform comparisons on it. i.e. we have to "hop over"
+		// (hop up) past the ChoiceLink, before resuming the search.
+		// The easiest way to hop is to do it recursively... i.e.
+		// call ourselves again.
+		dbgprt("Exploring ChoiceLink below root\n");
+
+		OC_ASSERT(not have_choice(parent, hg),
+		          "Something is wrong with the ChoiceLink code");
+
+		_need_choice_push = true;
+		if (do_term_up(parent, hg, clause_root)) found = true;
+	}
+
 	return found;
 }
 
@@ -1363,7 +1368,7 @@ bool PatternMatchEngine::do_next_clause(void)
 				// we'll loop around back to here again.
 				clause_accepted = false;
 				Handle hgnd = var_grounding[joiner];
-				found = explore_link_branches(joiner, hgnd, curr_root);
+				found = explore_term_branches(joiner, hgnd, curr_root);
 			}
 		}
 	}
@@ -1756,7 +1761,7 @@ bool PatternMatchEngine::explore_clause(const Handle& term,
 	if (not is_evaluatable(clause))
 	{
 		dbgprt("Clause is matchable; start matching it.\n");
-		bool found = explore_link_branches(term, grnd, clause);
+		bool found = explore_term_branches(term, grnd, clause);
 
 		// If found is false, then there's no solution here.
 		// Bail out, return false to try again with the next candidate.

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -326,9 +326,9 @@ bool PatternMatchEngine::choice_compare(const PatternTermPtr& ptm,
 	size_t icurr = curr_choice(ptm, hg, fresh);
 	if (fresh) choose_next = false; // took a step, clear the flag
 
-	dbgprt("tree_comp resume choice search at %zu of %zu of UUID=%lu "
+	dbgprt("tree_comp resume choice search at %zu of %zu of term=%s, "
           "choose_next=%d\n",
-	       icurr, iend, hp.value(), choose_next);
+	       icurr, iend, ptm->toString().c_str(), choose_next);
 
 	// XXX This is almost surely wrong... if there are two
 	// nested choice links, then this will hog the steps,
@@ -575,15 +575,16 @@ bool PatternMatchEngine::unorder_compare(const PatternTermPtr& ptm,
 	// If we are here, we've got possibilities to explore.
 #ifdef DEBUG
 	int num_perms = facto(mutation.size());
-	dbgprt("tree_comp resume unordered search at %d of %d of UUID=%lu "
+	dbgprt("tree_comp resume unordered search at %d of %d of term=%s "
 	       "take_step=%d have_more=%d\n",
-	       perm_count[Unorder(ptm, hg)], num_perms, hp.value(),
+	       perm_count[Unorder(ptm, hg)], num_perms, ptm->toString().c_str(),
 	       take_step, have_more);
 #endif
 	do
 	{
-		dbgprt("tree_comp explore unordered perm %d of %d of UUID=%lu\n",
-		       perm_count[Unorder(ptm, hg)], num_perms, hp.value());
+		dbgprt("tree_comp explore unordered perm %d of %d of term=%s\n",
+		       perm_count[Unorder(ptm, hg)], num_perms,
+		       ptm->toString().c_str());
 
 		solution_push();
 		bool match = true;
@@ -642,15 +643,16 @@ bool PatternMatchEngine::unorder_compare(const PatternTermPtr& ptm,
 
 				// Handle case 5&7 of description above.
 				have_more = true;
-				dbgprt("Good permutation %d for UUID=%lu have_more=%d\n",
-				       perm_count[Unorder(ptm, hg)], hp.value(), have_more);
+				dbgprt("Good permutation %d for term=%s have_more=%d\n",
+				       perm_count[Unorder(ptm, hg)], ptm->toString().c_str(),
+				       have_more);
 				_perm_state[Unorder(ptm, hg)] = mutation;
 				return true;
 			}
 		}
 		// If we are here, we are handling case 8.
-		dbgprt("Above permuation %d failed UUID=%lu\n",
-		       perm_count[Unorder(ptm, hg)], hp.value());
+		dbgprt("Above permuation %d failed term=%s\n",
+		       perm_count[Unorder(ptm, hg)], ptm->toString().c_str());
 
 take_next_step:
 		take_step = false; // we are taking a step, so clear the flag.
@@ -662,7 +664,7 @@ take_next_step:
 	} while (std::next_permutation(mutation.begin(), mutation.end()));
 
 	// If we are here, we've explored all the possibilities already
-	dbgprt("Exhausted all permuations of UUID=%lu\n", hp.value());
+	dbgprt("Exhausted all permuations of term=%s\n", ptm->toString().c_str());
 	_perm_state.erase(Unorder(ptm, hg));
 	have_more = false;
 	return false;
@@ -681,8 +683,8 @@ PatternMatchEngine::curr_perm(const PatternTermPtr& ptm,
 	catch(...)
 	{
 #ifdef DEBUG
-		const Handle &hp = ptm->getHandle();
-		dbgprt("tree_comp fresh start unordered link UUID=%lu\n", hp.value());
+		dbgprt("tree_comp fresh start unordered link term=%s\n",
+		       ptm->toString().c_str());
 		perm_count[Unorder(ptm, hg)] = 0;
 #endif
 		perm = ptm->getOutgoingSet();
@@ -913,12 +915,12 @@ bool PatternMatchEngine::explore_up_branches(const PatternTermPtr& ptm,
 	// Move up the solution graph, looking for a match.
 	IncomingSet iset = _pmc.get_incoming_set(hg);
 	size_t sz = iset.size();
-	dbgprt("Looking upward for pat-UUID=%lu have %zu branches\n",
-	        ptm->getHandle().value(), sz);
+	dbgprt("Looking upward for term=%s have %zu branches\n",
+	        ptm->toString().c_str(), sz);
 	bool found = false;
 	for (size_t i = 0; i < sz; i++) {
-		dbgprt("Try upward branch %zu of %zu for pat-UUID=%lu propose=%lu\n",
-		       i, sz, ptm->getHandle().value(), Handle(iset[i]).value());
+		dbgprt("Try upward branch %zu of %zu for term=%s propose=%lu\n",
+		       i, sz, ptm->toString().c_str(), Handle(iset[i]).value());
 		found = explore_link_branches(ptm, Handle(iset[i]), clause_root);
 		if (found) break;
 	}
@@ -1053,21 +1055,21 @@ bool PatternMatchEngine::explore_single_branch(const PatternTermPtr& ptm,
 {
 	solution_push();
 
-	dbgprt("Checking pattern UUID=%lu for soln by %lu\n",
-	       ptm->getHandle().value(), hg.value());
+	dbgprt("Checking pattern term=%s for soln by %lu\n",
+	       ptm->toString().c_str(), hg.value());
 
 	bool match = tree_compare(ptm, hg, CALL_SOLN);
 
 	if (not match)
 	{
-		dbgprt("Pattern UUID=%lu NOT solved by %lu\n",
-		       ptm->getHandle().value(), hg.value());
+		dbgprt("Pattern term=%s NOT solved by %lu\n",
+		       ptm->toString().c_str(), hg.value());
 		solution_pop();
 		return false;
 	}
 
-	dbgprt("UUID=%lu solved by %lu move up\n",
-          ptm->getHandle().value(), hg.value());
+	dbgprt("Pattern term=%s solved by %lu move up\n",
+           ptm->toString().c_str(), hg.value());
 
 	// XXX should not do perm_push every time... only selectively.
 	// But when? This is very confusing ...
@@ -1137,8 +1139,8 @@ bool PatternMatchEngine::do_term_up(const PatternTermPtr& ptm,
 	// find its parent in the clause. For an evaluatable term, we find
 	// the parent evaluatable in the clause, which may be many steps
 	// higher.
-	dbgprt("Term UUID = %lu of clause UUID = %lu has ground, move upwards.\n",
-	       hp.value(), clause_root.value());
+	dbgprt("Term = %s of clause UUID = %lu has ground, move upwards.\n",
+	       ptm->toString().c_str(), clause_root.value());
 
 	if (0 < _pat->in_evaluatable.count(hp))
 	{

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -94,14 +94,14 @@ class PatternMatchEngine
 
 		// -------------------------------------------
 		// ChoiceLink state management
-		typedef std::pair<Handle, Handle> Choice;
+		typedef std::pair<PatternTermPtr, Handle> Choice;
 		typedef std::map<Choice, size_t> ChoiceState;
 
 		ChoiceState _choice_state;
 		bool _need_choice_push;
 
-		size_t curr_choice(const Handle&, const Handle&, bool&);
-		bool have_choice(const Handle&, const Handle&);
+		size_t curr_choice(const PatternTermPtr&, const Handle&, bool&);
+		bool have_choice(const PatternTermPtr&, const Handle&);
 
 		// Iteration control for choice links. Branchpoint advances
 		// whenever take_step is set to true.
@@ -109,13 +109,13 @@ class PatternMatchEngine
 
 		// -------------------------------------------
 		// Unordered Link suppoprt
-		typedef std::vector<Handle> Permutation;
-		typedef std::pair<Handle, Handle> Unorder; // Choice
+		typedef std::pair<PatternTermPtr, Handle> Unorder; // Choice
+		typedef PatternTermSeq Permutation;
 		typedef std::map<Unorder, Permutation> PermState; // ChoiceState
 
 		PermState _perm_state;
-		Permutation curr_perm(const Handle&, const Handle&, bool&);
-		bool have_perm(const Handle&, const Handle&);
+		Permutation curr_perm(const PatternTermPtr&, const Handle&, bool&);
+		bool have_perm(const PatternTermPtr&, const Handle&);
 
 		// Iteration control for unordered links. Branchpoint advances
 		// whenever take_step is set to true.
@@ -182,28 +182,36 @@ class PatternMatchEngine
 			CALL_SOLN
 		} Caller;   // temporary scaffolding !???
 
-		bool tree_compare(const Handle&, const Handle&, Caller);
-		bool quote_compare(const Handle&, const Handle&);
+		bool tree_compare(const PatternTermPtr&, const Handle&, Caller);
+
+		bool quote_compare(const PatternTermPtr&, const Handle&);
 		bool variable_compare(const Handle&, const Handle&);
 		bool self_compare(const Handle&);
 		bool node_compare(const Handle&, const Handle&);
 		bool redex_compare(const LinkPtr&, const LinkPtr&);
-		bool choice_compare(const Handle&, const Handle&,
+		bool choice_compare(const PatternTermPtr&, const Handle&,
 		                    const LinkPtr&, const LinkPtr&);
-		bool ordered_compare(const Handle&, const Handle&,
+		bool ordered_compare(const PatternTermPtr&, const Handle&,
 		                     const LinkPtr&, const LinkPtr&);
-		bool unorder_compare(const Handle&, const Handle&,
+		bool unorder_compare(const PatternTermPtr&, const Handle&,
 		                     const LinkPtr&, const LinkPtr&);
 
 		// -------------------------------------------
 		// Upwards-walking and grounding of a single clause.
 		// See PatternMatchEngine.cc for descriptions
 		bool explore_clause(const Handle&, const Handle&, const Handle&);
-		bool explore_up_branches(const Handle&, const Handle&, const Handle&);
-		bool explore_link_branches(const Handle&, const Handle&, const Handle&);
-		bool explore_choice_branches(const Handle&, const Handle&, const Handle&);
-		bool explore_single_branch(const Handle&, const Handle&, const Handle&);
-		bool do_term_up(const Handle&, const Handle&, const Handle&);
+		bool explore_term_branches(const Handle&, const Handle&,
+		                           const Handle&);
+		bool explore_up_branches(const PatternTermPtr&, const Handle&,
+		                         const Handle&);
+		bool explore_link_branches(const PatternTermPtr&, const Handle&,
+		                           const Handle&);
+		bool explore_choice_branches(const PatternTermPtr&, const Handle&,
+		                             const Handle&);
+		bool explore_single_branch(const PatternTermPtr&, const Handle&,
+		                           const Handle&);
+		bool do_term_up(const PatternTermPtr&, const Handle&,
+		                const Handle&);
 		bool clause_accept(const Handle&, const Handle&);
 
 	public:

--- a/opencog/query/PatternTerm.h
+++ b/opencog/query/PatternTerm.h
@@ -1,0 +1,99 @@
+/*
+ * PatternTerm.h
+ *
+ * Copyright (C) 2015 OpenCog Foundation
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Created by Jacek Świergocki <jswiergo@gmail.com> July 2015
+ */
+
+#ifndef _OPENCOG_PATTERN_TERM_H
+#define _OPENCOG_PATTERN_TERM_H
+
+#include <vector>
+
+#include <opencog/atomspace/Handle.h>
+#include <opencog/atomspace/Link.h>
+
+namespace opencog {
+
+class PatternTerm;
+typedef std::shared_ptr<PatternTerm> PatternTermPtr;
+typedef std::vector<PatternTermPtr> PatternTermSeq;
+
+class PatternTerm
+{
+	protected:
+		Handle _handle;
+		PatternTermPtr _parent;
+		PatternTermSeq _outgoing;
+
+	public:
+		static const PatternTermPtr UNDEFINED;
+
+		PatternTerm()
+		{
+			_handle = Handle::UNDEFINED;
+			_parent = PatternTerm::UNDEFINED;
+		}
+
+		PatternTerm(const PatternTermPtr& parent, const Handle& h)
+		{
+			_parent = parent;
+			_handle = h;
+		}
+
+		void addOutgoingTerm(const PatternTermPtr& ptm)
+		{
+			_outgoing.push_back(ptm);
+		}
+
+		inline Handle getHandle()
+		{
+			return _handle;
+		};
+	
+		inline PatternTermPtr getParent()
+		{
+			return _parent;
+		};
+
+		inline const PatternTermSeq& getOutgoingSet() const
+		{
+			return _outgoing;
+		}
+
+		inline Arity getArity() const {
+			return _outgoing.size();
+		}
+
+		inline PatternTermPtr getOutgoingTerm(Arity pos) const throw (RuntimeException)
+		{
+			// Checks for a valid position
+			if (pos < getArity()) {
+				return _outgoing[pos];
+			} else {
+				throw RuntimeException(TRACE_INFO, "invalid outgoing set index %d", pos);
+			}
+		}
+
+};
+
+} // namespace opencog
+
+#endif // _OPENCOG_PATTERN_TERM_H

--- a/opencog/query/PatternTerm.h
+++ b/opencog/query/PatternTerm.h
@@ -94,6 +94,14 @@ class PatternTerm
 			}
 		}
 
+		inline std::string toString(std::string indent = ":") const
+		{
+			if (_handle == Handle::UNDEFINED) return "-";
+			std::string str = _parent->toString();
+			str += indent + std::to_string(_handle.value());
+			return str;
+		}
+
 };
 
 } // namespace opencog
@@ -110,7 +118,7 @@ namespace std {
 template<>
 struct less<PatternTermPtr>
 {
-	bool operator()(const PatternTermPtr& lhs, const PatternTermPtr& rhs)
+	bool operator()(const PatternTermPtr& lhs, const PatternTermPtr& rhs) const
 	{
 		const Handle& lHandle = lhs->getHandle();
 		const Handle& rHandle = rhs->getHandle();
@@ -121,6 +129,7 @@ struct less<PatternTermPtr>
 		}
 		return lHandle < rHandle;
 	}
+
 };
 
 }; // namespace std;

--- a/opencog/query/PatternTerm.h
+++ b/opencog/query/PatternTerm.h
@@ -82,18 +82,47 @@ class PatternTerm
 			return _outgoing.size();
 		}
 
-		inline PatternTermPtr getOutgoingTerm(Arity pos) const throw (RuntimeException)
+		inline PatternTermPtr getOutgoingTerm(Arity pos) const
+			throw (RuntimeException)
 		{
 			// Checks for a valid position
 			if (pos < getArity()) {
 				return _outgoing[pos];
 			} else {
-				throw RuntimeException(TRACE_INFO, "invalid outgoing set index %d", pos);
+				throw RuntimeException(TRACE_INFO,
+				                       "invalid outgoing set index %d", pos);
 			}
 		}
 
 };
 
 } // namespace opencog
+
+using namespace opencog;
+
+namespace std {
+
+// We need to overload standard comparison operator for PatternTerm pointers.
+// Now we do not care much about complexity of this comparison. The cases of
+// queries having repeated atoms that are deep should be very rare. So we just
+// traverse up towards root node. Typically we compare only the first level
+// handles on this path.
+template<>
+struct less<PatternTermPtr>
+{
+	bool operator()(const PatternTermPtr& lhs, const PatternTermPtr& rhs)
+	{
+		const Handle& lHandle = lhs->getHandle();
+		const Handle& rHandle = rhs->getHandle();
+		if (lHandle == rHandle)
+		{
+			if (lHandle == Handle::UNDEFINED) return false;
+			return lhs->getParent() < rhs->getParent();
+		}
+		return lHandle < rHandle;
+	}
+};
+
+}; // namespace std;
 
 #endif // _OPENCOG_PATTERN_TERM_H


### PR DESCRIPTION
This changes are dependent and may be merged after:
#227 pattern matcher unique results
#228 ChoiceLink unneeded special case

This are next changes that partly address problem #148 (Pattern matcher branch exploration problem)

The idea of solution is to preprocess pattern query and build internal tree structure of unique terms. Each term corresponds to one atom handle. If the same atom appears many times in the query then it corresponds to many unique terms, one for each occurrence. Having that structures, pattern matcher traverses the pattern tree exactly as before but uses term pointers instead of atom handles to know its exact position. Then it keeps states of unordered links and choice links in the language of term pointers (e.g. permutation of unique pointers instead of permutation of not unique handles).

Test status after merging #227 and #228:
```
100% tests passed, 0 tests failed out of 81
```

This changes are ready and stable. More work is needed to solve the problem entirely.