### PR TITLE
Now that TV is immutable, cloning is not required.

### DIFF
--- a/opencog/atoms/NumberNode.h
+++ b/opencog/atoms/NumberNode.h
@@ -58,7 +58,7 @@ public:
 
 	NumberNode(Node &n)
 		: Node(NUMBER_NODE, std::to_string(std::stod(n.getName())),
-		       n.getTruthValue()->clone(), n.getAttentionValue()->clone()),
+		       n.getTruthValue(), n.getAttentionValue()),
 		  value(std::stod(n.getName()))
 	{
 		OC_ASSERT(NUMBER_NODE == n.getType(), "Bad NumberNode constructor!");

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -119,8 +119,7 @@ protected:
      * @param The type of the atom.
      * @param Outgoing set of the atom, that is, the set of atoms this
      * atom references. It must be an empty vector if the atom is a node.
-     * @param The truthValue of the atom. note: This is not cloned as
-     *        in setTruthValue.
+     * @param The truthValue of the atom.
      */
     Atom(Type t, TruthValuePtr tv = TruthValue::DEFAULT_TV(),
             AttentionValuePtr av = AttentionValue::DEFAULT_AV())

--- a/opencog/atoms/base/Link.h
+++ b/opencog/atoms/base/Link.h
@@ -71,8 +71,7 @@ public:
      * @param Link type.
      * @param Outgoing set, which is an array of the atom handles
      *        referenced by this link.
-     * @param Link truthvalue, which will be cloned before being
-     *        stored in this Link.
+     * @param Link truthvalue.
      */
     Link(Type t, const HandleSeq& oset,
          TruthValuePtr tv = TruthValue::DEFAULT_TV(),
@@ -133,11 +132,7 @@ public:
      * Cannot be const, because the get() functions can't be,
      * because thread-safe locking required in the gets. */
     Link(Link &l)
-        : Atom(l.getType(),
-               ({ TruthValuePtr tv(l.getTruthValue());
-                  tv->isDefinedTV() ? tv : tv->clone(); }),
-               ({ AttentionValuePtr av(l.getAttentionValue());
-                  av->isDefaultAV() ? av : av->clone(); }))
+        : Atom(l.getType(), l.getTruthValue(), l.getAttentionValue())
     {
         init(l.getOutgoingSet());
     }

--- a/opencog/atoms/base/Node.h
+++ b/opencog/atoms/base/Node.h
@@ -72,11 +72,7 @@ public:
      * because thread-safe locking required in the gets.
      */
     Node(Node &n)
-        : Atom(n.getType(),
-               ({ TruthValuePtr tv(n.getTruthValue());
-                  tv->isDefinedTV() ? tv : tv->clone(); }),
-               ({ AttentionValuePtr av(n.getAttentionValue());
-                  av->isDefaultAV() ? av : av->clone(); }))
+        : Atom(n.getType(), n.getTruthValue(), n.getAttentionValue())
     {
         init(n._name);
     }

--- a/opencog/persist/zmq/atomspace_needfixing/ZMQServer.cc
+++ b/opencog/persist/zmq/atomspace_needfixing/ZMQServer.cc
@@ -60,8 +60,8 @@ void ZMQServer::zmqLoop(string networkAddress)
 		{
 			case ZMQgetAtom:
 			{
-				AtomPtr atom = atomSpace->cloneAtom(
-				        Handle(requestMessage.handle()));
+				AtomPtr atom = atomSpace->get_atom(
+				        requestMessage.handle());
 				ProtocolBufferSerializer::serialize(*atom, replyMessage.mutable_atom());
 				break;
 			}

--- a/opencog/truthvalue/FuzzyTruthValue.cc
+++ b/opencog/truthvalue/FuzzyTruthValue.cc
@@ -80,9 +80,9 @@ TruthValuePtr FuzzyTruthValue::merge(TruthValuePtr other,
     }
 
     if (other->getConfidence() > getConfidence()) {
-        return other->clone();
+        return other;
     }
-    return clone();
+    return shared_from_this();
 }
 
 std::string FuzzyTruthValue::toString() const

--- a/opencog/truthvalue/GenericTruthValue.cc
+++ b/opencog/truthvalue/GenericTruthValue.cc
@@ -51,6 +51,26 @@ GenericTruthValue::GenericTruthValue(GenericTruthValue const& gtv)
     entropy = gtv.entropy;
 }
 
+TruthValueType GenericTruthValue::getType() const
+{
+    return GENERIC_TRUTH_VALUE;
+}
+
+count_t GenericTruthValue::getCount() const
+{
+    return frequency;
+}
+
+confidence_t GenericTruthValue::getConfidence() const
+{
+    return confidence;
+}
+
+strength_t GenericTruthValue::getMean() const
+{
+    return totalEvidence;
+}
+
 count_t GenericTruthValue::getPositiveEvidence() const
 {
     return positiveEvidence;
@@ -91,11 +111,6 @@ strength_t GenericTruthValue::getLogFuzzyStrength() const
     return log(fuzzyStrength);
 }
 
-confidence_t GenericTruthValue::getConfidence() const
-{
-    return confidence;
-}
-
 confidence_t GenericTruthValue::getLogConfidence() const
 {
     return log(confidence);
@@ -106,8 +121,10 @@ entropy_t GenericTruthValue::getEntropy() const
     return entropy;
 }
 
-GenericTruthValuePtr GenericTruthValue::merge(GenericTruthValuePtr gtv) const
+TruthValuePtr GenericTruthValue::merge(TruthValuePtr tv, const MergeCtrl& mc) const
 {
+    GenericTruthValuePtr gtv = std::dynamic_pointer_cast<const GenericTruthValue>(tv);
+    if (NULL == gtv) return tv;
     auto other_te = gtv->getTotalEvidence();
     auto new_pe = positiveEvidence + gtv->getPositiveEvidence();
     auto new_te = totalEvidence + other_te
@@ -125,24 +142,27 @@ GenericTruthValuePtr GenericTruthValue::merge(GenericTruthValuePtr gtv) const
 }
 
 
-bool GenericTruthValue::operator==(const GenericTruthValue& rhs) const
+bool GenericTruthValue::operator==(const TruthValue& rhs) const
 {
     if (NULL == &rhs) return false;
 
+    const GenericTruthValue *gtv = dynamic_cast<const GenericTruthValue *>(&rhs);
+    if (NULL == gtv) return false;
+
 #define FLOAT_ACCEPTABLE_ERROR 0.000001
-    if (FLOAT_ACCEPTABLE_ERROR < fabs(frequency - rhs.frequency))
+    if (FLOAT_ACCEPTABLE_ERROR < fabs(frequency - gtv->frequency))
         return false;
-    if (FLOAT_ACCEPTABLE_ERROR < fabs(fuzzyStrength - rhs.fuzzyStrength))
+    if (FLOAT_ACCEPTABLE_ERROR < fabs(fuzzyStrength - gtv->fuzzyStrength))
         return false;
-    if (FLOAT_ACCEPTABLE_ERROR < fabs(confidence - rhs.confidence))
+    if (FLOAT_ACCEPTABLE_ERROR < fabs(confidence - gtv->confidence))
         return false;
 
 #define DOUBLE_ACCEPTABLE_ERROR 1.0e-14
-    if (DOUBLE_ACCEPTABLE_ERROR < fabs(1.0 - (rhs.positiveEvidence/positiveEvidence)))
+    if (DOUBLE_ACCEPTABLE_ERROR < fabs(1.0 - (gtv->positiveEvidence/positiveEvidence)))
         return false;
-    if (DOUBLE_ACCEPTABLE_ERROR < fabs(1.0 - (rhs.totalEvidence/totalEvidence)))
+    if (DOUBLE_ACCEPTABLE_ERROR < fabs(1.0 - (gtv->totalEvidence/totalEvidence)))
         return false;
-    if (DOUBLE_ACCEPTABLE_ERROR < fabs(1.0 - (rhs.entropy/entropy)))
+    if (DOUBLE_ACCEPTABLE_ERROR < fabs(1.0 - (gtv->entropy/entropy)))
         return false;
 
     return true;

--- a/opencog/truthvalue/GenericTruthValue.h
+++ b/opencog/truthvalue/GenericTruthValue.h
@@ -73,12 +73,12 @@ class GenericTruthValue
 
         GenericTruthValuePtr merge(GenericTruthValuePtr) const;
 
-        GenericTruthValuePtr clone() const
+        TruthValuePtr clone() const
         {
             return std::make_shared<GenericTruthValue>(*this);
         }
 
-        GenericTruthValue* rawclone() const
+        TruthValue* rawclone() const
         {
             return new GenericTruthValue(*this);
         }

--- a/opencog/truthvalue/GenericTruthValue.h
+++ b/opencog/truthvalue/GenericTruthValue.h
@@ -28,6 +28,7 @@
 #include <memory>
 
 #include <opencog/util/exceptions.h>
+#include <opencog/truthvalue/TruthValue.h>
 
 namespace opencog
 {
@@ -38,10 +39,9 @@ typedef double count_t;
 typedef double entropy_t;
 
 class GenericTruthValue;
-typedef std::shared_ptr<GenericTruthValue> GenericTruthValuePtr;
+typedef std::shared_ptr<const GenericTruthValue> GenericTruthValuePtr;
 
-class GenericTruthValue
-        : public std::enable_shared_from_this<GenericTruthValue>
+class GenericTruthValue : public TruthValue
 {
     // Truth values are immutable
     GenericTruthValue& operator=(const GenericTruthValue& rhs) {
@@ -53,6 +53,11 @@ class GenericTruthValue
                           strength_t, strength_t,
                           confidence_t, entropy_t);
         GenericTruthValue(GenericTruthValue const&);
+
+        TruthValueType getType() const;
+        strength_t getMean() const;
+        count_t getCount() const;
+        confidence_t getConfidence() const;
 
         count_t getPositiveEvidence() const;
         count_t getLogPositiveEvidence() const;
@@ -66,12 +71,11 @@ class GenericTruthValue
         strength_t getFuzzyStrength() const;
         strength_t getLogFuzzyStrength() const;
 
-        confidence_t getConfidence() const;
         confidence_t getLogConfidence() const;
 
         entropy_t getEntropy() const;
 
-        GenericTruthValuePtr merge(GenericTruthValuePtr) const;
+        TruthValuePtr merge(TruthValuePtr, const MergeCtrl& = MergeCtrl()) const;
 
         TruthValuePtr clone() const
         {
@@ -83,7 +87,7 @@ class GenericTruthValue
             return new GenericTruthValue(*this);
         }
 
-        virtual bool operator==(const GenericTruthValue& rhs) const;
+        bool operator==(const TruthValue&) const;
         std::string toString() const;
 
     protected:

--- a/opencog/truthvalue/TruthValue.cc
+++ b/opencog/truthvalue/TruthValue.cc
@@ -147,7 +147,7 @@ bool TruthValue::isDefinedTV() const
 TruthValuePtr TruthValue::higher_confidence_merge(TruthValuePtr other) const
 {
     if (other->getConfidence() > getConfidence()) {
-        return other->clone();
+        return other;
     }
-    return clone();
+    return shared_from_this();
 }

--- a/opencog/truthvalue/TruthValue.h
+++ b/opencog/truthvalue/TruthValue.h
@@ -68,6 +68,7 @@ enum TruthValueType
     INDEFINITE_TRUTH_VALUE,
     FUZZY_TRUTH_VALUE,
     PROBABILISTIC_TRUTH_VALUE,
+    GENERIC_TRUTH_VALUE,
     NUMBER_OF_TRUTH_VALUE_TYPES
 };
 
@@ -194,7 +195,7 @@ public:
      *        https://github.com/opencog/opencog/issues/1295
      */
     virtual TruthValuePtr merge(TruthValuePtr,
-                                const MergeCtrl& mc=MergeCtrl()) const = 0;
+                                const MergeCtrl& = MergeCtrl()) const = 0;
 
     /**
      * Check if this TV is a null TV.

--- a/tests/atomspace/MultiSpaceUTest.cxxtest
+++ b/tests/atomspace/MultiSpaceUTest.cxxtest
@@ -143,12 +143,6 @@ public:
 		Handle h2 = as2.add_atom(h1);
 		Handle h3 = as3.add_atom(h2);
 
-		// The truth value *pointers* should differ; they should
-		// have been copied on atom insertion.
-		TS_ASSERT(h1->getTruthValue() != h2->getTruthValue());
-		TS_ASSERT(h1->getTruthValue() != h3->getTruthValue());
-		TS_ASSERT(h2->getTruthValue() != h3->getTruthValue());
-
 		// The truth values themselves should be equal, as values.
 		TS_ASSERT(*h1->getTruthValue() == *tv);
 		TS_ASSERT(*h2->getTruthValue() == *tv);
@@ -220,20 +214,6 @@ public:
 		TS_ASSERT(h2n1.value() != h3n1.value());
 		TS_ASSERT(h2n2.value() != h3n2.value());
 		TS_ASSERT(h2n3.value() != h3n3.value());
-
-		// The truth value *pointers* should differ; they should
-		// have been copied on atom insertion.
-		TS_ASSERT(h1n1->getTruthValue() != h2n1->getTruthValue());
-		TS_ASSERT(h1n1->getTruthValue() != h3n1->getTruthValue());
-		TS_ASSERT(h2n1->getTruthValue() != h3n1->getTruthValue());
-
-		TS_ASSERT(h1n2->getTruthValue() != h2n2->getTruthValue());
-		TS_ASSERT(h1n2->getTruthValue() != h3n2->getTruthValue());
-		TS_ASSERT(h2n2->getTruthValue() != h3n2->getTruthValue());
-
-		TS_ASSERT(h1n3->getTruthValue() != h2n3->getTruthValue());
-		TS_ASSERT(h1n3->getTruthValue() != h3n3->getTruthValue());
-		TS_ASSERT(h2n3->getTruthValue() != h3n3->getTruthValue());
 
 		// The truth values themselves should be equal, as values.
 		TS_ASSERT(*h1n1->getTruthValue() == *tv1);


### PR DESCRIPTION
This will speed up performance a bit.

Also fix the totally borked GenericTruthValue.