### PR TITLE
Pattern Matcher: Store the removed constant clauses

### DIFF
--- a/opencog/atoms/bind/PatternLink.cc
+++ b/opencog/atoms/bind/PatternLink.cc
@@ -48,7 +48,7 @@ void PatternLink::common_init(void)
 		return;
 	}
 
-	validate_clauses(_varlist.varset, _pat.clauses);
+	validate_clauses(_varlist.varset, _pat.clauses, _pat.constants);
 	extract_optionals(_varlist.varset, _pat.clauses);
 
 	// Locate the black-box clauses.
@@ -379,7 +379,8 @@ void PatternLink::locate_defines(HandleSeq& clauses)
  * that are constants and can be trivially discarded.
  */
 void PatternLink::validate_clauses(std::set<Handle>& vars,
-                                   HandleSeq& clauses)
+                                   HandleSeq& clauses,
+                                   HandleSeq& constants)
 
 {
 	// The Fuzzy matcher does some strange things: it declares no
@@ -394,7 +395,7 @@ void PatternLink::validate_clauses(std::set<Handle>& vars,
 		// The presence of constant clauses will mess up the current
 		// pattern matcher.  Constant clauses are "trivial" to match,
 		// and so its pointless to even send them through the system.
-		bool bogus = remove_constants(vars, clauses);
+		bool bogus = remove_constants(vars, clauses, constants);
 		if (bogus)
 		{
 			logger().warn("%s: Constant clauses removed from pattern",

--- a/opencog/atoms/bind/PatternLink.h
+++ b/opencog/atoms/bind/PatternLink.h
@@ -96,7 +96,8 @@ protected:
 	void unbundle_clauses(const Handle& body);
 	void locate_defines(HandleSeq& clauses);
 	void validate_clauses(std::set<Handle>& vars,
-	                      HandleSeq& clauses);
+	                      HandleSeq& clauses,
+	                      HandleSeq& constants);
 
 	void extract_optionals(const std::set<Handle> &vars,
 	                       const std::vector<Handle> &component);

--- a/opencog/atoms/bind/PatternUtils.cc
+++ b/opencog/atoms/bind/PatternUtils.cc
@@ -51,7 +51,8 @@ namespace opencog {
  * Returns true if the list of clauses was modified, else returns false.
  */
 bool remove_constants(const std::set<Handle> &vars,
-                      std::vector<Handle> &clauses)
+                      std::vector<Handle> &clauses,
+                      std::vector<Handle> &constants)
 {
 	bool modified = false;
 
@@ -70,6 +71,7 @@ bool remove_constants(const std::set<Handle> &vars,
 		}
 		else
 		{
+			constants.push_back(clause);
 			i = clauses.erase(i);
 			modified = true;
 		}

--- a/opencog/atoms/bind/PatternUtils.h
+++ b/opencog/atoms/bind/PatternUtils.h
@@ -39,7 +39,8 @@ namespace opencog {
 // Make sure that variables can be found in the clauses.
 // See C file for description
 bool remove_constants(const std::set<Handle> &vars,
-                      std::vector<Handle> &clauses);
+                      std::vector<Handle> &clauses,
+                      std::vector<Handle> &constants);
 
 
 // See C file for description

--- a/opencog/query/Pattern.h
+++ b/opencog/query/Pattern.h
@@ -81,6 +81,9 @@ struct Pattern
 	/// The actual clauses. Set by validate_clauses()
 	HandleSeq        clauses;
 
+	/// The removed constant clauses, Set by validate_clauses()
+	HandleSeq        constants;
+
 	// The cnf_clauses are the clauses, but with the AbsentLink removed.
 	// This simplifies graph discovery, so that when they are found,
 	// they can be rejected (e.g. are not absent).


### PR DESCRIPTION
I want to be able to tell if Pattern Matcher removed a clause.