### PR TITLE
Add guile wrapper for Atomspace argument

### DIFF
--- a/opencog/guile/SchemePrimitive.h
+++ b/opencog/guile/SchemePrimitive.h
@@ -529,7 +529,7 @@ class SchemePrimitive : public PrimitiveEnviron
 				{
 					Type t = SchemeSmob::verify_atom_type(scm_car(args), scheme_name, 1);
 
-					int i = scm_to_int(scm_cadr(args));
+					int i = SchemeSmob::verify_int(scm_cadr(args), scheme_name, 2);
 
 					(that->*method.v_ti)(t, i);
 					break;
@@ -537,10 +537,9 @@ class SchemePrimitive : public PrimitiveEnviron
 				case V_TIDI:
 				{
 					Type t = SchemeSmob::verify_atom_type(scm_car(args), scheme_name, 1);
-					int i = scm_to_int(scm_cadr(args));
+					int i = SchemeSmob::verify_int(scm_cadr(args), scheme_name, 2);
 					double d = scm_to_double(scm_caddr(args));
-					int i2 = scm_to_int(scm_cadddr(args));
-
+					int i2 = SchemeSmob::verify_int(scm_cadddr(args), scheme_name, 4);
 					(that->*method.v_tidi)(t, i, d, i2);
 					break;
 				}

--- a/opencog/guile/SchemePrimitive.h
+++ b/opencog/guile/SchemePrimitive.h
@@ -527,20 +527,7 @@ class SchemePrimitive : public PrimitiveEnviron
 				}
 				case V_TI:
 				{
-					SCM input = scm_car(args);
-					//Assuming that the type is input as a string or symbol, eg
-					//(f 'SimilarityLink) or (f "SimilarityLink")
-					if (scm_is_true(scm_symbol_p(input)))
-						input = scm_symbol_to_string(input);
-
-					Type t = NOTYPE;
-					if (scm_is_integer(input))
-						t = scm_to_ushort(input);
-					else
-					{
-						const char *lstr = scm_i_string_chars(input);
-						t = classserver().getType(lstr);
-					}
+					Type t = SchemeSmob::verify_atom_type(scm_car(args), scheme_name, 1);
 
 					int i = scm_to_int(scm_cadr(args));
 
@@ -549,22 +536,7 @@ class SchemePrimitive : public PrimitiveEnviron
 				}
 				case V_TIDI:
 				{
-xxxxxxxxxx
-					SCM input = scm_car(args);
-					// Assume that the type is input as a string or symbol,
-					// e.g. (f 'SimilarityLink) or (f "SimilarityLink")
-					if (scm_is_true(scm_symbol_p(input)))
-						input = scm_symbol_to_string(input);
-
-					Type t = NOTYPE;
-					if (scm_is_integer(input))
-						t = scm_to_ushort(input);
-					else
-					{
-						const char *lstr = scm_i_string_chars(input);
-						t = classserver().getType(lstr);
-					}
-
+					Type t = SchemeSmob::verify_atom_type(scm_car(args), scheme_name, 1);
 					int i = scm_to_int(scm_cadr(args));
 					double d = scm_to_double(scm_caddr(args));
 					int i2 = scm_to_int(scm_cadddr(args));

--- a/opencog/guile/SchemePrimitive.h
+++ b/opencog/guile/SchemePrimitive.h
@@ -426,7 +426,7 @@ class SchemePrimitive : public PrimitiveEnviron
 					// First argument is an StomSpace ptr.
 					AtomSpace* as = SchemeSmob::verify_atomspace(scm_car(args), scheme_name, 1);
 					// Second argument is a string
-					std::string str(SchemeSmob::verify_string(scm_car(args), scheme_name, 2));
+					std::string str(SchemeSmob::verify_string(scm_cadr(args), scheme_name, 2));
 
 					const std::string &rs = (that->*method.s_as)(as, str);
 					rc = scm_from_utf8_string(rs.c_str());

--- a/opencog/guile/SchemePrimitive.h
+++ b/opencog/guile/SchemePrimitive.h
@@ -538,7 +538,7 @@ class SchemePrimitive : public PrimitiveEnviron
 				{
 					Type t = SchemeSmob::verify_atom_type(scm_car(args), scheme_name, 1);
 					int i = SchemeSmob::verify_int(scm_cadr(args), scheme_name, 2);
-					double d = scm_to_double(scm_caddr(args));
+					double d = SchemeSmob::verify_real(scm_caddr(args), scheme_name, 3);
 					int i2 = SchemeSmob::verify_int(scm_cadddr(args), scheme_name, 4);
 					(that->*method.v_tidi)(t, i, d, i2);
 					break;

--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -254,7 +254,7 @@ void SchemeSmob::register_procs(void*)
 	register_proc("cog-af-boundary",       0, 0, 0, C(ss_af_boundary));
 	register_proc("cog-set-af-boundary!",  1, 0, 0, C(ss_set_af_boundary));
 	register_proc("cog-af",                0, 0, 0, C(ss_af));
-    
+
 	// Atom types
 	register_proc("cog-get-types",         0, 0, 0, C(ss_get_types));
 	register_proc("cog-type->int",         1, 0, 0, C(ss_get_type));

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -176,10 +176,11 @@ private:
 
 	// validate arguments coming from scheme passing into C++
 	static void throw_exception(const char *, const char *);
+	static AtomSpace* verify_atomspace(SCM, const char *, int pos = 1);
 	static Type verify_atom_type(SCM, const char *, int pos = 1);
 	static Handle verify_handle(SCM, const char *, int pos = 1);
-	static TruthValue * verify_tv(SCM, const char *, int pos = 1);
-	static AttentionValue * verify_av(SCM, const char *, int pos = 1);
+	static TruthValue* verify_tv(SCM, const char *, int pos = 1);
+	static AttentionValue* verify_av(SCM, const char *, int pos = 1);
 	static std::vector<Handle> verify_handle_list (SCM, const char *,
 	                                               int pos = 1);
 	static std::string verify_string (SCM, const char *, int pos = 1,

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -187,6 +187,8 @@ private:
 	                                  const char *msg = "expecting string");
 	static int verify_int (SCM, const char *, int pos = 1,
 	                       const char *msg = "expecting integer");
+	static double verify_real (SCM, const char *, int pos = 1,
+	                           const char *msg = "expecting real number");
 
 	static SCM atomspace_fluid;
 	static void ss_set_env_as(AtomSpace *);

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -160,7 +160,7 @@ private:
 	static SCM ss_af_boundary(void);
 	static SCM ss_set_af_boundary(SCM);
 	static SCM ss_af(void);
-        
+
 	// Callback into misc C++ code.
 	static SCM ss_ad_hoc(SCM, SCM);
 

--- a/opencog/guile/SchemeSmobAF.cc
+++ b/opencog/guile/SchemeSmobAF.cc
@@ -61,12 +61,12 @@ SCM SchemeSmob::ss_set_af_boundary (SCM sboundary)
 SCM SchemeSmob::ss_af (void)
 {
     AtomSpace* atomspace = ss_get_env_as("cog-af");
-    
+
     HandleSeq attentionalFocus;
     atomspace->get_handle_set_in_attentional_focus(back_inserter(attentionalFocus));
     size_t isz = attentionalFocus.size();
 	if (0 == isz) return SCM_EOL;
-    
+
     SCM head = SCM_EOL;
     for (size_t i = 0; i < isz; i++) {
         Handle hi = attentionalFocus[i];

--- a/opencog/guile/SchemeSmobAS.cc
+++ b/opencog/guile/SchemeSmobAS.cc
@@ -188,6 +188,19 @@ AtomSpace* SchemeSmob::ss_to_atomspace(SCM sas)
 }
 
 /* ============================================================== */
+
+AtomSpace* SchemeSmob::verify_atomspace(SCM sas, const char * subrname, int pos)
+{
+   AtomSpace* as = ss_to_atomspace(sas);
+   if (nullptr == as)
+      scm_wrong_type_arg_msg(subrname, pos, satom, "opencog atomspace");
+
+   return as;
+}
+
+
+
+/* ============================================================== */
 /**
  * Return UUID of the atomspace
  */

--- a/opencog/guile/SchemeSmobAS.cc
+++ b/opencog/guile/SchemeSmobAS.cc
@@ -193,12 +193,10 @@ AtomSpace* SchemeSmob::verify_atomspace(SCM sas, const char * subrname, int pos)
 {
    AtomSpace* as = ss_to_atomspace(sas);
    if (nullptr == as)
-      scm_wrong_type_arg_msg(subrname, pos, satom, "opencog atomspace");
+      scm_wrong_type_arg_msg(subrname, pos, sas, "opencog atomspace");
 
    return as;
 }
-
-
 
 /* ============================================================== */
 /**

--- a/opencog/guile/SchemeSmobNew.cc
+++ b/opencog/guile/SchemeSmobNew.cc
@@ -259,7 +259,7 @@ Type SchemeSmob::verify_atom_type (SCM stype, const char *subrname, int pos)
  * Return the string, in C.
  */
 std::string SchemeSmob::verify_string (SCM sname, const char *subrname,
-									   int pos, const char * msg)
+                                       int pos, const char * msg)
 {
 	if (scm_is_false(scm_string_p(sname)))
 		scm_wrong_type_arg_msg(subrname, pos, sname, msg);
@@ -275,12 +275,25 @@ std::string SchemeSmob::verify_string (SCM sname, const char *subrname,
  * Return the int.
  */
 int SchemeSmob::verify_int (SCM sint, const char *subrname,
-							int pos, const char * msg)
+                            int pos, const char * msg)
 {
 	if (scm_is_false(scm_integer_p(sint)))
 		scm_wrong_type_arg_msg(subrname, pos, sint, msg);
 
 	return scm_to_int(sint);
+}
+
+/**
+ * Check that the argument is convertible to a real, else throw errors.
+ * Return as a float.
+ */
+double SchemeSmob::verify_real (SCM sreal, const char *subrname,
+                                int pos, const char * msg)
+{
+	if (scm_is_false(scm_real_p(sreal)))
+		scm_wrong_type_arg_msg(subrname, pos, sreal, msg);
+
+	return scm_to_double(sreal);
 }
 
 /**

--- a/opencog/guile/SchemeSmobTV.cc
+++ b/opencog/guile/SchemeSmobTV.cc
@@ -395,7 +395,7 @@ SCM SchemeSmob::ss_tv_get_value (SCM s)
 			SCM scont = scm_from_utf8_symbol("count");
 	
 			SCM rc = SCM_EOL;
-			rc = scm_acons(scont, cont, rc), 
+			rc = scm_acons(scont, cont, rc),
 			rc = scm_acons(sconf, conf, rc);
 			rc = scm_acons(smean, mean, rc);
 			scm_remember_upto_here_1(s);
@@ -413,7 +413,7 @@ SCM SchemeSmob::ss_tv_get_value (SCM s)
 	
 			SCM rc = SCM_EOL;
 			rc = scm_acons(sconf_level, conf_level, rc);
-			rc = scm_acons(supper, upper, rc), 
+			rc = scm_acons(supper, upper, rc),
 			rc = scm_acons(slower, lower, rc);
 			scm_remember_upto_here_1(s);
 			return rc;


### PR DESCRIPTION
Some functions need to pass an atomspace. Add a wrapper for that.

Fix two functions that should have used the verify wrappers, instead of
hand-coding  argument unwrapping code.