### PR TITLE
Add google-protobuf dependency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ the build, will be more precise as to which parts will not be built.
 > Asynchronous messaging library
 > http://zeromq.org/intro:get-the-software | libzmq3-dev
 
+###### Google Protocol Buffers
+> Google's data interchange format (used by ZeroMQ)
+> https://developers.google.com/protocol-buffers | libprotobuf-dev
+
+
 Building AtomSpace
 ------------------
 Perform the following steps at the shell prompt:


### PR DESCRIPTION
@linas Got the following error while building atomspace so I had to install google protobuff. Adding it as an optional dependency.
```
[ 82%] Building CXX object opencog/persist/sql/CMakeFiles/persist-sql.dir/AtomStorage.cc.o
[ 82%] Building CXX object opencog/persist/sql/CMakeFiles/persist-sql.dir/SQLPersistSCM.cc.o
Linking CXX shared library libpersist-sql.so
[ 82%] Built target persist-sql
Scanning dependencies of target sniff
[ 82%] Building CXX object opencog/persist/sql/CMakeFiles/sniff.dir/sniff.cc.o
Linking CXX executable sniff
[ 82%] Built target sniff
Scanning dependencies of target zmqatoms
[ 82%] Building CXX object opencog/persist/zmq/atomspace/CMakeFiles/zmqatoms.dir/ZMQMessages.pb.cc.o
In file included from /home/sanuj/Projects/opencog-full/atomspace/opencog/persist/zmq/atomspace/ZMQMessages.pb.cc:5:0:
/home/sanuj/Projects/opencog-full/atomspace/opencog/persist/zmq/atomspace/ZMQMessages.pb.h:9:42: fatal error: google/protobuf/stubs/common.h: No such file or directory
 #include <google/protobuf/stubs/common.h>
                                          ^
compilation terminated.
make[2]: *** [opencog/persist/zmq/atomspace/CMakeFiles/zmqatoms.dir/ZMQMessages.pb.cc.o] Error 1
make[1]: *** [opencog/persist/zmq/atomspace/CMakeFiles/zmqatoms.dir/all] Error 2
make: *** [all] Error 2

```