### PR TITLE
Syntax checking for ExecutionOutputLink

### DIFF
--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -357,13 +357,13 @@ TruthValuePtr EvaluationLink::do_eval_scratch(AtomSpace* as,
 	}
 
 	// We get exceptions here in two differet ways: (a) due to user
-	// error, in which case we need o print an error, ad (b) automatic,
+	// error, in which case we need to print an error, and (b) intentionally,
 	// e.g. when Instantiator calls us, knowing it will get an error,
 	// in which case, printing the exception message is a waste of CPU
 	// time...
 	//
-	// DefaultPatternMatchCB.cc and also Instantiator wants to
-	// catch the NotEvaluatableException thrw here.  Basically, these
+	// DefaultPatternMatchCB.cc and also Instantiator wants to catch
+	// the NotEvaluatableException thrown here.  Basically, these
 	// know that they might be sending non-evaluatable atoms here, and
 	// don't want to garbage up the log files with bogus errors.
 	if (silent)

--- a/opencog/atoms/execution/ExecutionOutputLink.cc
+++ b/opencog/atoms/execution/ExecutionOutputLink.cc
@@ -43,7 +43,7 @@ ExecutionOutputLink::ExecutionOutputLink(const HandleSeq& oset,
 	   GROUNDED_SCHEMA_NODE != oset[0]->getType()) or
 	   LIST_LINK != oset[1]->getType())
 	{
-		throw RuntimeException(TRACE_INFO,
+		throw SyntaxException(TRACE_INFO,
 			"ExecutionOutputLink must have schema and args!");
 	}
 }
@@ -60,7 +60,7 @@ ExecutionOutputLink::ExecutionOutputLink(const Handle& schema,
 		throw RuntimeException(TRACE_INFO, "Expecting SchemaNode!");
 
 	if (LIST_LINK != args->getType())
-		throw RuntimeException(TRACE_INFO,
+		throw SyntaxException(TRACE_INFO,
 			"ExecutionOutputLink must have schema and args!");
 }
 
@@ -69,7 +69,7 @@ ExecutionOutputLink::ExecutionOutputLink(Link& l)
 {
 	Type tscope = l.getType();
 	if (EXECUTION_OUTPUT_LINK != tscope)
-		throw RuntimeException(TRACE_INFO,
+		throw SyntaxException(TRACE_INFO,
 			"Expection an ExecutionOutputLink!");
 }
 

--- a/opencog/atoms/execution/ExecutionOutputLink.cc
+++ b/opencog/atoms/execution/ExecutionOutputLink.cc
@@ -38,14 +38,24 @@ ExecutionOutputLink::ExecutionOutputLink(const HandleSeq& oset,
                                          AttentionValuePtr av)
 	: FunctionLink(EXECUTION_OUTPUT_LINK, oset, tv, av)
 {
-	if (2 != oset.size() or
-	   (DEFINED_SCHEMA_NODE != oset[0]->getType() and
-	   GROUNDED_SCHEMA_NODE != oset[0]->getType()) or
-	   LIST_LINK != oset[1]->getType())
+	if (2 != oset.size())
+		throw SyntaxException(TRACE_INFO,
+			"ExecutionOutputLink must have schema and args! Got arity=%d",
+			oset.size());
+
+	if (DEFINED_SCHEMA_NODE != oset[0]->getType() and
+	    LAMBDA_LINK != oset[0]->getType() and
+	    GROUNDED_SCHEMA_NODE != oset[0]->getType())
 	{
 		throw SyntaxException(TRACE_INFO,
-			"ExecutionOutputLink must have schema and args!");
+			"ExecutionOutputLink must have schema! Got %s",
+			oset[0]->toString().c_str());
 	}
+
+	if (LIST_LINK != oset[1]->getType())
+		throw SyntaxException(TRACE_INFO,
+			"ExecutionOutputLink must have args! Got %s",
+			oset[1]->toString().c_str());
 }
 
 ExecutionOutputLink::ExecutionOutputLink(const Handle& schema,
@@ -56,12 +66,18 @@ ExecutionOutputLink::ExecutionOutputLink(const Handle& schema,
 {
 	Type stype = schema->getType();
 	if (GROUNDED_SCHEMA_NODE != stype and
+	    LAMBDA_LINK != stype and
 	    DEFINED_SCHEMA_NODE != stype)
-		throw RuntimeException(TRACE_INFO, "Expecting SchemaNode!");
+	{
+		throw SyntaxException(TRACE_INFO,
+			"ExecutionOutputLink expecting schema, got %s",
+			schema->toString().c_str());
+	}
 
 	if (LIST_LINK != args->getType())
 		throw SyntaxException(TRACE_INFO,
-			"ExecutionOutputLink must have schema and args!");
+			"ExecutionOutputLink expecting args, got %s",
+			args->toString().c_str());
 }
 
 ExecutionOutputLink::ExecutionOutputLink(Link& l)

--- a/opencog/atoms/execution/ExecutionOutputLink.h
+++ b/opencog/atoms/execution/ExecutionOutputLink.h
@@ -49,6 +49,9 @@ public:
 	ExecutionOutputLink(Link& l);
 
 	virtual Handle execute(AtomSpace* = NULL) const;
+
+	Handle get_schema(void) const { return getOutgoingAtom(0); }
+	Handle get_args(void) const { return getOutgoingAtom(1); }
 };
 
 typedef std::shared_ptr<ExecutionOutputLink> ExecutionOutputLinkPtr;

--- a/opencog/atoms/execution/Instantiator.cc
+++ b/opencog/atoms/execution/Instantiator.cc
@@ -171,12 +171,18 @@ Handle Instantiator::walk_tree(const Handle& expr)
 	// below. This is due to a circular shared-libarary dependency.
 	if (EXECUTION_OUTPUT_LINK == t)
 	{
+		// XXX Force syntax checking; normally this would be done in the
+		// atomspace factory, but that is currently broken, so do it here.
+		ExecutionOutputLinkPtr eolp(ExecutionOutputLinkCast(expr));
+		if (nullptr == eolp)
+			eolp = createExecutionOutputLink(lexpr->getOutgoingSet());
+
 		// At this time, the GSN or the DSN is always in position 0
 		// of the outgoing set, and the ListLink of arguments is always
 		// in position 1.  Someday in the future, there may be a variable
 		// declaration; we punt on that.
-		Handle sn(lexpr->getOutgoingAtom(0));
-		Handle args(lexpr->getOutgoingAtom(1));
+		Handle sn(eolp->get_schema());
+		Handle args(eolp->get_args());
 
 		// Perform substitution on the args, only.
 		args = walk_tree(args);
@@ -204,8 +210,8 @@ Handle Instantiator::walk_tree(const Handle& expr)
 			return walk_tree(beta_reduced);
 		}
 
-		ExecutionOutputLinkPtr eolp(createExecutionOutputLink(sn, args));
-		return eolp->execute(_as);
+		ExecutionOutputLinkPtr geolp(createExecutionOutputLink(sn, args));
+		return geolp->execute(_as);
 	}
 
 	// Handle DeleteLink's before general FunctionLink's; they

--- a/opencog/atoms/execution/README.md
+++ b/opencog/atoms/execution/README.md
@@ -8,7 +8,7 @@ Unfortunately, it is no longer simple, straight-forward.
 
 Vocabulary
 ----------
-Some vobabulary:
+Some vocabulary:
 
 * "Substitution" means the substitution of values for thier place holders.
   There are several variants:
@@ -38,17 +38,17 @@ at some abstract level, its the same thing; we just use the word
 Design complexity
 -----------------
 The design has gotten complex due to mutiple reasons.  But first,
-Here is why execution is complex:
+here is why execution is complex:
 
 * Execution must be done recursively, starting at the leafs.
-  That is, must (but not all) functions require the function
+  That is, most (but not all) functions require the function
   arguments to be in thier final reduced 'value' form, before
   the function can be executed.  That is, execution does NOT
   commute with substitution.
 
 * Substitution has to be done recursviely, but with care: Not all
   variables are free; not all variables are bound. Thus, for example,
-  the PutLink has to parts: all variables in the body of the PutLink
+  the PutLink has two parts: all variables in the body of the PutLink
   are bound, but all variables in the value-list are free.  Thus,
   if there is variable substitution outside of PutLink, only the
   free variables can be subsituted!
@@ -58,7 +58,7 @@ Here is why execution is complex:
   beta reduction. It is easier to handle execution of e.g.
   delete links if execution is done before beta reduction.
 
-* The exeuction of black-box links requires that the argument atoms
+* The execution of black-box links requires that the argument atoms
   be placed into the atomspace, first. This is for two reasons:
   -- Both python and guile rely on the atomspace to find atoms.
      If the argument to a scheme/python function is not in the
@@ -75,6 +75,11 @@ Here is why execution is complex:
   told the atom when it was being inserted, but, right now, the
   atomspace does not send an "insert" message to the atoms being
   inserted.
+
+* Execution is currently done in an eager fashion, and should be
+  done in a lazy fashion. Until recently, this did not matter, because
+  conditional links were no much used... well, now they are (e.g. the
+  RandomChoiceLink -- only one branch needs to be instantiated/executed).
 
 
 Garbage Collection
@@ -150,12 +155,12 @@ Non-string values
 Some node types need to store one or more non-string values.  The
 NumberNode here is a rough prototype for how that could be done. By
 storing a double-precision floating point number (i.e. "caching" it)
-it can potentially avoid string->double and double->string conversions
+it can potentially avoid `string->double` and `double->string` conversions
 every time that it is accessed.  There are several caveats:
 
  * This works only if all possible Handles and AtomPtr's actually
    point to an instance of the NumberNode class, instead of an
-   instance of a Node class, with the type set to NUMBER_NODE.
+   instance of a Node class, with the type set to `NUMBER_NODE`.
 
  * The above can happen only if the AtomSpace itself is careful to
    always work with instances of NumberNode, as it is the final


### PR DESCRIPTION
Bad syntax causes mysterious errors; avoid this with a syntax-check early-on.