### PR TITLE
UniqueLink, StateLink

### DIFF
--- a/examples/guile/README.md
+++ b/examples/guile/README.md
@@ -70,6 +70,7 @@ The current list of modules that wrap C++ code includes:
                  callbacks written in python or scheme.
 * assign.scm  -- an example of asserting facts in the AtomSpace.
 * get-put.scm -- a different way of asserting facts in the AtomSpace.
+* state.scm   -- maintaining unique state
 * filter.scm  -- filtering sets of atoms.
 * except.scm  -- an example of exceptions being thrown and passed.
 * persist-example.scm -- and example of saving atomspace data in an SQL

--- a/examples/guile/state.scm
+++ b/examples/guile/state.scm
@@ -1,0 +1,26 @@
+;
+; state.scm
+;
+; This provides a very simple demo of using the StateLink to maintain
+; unique state. A Statelink is a kind of link of which only one can ever
+; exist in the atomspace, for a given "state" atom.  Whenever a new
+; StateLink is added to the atomspace, the old one is automatically
+; removed.
+
+; The current state of "fruit" is "apple".
+(StateLink (AnchorNode "fruit") (ConceptNode "apple"))
+
+; Lets make sure of that:
+(cog-incoming-set (AnchorNode "fruit"))
+
+; Change the state to bananna:
+(StateLink (AnchorNode "fruit") (ConceptNode "bananna"))
+
+; Lets make sure the state changed:
+(cog-incoming-set (AnchorNode "fruit"))
+
+; Change it back to apple:
+(StateLink (AnchorNode "fruit") (ConceptNode "apple"))
+
+; Lets make sure the state changed:
+(cog-incoming-set (AnchorNode "fruit"))

--- a/opencog/atoms/core/CMakeLists.txt
+++ b/opencog/atoms/core/CMakeLists.txt
@@ -10,6 +10,7 @@ ADD_LIBRARY (atomcore SHARED
 	FunctionLink.cc
 	LambdaLink.cc
 	PutLink.cc
+	StateLink.cc
 	UniqueLink.cc
 	VariableList.cc
 )
@@ -33,6 +34,7 @@ INSTALL (FILES
 	FunctionLink.h
 	LambdaLink.h
 	PutLink.h
+	StateLink.h
 	UniqueLink.h
 	VariableList.h
 	DESTINATION "include/opencog/atoms/core"

--- a/opencog/atoms/core/CMakeLists.txt
+++ b/opencog/atoms/core/CMakeLists.txt
@@ -10,6 +10,7 @@ ADD_LIBRARY (atomcore SHARED
 	FunctionLink.cc
 	LambdaLink.cc
 	PutLink.cc
+	UniqueLink.cc
 	VariableList.cc
 )
 
@@ -32,6 +33,7 @@ INSTALL (FILES
 	FunctionLink.h
 	LambdaLink.h
 	PutLink.h
+	UniqueLink.h
 	VariableList.h
 	DESTINATION "include/opencog/atoms/core"
 )

--- a/opencog/atoms/core/DefineLink.h
+++ b/opencog/atoms/core/DefineLink.h
@@ -73,8 +73,8 @@ public:
 	           AttentionValuePtr av = AttentionValue::DEFAULT_AV());
 
 	DefineLink(Link &l);
-	Handle get_alias(void) { return _outgoing[0]; }
-	Handle get_definition(void) { return _outgoing[1]; }
+	Handle get_alias(void) const { return _outgoing[0]; }
+	Handle get_definition(void) const { return _outgoing[1]; }
 
 	/**
 	 * Given a Handle pointing to <name> in

--- a/opencog/atoms/core/DefineLink.h
+++ b/opencog/atoms/core/DefineLink.h
@@ -25,7 +25,7 @@
 
 #include <map>
 
-#include <opencog/atomspace/Link.h>
+#include <opencog/atoms/core/UniqueLink.h>
 
 namespace opencog
 {
@@ -59,15 +59,10 @@ namespace opencog
 /// Of the three, the last is the most important, as, right now, there
 /// is no other way of sprecifying recursive functions in the atomspace.
 ///
-class DefineLink : public Link
+class DefineLink : public UniqueLink
 {
 protected:
-	// Reference to the definition body (typically a node)
-	Handle _alias;
-	// Definition body that this link is defining.
-	Handle _definition;
-
-	void init(const HandleSeq&);
+	void init();
 public:
 	DefineLink(const HandleSeq&,
 	           TruthValuePtr tv = TruthValue::DEFAULT_TV(),
@@ -78,8 +73,8 @@ public:
 	           AttentionValuePtr av = AttentionValue::DEFAULT_AV());
 
 	DefineLink(Link &l);
-	Handle get_alias(void) { return _alias; }
-	Handle get_definition(void) { return _definition; }
+	Handle get_alias(void) { return _outgoing[0]; }
+	Handle get_definition(void) { return _outgoing[1]; }
 
 	/**
 	 * Given a Handle pointing to <name> in

--- a/opencog/atoms/core/DeleteLink.cc
+++ b/opencog/atoms/core/DeleteLink.cc
@@ -40,6 +40,7 @@ void DeleteLink::init(void)
 	// time, because we don't know the atomspace yet.  So we hack
 	// around this by thowing at construtor time.
 	//
+	FreeLink::init();
 	if (0 == _varseq.size())
 		// throw DeleteException();
 		throw InvalidParamException(TRACE_INFO,

--- a/opencog/atoms/core/DeleteLink.h
+++ b/opencog/atoms/core/DeleteLink.h
@@ -35,8 +35,8 @@ namespace opencog
  *  @{
  */
 
-/// The DeleteLink is used to delete any atom that is not a
-/// VariableNode.  That is, if in attempts to insert a DeleteLink into
+/// The DeleteLink is used to delete any atom that does not contain a
+/// VariableNode.  That is, if one attempts to insert a DeleteLink into
 /// the atomspace, and the DeleteLink does not have any VariableNodes
 /// in it, the insertion will fail, and furthermore, the atom(s)
 /// that it is holding (in its outgoing set) will be deleted from the

--- a/opencog/atoms/core/LambdaLink.cc
+++ b/opencog/atoms/core/LambdaLink.cc
@@ -97,7 +97,7 @@ LambdaLink::LambdaLink(Link &l)
 ///
 void LambdaLink::extract_variables(const HandleSeq& oset)
 {
-	Type decls = oset[0]->getType();
+	Type decls = oset.at(0)->getType();
 
 	// If the first atom is not explicitly a variable declaration, then
 	// there are no variable declarations; extract all free variables.

--- a/opencog/atoms/core/StateLink.cc
+++ b/opencog/atoms/core/StateLink.cc
@@ -1,0 +1,70 @@
+/*
+ * StateLink.cc
+ *
+ * Copyright (C) 2015 Linas Vepstas
+ *
+ * Author: Linas Vepstas <linasvepstas@gmail.com>  May 2015
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the
+ * exceptions at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/atomspace/ClassServer.h>
+
+#include "StateLink.h"
+
+using namespace opencog;
+
+void StateLink::init()
+{
+	// Must have name and body
+	if (2 != _outgoing.size())
+		throw InvalidParamException(TRACE_INFO,
+			"Expecting name and state, got size %d", _outgoing.size());
+}
+
+StateLink::StateLink(const HandleSeq& oset,
+                       TruthValuePtr tv, AttentionValuePtr av)
+	: UniqueLink(STATE_LINK, oset, tv, av)
+{
+	init();
+}
+
+StateLink::StateLink(const Handle& name, const Handle& defn,
+                       TruthValuePtr tv, AttentionValuePtr av)
+	: UniqueLink(STATE_LINK, HandleSeq({name, defn}), tv, av)
+{
+	init();
+}
+
+StateLink::StateLink(Link &l)
+	: UniqueLink(l)
+{
+	init();
+}
+
+/**
+ * Get the state associated with the alias.
+ * This will be the second atom of some StateLink, where
+ * `alias` is the first.
+ */
+Handle StateLink::get_state(const Handle& alias)
+{
+	Handle uniq(get_unique(alias, STATE_LINK));
+	LinkPtr luniq(LinkCast(uniq));
+	return luniq->getOutgoingAtom(1);
+}
+
+/* ===================== END OF FILE ===================== */

--- a/opencog/atoms/core/StateLink.cc
+++ b/opencog/atoms/core/StateLink.cc
@@ -67,4 +67,32 @@ Handle StateLink::get_state(const Handle& alias)
 	return luniq->getOutgoingAtom(1);
 }
 
+/**
+ * Get the link associated with the alias.  This will be the StateLink
+ * which has `alias` as the first member of the outgoing set.
+ */
+Handle StateLink::get_link(const Handle& alias)
+{
+	return get_unique(alias, STATE_LINK);
+}
+
+/**
+ * If there is a *second* StateLink, equivalent to this one,
+ * return it.  This is used for managing state in the AtomSpace.
+ */
+Handle StateLink::get_other(void) const
+{
+	// Get all StateLinks associated with the alias. Ignore this one.
+	const Handle& alias = _outgoing[0];
+	IncomingSet defs = alias->getIncomingSetByType(STATE_LINK);
+
+	// Return any non-unique definition that isn't this one.
+	for (const LinkPtr& defl : defs)
+	{
+		if (defl->getOutgoingAtom(0) == alias and defl.get() != this)
+			return defl->getHandle();
+	}
+	return Handle();
+}
+
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/core/StateLink.h
+++ b/opencog/atoms/core/StateLink.h
@@ -58,8 +58,9 @@ public:
 	           AttentionValuePtr av = AttentionValue::DEFAULT_AV());
 
 	StateLink(Link &l);
-	Handle get_alias(void) { return _outgoing[0]; }
-	Handle get_state(void) { return _outgoing[1]; }
+	Handle get_alias(void) const { return _outgoing[0]; }
+	Handle get_state(void) const { return _outgoing[1]; }
+	Handle get_other(void) const;
 
 	/**
 	 * Given a Handle pointing to <name> in
@@ -70,6 +71,7 @@ public:
 	 *
 	 * return <body>
 	 */
+	static Handle get_link(const Handle& alias);
 	static Handle get_state(const Handle& alias);
 };
 

--- a/opencog/atoms/core/StateLink.h
+++ b/opencog/atoms/core/StateLink.h
@@ -1,0 +1,88 @@
+/*
+ * opencog/atoms/StateLink.h
+ *
+ * Copyright (C) 2015 Linas Vepstas
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef _OPENCOG_STATE_LINK_H
+#define _OPENCOG_STATE_LINK_H
+
+#include <map>
+
+#include <opencog/atoms/core/UniqueLink.h>
+
+namespace opencog
+{
+/** \addtogroup grp_atomspace
+ *  @{
+ */
+
+/// The StateLink is used to maintain unique state. Given an atom,
+/// the atomspace can only contain one instance of a StateLink with
+/// that atom in the first position.  Adding another StateLink with
+/// the same first-atom causes teh previous StateLink to be removed!
+///
+/// This class is intended for holding single-valued state in a safe,
+/// automated fashion. Of course, a user can also store unique state
+/// simply by being careful to delete the old state after adding the
+/// new state; but this can be error prone.  Thus link type provides
+/// convenience and safety.
+///
+class StateLink : public UniqueLink
+{
+protected:
+	void init();
+public:
+	StateLink(const HandleSeq&,
+	           TruthValuePtr tv = TruthValue::DEFAULT_TV(),
+	           AttentionValuePtr av = AttentionValue::DEFAULT_AV());
+
+	StateLink(const Handle& alias, const Handle& body,
+	           TruthValuePtr tv = TruthValue::DEFAULT_TV(),
+	           AttentionValuePtr av = AttentionValue::DEFAULT_AV());
+
+	StateLink(Link &l);
+	Handle get_alias(void) { return _outgoing[0]; }
+	Handle get_state(void) { return _outgoing[1]; }
+
+	/**
+	 * Given a Handle pointing to <name> in
+	 *
+	 * StateLink
+	 *    <name>
+	 *    <body>
+	 *
+	 * return <body>
+	 */
+	static Handle get_state(const Handle& alias);
+};
+
+typedef std::shared_ptr<StateLink> StateLinkPtr;
+static inline StateLinkPtr StateLinkCast(const Handle& h)
+	{ AtomPtr a(h); return std::dynamic_pointer_cast<StateLink>(a); }
+static inline StateLinkPtr StateLinkCast(AtomPtr a)
+	{ return std::dynamic_pointer_cast<StateLink>(a); }
+
+// XXX temporary hack ...
+#define createStateLink std::make_shared<StateLink>
+
+/** @}*/
+}
+
+#endif // _OPENCOG_STATE_LINK_H

--- a/opencog/atoms/core/UniqueLink.cc
+++ b/opencog/atoms/core/UniqueLink.cc
@@ -109,7 +109,6 @@ Handle UniqueLink::get_unique(const Handle& alias, Type type)
 	throw InvalidParamException(TRACE_INFO,
 	                            "Cannot find defined hypergraph for atom %s",
 	                            alias->toString().c_str());
-	return Handle();
 }
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/core/UniqueLink.cc
+++ b/opencog/atoms/core/UniqueLink.cc
@@ -60,6 +60,9 @@ UniqueLink::UniqueLink(Type type, const HandleSeq& oset,
 		throw InvalidParamException(TRACE_INFO,
 			"Expecting a UniqueLink, got %s", tname.c_str());
 	}
+
+	// Derived types have thier own initialization
+	if (UNIQUE_LINK != type) return;
 	init();
 }
 
@@ -88,6 +91,9 @@ UniqueLink::UniqueLink(Link &l)
 		throw InvalidParamException(TRACE_INFO,
 			"Expecting a UniqueLink, got %s", tname.c_str());
 	}
+
+	// Derived types have thier own initialization
+	if (UNIQUE_LINK != type) return;
 	init();
 }
 

--- a/opencog/atoms/core/UniqueLink.cc
+++ b/opencog/atoms/core/UniqueLink.cc
@@ -1,0 +1,102 @@
+/*
+ * UniqueLink.cc
+ *
+ * Copyright (C) 2015 Linas Vepstas
+ *
+ * Author: Linas Vepstas <linasvepstas@gmail.com>  May 2015
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the
+ * exceptions at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/atomspace/ClassServer.h>
+
+#include "UniqueLink.h"
+
+using namespace opencog;
+
+void UniqueLink::init(Type type)
+{
+	// The name must not be used in another definition
+	const Handle& alias = _outgoing[0];
+	IncomingSet defs = alias->getIncomingSetByType(type);
+	for (LinkPtr def : defs)
+	{
+		if (def->getOutgoingAtom(0) == alias)
+		{
+			size_t sz = _outgoing.size();
+			for (size_t i=1; i<sz; i++)
+			{
+				if (def->getOutgoingAtom(i) != _outgoing[i])
+				{
+					throw InvalidParamException(TRACE_INFO,
+					      "Already defined: %s\n",
+					       alias->toString().c_str());
+				}
+			}
+		}
+	}
+}
+
+UniqueLink::UniqueLink(const HandleSeq& oset,
+                       TruthValuePtr tv, AttentionValuePtr av)
+	: Link(UNIQUE_LINK, oset, tv, av)
+{
+	init(UNIQUE_LINK);
+}
+
+UniqueLink::UniqueLink(const Handle& name, const Handle& defn,
+                       TruthValuePtr tv, AttentionValuePtr av)
+	: Link(UNIQUE_LINK, HandleSeq({name, defn}), tv, av)
+{
+	init(UNIQUE_LINK);
+}
+
+UniqueLink::UniqueLink(Link &l)
+	: Link(l)
+{
+	// Type must be as expected
+	Type tscope = l.getType();
+	if (not classserver().isA(tscope, UNIQUE_LINK))
+	{
+		const std::string& tname = classserver().getTypeName(tscope);
+		throw InvalidParamException(TRACE_INFO,
+			"Expecting a UniqueLink, got %s", tname.c_str());
+	}
+	init(tscope);
+}
+
+Handle UniqueLink::get_unique(const Handle& alias, Type type)
+{
+	// Get all UniqueLinks associated with that alias. Be aware that
+	// the incoming set will also include those UniqueLinks which
+	// have the alias in a position other than the first.
+	IncomingSet defs = alias->getIncomingSetByType(type);
+
+	// Return the first (supposedly unique) definition
+	for (LinkPtr defl : defs)
+	{
+		if (defl->getOutgoingAtom(0) == alias)
+			return defl->getHandle();
+	}
+
+	// There is no definition for the alias
+	throw InvalidParamException(TRACE_INFO,
+	                            "Cannot find defined hypergraph for atom %s",
+	                            alias->toString().c_str());
+	return Handle();
+}
+
+/* ===================== END OF FILE ===================== */

--- a/opencog/atoms/core/UniqueLink.cc
+++ b/opencog/atoms/core/UniqueLink.cc
@@ -99,7 +99,7 @@ Handle UniqueLink::get_unique(const Handle& alias, Type type)
 	IncomingSet defs = alias->getIncomingSetByType(type);
 
 	// Return the first (supposedly unique) definition
-	for (LinkPtr defl : defs)
+	for (const LinkPtr& defl : defs)
 	{
 		if (defl->getOutgoingAtom(0) == alias)
 			return defl->getHandle();

--- a/opencog/atoms/core/UniqueLink.cc
+++ b/opencog/atoms/core/UniqueLink.cc
@@ -27,12 +27,12 @@
 
 using namespace opencog;
 
-void UniqueLink::init(Type type)
+void UniqueLink::init()
 {
 	// The name must not be used in another definition
 	const Handle& alias = _outgoing[0];
-	IncomingSet defs = alias->getIncomingSetByType(type);
-	for (LinkPtr def : defs)
+	IncomingSet defs = alias->getIncomingSetByType(_type);
+	for (const LinkPtr& def : defs)
 	{
 		if (def->getOutgoingAtom(0) == alias)
 		{
@@ -50,32 +50,45 @@ void UniqueLink::init(Type type)
 	}
 }
 
+UniqueLink::UniqueLink(Type type, const HandleSeq& oset,
+                       TruthValuePtr tv, AttentionValuePtr av)
+	: Link(type, oset, tv, av)
+{
+	if (not classserver().isA(type, UNIQUE_LINK))
+	{
+		const std::string& tname = classserver().getTypeName(type);
+		throw InvalidParamException(TRACE_INFO,
+			"Expecting a UniqueLink, got %s", tname.c_str());
+	}
+	init();
+}
+
 UniqueLink::UniqueLink(const HandleSeq& oset,
                        TruthValuePtr tv, AttentionValuePtr av)
 	: Link(UNIQUE_LINK, oset, tv, av)
 {
-	init(UNIQUE_LINK);
+	init();
 }
 
 UniqueLink::UniqueLink(const Handle& name, const Handle& defn,
                        TruthValuePtr tv, AttentionValuePtr av)
 	: Link(UNIQUE_LINK, HandleSeq({name, defn}), tv, av)
 {
-	init(UNIQUE_LINK);
+	init();
 }
 
 UniqueLink::UniqueLink(Link &l)
 	: Link(l)
 {
 	// Type must be as expected
-	Type tscope = l.getType();
-	if (not classserver().isA(tscope, UNIQUE_LINK))
+	Type type = l.getType();
+	if (not classserver().isA(type, UNIQUE_LINK))
 	{
-		const std::string& tname = classserver().getTypeName(tscope);
+		const std::string& tname = classserver().getTypeName(type);
 		throw InvalidParamException(TRACE_INFO,
 			"Expecting a UniqueLink, got %s", tname.c_str());
 	}
-	init(tscope);
+	init();
 }
 
 Handle UniqueLink::get_unique(const Handle& alias, Type type)

--- a/opencog/atoms/core/UniqueLink.h
+++ b/opencog/atoms/core/UniqueLink.h
@@ -33,10 +33,12 @@ namespace opencog
  *  @{
  */
 
-/// The UniqueLink is used to force uniqueness of a link, given the
-/// first atom of the outgoing set.  Any attempt to make a different
-/// definition with the same name will throw an error.  Thus, only
-/// ONE UniqueLink with a given first-atom can exist at a time.
+/// The UniqueLink is used to force uniqueness of a link from a given
+/// atom, appearing as the first member of the outgoing set, to the
+/// rest of the outgoing set.  Any attempt to make another UniqueLink
+/// with the same atom in the first outgoing slot will throw an error.
+/// Thus, only ONE UniqueLink with a given first-atom can exist at a
+/// time.
 ///
 /// This class is intended to be the base class for DefineLink, which
 /// is used to name things, and StateLink, which is used to maintain

--- a/opencog/atoms/core/UniqueLink.h
+++ b/opencog/atoms/core/UniqueLink.h
@@ -45,8 +45,12 @@ namespace opencog
 class UniqueLink : public Link
 {
 protected:
-	void init(Type);
+	void init();
 	static Handle get_unique(const Handle&, Type);
+	UniqueLink(Type, const HandleSeq&,
+	           TruthValuePtr tv = TruthValue::DEFAULT_TV(),
+	           AttentionValuePtr av = AttentionValue::DEFAULT_AV());
+
 public:
 	UniqueLink(const HandleSeq&,
 	           TruthValuePtr tv = TruthValue::DEFAULT_TV(),

--- a/opencog/atoms/core/UniqueLink.h
+++ b/opencog/atoms/core/UniqueLink.h
@@ -1,0 +1,76 @@
+/*
+ * opencog/atoms/UniqueLink.h
+ *
+ * Copyright (C) 2015 Linas Vepstas
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef _OPENCOG_UNIQUE_LINK_H
+#define _OPENCOG_UNIQUE_LINK_H
+
+#include <map>
+
+#include <opencog/atomspace/Link.h>
+
+namespace opencog
+{
+/** \addtogroup grp_atomspace
+ *  @{
+ */
+
+/// The UniqueLink is used to force uniqueness of a link, given the
+/// first atom of the outgoing set.  Any attempt to make a different
+/// definition with the same name will throw an error.  Thus, only
+/// ONE UniqueLink with a given first-atom can exist at a time.
+///
+/// This class is intended to be the base class for DefineLink, which
+/// is used to name things, and StateLink, which is used to maintain
+/// current state.
+///
+class UniqueLink : public Link
+{
+protected:
+	void init(Type);
+	static Handle get_unique(const Handle&, Type);
+public:
+	UniqueLink(const HandleSeq&,
+	           TruthValuePtr tv = TruthValue::DEFAULT_TV(),
+	           AttentionValuePtr av = AttentionValue::DEFAULT_AV());
+
+	UniqueLink(const Handle& alias, const Handle& body,
+	           TruthValuePtr tv = TruthValue::DEFAULT_TV(),
+	           AttentionValuePtr av = AttentionValue::DEFAULT_AV());
+
+	UniqueLink(Link &l);
+
+	Handle get_alias(void) const { return _outgoing[0]; }
+};
+
+typedef std::shared_ptr<UniqueLink> UniqueLinkPtr;
+static inline UniqueLinkPtr UniqueLinkCast(const Handle& h)
+	{ AtomPtr a(h); return std::dynamic_pointer_cast<UniqueLink>(a); }
+static inline UniqueLinkPtr UniqueLinkCast(AtomPtr a)
+	{ return std::dynamic_pointer_cast<UniqueLink>(a); }
+
+// XXX temporary hack ...
+#define createUniqueLink std::make_shared<UniqueLink>
+
+/** @}*/
+}
+
+#endif // _OPENCOG_UNIQUE_LINK_H

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -330,13 +330,14 @@ AtomPtr AtomTable::do_factory(Type atom_type, AtomPtr atom)
         try {
             delp = createDeleteLink(*LinkCast(atom));
         }
-        catch(...) {
+        catch (...) {
             LinkPtr lp(LinkCast(atom));
             for (Handle ho : lp->getOutgoingSet()) {
                 this->extract(ho);
             }
             return Handle();
         }
+        return delp;
     }
     return atom;
 }

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -45,6 +45,8 @@
 #include <opencog/atoms/core/FunctionLink.h>
 #include <opencog/atoms/core/LambdaLink.h>
 #include <opencog/atoms/core/PutLink.h>
+#include <opencog/atoms/core/StateLink.h>
+#include <opencog/atoms/core/UniqueLink.h>
 #include <opencog/atoms/core/VariableList.h>
 #include <opencog/atoms/execution/EvaluationLink.h>
 #include <opencog/atoms/execution/ExecutionOutputLink.h>
@@ -297,12 +299,18 @@ AtomPtr do_factory(Type atom_type, AtomPtr atom)
     } else if (SATISFACTION_LINK == atom_type) {
         if (NULL == PatternLinkCast(atom))
             return createPatternLink(*LinkCast(atom));
-    } else if (LAMBDA_LINK == atom_type) {
-        if (NULL == LambdaLinkCast(atom))
-            return createLambdaLink(*LinkCast(atom));
+    } else if (STATE_LINK == atom_type) {
+        if (NULL == StateLinkCast(atom))
+            return createStateLink(*LinkCast(atom));
+    } else if (UNIQUE_LINK == atom_type) {
+        if (NULL == UniqueLinkCast(atom))
+            return createUniqueLink(*LinkCast(atom));
     } else if (VARIABLE_LIST == atom_type) {
         if (NULL == VariableListCast(atom))
             return createVariableList(*LinkCast(atom));
+    } else if (LAMBDA_LINK == atom_type) {
+        if (NULL == LambdaLinkCast(atom))
+            return createLambdaLink(*LinkCast(atom));
     } else if (classserver().isA(atom_type, FUNCTION_LINK)) {
 /* More circular-dependency heart-ache
         if (NULL == FunctionLinkCast(atom))
@@ -348,10 +356,14 @@ static AtomPtr do_clone_factory(Type atom_type, AtomPtr atom)
         return createPutLink(*LinkCast(atom));
     if (SATISFACTION_LINK == atom_type)
         return createPatternLink(*LinkCast(atom));
-    if (LAMBDA_LINK == atom_type)
-        return createLambdaLink(*LinkCast(atom));
+    if (STATE_LINK == atom_type)
+        return createStateLink(*LinkCast(atom));
+    if (UNIQUE_LINK == atom_type)
+        return createUniqueLink(*LinkCast(atom));
     if (VARIABLE_LIST == atom_type)
         return createVariableList(*LinkCast(atom));
+    if (LAMBDA_LINK == atom_type)
+        return createLambdaLink(*LinkCast(atom));
     if (classserver().isA(atom_type, FUNCTION_LINK))
         // XXX FIXME more circular-dependency heart-ache
         // return FunctionLink::factory(LinkCast(atom));

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -423,17 +423,6 @@ Handle AtomTable::add(AtomPtr atom, bool async)
     if (inEnviron(atom))
         return atom->getHandle();
 
-#if LATER
-    // XXX FIXME -- technically, this throw is correct, except
-    // that SavingLoading gives us atoms with handles preset.
-    // So we have to accept that, and hope its correct and consistent.
-    // XXX this can also occur if the atom is in some other atomspace;
-    // so we need to move this check elsewhere.
-    if (atom->_uuid != Handle::INVALID_UUID)
-        throw RuntimeException(TRACE_INFO,
-          "AtomTable - Attempting to insert atom with handle already set!");
-#endif
-
     // Lock before checking to see if this kind of atom can already
     // be found in the atomspace.  We need to lock here, to avoid two
     // different threads from trying to add exactly the same atom.

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -300,9 +300,6 @@ AtomPtr AtomTable::do_factory(Type atom_type, AtomPtr atom)
     } else if (SATISFACTION_LINK == atom_type) {
         if (NULL == PatternLinkCast(atom))
             return createPatternLink(*LinkCast(atom));
-    } else if (STATE_LINK == atom_type) {
-        if (NULL == StateLinkCast(atom))
-            return createStateLink(*LinkCast(atom));
     } else if (UNIQUE_LINK == atom_type) {
         if (NULL == UniqueLinkCast(atom))
             return createUniqueLink(*LinkCast(atom));
@@ -317,9 +314,10 @@ AtomPtr AtomTable::do_factory(Type atom_type, AtomPtr atom)
         if (NULL == FunctionLinkCast(atom))
             return FunctionLink::factory(LinkCast(atom));
 */
+    }
 
     // Very special handling for DeleteLink's
-    } else if (DELETE_LINK == atom_type) {
+    else if (DELETE_LINK == atom_type) {
         DeleteLinkPtr delp(DeleteLinkCast(atom));
         // If it can be cast, then its not an open term.
         if (nullptr != delp)
@@ -338,6 +336,21 @@ AtomPtr AtomTable::do_factory(Type atom_type, AtomPtr atom)
             return Handle();
         }
         return delp;
+    }
+
+    // Very special handling for StateLink's
+    else if (STATE_LINK == atom_type) {
+        StateLinkPtr slp(StateLinkCast(atom));
+        if (NULL == slp)
+            slp = createStateLink(*LinkCast(atom));
+
+        // Compare to the current state
+        Handle old_state(slp->get_other());
+        while (nullptr != old_state) {
+            this->extract(old_state);
+            old_state = slp->get_other();
+        }
+        return slp;
     }
     return atom;
 }

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -456,6 +456,7 @@ Handle AtomTable::add(AtomPtr atom, bool async)
         return atom->getHandle();
 
     // Factory implements experimental C++ atom types support code
+    AtomPtr orig(atom);
     Type atom_type = atom->getType();
     atom = factory(atom_type, atom);
 
@@ -492,9 +493,14 @@ Handle AtomTable::add(AtomPtr atom, bool async)
         atom = createLink(atom_type, closet,
                           atom->getTruthValue(),
                           atom->getAttentionValue());
+        atom = clone_factory(atom_type, atom);
         atom->_uuid = save;
     }
-    atom = clone_factory(atom_type, atom);
+
+    // Clone, if we haven't done so already. We MUST maintain our own
+    // private copy of the atom, else crazy things go wrong.
+    if (atom == orig)
+        atom = clone_factory(atom_type, atom);
 
     // Sometimes one inserts an atom that was previously deleted.
     // In this case, the removal flag might still be set. Clear it.

--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -188,8 +188,9 @@ public:
     Handle getHandle(const AtomPtr&) const;
     Handle getHandle(UUID) const;
 
-    static AtomPtr factory(Type atom_type, AtomPtr atom);
-    static AtomPtr clone_factory(Type, AtomPtr);
+    AtomPtr do_factory(Type atom_type, AtomPtr atom);
+    AtomPtr factory(Type atom_type, AtomPtr atom);
+    AtomPtr clone_factory(Type, AtomPtr);
 
 public:
     /**

--- a/opencog/atomspace/atom_types.script
+++ b/opencog/atomspace/atom_types.script
@@ -115,8 +115,17 @@ VARIABLE_LIST <- LIST_LINK
 // restrictions on the variables.
 LAMBDA_LINK <- ORDERED_LINK
 
-// Naming things, tagging things.
-DEFINE_LINK <- ORDERED_LINK
+// Only one UniqueLink may exist (in the atomspace) for a fixed
+// first atom of the link.  Useful for defining state.
+UNIQUE_LINK <- ORDERED_LINK
+
+// Inserting a StateLink into the atomspace causes the previous
+// state to be removed from the atomspace.
+STATE_LINK <- UNIQUE_LINK
+
+// Uniquely naming things, tagging things. Attempting to insert a
+// second definition into the atomspace will throw an exception.
+DEFINE_LINK <- UNIQUE_LINK
 
 // Pattern definition, pattern grounding/satisfaction.
 // The PatternLink implements the base class holding a pattern that

--- a/tests/atoms/CMakeLists.txt
+++ b/tests/atoms/CMakeLists.txt
@@ -17,3 +17,6 @@ TARGET_LINK_LIBRARIES(DeleteLinkUTest execution atomspace)
 
 ADD_CXXTEST(PutLinkUTest)
 TARGET_LINK_LIBRARIES(PutLinkUTest execution atomspace)
+
+ADD_CXXTEST(StateLinkUTest)
+TARGET_LINK_LIBRARIES(StateLinkUTest atomspace)

--- a/tests/atoms/DeleteLinkUTest.cxxtest
+++ b/tests/atoms/DeleteLinkUTest.cxxtest
@@ -45,11 +45,23 @@ public:
 
 	void tearDown() {}
 
+	void test_throws();
 	void test_free_delete();
 };
 
 #define N _as.add_node
 #define L _as.add_link
+
+// Attempting to create a full grounded DeleteLink should throw.
+// The AtomTable code depnds on this working correctly.
+void DeleteLinkUTest::test_throws()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+	TS_ASSERT_THROWS(
+		L(DELETE_LINK, N(CONCEPT_NODE, "apple")),
+		opencog::RuntimeException);
+	logger().info("END TEST: %s", __FUNCTION__);
+}
 
 // Test to make sure that DeleteLink is a FreeLink, i.e. does not
 // bind any of its variables. See bug #333 for the original report.

--- a/tests/atoms/DeleteLinkUTest.cxxtest
+++ b/tests/atoms/DeleteLinkUTest.cxxtest
@@ -58,8 +58,12 @@ void DeleteLinkUTest::test_throws()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 	TS_ASSERT_THROWS(
-		L(DELETE_LINK, N(CONCEPT_NODE, "apple")),
-		opencog::RuntimeException);
+		createDeleteLink(HandleSeq({N(CONCEPT_NODE, "apple")})),
+		opencog::InvalidParamException);
+
+	Handle added = L(DELETE_LINK, N(CONCEPT_NODE, "apple"));
+	TS_ASSERT_EQUALS(added, Handle::UNDEFINED);
+
 	logger().info("END TEST: %s", __FUNCTION__);
 }
 

--- a/tests/atoms/StateLinkUTest.cxxtest
+++ b/tests/atoms/StateLinkUTest.cxxtest
@@ -1,0 +1,129 @@
+/*
+ * tests/atomspace/StateUTest.cxxtest
+ *
+ * Copyright (C) 2015 Linas Vepstas
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/atomspace/Atom.h>
+#include <opencog/atomspace/AtomSpace.h>
+#include <opencog/atoms/core/StateLink.h>
+
+using namespace opencog;
+
+// Test the StateLink.
+//
+class StateLinkUTest :  public CxxTest::TestSuite
+{
+private:
+	AtomSpace _as;
+
+public:
+	StateLinkUTest()
+	{
+		logger().setPrintToStdoutFlag(true);
+	}
+
+	void setUp() {}
+
+	void tearDown() {}
+
+	void test_setting();
+};
+
+#define N _as.add_node
+#define L _as.add_link
+
+// Test to make sure that there is only ever one StateLink.
+void StateLinkUTest::test_setting()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Set the state to apple.
+	Handle fruit, apple, bananna;
+	LinkPtr link = LinkCast(
+		L(STATE_LINK,
+			fruit = N(ANCHOR_NODE, "fruit"),
+			apple = N(CONCEPT_NODE, "apple")));
+
+	bananna = N(CONCEPT_NODE, "bananna");
+
+	// The incoming set should be simple.
+	TS_ASSERT_EQUALS(1, fruit->getIncomingSetSize());
+	TS_ASSERT_EQUALS(1, apple->getIncomingSetSize());
+	TS_ASSERT_EQUALS(0, bananna->getIncomingSetSize());
+	TS_ASSERT_EQUALS(fruit, link->getOutgoingAtom(0));
+	TS_ASSERT_EQUALS(apple, link->getOutgoingAtom(1));
+
+	// Change the state to bananna
+	link = LinkCast(
+		L(STATE_LINK,
+			N(ANCHOR_NODE, "fruit"),
+			N(CONCEPT_NODE, "bananna")));
+
+	// The incoming set should be simple.
+	TS_ASSERT_EQUALS(1, fruit->getIncomingSetSize());
+	TS_ASSERT_EQUALS(0, apple->getIncomingSetSize());
+	TS_ASSERT_EQUALS(1, bananna->getIncomingSetSize());
+	TS_ASSERT_EQUALS(fruit, link->getOutgoingAtom(0));
+	TS_ASSERT_EQUALS(bananna, link->getOutgoingAtom(1));
+
+
+	// Change the state back to apple.
+	link = LinkCast(
+		L(STATE_LINK,
+			N(ANCHOR_NODE, "fruit"),
+			N(CONCEPT_NODE, "apple")));
+
+	// The incoming set should be simple.
+	TS_ASSERT_EQUALS(1, fruit->getIncomingSetSize());
+	TS_ASSERT_EQUALS(1, apple->getIncomingSetSize());
+	TS_ASSERT_EQUALS(0, bananna->getIncomingSetSize());
+	TS_ASSERT_EQUALS(fruit, link->getOutgoingAtom(0));
+	TS_ASSERT_EQUALS(apple, link->getOutgoingAtom(1));
+
+	// Change the state to back to bananna, again
+	link = LinkCast(
+		L(STATE_LINK,
+			N(ANCHOR_NODE, "fruit"),
+			N(CONCEPT_NODE, "bananna")));
+
+	// The incoming set should be simple.
+	TS_ASSERT_EQUALS(1, fruit->getIncomingSetSize());
+	TS_ASSERT_EQUALS(0, apple->getIncomingSetSize());
+	TS_ASSERT_EQUALS(1, bananna->getIncomingSetSize());
+	TS_ASSERT_EQUALS(fruit, link->getOutgoingAtom(0));
+	TS_ASSERT_EQUALS(bananna, link->getOutgoingAtom(1));
+
+
+	// Change the state back to apple, again
+	link = LinkCast(
+		L(STATE_LINK,
+			N(ANCHOR_NODE, "fruit"),
+			N(CONCEPT_NODE, "apple")));
+
+	// The incoming set should be simple.
+	TS_ASSERT_EQUALS(1, fruit->getIncomingSetSize());
+	TS_ASSERT_EQUALS(1, apple->getIncomingSetSize());
+	TS_ASSERT_EQUALS(0, bananna->getIncomingSetSize());
+	TS_ASSERT_EQUALS(fruit, link->getOutgoingAtom(0));
+	TS_ASSERT_EQUALS(apple, link->getOutgoingAtom(1));
+
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}


### PR DESCRIPTION
Add two new link types, closely related to DefineLink:

First, UniqueLink serves as a base class

StateLink is like DefineLink in that only one can ever exist at a time; however, creatig a new StateLink always deletes the old one, whereas DefineLink always throws.