### PR TITLE
Fix build break.

### DIFF
--- a/opencog/atoms/execution/ExecutionOutputLink.cc
+++ b/opencog/atoms/execution/ExecutionOutputLink.cc
@@ -20,6 +20,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <dlfcn.h>
 #include <stdlib.h>
 
 #include <opencog/atomspace/atom_types.h>


### PR DESCRIPTION
Fix a terribly OBVIOUS build break which circle-CI didn't catch. Once again, what good is circle-CI, if it can't even perform basic checks?