### PR TITLE
Rework handle comparison code

### DIFF
--- a/opencog/atomspace/Atom.cc
+++ b/opencog/atomspace/Atom.cc
@@ -249,7 +249,7 @@ void Atom::setAtomTable(AtomTable *tb)
     if (NULL != _atomTable) {
         // Atom is being removed from the atom table.
         // UUID's belong to the atom table, not the atom. Reclaim it.
-        _uuid = Handle::UNDEFINED.value();
+        _uuid = Handle::INVALID_UUID;
     }
     _atomTable = tb;
 }

--- a/opencog/atomspace/Atom.h
+++ b/opencog/atomspace/Atom.h
@@ -121,7 +121,7 @@ protected:
      */
     Atom(Type t, TruthValuePtr tv = TruthValue::DEFAULT_TV(),
             AttentionValuePtr av = AttentionValue::DEFAULT_AV())
-      : _uuid(Handle::UNDEFINED.value()),
+      : _uuid(Handle::INVALID_UUID),
         _atomTable(NULL),
         _type(t),
         _flags(0),

--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -354,7 +354,7 @@ public:
      * exists in RAM (and is thus usable as a naked atom).
      */
     bool is_valid_handle(Handle h) const {
-        // The h->get_handle() maneuver below is a trick to get at the
+        // The h->getHandle() maneuver below is a trick to get at the
         // UUID of the actual atom, rather than the cached UUID in the
         // handle. Technically, this is not quite right, since, in
         // principle, a handle could have a valid UUID, but the atom
@@ -369,7 +369,8 @@ public:
         // which causes h.operator!=() to run, which fixes up the atom
         // pointer, as needed.
         //
-        return (NULL != h) and (h->getHandle() != Handle::UNDEFINED);
+        bool stuff = (NULL != h) and (h->getHandle().value() != ULONG_MAX);
+        return stuff;
     }
 
     /**

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -182,7 +182,7 @@ Handle AtomTable::getHandle(Type t, const HandleSeq &seq) const
 
     std::lock_guard<std::recursive_mutex> lck(_mtx);
     Handle h(linkIndex.getHandle(t, resolved_seq));
-    if (_environ and Handle::UNDEFINED == h)
+    if (_environ and Handle::UNDEFINED.value() == h.value())
         return _environ->getHandle(t, resolved_seq);
     return h;
 }
@@ -483,7 +483,7 @@ Handle AtomTable::add(AtomPtr atom, bool async)
             // UUID but no pointer? Some persistance scenario ???
             // Please explain ...
             if (NULL == h._ptr.get()) {
-                if (Handle::UNDEFINED == h) {
+                if (Handle::UNDEFINED.value() == h.value()) {
                     prt_diag(atom, i, arity, ogs);
                     throw RuntimeException(TRACE_INFO,
                                "AtomTable - Attempting to insert link with "
@@ -549,7 +549,7 @@ Handle AtomTable::add(AtomPtr atom, bool async)
                 ho->remove_atom(llc);
                 llc->_outgoing[i] = add(ho, async);
             }
-            else if (ho == Handle::UNDEFINED) {
+            else if (ho.value() == Handle::UNDEFINED.value()) {
                 // If we are here, then the atom is in the atomspace,
                 // but the handle has an invalid UUID. This can happen
                 // if the atom appears more than once in the outgoing

--- a/opencog/atomspace/Handle.cc
+++ b/opencog/atomspace/Handle.cc
@@ -44,6 +44,26 @@ Handle& Handle::operator=(const AtomPtr& a)
 }
 
 // ===================================================
+// Atom comparison.
+
+bool Handle::atoms_eq(const AtomPtr& a, const AtomPtr& b)
+{
+    if (a == b) return true;
+    if (NULL == a or NULL == b) return false;
+    return *a == *b;
+}
+
+bool Handle::atoms_less(const AtomPtr& a, const AtomPtr& b)
+{
+    if (a == b) return false;
+    if (NULL == a) return true;
+    if (NULL == b) return false;
+    if (*a == *b) return false;
+    return a < b;
+}
+
+
+// ===================================================
 // Handle resolution stuff.
 
 // Its a vector, not a set, because its priority ranked.

--- a/opencog/atomspace/Handle.h
+++ b/opencog/atomspace/Handle.h
@@ -177,12 +177,12 @@ public:
     inline bool operator<=(const Handle& h) const noexcept {
         if (ULONG_MAX != _uuid and ULONG_MAX != h._uuid)
             return _uuid <= h._uuid;
-        return atoms_less(_ptr, h._ptr) or atoms_eq(_ptr, h._ptr);
+        return not atoms_less(h._ptr, _ptr);
     }
     inline bool operator>=(const Handle& h) const noexcept {
         if (ULONG_MAX != _uuid and ULONG_MAX != h._uuid)
             return _uuid >= h._uuid;
-        return atoms_less(h._ptr, _ptr) or atoms_eq(_ptr, h._ptr);
+        return not atoms_less(_ptr, h._ptr);
     }
 
     /**

--- a/opencog/atomspace/Handle.h
+++ b/opencog/atomspace/Handle.h
@@ -155,32 +155,32 @@ public:
     // still need the handle comparison to work correctly, else stuff
     // breaks. We resort to comparing atoms, in that case.
     inline bool operator==(const Handle& h) const noexcept {
-        if (ULONG_MAX != _uuid and ULONG_MAX != h._uuid)
+        if (ULONG_MAX != _uuid or ULONG_MAX != h._uuid)
             return _uuid == h._uuid;
         return atoms_eq(_ptr, h._ptr);
     }
     inline bool operator!=(const Handle& h) const noexcept {
-        if (ULONG_MAX != _uuid and ULONG_MAX != h._uuid)
+        if (ULONG_MAX != _uuid or ULONG_MAX != h._uuid)
             return _uuid != h._uuid;
         return not atoms_eq(_ptr, h._ptr);
     }
     inline bool operator< (const Handle& h) const noexcept {
-        if (ULONG_MAX != _uuid and ULONG_MAX != h._uuid)
+        if (ULONG_MAX != _uuid or ULONG_MAX != h._uuid)
             return _uuid < h._uuid;
         return atoms_less(_ptr, h._ptr);
     }
     inline bool operator> (const Handle& h) const noexcept {
-        if (ULONG_MAX != _uuid and ULONG_MAX != h._uuid)
+        if (ULONG_MAX != _uuid or ULONG_MAX != h._uuid)
             return _uuid > h._uuid;
         return atoms_less(h._ptr, _ptr);
     }
     inline bool operator<=(const Handle& h) const noexcept {
-        if (ULONG_MAX != _uuid and ULONG_MAX != h._uuid)
+        if (ULONG_MAX != _uuid or ULONG_MAX != h._uuid)
             return _uuid <= h._uuid;
         return not atoms_less(h._ptr, _ptr);
     }
     inline bool operator>=(const Handle& h) const noexcept {
-        if (ULONG_MAX != _uuid and ULONG_MAX != h._uuid)
+        if (ULONG_MAX != _uuid or ULONG_MAX != h._uuid)
             return _uuid >= h._uuid;
         return not atoms_less(_ptr, h._ptr);
     }

--- a/opencog/atomspace/Handle.h
+++ b/opencog/atomspace/Handle.h
@@ -77,11 +77,12 @@ private:
     static const AtomPtr NULL_POINTER;
 public:
 
+    static const UUID INVALID_UUID = ULONG_MAX;
     static const Handle UNDEFINED;
 
     explicit Handle(const AtomPtr& atom);
     explicit Handle(const UUID u) : _uuid(u) {}
-    explicit Handle() : _uuid(ULONG_MAX) {}
+    explicit Handle() : _uuid(INVALID_UUID) {}
     Handle(const Handle& h) : _uuid(h._uuid), _ptr(h._ptr) {}
     ~Handle() {}
 
@@ -112,14 +113,14 @@ public:
     inline Atom* operator->() {
         Atom* ptr = _ptr.get();
         if (ptr) return ptr;
-        if (ULONG_MAX == _uuid) return NULL;
+        if (INVALID_UUID == _uuid) return NULL;
         return resolve();
     }
 
     inline Atom* operator->() const {
         Atom* ptr = _ptr.get();
         if (ptr) return ptr;
-        if (ULONG_MAX == _uuid) return NULL;
+        if (INVALID_UUID == _uuid) return NULL;
         return cresolve();
     }
 
@@ -155,32 +156,32 @@ public:
     // still need the handle comparison to work correctly, else stuff
     // breaks. We resort to comparing atoms, in that case.
     inline bool operator==(const Handle& h) const noexcept {
-        if (ULONG_MAX != _uuid or ULONG_MAX != h._uuid)
+        if (INVALID_UUID != _uuid or INVALID_UUID != h._uuid)
             return _uuid == h._uuid;
         return atoms_eq(_ptr, h._ptr);
     }
     inline bool operator!=(const Handle& h) const noexcept {
-        if (ULONG_MAX != _uuid or ULONG_MAX != h._uuid)
+        if (INVALID_UUID != _uuid or INVALID_UUID != h._uuid)
             return _uuid != h._uuid;
         return not atoms_eq(_ptr, h._ptr);
     }
     inline bool operator< (const Handle& h) const noexcept {
-        if (ULONG_MAX != _uuid or ULONG_MAX != h._uuid)
+        if (INVALID_UUID != _uuid or INVALID_UUID != h._uuid)
             return _uuid < h._uuid;
         return atoms_less(_ptr, h._ptr);
     }
     inline bool operator> (const Handle& h) const noexcept {
-        if (ULONG_MAX != _uuid or ULONG_MAX != h._uuid)
+        if (INVALID_UUID != _uuid or INVALID_UUID != h._uuid)
             return _uuid > h._uuid;
         return atoms_less(h._ptr, _ptr);
     }
     inline bool operator<=(const Handle& h) const noexcept {
-        if (ULONG_MAX != _uuid or ULONG_MAX != h._uuid)
+        if (INVALID_UUID != _uuid or INVALID_UUID != h._uuid)
             return _uuid <= h._uuid;
         return not atoms_less(h._ptr, _ptr);
     }
     inline bool operator>=(const Handle& h) const noexcept {
-        if (ULONG_MAX != _uuid or ULONG_MAX != h._uuid)
+        if (INVALID_UUID != _uuid or INVALID_UUID != h._uuid)
             return _uuid >= h._uuid;
         return not atoms_less(_ptr, h._ptr);
     }
@@ -205,19 +206,19 @@ public:
 
     operator AtomPtr() const {
         if (_ptr.get()) return _ptr;
-        if (ULONG_MAX == _uuid) return NULL_POINTER;
+        if (INVALID_UUID == _uuid) return NULL_POINTER;
         Handle h(*this);
         return h.resolve_ptr();
     }
     operator AtomPtr() {
         if (_ptr.get()) return _ptr;
-        if (ULONG_MAX == _uuid) return NULL_POINTER;
+        if (INVALID_UUID == _uuid) return NULL_POINTER;
         return resolve_ptr();
     }
 /***
     operator const AtomPtr&() {
         if (_ptr.get()) return _ptr;
-        if (ULONG_MAX == _uuid) return NULL_POINTER;
+        if (INVALID_UUID == _uuid) return NULL_POINTER;
         return resolve_ptr();
     }
 ***/

--- a/opencog/atomspace/TLB.h
+++ b/opencog/atomspace/TLB.h
@@ -141,7 +141,7 @@ inline bool TLB::isValidHandle(const Handle& h)
 
 inline void TLB::addAtom(AtomPtr atom)
 {
-    if (atom->_uuid != Handle::UNDEFINED.value())
+    if (atom->_uuid != Handle::INVALID_UUID)
         throw InvalidParamException(TRACE_INFO,
                 "Atom is already in the TLB!");
 

--- a/opencog/guile/SchemeSmobNew.cc
+++ b/opencog/guile/SchemeSmobNew.cc
@@ -188,7 +188,7 @@ SCM SchemeSmob::ss_handle (SCM satom)
  */
 SCM SchemeSmob::ss_undefined_handle (void)
 {
-	return scm_from_ulong(Handle::UNDEFINED.value());
+	return scm_from_ulong(Handle::INVALID_UUID);
 }
 
 /* ============================================================== */

--- a/opencog/persist/sql/AtomStorage.cc
+++ b/opencog/persist/sql/AtomStorage.cc
@@ -405,7 +405,7 @@ void AtomStorage::init(const char * dbname,
                        const char * username,
                        const char * authentication)
 {
-	// Create six, by default ... maybe make more? 
+	// Create six, by default ... maybe make more?
 	// There should probably be a few more here, than the number of
 	// startWriterThread() calls below.
 #define DEFAULT_NUM_CONNS 6
@@ -462,7 +462,7 @@ AtomStorage::~AtomStorage()
 }
 
 /**
- * connected -- return true if a successful connection to the 
+ * connected -- return true if a successful connection to the
  * database exists; else return false.  Note that this may block,
  * if all database connections are in use...
  */
@@ -617,7 +617,7 @@ TruthValue* AtomStorage::getTV(int tvid)
 /**
  * Return largest distance from this atom to any node under it.
  * Nodes have a height of 0, by definition.  Links that contain only
- * nodes in their outgoing set have a height of 1, by definition. 
+ * nodes in their outgoing set have a height of 1, by definition.
  * The height of a link is, by definition, one more than the height
  * of the tallest atom in its outgoing set.
  * @note This can conversely be viewed as the depth of a tree.
@@ -644,7 +644,7 @@ int AtomStorage::get_height(AtomPtr atom)
 
 std::string AtomStorage::oset_to_string(const std::vector<Handle>& out,
                                         int arity)
-{ 
+{
 	std::string str;
 	str += "\'{";
 	for (int i=0; i<arity; i++)
@@ -676,7 +676,7 @@ void AtomStorage::flushStoreQueue()
 /**
  * Recursively store the indicated atom, and all that it points to.
  * Store its truth values too. The recursive store is unconditional;
- * its assumed that all sorts of underlying truuth values have changed, 
+ * its assumed that all sorts of underlying truuth values have changed,
  * so that the whole thing needs to be stored.
  *
  * By default, the actual store is done asynchronously (in a different
@@ -800,7 +800,7 @@ void AtomStorage::do_store_single_atom(AtomPtr atom, int aheight)
 		Type t = atom->getType();
 		int dbtype = storing_typemap[t];
 		STMTI("type", dbtype);
-	
+
 		// Store the node name, if its a node
 		NodePtr n(NodeCast(atom));
 		if (n)
@@ -812,7 +812,7 @@ void AtomStorage::do_store_single_atom(AtomPtr atom, int aheight)
 			qname += "'";
 #else
 			// Use postgres $-quoting to make unicode strings
-			// easier to deal with. 
+			// easier to deal with.
 			std::string qname = " $ocp$";
 			qname += n->getName();
 			qname += "$ocp$ ";
@@ -898,23 +898,23 @@ void AtomStorage::do_store_single_atom(AtomPtr atom, int aheight)
 /**
  * Store the concordance of type names to type values.
  *
- * The concordance is used to match up the type id's stored in 
+ * The concordance is used to match up the type id's stored in
  * the SQL database, against those currently in use in the current
  * version of the opencog server. The basic problem is that types
- * can be dynamic in OpenCog -- different versions will have 
+ * can be dynamic in OpenCog -- different versions will have
  * different types, and will assign different type numbers to some
  * given type name. To overcome this, the SQL database stores all
  * atoms according to the type *name* -- although, to save space, it
  * actually stored type ids; however, the SQL type-name-to-type-id
  * mapping can be completely different than the OpenCog type-name
- * to type-id mapping. Thus, tables to convert the one to the other 
+ * to type-id mapping. Thus, tables to convert the one to the other
  * id are needed.
  *
  * Given an opencog type t, the storing_typemap[t] will contain the
  * sqlid for the named type. The storing_typemap[t] will *always*
  * contain a valid value.
  *
- * Given an SQL type sq, the loading_typemap[sq] will contain the 
+ * Given an SQL type sq, the loading_typemap[sq] will contain the
  * opencog type t for the named type, or NOTYPE if this version of
  * opencog does not have this kind of atom.
  *
@@ -1064,7 +1064,7 @@ std::unique_lock<std::mutex> AtomStorage::maybe_create_id(UUID uuid)
 		cache_lock.unlock();
 		while (true)
 		{
-			// If we are here, some other thread is making this UUID, 
+			// If we are here, some other thread is making this UUID,
 			// and so we need to wait till they're done. Wait by stalling
 			// on the creation lock.
 			std::unique_lock<std::mutex> local_create_lock(id_create_mutex);
@@ -1078,7 +1078,7 @@ std::unique_lock<std::mutex> AtomStorage::maybe_create_id(UUID uuid)
 				return std::unique_lock<std::mutex>();
 			}
 			cache_lock.unlock();
-		} 
+		}
 	}
 
 	// If we are here, then no one has attempted to make this UUID before.
@@ -1235,7 +1235,7 @@ NodePtr AtomStorage::getNode(Type t, const char * str)
 	setup_typemap();
 	char buff[40*BUFSZ];
 
-	// Use postgres $-quoting to make unicode strings easier to deal with. 
+	// Use postgres $-quoting to make unicode strings easier to deal with.
 	int nc = snprintf(buff, 4*BUFSZ, "SELECT * FROM Atoms WHERE "
 	    "type = %hu AND name = $ocp$%s$ocp$ ;", storing_typemap[t], str);
 
@@ -1265,7 +1265,7 @@ LinkPtr AtomStorage::getLink(Type t, const std::vector<Handle>&oset)
 	setup_typemap();
 
 	char buff[BUFSZ];
-	snprintf(buff, BUFSZ, 
+	snprintf(buff, BUFSZ,
 	    "SELECT * FROM Atoms WHERE type = %hu AND outgoing = ",
 	    storing_typemap[t]);
 
@@ -1277,7 +1277,7 @@ LinkPtr AtomStorage::getLink(Type t, const std::vector<Handle>&oset)
 	return LinkCast(atom);
 }
 
-/** 
+/**
  * Instantiate a new atom, from the response buffer contents
  */
 AtomPtr AtomStorage::makeAtom(Response &rp, Handle h)
@@ -1299,7 +1299,7 @@ AtomPtr AtomStorage::makeAtom(Response &rp, Handle h)
 		// All height zero atoms are nodes,
 		// All positive height atoms are links.
 		// A negative height is "unknown" and must be checked.
-		if ((0 == rp.height) || 
+		if ((0 == rp.height) ||
 		    ((-1 == rp.height) &&
 		      classserver().isA(realtype, NODE)))
 		{
@@ -1349,7 +1349,7 @@ AtomPtr AtomStorage::makeAtom(Response &rp, Handle h)
 				uuid, realtype, atom->getType());
 		}
 		// If we are here, and the atom uuid is set, then it should match.
-		if (Handle::INVALID_UUID != atom->_uuid and 
+		if (Handle::INVALID_UUID != atom->_uuid and
 		    atom->_uuid != h.value())
 		{
 			throw RuntimeException(TRACE_INFO,
@@ -1620,7 +1620,7 @@ void AtomStorage::create_tables(void)
 	ODBCConnection* db_conn = get_conn();
 	Response rp;
 
-	// See the file "atom.sql" for detailed documentation as to the 
+	// See the file "atom.sql" for detailed documentation as to the
 	// structure of the SQL tables.
 	rp.rs = db_conn->exec("CREATE TABLE Atoms ("
 	                      "uuid     BIGINT PRIMARY KEY,"
@@ -1673,7 +1673,7 @@ void AtomStorage::kill_data(void)
 	ODBCConnection* db_conn = get_conn();
 	Response rp;
 
-	// See the file "atom.sql" for detailed documentation as to the 
+	// See the file "atom.sql" for detailed documentation as to the
 	// structure of the SQL tables.
 	rp.rs = db_conn->exec("DELETE from Atoms;");
 	rp.rs->release();
@@ -1687,7 +1687,7 @@ void AtomStorage::kill_data(void)
 
 void AtomStorage::setMaxHeight(int sqmax)
 {
-	// Max height of db contents can only get larger! 
+	// Max height of db contents can only get larger!
 	if (max_height < sqmax) max_height = sqmax;
 
 	char buff[BUFSZ];

--- a/opencog/persist/sql/AtomStorage.cc
+++ b/opencog/persist/sql/AtomStorage.cc
@@ -1157,7 +1157,7 @@ AtomPtr  AtomStorage::getAtom(const char * query, int height)
 
 	// Did we actually find anything?
 	// DO NOT USE TLB::IsInvalidHandle() HERE! It won't work, duhh!
-	if (rp.handle.value() == Handle::UNDEFINED.value())
+	if (rp.handle.value() == Handle::INVALID_UUID)
 	{
 		rp.rs->release();
 		put_conn(db_conn);
@@ -1349,7 +1349,7 @@ AtomPtr AtomStorage::makeAtom(Response &rp, Handle h)
 				uuid, realtype, atom->getType());
 		}
 		// If we are here, and the atom uuid is set, then it should match.
-		if (Handle::UNDEFINED.value() != atom->_uuid and 
+		if (Handle::INVALID_UUID != atom->_uuid and 
 		    atom->_uuid != h.value())
 		{
 			throw RuntimeException(TRACE_INFO,

--- a/tests/atomspace/AtomTableUTest.cxxtest
+++ b/tests/atomspace/AtomTableUTest.cxxtest
@@ -222,8 +222,8 @@ public:
         delete rng;
     }
 
-    /* test the fix for the bug triggered whenever we had a link pointing to the
-     * same atom twice (or more) */
+    /* test the fix for the bug triggered whenever we had a link
+     * pointing to the same atom twice (or more). */
     void testDoubleLink()
     {
         NodePtr n1(createNode(NUMBER_NODE, "1"));
@@ -236,6 +236,7 @@ public:
         LinkPtr l1(createLink(LIST_LINK, os));
         Handle hl1 = table->add(l1, false);
 
+        // Now, remove hn1 from the table ...
         table->extract(hn1, true);
 
         // Number nodes are handled differently, in the atomspace. Try

--- a/tests/atomspace/AtomTableUTest.cxxtest
+++ b/tests/atomspace/AtomTableUTest.cxxtest
@@ -139,28 +139,28 @@ public:
         Handle hle(createLink(EVALUATION_LINK, hnp, hll));
 
         // No UUID should be assigned yet.
-        TS_ASSERT_EQUALS(hn1.value(), Handle::UNDEFINED.value());
-        TS_ASSERT_EQUALS(hn2.value(), Handle::UNDEFINED.value());
-        TS_ASSERT_EQUALS(hn3.value(), Handle::UNDEFINED.value());
-        TS_ASSERT_EQUALS(hn4.value(), Handle::UNDEFINED.value());
-        TS_ASSERT_EQUALS(hnp.value(), Handle::UNDEFINED.value());
-        TS_ASSERT_EQUALS(hll.value(), Handle::UNDEFINED.value());
-        TS_ASSERT_EQUALS(hle.value(), Handle::UNDEFINED.value());
+        TS_ASSERT_EQUALS(hn1.value(), Handle::INVALID_UUID);
+        TS_ASSERT_EQUALS(hn2.value(), Handle::INVALID_UUID);
+        TS_ASSERT_EQUALS(hn3.value(), Handle::INVALID_UUID);
+        TS_ASSERT_EQUALS(hn4.value(), Handle::INVALID_UUID);
+        TS_ASSERT_EQUALS(hnp.value(), Handle::INVALID_UUID);
+        TS_ASSERT_EQUALS(hll.value(), Handle::INVALID_UUID);
+        TS_ASSERT_EQUALS(hle.value(), Handle::INVALID_UUID);
 
         // Add the link.  All the outgoing atoms should get added too.
         Handle hlet = table->add(hle, false);
-        TS_ASSERT(hlet.value() != Handle::UNDEFINED.value());
+        TS_ASSERT(hlet.value() != Handle::INVALID_UUID);
         LinkPtr let(LinkCast(hlet));
         const HandleSeq& hs = let->getOutgoingSet();
-        TS_ASSERT(hs[0].value() != Handle::UNDEFINED.value());
-        TS_ASSERT(hs[1].value() != Handle::UNDEFINED.value());
+        TS_ASSERT(hs[0].value() != Handle::INVALID_UUID);
+        TS_ASSERT(hs[1].value() != Handle::INVALID_UUID);
 
         LinkPtr llt(LinkCast(hs[1]));
         const HandleSeq& hsl = llt->getOutgoingSet();
-        TS_ASSERT(hsl[0].value() != Handle::UNDEFINED.value());
-        TS_ASSERT(hsl[1].value() != Handle::UNDEFINED.value());
-        TS_ASSERT(hsl[2].value() != Handle::UNDEFINED.value());
-        TS_ASSERT(hsl[3].value() != Handle::UNDEFINED.value());
+        TS_ASSERT(hsl[0].value() != Handle::INVALID_UUID);
+        TS_ASSERT(hsl[1].value() != Handle::INVALID_UUID);
+        TS_ASSERT(hsl[2].value() != Handle::INVALID_UUID);
+        TS_ASSERT(hsl[3].value() != Handle::INVALID_UUID);
 
         // Now test resolution.  Given the version of the atom that is
         // not yet in the atomspace, we should be able to find the one

--- a/tests/query/CMakeLists.txt
+++ b/tests/query/CMakeLists.txt
@@ -135,6 +135,8 @@ CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/tests/query/stackmore-u-u.scm
     ${PROJECT_BINARY_DIR}/tests/query/stackmore-u-u.scm)
 CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/tests/query/substitution.scm
     ${PROJECT_BINARY_DIR}/tests/query/substitution.scm)
+CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/tests/query/test_types.scm
+    ${PROJECT_BINARY_DIR}/tests/query/test_types.scm)
 CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/tests/query/unordered.scm
     ${PROJECT_BINARY_DIR}/tests/query/unordered.scm)
 CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/tests/query/unordered-more.scm

--- a/tests/query/DisconnectedUTest.cxxtest
+++ b/tests/query/DisconnectedUTest.cxxtest
@@ -57,6 +57,7 @@ class Disconnected :  public CxxTest::TestSuite
 
 		void test_components(void);
 		void test_variables(void);
+		void test_cvariables(void);
 };
 
 /*
@@ -142,6 +143,7 @@ void Disconnected::test_variables(void)
 		caught = true;
 	}
 	logger().info("Caught exception? %d\n", caught);
+	TSM_ASSERT("Failed to catch expected exception", caught);
 
 	// We expect to catch an error here. ------------------------------
 	caught = false;
@@ -155,6 +157,7 @@ void Disconnected::test_variables(void)
 		caught = true;
 	}
 	logger().info("Caught exception? %d\n", caught);
+	TSM_ASSERT("Failed to catch expected exception", caught);
 
 	// We expect to catch an error here. ------------------------------
 	caught = false;
@@ -168,6 +171,37 @@ void Disconnected::test_variables(void)
 		caught = true;
 	}
 	logger().info("Caught exception? %d\n", caught);
+	TSM_ASSERT("Failed to catch expected exception", caught);
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+// Similar to above, except that the stuff is build up in C++ not in
+// scheme.  See bug #172.
+void Disconnected::test_cvariables(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	// We expect to catch an error here.
+	bool caught = false;
+	try
+	{
+		Handle va(createNode(VARIABLE_NODE, "$A"));
+		Handle vb(createNode(VARIABLE_NODE, "$B"));
+		Handle blv(createLink(VARIABLE_LIST, va, vb));
+		Handle blb(createLink(AND_LINK, va));
+		Handle blt(createLink(LIST_LINK, va));
+		HandleSeq bll = {blv, blb, blt};
+		Handle bl_final(createLink(BIND_LINK, bll));
+		as->add_atom(bl_final);
+	}
+	catch (const InvalidParamException& ex)
+	{
+		logger().debug("Caught exception, just as expected: %s", ex.getMessage());
+		caught = true;
+	}
+	logger().info("Caught exception? %d\n", caught);
+	TSM_ASSERT("Failed to catch expected exception", caught);
 
 	logger().debug("END TEST: %s", __FUNCTION__);
 }


### PR DESCRIPTION
This is an extensive set of changes with the goal of allowing atoms to be compared directly, as atoms, reducing some of the excessive dependency on UUID's in the code.

This was prompted as a fix to issue #172.

This also breaks BackwardChainerUTest in the fashion described at the bottom of #172