### PR TITLE
Get a rule by its handle

### DIFF
--- a/opencog/rule-engine/UREConfigReader.cc
+++ b/opencog/rule-engine/UREConfigReader.cc
@@ -60,6 +60,16 @@ std::vector<Rule>& UREConfigReader::get_rules()
 	return _rbparams.rules;
 }
 
+const Rule& UREConfigReader::get_rule(const Handle& hblink)
+{
+    if (hblink->getType() != BIND_LINK) {
+        throw InvalidParamException(TRACE_INFO,
+                                    "UREConfigReader - Expected a BindLink.");
+    }
+
+    return _rbparams.get_rule(hblink);
+}
+
 bool UREConfigReader::get_attention_allocation() const
 {
 	return _rbparams.attention_alloc;

--- a/opencog/rule-engine/UREConfigReader.h
+++ b/opencog/rule-engine/UREConfigReader.h
@@ -85,8 +85,7 @@ private:
 
 	AtomSpace& _as;
 
-	class RuleBaseParameters {
-	public:
+	struct RuleBaseParameters {
 		std::vector<Rule> rules;
 		bool attention_alloc;
 		int max_iter;

--- a/opencog/rule-engine/UREConfigReader.h
+++ b/opencog/rule-engine/UREConfigReader.h
@@ -52,6 +52,7 @@ public:
 	// Access methods, return parameters given a rule-based system
 	const std::vector<Rule>& get_rules() const;
 	std::vector<Rule>& get_rules();
+	const Rule& get_rule(const Handle& h);
 	bool get_attention_allocation() const;
 	int get_maximum_iterations() const;
 
@@ -89,6 +90,17 @@ private:
 		std::vector<Rule> rules;
 		bool attention_alloc;
 		int max_iter;
+
+		const Rule& get_rule(const Handle& h) const
+		{
+			for (const auto& rule : rules) {
+				if (rule.get_handle() == h)
+					return rule;
+			}
+
+			throw InvalidParamException(
+			        TRACE_INFO, "No rule with the given handle was found.");
+		}
 	};
 	RuleBaseParameters _rbparams;
 


### PR DESCRIPTION
Useful for referring all attributes related to a rule given a valid BindLink handle.