### PR TITLE
Ure config fixes

### DIFF
--- a/examples/rule-engine/chaining/frog.scm
+++ b/examples/rule-engine/chaining/frog.scm
@@ -23,7 +23,7 @@
 	)
 )
 
-(define rule1-name (Node "rule1"))
+(define rule1-name (DefinedSchemaNode "rule1"))
 (DefineLink rule1-name rule1)
 
 (define rule2
@@ -42,7 +42,7 @@
 	)
 )
 
-(define rule2-name (Node "rule2"))
+(define rule2-name (DefinedSchemaNode "rule2"))
 (DefineLink rule2-name rule2)
 
 (define source

--- a/examples/rule-engine/rules/crisp-deduction-rule.scm
+++ b/examples/rule-engine/rules/crisp-deduction-rule.scm
@@ -70,7 +70,8 @@
           (cog-set-tv! AC (stv 1 1)))))
 
 ; Associate a name to the rule
-(define crisp-deduction-rule-name (Node "crisp-deduction-rule"))
+(define crisp-deduction-rule-name
+  (DefinedSchemaNode "crisp-deduction-rule"))
 (DefineLink
   crisp-deduction-rule-name
   crisp-deduction-rule)

--- a/examples/rule-engine/rules/crisp-modus-ponens-rule.scm
+++ b/examples/rule-engine/rules/crisp-modus-ponens-rule.scm
@@ -45,7 +45,8 @@
           (cog-set-tv! B (stv 1 1)))))
 
 ; Associate a name to the rule
-(define crisp-modus-ponens-rule-name (Node "crisp-modus-ponens-rule"))
+(define crisp-modus-ponens-rule-name
+  (DefinedSchemaNode "crisp-modus-ponens-rule"))
 (DefineLink
   crisp-modus-ponens-rule-name
   crisp-modus-ponens-rule)

--- a/opencog/rule-engine/Rule.cc
+++ b/opencog/rule-engine/Rule.cc
@@ -36,6 +36,17 @@ using namespace opencog;
 
 Rule::Rule(Handle rule)
 {
+	init(rule);
+}
+
+Rule::Rule(Handle rule_name, Handle rbs)
+{
+	AtomSpace* as = rule_name->getAtomSpace();
+	init(as->get_link(MEMBER_LINK, rule_name, rbs));
+}
+
+void Rule::init(Handle rule)
+{
 	if (rule == Handle::UNDEFINED)
 		rule_handle_ = Handle::UNDEFINED;
 	else
@@ -46,11 +57,11 @@ Rule::Rule(Handle rule)
 		                                rule->toString().c_str());
 
 		rule_alias_ = LinkCast(rule)->getOutgoingAtom(0);
-		Handle rbs_h = LinkCast(rule)->getOutgoingAtom(1);
+		Handle rbs = LinkCast(rule)->getOutgoingAtom(1);
 
 		rule_handle_ = DefineLink::get_definition(rule_alias_);
 		name_ = NodeCast(rule_alias_)->getName();
-		category_ = NodeCast(rbs_h)->getName();
+		category_ = NodeCast(rbs)->getName();
 		weight_ = rule->getTruthValue()->getMean();
 	}
 }

--- a/opencog/rule-engine/Rule.h
+++ b/opencog/rule-engine/Rule.h
@@ -46,7 +46,10 @@ public:
 	//    <rule name>
 	//    <rbs>
 	Rule(Handle rule);
+	Rule(Handle rule_name, Handle rbs);
 
+	void init(Handle rule);
+	
 	// Comparison
 	bool operator==(const Rule& r) const {
 		return r.rule_handle_ == rule_handle_;

--- a/opencog/rule-engine/UREConfigReader.cc
+++ b/opencog/rule-engine/UREConfigReader.cc
@@ -40,8 +40,8 @@ UREConfigReader::UREConfigReader(AtomSpace& as, Handle rbs) : _as(as)
 			"UREConfigReader - invalid rulebase specified!");
 
 	// Retrieve the rules (MemberLinks) and instantiate them
-	for (Handle rule : fetch_rules(rbs))
-		_rbparams.rules.emplace_back(rule);
+	for (Handle rule_name : fetch_rule_names(rbs))
+		_rbparams.rules.emplace_back(rule_name, rbs);
 
 	// Fetch maximum number of iterations
 	_rbparams.max_iter = fetch_num_param(max_iter_name, rbs);
@@ -90,13 +90,13 @@ void UREConfigReader::set_maximum_iterations(int mi)
 	_rbparams.max_iter = mi;
 }
 
-HandleSeq UREConfigReader::fetch_rules(Handle rbs)
+HandleSeq UREConfigReader::fetch_rule_names(Handle rbs)
 {
 	// Retrieve rules
 	Handle rule_var = _as.add_node(VARIABLE_NODE, "__URE_RULE__");
 	Handle rule_pat = _as.add_link(MEMBER_LINK, rule_var, rbs);
-	Handle gl = _as.add_link(BIND_LINK, rule_pat, rule_pat);
-	Handle rule_names = bindlink(&_as, gl);
+	Handle gl = _as.add_link(GET_LINK, rule_pat);
+	Handle rule_names = satisfying_set(&_as, gl);
 
 	// Remove the GetLink pattern from the AtomSpace as it is no
 	// longer useful

--- a/opencog/rule-engine/UREConfigReader.h
+++ b/opencog/rule-engine/UREConfigReader.h
@@ -81,7 +81,7 @@ private:
 	// MemberLink <TV>
 	//    <rule name>
 	//    <rbs>
-	HandleSeq fetch_rules(Handle rbs);
+	HandleSeq fetch_rule_names(Handle rbs);
 
 	AtomSpace& _as;
 

--- a/opencog/scm/rule-engine-utils.scm
+++ b/opencog/scm/rule-engine-utils.scm
@@ -38,7 +38,7 @@
 "
     ; Didn't add type checking here b/c the ure-configuration format isn't
     ; set in stone yet. And the best place to do that is in c++ UREConfigReader
-    (let ((alias (Node rule-name)))
+    (let ((alias (DefinedSchemaNode rule-name)))
         (DefineLink alias rule)
 
         (MemberLink (stv weight 1)

--- a/tests/rule-engine/bc-modus-ponens.scm
+++ b/tests/rule-engine/bc-modus-ponens.scm
@@ -53,7 +53,7 @@
                     cA))))
 
 ; Associate a name to the rule
-(define pln-rule-modus-ponens-name (Node "pln-rule-modus-ponens"))
+(define pln-rule-modus-ponens-name (DefinedSchemaNode "pln-rule-modus-ponens"))
 (DefineLink
   pln-rule-modus-ponens-name
   pln-rule-modus-ponens)


### PR DESCRIPTION
Use DefinedSchemaNode instead of Node.

WARNING: I'm not sure, this might break the opencog repo, I don't understand why.

@linas If you want to restrict DefineLink to use only DefinedSchemaNode, DefinedPredicateNode or DefinedTypeNode I think you now can.