### PR TITLE
PM: explore only the current atomspace

### DIFF
--- a/opencog/atomspace/Atom.cc
+++ b/opencog/atomspace/Atom.cc
@@ -36,6 +36,7 @@
 #include <opencog/util/platform.h>
 
 #include <opencog/atomspace/Atom.h>
+#include <opencog/atomspace/AtomSpace.h>
 #include <opencog/atomspace/AtomTable.h>
 #include <opencog/atomspace/ClassServer.h>
 #include <opencog/atomspace/Link.h>
@@ -318,10 +319,24 @@ size_t Atom::getIncomingSetSize()
 // is not thread-safe during reading while simultaneous insertion and
 // deletion.  Besides, the incoming set is weak; we have to make it
 // strong in order to hand it out.
-IncomingSet Atom::getIncomingSet()
+IncomingSet Atom::getIncomingSet(AtomSpace* as)
 {
     static IncomingSet empty_set;
     if (NULL == _incoming_set) return empty_set;
+
+    if (as) {
+        const AtomTable *atab = &as->get_atomtable();
+        // Prevent update of set while a copy is being made.
+        std::lock_guard<std::mutex> lck (_mtx);
+        IncomingSet iset;
+        for (WinkPtr w : _incoming_set->_iset)
+        {
+            LinkPtr l(w.lock());
+            if (l and atab->in_environ(l))
+					iset.emplace_back(l);
+        }
+        return iset;
+    }
 
     // Prevent update of set while a copy is being made.
     std::lock_guard<std::mutex> lck (_mtx);

--- a/opencog/atomspace/Atom.h
+++ b/opencog/atomspace/Atom.h
@@ -50,6 +50,8 @@ namespace opencog
  *  @{
  */
 
+class AtomSpace;
+
 class Link;
 typedef std::shared_ptr<Link> LinkPtr;
 typedef std::vector<LinkPtr> IncomingSet; // use vector; see below.
@@ -78,7 +80,6 @@ class Atom
     friend class AtomSpace;       // Needs to call getAtomTable()
     friend class ImportanceIndex; // Needs to call setFlag()
     friend class Handle;          // Needs to view _uuid
-    friend class SavingLoading;   // Needs to set _uuid
     friend class TLB;             // Needs to view _uuid
     friend class CreateLink;      // Needs to call getAtomTable();
     friend class DeleteLink;      // Needs to call getAtomTable();
@@ -296,10 +297,15 @@ public:
     size_t getIncomingSetSize();
 
     //! Return the incoming set of this atom.
-    //! The resulting incoming set consists of strong pointers,
-    //! that is, to valid, non-null handles that were part of the
-    //! incoming set at the time this call was made.
-    IncomingSet getIncomingSet();
+    //! If the AtomSpace pointer is non-null, then only those atoms
+    //! that belonged to that atomspace at the time this call was made
+    //! are returned. Otherwise, the entire incoming set is returned.
+    //!
+    //! This call is thread-safe again simultaneous deletion of atoms.
+    //! That is, this call returns the incoming set as it was att the
+    //! time of the call; any deletions that occur afterwards (possibly
+    //! in other threads) will not be reflected in the returned set.
+    IncomingSet getIncomingSet(AtomSpace* = NULL);
 
     //! Place incoming set into STL container of Handles.
     //! Example usage:

--- a/opencog/atomspace/AtomSpace.cc
+++ b/opencog/atomspace/AtomSpace.cc
@@ -351,24 +351,6 @@ Handle AtomSpace::fetch_atom(UUID uuid)
     return atomTable.add(a, false);
 }
 
-Handle AtomSpace::get_atom(Handle h)
-{
-    Handle he(atomTable.getHandle(h));
-    if (he) return he;
-    if (backing_store)
-        return fetch_atom(h);
-    return Handle::UNDEFINED;
-}
-
-Handle AtomSpace::get_atom(UUID uuid)
-{
-    Handle he(atomTable.getHandle(uuid));
-    if (he) return he;
-    if (backing_store)
-        return fetch_atom(uuid);
-    return Handle::UNDEFINED;
-}
-
 Handle AtomSpace::fetch_incoming_set(Handle h, bool recursive)
 {
     if (NULL == backing_store)

--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -208,12 +208,11 @@ public:
     Handle fetch_atom(UUID);
 
     /**
-     * Get an atom from the AtomTable. If not found there, get it from
-     * the backingstore (and add it to the AtomTable).  If the atom is
-     * not found in either place, return Handle::UNDEFINED.
+     * Get an atom from the AtomTable. If the atom is not there, then
+     * return Handle::UNDEFINED.
      */
-    Handle get_atom(Handle);
-    Handle get_atom(UUID);
+    Handle get_atom(const Handle& h) { return atomTable.getHandle(h); }
+    Handle get_atom(UUID uuid) { return atomTable.getHandle(uuid); }
 
     /**
      * Load *all* atoms of the given type, but only if they are not

--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -53,7 +53,7 @@ namespace opencog
  */
 class AtomSpace
 {
-    friend class SavingLoading;
+    friend class Atom;               // Needs to call get_atomtable()
     friend class SQLPersistSCM;
     friend class ZMQPersistSCM;
     friend class ::AtomTableUTest;

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -188,13 +188,8 @@ Handle AtomTable::getHandle(Type t, const HandleSeq &seq) const
 /// is the bad handle.
 Handle AtomTable::getHandle(const AtomPtr& a) const
 {
-    const AtomTable *env = this;
-    if (a->_atomTable) {
-        do {
-            if (a->_atomTable == env) return a->getHandle();
-            env = env->_environ;
-        } while (env);
-    }
+    if (inEnviron(a))
+        return a->getHandle();
 
     NodePtr nnn(NodeCast(a));
     if (nnn)

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -160,20 +160,6 @@ Handle AtomTable::getHandle(Type t, std::string name) const
     return Handle::UNDEFINED;
 }
 
-/// Find an equivalent atom that has exactly the same name and type.
-/// That is, if there is an atom with this name and type already in
-/// the table, then return that; else return undefined.
-Handle AtomTable::getHandle(const NodePtr& n) const
-{
-    const AtomTable *env = this;
-    do {
-        if (n->_atomTable == env) return Handle(n);
-        env = env->_environ;
-    } while (env);
-
-    return getHandle(n->getType(), n->getName());
-}
-
 Handle AtomTable::getHandle(Type t, const HandleSeq &seq) const
 {
     // Make sure all the atoms in the outgoing set are resolved :-)
@@ -197,34 +183,26 @@ Handle AtomTable::getHandle(Type t, const HandleSeq &seq) const
     return h;
 }
 
-/// Find an equivalent atom that has exactly the same type and outgoing
-/// set.  That is, if there is an atom with this ype and outset already
-/// in the table, then return that; else return undefined.
-Handle AtomTable::getHandle(const LinkPtr& l) const
-{
-    const AtomTable *env = this;
-    if (l->_atomTable) {
-        do {
-            if (l->_atomTable == env) return Handle(l);
-            env = env->_environ;
-        } while (env);
-    }
-
-    return getHandle(l->getType(), l->getOutgoingSet());
-}
-
 /// Find an equivalent atom that is exactly the same as the arg. If
 /// such an atom is in the table, it is returned, else the return
 /// is the bad handle.
 Handle AtomTable::getHandle(const AtomPtr& a) const
 {
+    const AtomTable *env = this;
+    if (a->_atomTable) {
+        do {
+            if (a->_atomTable == env) return a->getHandle();
+            env = env->_environ;
+        } while (env);
+    }
+
     NodePtr nnn(NodeCast(a));
     if (nnn)
-         return getHandle(nnn);
+        return getHandle(nnn->getType(), nnn->getName());
     else {
         LinkPtr lll(LinkCast(a));
         if (lll)
-            return getHandle(lll);
+            return getHandle(lll->getType(), lll->getOutgoingSet());
     }
     return Handle::UNDEFINED;
 }

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -218,6 +218,7 @@ Handle AtomTable::getHandle(UUID uuid) const
 /// environment for this atomtable.
 bool AtomTable::in_environ(const AtomPtr& atom) const
 {
+    if (nullptr == atom) return false;
     AtomTable* atab = atom->getAtomTable();
     const AtomTable* env = this;
     while (env) {

--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -75,7 +75,6 @@ class AtomSpace;
  */
 class AtomTable
 {
-    friend class SavingLoading;
     friend class ::AtomTableUTest;
 
 private:
@@ -140,7 +139,6 @@ private:
     /// operation. Viz, other computers on the network may have a copy
     /// of this atomtable, and so need to have its UUID to sync up.
     AtomTable* _environ;
-    bool inEnviron(AtomPtr);
     UUID _uuid;
 
     // The AtomSpace that is holding us (if any). Needed for DeleteLink operation
@@ -162,6 +160,12 @@ public:
     UUID get_uuid(void) const { return _uuid; }
     AtomTable* get_environ(void) const { return _environ; }
     AtomSpace* getAtomSpace(void) const { return _as; }
+
+    /**
+     * Return true if the atom is in this atomtable, or if it is
+     * in the environment of this atomspace.
+     */
+    bool in_environ(const AtomPtr&) const;
 
     /**
      * Return the number of atoms contained in a table.

--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -181,10 +181,7 @@ public:
      * @return The handle of the desired atom if found.
      */
     Handle getHandle(Type, std::string) const;
-    Handle getHandle(const NodePtr&) const;
-
     Handle getHandle(Type, const HandleSeq&) const;
-    Handle getHandle(const LinkPtr&) const;
     Handle getHandle(const AtomPtr&) const;
     Handle getHandle(UUID) const;
 

--- a/opencog/atomspace/TruthValue.h
+++ b/opencog/atomspace/TruthValue.h
@@ -88,7 +88,6 @@ typedef std::shared_ptr<TruthValue> TruthValuePtr;
 class TruthValue
     : public std::enable_shared_from_this<TruthValue>
 {
-    friend class SavingLoading;
     friend class Atom;
 
     // the TruthValueUTest class needs to access private members from the

--- a/opencog/query/DefaultPatternMatchCB.cc
+++ b/opencog/query/DefaultPatternMatchCB.cc
@@ -248,6 +248,13 @@ bool DefaultPatternMatchCB::optional_clause_match(const Handle& ptrn,
 
 /* ======================================================== */
 
+IncomingSet DefaultPatternMatchCB::get_incoming_set(const Handle& h)
+{
+	return h->getIncomingSet(_as);
+}
+
+/* ======================================================== */
+
 bool DefaultPatternMatchCB::eval_term(const Handle& virt,
                                       const std::map<Handle, Handle>& gnds)
 {

--- a/opencog/query/DefaultPatternMatchCB.h
+++ b/opencog/query/DefaultPatternMatchCB.h
@@ -69,6 +69,8 @@ class DefaultPatternMatchCB : public virtual PatternMatchCallback
 		virtual bool optional_clause_match(const Handle& pattrn,
 		                                   const Handle& grnd);
 
+		virtual IncomingSet get_incoming_set(const Handle&);
+
 		/**
 		 * Called when a virtual link is encountered. Returns false
 		 * to reject the match.

--- a/opencog/scm/utilities.scm
+++ b/opencog/scm/utilities.scm
@@ -999,7 +999,11 @@
 		(throw 'badpop "More pops than pushes!"))
 	(cog-set-atomspace! (car cog-atomspace-stack))
 	(set! cog-atomspace-stack (cdr cog-atomspace-stack))
-	(gc) (gc) (gc)) ; MUST GC OR ELSE DELETED ATOMSPACE STICKS AROUND!!
+	; Performing a gc here helps ensure that the removed atomspace
+	; is deleted, thus cleaning up incoming sets of many atoms.
+	; The pattern matcher will work correctly without this cleanup,
+	; but I think it helps. Do it twice; once is sometimes not enough.
+	(gc) (gc))
 
 ; ---------------------------------------------------------------------
 


### PR DESCRIPTION
During the pattern match, explore only the current atomspace (or it's parents) this requires that the atomspace be checked when getting the incoming set.