### PR TITLE
ChoiceLink exploration fix

### DIFF
--- a/opencog/query/InitiateSearchCB.cc
+++ b/opencog/query/InitiateSearchCB.cc
@@ -295,10 +295,8 @@ bool InitiateSearchCB::neighbor_search(PatternMatchEngine *pme)
 	// Cannot find a starting point! This can happen if:
 	// 1) all of the clauses contain nothing but variables,
 	// 2) all of the clauses are evaluatable(!),
-	// 3) all of the clauses are under a ChoiceLink.
-	// Somewhat unusual, but it can happen.  For the first two cases,
-	// we need some other, alternative search strategy. We can (we
-	// should) handle the third case here, but its more cumbersome.
+	// Somewhat unusual, but it can happen.  For this, we need
+	// some other, alternative search strategy.
 	if (Handle::UNDEFINED == best_start and 0 == _choices.size())
 	{
 		_search_fail = true;

--- a/opencog/query/InitiateSearchCB.cc
+++ b/opencog/query/InitiateSearchCB.cc
@@ -189,7 +189,7 @@ InitiateSearchCB::find_starter_recursive(const Handle& h, size_t& depth,
 			}
 			else
 			if (brwid < thinnest
-		         or (brwid == thinnest and deepest < brdepth))
+			    or (brwid == thinnest and deepest < brdepth))
 			{
 				deepest = brdepth;
 				hdeepest = s;

--- a/opencog/query/InitiateSearchCB.h
+++ b/opencog/query/InitiateSearchCB.h
@@ -69,6 +69,15 @@ class InitiateSearchCB : public virtual PatternMatchCallback
 		Handle _root;
 		Handle _starter_term;
 
+		struct Choice
+		{
+			size_t clause;
+			Handle best_start;
+			Handle start_term;
+		};
+		size_t _curr_clause;
+		std::vector<Choice> _choices;
+
 		virtual Handle find_starter(const Handle&, size_t&, Handle&, size_t&);
 		virtual Handle find_starter_recursive(const Handle&, size_t&, Handle&,
 		                                      size_t&);

--- a/opencog/query/Satisfier.cc
+++ b/opencog/query/Satisfier.cc
@@ -47,7 +47,7 @@ bool SatisfyingSet::grounding(const std::map<Handle, Handle> &var_soln,
 
 	if (1 == _varseq.size())
 	{
-		_satisfying_set.push_back(var_soln.at(_varseq[0]));
+		_satisfying_set.emplace(var_soln.at(_varseq[0]));
 		return false;
 	}
 
@@ -58,7 +58,7 @@ bool SatisfyingSet::grounding(const std::map<Handle, Handle> &var_soln,
 	{
 		vargnds.push_back(var_soln.at(hv));
 	}
-	_satisfying_set.push_back(Handle(createLink(LIST_LINK, vargnds)));
+	_satisfying_set.emplace(Handle(createLink(LIST_LINK, vargnds)));
 
 	// Look for more groundings.
 	return false;
@@ -99,7 +99,13 @@ Handle opencog::satisfying_set(AtomSpace* as, const Handle& hlink)
 	SatisfyingSet sater(as);
 	bl->satisfy(sater);
 
-	return as->add_link(SET_LINK, sater._satisfying_set);
+	// Ugh. We used an std::set to avoid duplicates. But now, we need a
+	// vector.  Which means copying. Got a better idea?
+	HandleSeq satvec;
+	for (const Handle& h : sater._satisfying_set)
+		satvec.push_back(h);
+
+	return as->add_link(SET_LINK, satvec);
 }
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/query/Satisfier.h
+++ b/opencog/query/Satisfier.h
@@ -92,7 +92,7 @@ class SatisfyingSet :
 		SatisfyingSet(AtomSpace* as) :
 			InitiateSearchCB(as), DefaultPatternMatchCB(as) {}
 		HandleSeq _varseq;
-		HandleSeq _satisfying_set;
+		std::set<Handle> _satisfying_set;
 
 		virtual void set_pattern(const Variables& vars,
 		                         const Pattern& pat)

--- a/tests/query/CMakeLists.txt
+++ b/tests/query/CMakeLists.txt
@@ -101,6 +101,8 @@ CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/tests/query/choice-nest.scm
     ${PROJECT_BINARY_DIR}/tests/query/choice-nest.scm)
 CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/tests/query/choice-top-nest.scm
     ${PROJECT_BINARY_DIR}/tests/query/choice-top-nest.scm)
+CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/tests/query/choice-typed.scm
+    ${PROJECT_BINARY_DIR}/tests/query/choice-typed.scm)
 CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/tests/query/choice-unary.scm
     ${PROJECT_BINARY_DIR}/tests/query/choice-unary.scm)
 CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/tests/query/define.scm

--- a/tests/query/ChoiceLinkUTest.cxxtest
+++ b/tests/query/ChoiceLinkUTest.cxxtest
@@ -68,6 +68,7 @@ public:
     void test_embed_disco(void);
     void test_double_or(void);
     void test_unary(void);
+    void test_typed(void);
 };
 
 void ChoiceLinkUTest::tearDown(void)
@@ -255,4 +256,23 @@ void ChoiceLinkUTest::test_unary(void)
 
     printf("unary door-bc found:\n%s\n", doors->toString().c_str());
     TS_ASSERT_EQUALS(4, as->get_arity(doors));
+}
+
+/*
+ * ChoiceLinks with typed ariables in them.
+ */
+void ChoiceLinkUTest::test_typed(void)
+{
+    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+    config().set("SCM_PRELOAD", "tests/query/choice-typed.scm");
+    load_scm_files_from_config(*as);
+
+    // Needed to define cog-execute!
+    eval->eval("(use-modules (opencog exec))");
+
+    Handle rules = eval->eval_h("(cog-execute! get-nodes1)");
+
+    printf("typed get-nodes found:\n%s\n", rules->toString().c_str());
+    TS_ASSERT_EQUALS(2, as->get_arity(rules));
 }

--- a/tests/query/choice-typed.scm
+++ b/tests/query/choice-typed.scm
@@ -1,0 +1,35 @@
+;
+; ChoiceLink unit test.
+; This test originally failed, because the initiate-search method
+; failed to look at the two choices, which caused a fall-through
+; to the variable-initiate-search, which failed because the variables
+; were typed. (and was also wildly inefficient).
+
+
+(EvaluationLink
+   (PredicateNode "OpenPsi:Decrease")
+   (ListLink
+      (Node "OpenPsi: Energy-rule-xej90")
+      (ConceptNode "OpenPsi:Energy")))
+(EvaluationLink
+   (PredicateNode "OpenPsi:Increase")
+   (ListLink
+      (Node "OpenPsi: Energy-rule-pG1ez")
+      (ConceptNode "OpenPsi:Energy")))
+
+(define get-nodes1
+    (GetLink
+       (TypedVariableLink
+          (VariableNode "x")
+          (TypeNode "Node"))
+       (ChoiceLink
+          (EvaluationLink
+             (PredicateNode "OpenPsi:Increase")
+             (ListLink
+                (VariableNode "x")
+                (ConceptNode "OpenPsi:Energy")))
+          (EvaluationLink
+             (PredicateNode "OpenPsi:Decrease")
+             (ListLink
+                (VariableNode "x")
+                (ConceptNode "OpenPsi:Energy"))))))


### PR DESCRIPTION
Fix for bug #326 

The bug appeared because the initiate-search method failed to look at the two choices, which caused a fall-through to the variable-initiate-search, which failed because the variables were typed. (and was also wildly inefficient).