### PR TITLE
Fix for HaskellExecutionTest sometimes failing

### DIFF
--- a/tests/haskell/libExecutionOutputTest/buildTest.sh
+++ b/tests/haskell/libExecutionOutputTest/buildTest.sh
@@ -1,14 +1,13 @@
 BIN_DIR=$1
 SOURCE_DIR=$2
 
-libname=$(stack query | awk 'NR==2' | sed 's/://g'| sed 's/ //g')
-libver=$(stack query | awk 'NR==4' | sed 's/version: //g' | sed "s/'//g" | sed "s/ //g")
+libname="opencoglib"
+libver="0.1.0.0"
 
 if [ "$(id -u)" -ne 0 ]
 then
     # Build haskell bindings package.
     stack build --no-run-tests --extra-lib-dirs=${BIN_DIR}
-
 
     LIB=$(find . -name "*$libname*.so" | awk 'NR==1')
 


### PR DESCRIPTION
for some reason the code to get the library name doesn't work all the time. For this test it should be no problem to hardcode it.