### PR TITLE
Type signature comparison

### DIFF
--- a/examples/pattern-matcher/type-signature.scm
+++ b/examples/pattern-matcher/type-signature.scm
@@ -73,3 +73,33 @@
 		(AndLink (Variable "$x"))))
 
 (cog-execute! predicate-search)
+
+; =============================================================
+
+; The cog-value-is-type? function allows signatures to be
+; directly validated. Consider these examples:
+
+; Should evaluate to true.
+(cog-value-is-type?
+	(Signature (Inheritance (Concept "foo") (Type "ConceptNode")))
+	(Inheritance (Concept "foo") (ConceptNode "bar")))
+
+; Should evaluate to false.
+(cog-value-is-type?
+	(Signature (Inheritance (Concept "foo") (Type "ConceptNode")))
+	(Inheritance (Concept "failure-mode") (ConceptNode "bar")))
+
+; We can define new types, too.
+(DefineLink
+	(DefinedType "My foo type")
+	(Signature (Inheritance (Concept "foo") (Type "ConceptNode"))))
+
+; Should evaluate to true
+(cog-value-is-type?
+	(DefinedType "My foo type")
+	(Inheritance (Concept "foo") (ConceptNode "bar")))
+
+; Should evaluate to false.
+(cog-value-is-type?
+	(DefinedType "My foo type")
+	(Inheritance (Concept "failure-mode") (ConceptNode "bar")))

--- a/opencog/atomutils/TypeUtils.cc
+++ b/opencog/atomutils/TypeUtils.cc
@@ -114,7 +114,9 @@ bool opencog::value_is_type(const Handle& spec, const Handle& val)
 
 /*
  * The implementation below feels awfully hacky and bug-prone,
- * but I don't see a better way.
+ * but I don't see a better way.  Since below is essentially
+ * a whizzy set-subset operation, one could go all formal operator
+ * and etc. but more abstraction seems unlikely to make it better.
  */
 static bool type_match_rec(const Handle& left_, const Handle& right_, bool toplevel)
 {
@@ -136,7 +138,6 @@ static bool type_match_rec(const Handle& left_, const Handle& right_, bool tople
 		LinkPtr larrow(LinkCast(left));
 		left = larrow->getOutgoingAtom(0); // 0 == input
 		ltype = left->getType();
-printf("dduuuude left arrow %s", left->toString().c_str());
 	}
 
 	// If right is not a type, then just use value-check.
@@ -168,6 +169,7 @@ printf("dduuuude left arrow %s", left->toString().c_str());
 	{
 		LinkPtr rarrow(LinkCast(right));
 		right = rarrow->getOutgoingAtom(1); // 1 == output
+		rtype = right->getType();
 	}
 
 	// Should be safe to unpack signatures now.
@@ -182,7 +184,6 @@ printf("dduuuude left arrow %s", left->toString().c_str());
 	{
 		right = LinkCast(right)->getOutgoingAtom(0);
 		rtype = right->getType();
-printf("dduuuude right sig %s", right->toString().c_str());
 	}
 
 	// Exact matchees are always good.
@@ -219,7 +220,6 @@ printf("dduuuude right sig %s", right->toString().c_str());
 		}
 		return false;
 	}
-printf("duude rayyyy! \n");
 
 	// At this point we expect both left an right to be links
 	// that are not type-links, i.e. should be ordinary links,
@@ -229,7 +229,7 @@ printf("duude rayyyy! \n");
 	LinkPtr lptr(LinkCast(left));
 	LinkPtr rptr(LinkCast(right));
 
-	OC_ASSERT(nullptr != lptr and nullptr != rptr, "expecting links!");
+	if (nullptr == lptr or nullptr == rptr) return false;
 
 	// Unordered links are a pain in the butt.
 	if (classserver().isA(ltype, UNORDERED_LINK))
@@ -240,7 +240,6 @@ printf("duude rayyyy! \n");
 	const HandleSeq& rout(rptr->getOutgoingSet());
 
 	if (lout.size() != rout.size()) return false;
-printf("duude rockin it\n");
 
 	for (size_t i=0; i< lout.size(); i++)
 	{

--- a/opencog/atomutils/TypeUtils.cc
+++ b/opencog/atomutils/TypeUtils.cc
@@ -110,4 +110,64 @@ bool opencog::value_is_type(const Handle& spec, const Handle& val)
 	return true;
 }
 
+/* ================================================================= */
+
+bool type_match(const Handle& left_, const Handle& right_)
+{
+	Handle left(left_);
+	Type ltype = left->getType();
+
+	// If it's a user-defined type, replace by it's defintion.
+	if (DEFINED_TYPE_NODE == ltype)
+	{
+		left = DefineLink::get_definition(left);
+		ltype = left->getType();
+	}
+
+	// Unpack the arrow; right must match left's input.
+	if (ARROW_LINK == ltype)
+	{
+		LinkPtr larrow(LinkCast(left));
+		left = larrow->getOutgoingAtom(0); // 0 == input
+	}
+
+	// If right is not a type, then just use value-check.
+	Type rtype = right_->getType();
+	if (TYPE_NODE != rtype and
+	    TYPE_CHOICE != rtype and
+	    SIGNATURE_LINK != rtype and
+	    DEFINED_TYPE_NODE != rtype and
+	    ARROW_LINK != rtype)
+	{
+		return value_is_type(left, right_);
+	}
+
+	Handle right(right_);
+
+	// If it's a user-defined type, replace by it's defintion.
+	if (DEFINED_TYPE_NODE == rtype)
+	{
+		right = DefineLink::get_definition(right);
+		rtype = right->getType();
+	}
+
+	// Unpack the arrow; right's output must match left.
+	if (ARROW_LINK == rtype)
+	{
+		LinkPtr rarrow(LinkCast(right));
+		right = rarrow->getOutgoingAtom(1); // 1 == output
+	}
+
+
+
+	return false;
+}
+
+Handle type_compose(const Handle& left, const Handle& right)
+{
+	return Handle::UNDEFINED;
+}
+
+
+
 /* ===================== END OF FILE ===================== */

--- a/opencog/atomutils/TypeUtils.h
+++ b/opencog/atomutils/TypeUtils.h
@@ -42,6 +42,72 @@ namespace opencog
  */
 bool value_is_type(const Handle& type_spec, const Handle& val);
 
+/**
+ * Type matcher. Returns true if `left` can mate with `right`.
+ * Here, `left` can be a type definition, and `right` can be
+ * another type defintion, or a value.  Mating is possible whenever
+ * `left` is broader, less restricitve than `right`; equivalently
+ * if `right` is narrower than 'left`.
+ *
+ * Mating types and values:
+ * left == (Type "Concept")    right == (Concept "foo")  can mate.
+ * left == (Type "Concept")    right == (Number 13)  cannot.
+ *
+ * Mating types and types:
+ * left == (Type "Concept")    right == (Type "Concept")  can mate.
+ *
+ * Left is wider (polymorphic, in this case)
+ *   left == (TypeChoice (Type "Concept") (Type "Number"))
+ *   right == (Type "Number")  can mate.
+ *
+ * Function call arguments can be checked:
+ *   left == (Arrow (Type "Concept") (Type "Number"))
+ *   right == (Concept "foo")  can mate.
+ *
+ *   left == (Arrow (Type "Concept") (Type "Number"))
+ *   right == (Number 13)  cannot.
+ *
+ * Function call chains can be checked:
+ *   left == (Arrow (Type "Concept") (Type "Number"))
+ *   right == (Type "Concept")  can mate.
+ *
+ * The following can mate, because left accepts a concept as input,
+ * and right generates a concept as output:
+ *   left == (Arrow (Type "Concept") (Type "Number"))
+ *   right == (Arrow (Type "Evaluation") (Type "Concept")
+ *
+ * Any type specification is valid: SignatureLinks, etc work too.
+ */
+
+bool type_match(const Handle&, const Handle&);
+
+/**
+ * Same as above, but return the composition (beta-reduction) of the
+ * match. If the types do NOT match, theundefined handle is returned.
+ * If the types do match, then, for many cases, the right side is the
+ * result.  The compostion of arrows, however, results either in a
+ * new arrow, or a simple return type.
+ *
+ * Examples:
+ *
+ * Function call arguments can be checked:
+ *   left == (Arrow (Type "Concept") (Type "Number"))
+ *   right == (Concept "foo")  can mate.
+ *   result = (Type "Number")
+ *
+ * Function call chains:
+ *   left == (Arrow (Type "Concept") (Type "Number"))
+ *   right == (Type "Concept")  can mate.
+ *   result = (Type "Number")
+ *
+ * The following can mate, because left accepts a concept as input,
+ * and right generates a concept as output:
+ *   left == (Arrow (Type "Concept") (Type "Number"))
+ *   right == (Arrow (Type "Evaluation") (Type "Concept")
+ *   result = (Arrow (Type "Evaluation") (Type "Number"))
+ */
+Handle type_compose(const Handle&, const Handle&);
+
 /** @}*/
 }
 

--- a/opencog/query/PatternSCM.cc
+++ b/opencog/query/PatternSCM.cc
@@ -38,6 +38,16 @@ bool PatternSCM::value_is_type(Handle type, Handle val)
 	return opencog::value_is_type(type, val);
 }
 
+bool PatternSCM::type_match(Handle left, Handle right)
+{
+	return opencog::type_match(left, right);
+}
+
+Handle PatternSCM::type_compose(Handle left, Handle right)
+{
+	return opencog::type_compose(left, right);
+}
+
 // ========================================================
 
 // XXX HACK ALERT This needs to be static, in order for python to
@@ -85,9 +95,15 @@ void PatternSCM::init(void)
 	define_scheme_primitive("cog-fuzzy-match",
 		&PatternSCM::find_approximate_match, this, "query");
 
-	// This also belongs somewhere else. Not sure where.
+	// These below also belong somewhere else. Not sure where.
 	define_scheme_primitive("cog-value-is-type?",
 		&PatternSCM::value_is_type, this, "query");
+
+	define_scheme_primitive("cog-type-match?",
+		&PatternSCM::type_match, this, "query");
+
+	define_scheme_primitive("cog-type-compose",
+		&PatternSCM::type_compose, this, "query");
 }
 
 PatternSCM::~PatternSCM()

--- a/opencog/query/PatternSCM.h
+++ b/opencog/query/PatternSCM.h
@@ -19,6 +19,8 @@ class PatternSCM : public ModuleWrap
 		static std::vector<FunctionWrap*> _binders;
 		Handle find_approximate_match(Handle);
 		bool value_is_type(Handle, Handle);
+		bool type_match(Handle, Handle);
+		Handle type_compose(Handle, Handle);
 	public:
 		PatternSCM(void);
 		~PatternSCM();

--- a/tests/query/DeepTypeUTest.cxxtest
+++ b/tests/query/DeepTypeUTest.cxxtest
@@ -136,6 +136,7 @@ void DeepTypeUTest::test_type_match(void)
 	std::string rv;
 	as->clear();
 
+	// ----------------------
 	rv = eval->eval(
 		"(cog-type-match? "
 		"	(Concept \"aaa\")"
@@ -152,6 +153,7 @@ void DeepTypeUTest::test_type_match(void)
 	printf("expect false, got %s", rv.c_str());
 	TSM_ASSERT("Expected false", rv == "#f\n");
 
+	// ----------------------
 	rv = eval->eval(
 		"(cog-type-match? "
 		"	(Type \"ConceptNode\")"
@@ -168,6 +170,117 @@ void DeepTypeUTest::test_type_match(void)
 	printf("expect false, got %s", rv.c_str());
 	TSM_ASSERT("Expected false", rv == "#f\n");
 
+	// ----------------------
+	rv = eval->eval(
+		"(cog-type-match? "
+		"	(Type \"ConceptNode\")"
+		"	(Type \"ConceptNode\"))");
+
+	printf("expect true, got %s", rv.c_str());
+	TSM_ASSERT("Expected true", rv == "#t\n");
+
+	rv = eval->eval(
+		"(cog-type-match? "
+		"	(TypeChoice (Type \"ConceptNode\") (Type \"NumberNode\"))"
+		"	(Type \"ConceptNode\"))");
+
+	printf("expect true, got %s", rv.c_str());
+	TSM_ASSERT("Expected true", rv == "#t\n");
+
+	rv = eval->eval(
+		"(cog-type-match? "
+		"	(Type \"ConceptNode\")"
+		"	(TypeChoice (Type \"ConceptNode\") (Type \"NumberNode\")))");
+
+	printf("expect false, got %s", rv.c_str());
+	TSM_ASSERT("Expected false", rv == "#f\n");
+
+	// ----------------------
+	rv = eval->eval(
+		"(cog-type-match? "
+		"	(SignatureLink (EvaluationLink "
+		"		(Type \"PredicateNode\")"
+		"		(ListLink (Type \"ConceptNode\") (Type \"NumberNode\"))))"
+		"	(SignatureLink (EvaluationLink "
+		"		(Type \"PredicateNode\")"
+		"		(ListLink (Type \"ConceptNode\") (Type \"NumberNode\"))))");
+
+	printf("expect true, got %s", rv.c_str());
+	TSM_ASSERT("Expected true", rv == "#t\n");
+
+	rv = eval->eval(
+		"(cog-type-match? "
+		"	(SignatureLink (EvaluationLink "
+		"		(Type \"PredicateNode\")"
+		"		(ListLink (Type \"ConceptNode\") (Type \"NumberNode\"))))"
+		"	(SignatureLink (EvaluationLink "
+		"		(Type \"PredicateNode\")"
+		"		(ListLink (Type \"NumberNode\") (Type \"NumberNode\"))))");
+
+	printf("expect false, got %s", rv.c_str());
+	TSM_ASSERT("Expected false", rv == "#f\n");
+
+	rv = eval->eval(
+		"(cog-type-match? "
+		"	(SignatureLink (EvaluationLink "
+		"		(Type \"PredicateNode\")"
+		"		(ListLink (Type \"ConceptNode\") (Type \"NumberNode\"))))"
+		"	(SignatureLink (EvaluationLink "
+		"		(PredicateNode \"foo\")"
+		"		(ListLink (Type \"ConceptNode\") (NumberNode 42))))");
+
+	printf("expect true, got %s", rv.c_str());
+	TSM_ASSERT("Expected true", rv == "#t\n");
+
+	rv = eval->eval(
+		"(cog-type-match? "
+		"	(SignatureLink (EvaluationLink "
+		"		(Type \"PredicateNode\")"
+		"		(ListLink (Type \"ConceptNode\") (Type \"NumberNode\"))))"
+		"	(EvaluationLink "
+		"		(PredicateNode \"foo\")"
+		"		(ListLink (ConceptNode \"bar\") (NumberNode 42))))");
+
+	printf("expect true, got %s", rv.c_str());
+	TSM_ASSERT("Expected true", rv == "#t\n");
+
+	rv = eval->eval(
+		"(cog-type-match? "
+		"	(SignatureLink (EvaluationLink "
+		"		(Type \"PredicateNode\")"
+		"		(ListLink (Type \"ConceptNode\") (Type \"NumberNode\"))))"
+		"	(EvaluationLink "
+		"		(PredicateNode \"foo\")"
+		"		(ListLink (NumberNode 13) (NumberNode 42))))");
+
+	printf("expect false, got %s", rv.c_str());
+	TSM_ASSERT("Expected false", rv == "#f\n");
+
+	rv = eval->eval(
+		"(cog-type-match? "
+		"	(SignatureLink (EvaluationLink "
+		"		(PredicateNode \"foo\")"
+		"		(ListLink (Type \"ConceptNode\") (Type \"NumberNode\"))))"
+		"	(EvaluationLink "
+		"		(PredicateNode \"foo\")"
+		"		(ListLink (ConceptNode \"bar\") (NumberNode 42))))");
+
+	printf("expect true, got %s", rv.c_str());
+	TSM_ASSERT("Expected true", rv == "#t\n");
+
+	rv = eval->eval(
+		"(cog-type-match? "
+		"	(SignatureLink (EvaluationLink "
+		"		(PredicateNode \"foo\")"
+		"		(ListLink (Type \"ConceptNode\") (Type \"NumberNode\"))))"
+		"	(EvaluationLink "
+		"		(PredicateNode \"bar\")"
+		"		(ListLink (ConceptNode \"bar\") (NumberNode 42))))");
+
+	printf("expect false, got %s", rv.c_str());
+	TSM_ASSERT("Expected false", rv == "#f\n");
+
+	// ----------------------
 	logger().debug("END TEST: %s", __FUNCTION__);
 }
 

--- a/tests/query/DeepTypeUTest.cxxtest
+++ b/tests/query/DeepTypeUTest.cxxtest
@@ -325,75 +325,142 @@ void DeepTypeUTest::test_match_arrow(void)
 
 	rv = eval->eval(
 		"(cog-type-match? "
-		"	(SignatureLink (EvaluationLink "
-		"		(Type \"PredicateNode\")"
-		"		(ListLink (Type \"ConceptNode\") (Type \"NumberNode\"))))"
+		"	(Arrow "
+		"		(EvaluationLink "
+		"			(Type \"PredicateNode\")"
+		"			(ListLink (Type \"ConceptNode\") (Type \"NumberNode\")))"
+		"		(Type \"SetLink\"))"
 		"	(SignatureLink (EvaluationLink "
 		"		(Type \"PredicateNode\")"
 		"		(ListLink (Type \"NumberNode\") (Type \"NumberNode\")))))");
 
-	printf("(nn) expect false, got %s", rv.c_str());
+	printf("(aro nn) expect false, got %s", rv.c_str());
 	TSM_ASSERT("Expected false", rv == "#f\n");
 
 	rv = eval->eval(
 		"(cog-type-match? "
-		"	(SignatureLink (EvaluationLink "
-		"		(Type \"PredicateNode\")"
-		"		(ListLink (Type \"ConceptNode\") (Type \"NumberNode\"))))"
-		"	(SignatureLink (EvaluationLink "
-		"		(PredicateNode \"foo\")"
-		"		(ListLink (Type \"ConceptNode\") (NumberNode 42)))))");
+		"	(Arrow "
+		"		(EvaluationLink "
+		"			(Type \"PredicateNode\")"
+		"			(ListLink (Type \"ConceptNode\") (Type \"NumberNode\")))"
+		"		(Type \"SetLink\"))"
+		"	(Arrow "
+		"		(Type \"MemberLink\")"
+		"		(EvaluationLink "
+		"			(Type \"PredicateNode\")"
+		"			(ListLink (Type \"ConceptNode\") (NumberNode 42)))))");
 
-	printf("(cpred) expect true, got %s", rv.c_str());
+	printf("(aro cpred) expect true, got %s", rv.c_str());
 	TSM_ASSERT("Expected true", rv == "#t\n");
 
 	rv = eval->eval(
 		"(cog-type-match? "
-		"	(SignatureLink (EvaluationLink "
-		"		(Type \"PredicateNode\")"
-		"		(ListLink (Type \"ConceptNode\") (Type \"NumberNode\"))))"
-		"	(EvaluationLink "
-		"		(PredicateNode \"foo\")"
-		"		(ListLink (ConceptNode \"bar\") (NumberNode 42))))");
+		"	(Arrow "
+		"		(EvaluationLink "
+		"			(Type \"PredicateNode\")"
+		"			(ListLink (Type \"ConceptNode\") (Type \"NumberNode\")))"
+		"		(Type \"SetLink\"))"
+		"	(Arrow "
+		"		(Type \"MemberLink\")"
+		"		(EvaluationLink "
+		"			(PredicateNode \"foo\")"
+		"			(ListLink (ConceptNode \"bar\") (NumberNode 42)))))");
 
-	printf("(concr) expect true, got %s", rv.c_str());
+	printf("(aro concr) expect true, got %s", rv.c_str());
 	TSM_ASSERT("Expected true", rv == "#t\n");
 
 	rv = eval->eval(
 		"(cog-type-match? "
-		"	(SignatureLink (EvaluationLink "
-		"		(Type \"PredicateNode\")"
-		"		(ListLink (Type \"ConceptNode\") (Type \"NumberNode\"))))"
-		"	(EvaluationLink "
-		"		(PredicateNode \"foo\")"
-		"		(ListLink (NumberNode 13) (NumberNode 42))))");
+		"	(Arrow "
+		"		(EvaluationLink "
+		"			(Type \"PredicateNode\")"
+		"			(ListLink (Type \"ConceptNode\") (Type \"NumberNode\")))"
+		"		(Type \"SetLink\"))"
+		"	(Arrow "
+		"		(Type \"MemberLink\")"
+		"		(EvaluationLink "
+		"			(PredicateNode \"foo\")"
+		"			(ListLink (NumberNode 13) (NumberNode 42)))))");
 
-	printf("(badnum) expect false, got %s", rv.c_str());
+	printf("(aro badnum) expect false, got %s", rv.c_str());
 	TSM_ASSERT("Expected false", rv == "#f\n");
 
 	rv = eval->eval(
 		"(cog-type-match? "
-		"	(SignatureLink (EvaluationLink "
-		"		(PredicateNode \"foo\")"
-		"		(ListLink (Type \"ConceptNode\") (Type \"NumberNode\"))))"
-		"	(EvaluationLink "
-		"		(PredicateNode \"foo\")"
-		"		(ListLink (ConceptNode \"bar\") (NumberNode 42))))");
+		"	(Arrow "
+		"		(EvaluationLink "
+		"			(TypeChoice "
+		"				(Type \"PredicateNode\")"
+		"				(Type \"GroundedPredicateNode\"))"
+		"			(ListLink (Type \"ConceptNode\") (Type \"NumberNode\")))"
+		"		(Type \"SetLink\"))"
+		"	(Arrow "
+		"		(Type \"MemberLink\")"
+		"		(EvaluationLink "
+		"			(PredicateNode \"foo\")"
+		"			(ListLink (ConceptNode \"bar\") (NumberNode 42)))))");
 
-	printf("(foo-concr) expect true, got %s", rv.c_str());
+	printf("(aro choice) expect true, got %s", rv.c_str());
 	TSM_ASSERT("Expected true", rv == "#t\n");
 
 	rv = eval->eval(
 		"(cog-type-match? "
-		"	(SignatureLink (EvaluationLink "
-		"		(PredicateNode \"foo\")"
-		"		(ListLink (Type \"ConceptNode\") (Type \"NumberNode\"))))"
-		"	(EvaluationLink "
-		"		(PredicateNode \"bar\")"
-		"		(ListLink (ConceptNode \"bar\") (NumberNode 42))))");
+		"	(Arrow "
+		"		(EvaluationLink "
+		"			(TypeChoice "
+		"				(PredicateNode \"foo\")"
+		"				(PredicateNode \"bar\")"
+		"				(Type \"GroundedPredicateNode\"))"
+		"			(ListLink (Type \"ConceptNode\") (Type \"NumberNode\")))"
+		"		(Type \"SetLink\"))"
+		"	(Arrow "
+		"		(Type \"MemberLink\")"
+		"		(EvaluationLink "
+		"			(PredicateNode \"foo\")"
+		"			(ListLink (ConceptNode \"bar\") (NumberNode 42)))))");
 
-	printf("(foobar) expect false, got %s", rv.c_str());
+	printf("(aro choice concr) expect true, got %s", rv.c_str());
+	TSM_ASSERT("Expected true", rv == "#t\n");
+
+	rv = eval->eval(
+		"(cog-type-match? "
+		"	(Arrow "
+		"		(EvaluationLink "
+		"			(TypeChoice "
+		"				(PredicateNode \"bar\")"
+		"				(Type \"GroundedPredicateNode\"))"
+		"			(ListLink (Type \"ConceptNode\") (Type \"NumberNode\")))"
+		"		(Type \"SetLink\"))"
+		"	(Arrow "
+		"		(Type \"MemberLink\")"
+		"		(EvaluationLink "
+		"			(PredicateNode \"foo\")"
+		"			(ListLink (ConceptNode \"bar\") (NumberNode 42)))))");
+
+	printf("(aro choice foobar) expect false, got %s", rv.c_str());
 	TSM_ASSERT("Expected false", rv == "#f\n");
+
+	rv = eval->eval(
+		"(cog-type-match? "
+		"	(Arrow "
+		"		(EvaluationLink "
+		"			(TypeChoice "
+		"				(PredicateNode \"foo\")"
+		"				(PredicateNode \"bar\")"
+		"				(PredicateNode \"baz\")"
+		"				(Type \"GroundedPredicateNode\"))"
+		"			(ListLink (Type \"ConceptNode\") (Type \"NumberNode\")))"
+		"		(Type \"SetLink\"))"
+		"	(Arrow "
+		"		(Type \"MemberLink\")"
+		"		(EvaluationLink "
+		"			(TypeChoice "
+		"				(PredicateNode \"foo\")"
+		"				(GroundedPredicateNode \"scm: stuff huff\"))"
+		"			(ListLink (ConceptNode \"bar\") (NumberNode 42)))))");
+
+	printf("(aro choice subset) expect true, got %s", rv.c_str());
+	TSM_ASSERT("Expected true", rv == "#t\n");
 
 	// ----------------------
 	logger().debug("END TEST: %s", __FUNCTION__);

--- a/tests/query/DeepTypeUTest.cxxtest
+++ b/tests/query/DeepTypeUTest.cxxtest
@@ -69,6 +69,7 @@ public:
 	void test_is_type(void);
 	void test_type_match(void);
 	void test_match_signature(void);
+	void test_match_arrow(void);
 	void test_get_signature(void);
 };
 
@@ -200,7 +201,7 @@ void DeepTypeUTest::test_type_match(void)
 }
 
 /*
- * Basic deep-type unit test.
+ * Signature unit test.
  */
 void DeepTypeUTest::test_match_signature(void)
 {
@@ -219,6 +220,107 @@ void DeepTypeUTest::test_match_signature(void)
 		"		(ListLink (Type \"ConceptNode\") (Type \"NumberNode\")))))");
 
 	printf("(seq) expect true, got %s", rv.c_str());
+	TSM_ASSERT("Expected true", rv == "#t\n");
+
+	rv = eval->eval(
+		"(cog-type-match? "
+		"	(SignatureLink (EvaluationLink "
+		"		(Type \"PredicateNode\")"
+		"		(ListLink (Type \"ConceptNode\") (Type \"NumberNode\"))))"
+		"	(SignatureLink (EvaluationLink "
+		"		(Type \"PredicateNode\")"
+		"		(ListLink (Type \"NumberNode\") (Type \"NumberNode\")))))");
+
+	printf("(nn) expect false, got %s", rv.c_str());
+	TSM_ASSERT("Expected false", rv == "#f\n");
+
+	rv = eval->eval(
+		"(cog-type-match? "
+		"	(SignatureLink (EvaluationLink "
+		"		(Type \"PredicateNode\")"
+		"		(ListLink (Type \"ConceptNode\") (Type \"NumberNode\"))))"
+		"	(SignatureLink (EvaluationLink "
+		"		(PredicateNode \"foo\")"
+		"		(ListLink (Type \"ConceptNode\") (NumberNode 42)))))");
+
+	printf("(cpred) expect true, got %s", rv.c_str());
+	TSM_ASSERT("Expected true", rv == "#t\n");
+
+	rv = eval->eval(
+		"(cog-type-match? "
+		"	(SignatureLink (EvaluationLink "
+		"		(Type \"PredicateNode\")"
+		"		(ListLink (Type \"ConceptNode\") (Type \"NumberNode\"))))"
+		"	(EvaluationLink "
+		"		(PredicateNode \"foo\")"
+		"		(ListLink (ConceptNode \"bar\") (NumberNode 42))))");
+
+	printf("(concr) expect true, got %s", rv.c_str());
+	TSM_ASSERT("Expected true", rv == "#t\n");
+
+	rv = eval->eval(
+		"(cog-type-match? "
+		"	(SignatureLink (EvaluationLink "
+		"		(Type \"PredicateNode\")"
+		"		(ListLink (Type \"ConceptNode\") (Type \"NumberNode\"))))"
+		"	(EvaluationLink "
+		"		(PredicateNode \"foo\")"
+		"		(ListLink (NumberNode 13) (NumberNode 42))))");
+
+	printf("(badnum) expect false, got %s", rv.c_str());
+	TSM_ASSERT("Expected false", rv == "#f\n");
+
+	rv = eval->eval(
+		"(cog-type-match? "
+		"	(SignatureLink (EvaluationLink "
+		"		(PredicateNode \"foo\")"
+		"		(ListLink (Type \"ConceptNode\") (Type \"NumberNode\"))))"
+		"	(EvaluationLink "
+		"		(PredicateNode \"foo\")"
+		"		(ListLink (ConceptNode \"bar\") (NumberNode 42))))");
+
+	printf("(foo-concr) expect true, got %s", rv.c_str());
+	TSM_ASSERT("Expected true", rv == "#t\n");
+
+	rv = eval->eval(
+		"(cog-type-match? "
+		"	(SignatureLink (EvaluationLink "
+		"		(PredicateNode \"foo\")"
+		"		(ListLink (Type \"ConceptNode\") (Type \"NumberNode\"))))"
+		"	(EvaluationLink "
+		"		(PredicateNode \"bar\")"
+		"		(ListLink (ConceptNode \"bar\") (NumberNode 42))))");
+
+	printf("(foobar) expect false, got %s", rv.c_str());
+	TSM_ASSERT("Expected false", rv == "#f\n");
+
+	// ----------------------
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+/*
+ * Arrow unit test.
+ * Mostly a cut-n-paste of above signature test, but with arrows, instead.
+ */
+void DeepTypeUTest::test_match_arrow(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	std::string rv;
+	as->clear();
+
+	rv = eval->eval(
+		"(cog-type-match? "
+		"	(Arrow "
+		"		(EvaluationLink "
+		"			(Type \"PredicateNode\")"
+		"			(ListLink (Type \"ConceptNode\") (Type \"NumberNode\")))"
+		"		(Type \"SetLink\"))"
+		"	(SignatureLink (EvaluationLink "
+		"		(Type \"PredicateNode\")"
+		"		(ListLink (Type \"ConceptNode\") (Type \"NumberNode\")))))");
+
+	printf("(aro seq) expect true, got %s", rv.c_str());
 	TSM_ASSERT("Expected true", rv == "#t\n");
 
 	rv = eval->eval(

--- a/tests/query/DeepTypeUTest.cxxtest
+++ b/tests/query/DeepTypeUTest.cxxtest
@@ -68,6 +68,7 @@ public:
 
 	void test_is_type(void);
 	void test_type_match(void);
+	void test_match_signature(void);
 	void test_get_signature(void);
 };
 
@@ -195,7 +196,19 @@ void DeepTypeUTest::test_type_match(void)
 	printf("expect false, got %s", rv.c_str());
 	TSM_ASSERT("Expected false", rv == "#f\n");
 
-	// ----------------------
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+/*
+ * Basic deep-type unit test.
+ */
+void DeepTypeUTest::test_match_signature(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	std::string rv;
+	as->clear();
+
 	rv = eval->eval(
 		"(cog-type-match? "
 		"	(SignatureLink (EvaluationLink "
@@ -203,9 +216,9 @@ void DeepTypeUTest::test_type_match(void)
 		"		(ListLink (Type \"ConceptNode\") (Type \"NumberNode\"))))"
 		"	(SignatureLink (EvaluationLink "
 		"		(Type \"PredicateNode\")"
-		"		(ListLink (Type \"ConceptNode\") (Type \"NumberNode\"))))");
+		"		(ListLink (Type \"ConceptNode\") (Type \"NumberNode\")))))");
 
-	printf("expect true, got %s", rv.c_str());
+	printf("(seq) expect true, got %s", rv.c_str());
 	TSM_ASSERT("Expected true", rv == "#t\n");
 
 	rv = eval->eval(
@@ -215,9 +228,9 @@ void DeepTypeUTest::test_type_match(void)
 		"		(ListLink (Type \"ConceptNode\") (Type \"NumberNode\"))))"
 		"	(SignatureLink (EvaluationLink "
 		"		(Type \"PredicateNode\")"
-		"		(ListLink (Type \"NumberNode\") (Type \"NumberNode\"))))");
+		"		(ListLink (Type \"NumberNode\") (Type \"NumberNode\")))))");
 
-	printf("expect false, got %s", rv.c_str());
+	printf("(nn) expect false, got %s", rv.c_str());
 	TSM_ASSERT("Expected false", rv == "#f\n");
 
 	rv = eval->eval(
@@ -227,9 +240,9 @@ void DeepTypeUTest::test_type_match(void)
 		"		(ListLink (Type \"ConceptNode\") (Type \"NumberNode\"))))"
 		"	(SignatureLink (EvaluationLink "
 		"		(PredicateNode \"foo\")"
-		"		(ListLink (Type \"ConceptNode\") (NumberNode 42))))");
+		"		(ListLink (Type \"ConceptNode\") (NumberNode 42)))))");
 
-	printf("expect true, got %s", rv.c_str());
+	printf("(cpred) expect true, got %s", rv.c_str());
 	TSM_ASSERT("Expected true", rv == "#t\n");
 
 	rv = eval->eval(
@@ -241,7 +254,7 @@ void DeepTypeUTest::test_type_match(void)
 		"		(PredicateNode \"foo\")"
 		"		(ListLink (ConceptNode \"bar\") (NumberNode 42))))");
 
-	printf("expect true, got %s", rv.c_str());
+	printf("(concr) expect true, got %s", rv.c_str());
 	TSM_ASSERT("Expected true", rv == "#t\n");
 
 	rv = eval->eval(
@@ -253,7 +266,7 @@ void DeepTypeUTest::test_type_match(void)
 		"		(PredicateNode \"foo\")"
 		"		(ListLink (NumberNode 13) (NumberNode 42))))");
 
-	printf("expect false, got %s", rv.c_str());
+	printf("(badnum) expect false, got %s", rv.c_str());
 	TSM_ASSERT("Expected false", rv == "#f\n");
 
 	rv = eval->eval(
@@ -265,7 +278,7 @@ void DeepTypeUTest::test_type_match(void)
 		"		(PredicateNode \"foo\")"
 		"		(ListLink (ConceptNode \"bar\") (NumberNode 42))))");
 
-	printf("expect true, got %s", rv.c_str());
+	printf("(foo-concr) expect true, got %s", rv.c_str());
 	TSM_ASSERT("Expected true", rv == "#t\n");
 
 	rv = eval->eval(
@@ -277,7 +290,7 @@ void DeepTypeUTest::test_type_match(void)
 		"		(PredicateNode \"bar\")"
 		"		(ListLink (ConceptNode \"bar\") (NumberNode 42))))");
 
-	printf("expect false, got %s", rv.c_str());
+	printf("(foobar) expect false, got %s", rv.c_str());
 	TSM_ASSERT("Expected false", rv == "#f\n");
 
 	// ----------------------

--- a/tests/query/DeepTypeUTest.cxxtest
+++ b/tests/query/DeepTypeUTest.cxxtest
@@ -66,6 +66,7 @@ public:
 	void setUp(void);
 	void tearDown(void);
 
+	void test_is_type(void);
 	void test_get_signature(void);
 };
 
@@ -75,8 +76,54 @@ void DeepTypeUTest::tearDown(void)
 
 void DeepTypeUTest::setUp(void)
 {
+	as->clear();
 }
 
+/*
+ * Basic deep-type unit test.
+ */
+void DeepTypeUTest::test_is_type(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	as->clear();
+	config().set("SCM_PRELOAD", "tests/query/deep-types.scm");
+	load_scm_files_from_config(*as);
+
+	std::string rv = eval->eval(
+		"(cog-value-is-type? "
+		"	(Signature (Inheritance (Concept \"foo\") (Type \"ConceptNode\")))"
+		"	(Inheritance (Concept \"foo\") (ConceptNode \"bar\")))");
+
+	printf("expect true, got %s", rv.c_str());
+	TSM_ASSERT("Expected true", rv == "#t\n");
+
+	rv = eval->eval(
+		"(cog-value-is-type? "
+		"	(Signature (Inheritance (Concept \"foo\") (Type \"ConceptNode\")))"
+		"	(Inheritance (Concept \"failure-mode\") (ConceptNode \"bar\")))");
+
+	printf("expect false, got %s", rv.c_str());
+	TSM_ASSERT("Expected false", rv == "#f\n");
+
+	rv = eval->eval(
+		"(cog-value-is-type? "
+		"	(DefinedType \"My foo type\")"
+		"	(Inheritance (Concept \"foo\") (ConceptNode \"bar\")))");
+
+	printf("expect true, got %s", rv.c_str());
+	TSM_ASSERT("Expected true", rv == "#t\n");
+
+	rv = eval->eval(
+		"(cog-value-is-type? "
+		"	(DefinedType \"My foo type\")"
+		"	(Inheritance (Concept \"failure-mode\") (ConceptNode \"bar\")))");
+
+	printf("expect false, got %s", rv.c_str());
+	TSM_ASSERT("Expected false", rv == "#f\n");
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
 /*
  * Basic deep-type unit test.
  */

--- a/tests/query/DeepTypeUTest.cxxtest
+++ b/tests/query/DeepTypeUTest.cxxtest
@@ -67,6 +67,7 @@ public:
 	void tearDown(void);
 
 	void test_is_type(void);
+	void test_type_match(void);
 	void test_get_signature(void);
 };
 
@@ -124,6 +125,52 @@ void DeepTypeUTest::test_is_type(void)
 
 	logger().debug("END TEST: %s", __FUNCTION__);
 }
+
+/*
+ * Basic deep-type unit test.
+ */
+void DeepTypeUTest::test_type_match(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	std::string rv;
+	as->clear();
+
+	rv = eval->eval(
+		"(cog-type-match? "
+		"	(Concept \"aaa\")"
+		"	(Concept \"aaa\"))");
+
+	printf("expect true, got %s", rv.c_str());
+	TSM_ASSERT("Expected true", rv == "#t\n");
+
+	rv = eval->eval(
+		"(cog-type-match? "
+		"	(Concept \"aaa\")"
+		"	(Concept \"bar\"))");
+
+	printf("expect false, got %s", rv.c_str());
+	TSM_ASSERT("Expected false", rv == "#f\n");
+
+	rv = eval->eval(
+		"(cog-type-match? "
+		"	(Type \"ConceptNode\")"
+		"	(Concept \"bar\"))");
+
+	printf("expect true, got %s", rv.c_str());
+	TSM_ASSERT("Expected true", rv == "#t\n");
+
+	rv = eval->eval(
+		"(cog-type-match? "
+		"	(Concept \"bar\")"
+		"	(Type \"ConceptNode\"))");
+
+	printf("expect false, got %s", rv.c_str());
+	TSM_ASSERT("Expected false", rv == "#f\n");
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
 /*
  * Basic deep-type unit test.
  */

--- a/tests/query/deep-types.scm
+++ b/tests/query/deep-types.scm
@@ -73,3 +73,32 @@
 		(AndLink (Variable "$x"))))
 
 ; (cog-execute! predicate-search)
+; =============================================================
+
+; The cog-value-is-type? function allows signatures to be
+; directly validated. Consider these examples:
+
+; Should evaluate to true.
+;(cog-value-is-type?
+;   (Signature (Inheritance (Concept "foo") (Type "ConceptNode")))
+;   (Inheritance (Concept "foo") (ConceptNode "bar")))
+
+; Should evaluate to false.
+;(cog-value-is-type?
+;   (Signature (Inheritance (Concept "foo") (Type "ConceptNode")))
+;   (Inheritance (Concept "failure-mode") (ConceptNode "bar")))
+
+; We can define new types, too.
+(DefineLink
+   (DefinedType "My foo type")
+   (Signature (Inheritance (Concept "foo") (Type "ConceptNode"))))
+
+; Should evaluate to true
+;(cog-value-is-type?
+;   (DefinedType "My foo type")
+;   (Inheritance (Concept "foo") (ConceptNode "bar")))
+
+; Should evaluate to false.
+;(cog-value-is-type?
+;   (DefinedType "My foo type")
+;   (Inheritance (Concept "failure-mode") (ConceptNode "bar")))


### PR DESCRIPTION
Unit tested, seems to work.

This should be usable for e.g. the backward chainer, to see if  one rule can be attached to another.