### PR TITLE
add utility for checking alpha-convertability.

### DIFF
--- a/opencog/atoms/core/ScopeLink.cc
+++ b/opencog/atoms/core/ScopeLink.cc
@@ -157,4 +157,24 @@ void ScopeLink::init_scoped_variables(const Handle& hvar)
 	}
 }
 
+/* ================================================================= */
+///
+/// Compare other ScopeLink, return true if it is equal to this one,
+/// to to an alpha-conversion of variables.
+///
+bool ScopeLink::is_equal(const Handle& other) const
+{
+	if (other == this) return true;
+	if (other->getType() != _type) return false;
+
+	ScopeLinkPtr scother(ScopeLinkCast(other));
+
+	// Variable declarations must match.
+	if (not _varlist.is_equal(scother->_varlist)) return false;
+
+	// Body, with substituted variables, must match.
+
+	return true;
+}
+
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/core/ScopeLink.cc
+++ b/opencog/atoms/core/ScopeLink.cc
@@ -172,7 +172,13 @@ bool ScopeLink::is_equal(const Handle& other) const
 	// Variable declarations must match.
 	if (not _varlist.is_equal(scother->_varlist)) return false;
 
-	// Body, with substituted variables, must match.
+	// Other body, with our ariables in place of its variables,
+	// should be same as our body.
+	Handle altbod = scother->_varlist.substitute_nocheck(scother->_body,
+	                                                  _varlist.varseq);
+
+	// Compare bodies, they should match.
+	if (*((AtomPtr)altbod) != *((AtomPtr) _body)) return false;
 
 	return true;
 }

--- a/opencog/atoms/core/ScopeLink.cc
+++ b/opencog/atoms/core/ScopeLink.cc
@@ -183,4 +183,15 @@ bool ScopeLink::is_equal(const Handle& other) const
 	return true;
 }
 
+bool ScopeLink::operator==(const Atom& ac) const
+{
+	Atom& a = (Atom&) ac; // cast away constness, for smart ptr.
+	return is_equal(a.getHandle());
+}
+
+bool ScopeLink::operator!=(const Atom& a) const
+{
+	return not operator==(a);
+}
+
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/core/ScopeLink.h
+++ b/opencog/atoms/core/ScopeLink.h
@@ -92,6 +92,10 @@ public:
 	const Handle& get_vardecl(void) const { return _vardecl; }
 	const Handle& get_body(void) const { return _body; }
 
+	// Return true if the other Handle is equal to this one,
+	// i.e. is the same, up to alpha conversion.
+	bool is_equal(const Handle&) const;
+
 	// Take the list of values `vals`, and substitute them in for the
 	// variables in the body of this lambda. The values must satisfy all
 	// type restrictions, else an exception will be thrown.

--- a/opencog/atoms/core/ScopeLink.h
+++ b/opencog/atoms/core/ScopeLink.h
@@ -96,6 +96,10 @@ public:
 	// i.e. is the same, up to alpha conversion.
 	bool is_equal(const Handle&) const;
 
+	// Overload equality check!
+	virtual bool operator==(const Atom&) const;
+	virtual bool operator!=(const Atom&) const;
+
 	// Take the list of values `vals`, and substitute them in for the
 	// variables in the body of this lambda. The values must satisfy all
 	// type restrictions, else an exception will be thrown.

--- a/opencog/atoms/core/VariableList.cc
+++ b/opencog/atoms/core/VariableList.cc
@@ -140,8 +140,11 @@ void VariableList::get_vartype(const Handle& htypelink)
 	if (TYPE_NODE == t)
 	{
 		Type vt = TypeNodeCast(vartype)->get_value();
-		std::set<Type> ts = {vt};
-		_varlist._simple_typemap.insert({varname, ts});
+		if (vt != ATOM)  // Atom type is same as untyped.
+		{
+			std::set<Type> ts = {vt};
+			_varlist._simple_typemap.insert({varname, ts});
+		}
 	}
 	else if (TYPE_CHOICE == t)
 	{
@@ -158,7 +161,7 @@ void VariableList::get_vartype(const Handle& htypelink)
 			if (TYPE_NODE == var_type)
 			{
 				Type vt = TypeNodeCast(ht)->get_value();
-				typeset.insert(vt);
+				if (ATOM != vt) typeset.insert(vt);
 			}
 			else if (SIGNATURE_LINK == var_type)
 			{

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -184,7 +184,7 @@ bool Variables::is_equal(const Variables& other) const
 		if (sime != _simple_typemap.end())
 		{
 			if (soth == other._simple_typemap.end()) return false;
-			if (*sime != *soth) return false;
+			if (sime->second != soth->second) return false;
 		}
 
 		// If typed, types must match.
@@ -196,7 +196,7 @@ bool Variables::is_equal(const Variables& other) const
 		if (dime != _deep_typemap.end())
 		{
 			if (doth == other._deep_typemap.end()) return false;
-			if (*dime != *doth) return false;
+			if (dime->second != doth->second) return false;
 		}
 
 		// XXX TODO fuzzy?

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -160,6 +160,53 @@ Handle FreeVariables::substitute_nocheck(const Handle& term,
 }
 
 /* ================================================================= */
+
+/// Return true if the other Variables struct is equal to this one,
+/// up to alpha-conversion. That is, same number of variables, same
+/// type restrictions, but different actual variable names.
+bool Variables::is_equal(const Variables& other) const
+{
+	size_t sz = varseq.size();
+	if (other.varseq.size() != sz) return false;
+
+	// Side-by-side comparison
+	for (size_t i=0; i<sz; i++)
+	{
+		const Handle& vme(varseq[i]);
+		const Handle& voth(other.varseq[i]);
+
+		// If typed, types must match.
+		auto sime = _simple_typemap.find(vme);
+		auto soth = other._simple_typemap.find(voth);
+		if (sime == _simple_typemap.end() and
+		    soth != other._simple_typemap.end()) return false;
+
+		if (sime != _simple_typemap.end())
+		{
+			if (soth == other._simple_typemap.end()) return false;
+			if (*sime != *soth) return false;
+		}
+
+		// If typed, types must match.
+		auto dime = _deep_typemap.find(vme);
+		auto doth = other._deep_typemap.find(voth);
+		if (dime == _deep_typemap.end() and
+		    doth != other._deep_typemap.end()) return false;
+
+		if (dime != _deep_typemap.end())
+		{
+			if (doth == other._deep_typemap.end()) return false;
+			if (*dime != *doth) return false;
+		}
+
+		// XXX TODO fuzzy?
+	}
+
+	// If we got toe here, everything must be OK.
+	return true;
+}
+
+/* ================================================================= */
 /**
  * Simple type checker.
  *

--- a/opencog/atoms/core/Variables.h
+++ b/opencog/atoms/core/Variables.h
@@ -110,6 +110,15 @@ struct Variables : public FreeVariables
 	VariableDeepTypeMap _deep_typemap;
 	VariableDeepTypeMap _fuzzy_typemap;
 
+	// Return true if the other Variables struct is equal to this one,
+	// up to alpha-conversion. That is, same number of variables, same
+	// type restrictions, but different actual variable names.
+	bool is_equal(const Variables&) const;
+	inline bool operator==(const Variables& other) const
+	{ return is_equal(other); }
+	inline bool operator!=(const Variables& other) const
+	{ return not is_equal(other); }
+
 	// Return true if we are holding a single variable, and the handle
 	// given as the argument satisfies the type restrictions (if any).
 	// Else return false.

--- a/opencog/atomspace/Atom.h
+++ b/opencog/atomspace/Atom.h
@@ -411,8 +411,6 @@ public:
      * @return true if the atoms are different, false otherwise.
      */
     virtual bool operator!=(const Atom&) const = 0;
-
-
 };
 
 /** @}*/

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -236,21 +236,21 @@ AtomPtr AtomTable::do_factory(Type atom_type, AtomPtr atom)
 {
     // Nodes of various kinds -----------
     if (NUMBER_NODE == atom_type) {
-        if (NULL == NumberNodeCast(atom))
+        if (nullptr == NumberNodeCast(atom))
             return createNumberNode(*NodeCast(atom));
     } else if (TYPE_NODE == atom_type) {
-        if (NULL == TypeNodeCast(atom))
+        if (nullptr == TypeNodeCast(atom))
             return createTypeNode(*NodeCast(atom));
 
     // Links of various kinds -----------
     } else if (BIND_LINK == atom_type) {
-        if (NULL == BindLinkCast(atom))
+        if (nullptr == BindLinkCast(atom))
             return createBindLink(*LinkCast(atom));
     } else if (PATTERN_LINK == atom_type) {
-        if (NULL == PatternLinkCast(atom))
+        if (nullptr == PatternLinkCast(atom))
             return createPatternLink(*LinkCast(atom));
     } else if (DEFINE_LINK == atom_type) {
-        if (NULL == DefineLinkCast(atom))
+        if (nullptr == DefineLinkCast(atom))
             return createDefineLink(*LinkCast(atom));
 /*
     XXX FIXME: cannot do this, due to a circular shared library
@@ -261,43 +261,47 @@ AtomPtr AtomTable::do_factory(Type atom_type, AtomPtr atom)
 */
     } else if (EVALUATION_LINK == atom_type) {
 /*
-        if (NULL == EvaluationLinkCast(atom))
+        if (nullptr == EvaluationLinkCast(atom))
             return createEvaluationLink(*LinkCast(atom));
 */
     } else if (EXECUTION_OUTPUT_LINK == atom_type) {
 /*
-        if (NULL == ExecutionOutputLinkCast(atom))
+        if (nullptr == ExecutionOutputLinkCast(atom))
             return createExecutionOutputLink(*LinkCast(atom));
 */
     } else if (GET_LINK == atom_type) {
-        if (NULL == PatternLinkCast(atom))
+        if (nullptr == PatternLinkCast(atom))
             return createPatternLink(*LinkCast(atom));
     } else if (PUT_LINK == atom_type) {
-        if (NULL == PutLinkCast(atom))
+        if (nullptr == PutLinkCast(atom))
             return createPutLink(*LinkCast(atom));
     } else if (SATISFACTION_LINK == atom_type) {
-        if (NULL == PatternLinkCast(atom))
+        if (nullptr == PatternLinkCast(atom))
             return createPatternLink(*LinkCast(atom));
     } else if (TYPED_ATOM_LINK == atom_type) {
-        if (NULL == TypedAtomLinkCast(atom))
+        if (nullptr == TypedAtomLinkCast(atom))
             return createTypedAtomLink(*LinkCast(atom));
     } else if (UNIQUE_LINK == atom_type) {
-        if (NULL == UniqueLinkCast(atom))
+        if (nullptr == UniqueLinkCast(atom))
             return createUniqueLink(*LinkCast(atom));
     } else if (VARIABLE_LIST == atom_type) {
-        if (NULL == VariableListCast(atom))
+        if (nullptr == VariableListCast(atom))
             return createVariableList(*LinkCast(atom));
     } else if (LAMBDA_LINK == atom_type) {
-        if (NULL == LambdaLinkCast(atom))
+        if (nullptr == LambdaLinkCast(atom))
             return createLambdaLink(*LinkCast(atom));
     } else if (IMPLICATION_LINK == atom_type) {
-        if (NULL == ImplicationLinkCast(atom))
+        if (nullptr == ImplicationLinkCast(atom))
             return createImplicationLink(*LinkCast(atom));
     } else if (classserver().isA(atom_type, FUNCTION_LINK)) {
 /* More circular-dependency heart-ache
-        if (NULL == FunctionLinkCast(atom))
+        if (nullptr == FunctionLinkCast(atom))
             return FunctionLink::factory(LinkCast(atom));
 */
+    } else if (classserver().isA(atom_type, SCOPE_LINK)) {
+        // isA because we want to force alpha-conversion.
+        if (nullptr == ScopeLinkCast(atom))
+            return createScopeLink(*LinkCast(atom));
     }
 
     // Very special handling for DeleteLink's
@@ -391,6 +395,11 @@ static AtomPtr do_clone_factory(Type atom_type, AtomPtr atom)
         // XXX FIXME more circular-dependency heart-ache
         // return FunctionLink::factory(LinkCast(atom));
         return createLink(*LinkCast(atom));
+
+    // isA because we want to force alpha-conversion.
+    if (classserver().isA(atom_type, SCOPE_LINK))
+        return createScopeLink(*LinkCast(atom));
+
     if (classserver().isA(atom_type, LINK))
         return createLink(*LinkCast(atom));
 

--- a/opencog/atomspace/Handle.h
+++ b/opencog/atomspace/Handle.h
@@ -103,14 +103,11 @@ public:
         return false;
     }
 
-    inline bool operator==(std::nullptr_t) const noexcept {
-        if (_ptr.get()) return false;
-        return true;
+    inline bool operator==(const Atom* ap) const noexcept {
+        return _ptr.get() == ap;
     }
-
-    inline bool operator!=(std::nullptr_t) const noexcept {
-        if (_ptr.get()) return true;
-        return false;
+    inline bool operator!=(const Atom* ap) const noexcept {
+        return _ptr.get() != ap;
     }
 
     inline bool operator==(const Handle& h) const noexcept {
@@ -164,10 +161,10 @@ public:
 };
 
 static inline bool operator== (std::nullptr_t, const Handle& rhs) noexcept
-    { return rhs == NULL; }
+    { return rhs == nullptr; }
 
 static inline bool operator!= (std::nullptr_t, const Handle& rhs) noexcept
-    { return rhs != NULL; }
+    { return rhs != nullptr; }
 
 class HandlePredicate {
 public:

--- a/tests/atoms/AlphaConvertUTest.cxxtest
+++ b/tests/atoms/AlphaConvertUTest.cxxtest
@@ -1,0 +1,79 @@
+/*
+ * tests/atoms/AlphaConvertUTest.cxxtest
+ *
+ * Copyright (C) 2015 Linas Vepstas
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/atomspace/Atom.h>
+#include <opencog/atomspace/AtomSpace.h>
+#include <opencog/atoms/core/ScopeLink.h>
+
+using namespace opencog;
+
+// Test the AlphaConvert.
+//
+class AlphaConvertUTest :  public CxxTest::TestSuite
+{
+private:
+	AtomSpace _asa;
+	AtomSpace _asb;
+
+public:
+	AlphaConvertUTest()
+	{
+		logger().setPrintToStdoutFlag(true);
+	}
+
+	void setUp() {}
+
+	void tearDown() {}
+
+	void test_variables();
+};
+
+#define NA _asa.add_node
+#define LA _asa.add_link
+
+#define NB _asb.add_node
+#define LB _asb.add_link
+
+// Test AlphaConvert over a ConceptNode
+void AlphaConvertUTest::test_variables()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Create ScopeLinks.
+	Handle hscox =
+	LA(SCOPE_LINK,
+		NA(VARIABLE_NODE, "$X"),
+		LA(AND_LINK, NA(VARIABLE_NODE, "$X")));
+
+	ScopeLinkPtr scox(ScopeLinkCast(hscox));
+
+	Handle hscoy =
+	LB(SCOPE_LINK,
+		NB(VARIABLE_NODE, "$Y"),
+		LB(AND_LINK, NB(VARIABLE_NODE, "$Y")));
+
+	ScopeLinkPtr scoy(ScopeLinkCast(hscoy));
+
+	TS_ASSERT(scox->is_equal(hscoy));
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}

--- a/tests/atoms/AlphaConvertUTest.cxxtest
+++ b/tests/atoms/AlphaConvertUTest.cxxtest
@@ -47,6 +47,7 @@ public:
 	void test_untyped_variable();
 	void test_variable();
 	void test_body();
+	void test_atomspace();
 };
 
 #define NA _asa.add_node
@@ -195,6 +196,63 @@ void AlphaConvertUTest::test_body()
 
 	// x and y should be NOT equal
 	TS_ASSERT(not scox->is_equal(hscoy));
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// Test alpha conversion in the atomspace.
+void AlphaConvertUTest::test_atomspace()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Create ScopeLinks.
+	Handle hscox =
+	LA(SCOPE_LINK,
+		NA(VARIABLE_NODE, "$X"),
+		LA(AND_LINK, NA(VARIABLE_NODE, "$X")));
+
+	Handle hscoy =
+	LA(SCOPE_LINK,
+		NA(VARIABLE_NODE, "$Y"),
+		LA(AND_LINK, NA(VARIABLE_NODE, "$Y")));
+
+	// x and y should be equal
+	// TS_ASSERT(hscox == hscoy);
+
+	printf("Expecting same atom: x=%s vs y=%s\n",
+		hscox->toString().c_str(), hscoy->toString().c_str());
+
+#if 0
+	Handle hscoz =
+	LA(SCOPE_LINK,
+		LA(VARIABLE_LIST, NA(VARIABLE_NODE, "$Z")),
+		LA(AND_LINK, NA(VARIABLE_NODE, "$Z")));
+
+	// x and z should be equal
+	TS_ASSERT(scox->is_equal(hscoz));
+
+	// Constraining something to be "type Atom" is not a constraint.
+	_asb.clear();
+	Handle hscow =
+	LA(SCOPE_LINK,
+		LA(TYPED_VARIABLE_LINK,
+			NA(VARIABLE_NODE, "$W"), NA(TYPE_NODE, "Atom")),
+		LA(AND_LINK, NA(VARIABLE_NODE, "$W")));
+
+	// x and w should be equal
+	TS_ASSERT(scox->is_equal(hscow));
+
+	_asb.clear();
+	Handle hscot =
+	LA(SCOPE_LINK,
+		LA(TYPED_VARIABLE_LINK,
+			NA(VARIABLE_NODE, "$T"),
+			LA(TYPE_CHOICE, NA(TYPE_NODE, "Atom"))),
+		LA(AND_LINK, NA(VARIABLE_NODE, "$T")));
+
+	// x and t should be equal
+	TS_ASSERT(scox->is_equal(hscot));
+#endif
 
 	logger().info("END TEST: %s", __FUNCTION__);
 }

--- a/tests/atoms/AlphaConvertUTest.cxxtest
+++ b/tests/atoms/AlphaConvertUTest.cxxtest
@@ -86,5 +86,16 @@ void AlphaConvertUTest::test_variables()
 	// x and z should be equal
 	TS_ASSERT(scox->is_equal(hscoz));
 
+	// Constraining something to be "type Atom" is not a constraint.
+	_asb.clear();
+	Handle hscow =
+	LB(SCOPE_LINK,
+		LB(TYPED_VARIABLE_LINK,
+			NB(VARIABLE_NODE, "$W"), NB(TYPE_NODE, "Atom")),
+		LB(AND_LINK, NB(VARIABLE_NODE, "$W")));
+
+	// x and w should be equal
+	TS_ASSERT(scox->is_equal(hscow));
+
 	logger().info("END TEST: %s", __FUNCTION__);
 }

--- a/tests/atoms/AlphaConvertUTest.cxxtest
+++ b/tests/atoms/AlphaConvertUTest.cxxtest
@@ -46,6 +46,7 @@ public:
 
 	void test_untyped_variable();
 	void test_variable();
+	void test_body();
 };
 
 #define NA _asa.add_node
@@ -167,6 +168,33 @@ void AlphaConvertUTest::test_variable()
 
 	// x and t should be equal
 	TS_ASSERT(scox->is_equal(hscot));
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// Test AlphaConvert for differeing bodies.
+void AlphaConvertUTest::test_body()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Create ScopeLinks.
+	Handle hscox =
+	LA(SCOPE_LINK,
+		NA(VARIABLE_NODE, "$X"),
+		LA(AND_LINK, NA(VARIABLE_NODE, "$X")));
+
+	ScopeLinkPtr scox(ScopeLinkCast(hscox));
+	TS_ASSERT(scox != nullptr);
+
+	Handle hscoy =
+	LB(SCOPE_LINK,
+		NB(VARIABLE_NODE, "$X"),
+		LB(OR_LINK, NB(VARIABLE_NODE, "$X")));
+
+	ScopeLinkPtr scoy(ScopeLinkCast(hscoy));
+
+	// x and y should be NOT equal
+	TS_ASSERT(not scox->is_equal(hscoy));
 
 	logger().info("END TEST: %s", __FUNCTION__);
 }

--- a/tests/atoms/AlphaConvertUTest.cxxtest
+++ b/tests/atoms/AlphaConvertUTest.cxxtest
@@ -44,7 +44,8 @@ public:
 
 	void tearDown() {}
 
-	void test_variables();
+	void test_untyped_variable();
+	void test_variable();
 };
 
 #define NA _asa.add_node
@@ -53,8 +54,8 @@ public:
 #define NB _asb.add_node
 #define LB _asb.add_link
 
-// Test AlphaConvert over a ConceptNode
-void AlphaConvertUTest::test_variables()
+// Test AlphaConvert over an untyped variable.
+void AlphaConvertUTest::test_untyped_variable()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
@@ -96,6 +97,76 @@ void AlphaConvertUTest::test_variables()
 
 	// x and w should be equal
 	TS_ASSERT(scox->is_equal(hscow));
+
+	_asb.clear();
+	Handle hscot =
+	LB(SCOPE_LINK,
+		LB(TYPED_VARIABLE_LINK,
+			NB(VARIABLE_NODE, "$T"),
+			LB(TYPE_CHOICE, NB(TYPE_NODE, "Atom"))),
+		LB(AND_LINK, NB(VARIABLE_NODE, "$T")));
+
+	// x and t should be equal
+	TS_ASSERT(scox->is_equal(hscot));
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// Test AlphaConvert over an variable types as ConceptNode.
+void AlphaConvertUTest::test_variable()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Create ScopeLinks.
+	Handle hscox =
+	LA(SCOPE_LINK,
+		LA(TYPED_VARIABLE_LINK,
+			NA(VARIABLE_NODE, "$X"), NA(TYPE_NODE, "ConceptNode")),
+		LA(AND_LINK, NA(VARIABLE_NODE, "$X")));
+
+	ScopeLinkPtr scox(ScopeLinkCast(hscox));
+	TS_ASSERT(scox != nullptr);
+
+	Handle hscoy =
+	LB(SCOPE_LINK,
+		NB(VARIABLE_NODE, "$Y"),
+		LB(AND_LINK, NB(VARIABLE_NODE, "$Y")));
+
+	ScopeLinkPtr scoy(ScopeLinkCast(hscoy));
+
+	// x and y should be not equal
+	TS_ASSERT(not scox->is_equal(hscoy));
+
+	_asb.clear();
+	Handle hscoz =
+	LB(SCOPE_LINK,
+		LB(VARIABLE_LIST, NB(VARIABLE_NODE, "$Z")),
+		LB(AND_LINK, NB(VARIABLE_NODE, "$Z")));
+
+	// x and z should be not equal
+	TS_ASSERT(not scox->is_equal(hscoz));
+
+	// Constraining should work.
+	_asb.clear();
+	Handle hscow =
+	LB(SCOPE_LINK,
+		LB(TYPED_VARIABLE_LINK,
+			NB(VARIABLE_NODE, "$W"), NB(TYPE_NODE, "ConceptNode")),
+		LB(AND_LINK, NB(VARIABLE_NODE, "$W")));
+
+	// x and w should be equal
+	TS_ASSERT(scox->is_equal(hscow));
+
+	_asb.clear();
+	Handle hscot =
+	LB(SCOPE_LINK,
+		LB(TYPED_VARIABLE_LINK,
+			NB(VARIABLE_NODE, "$T"),
+			LB(TYPE_CHOICE, NB(TYPE_NODE, "Atom"), NB(TYPE_NODE, "ConceptNode"))),
+		LB(AND_LINK, NB(VARIABLE_NODE, "$T")));
+
+	// x and t should be equal
+	TS_ASSERT(scox->is_equal(hscot));
 
 	logger().info("END TEST: %s", __FUNCTION__);
 }

--- a/tests/atoms/AlphaConvertUTest.cxxtest
+++ b/tests/atoms/AlphaConvertUTest.cxxtest
@@ -65,6 +65,7 @@ void AlphaConvertUTest::test_variables()
 		LA(AND_LINK, NA(VARIABLE_NODE, "$X")));
 
 	ScopeLinkPtr scox(ScopeLinkCast(hscox));
+	TS_ASSERT(scox != nullptr);
 
 	Handle hscoy =
 	LB(SCOPE_LINK,
@@ -73,7 +74,17 @@ void AlphaConvertUTest::test_variables()
 
 	ScopeLinkPtr scoy(ScopeLinkCast(hscoy));
 
+	// x and y should be equal
 	TS_ASSERT(scox->is_equal(hscoy));
+
+	_asb.clear();
+	Handle hscoz =
+	LB(SCOPE_LINK,
+		LB(VARIABLE_LIST, NB(VARIABLE_NODE, "$Z")),
+		LB(AND_LINK, NB(VARIABLE_NODE, "$Z")));
+
+	// x and z should be equal
+	TS_ASSERT(scox->is_equal(hscoz));
 
 	logger().info("END TEST: %s", __FUNCTION__);
 }

--- a/tests/atoms/CMakeLists.txt
+++ b/tests/atoms/CMakeLists.txt
@@ -10,6 +10,9 @@ IF(HAVE_GUILE)
 	TARGET_LINK_LIBRARIES(ReductUTest atomspace smob clearbox execution)
 ENDIF(HAVE_GUILE)
 
+ADD_CXXTEST(AlphaConvertUTest)
+TARGET_LINK_LIBRARIES(AlphaConvertUTest atomspace)
+
 ADD_CXXTEST(DefineLinkUTest)
 TARGET_LINK_LIBRARIES(DefineLinkUTest atomspace)
 

--- a/tests/atoms/DefineLinkUTest.cxxtest
+++ b/tests/atoms/DefineLinkUTest.cxxtest
@@ -1,5 +1,5 @@
 /*
- * tests/atomspace/DefineUTest.cxxtest
+ * tests/atoms/DefineUTest.cxxtest
  *
  * Copyright (C) 2015 Nil Geisweiller
  * All Rights Reserved

--- a/tests/atoms/DeleteLinkUTest.cxxtest
+++ b/tests/atoms/DeleteLinkUTest.cxxtest
@@ -1,5 +1,5 @@
 /*
- * tests/atomspace/DeleteUTest.cxxtest
+ * tests/atoms/DeleteUTest.cxxtest
  *
  * Copyright (C) 2015 Linas Vepstas
  * All Rights Reserved

--- a/tests/atoms/FreeLinkUTest.cxxtest
+++ b/tests/atoms/FreeLinkUTest.cxxtest
@@ -1,5 +1,5 @@
 /*
- * tests/query/FreeLinkUTest.cxxtest
+ * tests/atoms/FreeLinkUTest.cxxtest
  *
  * Copyright (C) 2015 Linas Vepstas
  * All Rights Reserved

--- a/tests/atoms/PutLinkUTest.cxxtest
+++ b/tests/atoms/PutLinkUTest.cxxtest
@@ -1,5 +1,5 @@
 /*
- * tests/atomspace/PutUTest.cxxtest
+ * tests/atoms/PutUTest.cxxtest
  *
  * Copyright (C) 2015 Linas Vepstas
  * All Rights Reserved

--- a/tests/atoms/ReductUTest.cxxtest
+++ b/tests/atoms/ReductUTest.cxxtest
@@ -1,5 +1,5 @@
 /*
- * tests/query/ReductUTest.cxxtest
+ * tests/atoms/ReductUTest.cxxtest
  *
  * Copyright (C) 2015 Linas Vepstas
  * All Rights Reserved

--- a/tests/atoms/StateLinkUTest.cxxtest
+++ b/tests/atoms/StateLinkUTest.cxxtest
@@ -1,5 +1,5 @@
 /*
- * tests/atomspace/StateUTest.cxxtest
+ * tests/atoms/StateUTest.cxxtest
  *
  * Copyright (C) 2015 Linas Vepstas
  * All Rights Reserved

--- a/tests/atomspace/AtomSpaceAsyncUTest.cxxtest
+++ b/tests/atomspace/AtomSpaceAsyncUTest.cxxtest
@@ -277,7 +277,7 @@ public:
             [&](Type t)->void {
                 Handle h(as->get_handle(t, name));
                 if (h) *(result++) = h; }, NODE);
-        result;
+        return result;
     }
 
     void threadedRemove(int start, int interval)


### PR DESCRIPTION
Given two ScopeLinks (e.g. a SatisfyingSetLink is  ScopeLink)  the utility will return true/false 
if the two can be alpha-converted into one-another.  As per email discussions.