### PR TITLE
Proposed fix for issue #508

### DIFF
--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -283,12 +283,43 @@ void SchemeSmob::register_procs(void*)
 
 	// Iterators
 	register_proc("cog-map-type",          2, 0, 0, C(ss_map_type));
+
+	// Load scheme files from load-path either set by GUILE_LOAD_PATH or
+	// (add-to-load-path "...")
+	// Load core atom types.
+	// The remaining atom types from the cogserver are in (opencog atom-types)
+	register_proc_from_scm("core_types.scm");
+
+	// Load other grunge too.
+	// Some of these things should probably be modules ...?
+	register_proc_from_scm("config.scm");
+
+	register_proc_from_scm("core-docs.scm");
+
+	register_proc_from_scm("utilities.scm");
+
+	register_proc_from_scm("apply.scm");
+	register_proc_from_scm("av-tv.scm");
+	register_proc_from_scm("file-utils.scm");
+	register_proc_from_scm("debug-trace.scm");
+
 }
 
 void SchemeSmob::register_proc(const char* name, int req, int opt, int rst, scm_t_subr fcn)
 {
 	scm_c_define_gsubr(name, req, opt, rst, fcn);
 	scm_c_export(name, NULL);
+}
+
+void SchemeSmob::register_proc_from_scm(const char* filename)
+{
+	//scm_c_primitive_load_path(filename);
+	auto path = scm_sys_search_load_path(scm_from_utf8_string(filename));
+	if (scm_is_true (path)) {
+		scm_c_primitive_load_path(filename);
+	} else {
+		std::cout << "Didn't find " << filename << std::endl;
+	}
 }
 
 #endif

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -53,6 +53,7 @@ private:
 	static std::atomic_flag is_inited;
 	static void register_procs(void*);
 	static void register_proc(const char*, int, int, int, scm_t_subr);
+	static void register_proc_from_scm(const char*);
 
 	// The cog_misc_tag are for all other opencog types, such
 	// as truth values, which are ephemeral (garbage-collected)
@@ -156,7 +157,7 @@ private:
 	static SCM ss_af_boundary(void);
 	static SCM ss_set_af_boundary(SCM);
 	static SCM ss_af(void);
-        
+
 	// Callback into misc C++ code.
 	static SCM ss_ad_hoc(SCM, SCM);
 

--- a/opencog/scm/opencog.scm
+++ b/opencog/scm/opencog.scm
@@ -15,9 +15,6 @@
 ; libsmob won't be found unless we setenv where to find it!
 (setenv "LTDL_LIBRARY_PATH" "/usr/local/lib/opencog")
 
-; Work-around another common usability issue...
-(add-to-load-path "/usr/local/share/opencog/scm")
-
 (define-module (opencog))
 (load-extension "libsmob" "opencog_guile_init")
 
@@ -45,20 +42,3 @@
 		(set! cog-initial-as (cog-new-atomspace))
 		; Initialize a default atomspace, just to keep things sane...
 		(cog-set-atomspace! cog-initial-as)))
-
-; Load core atom types.
-; The remaining atom types from the cogserver are in (opencog atom-types)
-(load-from-path "core_types.scm")
-
-; Load other grunge too.
-; Some of these things should probably be modules ...?
-(load-from-path "config.scm")
-
-(load-from-path "core-docs.scm")
-
-(load-from-path "utilities.scm")
-
-(load-from-path "apply.scm")
-(load-from-path "av-tv.scm")
-(load-from-path "file-utils.scm")
-(load-from-path "debug-trace.scm")


### PR DESCRIPTION
### WIP Don't Merge
I am not sure whether this is a good approach for solving https://github.com/opencog/atomspace/issues/508 thus a proposal. 

**Intention:** be able to run `(use-modules (opencog))` without having to deal with hardcoding path in tests . Detail of usability and technical issue see https://github.com/opencog/atomspace/issues/508#issuecomment-160695583 and https://github.com/opencog/atomspace/issues/508#issuecomment-160706429 

**Proposed Solution:** use `GUILE_LOAD_PATH` to set the path to be searched for modules. That way path variables need not be hard-coded in source-files, and cmake could be used to set the value of `GUILE_LOAD_PATH`.


As it is right now ths fixes the https://github.com/opencog/atomspace/issues/508, but ParallelUTest fails, and using cmake's `SET_TESTS_PROPERTIES` as used for setting "PYTHONPATH" in other tests seems to have no effect. Don't know why for both.