### PR TITLE
Check for ill-formed expressions.

### DIFF
--- a/opencog/atoms/bind/PatternLink.cc
+++ b/opencog/atoms/bind/PatternLink.cc
@@ -81,6 +81,7 @@ void PatternLink::common_init(void)
 		// Is this related to the other XXX for validate_clauses??
 		// _pat.cnf_clauses = _components[0];
 	   make_connectivity_map(_pat.cnf_clauses);
+		check_satisfiability(_varlist.varset);
 	}
 
 	make_term_trees();
@@ -634,6 +635,30 @@ void PatternLink::make_map_recursive(const Handle& root, const Handle& h)
 	{
 		for (const Handle& ho: l->getOutgoingSet())
 			make_map_recursive(root, ho);
+	}
+}
+
+/// Make sure that every variable appears in some groundable clause.
+/// Variables have to be grounded to get used; it makes no sense to
+/// bind variables that are fundamentally ungroundable.
+void PatternLink::check_satisfiability(const std::set<Handle>& vars)
+{
+	for (const Handle& v : vars)
+	{
+		bool whoops = false;
+		try
+		{
+			_pat.connectivity_map.at(v);
+		}
+		catch(const std::out_of_range&) 
+		{
+			whoops = true;
+		}
+		if (whoops)
+		{
+			throw InvalidParamException(TRACE_INFO,
+				"Cannot ground variable %s\n", v->toString().c_str());
+		}
 	}
 }
 

--- a/opencog/atoms/bind/PatternLink.h
+++ b/opencog/atoms/bind/PatternLink.h
@@ -113,7 +113,8 @@ protected:
 	void make_connectivity_map(const HandleSeq&);
 	void make_map_recursive(const Handle&, const Handle&);
 	void check_connectivity(const std::vector<HandleSeq>&);
-	void check_satisfiability(const std::set<Handle>&);
+	void check_satisfiability(const std::set<Handle>&,
+	                          const std::vector<std::set<Handle>>&);
 
 	void make_term_trees();
 	void make_term_tree_recursive(const Handle&, const Handle&,

--- a/opencog/atoms/bind/PatternLink.h
+++ b/opencog/atoms/bind/PatternLink.h
@@ -111,8 +111,9 @@ protected:
 	                       const HandleSeq& clauses);
 
 	void make_connectivity_map(const HandleSeq&);
-	void check_connectivity(const std::vector<HandleSeq>&);
 	void make_map_recursive(const Handle&, const Handle&);
+	void check_connectivity(const std::vector<HandleSeq>&);
+	void check_satisfiability(const std::set<Handle>&);
 
 	void make_term_trees();
 	void make_term_tree_recursive(const Handle&, const Handle&,

--- a/opencog/query/PatternMatchCallback.h
+++ b/opencog/query/PatternMatchCallback.h
@@ -31,7 +31,7 @@
 #include <opencog/query/Pattern.h> // for VariableTypeMap
 #include <opencog/atoms/core/VariableList.h> // for VariableTypeMap
 
-#define DEBUG 1
+// #define DEBUG 1
 
 namespace opencog {
 class PatternMatchEngine;

--- a/opencog/query/PatternMatchCallback.h
+++ b/opencog/query/PatternMatchCallback.h
@@ -31,7 +31,7 @@
 #include <opencog/query/Pattern.h> // for VariableTypeMap
 #include <opencog/atoms/core/VariableList.h> // for VariableTypeMap
 
-// #define DEBUG 1
+#define DEBUG 1
 
 namespace opencog {
 class PatternMatchEngine;

--- a/tests/query/CMakeLists.txt
+++ b/tests/query/CMakeLists.txt
@@ -112,6 +112,8 @@ CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/tests/query/choice-unary.scm
     ${PROJECT_BINARY_DIR}/tests/query/choice-unary.scm)
 CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/tests/query/define.scm
     ${PROJECT_BINARY_DIR}/tests/query/define.scm)
+CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/tests/query/disco-vars.scm
+    ${PROJECT_BINARY_DIR}/tests/query/disco-vars.scm)
 CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/tests/query/evaluation.scm
     ${PROJECT_BINARY_DIR}/tests/query/evaluation.scm)
 CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/tests/query/finite-state-machine.scm

--- a/tests/query/DisconnectedUTest.cxxtest
+++ b/tests/query/DisconnectedUTest.cxxtest
@@ -55,7 +55,8 @@ class Disconnected :  public CxxTest::TestSuite
 		void setUp(void);
 		void tearDown(void);
 
-		void test_exec(void);
+		void test_components(void);
+		void test_variables(void);
 };
 
 /*
@@ -85,7 +86,7 @@ void Disconnected::tearDown(void)
 #define getlink(hand,pos) as->getOutgoing(hand,pos)
 #define getarity(hand) as->getArity(hand)
 
-void Disconnected::test_exec(void)
+void Disconnected::test_components(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
@@ -114,6 +115,59 @@ void Disconnected::test_exec(void)
 	// disconnected queries. Yes, naive users will shoot themselves
 	// in the foot because of this, but wise users need this.
 	// TSM_ASSERT("Failed to catch expected exception", caught);
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+/*
+ * Test several patterns carrying ill-formed variable declarations
+ */
+void Disconnected::test_variables(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	config().set("SCM_PRELOAD",
+		"tests/query/disco-vars.scm");
+	load_scm_files_from_config(*as);
+
+	// We expect to catch an error here. ------------------------------
+	bool caught = false;
+	try
+	{
+		eval->eval_h("(B)");
+	}
+	catch (const RuntimeException& ex)
+	{
+		logger().debug("Caught exception, just as expected: %s", ex.getMessage());
+		caught = true;
+	}
+	logger().info("Caught exception? %d\n", caught);
+
+	// We expect to catch an error here. ------------------------------
+	caught = false;
+	try
+	{
+		eval->eval_h("(Ba)");
+	}
+	catch (const RuntimeException& ex)
+	{
+		logger().debug("Caught exception, just as expected: %s", ex.getMessage());
+		caught = true;
+	}
+	logger().info("Caught exception? %d\n", caught);
+
+	// We expect to catch an error here. ------------------------------
+	caught = false;
+	try
+	{
+		eval->eval_h("(Bu)");
+	}
+	catch (const RuntimeException& ex)
+	{
+		logger().debug("Caught exception, just as expected: %s", ex.getMessage());
+		caught = true;
+	}
+	logger().info("Caught exception? %d\n", caught);
 
 	logger().debug("END TEST: %s", __FUNCTION__);
 }

--- a/tests/query/DisconnectedUTest.cxxtest
+++ b/tests/query/DisconnectedUTest.cxxtest
@@ -35,7 +35,7 @@ class Disconnected :  public CxxTest::TestSuite
 {
 	private:
 		AtomSpace *as;
-		Handle bindlinkh;
+		SchemeEval* eval;
 
 	public:
 
@@ -66,18 +66,12 @@ class Disconnected :  public CxxTest::TestSuite
 void Disconnected::setUp(void)
 {
 	as = new AtomSpace();
+	eval = new SchemeEval(as);
 
 	config().set("SCM_PRELOAD",
 		"opencog/atomspace/core_types.scm, "
-		"tests/query/test_types.scm, "
-		"tests/query/disconnected.scm");
-
+		"tests/query/test_types.scm");
 	load_scm_files_from_config(*as);
-
-	// Create an implication link that will be tested.
-	SchemeEval* evaluator = new SchemeEval(as);
-	bindlinkh = evaluator->apply("get-bindlink", Handle::UNDEFINED);
-	delete evaluator;
 }
 
 void Disconnected::tearDown(void)
@@ -95,6 +89,11 @@ void Disconnected::test_exec(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
+	config().set("SCM_PRELOAD",
+		"tests/query/disconnected.scm");
+	load_scm_files_from_config(*as);
+
+	Handle bindlinkh = eval->apply("get-bindlink", Handle::UNDEFINED);
 	// Make sure the scheme file actually loaded!
 	TSM_ASSERT("Failed to load test data", Handle::UNDEFINED != bindlinkh);
 

--- a/tests/query/disco-vars.scm
+++ b/tests/query/disco-vars.scm
@@ -1,0 +1,24 @@
+;
+; disco-vars.scm
+;
+; Several patterns with ill-formed variable declarations.
+
+(define (B)
+(GetLink
+   (VariableList (VariableNode "$A") (VariableNode "$B"))
+   (AndLink
+      (EqualLink (VariableNode "$A") (VariableNode "$B")))))
+
+(define (Ba)
+(GetLink
+   (VariableList (VariableNode "$A") (VariableNode "$B"))
+   (AndLink
+      (PresentLink (VariableNode "$A"))
+      (EqualLink (VariableNode "$A") (VariableNode "$B")))))
+
+(define (Bu)
+(GetLink
+   (VariableList (VariableNode "$A") (VariableNode "$B") (VariableNode "$C"))
+   (AndLink
+      (InheritanceLink (VariableNode "$A") (VariableNode "$B"))
+      (EqualLink (VariableNode "$A") (VariableNode "$C")))))


### PR DESCRIPTION
This adds code to explicitly check for the kinds of links defined in bug #165 and #171 and throw an error as a result.