### PR TITLE
Fixed FC example rule frog.scm

### DIFF
--- a/examples/rule-engine/forward_chaining/frog.scm
+++ b/examples/rule-engine/forward_chaining/frog.scm
@@ -28,7 +28,9 @@
 
 (define rule2
 	(BindLink
-		(VariableNode "$x")
+		(VariableList
+			(VariableNode "$x")
+		)
 		(InheritanceLink
 			(VariableNode "$x")
 			(ConceptNode "frog")


### PR DESCRIPTION
The way the "Rule" class works and how it is used throughout FC & BC requires the variable list actually be VariableList.   This is a lazy fix.