### PR TITLE
Support disconnected optionals in Pattern Match

### DIFF
--- a/opencog/query/PatternMatch.cc
+++ b/opencog/query/PatternMatch.cc
@@ -390,13 +390,8 @@ bool PatternLink::satisfy(PatternMatchCallback& pmcb) const
 		PatternLinkPtr clp(PatternLinkCast(_component_patterns.at(i)));
 		clp->satisfy(gcb);
 
-		// Special handling for disconnected pure optionals:
-		// 1) Returns false to end the search if this disconnected pure optional
-		//    is found
-		// 2) Keep the search going without inserting an empty _var_groundings
-		//    nor an empty _term_groundings into comp_var_gnds and comp_term_gnds
-		//    respectively, so that potential solutions for mandatory clauses,
-		//    if any, will get a chance to reach the grounding callback
+		// Special handling for disconnected pure optionals -- Returns false to
+		// end the search if this disconnected pure optional is found
 		if (is_pure_optional)
 		{
 			DefaultPatternMatchCB* dpmcb = dynamic_cast<DefaultPatternMatchCB*>(&pmcb);

--- a/opencog/query/PatternMatch.cc
+++ b/opencog/query/PatternMatch.cc
@@ -390,13 +390,19 @@ bool PatternLink::satisfy(PatternMatchCallback& pmcb) const
 		PatternLinkPtr clp(PatternLinkCast(_component_patterns.at(i)));
 		clp->satisfy(gcb);
 
+		// Special handling for disconnected pure optionals:
+		// 1) Returns false to end the search if this disconnected pure optional
+		//    is found
+		// 2) Keep the search going without inserting an empty _var_groundings
+		//    nor an empty _term_groundings into comp_var_gnds and comp_term_gnds
+		//    respectively, so that potential solutions for mandatory clauses,
+		//    if any, will get a chance to reach the grounding callback
 		if (is_pure_optional)
 		{
 			DefaultPatternMatchCB* dpmcb = dynamic_cast<DefaultPatternMatchCB*>(&pmcb);
 			if (dpmcb->optionals_present()) return false;
 		}
-
-		if (0 < gcb._var_groundings.size() and 0 < gcb._term_groundings.size())
+		else
 		{
 			comp_var_gnds.push_back(gcb._var_groundings);
 			comp_term_gnds.push_back(gcb._term_groundings);

--- a/tests/query/AbsentUTest.cxxtest
+++ b/tests/query/AbsentUTest.cxxtest
@@ -60,6 +60,10 @@ public:
 
 	void test_single(void);
 	void test_double(void);
+	void test_connect_exist(void);
+	void test_connect_not_exist(void);
+	void test_discon_exist(void);
+	void test_discon_not_exist(void);
 };
 
 void AbsentUTest::tearDown(void)
@@ -218,6 +222,74 @@ void AbsentUTest::test_double(void)
 
 	state = eval->eval_h("(show-ufo-state)");
 	TS_ASSERT_EQUALS(state, exists);
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+void AbsentUTest::test_connect_exist(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	config().set("SCM_PRELOAD", "tests/query/absent-conn1.scm");
+	load_scm_files_from_config(*as);
+
+	Handle rtn = eval->eval_h("(cog-bind test)");
+
+	Handle soln = eval->eval_h("soln");
+
+	TSM_ASSERT_EQUALS("Wrong number of solutions", as->get_arity(rtn), 0);
+	TS_ASSERT_EQUALS(rtn, soln);
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+void AbsentUTest::test_connect_not_exist(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	config().set("SCM_PRELOAD", "tests/query/absent-conn2.scm");
+	load_scm_files_from_config(*as);
+
+	Handle rtn = eval->eval_h("(cog-bind test)");
+
+	Handle soln = eval->eval_h("soln");
+
+	TSM_ASSERT_EQUALS("Wrong number of solutions", as->get_arity(rtn), 1);
+	TS_ASSERT_EQUALS(rtn, soln);
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+void AbsentUTest::test_discon_exist(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	config().set("SCM_PRELOAD", "tests/query/absent-disconn1.scm");
+	load_scm_files_from_config(*as);
+
+	Handle rtn = eval->eval_h("(cog-bind test)");
+
+	Handle soln = eval->eval_h("soln");
+
+	TSM_ASSERT_EQUALS("Wrong number of solutions", as->get_arity(rtn), 0);
+	TS_ASSERT_EQUALS(rtn, soln);
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+void AbsentUTest::test_discon_not_exist(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	config().set("SCM_PRELOAD", "tests/query/absent-disconn2.scm");
+	load_scm_files_from_config(*as);
+
+	Handle rtn = eval->eval_h("(cog-bind test)");
+
+	Handle soln = eval->eval_h("soln");
+
+	TSM_ASSERT_EQUALS("Wrong number of solutions", as->get_arity(rtn), 1);
+	TS_ASSERT_EQUALS(rtn, soln);
 
 	logger().debug("END TEST: %s", __FUNCTION__);
 }

--- a/tests/query/absent-conn1.scm
+++ b/tests/query/absent-conn1.scm
@@ -1,0 +1,28 @@
+(define soln (SetLink))
+
+(ListLink (ConceptNode "A") (ConceptNode "X"))
+
+(define test
+    (BindLink
+        (VariableList
+            (TypedVariableLink (VariableNode "$var1") (TypeNode "ConceptNode"))
+            (TypedVariableLink (VariableNode "$var2") (TypeNode "ConceptNode"))
+        )
+        (AndLink
+            (ListLink
+                (VariableNode "$var1")
+                (VariableNode "$var2")
+            )
+            (AbsentLink
+                (ListLink
+                    (VariableNode "$var1")
+                    (ConceptNode "X")
+                )
+            )
+        )
+        (ListLink
+            (VariableNode "$var1")
+            (VariableNode "$var2")
+        )
+    )
+)

--- a/tests/query/absent-conn2.scm
+++ b/tests/query/absent-conn2.scm
@@ -1,0 +1,26 @@
+(define soln (SetLink (ListLink (ConceptNode "A") (ConceptNode "B"))))
+
+(define test
+    (BindLink
+        (VariableList
+            (TypedVariableLink (VariableNode "$var1") (TypeNode "ConceptNode"))
+            (TypedVariableLink (VariableNode "$var2") (TypeNode "ConceptNode"))
+        )
+        (AndLink
+            (ListLink
+                (VariableNode "$var1")
+                (VariableNode "$var2")
+            )
+            (AbsentLink
+                (ListLink
+                    (VariableNode "$var1")
+                    (ConceptNode "X")
+                )
+            )
+        )
+        (ListLink
+            (VariableNode "$var1")
+            (VariableNode "$var2")
+        )
+    )
+)

--- a/tests/query/absent-disconn1.scm
+++ b/tests/query/absent-disconn1.scm
@@ -1,0 +1,30 @@
+(define soln (SetLink))
+
+(ListLink (ConceptNode "A") (ConceptNode "B"))
+(ListLink (ConceptNode "Y") (ConceptNode "X"))
+
+(define test
+    (BindLink
+        (VariableList
+            (TypedVariableLink (VariableNode "$var1") (TypeNode "ConceptNode"))
+            (TypedVariableLink (VariableNode "$var2") (TypeNode "ConceptNode"))
+            (TypedVariableLink (VariableNode "$var3") (TypeNode "ConceptNode"))
+        )
+        (AndLink
+            (ListLink
+                (VariableNode "$var1")
+                (VariableNode "$var2")
+            )
+            (AbsentLink
+                (ListLink
+                    (VariableNode "$var3")
+                    (ConceptNode "X")
+                )
+            )
+        )
+        (ListLink
+            (VariableNode "$var1")
+            (VariableNode "$var2")
+        )
+    )
+)

--- a/tests/query/absent-disconn2.scm
+++ b/tests/query/absent-disconn2.scm
@@ -1,0 +1,27 @@
+(define soln (SetLink (ListLink (ConceptNode "A") (ConceptNode "B"))))
+
+(define test
+    (BindLink
+        (VariableList
+            (TypedVariableLink (VariableNode "$var1") (TypeNode "ConceptNode"))
+            (TypedVariableLink (VariableNode "$var2") (TypeNode "ConceptNode"))
+            (TypedVariableLink (VariableNode "$var3") (TypeNode "ConceptNode"))
+        )
+        (AndLink
+            (ListLink
+                (VariableNode "$var1")
+                (VariableNode "$var2")
+            )
+            (AbsentLink
+                (ListLink
+                    (VariableNode "$var3")
+                    (ConceptNode "X")
+                )
+            )
+        )
+        (ListLink
+            (VariableNode "$var1")
+            (VariableNode "$var2")
+        )
+    )
+)


### PR DESCRIPTION
This allows us to have disconnected optional clauses in the pattern, but I am not sure if this is enough to handle every cases