### PR TITLE
Remove a function definition from cython binding

### DIFF
--- a/examples/python/scheme_timer.py
+++ b/examples/python/scheme_timer.py
@@ -12,10 +12,8 @@ __author__ = 'Cosmo Harrigan'
 NUMBER_OF_ITERATIONS = 50000
 
 from opencog.atomspace import AtomSpace, TruthValue, types, get_type_name
-from opencog.scheme_wrapper import load_scm, scheme_eval, scheme_eval_h, __init__
-
+from opencog.scheme_wrapper import load_scm, scheme_eval
 atomspace = AtomSpace()
-__init__(atomspace)
 
 data = ["opencog/atomspace/core_types.scm",
         "opencog/scm/utilities.scm"]

--- a/opencog/benchmark/README
+++ b/opencog/benchmark/README
@@ -31,7 +31,7 @@ Built atomspace, execution time: 1.95s
 Benchmarking AtomSpace's addLink method 1000 times ........................
 Sum time for all requests: 0.056635 seconds
 Memory (max RSS) change after benchmark: 464kb
-Per operation stats, in CPU clock ticks: 
+Per operation stats, in CPU clock ticks:
   N: 1000
   mean: 56
   min: 7
@@ -87,7 +87,7 @@ new Cython bindings.
 To use the python benchmark, make sure you have your PYTHONPATH set to include
 the cython directory:
 
- $ export PYTHONPATH="${PYTHONPATH}:${HOME}/src/opencog/build/opencog/cython:${HOME}/src/opencog/opencog/python::${HOME}/src/opencog/opencog/nlp"
+ $ export PYTHONPATH="${PYTHONPATH}:${HOME}/src/opencog/build/opencog/cython:${HOME}/src/opencog/opencog/python:${HOME}/src/opencog/opencog/nlp"
 
 and then run:
 
@@ -114,10 +114,8 @@ optional arguments:
   -t {spread,node,bindlink,traverse,scheme}, --test {spread,node,bindlink,traverse,scheme}
                         Test to benchmark, where:
                           spread    - a spread of tests across areas (default)
-                          node      - atomspace node operations 
+                          node      - atomspace node operations
                           bindlink  - all the bindlink forms
                           traverse  - traversal of atomspace lists
                           scheme    - scheme evaluation functions
   -i N, --iterations N  iterations to average (default=10)
-
-

--- a/opencog/benchmark/benchmark.py
+++ b/opencog/benchmark/benchmark.py
@@ -53,7 +53,7 @@ class SmartFormatter(argparse.HelpFormatter):
     def _split_lines(self, text, width):
         # this is the RawTextHelpFormatter._split_lines
         if text.startswith('R|'):
-            return text[2:].splitlines()  
+            return text[2:].splitlines()
         return argparse.HelpFormatter._split_lines(self, text, width)
 
 # Setup the argument parser.
@@ -84,9 +84,9 @@ if args.verbose:
 # Number of test iterations to average for timing.
 test_iterations = args.iterations
 
-scheme_preload = [  
+scheme_preload = [
                     "opencog/atomspace/core_types.scm",
-                    "opencog/scm/utilities.scm" 
+                    "opencog/scm/utilities.scm"
                  ]
 
 def loop_time_per_op():
@@ -149,11 +149,7 @@ def prep_get_outgoing(atomspace):
     # Number of vertices plus number of edges in a fully connected graph
     return n + (n**2 - n) / 2
 
-def prep_scheme(atomspace):
-    scheme.__init__(atomspace)
-
 def prep_bind(atomspace):
-    scheme.__init__(atomspace)
     for scheme_file in scheme_preload:
         load_scm(atomspace, scheme_file)
 
@@ -211,7 +207,6 @@ def prep_bind_scheme(atomspace):
     scheme_eval_h(atomspace, scheme_query)
 
 def prep_predicates(atomspace):
-    scheme.__init__(atomspace)
     for scheme_file in scheme_preload:
         load_scm(atomspace, scheme_file)
 
@@ -416,7 +411,7 @@ def test_get_predicates_scheme(atomspace, prep_result):
 # atomspace goes out of scope. So each test begins with a new AtomSpace.
 def do_test(prep, test, description, op_time_adjustment):
     """Runs tests and prints the test name and performance"""
-    if not args.columns: 
+    if not args.columns:
         print description
     if (test != None):
         total_time = 0
@@ -485,10 +480,10 @@ tests = [
 (['bindlink','spread'],     prep_bind_python,       test_bind,                  "Bind - bindlink - Cython"),
 
 (['all'],                   None,                   None,                       "-- Testing Scheme Eval --"),
-(['scheme','spread'],       prep_scheme,            test_scheme_eval,           "Test scheme_eval_h(+ 2 2)"),
+(['scheme','spread'],       prep_none,              test_scheme_eval,           "Test scheme_eval_h(+ 2 2)"),
 (['scheme'],                prep_bind_scheme,       test_bind_scheme,           "Bind - cog-bind - Scheme"),
-(['scheme'],                prep_scheme,            test_add_nodes_scheme,      "Add nodes - cog-new-node - Scheme"),
-(['scheme'],                prep_scheme,            test_add_nodes_sugar,       "Add nodes - ConceptNode sugar - Scheme"),
+(['scheme'],                prep_none,              test_add_nodes_scheme,      "Add nodes - cog-new-node - Scheme"),
+(['scheme'],                prep_none,              test_add_nodes_sugar,       "Add nodes - ConceptNode sugar - Scheme"),
 
 (['all'],                   None,                   None,                       "-- Testing Get Predicates --"),
 (['predicates','spread'],   prep_predicates,        test_get_predicates,        "Predicates - get_predicates"),
@@ -497,7 +492,7 @@ tests = [
 ]
 
 
-print 
+print
 print "--- OpenCog Python Benchmark - ", str(datetime.datetime.now()), "---"
 print
 

--- a/opencog/benchmark/python_diary.txt
+++ b/opencog/benchmark/python_diary.txt
@@ -93,9 +93,9 @@ Some notes:
 Here are the timing differences on my machine (details below):
 
 Bind with Python bindings:  24.19µs
-Bind with scheme_eval_h and cog-bind: 120.98µs 
+Bind with scheme_eval_h and cog-bind: 120.98µs
 
-The overhead isn't so much the fact that you're calling from Python as it 
+The overhead isn't so much the fact that you're calling from Python as it
 is just plain guile interpreter overhead, it appears. Even minor changes in
 the parsing requirement has a significant measurable effect on the execution
 timing. For example,
@@ -121,7 +121,6 @@ The prep for the bind tests is:
 
 
     def prep_bind(atomspace):
-        __init__(atomspace)
         for scheme_file in scheme_preload:
             load_scm(atomspace, scheme_file)
 
@@ -200,13 +199,13 @@ The Scheme tests use:
 
     result = scheme_eval_h(atomspace, '(cog-bind find-animals)')
 
-In both cases, this is about the fastest way you can do a bind using the 
+In both cases, this is about the fastest way you can do a bind using the
 respective mechanisms since the BindLink node is already created and referenced
 in the test setup, in the case of scheme via find-animals, and for Python the
 test prep creates an atom for bindlink_handle which has been prepopulated in
 the test atomspace.
 
-In order to determine how much time was spend in the bindings themselves, I 
+In order to determine how much time was spend in the bindings themselves, I
 created a stub that had the same signature as the C++:
 
 Handle bindlink(AtomSpace*, Handle)
@@ -272,7 +271,7 @@ Resolve handle 1M - by type
 
 The "Bare atom traversal" test is just iterating over the Handle list without
 doing anything which requires a resolution. It's just a pass in Python in the
-loop so it is timing iteration over a Python list. The "Resolve handle traversal" 
+loop so it is timing iteration over a Python list. The "Resolve handle traversal"
 tests call atomspace.isValidHandle(Handle) which requires a resolve from the
 UUID to the actual AtomPtr. Notice that the resolve takes 0.552µs for a 10K
 atomspace, 0.575µs for 100K, and 0.667µs for a 1 million node atomspace.
@@ -315,8 +314,8 @@ Resolve handle 1M - by type
   Op time:        0.312µs
   Ops/sec:    3,209,804
 
-The resolve time drops from 0.552µs to 0.470µs at 10K nodes in the atomspace, 
-0.575µs to 0.334µs at 100K nodes, and 0.667µs to 0.312µs at 1M nodes. The times 
+The resolve time drops from 0.552µs to 0.470µs at 10K nodes in the atomspace,
+0.575µs to 0.334µs at 100K nodes, and 0.667µs to 0.312µs at 1M nodes. The times
 actually drop for large traversals using std::unordered_set, probably because
 the processor caches are hitting for almost all the accesses and accesses for
 hash table entries don't take more time as the tables get bigger, unlike binary

--- a/opencog/cython/opencog/scheme_wrapper.pyx
+++ b/opencog/cython/opencog/scheme_wrapper.pyx
@@ -21,17 +21,6 @@ cdef extern from "<string>" namespace "std":
         char * c_str()
         int size()
 
-# This needs to be explicitly initialized...
-cdef extern from "opencog/query/PatternSCM.h" namespace "opencog":
-    cdef cppclass PatternSCM:
-        PatternSCM()
-
-def __init__(AtomSpace a):
-    # Do something, anything, to force initialization
-    eval_scheme(deref(a.atomspace), "(+ 2 2)")
-    PatternSCM()
-
-
 cdef extern from "opencog/cython/opencog/PyScheme.h" namespace "opencog":
     string eval_scheme(cAtomSpace& as, const string& s) except +
 
@@ -64,4 +53,3 @@ cdef extern from "opencog/guile/load-file.h" namespace "opencog":
 def load_scm(AtomSpace a, char* fname):
     status = load_scm_file_relative(deref(a.atomspace), fname)
     return status == 0
-

--- a/tests/cython/guile/test_pattern.py
+++ b/tests/cython/guile/test_pattern.py
@@ -8,7 +8,6 @@ from opencog.scheme_wrapper import load_scm, scheme_eval, scheme_eval_h
 # We are poking atoms into this from the scm files, so we want
 # them to still be there, later.
 shared_space = AtomSpace()
-#__init__(shared_space)
 
 class SchemeTest(TestCase):
 

--- a/tests/cython/guile/test_pattern.py
+++ b/tests/cython/guile/test_pattern.py
@@ -2,13 +2,13 @@ from unittest import TestCase
 
 from opencog.atomspace import AtomSpace, TruthValue, Atom, Handle
 from opencog.atomspace import types, is_a, get_type, get_type_name
-from opencog.scheme_wrapper import load_scm, scheme_eval, scheme_eval_h, __init__
+from opencog.scheme_wrapper import load_scm, scheme_eval, scheme_eval_h
 
 
 # We are poking atoms into this from the scm files, so we want
 # them to still be there, later.
 shared_space = AtomSpace()
-__init__(shared_space)
+#__init__(shared_space)
 
 class SchemeTest(TestCase):
 

--- a/tests/cython/utilities/utilities.py
+++ b/tests/cython/utilities/utilities.py
@@ -9,11 +9,11 @@ from opencog.type_constructors import *
 atomspace = AtomSpace()
 
 # Initialize Scheme
-scheme_preload = [  
+scheme_preload = [
                     "opencog/atomspace/core_types.scm",
-                    "opencog/scm/utilities.scm" 
+                    "opencog/scm/utilities.scm"
                  ]
-scheme.__init__(atomspace)
+#scheme.__init__(atomspace)
 for scheme_file in scheme_preload:
     load_scm(atomspace, scheme_file)
 
@@ -49,11 +49,11 @@ else:
 
 executed = False
 execute_atom( atomspace,
-    ExecutionOutputLink( 
+    ExecutionOutputLink(
         GroundedSchemaNode("py: add_link"),
         ListLink(
             ConceptNode("one"),
-            ConceptNode("two") 
+            ConceptNode("two")
         )
     )
 )

--- a/tests/cython/utilities/utilities.py
+++ b/tests/cython/utilities/utilities.py
@@ -13,7 +13,7 @@ scheme_preload = [
                     "opencog/atomspace/core_types.scm",
                     "opencog/scm/utilities.scm"
                  ]
-#scheme.__init__(atomspace)
+
 for scheme_file in scheme_preload:
     load_scm(atomspace, scheme_file)
 


### PR DESCRIPTION
* The `scheme_wrapper.__init__(AtomSpace a)` is supposed to initialize something, which is not clear.
* The `scheme_wrapper.pyx` module is wrapping functions not a class, so doesn't make sense, and only results in confusion for a user, provided it doesn't have some other purpose.
* It could be their, to speedup the `SchemeEval` initialization stage, but couldn't observe any significant difference when running the python benchmark test, before and after the change. That could be b/c my setup isn't correct, not sure.
