### PR TITLE
Add eclipse project files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,11 @@ ui_*.h
 Makefile
 *-build-*
 
+# Eclipse
+.cproject
+.project
+.settings/
+
 ### Linux ###
 *~
 *.autosave


### PR DESCRIPTION
Ignore files for Qt & Idea are already there, so I thought that Eclipse ones are also acceptable (while I can add them in my own repo excludes).