### PR TITLE
Allow constant terms in the default pattern matcher

### DIFF
--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -958,12 +958,6 @@ bool PatternMatchEngine::explore_link_branches(const PatternTermPtr& ptm,
                                                const Handle& clause_root)
 {
 	const Handle& hp = ptm->getHandle();
-	// Let's not stare at our own navel. ... Unless the current
-	// clause has GroundedPredicateNodes in it. In that case, we
-	// have to make sure that they get evaluated.
-	if ((hg == clause_root)
-	    and not is_evaluatable(clause_root))
-		return false;
 
 	// If its not an unordered link, then don't try to iterate over
 	// all permutations.

--- a/tests/query/ArcanaUTest.cxxtest
+++ b/tests/query/ArcanaUTest.cxxtest
@@ -59,6 +59,7 @@ public:
     void tearDown(void);
 
     void test_repeats(void);
+    void test_const(void);
 };
 
 void ArcanaUTest::tearDown(void)
@@ -123,4 +124,33 @@ void ArcanaUTest::test_repeats(void)
     Handle once = eval->eval_h("(cog-bind (repeat-once))");
     printf("once, num solutions=%d\n", as->get_arity(once));
     TS_ASSERT_EQUALS(1, as->get_arity(once));
+
+    // ----
+    logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+/*
+ * Miscellaneous Arcana
+ * This one allows constant terms to trigger a match.
+ */
+void ArcanaUTest::test_const(void)
+{
+    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+    config().set("SCM_PRELOAD", "tests/query/arcana-const.scm");
+    load_scm_files_from_config(*as);
+
+    Handle marconi = eval->eval_h("marconi");
+
+    Handle answer = eval->eval_h("(cog-bind who)");
+    printf("radio=%s\n", answer->toString().c_str());
+
+    TS_ASSERT_EQUALS(1, as->get_arity(answer));
+    LinkPtr lp = LinkCast(answer);
+    answer = lp->getOutgoingAtom(0);
+
+    TS_ASSERT_EQUALS(marconi, answer);
+
+    // ----
+    logger().debug("END TEST: %s", __FUNCTION__);
 }

--- a/tests/query/ArcanaUTest.cxxtest
+++ b/tests/query/ArcanaUTest.cxxtest
@@ -140,6 +140,7 @@ void ArcanaUTest::test_const(void)
     config().set("SCM_PRELOAD", "tests/query/arcana-const.scm");
     load_scm_files_from_config(*as);
 
+    // ----
     Handle marconi = eval->eval_h("marconi");
 
     Handle answer = eval->eval_h("(cog-bind who)");
@@ -147,9 +148,17 @@ void ArcanaUTest::test_const(void)
 
     TS_ASSERT_EQUALS(1, as->get_arity(answer));
     LinkPtr lp = LinkCast(answer);
-    answer = lp->getOutgoingAtom(0);
+    Handle devel = lp->getOutgoingAtom(0);
 
-    TS_ASSERT_EQUALS(marconi, answer);
+    TS_ASSERT_EQUALS(marconi, devel);
+
+    // ----
+    // Test DefinedSchemaNode as an answer.
+    Handle defans = eval->eval_h("(cog-bind whodfn)");
+    printf("defined radio=%s\n", defans->toString().c_str());
+
+    TS_ASSERT_EQUALS(1, as->get_arity(defans));
+    TS_ASSERT_EQUALS(defans, answer);
 
     // ----
     logger().debug("END TEST: %s", __FUNCTION__);

--- a/tests/query/arcana-const.scm
+++ b/tests/query/arcana-const.scm
@@ -1,0 +1,22 @@
+;
+; Unit testing for a constant pattern
+;
+(use-modules (opencog))
+(use-modules (opencog query))
+
+(define marconi
+	(ListLink
+		(ConceptNode "Marconi")
+		(ConceptNode "developed")
+		(ConceptNode "the")
+		(ConceptNode "first")
+		(ConceptNode "practical")
+		(ConceptNode "wireless.")))
+
+(define who
+	(BindLink
+		(ListLink
+			(ConceptNode "WHO")
+			(ConceptNode "INVENTED")
+			(ConceptNode "RADIO"))
+		marconi))

--- a/tests/query/arcana-const.scm
+++ b/tests/query/arcana-const.scm
@@ -13,6 +13,7 @@
 		(ConceptNode "practical")
 		(ConceptNode "wireless.")))
 
+; A query with no variables in it.
 (define who
 	(BindLink
 		(ListLink
@@ -20,3 +21,14 @@
 			(ConceptNode "INVENTED")
 			(ConceptNode "RADIO"))
 		marconi))
+
+(DefineLink (DefinedSchemaNode "Marco did") marconi)
+
+; Same query as above, but with the answer wrapped up in a define.
+(define whodfn
+	(BindLink
+		(ListLink
+			(ConceptNode "WHO")
+			(ConceptNode "INVENTED")
+			(ConceptNode "RADIO"))
+		(DefinedSchemaNode "Marco did")))


### PR DESCRIPTION
Turns out this can be a useful feature... e.g. for the AIML work.