### PR TITLE
Replace stdout debug by log in pattern matcher

### DIFF
--- a/opencog/atoms/bind/PatternLink.cc
+++ b/opencog/atoms/bind/PatternLink.cc
@@ -793,55 +793,59 @@ void PatternLink::check_connectivity(const std::vector<HandleSeq>& components)
 
 /* ================================================================= */
 
-void PatternLink::debug_print(void) const
+void PatternLink::debug_log(void) const
 {
-	// Print out the predicate ...
-	printf("\nPattern '%s' has following clauses:\n",
-	       _pat.redex_name.c_str());
+	if (!logger().isFineEnabled())
+		return;
+
+	// Log the predicate ...
+	logger().fine("Pattern '%s' has following clauses:",
+	              _pat.redex_name.c_str());
 	int cl = 0;
 	for (const Handle& h : _pat.mandatory)
 	{
-		printf("Mandatory %d:", cl);
+		std::stringstream ss;
+		ss << "Mandatory " << cl << ":";
 		if (_pat.evaluatable_holders.find(h) != _pat.evaluatable_holders.end())
-			printf(" (evaluatable)");
+			ss << " (evaluatable)";
 		if (_pat.executable_holders.find(h) != _pat.executable_holders.end())
-			printf(" (executable)");
-		printf("\n");
-		prt(h);
+			ss << " (executable)";
+		ss << std::endl;
+		ss << h->toShortString();
+		logger().fine() << ss.str();
 		cl++;
 	}
 
 	if (0 < _pat.optionals.size())
 	{
-		printf("Predicate includes the following optional clauses:\n");
+		logger().fine("Predicate includes the following optional clauses:");
 		cl = 0;
 		for (const Handle& h : _pat.optionals)
 		{
-			printf("Optional clause %d:", cl);
+			std::stringstream ss;
+			ss << "Optional clause " << cl << ":";
 			if (_pat.evaluatable_holders.find(h) != _pat.evaluatable_holders.end())
-				printf(" (evaluatable)");
+				ss << " (evaluatable)";
 			if (_pat.executable_holders.find(h) != _pat.executable_holders.end())
-				printf(" (executable)");
-			printf("\n");
-			prt(h);
+				ss << " (executable)";
+			ss << std::endl;
+			ss << h->toShortString();
+			logger().fine() << ss.str();
 			cl++;
 		}
 	}
 	else
-		printf("No optional clauses\n");
+		logger().fine("No optional clauses");
 
 	// Print out the bound variables in the predicate.
 	for (const Handle& h : _varlist.varset)
 	{
 		if (NodeCast(h))
-			printf("Bound var: "); prt(h);
+			logger().fine() << "Bound var: " << h->toShortString();
 	}
 
 	if (_varlist.varset.empty())
-		printf("There are no bound vars in this pattern\n");
-
-	printf("\n");
-	fflush(stdout);
+		logger().fine("There are no bound vars in this pattern");
 }
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/bind/PatternLink.h
+++ b/opencog/atoms/bind/PatternLink.h
@@ -173,7 +173,7 @@ public:
 
 	bool satisfy(PatternMatchCallback&) const;
 
-	void debug_print(void) const;
+	void debug_log(void) const;
 };
 
 typedef std::shared_ptr<PatternLink> PatternLinkPtr;

--- a/opencog/query/AttentionalFocusCB.cc
+++ b/opencog/query/AttentionalFocusCB.cc
@@ -24,14 +24,6 @@
 
 using namespace opencog;
 
-// Uncomment below to enable debug print
-// #define DEBUG
-#ifdef DEBUG
-   #define dbgprt(f, varargs...) printf(f, ##varargs)
-#else
-   #define dbgprt(f, varargs...)
-#endif
-
 AttentionalFocusCB::AttentionalFocusCB(AtomSpace* as) :
 	DefaultPatternMatchCB(as)
 {

--- a/opencog/query/DefaultPatternMatchCB.cc
+++ b/opencog/query/DefaultPatternMatchCB.cc
@@ -21,6 +21,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <opencog/util/Logger.h>
+
 #include <opencog/atoms/execution/EvaluationLink.h>
 #include <opencog/atoms/execution/Instantiator.h>
 #include <opencog/atomutils/FindUtils.h>
@@ -28,14 +30,6 @@
 #include "DefaultPatternMatchCB.h"
 
 using namespace opencog;
-
-// Uncomment below to enable debug print
-// #define DEBUG
-#ifdef DEBUG
-#define dbgprt(f, varargs...) printf(f, ##varargs)
-#else
-#define dbgprt(f, varargs...)
-#endif
 
 /* ======================================================== */
 
@@ -197,8 +191,9 @@ bool DefaultPatternMatchCB::clause_match(const Handle& ptrn,
 	    LinkCast(grnd)->getOutgoingAtom(0)->getType() ==
 	                                     GROUNDED_PREDICATE_NODE)
 	{
-		dbgprt("Evaluate the grounding clause=\n%s\n",
-		        grnd->toShortString().c_str());
+		LAZY_LOG_FINE << "Evaluate the grounding clause=" << std::endl
+		              << grnd->toShortString() << std::endl;
+
 		// We make two awkard asumptions here: the ground term itself
 		// does not contain any variables, and so does not need any
 		// further grounding. This actuall seems reasonable. The second
@@ -209,7 +204,8 @@ bool DefaultPatternMatchCB::clause_match(const Handle& ptrn,
 		_temp_aspace.clear();
 		TruthValuePtr tvp(EvaluationLink::do_evaluate(&_temp_aspace, grnd));
 
-		dbgprt("clause_match evaluation yeilded tv=%s\n", tvp->toString().c_str());
+		LAZY_LOG_FINE << "Clause_match evaluation yeilded tv"
+		              << std::endl << tvp->toString() << std::endl;
 
 		// XXX FIXME: we are making a crisp-logic go/no-go decision
 		// based on the TV strength. Perhaps something more subtle might be
@@ -248,11 +244,10 @@ bool DefaultPatternMatchCB::eval_term(const Handle& virt,
 
 	Handle gvirt(_instor.instantiate(virt, gnds));
 
-	dbgprt("Enter eval_term CB with virt=\n%s\n",
-	        virt->toShortString().c_str());
-	dbgprt("grounded by gvirt=\n%s\n",
-	        gvirt->toShortString().c_str());
-
+	LAZY_LOG_FINE << "Enter eval_term CB with virt=" << std::endl
+	              << virt->toShortString() << std::endl;
+	LAZY_LOG_FINE << "Grounded by gvirt=" << std::endl
+	              << gvirt->toShortString() << std::endl;
 
 	// At this time, we expect all virutal links to be in one of two
 	// forms: either EvaluationLink's or GreaterThanLink's.  The
@@ -311,7 +306,8 @@ bool DefaultPatternMatchCB::eval_term(const Handle& virt,
 	            "Expecting a TruthValue for an evaluatable link: %s\n",
 	            gvirt->toShortString().c_str());
 
-	dbgprt("eval_term evaluation yeilded tv=%s\n", tvp->toString().c_str());
+	LAZY_LOG_FINE << "Eval_term evaluation yeilded tv="
+	              << tvp->toString() << std::endl;
 
 	// XXX FIXME: we are making a crsip-logic go/no-go decision
 	// based on the TV strength. Perhaps something more subtle might be
@@ -332,8 +328,8 @@ bool DefaultPatternMatchCB::eval_term(const Handle& virt,
 bool DefaultPatternMatchCB::eval_sentence(const Handle& top,
                               const std::map<Handle, Handle>& gnds)
 {
-	dbgprt("Enter eval_sentence CB with top=\n%s\n",
-	        top->toShortString().c_str());
+	LAZY_LOG_FINE << "Enter eval_sentence CB with top=" << std::endl
+	              << top->toShortString() << std::endl;
 
 	if (top->getType() == VARIABLE_NODE)
 	{
@@ -429,7 +425,8 @@ bool DefaultPatternMatchCB::eval_sentence(const Handle& top,
 	{
 		Handle g = gnds.at(top);
 		TruthValuePtr tvp(g->getTruthValue());
-		dbgprt("non-logical atom has tv=%s\n", tvp->toString().c_str());
+		LAZY_LOG_FINE << "Non-logical atom has tv="
+		              << tvp->toString() << std::endl;
 		// XXX FIXME: we are making a crsip-logic go/no-go decision
 		// based on the TV strength. Perhaps something more subtle might be
 		// wanted, here.

--- a/opencog/query/FuzzyMatch/FuzzyPatternMatch.cc
+++ b/opencog/query/FuzzyMatch/FuzzyPatternMatch.cc
@@ -29,8 +29,6 @@
 
 using namespace opencog;
 
-//#define DEBUG
-
 /**
  * Implement the "cog-fuzzy-match" scheme primitive.
  * It uses the Pattern Matcher to find hypergraphs in the atomspace that are
@@ -57,10 +55,10 @@ Handle opencog::find_approximate_match(AtomSpace* as, const Handle& hp,
     PatternLinkPtr slp(createPatternLink(no_vars, terms));
     slp->satisfy(fpmcb);
 
-#ifdef DEBUG
-    std::cout << "\n---------- solns ----------\n";
-    for (Handle h : fpmcb.solns) std::cout << h->toShortString();
-#endif
+    if (logger().isFineEnabled()) {
+	    logger().fine() << "---------- solns ----------";
+	    for (Handle h : fpmcb.solns) logger().fine() << h->toShortString();
+    }
 
     // The result_list contains a list of the grounded expressions.
     // Turn it into a true list, and return it.

--- a/opencog/query/FuzzyMatch/FuzzyPatternMatchCB.cc
+++ b/opencog/query/FuzzyMatch/FuzzyPatternMatchCB.cc
@@ -26,8 +26,6 @@
 
 using namespace opencog;
 
-//#define DEBUG
-
 FuzzyPatternMatchCB::FuzzyPatternMatchCB(AtomSpace* as, Type rt, const HandleSeq& excl)
         : DefaultPatternMatchCB(as),
           rtn_type(rt),
@@ -125,24 +123,22 @@ bool FuzzyPatternMatchCB::initiate_search(PatternMatchEngine* pme)
         const Handle& best_start = starters[search_cnt].handle;
         search_cnt++;
 
-#ifdef DEBUG
-        std::cout << "\n========================================\n";
-        std::cout << "Initiating the fuzzy match... (" << search_cnt << "/"
-                  << num_starters << ")\n";
-        std::cout << "Starter:\n" << best_start->toShortString() << "\n";
-        std::cout << "Start term:\n" << starter_term->toShortString();
-        std::cout << "========================================\n\n";
-#endif
+        LAZY_LOG_FINE << "\n========================================\n"
+                      << "Initiating the fuzzy match... ("
+                      << search_cnt << "/"
+                      << num_starters << ")\n"
+                      << "Starter:\n" << best_start->toShortString() << "\n"
+                      << "Start term:\n" << starter_term->toShortString()
+                      << "========================================\n";
 
         IncomingSet iset = best_start->getIncomingSet();
         size_t iset_size = iset.size();
         for (size_t i = 0; i < iset_size; i++) {
             Handle h(iset[i]);
 
-#ifdef DEBUG
-            std::cout << "Loop candidate (" << (i + 1) << "/" << iset_size << "):\n"
-                      << h->toShortString() << "\n";
-#endif
+            LAZY_LOG_FINE << "Loop candidate ("
+                          << (i + 1) << "/" << iset_size << "):\n"
+                          << h->toShortString() << "\n";
 
             pme->explore_neighborhood(clause, starter_term, h);
         }
@@ -202,11 +198,10 @@ void FuzzyPatternMatchCB::check_if_accept(const Handle& gh)
     // Reject if the potential solution contains any atoms that we want to exclude
     for (const Handle& eh : excl_list) {
         if (std::find(gn.begin(), gn.end(), eh) != gn.end()) {
-#ifdef DEBUG
-        std::cout << "Rejecting:\n" << gh->toShortString()
-                  << "due to the existance of:\n" << eh->toShortString()
-                  << "\n";
-#endif
+
+	        LAZY_LOG_FINE << "Rejecting:\n" << gh->toShortString()
+	                      << "due to the existance of:\n"
+	                      << eh->toShortString();
             return;
         }
     }
@@ -237,16 +232,14 @@ void FuzzyPatternMatchCB::check_if_accept(const Handle& gh)
         similarity += 1.0 / iss;
     }
 
-#ifdef DEBUG
-    std::cout << "\n========================================\n";
-    std::cout << "Compaing:\n" << clause->toShortString() << "--- and:\n"
-              << gh->toShortString() << "\n";
-    std::cout << "Common nodes = " << common_nodes.size() << "\n";
-    std::cout << "Size diff = " << diff << "\n";
-    std::cout << "Similarity = " << similarity << "\n";
-    std::cout << "Most similar = " << max_similarity << "\n";
-    std::cout << "========================================\n\n";
-#endif
+    LAZY_LOG_FINE << "\n========================================\n"
+                  << "Compaing:\n" << clause->toShortString() << "--- and:\n"
+                  << gh->toShortString() << "\n"
+                  << "Common nodes = " << common_nodes.size() << "\n"
+                  << "Size diff = " << diff << "\n"
+                  << "Similarity = " << similarity << "\n"
+                  << "Most similar = " << max_similarity << "\n"
+                  << "========================================\n";
 
     // Decide if we should accept the potential solutions or not
     if ((similarity > max_similarity) or

--- a/opencog/query/InitiateSearchCB.cc
+++ b/opencog/query/InitiateSearchCB.cc
@@ -35,14 +35,6 @@
 
 using namespace opencog;
 
-// Uncomment below to enable debug print
-// #define DEBUG
-#ifdef DEBUG
-#define dbgprt(f, varargs...) printf(f, ##varargs)
-#else
-#define dbgprt(f, varargs...)
-#endif
-
 /* ======================================================== */
 
 InitiateSearchCB::InitiateSearchCB(AtomSpace* as) :
@@ -324,10 +316,11 @@ bool InitiateSearchCB::neighbor_search(PatternMatchEngine *pme)
 		_starter_term = ch.start_term;
 
 		_root = clauses[bestclause];
-		dbgprt("Search start node: %s\n", best_start->toShortString().c_str());
-		dbgprt("Start term is: %s\n", _starter_term == Handle::UNDEFINED ?
-		       "UNDEFINED" : _starter_term->toShortString().c_str());
-		dbgprt("Root clause is: %s\n", _root->toShortString().c_str());
+		LAZY_LOG_FINE << "Search start node: " << best_start->toShortString();
+		LAZY_LOG_FINE << "Start term is: "
+		              << (_starter_term == Handle::UNDEFINED ?
+		                  "UNDEFINED" : _starter_term->toShortString());
+		LAZY_LOG_FINE << "Root clause is: " <<  _root->toShortString();
 
 		// This should be calling the over-loaded virtual method
 		// get_incoming_set(), so that, e.g. it gets sorted by attentional
@@ -337,9 +330,9 @@ bool InitiateSearchCB::neighbor_search(PatternMatchEngine *pme)
 		for (size_t i = 0; i < sz; i++)
 		{
 			Handle h(iset[i]);
-			dbgprt("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n");
-			dbgprt("Loop candidate (%lu/%lu):\n%s\n", i+1, sz,
-			       h->toShortString().c_str());
+			LAZY_LOG_FINE << "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n"
+			              << "Loop candidate (" << i+1 << "/" << sz << "):\n"
+			              << h->toShortString();
 			bool found = pme->explore_neighborhood(_root, _starter_term, h);
 
 			// Terminate search if satisfied.
@@ -445,7 +438,7 @@ bool InitiateSearchCB::initiate_search(PatternMatchEngine *pme)
 {
 	jit_analyze(pme);
 
-	dbgprt("Attempt to use node-neighbor search\n");
+	logger().fine("Attempt to use node-neighbor search");
 	_search_fail = false;
 	bool found = neighbor_search(pme);
 	if (found) return true;
@@ -456,7 +449,7 @@ bool InitiateSearchCB::initiate_search(PatternMatchEngine *pme)
 	// they are all evaluatable. This can happen for sequence links;
 	// we want to quickly rule out this case before moving to more
 	// complex searches, below.
-	dbgprt("Cannot use node-neighbor search, use no-var search\n");
+	logger().fine("Cannot use node-neighbor search, use no-var search");
 	_search_fail = false;
 	found = no_search(pme);
 	if (found) return true;
@@ -467,7 +460,7 @@ bool InitiateSearchCB::initiate_search(PatternMatchEngine *pme)
 	// variables! Which can happen (there is a unit test for this,
 	// the LoopUTest), and so instead, we search based on the link
 	// types that occur in the atomspace.
-	dbgprt("Cannot use no-var search, use link-type search\n");
+	logger().fine("Cannot use no-var search, use link-type search");
 	_search_fail = false;
 	found = link_type_search(pme);
 	if (found) return true;
@@ -479,7 +472,7 @@ bool InitiateSearchCB::initiate_search(PatternMatchEngine *pme)
 	// variable, all by itself, and set some type restrictions on it,
 	// and that's all. We deal with this in the variable_search()
 	// method.
-	dbgprt("Cannot use link-type search, use variable-type search\n");
+	logger().fine("Cannot use link-type search, use variable-type search");
 	_search_fail = false;
 	found = variable_search(pme);
 	return found;
@@ -556,8 +549,8 @@ bool InitiateSearchCB::link_type_search(PatternMatchEngine *pme)
 		return false;
 	}
 
-	dbgprt("Start clause is: %s\n", _root->toShortString().c_str());
-	dbgprt("Start term is: %s\n", _starter_term->toShortString().c_str());
+	LAZY_LOG_FINE << "Start clause is: " << _root->toShortString();
+	LAZY_LOG_FINE << "Start term is: " << _starter_term->toShortString();
 
 	// Get type of the rarest link
 	Type ptype = _starter_term->getType();
@@ -565,14 +558,12 @@ bool InitiateSearchCB::link_type_search(PatternMatchEngine *pme)
 	HandleSeq handle_set;
 	_as->get_handles_by_type(handle_set, ptype);
 
-#ifdef DEBUG
-	size_t i = 0;
-#endif
+	size_t i = 0, hsz = handle_set.size();
 	for (const Handle& h : handle_set)
 	{
-		dbgprt("yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy\n");
-		dbgprt("Loop candidate (%lu/%lu):\n%s\n", ++i, handle_set.size(),
-		       h->toShortString().c_str());
+		LAZY_LOG_FINE << "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy\n"
+		              << "Loop candidate (" << i+1 << "/" << hsz << "):\n"
+		              << h->toShortString();
 		bool found = pme->explore_neighborhood(_root, _starter_term, h);
 		if (found) return true;
 	}
@@ -600,21 +591,23 @@ bool InitiateSearchCB::variable_search(PatternMatchEngine *pme)
 	size_t count = SIZE_MAX;
 	Type ptype = ATOM;
 
-	dbgprt("varset size = %lu\n", _variables->varset.size());
+	LAZY_LOG_FINE << "varset size = " <<  _variables->varset.size();
 	_root = Handle::UNDEFINED;
 	_starter_term = Handle::UNDEFINED;
 	for (const Handle& var: _variables->varset)
 	{
-		dbgprt("Examine variable %s\n", var->toShortString().c_str());
+		LAZY_LOG_FINE << "Examine variable " << var->toShortString();
 		auto tit = _type_restrictions->find(var);
 		if (_type_restrictions->end() == tit) continue;
 		const std::set<Type>& typeset = tit->second;
-		dbgprt("Type-restictions set size = %lu\n", typeset.size());
+		LAZY_LOG_FINE << "Type-restictions set size = "
+		              << typeset.size();
 		for (Type t : typeset)
 		{
 			size_t num = (size_t) _as->get_num_atoms_of_type(t);
-			dbgprt("Type = %s has %lu atoms in the atomspace\n",
-			       _classserver.getTypeName(t).c_str(), num);
+			LAZY_LOG_FINE << "Type = "
+			              << _classserver.getTypeName(t) << " has "
+			              << num << " atoms in the atomspace";
 			if (0 < num and num < count)
 			{
 				for (const Handle& cl : clauses)
@@ -630,7 +623,7 @@ bool InitiateSearchCB::variable_search(PatternMatchEngine *pme)
 						_starter_term = cl;
 						count = num;
 						ptype = t;
-						dbgprt("New minimum count of %lu\n", count);
+						LAZY_LOG_FINE << "New minimum count of " << count;
 						break;
 					}
 					if (0 < fa.least_holders.size())
@@ -639,7 +632,8 @@ bool InitiateSearchCB::variable_search(PatternMatchEngine *pme)
 						_starter_term = *fa.least_holders.begin();
 						count = num;
 						ptype = t;
-						dbgprt("New minimum count of %lu (nonroot)\n", count);
+						LAZY_LOG_FINE << "New minimum count of "
+						              << count << "(nonroot)";
 						break;
 					}
 				}
@@ -650,7 +644,7 @@ bool InitiateSearchCB::variable_search(PatternMatchEngine *pme)
 	// There were no type restrictions!
 	if (Handle::UNDEFINED == _root)
 	{
-		dbgprt("There were no type restrictions! That must be wrong!\n");
+		logger().fine("There were no type restrictions! That must be wrong!");
 		if (0 == clauses.size())
 		{
 			// This is kind-of weird, it can happen if all clauses
@@ -667,16 +661,14 @@ bool InitiateSearchCB::variable_search(PatternMatchEngine *pme)
 	else
 		_as->get_handles_by_type(handle_set, ptype);
 
-	dbgprt("Atomspace reported %lu atoms\n", handle_set.size());
+	LAZY_LOG_FINE << "Atomspace reported " << handle_set.size() << " atoms";
 
-#ifdef DEBUG
-	size_t i = 0;
-#endif
+	size_t i = 0, hsz = handle_set.size();
 	for (const Handle& h : handle_set)
 	{
-		dbgprt("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz\n");
-		dbgprt("Loop candidate (%lu/%lu):\n%s\n", ++i, handle_set.size(),
-		       h->toShortString().c_str());
+		LAZY_LOG_FINE << "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz\n"
+		              << "Loop candidate (" << i+1 << "/" << hsz << "):\n"
+		              << h->toShortString();
 		bool found = pme->explore_neighborhood(_root, _starter_term, h);
 		if (found) return true;
 	}
@@ -714,8 +706,8 @@ bool InitiateSearchCB::no_search(PatternMatchEngine *pme)
 		return false;
 	}
 
-	dbgprt("wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww\n");
-	dbgprt("Non-search: no variables, no non-evaluatable clauses\n");
+	LAZY_LOG_FINE << "wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww\n"
+	              << "Non-search: no variables, no non-evaluatable clauses";
 	_root = _starter_term = clauses[0];
 	bool found = pme->explore_neighborhood(_root, _starter_term, _root);
 	return found;
@@ -780,10 +772,8 @@ void InitiateSearchCB::jit_analyze(PatternMatchEngine* pme)
 
 	pme->set_pattern(*_variables, *_pattern);
 	set_pattern(*_variables, *_pattern);
-#ifdef DEBUG
-	dbgprt("JIT expanded!\n");
-	_pl->debug_print();
-#endif
+	logger().fine("JIT expanded!");
+	_pl->debug_log();
 }
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/query/PatternMatchCallback.h
+++ b/opencog/query/PatternMatchCallback.h
@@ -31,8 +31,6 @@
 #include <opencog/query/Pattern.h> // for VariableTypeMap
 #include <opencog/atoms/core/VariableList.h> // for VariableTypeMap
 
-// #define DEBUG 1
-
 namespace opencog {
 class PatternMatchEngine;
 

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -43,45 +43,23 @@ using namespace opencog;
  */
 /* ======================================================== */
 
-// To enable debug print you must
-//
-// 1. Uncomment #define DEBUG below
-//
-// 2. Comment out #ifdef DEBUG and #endif in PatternMatchEngine.h in
-// order to have perm_count and perm_count_stack defined.
+// The macro POPSTK has an OC_ASSERT when DEBUG is defined, so we keep
+// that #define around, although it's not clear why that OC_ASSERT
+// wouldn't be kept no matter what (it's not like it's gonna take up a
+// lot of resources).
 // #define DEBUG
-#ifdef WIN32
-#ifdef DEBUG
-	#define dbgprt printf
-#else
-	// something better?
-	#define dbgprt
-#endif
-#else
-#ifdef DEBUG
-	#define dbgprt(f, varargs...) printf(f, ##varargs)
-#else
-	#define dbgprt(f, varargs...)
-#endif
-#endif
 
-static inline bool prt(const Handle& h)
+static inline bool log(const Handle& h)
 {
-	std::string str = h->toShortString();
-	printf ("%s\n", str.c_str());
+	LAZY_LOG_FINE << h->toShortString();
 	return false;
 }
 
-static inline void prtmsg(const char * msg, const Handle& h)
+static inline void logmsg(const char * msg, const Handle& h)
 {
-#ifdef DEBUG
-	if (h == Handle::UNDEFINED) {
-		printf ("%s (invalid handle)\n", msg);
-		return;
-	}
-	std::string str = h->toShortString();
-	printf ("%s %s\n", msg, str.c_str());
-#endif
+	LAZY_LOG_FINE << msg << (h == Handle::UNDEFINED ?
+	                         std::string("(invalid handle)") :
+	                         h->toShortString());
 }
 
 /* ======================================================== */
@@ -169,9 +147,9 @@ bool PatternMatchEngine::variable_compare(const Handle& hp,
 			// OK, which variable is it?
 			if (is_unquoted_in_tree(hg, vh))
 			{
-				prtmsg("miscompare; found bound variable in grounding tree:", vh);
-				prtmsg("matching  variable  is:", hp);
-				prtmsg("proposed grounding is:", hg);
+				logmsg("miscompare; found bound variable in grounding tree:", vh);
+				logmsg("matching  variable  is:", hp);
+				logmsg("proposed grounding is:", hg);
 				return false;
 			}
 		}
@@ -185,9 +163,9 @@ bool PatternMatchEngine::variable_compare(const Handle& hp,
 	if (not _pmc.variable_match (hp, hg)) return false;
 
 	// Make a record of it.
-	dbgprt("Found grounding of variable:\n");
-	prtmsg("$$ variable:    ", hp);
-	prtmsg("$$ ground term: ", hg);
+	LAZY_LOG_FINE << "Found grounding of variable:";
+	logmsg("$$ variable:    ", hp);
+	logmsg("$$ ground term: ", hg);
 	if (hp != hg) var_grounding[hp] = hg;
 	return true;
 }
@@ -202,7 +180,7 @@ bool PatternMatchEngine::variable_compare(const Handle& hp,
 ///
 bool PatternMatchEngine::self_compare(const PatternTermPtr& ptm)
 {
-	prtmsg("Compare atom to itself: ", ptm->getHandle());
+	logmsg("Compare atom to itself: ", ptm->getHandle());
 
 #ifdef NO_SELF_GROUNDING
 
@@ -222,9 +200,9 @@ bool PatternMatchEngine::node_compare(const Handle& hp,
 	bool match = _pmc.node_match(hp, hg);
 	if (match)
 	{
-		dbgprt("Found matching nodes\n");
-		prtmsg("# pattern: ", hp);
-		prtmsg("# match:   ", hg);
+		LAZY_LOG_FINE << "Found matching nodes";
+		logmsg("# pattern: ", hp);
+		logmsg("# match:   ", hg);
 		if (hp != hg) var_grounding[hp] = hg;
 	}
 	return match;
@@ -283,7 +261,7 @@ bool PatternMatchEngine::ordered_compare(const PatternTermPtr& ptm,
 	}
 
 	depth --;
-	dbgprt("tree_comp down link match=%d\n", match);
+	LAZY_LOG_FINE << "tree_comp down link match=" << match;
 
 	if (not match) return false;
 
@@ -322,9 +300,9 @@ bool PatternMatchEngine::choice_compare(const PatternTermPtr& ptm,
 	size_t icurr = curr_choice(ptm, hg, fresh);
 	if (fresh) choose_next = false; // took a step, clear the flag
 
-	dbgprt("tree_comp resume choice search at %zu of %zu of term=%s, "
-          "choose_next=%d\n",
-	       icurr, iend, ptm->toString().c_str(), choose_next);
+	LAZY_LOG_FINE << "tree_comp resume choice search at " << icurr
+	              << " of " << iend << " of term=" << ptm->toString()
+	              << ", choose_next=" << choose_next;
 
 	// XXX This is almost surely wrong... if there are two
 	// nested choice links, then this will hog the steps,
@@ -340,7 +318,8 @@ bool PatternMatchEngine::choice_compare(const PatternTermPtr& ptm,
 		solution_push();
 		const PatternTermPtr& hop = osp[icurr];
 
-		dbgprt("tree_comp or_link choice %zu of %zu\n", icurr, iend);
+		LAZY_LOG_FINE << "tree_comp or_link choice " << icurr
+		              << " of " << iend;
 
 		bool match = tree_compare(hop, hg, CALL_CHOICE);
 		if (match)
@@ -396,9 +375,7 @@ bool PatternMatchEngine::have_choice(const PatternTermPtr& ptm,
 }
 
 /* ======================================================== */
-#ifdef DEBUG
 static int facto (int n) { return (n==1)? 1 : n * facto(n-1); };
-#endif
 
 /// Unordered link comparison
 ///
@@ -569,19 +546,20 @@ bool PatternMatchEngine::unorder_compare(const PatternTermPtr& ptm,
 
 	// Cases C and D fall through.
 	// If we are here, we've got possibilities to explore.
-#ifdef DEBUG
-	int num_perms = facto(mutation.size());
-	dbgprt("tree_comp resume unordered search at %d of %d of term=%s "
-	       "take_step=%d have_more=%d\n",
-	       perm_count[Unorder(ptm, hg)], num_perms, ptm->toString().c_str(),
-	       take_step, have_more);
-#endif
+	int num_perms = 0;
+	// if (logger().isFineEnabled())
+	// {
+	// 	num_perms = facto(mutation.size());
+	// 	logger().fine("tree_comp resume unordered search at %d of %d of term=%s "
+	// 	              "take_step=%d have_more=%d\n",
+	// 	              perm_count[Unorder(ptm, hg)], num_perms,
+	// 	              ptm->toString().c_str(), take_step, have_more);
+	// }
 	do
 	{
-		dbgprt("tree_comp explore unordered perm %d of %d of term=%s\n",
-		       perm_count[Unorder(ptm, hg)], num_perms,
-		       ptm->toString().c_str());
-
+		LAZY_LOG_FINE << "tree_comp explore unordered perm "
+		              << perm_count[Unorder(ptm, hg)] << " of " << num_perms
+		              << " of term=" << ptm->toString();
 		solution_push();
 		bool match = true;
 		for (size_t i=0; i<max_size; i++)
@@ -639,28 +617,28 @@ bool PatternMatchEngine::unorder_compare(const PatternTermPtr& ptm,
 
 				// Handle case 5&7 of description above.
 				have_more = true;
-				dbgprt("Good permutation %d for term=%s have_more=%d\n",
-				       perm_count[Unorder(ptm, hg)], ptm->toString().c_str(),
-				       have_more);
+				LAZY_LOG_FINE << "Good permutation "
+				              << perm_count[Unorder(ptm, hg)]
+				              << "for term=" << ptm->toString()
+				              << " have_more=" << have_more;
 				_perm_state[Unorder(ptm, hg)] = mutation;
 				return true;
 			}
 		}
 		// If we are here, we are handling case 8.
-		dbgprt("Above permuation %d failed term=%s\n",
-		       perm_count[Unorder(ptm, hg)], ptm->toString().c_str());
+		LAZY_LOG_FINE << "Above permuation " << perm_count[Unorder(ptm, hg)]
+		              << " failed term=" << ptm->toString();
 
 take_next_step:
 		take_step = false; // we are taking a step, so clear the flag.
 		have_more = false; // start with a clean slate...
 		solution_pop();
-#ifdef DEBUG
-		perm_count[Unorder(ptm, hg)] ++;
-#endif
+		// if (logger().isFineEnabled())
+		// 	perm_count[Unorder(ptm, hg)] ++;
 	} while (std::next_permutation(mutation.begin(), mutation.end()));
 
 	// If we are here, we've explored all the possibilities already
-	dbgprt("Exhausted all permuations of term=%s\n", ptm->toString().c_str());
+	LAZY_LOG_FINE << "Exhausted all permuations of term=" << ptm->toString();
 	_perm_state.erase(Unorder(ptm, hg));
 	have_more = false;
 	return false;
@@ -678,11 +656,8 @@ PatternMatchEngine::curr_perm(const PatternTermPtr& ptm,
 	try { perm = _perm_state.at(Unorder(ptm, hg)); }
 	catch(...)
 	{
-#ifdef DEBUG
-		dbgprt("tree_comp fresh start unordered link term=%s\n",
-		       ptm->toString().c_str());
-		perm_count[Unorder(ptm, hg)] = 0;
-#endif
+		LAZY_LOG_FINE << "tree_comp fresh start unordered link term="
+		              << ptm->toString();
 		perm = ptm->getOutgoingSet();
 		sort(perm.begin(), perm.end());
 		fresh = true;
@@ -703,17 +678,15 @@ bool PatternMatchEngine::have_perm(const PatternTermPtr& ptm,
 void PatternMatchEngine::perm_push(void)
 {
 	perm_stack.push(_perm_state);
-#ifdef DEBUG
-	perm_count_stack.push(perm_count);
-#endif
+	// if (logger().isFineEnabled())
+	// 	perm_count_stack.push(perm_count);
 }
 
 void PatternMatchEngine::perm_pop(void)
 {
 	POPSTK(perm_stack, _perm_state);
-#ifdef DEBUG
-	POPSTK(perm_count_stack, perm_count);
-#endif
+	// if (logger().isFineEnabled())
+	// 	POPSTK(perm_count_stack, perm_count);
 }
 
 /* ======================================================== */
@@ -806,9 +779,9 @@ bool PatternMatchEngine::tree_compare(const PatternTermPtr& ptm,
 	bool match = _pmc.link_match(lp, lg);
 	if (not match) return false;
 
-	dbgprt("depth=%d\n", depth);
-	prtmsg("> tree_compare", hp);
-	prtmsg(">           to", hg);
+	LAZY_LOG_FINE << "depth=" << depth;
+	logmsg("> tree_compare", hp);
+	logmsg(">           to", hg);
 
 	// CHOICE_LINK's are multiple-choice links. As long as we can
 	// can match one of the sub-expressions of the ChoiceLink, then
@@ -882,9 +855,8 @@ bool PatternMatchEngine::explore_term_branches(const Handle& term,
 	}
 	catch (const std::out_of_range&)
 	{
-		dbgprt("Pattern term not found for %s, clause=%s\n",
-		        term->toShortString().c_str(),
-		        clause_root->toShortString().c_str());
+		LAZY_LOG_FINE << "Pattern term not found for " << term->toShortString()
+		              << ", clause=" << clause_root->toShortString();
 	}
 	return false;
 }
@@ -920,17 +892,18 @@ bool PatternMatchEngine::explore_up_branches(const PatternTermPtr& ptm,
 	// Move up the solution graph, looking for a match.
 	IncomingSet iset = _pmc.get_incoming_set(hg);
 	size_t sz = iset.size();
-	dbgprt("Looking upward for term=%s have %zu branches\n",
-	        ptm->toString().c_str(), sz);
+	LAZY_LOG_FINE << "Looking upward for term=" << ptm->toString()
+	              << " have " << sz << " branches";
 	bool found = false;
 	for (size_t i = 0; i < sz; i++) {
-		dbgprt("Try upward branch %zu of %zu for term=%s propose=%lu\n",
-		       i, sz, ptm->toString().c_str(), Handle(iset[i]).value());
+		LAZY_LOG_FINE << "Try upward branch " << i << " of " << sz
+		              << " for term=" << ptm->toString()
+		              << " propose=" << Handle(iset[i]).value();
 		found = explore_link_branches(ptm, Handle(iset[i]), clause_root);
 		if (found) break;
 	}
 
-	dbgprt("Found upward soln = %d\n", found);
+	LAZY_LOG_FINE << "Found upward soln = " << found;
 	return found;
 }
 
@@ -988,14 +961,14 @@ bool PatternMatchEngine::explore_link_branches(const PatternTermPtr& ptm,
 		if (explore_choice_branches(ptm, hg, clause_root))
 			return true;
 
-		dbgprt("Step to next permuation\n");
+		logger().fine("Step to next permuation");
 		// If we are here, there was no match.
 		// On the next go-around, take a step.
 		take_step = true;
 		have_more = false;
 	} while (have_perm(ptm, hg));
 
-	dbgprt("No more unordered permutations\n");
+	logger().fine("No more unordered permutations");
 
 	return false;
 }
@@ -1012,7 +985,7 @@ bool PatternMatchEngine::explore_choice_branches(const PatternTermPtr& ptm,
 	if (CHOICE_LINK != hp->getType())
 		return explore_single_branch(ptm, hg, clause_root);
 
-	dbgprt("Begin choice branchpoint iteration loop\n");
+	logger().fine("Begin choice branchpoint iteration loop");
 	do {
 		// XXX this "need_choice_push thing is probably wrong; it probably
 		// should resemble the perm_push() used for unordered links.
@@ -1027,13 +1000,13 @@ bool PatternMatchEngine::explore_choice_branches(const PatternTermPtr& ptm,
 		if (match)
 			return true;
 
-		dbgprt("Step to next choice\n");
+		logger().fine("Step to next choice");
 		// If we are here, there was no match.
 		// On the next go-around, take a step.
 		choose_next = true;
 	} while (have_choice(ptm, hg));
 
-	dbgprt("Exhausted all choice possibilities\n");
+	logger().fine("Exhausted all choice possibilities");
 
 	return false;
 }
@@ -1060,21 +1033,21 @@ bool PatternMatchEngine::explore_single_branch(const PatternTermPtr& ptm,
 {
 	solution_push();
 
-	dbgprt("Checking pattern term=%s for soln by %lu\n",
-	       ptm->toString().c_str(), hg.value());
+	LAZY_LOG_FINE << "Checking pattern term=" << ptm->toString()
+	              << " for soln by " << hg.value();
 
 	bool match = tree_compare(ptm, hg, CALL_SOLN);
 
 	if (not match)
 	{
-		dbgprt("Pattern term=%s NOT solved by %lu\n",
-		       ptm->toString().c_str(), hg.value());
+		LAZY_LOG_FINE << "Pattern term=" << ptm->toString()
+		              << " NOT solved by " << hg.value();
 		solution_pop();
 		return false;
 	}
 
-	dbgprt("Pattern term=%s solved by %lu move up\n",
-           ptm->toString().c_str(), hg.value());
+	LAZY_LOG_FINE << "Pattern term=" << ptm->toString()
+	              << " solved by " << hg.value() << " move up";
 
 	// XXX should not do perm_push every time... only selectively.
 	// But when? This is very confusing ...
@@ -1144,8 +1117,8 @@ bool PatternMatchEngine::do_term_up(const PatternTermPtr& ptm,
 	// find its parent in the clause. For an evaluatable term, we find
 	// the parent evaluatable in the clause, which may be many steps
 	// higher.
-	dbgprt("Term = %s of clause UUID = %lu has ground, move upwards.\n",
-	       ptm->toString().c_str(), clause_root.value());
+	LAZY_LOG_FINE << "Term = " << ptm->toString() << " of clause UUID = "
+	              << clause_root.value() << " has ground, move upwards";
 
 	if (0 < _pat->in_evaluatable.count(hp))
 	{
@@ -1189,8 +1162,8 @@ bool PatternMatchEngine::do_term_up(const PatternTermPtr& ptm,
 			if (not is_unquoted_in_tree(clause_root, evit->second))
 				continue;
 
-			prtmsg("Term inside evaluatable, move up to it's top:\n",
-			        evit->second);
+			logmsg("Term inside evaluatable, move up to it's top:\n",
+			       evit->second);
 
 			// All of the variables occurring in the term should have
 			// grounded by now. If not, then its virtual term, and we
@@ -1204,7 +1177,7 @@ bool PatternMatchEngine::do_term_up(const PatternTermPtr& ptm,
 // this?
 
 			bool found = _pmc.evaluate_sentence(clause_root, var_grounding);
-			dbgprt("After evaluating clause, found = %d\n", found);
+			logger().fine("After evaluating clause, found = %d", found);
 			if (found)
 				return clause_accept(clause_root, hg);
 
@@ -1222,12 +1195,12 @@ bool PatternMatchEngine::do_term_up(const PatternTermPtr& ptm,
 	if (CHOICE_LINK != hi->getType())
 	{
 		if (explore_up_branches(parent, hg, clause_root)) found = true;
-		dbgprt("After moving up the clause, found = %d\n", found);
+		logger().fine("After moving up the clause, found = %d", found);
 	}
 	else
 	if (hi == clause_root)
 	{
-		dbgprt("Exploring ChoiceLink at root\n");
+		logger().fine("Exploring ChoiceLink at root");
 		if (clause_accept(clause_root, hg)) found = true;
 	}
 	else
@@ -1239,7 +1212,7 @@ bool PatternMatchEngine::do_term_up(const PatternTermPtr& ptm,
 		// (hop up) past the ChoiceLink, before resuming the search.
 		// The easiest way to hop is to do it recursively... i.e.
 		// call ourselves again.
-		dbgprt("Exploring ChoiceLink below root\n");
+		logger().fine("Exploring ChoiceLink below root");
 
 		OC_ASSERT(not have_choice(parent, hg),
 		          "Something is wrong with the ChoiceLink code");
@@ -1267,18 +1240,18 @@ bool PatternMatchEngine::clause_accept(const Handle& clause_root,
 	{
 		clause_accepted = true;
 		match = _pmc.optional_clause_match(clause_root, hg);
-		dbgprt("optional clause match callback match=%d\n", match);
+		logger().fine("optional clause match callback match=%d", match);
 	}
 	else
 	{
 		match = _pmc.clause_match(clause_root, hg);
-		dbgprt("clause match callback match=%d\n", match);
+		logger().fine("clause match callback match=%d", match);
 	}
 	if (not match) return false;
 
 	clause_grounding[clause_root] = hg;
-	prtmsg("---------------------\nclause:", clause_root);
-	prtmsg("ground:", hg);
+	logmsg("---------------------\nclause:", clause_root);
+	logmsg("ground:", hg);
 
 	// Now go and do more clauses.
 	return do_next_clause();
@@ -1298,22 +1271,20 @@ bool PatternMatchEngine::do_next_clause(void)
 	bool found = false;
 	if (Handle::UNDEFINED == curr_root)
 	{
-#ifdef DEBUG
-		dbgprt ("==================== FINITO!\n");
-		print_solution(var_grounding, clause_grounding);
-#endif
+		logger().fine("==================== FINITO!");
+		log_solution(var_grounding, clause_grounding);
 		found = _pmc.grounding(var_grounding, clause_grounding);
 	}
 	else
 	{
-		prtmsg("Next clause is\n", curr_root);
-		dbgprt("This clause is %s\n",
-			is_optional(curr_root)? "optional" : "required");
-		dbgprt("This clause is %s\n",
-			is_evaluatable(curr_root)?
-			"dynamically evaluatable" : "non-dynamic");
-		prtmsg("Joining variable  is", joiner);
-		prtmsg("Joining grounding is", var_grounding[joiner]);
+		logmsg("Next clause is", curr_root);
+		LAZY_LOG_FINE << "This clause is "
+		              << (is_optional(curr_root)? "optional" : "required");
+		LAZY_LOG_FINE << "This clause is "
+		              << (is_evaluatable(curr_root)?
+		                  "dynamically evaluatable" : "non-dynamic");
+		logmsg("Joining variable  is", joiner);
+		logmsg("Joining grounding is", var_grounding[joiner]);
 
 		// Else, start solving the next unsolved clause. Note: this is
 		// a recursive call, and not a loop. Recursion is halted when
@@ -1347,7 +1318,7 @@ bool PatternMatchEngine::do_next_clause(void)
 		{
 			Handle undef(Handle::UNDEFINED);
 			bool match = _pmc.optional_clause_match(joiner, undef);
-			dbgprt ("Exhausted search for optional clause, cb=%d\n", match);
+			logger().fine("Exhausted search for optional clause, cb=%d", match);
 			if (not match) {
 				clause_stacks_pop();
 				return false;
@@ -1359,13 +1330,11 @@ bool PatternMatchEngine::do_next_clause(void)
 			joiner = next_joint;
 			curr_root = next_clause;
 
-			prtmsg("Next optional clause is", curr_root);
+			logmsg("Next optional clause is", curr_root);
 			if (Handle::UNDEFINED == curr_root)
 			{
-				dbgprt ("==================== FINITO BANDITO!\n");
-#ifdef DEBUG
-				print_solution(var_grounding, clause_grounding);
-#endif
+				logger().fine("==================== FINITO BANDITO!");
+				log_solution(var_grounding, clause_grounding);
 				found = _pmc.grounding(var_grounding, clause_grounding);
 			}
 			else
@@ -1611,7 +1580,8 @@ bool PatternMatchEngine::get_next_thinnest_clause(bool search_virtual,
 void PatternMatchEngine::clause_stacks_push(void)
 {
 	_clause_stack_depth++;
-	dbgprt("--- That's it, now push to stack depth=%d\n\n", _clause_stack_depth);
+	logger().fine("--- That's it, now push to stack depth=%d",
+	              _clause_stack_depth);
 
 	var_solutn_stack.push(var_grounding);
 	term_solutn_stack.push(clause_grounding);
@@ -1645,7 +1615,7 @@ void PatternMatchEngine::clause_stacks_pop(void)
 
 	_clause_stack_depth --;
 
-	dbgprt("pop to depth %d\n", _clause_stack_depth);
+	logger().fine("pop to depth %d", _clause_stack_depth);
 }
 
 /**
@@ -1765,7 +1735,7 @@ bool PatternMatchEngine::explore_clause(const Handle& term,
 	// evaluate to true or false.
 	if (not is_evaluatable(clause))
 	{
-		dbgprt("Clause is matchable; start matching it.\n");
+		logger().fine("Clause is matchable; start matching it");
 		bool found = explore_term_branches(term, grnd, clause);
 
 		// If found is false, then there's no solution here.
@@ -1774,9 +1744,9 @@ bool PatternMatchEngine::explore_clause(const Handle& term,
 	}
 
 	// If we are here, we have an evaluatable clause on our hands.
-	dbgprt("Clause is evaluatable; start evaluating it\n");
+	logger().fine("Clause is evaluatable; start evaluating it");
 	bool found = _pmc.evaluate_sentence(clause, var_grounding);
-	dbgprt("Post evaluating clause, found = %d\n", found);
+	logger().fine("Post evaluating clause, found = %d", found);
 	if (found)
 		return clause_accept(clause, grnd);
 
@@ -1838,11 +1808,14 @@ void PatternMatchEngine::set_pattern(const Variables& v,
 
 /* ======================================================== */
 
-void PatternMatchEngine::print_solution(
+void PatternMatchEngine::log_solution(
 	const std::map<Handle, Handle> &vars,
 	const std::map<Handle, Handle> &clauses)
 {
-	printf("\nVariable groundings:\n");
+	if (!logger().isFineEnabled())
+		return;
+
+	logger().fine("Variable groundings:");
 
 	// Print out the bindings of solutions to variables.
 	std::map<Handle, Handle>::const_iterator j = vars.begin();
@@ -1857,18 +1830,18 @@ void PatternMatchEngine::print_solution(
 
 		if (soln == Handle::UNDEFINED)
 		{
-			printf("ERROR: ungrounded variable %s\n",
-			       var->toShortString().c_str());
+			logger().fine("ERROR: ungrounded variable %s\n",
+			              var->toShortString().c_str());
 			continue;
 		}
 
-		printf("\t%s maps to %s\n",
-		       var->toShortString().c_str(),
-		       soln->toShortString().c_str());
+		logger().fine("\t%s maps to %s\n",
+		              var->toShortString().c_str(),
+		              soln->toShortString().c_str());
 	}
 
 	// Print out the full binding to all of the clauses.
-	printf("\nGrounded clauses:\n");
+	logger().fine("Grounded clauses:");
 	std::map<Handle, Handle>::const_iterator m;
 	int i = 0;
 	for (m = clauses.begin(); m != clauses.end(); ++m, ++i)
@@ -1876,27 +1849,26 @@ void PatternMatchEngine::print_solution(
 		if (m->second == Handle::UNDEFINED)
 		{
 			Handle mf(m->first);
-			prtmsg("ERROR: ungrounded clause: ", mf);
+			logmsg("ERROR: ungrounded clause: ", mf);
 			continue;
 		}
 		std::string str = m->second->toShortString();
-		printf ("%d.   %s\n", i, str.c_str());
+		logger().fine("%d.   %s", i, str.c_str());
 	}
-	printf ("\n");
 }
 
 /**
- * For debug printing only
+ * For debug logging only
  */
-void PatternMatchEngine::print_term(
+void PatternMatchEngine::log_term(
                   const std::set<Handle> &vars,
                   const std::vector<Handle> &clauses)
 {
-	printf("\nClauses:\n");
-	for (Handle h : clauses) prt(h);
+	logger().fine("Clauses:");
+	for (Handle h : clauses) log(h);
 
-	printf("\nVars:\n");
-	for (Handle h : vars) prt(h);
+	logger().fine("Vars:");
+	for (Handle h : vars) log(h);
 }
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -121,10 +121,8 @@ class PatternMatchEngine
 		// whenever take_step is set to true.
 		bool take_step;
 		bool have_more;
-#ifdef DEBUG
 		std::map<Unorder, int> perm_count;
 		std::stack<std::map<Unorder, int>> perm_count_stack;
-#endif
 
 		// --------------------------------------------
 		// Methods and state that select the next clause to be grounded.
@@ -222,11 +220,11 @@ class PatternMatchEngine
 		bool explore_neighborhood(const Handle&, const Handle&, const Handle&);
 
 		// Handy-dandy utilities
-		static void print_solution(const std::map<Handle, Handle> &vars,
-		                           const std::map<Handle, Handle> &clauses);
+		static void log_solution(const std::map<Handle, Handle> &vars,
+		                         const std::map<Handle, Handle> &clauses);
 
-		static void print_term(const std::set<Handle> &vars,
-		                            const std::vector<Handle> &clauses);
+		static void log_term(const std::set<Handle> &vars,
+		                     const std::vector<Handle> &clauses);
 };
 
 } // namespace opencog

--- a/tests/query/PatternUTest.cxxtest
+++ b/tests/query/PatternUTest.cxxtest
@@ -20,6 +20,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <cxxtest/TestSuite.h>
+
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/query/DefaultPatternMatchCB.h>
 #include <opencog/query/InitiateSearchCB.h>


### PR DESCRIPTION
This is to address issue #147 . All stdout debug messages have been replaced by fine debugging. The reason I use fine is because most pattern matcher tests enable debug level and this would slow down considerably run-time pattern matching. Generally I think we can assume that log levels behave that way

1. INFO: contain the bare minimum
2. DEBUG: contain useful information for debugging but do not slow down run-time substantially
3. FINE: may slow down run-time substantially and may not be used in production

The difference in performance is at DEBUG level is not significant, see statistics obtained by running scripts/query/benchmark_query.sh (which runs 20 times all pattern matcher unit tests, and spits out stats).

```
Before replacing stdout by log
========================
N   min    max    sum     mean     stddev
20  13.57  17.99  309.61  15.4805  1.43348
```

```
After replacing stdout by log
=======================
N   min    max    sum    mean    stddev
20  13.77  17.86  313.1  15.655  1.52332
```

The new version is 1% slower, but I don't think it is statistically significant given the standard deviation.

I think it's ready to be merged, but @linas I'll probably let you merge just in case.