### PR TITLE
Quoted variables matching refactor

### DIFF
--- a/opencog/atoms/bind/PatternLink.cc
+++ b/opencog/atoms/bind/PatternLink.cc
@@ -628,11 +628,27 @@ void PatternLink::make_term_tree_recursive(const Handle& root,
 	PatternTermPtr ptm(std::make_shared<PatternTerm>(parent, h));
 	parent->addOutgoingTerm(ptm);
 	_pat.connected_terms_map[{h, root}].push_back(ptm);
+
+	Type t = h->getType();
 	LinkPtr l(LinkCast(h));
 	if (l)
 	{
+		if (QUOTE_LINK == t)
+			ptm->addQuote();
+
 		for (const Handle& ho: l->getOutgoingSet())
 		     make_term_tree_recursive(root, ho, ptm);
+		return;
+	}
+
+	// If the current node is a bound variable store this information for
+	// later checks. The flag telling whether the term subtree contains
+	// any bound variable is set by addBoundVariable() method for all terms
+	// on the path up to the root (unless it has been set already).
+	if (VARIABLE_NODE == t && !ptm->isQuoted() &&
+	    _varlist.varset.end() != _varlist.varset.find(h))
+	{
+		ptm->addBoundVariable();
 	}
 }
 

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -171,7 +171,6 @@ class PatternMatchEngine
 		// -------------------------------------------
 		// Recursive tree comparison algorithm.
 		unsigned int depth; // Recursion depth for tree_compare.
-		bool in_quote;      // Everything below a quote is literal.
 
 		typedef enum {
 			CALL_QUOTE,
@@ -186,7 +185,7 @@ class PatternMatchEngine
 
 		bool quote_compare(const PatternTermPtr&, const Handle&);
 		bool variable_compare(const Handle&, const Handle&);
-		bool self_compare(const Handle&);
+		bool self_compare(const PatternTermPtr&);
 		bool node_compare(const Handle&, const Handle&);
 		bool redex_compare(const LinkPtr&, const LinkPtr&);
 		bool choice_compare(const PatternTermPtr&, const Handle&,

--- a/tests/query/QuoteUTest.cxxtest
+++ b/tests/query/QuoteUTest.cxxtest
@@ -279,11 +279,11 @@ void QuoteUTest::test_crash(void)
     Handle cr = eval->eval_h("(cog-bind crasher)");
     TS_ASSERT_EQUALS(1, as->get_arity(cr));
 
-    // This blows out the stack in an infinite loop, if the instantiator
-    // doesn't catch it and prevent it.
+    // This blows out the stack in an infinite loop, if the pattern
+    // matcher doesn't prevent it.
     Handle inf = eval->eval_h("(cog-bind infloop)");
     printf("infloop is %s\n", inf->toShortString().c_str());
-    TS_ASSERT_EQUALS(7, as->get_arity(inf));
+    TS_ASSERT_EQUALS(4, as->get_arity(inf));
 
     logger().debug("END TEST: %s", __FUNCTION__);
 }


### PR DESCRIPTION
This solves problems described in the comments:
https://github.com/opencog/atomspace/blob/master/opencog/query/PatternMatchEngine.cc#L812-L819
https://github.com/opencog/atomspace/blob/master/opencog/query/PatternMatchEngine.cc#L196-L198

The right answer for QuoteUTest : infloop is 4. Previously it grounded variable $x by atoms that contain this bound variable unquoted, so it might caused infinite loops, but after present changes this sort of cases are not possible.

```
100% tests passed, 0 tests failed out of 82
```