### PR TITLE
Avoid using Handle UUID's in SQL backingstore

### DIFF
--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -292,7 +292,7 @@ public:
     /**
      * Return true if the atom table holds this handle, else return false.
      */
-    bool holds(Handle& h) const {
+    bool holds(const Handle& h) const {
         return (NULL != h) and h->getAtomTable() == this;
     }
 

--- a/opencog/persist/sql/AtomStorage.cc
+++ b/opencog/persist/sql/AtomStorage.cc
@@ -1243,6 +1243,7 @@ AtomStorage::PseudoPtr AtomStorage::petAtom(UUID uuid)
 AtomPtr AtomStorage::getAtom(UUID uuid)
 {
 	PseudoPtr p(petAtom(uuid));
+	if (NULL == p) return NULL;
 
 	if (classserver().isA(p->type, NODE))
 	{
@@ -1301,8 +1302,6 @@ std::vector<Handle> AtomStorage::getIncomingSet(Handle h)
  * to fetch the associated TruthValue for this node.
  *
  * This method does *not* register the atom with any atomtable/atomspace
- * However, it does register with the TLB, as the SQL uuids and the
- * TLB Handles must be kept in sync, or all hell breaks loose.
  */
 NodePtr AtomStorage::getNode(Type t, const char * str)
 {
@@ -1322,7 +1321,9 @@ NodePtr AtomStorage::getNode(Type t, const char * str)
 	}
 
 	PseudoPtr p(getAtom(buff, 0));
-	NodePtr node = createNode(p->type, p->name, p->tv);
+	if (NULL == p) return NULL;
+
+	NodePtr node = createNode(t, str, p->tv);
 	node->_uuid = p->uuid;
 	return node;
 }
@@ -1349,6 +1350,8 @@ LinkPtr AtomStorage::getLink(Type t, const HandleSeq& oset)
 	ostr += ";";
 
 	PseudoPtr p = getAtom(ostr.c_str(), 1);
+	if (NULL == p) return NULL;
+
 	LinkPtr link = createLink(t, oset, p->tv);
 	link->_uuid = p->uuid;
 	return link;

--- a/opencog/persist/sql/AtomStorage.cc
+++ b/opencog/persist/sql/AtomStorage.cc
@@ -160,6 +160,7 @@ class AtomStorage::Response
 			{
 				AtomPtr atom(store->makeAtom(*this, uuid));
 				load_recursive_if_not_exists(atom);
+				table->add(atom, true);
 			}
 			return false;
 		}
@@ -181,7 +182,6 @@ class AtomStorage::Response
 					load_recursive_if_not_exists(a);
 				}
 			}
-			table->add(atom, true);
 		}
 
 		std::vector<Handle> *hvec;

--- a/opencog/persist/sql/AtomStorage.cc
+++ b/opencog/persist/sql/AtomStorage.cc
@@ -1360,7 +1360,7 @@ AtomPtr AtomStorage::makeAtom(Response &rp, UUID uuid)
 			// Break if there is no more atom in the outgoing set
 			// or the outgoing set is empty in the first place
 			if (*p == '}' or *p == '\0') break;
-			Handle hout = (Handle) strtoul(p+1, &p, 10);
+			Handle hout(strtoul(p+1, &p, 10));
 			outvec.push_back(hout);
 		}
 #endif /* USE_INLINE_EDGES */

--- a/opencog/persist/sql/AtomStorage.cc
+++ b/opencog/persist/sql/AtomStorage.cc
@@ -822,6 +822,7 @@ void AtomStorage::do_store_single_atom(AtomPtr atom, int aheight)
 		AtomTable * at = atom->getAtomTable();
 		// We allow storage of atoms that don't belong to an atomspace.
 		if (at) uuidbuff = std::to_string(at->get_uuid());
+		else uuidbuff = "0";
 		STMT("space", uuidbuff);
 
 		// Store the atom UUID

--- a/opencog/persist/sql/AtomStorage.cc
+++ b/opencog/persist/sql/AtomStorage.cc
@@ -159,7 +159,7 @@ class AtomStorage::Response
 			if (not table->holds(h))
 			{
 				AtomPtr atom(store->makeAtom(*this, uuid));
-				load_recursive_if_not_exists(atom);
+				atom = load_recursive_if_not_exists(atom);
 				table->add(atom, true);
 			}
 			return false;

--- a/opencog/persist/sql/AtomStorage.cc
+++ b/opencog/persist/sql/AtomStorage.cc
@@ -177,7 +177,7 @@ class AtomStorage::Response
 				for (Handle h : oset)
 				{
 					if (table->holds(h)) continue;
-					AtomPtr a(store->getAtom(h));
+					AtomPtr a(store->getAtom(h.value()));
 					load_recursive_if_not_exists(a);
 				}
 			}
@@ -1217,11 +1217,11 @@ AtomPtr  AtomStorage::getAtom(const char * query, int height)
  * However, it does register with the TLB, as the SQL uuids and the
  * TLB Handles must be kept in sync, or all hell breaks loose.
  */
-AtomPtr  AtomStorage::getAtom(Handle h)
+AtomPtr  AtomStorage::getAtom(UUID uuid)
 {
 	setup_typemap();
 	char buff[BUFSZ];
-	snprintf(buff, BUFSZ, "SELECT * FROM Atoms WHERE uuid = %lu;", h->_uuid);
+	snprintf(buff, BUFSZ, "SELECT * FROM Atoms WHERE uuid = %lu;", uuid);
 
 	return getAtom(buff, -1);
 }

--- a/opencog/persist/sql/AtomStorage.h
+++ b/opencog/persist/sql/AtomStorage.h
@@ -154,7 +154,7 @@ class AtomStorage
 
 		// Fetch atoms from DB
 		bool atomExists(Handle);
-		AtomPtr getAtom(Handle);
+		AtomPtr getAtom(UUID);
 		std::vector<Handle> getIncomingSet(Handle);
 		NodePtr getNode(Type, const char *);
 		NodePtr getNode(const Node &n)

--- a/opencog/persist/sql/AtomStorage.h
+++ b/opencog/persist/sql/AtomStorage.h
@@ -68,7 +68,7 @@ class AtomStorage
 		void store_atomtable_id(const AtomTable&);
 
 		// ---------------------------------------------
-		AtomPtr makeAtom (Response &, Handle);
+		AtomPtr makeAtom (Response &, AtomPtr, UUID);
 		AtomPtr getAtom (const char *, int);
 
 		int get_height(AtomPtr);

--- a/opencog/persist/sql/AtomStorage.h
+++ b/opencog/persist/sql/AtomStorage.h
@@ -68,8 +68,20 @@ class AtomStorage
 		void store_atomtable_id(const AtomTable&);
 
 		// ---------------------------------------------
-		AtomPtr makeAtom (Response &, UUID);
-		AtomPtr getAtom (const char *, int);
+		struct PseudoAtom
+			: public std::enable_shared_from_this<PseudoAtom>
+		{
+			Type type;
+			UUID uuid;
+			std::string name;
+			std::vector<UUID> oset;
+			TruthValuePtr tv;
+		};
+		typedef std::shared_ptr<PseudoAtom> PseudoPtr;
+		#define createPseudo std::make_shared<PseudoAtom>
+		PseudoPtr makeAtom(Response &, UUID);
+		PseudoPtr getAtom(const char *, int);
+		PseudoPtr petAtom(UUID);
 
 		int get_height(AtomPtr);
 		int max_height;

--- a/opencog/persist/sql/AtomStorage.h
+++ b/opencog/persist/sql/AtomStorage.h
@@ -68,7 +68,7 @@ class AtomStorage
 		void store_atomtable_id(const AtomTable&);
 
 		// ---------------------------------------------
-		AtomPtr makeAtom (Response &, AtomPtr, UUID);
+		AtomPtr makeAtom (Response &, UUID);
 		AtomPtr getAtom (const char *, int);
 
 		int get_height(AtomPtr);

--- a/opencog/persist/sql/SQLPersistSCM.cc
+++ b/opencog/persist/sql/SQLPersistSCM.cc
@@ -71,7 +71,7 @@ LinkPtr SQLBackingStore::getLink(Type t, const std::vector<Handle>& oset) const
 
 AtomPtr SQLBackingStore::getAtom(Handle h) const
 {
-	return _store->getAtom(h);
+	return _store->getAtom(h.value());
 }
 
 HandleSeq SQLBackingStore::getIncomingSet(Handle h) const

--- a/tests/persist/sql/BasicSaveUTest.cxxtest
+++ b/tests/persist/sql/BasicSaveUTest.cxxtest
@@ -239,8 +239,7 @@ void BasicSaveUTest::single_atom_save_restore(std::string id)
 	store->storeAtom(a, true);
 
 	// Fetch it back ...
-	Handle hb(uuid);
-	AtomPtr b = store->getAtom(hb);
+	AtomPtr b = store->getAtom(uuid);
 
 	// Are they equal ??
 	atomCompare(a, b, "Single node save-restore");
@@ -260,7 +259,7 @@ void BasicSaveUTest::single_atom_save_restore(std::string id)
 	store->storeAtom(l, true);
 
 	UUID ul = l->getHandle().value();
-	AtomPtr lb = store->getAtom(Handle(ul));
+	AtomPtr lb = store->getAtom(ul);
 	atomCompare(l, lb, "Single link save-restore");
 
 	store->kill_data();


### PR DESCRIPTION
A long-term goal is to remove UUID's from the Handle.  one of the roadblocks to accomplishing
that was the SQL backend. The other major roadblock is ... python.