### PR TITLE
Add a more convenient RandomChoiceLink format

### DIFF
--- a/opencog/atoms/core/RandomChoice.cc
+++ b/opencog/atoms/core/RandomChoice.cc
@@ -55,6 +55,68 @@ RandomChoiceLink::RandomChoiceLink(Link &l)
 
 // ---------------------------------------------------------------
 
+// When executed, this will randomly select and return an atom
+// in it's outgoing set. The selection can use either a uniform or
+// a weighted distribution.  Two different formats are used to specify
+// weights; if neither of these are used, a uniform distribution is
+// used.
+//
+// One way to specify weights is to use a weight-vector:
+//
+//    RandomChoiceLink
+//        ListLink
+//           NumberNode
+//           ...
+//           NumberNode
+//        ListLink
+//           AtomA
+//           ...
+//           AtomZ
+//
+// With the above format, the atoms A..Z will be selected with
+// distribution weights taken from the NumberNodes. The probability of
+// selection is in *proportion* to the weights; viz the probability is
+// given by dividing a given weight by the sum of the weights.
+// The Number of AtomsA..Z MUST match the number of NumberNodes!
+//
+// A second way to specify weights is much more GetLink friendly:
+//
+//    RandomChoiceLink
+//        SetLink
+//           ListLink
+//              NumberNode1
+//              AtomA
+//           ListLink
+//              NumberNode2
+//              AtomB
+//              ...
+//           ListLink
+//              NumberNodeN
+//              AtomZ
+//
+// Here, the weights and atoms are paired. The pairs appear in a
+// SetLink, which is an unordered link, and is the link type returned
+// by the GetLink query function.
+//
+// If neither of the above two formats appear to hold, then it is
+// assumed that the RandomChoiceLink simply holds a list of atoms;
+// these are selected with uniform weighting.  Viz:
+//
+//    RandomChoiceLink
+//        AtomA
+//        AtomB
+//        ...
+//        AtomZ
+//
+// or the GetLink-friendly format:
+//
+//    RandomChoiceLink
+//        SetLink
+//           AtomA
+//           AtomB
+//           ...
+//           AtomZ
+//
 Handle RandomChoiceLink::execute(AtomSpace * as) const
 {
 	size_t ary = _outgoing.size();

--- a/tests/atoms/RandomUTest.cxxtest
+++ b/tests/atoms/RandomUTest.cxxtest
@@ -59,6 +59,7 @@ public:
     void tearDown(void);
 
     void test_weights(void);
+    void test_pairs(void);
 };
 
 void RandomUTest::tearDown(void)
@@ -103,6 +104,53 @@ void RandomUTest::test_weights(void)
 
     TruthValuePtr tv = eval->eval_tv("(cog-evaluate! (DefinedPredicate \"test\"))");
     TS_ASSERT_LESS_THAN(0.5, tv->getMean());
+
+    logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+/*
+ * RandomChoiceLink unit test.
+ */
+void RandomUTest::test_pairs(void)
+{
+    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+    // Define a simple list of pairs
+    eval->eval_h(
+        "(DefineLink (DefinedSchema \"pairs\") "
+        "(RandomChoice "
+        "   (SetLink "
+        "      (ListLink (NumberNode 1) (Concept \"AAA\"))"
+        "      (ListLink (NumberNode 1) (Concept \"BBB\"))"
+        "      (ListLink (NumberNode 0.1) (Concept \"CCC\")) )))"
+    );
+
+    Handle A = eval->eval_h("(Concept \"AAA\")");
+    Handle B = eval->eval_h("(Concept \"BBB\")");
+    Handle C = eval->eval_h("(Concept \"CCC\")");
+
+    int cntA=0, cntB=0, cntC=0;
+    for (int i=0; i<1000; i++)
+    {
+        Handle pick = eval->eval_h(
+            "(cog-execute! (DefinedSchema \"pairs\"))");
+
+        if (pick == A) cntA++;
+        if (pick == B) cntB++;
+        if (pick == C) cntC++;
+    }
+
+    printf("Got counts A=%d B=%d C=%d\n", cntA, cntB, cntC);
+
+    // Loose bounds. My rand gen always gives the same answer:
+    // Got counts A=488 B=468 C=44
+    TS_ASSERT_LESS_THAN(450, cntA);
+    TS_ASSERT_LESS_THAN(450, cntB);
+    TS_ASSERT_LESS_THAN(35, cntC);
+
+    TS_ASSERT_LESS_THAN(cntA, 500);
+    TS_ASSERT_LESS_THAN(cntB, 500);
+    TS_ASSERT_LESS_THAN(cntC, 60);
 
     logger().debug("END TEST: %s", __FUNCTION__);
 }


### PR DESCRIPTION
The existing format was too clunky to work well with the pattern matcher; define a simpler format.