### PR TITLE
AtomSpace: Clear AS on destruction

### DIFF
--- a/opencog/atomspace/AtomSpace.cc
+++ b/opencog/atomspace/AtomSpace.cc
@@ -62,6 +62,7 @@ AtomSpace::AtomSpace(AtomSpace* parent) :
 
 AtomSpace::~AtomSpace()
 {
+    clear();
     // Be sure to disconnect the attention bank signals before the
     // atom table destructor runs. XXX FIXME yes this is an ugly hack.
     bank.shutdown();


### PR DESCRIPTION
Maybe this is a bad idea (too slow maybe), not sure.  I don't fully understand why this is happening yet.

It seems it is possible sometimes that the AtomSpace is not destroyed immediately, so if we have an extension

```
{ AtomSpace ex(&_as);   .... }
```

that goes out of scope, _as atoms' incoming set can still find atoms in `ex`.  It is like there's still some dangling shared pointer pointing to the atoms that was in `ex` (but in this case doing a `clear()` should not have affected it.....)  

In any case, adding a `clear()` to the destructor fixed it, so that atoms in _as will not see the destroyed one in `ex` after `ex` went out of scope.