### PR TITLE
Enable toString and toShortString in gdb

### DIFF
--- a/opencog/atomspace/Atom.h
+++ b/opencog/atomspace/Atom.h
@@ -383,8 +383,7 @@ public:
     virtual std::string toShortString(std::string indent) = 0;
 
 	// Work around gdb's incapability to build a string on the fly,
-	// see http://stackoverflow.com/questions/16734783 and
-	// http://stackoverflow.com/questions/2973976 for more
+	// see http://stackoverflow.com/questions/16734783 for more
 	// explanation.
 	std::string toString() { return toString(""); }
 	std::string toShortString() { return toShortString(""); }

--- a/opencog/atomspace/Atom.h
+++ b/opencog/atomspace/Atom.h
@@ -379,8 +379,15 @@ public:
      * @return A string representation of the node.
      * cannot be const, because observing the TV and AV requires a lock.
      */
-    virtual std::string toString(std::string indent = "") = 0;
-    virtual std::string toShortString(std::string indent = "") = 0;
+    virtual std::string toString(std::string indent) = 0;
+    virtual std::string toShortString(std::string indent) = 0;
+
+	// Work around gdb's incapability to build a string on the fly,
+	// see http://stackoverflow.com/questions/16734783 and
+	// http://stackoverflow.com/questions/2973976 for more
+	// explanation.
+	std::string toString() { return toString(""); }
+	std::string toShortString() { return toShortString(""); }
 
     /** Returns whether two atoms are equal.
      *

--- a/opencog/atomspace/Link.h
+++ b/opencog/atomspace/Link.h
@@ -206,7 +206,8 @@ public:
     std::string toShortString(std::string indent);
 
 	// Work around gdb's incapability to build a string on the fly,
-	// see http://stackoverflow.com/questions/16734783 for more
+	// see http://stackoverflow.com/questions/16734783 and
+	// http://stackoverflow.com/questions/2973976 for more
 	// explanation.
 	using Atom::toString;
 	using Atom::toShortString;

--- a/opencog/atomspace/Link.h
+++ b/opencog/atomspace/Link.h
@@ -193,7 +193,7 @@ public:
      *
      * @return A string representation of the link.
      */
-    std::string toString(std::string indent = "");
+    std::string toString(std::string indent);
 
     /**
      * Returns a short string representation of the link.
@@ -203,8 +203,14 @@ public:
      *
      * @return A short string representation of the link.
      */
-    std::string toShortString(std::string indent = "");
+    std::string toShortString(std::string indent);
 
+	// Work around gdb's incapability to build a string on the fly,
+	// see http://stackoverflow.com/questions/16734783 for more
+	// explanation.
+	using Atom::toString;
+	using Atom::toShortString;
+	
     /**
      * Returns whether a given handle is a source (the first outgoing
      * if the link is ordered) of this link.

--- a/opencog/atomspace/Node.h
+++ b/opencog/atomspace/Node.h
@@ -91,8 +91,15 @@ public:
      *
      * @return A string representation of the node.
      */
-    std::string toString(std::string indent = "");
-    std::string toShortString(std::string indent = "");
+    std::string toString(std::string indent);
+    std::string toShortString(std::string indent);
+
+	// Work around gdb's incapability to build a string on the fly,
+	// see http://stackoverflow.com/questions/16734783 and
+	// http://stackoverflow.com/questions/2973976 for more
+	// explanation.
+	using Atom::toString;
+	using Atom::toShortString;
 
     /**
      * Returns whether a given atom is equal to the current node.


### PR DESCRIPTION
Thanks to Eddie's request you may now use toString and toShortString in gdb :-).

Read on...

## Description
Add toString and toShortString overloads with no arguments to work
around gdb's incapability to build a std::string on the fly.

## Usage
Now
```
p h->toString()
```
prints the std::string of the hypergraph pointed
by handle h. For a pretty print (only the char* + newlines) you may
use
```
printf "%s", h->toString()._M_dataplus._M_p
```
