### PR TITLE
Attempt to work around a crash in forward-chainer.

### DIFF
--- a/opencog/README
+++ b/opencog/README
@@ -1,40 +1,28 @@
 
-                  OpenCog Source Code
+                  AtomSpace Source Code
                   -------------------
 
-This directory contains core OpenCog code.  Tests, example and demo 
+This directory contains core AtomSpace code.  Tests, example and demo
 programs have their own directories.
 
 Source code overview:
 
-atomspace       -- Defines atoms, nodes, links, truth values, etc. 
+atomspace       -- Defines atoms, nodes, links, truth values, etc.
                    Everything else depends on this.
 
+atoms           -- Assorted C++ definitions of specific atom types.
+                   These are the "imperative" atoms, atoms that
+                   "do things" when they are executed.
+
 persist         -- Methods for communication between servers, also,
-                   saving/restoring the atomspace to disk, database, etc.
+                   saving/restoring the atomspace to databases.
 
 query           -- Pattern matching, evaluation for the atomspace.
 
 guile, scm      -- Scheme language bindings.
-python,cython   -- Python langauge bindings.  
-shell           -- Command-line shell interface.
+haskell         -- Haskell language bindings.
+python,cython   -- Python langauge bindings.
 
-server          -- CogServer main server.
 benchmark       -- Performance benchmarks.
 
-nlp             -- English language processing
-reasoning       -- Backward-chainers
-
-dynamics        -- Attention allocation.
-spatial, spacetime -- Space and time matrix for avatars.
-embodiment      -- Avatars
-
-comboreduct     -- Combo language, term-rewriting system.
-learning        -- Supervised program learning, including MOSES
-
-visualization   -- Visualization, graphics.
-
-cycl-import     -- Import OpenCyc datasets
-
-@todo Create doxygen filter to parse scm files.
-
+rule-engine     -- Forward and backward-chainers.

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -450,6 +450,11 @@ Handle AtomTable::add(AtomPtr atom, bool async)
     if (in_environ(atom))
         return atom->getHandle();
 
+    // We expect to be given a valid atom...
+    if (nullptr == atom)
+        throw RuntimeException(TRACE_INFO,
+            "AtomTable - Cannot insert null atom! ");
+
     // Factory implements experimental C++ atom types support code
     AtomPtr orig(atom);
     Type atom_type = atom->getType();


### PR DESCRIPTION
Here:
opencog::ForwardChainer::apply_rule ()
opencog/rule-engine/forwardchainer/ForwardChainer.cc:396

its giving us a null pointer in the outgoing set.