### PR TITLE
AtomTable: Correctly add custom atom type with its own internal storage

### DIFF
--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -432,27 +432,25 @@ Handle AtomTable::add(AtomPtr atom, bool async)
     Handle hexist(getHandle(atom));
     if (hexist) return hexist;
 
-    // If this atom is in some other atomspace, then we need to clone
-    // it. We cannot insert it into this atomtable as-is.  (We already
-    // know that its not in this atomspace, or its environ.)
-    AtomTable* at = atom->getAtomTable();
-    if (at != NULL) {
-        LinkPtr lll(LinkCast(atom));
-        if (lll) {
-            // Well, if the link was in some other atomspace, then
-            // the outgoing set will probably be too. (It might not
-            // be if the other atomspace is a child of this one).
-            // So we recursively clone that too.
-            HandleSeq closet;
-            for (const Handle& h : lll->getOutgoingSet()) {
-                closet.push_back(add(h, async));
-            }
-            atom = createLink(atom_type, closet,
-                              atom->getTruthValue(),
-                              atom->getAttentionValue());
+    // If this atom is in some other atomspace or not in any atomspace,
+    // then we need to clone it. We cannot insert it into this atomtable
+    // as-is.  (We already know that its not in this atomspace, or its
+    // environ.)
+    LinkPtr lll(LinkCast(atom));
+    if (lll) {
+        // Well, if the link was in some other atomspace, then
+        // the outgoing set will probably be too. (It might not
+        // be if the other atomspace is a child of this one).
+        // So we recursively clone that too.
+        HandleSeq closet;
+        for (const Handle& h : lll->getOutgoingSet()) {
+            closet.push_back(add(h, async));
         }
-        atom = clone_factory(atom_type, atom);
+        atom = createLink(atom_type, closet,
+                          atom->getTruthValue(),
+                          atom->getAttentionValue());
     }
+    atom = clone_factory(atom_type, atom);
 
     // Sometimes one inserts an atom that was previously deleted.
     // In this case, the removal flag might still be set. Clear it.
@@ -463,7 +461,7 @@ Handle AtomTable::add(AtomPtr atom, bool async)
     // no pointers to actual atoms.  We want to have the actual atoms,
     // because later steps need the pointers to do stuff, in particular,
     // to make sure the child atoms are in an atomtable, too.
-    LinkPtr lll(LinkCast(atom));
+    lll = LinkCast(atom);
     if (lll) {
         const HandleSeq& ogs(lll->getOutgoingSet());
         size_t arity = ogs.size();

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -284,6 +284,9 @@ AtomPtr AtomTable::factory(Type atom_type, AtomPtr atom)
     } else if (BIND_LINK == atom_type) {
         if (NULL == BindLinkCast(atom))
             return createBindLink(*LinkCast(atom));
+    } else if (PATTERN_LINK == atom_type) {
+        if (NULL == PatternLinkCast(atom))
+            return createPatternLink(*LinkCast(atom));
     } else if (DEFINE_LINK == atom_type) {
         if (NULL == DefineLinkCast(atom))
             return createDefineLink(*LinkCast(atom));
@@ -342,6 +345,8 @@ static AtomPtr clone_factory(Type atom_type, AtomPtr atom)
     // Links of various kinds -----------
     if (BIND_LINK == atom_type)
         return createBindLink(*LinkCast(atom));
+    if (PATTERN_LINK == atom_type)
+        return createPatternLink(*LinkCast(atom));
     if (DEFINE_LINK == atom_type)
         return createDefineLink(*LinkCast(atom));
 /*

--- a/tests/atomspace/AtomTableUTest.cxxtest
+++ b/tests/atomspace/AtomTableUTest.cxxtest
@@ -39,6 +39,7 @@
 #include <opencog/atomspace/Link.h>
 #include <opencog/atomspace/Node.h>
 #include <opencog/atomspace/SimpleTruthValue.h>
+#include <opencog/atoms/core/VariableList.h>
 #include <opencog/guile/load-file.h>
 #include <opencog/util/Config.h>
 #include <opencog/util/Logger.h>
@@ -274,5 +275,28 @@ public:
         TS_ASSERT(table->getHandlex("1", MY_NUMBER_NODE) != Handle::UNDEFINED);
         TS_ASSERT(table->getHandlex("28675194", MY_CONCEPT_NODE) != Handle::UNDEFINED);
         TS_ASSERT(table->getHandle(MY_INHERITANCE_LINK, os) != Handle::UNDEFINED);
+    }
+
+    void testUnaddedCustomAtomTypes()
+    {
+        Handle hv1 = Handle(createNode(VARIABLE_NODE, "$1"));
+        Handle hv2 = Handle(createNode(VARIABLE_NODE, "$2"));
+        HandleSeq hvs{hv1, hv2};
+        Handle hlist = Handle(createVariableList(hvs));
+
+        VariableListPtr v_ptr(VariableListCast(hlist));
+        TS_ASSERT_EQUALS(v_ptr->get_variables().varset.count(hv1), 1);
+        TS_ASSERT_EQUALS(v_ptr->get_variables().varset.count(hv2), 1);
+
+        Handle hlist_added = table->add(hlist, false);
+
+        VariableListPtr v_added_ptr(VariableListCast(hlist_added));
+        TS_ASSERT_DIFFERS(v_added_ptr->get_variables().varset.count(hv1), 1);
+        TS_ASSERT_DIFFERS(v_added_ptr->get_variables().varset.count(hv2), 1);
+
+        Handle hv1_added = table->add(hv1, false);
+        Handle hv2_added = table->add(hv2, false);
+        TS_ASSERT_EQUALS(v_added_ptr->get_variables().varset.count(hv1_added), 1);
+        TS_ASSERT_EQUALS(v_added_ptr->get_variables().varset.count(hv2_added), 1);
     }
 };

--- a/tests/atomspace/AtomTableUTest.cxxtest
+++ b/tests/atomspace/AtomTableUTest.cxxtest
@@ -291,8 +291,8 @@ public:
         Handle hlist_added = table->add(hlist, false);
 
         VariableListPtr v_added_ptr(VariableListCast(hlist_added));
-        TS_ASSERT_DIFFERS(v_added_ptr->get_variables().varset.count(hv1), 1);
-        TS_ASSERT_DIFFERS(v_added_ptr->get_variables().varset.count(hv2), 1);
+        TS_ASSERT_EQUALS(v_added_ptr->get_variables().varset.count(hv1), 0);
+        TS_ASSERT_EQUALS(v_added_ptr->get_variables().varset.count(hv2), 0);
 
         Handle hv1_added = table->add(hv1, false);
         Handle hv2_added = table->add(hv2, false);


### PR DESCRIPTION
Custom atom types with its own internal Handle storage (such as VariableList) will store incorrect Handles if everything is added in one go.  This fixes that (see the unit test).