### PR TITLE
Refine the FuzzyMatch API

### DIFF
--- a/opencog/atomutils/CMakeLists.txt
+++ b/opencog/atomutils/CMakeLists.txt
@@ -3,6 +3,7 @@ ADD_LIBRARY (atomutils SHARED
 	AtomUtils
 	FindUtils
 	FuzzyMatch
+	FuzzyMatchBasic
 )
 
 ADD_DEPENDENCIES(atomutils opencog_atom_types)
@@ -27,6 +28,7 @@ INSTALL (FILES
 	FollowLink.h
 	ForeachChaseLink.h
 	FuzzyMatch.h
+	FuzzyMatchBasic.h
 	HandleMap.h
 	Substitutor.h
 	DESTINATION "include/opencog/atomutils"

--- a/opencog/atomutils/FuzzyMatch.cc
+++ b/opencog/atomutils/FuzzyMatch.cc
@@ -83,7 +83,7 @@ void FuzzyMatch::find_starters(const Handle& hp, const int& depth)
 /**
  * Find leaves at which a search can be started.
  */
-HandleSeq FuzzyMatch::perform_search(const Handle& target)
+RankedHandleSeq FuzzyMatch::perform_search(const Handle& target)
 {
 	start_search(target);
 

--- a/opencog/atomutils/FuzzyMatch.cc
+++ b/opencog/atomutils/FuzzyMatch.cc
@@ -35,7 +35,7 @@ void FuzzyMatch::explore(const LinkPtr& gl, int depth)
 	Handle soln(gl->getHandle());
 	if (soln == target) return;
 
-	bool look_for_more = note_match(soln, depth);
+	bool look_for_more = try_match(soln, depth);
 
 	if (not look_for_more) return;
 

--- a/opencog/atomutils/FuzzyMatch.cc
+++ b/opencog/atomutils/FuzzyMatch.cc
@@ -95,5 +95,6 @@ HandleSeq FuzzyMatch::perform_search(const Handle& targ)
 	// Find starting leaves from which to begin matches.
 	find_starters(target, 0);
 
-	return solns;
+	// Give the derived class a chance to wrap things up.
+	return finished_search();
 }

--- a/opencog/atomutils/FuzzyMatch.cc
+++ b/opencog/atomutils/FuzzyMatch.cc
@@ -42,7 +42,7 @@ bool FuzzyMatch::accept_starter(const NodePtr& np)
  * @param hp          The pattern (the hypergraph in the query)
  * @param depth       The depth of the starter in the pattern
  */
-void FuzzyMatch::find_starters(const Handle& hp, const size_t& depth)
+void FuzzyMatch::find_starters(const Handle& hp, const int& depth)
 {
 	// Traverse its outgoing set if it is a link
 	LinkPtr lp(LinkCast(hp));
@@ -88,21 +88,19 @@ HandleSeq FuzzyMatch::perform_search(const Handle& targ)
 	return solns;
 }
 
-void FuzzyMatch::explore(const LinkPtr& gl, size_t depth)
+void FuzzyMatch::explore(const LinkPtr& gl, int depth)
 {
-	if (0 < depth)
-	{
-		for (const LinkPtr& lptr : gl->getIncomingSet())
-		{
-			explore(lptr, depth-1);
-		}
-		return;
-	}
-
 	Handle soln(gl->getHandle());
 	if (soln == target) return;
 
-	accept_solution(soln);
+	bool look_for_more = accept_solution(soln, depth);
+
+	if (not look_for_more) return;
+
+	for (const LinkPtr& lptr : gl->getIncomingSet())
+	{
+		explore(lptr, depth-1);
+	}
 }
 
 /**
@@ -110,8 +108,11 @@ void FuzzyMatch::explore(const LinkPtr& gl, size_t depth)
  *
  * @param soln  The potential solution
  */
-void FuzzyMatch::accept_solution(const Handle& soln)
+bool FuzzyMatch::note_match(const Handle& soln, int depth)
 {
+	if (0 < depth) return true;
+	if (0 > depth) return false;
+
 	// Find out how many nodes it has in common with the pattern
 	HandleSeq common_nodes;
 	HandleSeq soln_nodes = get_all_nodes(soln);
@@ -153,4 +154,6 @@ void FuzzyMatch::accept_solution(const Handle& soln)
 	else if (similarity == max_similarity and diff == min_size_diff) {
 		solns.push_back(soln);
 	}
+
+	return true;
 }

--- a/opencog/atomutils/FuzzyMatch.cc
+++ b/opencog/atomutils/FuzzyMatch.cc
@@ -33,10 +33,7 @@ using namespace opencog;
 void FuzzyMatch::explore(const LinkPtr& gl, int depth)
 {
 	Handle soln(gl->getHandle());
-	if (soln == target) return;
-
 	bool look_for_more = try_match(soln, depth);
-
 	if (not look_for_more) return;
 
 	for (const LinkPtr& lptr : gl->getIncomingSet())
@@ -86,11 +83,9 @@ void FuzzyMatch::find_starters(const Handle& hp, const int& depth)
 /**
  * Find leaves at which a search can be started.
  */
-HandleSeq FuzzyMatch::perform_search(const Handle& targ)
+HandleSeq FuzzyMatch::perform_search(const Handle& target)
 {
-	target = targ;
-	target_nodes = get_all_nodes(target);
-	std::sort(target_nodes.begin(), target_nodes.end());
+	start_search(target);
 
 	// Find starting atoms from which to begin matches.
 	find_starters(target, 0);

--- a/opencog/atomutils/FuzzyMatch.h
+++ b/opencog/atomutils/FuzzyMatch.h
@@ -26,7 +26,6 @@
 
 #include <opencog/atomspace/Handle.h>
 #include <opencog/atomspace/Link.h>
-#include <opencog/atomspace/Node.h>
 
 namespace opencog
 {
@@ -89,7 +88,7 @@ protected:
     Handle target;
     HandleSeq target_nodes;
 
-    virtual bool accept_starter(const NodePtr&) = 0;
+    virtual bool accept_starter(const Handle&) = 0;
     virtual bool try_match(const Handle&, int depth) = 0;
     virtual HandleSeq finished_search(void) = 0;
 

--- a/opencog/atomutils/FuzzyMatch.h
+++ b/opencog/atomutils/FuzzyMatch.h
@@ -36,6 +36,47 @@ namespace opencog
  * all possible trees that have at least one leaf node in common with
  * the target pattern.  A similarity score is assigned to each such
  * tree, and the ones with the highest scores are returned.
+ *
+ * This is a virtual base class, providing three methods that must be
+ * implemented.  The accept_starter() should return true, if the trees
+ * attached to this leaf should be explored.  The note_match() method is
+ * called to suggest a possible matching tree. It should return true to
+ * continue searching.  The finished_serach() method is called when all
+ * trees have been explored; it should return a list of the best
+ * solutions.
+ *
+ * The `perform_search()` method performs the actual search for similar
+ * trees.  It is a rather simple algorithm, and works like this: it
+ * is given a Handle that specifies the target pattern to be matched.
+ * This target is just a tree, if one considers the outgoing sets of
+ * the links in it.  This tree has leaves, which are nodes.  Each leaf
+ * may occur in other trees as well, i.e. may be shared by other trees.
+ * These other trees can be found by exploring the incoming set to the
+ * leaf. Any tree that shares this leaf must, by definition, occur in
+ * it's incoming set.  Thus, to find potentially similar trees,  one
+ * needs only to recursively explore the incoming set of each leaf.
+ * So -- that is what the `perform_search()` method does: an exhaustive
+ * recursive search of all possible trees sharing at least one node
+ * leaf.
+ *
+ * Its possible that a similar tree will not have any leaf-nodes
+ * in common with the target. In this case, this class wil fail to
+ * consider such a tree; some other approach would be needed to find it.
+ *
+ * To limit the search, the return values of `accept_starter()` and
+ * `try_match()` are used.  The `accept_starter()` is called for every
+ * atom in the target tree. If it returns true, then other trees that
+ * share that atom are proposed to `try_match()`.  Initially, the
+ * smallest such trees are proposed; as long as `try_match() returns
+ * true, then larger and larger trees holding tthe starter are proposed.
+ * If it returns false, then the proposal of the ever-larger trees
+ * halts.
+ *
+ * The 'depth' parameter to `try_match()` is equal to the difference,
+ * in height, from the top of the target tree to the top of the
+ * proposed tree; the two trees being joined by sharing a common
+ * `accept_starter()` atom. The depth is negative is the propsed tree
+ * is shorter, and postive if the propsed tree is larger.
  */
 class FuzzyMatch
 {
@@ -49,7 +90,7 @@ protected:
     HandleSeq target_nodes;
 
     virtual bool accept_starter(const NodePtr&) = 0;
-    virtual bool note_match(const Handle&, int depth) = 0;
+    virtual bool try_match(const Handle&, int depth) = 0;
     virtual HandleSeq finished_search(void) = 0;
 
 private:

--- a/opencog/atomutils/FuzzyMatch.h
+++ b/opencog/atomutils/FuzzyMatch.h
@@ -50,12 +50,9 @@ protected:
 
     virtual bool accept_starter(const NodePtr&) = 0;
     virtual bool note_match(const Handle&, int depth) = 0;
-    virtual void finished_search(void) = 0;
+    virtual HandleSeq finished_search(void) = 0;
 
 private:
-    // The solutions that were found.
-    HandleSeq solns;
-
     void find_starters(const Handle& hg, const int& depth);
     void explore(const LinkPtr&, int);
 };

--- a/opencog/atomutils/FuzzyMatch.h
+++ b/opencog/atomutils/FuzzyMatch.h
@@ -77,17 +77,20 @@ namespace opencog
  * `accept_starter()` atom. The depth is negative is the propsed tree
  * is shorter, and postive if the propsed tree is larger.
  */
+
+typedef std::vector<std::pair<Handle, double>> RankedHandleSeq;
+
 class FuzzyMatch
 {
 public:
-    HandleSeq perform_search(const Handle&);
+    RankedHandleSeq perform_search(const Handle&);
     virtual ~FuzzyMatch() {}
 
 protected:
     virtual void start_search(const Handle&) = 0;
     virtual bool accept_starter(const Handle&) = 0;
     virtual bool try_match(const Handle&, int depth) = 0;
-    virtual HandleSeq finished_search(void) = 0;
+    virtual RankedHandleSeq finished_search(void) = 0;
 
 private:
     void find_starters(const Handle& hg, const int& depth);

--- a/opencog/atomutils/FuzzyMatch.h
+++ b/opencog/atomutils/FuzzyMatch.h
@@ -52,10 +52,10 @@ protected:
     HandleSeq target_nodes;
 
     virtual bool accept_starter(const NodePtr&);
-    virtual void accept_solution(const Handle&);
+    virtual bool note_match(const Handle&, int depth);
 
 private:
-    void explore(const LinkPtr&, size_t);
+    void explore(const LinkPtr&, int);
 
     // The solutions
     HandleSeq solns;
@@ -67,7 +67,7 @@ private:
     // The maximum similarity of all the potential solutions we found
     double max_similarity = -std::numeric_limits<double>::max();
 
-    void find_starters(const Handle& hg, const size_t& depth);
+    void find_starters(const Handle& hg, const int& depth);
 };
 
 } // namespace opencog

--- a/opencog/atomutils/FuzzyMatch.h
+++ b/opencog/atomutils/FuzzyMatch.h
@@ -84,10 +84,7 @@ public:
     virtual ~FuzzyMatch() {}
 
 protected:
-    // What we are matching
-    Handle target;
-    HandleSeq target_nodes;
-
+    virtual void start_search(const Handle&) = 0;
     virtual bool accept_starter(const Handle&) = 0;
     virtual bool try_match(const Handle&, int depth) = 0;
     virtual HandleSeq finished_search(void) = 0;

--- a/opencog/atomutils/FuzzyMatchBasic.cc
+++ b/opencog/atomutils/FuzzyMatchBasic.cc
@@ -21,7 +21,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/atomspace/AtomSpace.h>
+#include <opencog/atomspace/Node.h>
 #include <opencog/atomutils/AtomUtils.h>
 #include <opencog/atomutils/FindUtils.h>
 
@@ -29,10 +29,17 @@
 
 using namespace opencog;
 
-bool FuzzyMatchBasic::accept_starter(const NodePtr& np)
+/**
+ * hp is a subtree of the target tree. Should we start a search
+ * at that location?  Answer: yes if its a node, no, if its a link.
+ */
+bool FuzzyMatchBasic::accept_starter(const Handle& hp)
 {
-	return (np->getType() != VARIABLE_NODE and
-		np->getName().find("@") == std::string::npos);
+	NodePtr np(NodeCast(hp));
+	if (nullptr == np) return false;
+
+	// Ignore variables. (Why?)
+	return (np->getType() != VARIABLE_NODE);
 }
 
 /**

--- a/opencog/atomutils/FuzzyMatchBasic.cc
+++ b/opencog/atomutils/FuzzyMatchBasic.cc
@@ -43,12 +43,18 @@ bool FuzzyMatchBasic::accept_starter(const Handle& hp)
 }
 
 /**
- * Estimate how similar the potential solution and the target pattern are.
+ * Estimate how similar the proposed matching tree is to the target.
  *
- * @param soln  The potential solution
+ * @param soln  The proposed match.
+ * @param depth The difference in depth between the target and the
+ *              proposal.
  */
 bool FuzzyMatchBasic::try_match(const Handle& soln, int depth)
 {
+	// For some reason, this algo only wnts to compare proposed
+	// solutions that are exactly the same size as the target.
+	// Why? I dunno. Might not a similar tree be slightly bigger or
+	// smaller?  XXX Maybe FIXME ?
 	if (0 < depth) return true;
 	if (0 > depth) return false;
 

--- a/opencog/atomutils/FuzzyMatchBasic.cc
+++ b/opencog/atomutils/FuzzyMatchBasic.cc
@@ -40,7 +40,7 @@ bool FuzzyMatchBasic::accept_starter(const NodePtr& np)
  *
  * @param soln  The potential solution
  */
-bool FuzzyMatchBasic::note_match(const Handle& soln, int depth)
+bool FuzzyMatchBasic::try_match(const Handle& soln, int depth)
 {
 	if (0 < depth) return true;
 	if (0 > depth) return false;

--- a/opencog/atomutils/FuzzyMatchBasic.cc
+++ b/opencog/atomutils/FuzzyMatchBasic.cc
@@ -99,22 +99,23 @@ bool FuzzyMatchBasic::try_match(const Handle& soln, int depth)
 
 	// Decide if we should accept the potential solutions or not
 	if ((similarity > max_similarity) or
-		(similarity == max_similarity and diff < min_size_diff)) {
+		(similarity == max_similarity and diff < min_size_diff))
+	{
 		max_similarity = similarity;
 		min_size_diff = diff;
 		solns.clear();
-		solns.push_back(soln);
+		solns.push_back({soln, similarity});
 	}
 
 	else if (similarity == max_similarity and diff == min_size_diff) {
-		solns.push_back(soln);
+		solns.push_back({soln, similarity});
 	}
 
 	return false;
 }
 
 /* No-op; we already build "solns", just return it. */
-HandleSeq FuzzyMatchBasic::finished_search(void)
+RankedHandleSeq FuzzyMatchBasic::finished_search(void)
 {
 	return solns;
 }

--- a/opencog/atomutils/FuzzyMatchBasic.cc
+++ b/opencog/atomutils/FuzzyMatchBasic.cc
@@ -90,6 +90,8 @@ bool FuzzyMatchBasic::note_match(const Handle& soln, int depth)
 	return true;
 }
 
-/* No-op; we already build "solns" */
-void FuzzyMatchBasic::finish(void)
-{}
+/* No-op; we already build "solns", just return it. */
+HandleSeq FuzzyMatchBasic::finished_search(void)
+{
+	return solns;
+}

--- a/opencog/atomutils/FuzzyMatchBasic.cc
+++ b/opencog/atomutils/FuzzyMatchBasic.cc
@@ -110,7 +110,7 @@ bool FuzzyMatchBasic::try_match(const Handle& soln, int depth)
 		solns.push_back(soln);
 	}
 
-	return true;
+	return false;
 }
 
 /* No-op; we already build "solns", just return it. */

--- a/opencog/atomutils/FuzzyMatchBasic.cc
+++ b/opencog/atomutils/FuzzyMatchBasic.cc
@@ -29,6 +29,14 @@
 
 using namespace opencog;
 
+/** Set up the target. */
+void FuzzyMatchBasic::start_search(const Handle& trg)
+{
+	target = trg;
+	target_nodes = get_all_nodes(target);
+	std::sort(target_nodes.begin(), target_nodes.end());
+}
+
 /**
  * hp is a subtree of the target tree. Should we start a search
  * at that location?  Answer: yes if its a node, no, if its a link.
@@ -51,6 +59,8 @@ bool FuzzyMatchBasic::accept_starter(const Handle& hp)
  */
 bool FuzzyMatchBasic::try_match(const Handle& soln, int depth)
 {
+	if (soln == target) return false;
+
 	// For some reason, this algo only wnts to compare proposed
 	// solutions that are exactly the same size as the target.
 	// Why? I dunno. Might not a similar tree be slightly bigger or

--- a/opencog/atomutils/FuzzyMatchBasic.cc
+++ b/opencog/atomutils/FuzzyMatchBasic.cc
@@ -1,0 +1,95 @@
+/*
+ * FuzzyMatchBasic.cc
+ *
+ * Copyright (C) 2015 OpenCog Foundation
+ *
+ * Author: Leung Man Hin <https://github.com/leungmanhin>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/atomspace/AtomSpace.h>
+#include <opencog/atomutils/AtomUtils.h>
+#include <opencog/atomutils/FindUtils.h>
+
+#include "FuzzyMatchBasic.h"
+
+using namespace opencog;
+
+bool FuzzyMatchBasic::accept_starter(const NodePtr& np)
+{
+	return (np->getType() != VARIABLE_NODE and
+		np->getName().find("@") == std::string::npos);
+}
+
+/**
+ * Estimate how similar the potential solution and the target pattern are.
+ *
+ * @param soln  The potential solution
+ */
+bool FuzzyMatchBasic::note_match(const Handle& soln, int depth)
+{
+	if (0 < depth) return true;
+	if (0 > depth) return false;
+
+	// Find out how many nodes it has in common with the pattern
+	HandleSeq common_nodes;
+	HandleSeq soln_nodes = get_all_nodes(soln);
+
+	std::sort(soln_nodes.begin(), soln_nodes.end());
+
+	std::set_intersection(target_nodes.begin(), target_nodes.end(),
+	                      soln_nodes.begin(), soln_nodes.end(),
+	                      std::back_inserter(common_nodes));
+
+	// The size different between the pattern and the potential solution
+	size_t diff = std::abs((int)target_nodes.size() - (int)soln_nodes.size());
+
+	double similarity = 0.0;
+
+	// Roughly estimate how "rare" each node is by using 1 / incoming set size
+	// TODO: May use Truth Value instead
+	for (const Handle& common_node : common_nodes)
+		similarity += 1.0 / common_node->getIncomingSetSize();
+
+	LAZY_LOG_FINE << "\n========================================\n"
+	              << "Comparing:\n" << target->toShortString()
+	              << "----- and:\n" << soln->toShortString() << "\n"
+	              << "Common nodes = " << common_nodes.size() << "\n"
+	              << "Size diff = " << diff << "\n"
+	              << "Similarity = " << similarity << "\n"
+	              << "Most similar = " << max_similarity << "\n"
+	              << "========================================\n";
+
+	// Decide if we should accept the potential solutions or not
+	if ((similarity > max_similarity) or
+		(similarity == max_similarity and diff < min_size_diff)) {
+		max_similarity = similarity;
+		min_size_diff = diff;
+		solns.clear();
+		solns.push_back(soln);
+	}
+
+	else if (similarity == max_similarity and diff == min_size_diff) {
+		solns.push_back(soln);
+	}
+
+	return true;
+}
+
+/* No-op; we already build "solns" */
+void FuzzyMatchBasic::finish(void)
+{}

--- a/opencog/atomutils/FuzzyMatchBasic.h
+++ b/opencog/atomutils/FuzzyMatchBasic.h
@@ -42,7 +42,7 @@ class FuzzyMatchBasic : public FuzzyMatch
 {
 protected:
     virtual bool accept_starter(const NodePtr&);
-    virtual bool note_match(const Handle&, int);
+    virtual bool try_match(const Handle&, int);
     virtual HandleSeq finished_search(void);
 
 private:

--- a/opencog/atomutils/FuzzyMatchBasic.h
+++ b/opencog/atomutils/FuzzyMatchBasic.h
@@ -35,8 +35,7 @@ namespace opencog
  * the target pattern.  A similarity score is assigned to each such
  * tree, and the ones with the highest scores are returned.
  *
- * It can be called from C++ via find_approximate_matchBasic(), or from Scheme
- * via (cog-fuzzy-matchBasic).
+ * This class implements certain specific similarity score.
  */
 class FuzzyMatchBasic : public FuzzyMatch
 {

--- a/opencog/atomutils/FuzzyMatchBasic.h
+++ b/opencog/atomutils/FuzzyMatchBasic.h
@@ -43,7 +43,7 @@ protected:
     virtual void start_search(const Handle&);
     virtual bool accept_starter(const Handle&);
     virtual bool try_match(const Handle&, int);
-    virtual HandleSeq finished_search(void);
+    virtual RankedHandleSeq finished_search(void);
 
     // What we are matching
     Handle target;
@@ -51,7 +51,7 @@ protected:
 
 private:
     // The solutions that were found.
-    HandleSeq solns;
+    RankedHandleSeq solns;
 
     // The minimum difference between the pattern and all
     // the known solutions

--- a/opencog/atomutils/FuzzyMatchBasic.h
+++ b/opencog/atomutils/FuzzyMatchBasic.h
@@ -41,9 +41,14 @@ namespace opencog
 class FuzzyMatchBasic : public FuzzyMatch
 {
 protected:
+    virtual void start_search(const Handle&);
     virtual bool accept_starter(const Handle&);
     virtual bool try_match(const Handle&, int);
     virtual HandleSeq finished_search(void);
+
+    // What we are matching
+    Handle target;
+    HandleSeq target_nodes;
 
 private:
     // The solutions that were found.

--- a/opencog/atomutils/FuzzyMatchBasic.h
+++ b/opencog/atomutils/FuzzyMatchBasic.h
@@ -41,7 +41,7 @@ namespace opencog
 class FuzzyMatchBasic : public FuzzyMatch
 {
 protected:
-    virtual bool accept_starter(const NodePtr&);
+    virtual bool accept_starter(const Handle&);
     virtual bool try_match(const Handle&, int);
     virtual HandleSeq finished_search(void);
 

--- a/opencog/atomutils/FuzzyMatchBasic.h
+++ b/opencog/atomutils/FuzzyMatchBasic.h
@@ -42,9 +42,13 @@ class FuzzyMatchBasic : public FuzzyMatch
 {
 protected:
     virtual bool accept_starter(const NodePtr&);
-    virtual bool note_matchBasic(const Handle&, int depth);
+    virtual bool note_match(const Handle&, int);
+    virtual HandleSeq finished_search(void);
 
 private:
+    // The solutions that were found.
+    HandleSeq solns;
+
     // The minimum difference between the pattern and all
     // the known solutions
     size_t min_size_diff = SIZE_MAX;

--- a/opencog/atomutils/FuzzyMatchBasic.h
+++ b/opencog/atomutils/FuzzyMatchBasic.h
@@ -1,5 +1,5 @@
 /*
- * FuzzyMatch.h
+ * FuzzyMatchBasic.h
  *
  * Copyright (C) 2015 OpenCog Foundation
  *
@@ -21,44 +21,37 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef FUZZY_MATCH_H
-#define FUZZY_MATCH_H
+#ifndef FUZZY_MATCH_BASIC_H
+#define FUZZY_MATCH_BASIC_H
 
-#include <opencog/atomspace/Handle.h>
-#include <opencog/atomspace/Link.h>
-#include <opencog/atomspace/Node.h>
+#include <opencog/atomutils/FuzzyMatch.h>
 
 namespace opencog
 {
 /**
- * The fuzzy pattern matcher searches for trees which are similar but
+ * The fuzzy pattern matchBasicer searches for trees which are similar but
  * not identical to the input target pattern. This is done by examining
  * all possible trees that have at least one leaf node in common with
  * the target pattern.  A similarity score is assigned to each such
  * tree, and the ones with the highest scores are returned.
+ *
+ * It can be called from C++ via find_approximate_matchBasic(), or from Scheme
+ * via (cog-fuzzy-matchBasic).
  */
-class FuzzyMatch
+class FuzzyMatchBasic : public FuzzyMatch
 {
-public:
-    HandleSeq perform_search(const Handle&);
-    virtual ~FuzzyMatch() {}
-
 protected:
-    // What we are matching
-    Handle target;
-    HandleSeq target_nodes;
-
-    virtual bool accept_starter(const NodePtr&) = 0;
-    virtual bool note_match(const Handle&, int depth) = 0;
-    virtual void finished_search(void) = 0;
+    virtual bool accept_starter(const NodePtr&);
+    virtual bool note_matchBasic(const Handle&, int depth);
 
 private:
-    // The solutions that were found.
-    HandleSeq solns;
+    // The minimum difference between the pattern and all
+    // the known solutions
+    size_t min_size_diff = SIZE_MAX;
 
-    void find_starters(const Handle& hg, const int& depth);
-    void explore(const LinkPtr&, int);
+    // The maximum similarity of all the potential solutions we found
+    double max_similarity = -std::numeric_limits<double>::max();
 };
 
 } // namespace opencog
-#endif  // FUZZY_MATCH_H
+#endif  // FUZZY_MATCH_BASIC_H

--- a/opencog/query/PatternSCM.cc
+++ b/opencog/query/PatternSCM.cc
@@ -20,7 +20,10 @@ using namespace opencog;
 static Handle find_approximate_match(AtomSpace* as, const Handle& hp)
 {
 	FuzzyMatchBasic fpm;
-	HandleSeq solns = fpm.perform_search(hp);
+	RankedHandleSeq ranked_solns = fpm.perform_search(hp);
+	HandleSeq solns;
+	for (auto rs: ranked_solns)
+		solns.emplace_back(rs.first);
 	return as->add_link(LIST_LINK, solns);
 }
 

--- a/opencog/query/PatternSCM.cc
+++ b/opencog/query/PatternSCM.cc
@@ -5,7 +5,7 @@
  * Copyright (c) 2008, 2014, 2015 Linas Vepstas <linas@linas.org>
  */
 
-#include <opencog/atomutils/FuzzyMatch.h>
+#include <opencog/atomutils/FuzzyMatchBasic.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/guile/SchemeModule.h>
 
@@ -19,7 +19,7 @@ using namespace opencog;
 // Convenience wrapper
 static Handle find_approximate_match(AtomSpace* as, const Handle& hp)
 {
-	FuzzyMatch fpm;
+	FuzzyMatchBasic fpm;
 	HandleSeq solns = fpm.perform_search(hp);
 	return as->add_link(LIST_LINK, solns);
 }

--- a/tests/atomutils/FuzzyUTest.cxxtest
+++ b/tests/atomutils/FuzzyUTest.cxxtest
@@ -72,7 +72,10 @@ void FuzzyPatternUTest::setUp(void)
 Handle find_approximate_match(AtomSpace* as, const Handle& hp)
 {
     FuzzyMatchBasic fpm;
-    HandleSeq solns = fpm.perform_search(hp);
+    RankedHandleSeq ranked_solns = fpm.perform_search(hp);
+    HandleSeq solns;
+    for (auto rs: ranked_solns)
+        solns.emplace_back(rs.first);
     return as->add_link(LIST_LINK, solns);
 }
 

--- a/tests/atomutils/FuzzyUTest.cxxtest
+++ b/tests/atomutils/FuzzyUTest.cxxtest
@@ -23,7 +23,7 @@
  */
 
 #include <opencog/atomspace/AtomSpace.h>
-#include <opencog/atomutils/FuzzyMatch.h>
+#include <opencog/atomutils/FuzzyMatchBasic.h>
 #include <opencog/util/Config.h>
 #include <opencog/util/Logger.h>
 
@@ -71,7 +71,7 @@ void FuzzyPatternUTest::setUp(void)
 
 Handle find_approximate_match(AtomSpace* as, const Handle& hp)
 {
-    FuzzyMatch fpm;
+    FuzzyMatchBasic fpm;
     HandleSeq solns = fpm.perform_search(hp);
     return as->add_link(LIST_LINK, solns);
 }


### PR DESCRIPTION
Split the API into a generic base class, that performs the search, and a specific implementation that performs a specific kind of similarity scoring.   Change API to return a ranked sequence of solutions.

This is a pre-requisite to matching changes in opencog/opencog#1970