### PR TITLE
PatternLink: Fixes circular share_ptr in PatternTerm

### DIFF
--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -239,7 +239,7 @@ bool PatternMatchEngine::ordered_compare(const PatternTermPtr& ptm,
                                          const LinkPtr& lp,
                                          const LinkPtr& lg)
 {
-	const PatternTermSeq &osp = ptm->getOutgoingSet();
+	PatternTermSeq osp = ptm->getOutgoingSet();
 	const HandleSeq &osg = lg->getOutgoingSet();
 
 //	size_t oset_sz = osp.size();
@@ -314,7 +314,7 @@ bool PatternMatchEngine::choice_compare(const PatternTermPtr& ptm,
                                         const LinkPtr& lg)
 {
 	const Handle& hp = ptm->getHandle();
-	const PatternTermSeq &osp = ptm->getOutgoingSet();
+	PatternTermSeq osp = ptm->getOutgoingSet();
 
 	// _choice_state lets use resume where we last left off.
 	size_t iend = osp.size();
@@ -549,7 +549,7 @@ bool PatternMatchEngine::unorder_compare(const PatternTermPtr& ptm,
 {
 	const Handle& hp = ptm->getHandle();
 	const HandleSeq& osg = lg->getOutgoingSet();
-	const PatternTermSeq& osp = ptm->getOutgoingSet();
+	PatternTermSeq osp = ptm->getOutgoingSet();
 //	size_t arity = osp.size();
 	size_t osg_size = osg.size();
 	size_t osp_size = osp.size();

--- a/opencog/query/PatternTerm.h
+++ b/opencog/query/PatternTerm.h
@@ -54,14 +54,16 @@ namespace opencog {
 
 class PatternTerm;
 typedef std::shared_ptr<PatternTerm> PatternTermPtr;
+typedef std::weak_ptr<PatternTerm> PatternTermWPtr;
 typedef std::vector<PatternTermPtr> PatternTermSeq;
+typedef std::vector<PatternTermWPtr> PatternTermWSeq;
 
 class PatternTerm
 {
 	protected:
 		Handle _handle;
 		PatternTermPtr _parent;
-		PatternTermSeq _outgoing;
+		PatternTermWSeq _outgoing;
 
 		// Number of QuoteLinks on the path up to the root including this
 		// term. Zero means the term is unquoted. Quoted terms are matched
@@ -100,16 +102,23 @@ class PatternTerm
 		inline Handle getHandle()
 		{
 			return _handle;
-		};
+		}
 	
 		inline PatternTermPtr getParent()
 		{
 			return _parent;
-		};
+		}
 
-		inline const PatternTermSeq& getOutgoingSet() const
+		inline PatternTermSeq getOutgoingSet() const
 		{
-			return _outgoing;
+			PatternTermSeq oset;
+			for (PatternTermWPtr w : _outgoing)
+			{
+				PatternTermPtr s(w.lock());
+				if (s) oset.push_back(s);
+			}
+
+			return oset;
 		}
 
 		inline Arity getArity() const
@@ -133,7 +142,11 @@ class PatternTerm
 		{
 			// Checks for a valid position
 			if (pos < getArity()) {
-				return _outgoing[pos];
+				PatternTermPtr s(_outgoing[pos].lock());
+				if (not s)
+					throw RuntimeException(TRACE_INFO,
+					                       "expired outgoing set index %d", pos);
+				return s;
 			} else {
 				throw RuntimeException(TRACE_INFO,
 				                       "invalid outgoing set index %d", pos);


### PR DESCRIPTION
Found the real culprit of https://github.com/opencog/atomspace/pull/296

PatternTerm usage at https://github.com/opencog/atomspace/blob/7ebc0384925db1a6965df2435feca11926e138a6/opencog/atoms/bind/PatternLink.cc#L723-L724 
combined with https://github.com/opencog/atomspace/blob/7ebc0384925db1a6965df2435feca11926e138a6/opencog/atoms/bind/PatternLink.cc#L732-L733
is circular.

 `ptm` parent is `parent`, while `parent` outgoing contains `ptm`.  This is keeping the handle stored within the PatternTerm object in memory even when everything is out of scope.

Converted `_outgoing` to use weak pointer fixed it (like how it's done on Atom's incoming set).

The fix at https://github.com/opencog/atomspace/pull/303 should no longer be needed.