### PR TITLE
Change confidence_to_count and count_to_confidence to static methods

### DIFF
--- a/opencog/cython/opencog/truth_value.pyx
+++ b/opencog/cython/opencog/truth_value.pyx
@@ -63,8 +63,10 @@ cdef class TruthValue:
     def __str__(self):
         return self._ptr().toString().c_str()
 
-    def confidence_to_count(self, float conf):
+    @staticmethod
+    def confidence_to_count(float conf):
         return (<cSimpleTruthValue*> 0).confidenceToCount(conf)
 
-    def count_to_confidence(self, float count):
+    @staticmethod
+    def count_to_confidence(float count):
         return (<cSimpleTruthValue*> 0).countToConfidence(count)


### PR DESCRIPTION
It's part of the REST API Fix
No need for an instance of TruthValue to convert count to confidence and vice versa...