### PR TITLE
Support scm logger format

### DIFF
--- a/examples/guile/logger-example.scm
+++ b/examples/guile/logger-example.scm
@@ -30,3 +30,10 @@
 ; I'd like to have the stack trace on top of the log message, the
 ; error level provides that
 (cog-logger-error "First error message (comes with the stack trace)")
+
+; The logger supports scheme format (see
+; https://www.gnu.org/software/guile/manual/html_node/Formatted-Output.html
+; for more information), that way you can easily log messages about
+; atoms or any object.
+(define A (ConceptNode "A"))
+(cog-logger-info "My concept ~a" A)

--- a/opencog/guile/LoggerSCM.cc
+++ b/opencog/guile/LoggerSCM.cc
@@ -38,11 +38,11 @@ void LoggerSCM::init(void)
 	new FunctionWrap(do_logger_set_filename, "cog-logger-set-filename", "logger");
 	new FunctionWrap(do_logger_get_filename, "cog-logger-get-filename", "logger");
 	new FunctionWrap(do_logger_set_stdout, "cog-logger-set-stdout", "logger");
-	new FunctionWrap(do_logger_error, "cog-logger-error", "logger");
-	new FunctionWrap(do_logger_warn, "cog-logger-warn", "logger");
-	new FunctionWrap(do_logger_info, "cog-logger-info", "logger");
-	new FunctionWrap(do_logger_debug, "cog-logger-debug", "logger");
-	new FunctionWrap(do_logger_fine, "cog-logger-fine", "logger");
+	new FunctionWrap(do_logger_error, "cog-logger-error-str", "logger");
+	new FunctionWrap(do_logger_warn, "cog-logger-warn-str", "logger");
+	new FunctionWrap(do_logger_info, "cog-logger-info-str", "logger");
+	new FunctionWrap(do_logger_debug, "cog-logger-debug-str", "logger");
+	new FunctionWrap(do_logger_fine, "cog-logger-fine-str", "logger");
 }
 
 namespace opencog {

--- a/opencog/scm/CMakeLists.txt
+++ b/opencog/scm/CMakeLists.txt
@@ -13,6 +13,7 @@ INSTALL (FILES
 	repl-shell.scm
 	utilities.scm
 	rule-engine-utils.scm
+	logger-utils.scm
 	DESTINATION "${DATADIR}/scm"
 )
 

--- a/opencog/scm/logger-utils.scm
+++ b/opencog/scm/logger-utils.scm
@@ -1,0 +1,35 @@
+;
+; logger-utils.scm
+;
+;;; Commentary:
+;
+; Helper to use ice-9 format in logger functions
+;
+;;; Code:
+; Copyright (c) 2015, OpenCog Foundation
+;
+
+(use-modules (opencog))
+(use-modules (ice-9 format))
+
+(define (cog-logger-error msg . args)
+  (cog-logger-error-str (apply format #f msg args)))
+
+(define (cog-logger-warn msg . args)
+  (cog-logger-warn-str (apply format #f msg args)))
+
+(define (cog-logger-info msg . args)
+  (cog-logger-info-str (apply format #f msg args)))
+
+(define (cog-logger-debug msg . args)
+  (cog-logger-debug-str (apply format #f msg args)))
+
+(define (cog-logger-fine msg . args)
+  (cog-logger-fine-str (apply format #f msg args)))
+
+(define (export-logger-utils)
+  (export cog-logger-error
+          cog-logger-warn
+          cog-logger-info
+          cog-logger-debug
+          cog-logger-fine))

--- a/opencog/scm/opencog/logger.scm
+++ b/opencog/scm/opencog/logger.scm
@@ -5,3 +5,7 @@
 (define-module (opencog logger))
 
 (load-extension "libsmob" "opencog_logger_init")
+
+(load-from-path "logger-utils.scm")
+(export-logger-utils)
+

--- a/opencog/scm/rule-engine-utils.scm
+++ b/opencog/scm/rule-engine-utils.scm
@@ -86,4 +86,8 @@
      rbs)
 )
 
-(define (export-rule-engine-utils) (export ure-add-rules ure-set-num-parameter ure-set-fuzzy-bool-parameter export-rule-engine-utils))
+(define (export-rule-engine-utils)
+  (export ure-add-rules
+          ure-set-num-parameter
+          ure-set-fuzzy-bool-parameter
+          export-rule-engine-utils))


### PR DESCRIPTION
The logger scheme binding now supports scheme string formatting which allows to log things like:
```scheme
(cog-logger-info "My concept ~a" (ConceptNode "A"))
```
See http://wiki.opencog.org/wikihome/index.php/Scheme#Logger
