### PR TITLE
Backward Chainer: Temporary even more steps for the unit test

### DIFF
--- a/tests/rule-engine/BackwardChainerUTest.cxxtest
+++ b/tests/rule-engine/BackwardChainerUTest.cxxtest
@@ -78,7 +78,7 @@ void BackwardChainerUTest::test_1rule_bc()
 	Handle soln = eval_.eval_h("(ConceptNode \"Fritz\")");
 
 	bc.set_target(target);
-	bc.get_config().set_maximum_iterations(150);
+	bc.get_config().set_maximum_iterations(300);
 	bc.do_chain();
 
 	VarMultimap results = bc.get_chaining_result();
@@ -112,7 +112,7 @@ void BackwardChainerUTest::test_1rule_impossible_bc()
 
 	// should NOT be possible to find the solution without deduction rule
 	bc.set_target(target);
-	bc.get_config().set_maximum_iterations(700);
+	bc.get_config().set_maximum_iterations(1000);
 	bc.do_chain();
 
 	VarMultimap results = bc.get_chaining_result();
@@ -147,7 +147,7 @@ void BackwardChainerUTest::test_2rules_bc()
 	Handle soln = eval_.eval_h("(ConceptNode \"West\")");
 
 	bc.set_target(target);
-	bc.get_config().set_maximum_iterations(700);
+	bc.get_config().set_maximum_iterations(1000);
 	bc.do_chain();
 
 	VarMultimap results = bc.get_chaining_result();
@@ -180,7 +180,7 @@ void BackwardChainerUTest::test_tvq_bc()
 	                 "   (ConceptNode \"green\"))");
 
 	bc.set_target(target);
-	bc.get_config().set_maximum_iterations(150);
+	bc.get_config().set_maximum_iterations(300);
 	bc.do_chain();
 
 	TSM_ASSERT("Incorrect strength after BC!",
@@ -217,7 +217,7 @@ void BackwardChainerUTest::test_tvq_impossible_bc()
 	                             "   (ConceptNode \"Frog\"))");
 
 	bc.set_target(target);
-	bc.get_config().set_maximum_iterations(150);
+	bc.get_config().set_maximum_iterations(300);
 	bc.do_chain();
 
 	TSM_ASSERT("Incorrect strength of target after BC!", target->getTruthValue()->getMean() < 0.1f);
@@ -269,7 +269,7 @@ void BackwardChainerUTest::test_focus_set()
 	Handle soln2 = eval_.eval_h("(ConceptNode \"Fritz\")");
 
 	bc.set_target(target, focus_set);
-	bc.get_config().set_maximum_iterations(150);
+	bc.get_config().set_maximum_iterations(300);
 	bc.do_chain();
 
 	VarMultimap results = bc.get_chaining_result();

--- a/tests/rule-engine/BackwardChainerUTest.cxxtest
+++ b/tests/rule-engine/BackwardChainerUTest.cxxtest
@@ -112,7 +112,7 @@ void BackwardChainerUTest::test_1rule_impossible_bc()
 
 	// should NOT be possible to find the solution without deduction rule
 	bc.set_target(target);
-	bc.get_config().set_maximum_iterations(500);
+	bc.get_config().set_maximum_iterations(700);
 	bc.do_chain();
 
 	VarMultimap results = bc.get_chaining_result();
@@ -147,7 +147,7 @@ void BackwardChainerUTest::test_2rules_bc()
 	Handle soln = eval_.eval_h("(ConceptNode \"West\")");
 
 	bc.set_target(target);
-	bc.get_config().set_maximum_iterations(500);
+	bc.get_config().set_maximum_iterations(700);
 	bc.do_chain();
 
 	VarMultimap results = bc.get_chaining_result();


### PR DESCRIPTION
Seems like the probability of fail is not low enough.

I have double checked again what could cause the unit test to be undeterministic, and it is the same as my previous conclusion.  Basically the usage of AtomPtr address ordering is a problem, since the address change between runs.

The first divergence between a passing test and a failing test is
```
[2015-09-21 07:12:59:223] [DEBUG] [BackwardChainer] Reverse grounded as (AndLink (stv 1.000000 0.000000)
  (InheritanceLink (stv 1.000000 0.000000)
    (VariableNode "$A-pln-rule-deduction") ; [1465][95]
    (VariableNode "$B-pln-rule-deduction") ; [1467][95]
  ) ; [1472][95]
  (InheritanceLink (stv 1.000000 0.000000)
    (VariableNode "$B-pln-rule-deduction") ; [1467][95]
    (ConceptNode "criminal") ; [52][1]
  ) ; [1523][95]
  (NotLink (stv 1.000000 0.000000)
    (EqualLink (stv 1.000000 0.000000)
      (VariableNode "$A-pln-rule-deduction") ; [1465][95]
      (ConceptNode "criminal") ; [52][1]
    ) ; [1524][95]
  ) ; [1525][95]
) ; [1526][95]
```
vs
```
[2015-09-21 07:12:48:417] [DEBUG] [BackwardChainer] Reverse grounded as (AndLink (stv 1.000000 0.000000)
  (InheritanceLink (stv 1.000000 0.000000)
    (VariableNode "$A-pln-rule-deduction") ; [1465][95]
    (VariableNode "$B-pln-rule-deduction") ; [1467][95]
  ) ; [1472][95]
  (NotLink (stv 1.000000 0.000000)
    (EqualLink (stv 1.000000 0.000000)
      (VariableNode "$A-pln-rule-deduction") ; [1465][95]
      (ConceptNode "criminal") ; [52][1]
    ) ; [1523][95]
  ) ; [1524][95]
  (InheritanceLink (stv 1.000000 0.000000)
    (VariableNode "$B-pln-rule-deduction") ; [1467][95]
    (ConceptNode "criminal") ; [52][1]
  ) ; [1525][95]
) ; [1526][95]
```

Basically, the same atom get added and assign different UUID & ordering (since unordered link's is resorted, and in this case by AtomPtr address since the AndLink was not in the atomspace).  AtomPtr usage is also in the different index inside AtomTable, which could also affect traversal ordering of Pattern Matcher.

Perhaps there's some way to restrict the unit test to be ran within the same virtual address, or force the OS to always assign the same address...  not sure.
