### PR TITLE
initialize _vardecl when variable declaration is made, in BindLink

### DIFF
--- a/opencog/atoms/pattern/BindLink.cc
+++ b/opencog/atoms/pattern/BindLink.cc
@@ -86,6 +86,7 @@ void BindLink::extract_variables(const HandleSeq& oset)
 	// declarations; extract all free variables.
 	if (2 == sz)
 	{
+		_vardecl = Handle::UNDEFINED;
 		_body = oset[0];
 		_implicand = oset[1];
 		_varlist.find_variables(oset[0]);
@@ -94,6 +95,7 @@ void BindLink::extract_variables(const HandleSeq& oset)
 
 	// If we are here, then the first outgoing set member should be
 	// a variable declaration.
+	_vardecl = oset[0];
 	_body = oset[1];
 	_implicand = oset[2];
 

--- a/opencog/atoms/pattern/BindLink.cc
+++ b/opencog/atoms/pattern/BindLink.cc
@@ -86,7 +86,6 @@ void BindLink::extract_variables(const HandleSeq& oset)
 	// declarations; extract all free variables.
 	if (2 == sz)
 	{
-		_vardecl = Handle::UNDEFINED;
 		_body = oset[0];
 		_implicand = oset[1];
 		_varlist.find_variables(oset[0]);


### PR DESCRIPTION
mainly for consitancy in behavior of `get_vardecl()` from ScopeLink.