### PR TITLE
Start working for lazy execution

### DIFF
--- a/examples/guile/map.scm
+++ b/examples/guile/map.scm
@@ -2,7 +2,7 @@
 ; Mapping example.
 ;
 ; The MapLink implements a link type analogous to the `map` function
-; commmonly found in functional programming langauges, such as the
+; commmonly found in functional programming languages, such as the
 ; scheme srfi-1 `map`, or `map` in haskell.
 ;
 ; In many ways, MapLink is similar to BindLink, except that MapLink

--- a/opencog/atoms/execution/Instantiator.cc
+++ b/opencog/atoms/execution/Instantiator.cc
@@ -577,8 +577,8 @@ Handle Instantiator::instantiate(const Handle& expr,
 	// We do this here, instead of in walk_eager(), because adding
 	// atoms to the atomspace is an expensive process.  We can save
 	// some time by doing it just once, right here, in one big batch.
-	// return _as->add_atom(walk_eager(expr));
-	return _as->add_atom(walk_lazy(expr));
+	return _as->add_atom(walk_eager(expr));
+	// return _as->add_atom(walk_lazy(expr));
 }
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/execution/Instantiator.cc
+++ b/opencog/atoms/execution/Instantiator.cc
@@ -507,17 +507,12 @@ Handle Instantiator::walk_lazy(const Handle& expr, int quotation_level)
 
 	// FoldLink's are a kind-of FunctionLink, but are not currently
 	// handled by the FunctionLink factory below.  This should be fixed
-	// someday, when the reduct directory is re-desiged.
+	// someday, when the reduct directory is nuked.
 	if (classserver().isA(t, FOLD_LINK))
 	{
-		// At this time, no FoldLink ever has a variable declaration,
-		// and the number of arguments is not fixed, i.e. variadic.
-		// Perform substitution on all arguments before applying the
-		// function itself.
-		HandleSeq oset_results;
-		seq_eager(oset_results, lexpr->getOutgoingSet(), quotation_level);
-		Handle hl(FoldLink::factory(t, oset_results));
-		FoldLinkPtr flp(FoldLinkCast(hl));
+		FoldLinkPtr flp(FoldLinkCast(expr));
+		if (nullptr == flp)
+			flp = FoldLinkCast(FoldLink::factory(lexpr));
 		return flp->execute(_as);
 	}
 
@@ -527,12 +522,9 @@ Handle Instantiator::walk_lazy(const Handle& expr, int quotation_level)
 		// At this time, no FunctionLink that is outside of an
 		// ExecutionOutputLink ever has a variable declaration.
 		// Also, the number of arguments is not fixed, i.e. variadic.
-		// Perform substitution on all arguments before applying the
-		// function itself.
-		HandleSeq oset_results;
-		seq_eager(oset_results, lexpr->getOutgoingSet(), quotation_level);
-		Handle hl(FunctionLink::factory(t, oset_results));
-		FunctionLinkPtr flp(FunctionLinkCast(hl));
+		FunctionLinkPtr flp(FunctionLinkCast(expr));
+		if (nullptr == flp)
+			flp = FunctionLinkCast(FunctionLink::factory(lexpr));
 		return flp->execute(_as);
 	}
 
@@ -541,15 +533,7 @@ Handle Instantiator::walk_lazy(const Handle& expr, int quotation_level)
 	// PatternLink::satisfy() method.
 	if (GET_LINK == t)
 	{
-		HandleSeq oset_results;
-		seq_eager(oset_results, lexpr->getOutgoingSet(), quotation_level);
-		size_t sz = oset_results.size();
-		for (size_t i=0; i< sz; i++)
-			oset_results[i] = _as->add_atom(oset_results[i]);
-
-		LinkPtr lp(createLink(GET_LINK, oset_results));
-
-		return satisfying_set(_as, Handle(lp));
+		return satisfying_set(_as, expr);
 	}
 
 mere_recursive_call:

--- a/opencog/atoms/execution/Instantiator.h
+++ b/opencog/atoms/execution/Instantiator.h
@@ -61,9 +61,14 @@ private:
 	 * any execution. See also PutLink, which does substituion.
 	 * (actually, beta reduction).
 	 */
-	Handle walk_tree(const Handle& tree, int quotation_level = 0);
-	bool walk_tree(HandleSeq&, const HandleSeq& orig,
-	               int quotation_level = 0);
+	Handle walk_tree_eager(const Handle& tree, int quotation_level = 0);
+	bool walk_tree_eager(HandleSeq&, const HandleSeq& orig,
+	                     int quotation_level = 0);
+
+	/* Same as above, but does lazy execution. */
+	Handle walk_tree_lazy(const Handle& tree, int quotation_level = 0);
+	bool walk_tree_lazy(HandleSeq&, const HandleSeq& orig,
+	                     int quotation_level = 0);
 
 public:
 	Instantiator(AtomSpace* as) : _as(as) {}

--- a/opencog/atoms/execution/Instantiator.h
+++ b/opencog/atoms/execution/Instantiator.h
@@ -61,14 +61,17 @@ private:
 	 * any execution. See also PutLink, which does substituion.
 	 * (actually, beta reduction).
 	 */
-	Handle walk_tree_eager(const Handle& tree, int quotation_level = 0);
-	bool walk_tree_eager(HandleSeq&, const HandleSeq& orig,
+	Handle walk_eager(const Handle& tree, int quotation_level = 0);
+	bool seq_eager(HandleSeq&, const HandleSeq& orig,
 	                     int quotation_level = 0);
 
 	/* Same as above, but does lazy execution. */
-	Handle walk_tree_lazy(const Handle& tree, int quotation_level = 0);
-	bool walk_tree_lazy(HandleSeq&, const HandleSeq& orig,
+	Handle walk_lazy(const Handle& tree, int quotation_level = 0);
+	bool seq_lazy(HandleSeq&, const HandleSeq& orig,
 	                     int quotation_level = 0);
+
+	bool walk_tree(HandleSeq&, const HandleSeq&, int,
+	               Handle (Instantiator::*)(const Handle&, int));
 
 public:
 	Instantiator(AtomSpace* as) : _as(as) {}

--- a/opencog/atoms/reduct/ArithmeticLink.cc
+++ b/opencog/atoms/reduct/ArithmeticLink.cc
@@ -188,7 +188,7 @@ Handle ArithmeticLink::execute(AtomSpace* as) const
 	{
 		Handle arg = _outgoing[0];
 		FunctionLinkPtr flp(FunctionLinkCast(arg));
-		if (flp) arg = flp->execute();
+		if (flp) arg = flp->execute(as);
 
 		if (SET_LINK == arg->getType())
 		{

--- a/opencog/atoms/reduct/ArithmeticLink.cc
+++ b/opencog/atoms/reduct/ArithmeticLink.cc
@@ -157,6 +157,9 @@ static inline double get_double(AtomSpace *as, Handle h)
 
 NumberNodePtr ArithmeticLink::unwrap_set(Handle h) const
 {
+	FunctionLinkPtr flp(FunctionLinkCast(h));
+	if (flp) h = flp->execute();
+
 	// Pattern matching hack. The pattern matcher returns sets of atoms;
 	// if that set contains numbers or something numeric, then unwrap it.
 	if (SET_LINK == h->getType())
@@ -181,10 +184,20 @@ Handle ArithmeticLink::execute(AtomSpace* as) const
 {
 	// Pattern matching hack. The pattern matcher returns sets of atoms;
 	// if that set contains numbers or something numeric, then unwrap it.
-	if (SET_LINK == _type and 1 == _outgoing.size())
+	if (1 == _outgoing.size())
 	{
-		LinkPtr lp(LinkCast(_outgoing[0]));
-		return do_execute(as, lp->getOutgoingSet());
+		Handle arg = _outgoing[0];
+		FunctionLinkPtr flp(FunctionLinkCast(arg));
+		if (flp) arg = flp->execute();
+
+		if (SET_LINK == arg->getType())
+		{
+			LinkPtr lp(LinkCast(arg));
+			return do_execute(as, lp->getOutgoingSet());
+		}
+		HandleSeq o;
+		o.emplace_back(arg);
+		return do_execute(as, o);
 	}
 	return do_execute(as, _outgoing);
 }

--- a/opencog/atoms/reduct/ArithmeticLink.h
+++ b/opencog/atoms/reduct/ArithmeticLink.h
@@ -52,7 +52,7 @@ protected:
 	         AttentionValuePtr av = AttentionValue::DEFAULT_AV());
 
 	NumberNodePtr unwrap_set(Handle) const;
-	Handle do_execute(AtomSpace*, const HandleSeq&) const;
+	virtual Handle do_execute(AtomSpace*, const HandleSeq&) const;
 public:
 	ArithmeticLink(const HandleSeq& oset,
 	         TruthValuePtr tv = TruthValue::DEFAULT_TV(),

--- a/opencog/atoms/reduct/DivideLink.cc
+++ b/opencog/atoms/reduct/DivideLink.cc
@@ -81,18 +81,6 @@ void DivideLink::init(void)
 			"Don't know how to divide that!");
 }
 
-Handle DivideLink::execute(AtomSpace* as) const
-{
-	// Pattern matching hack. The pattern matcher returns sets of atoms;
-	// if that set contains numbers or something numeric, then unwrap it.
-	if (SET_LINK == _type and 1 == _outgoing.size())
-	{
-		LinkPtr lp(LinkCast(_outgoing[0]));
-		return do_execute(lp->getOutgoingSet());
-	}
-	return do_execute(_outgoing);
-}
-
 Handle DivideLink::do_execute(const HandleSeq& oset) const
 {
 	if (1 == oset.size())

--- a/opencog/atoms/reduct/DivideLink.cc
+++ b/opencog/atoms/reduct/DivideLink.cc
@@ -81,7 +81,7 @@ void DivideLink::init(void)
 			"Don't know how to divide that!");
 }
 
-Handle DivideLink::do_execute(const HandleSeq& oset) const
+Handle DivideLink::do_execute(AtomSpace* as, const HandleSeq& oset) const
 {
 	if (1 == oset.size())
 	{

--- a/opencog/atoms/reduct/DivideLink.h
+++ b/opencog/atoms/reduct/DivideLink.h
@@ -48,7 +48,7 @@ protected:
 	         TruthValuePtr tv = TruthValue::DEFAULT_TV(),
 	         AttentionValuePtr av = AttentionValue::DEFAULT_AV());
 
-	Handle do_execute(const HandleSeq&) const;
+	virtual Handle do_execute(const HandleSeq&) const;
 public:
 	DivideLink(const Handle& a, const Handle& b,
 	         TruthValuePtr tv = TruthValue::DEFAULT_TV(),
@@ -58,8 +58,6 @@ public:
 	         TruthValuePtr tv = TruthValue::DEFAULT_TV(),
 	         AttentionValuePtr av = AttentionValue::DEFAULT_AV());
 	DivideLink(Link& l);
-
-	virtual Handle execute(AtomSpace* as) const;
 };
 
 typedef std::shared_ptr<DivideLink> DivideLinkPtr;

--- a/opencog/atoms/reduct/DivideLink.h
+++ b/opencog/atoms/reduct/DivideLink.h
@@ -48,7 +48,7 @@ protected:
 	         TruthValuePtr tv = TruthValue::DEFAULT_TV(),
 	         AttentionValuePtr av = AttentionValue::DEFAULT_AV());
 
-	virtual Handle do_execute(const HandleSeq&) const;
+	virtual Handle do_execute(AtomSpace*, const HandleSeq&) const;
 public:
 	DivideLink(const Handle& a, const Handle& b,
 	         TruthValuePtr tv = TruthValue::DEFAULT_TV(),

--- a/opencog/atoms/reduct/MinusLink.cc
+++ b/opencog/atoms/reduct/MinusLink.cc
@@ -81,7 +81,7 @@ void MinusLink::init(void)
 			"Don't know how to subract that!");
 }
 
-Handle MinusLink::do_execute(const HandleSeq& oset) const
+Handle MinusLink::do_execute(AtomSpace* as, const HandleSeq& oset) const
 {
 	if (1 == oset.size())
 	{

--- a/opencog/atoms/reduct/MinusLink.cc
+++ b/opencog/atoms/reduct/MinusLink.cc
@@ -81,18 +81,6 @@ void MinusLink::init(void)
 			"Don't know how to subract that!");
 }
 
-Handle MinusLink::execute(AtomSpace* as) const
-{
-	// Pattern matching hack. The pattern matcher returns sets of atoms;
-	// if that set contains numbers or something numeric, then unwrap it.
-	if (SET_LINK == _type and 1 == _outgoing.size())
-	{
-		LinkPtr lp(LinkCast(_outgoing[0]));
-		return do_execute(lp->getOutgoingSet());
-	}
-	return do_execute(_outgoing);
-}
-
 Handle MinusLink::do_execute(const HandleSeq& oset) const
 {
 	if (1 == oset.size())

--- a/opencog/atoms/reduct/MinusLink.h
+++ b/opencog/atoms/reduct/MinusLink.h
@@ -48,7 +48,7 @@ protected:
 	         TruthValuePtr tv = TruthValue::DEFAULT_TV(),
 	         AttentionValuePtr av = AttentionValue::DEFAULT_AV());
 
-	Handle do_execute(const HandleSeq&) const;
+	virtual Handle do_execute(const HandleSeq&) const;
 public:
 	MinusLink(const Handle& a, const Handle& b,
 	         TruthValuePtr tv = TruthValue::DEFAULT_TV(),
@@ -58,8 +58,6 @@ public:
 	         TruthValuePtr tv = TruthValue::DEFAULT_TV(),
 	         AttentionValuePtr av = AttentionValue::DEFAULT_AV());
 	MinusLink(Link& l);
-
-	virtual Handle execute(AtomSpace* as) const;
 };
 
 typedef std::shared_ptr<MinusLink> MinusLinkPtr;

--- a/opencog/atoms/reduct/MinusLink.h
+++ b/opencog/atoms/reduct/MinusLink.h
@@ -48,7 +48,7 @@ protected:
 	         TruthValuePtr tv = TruthValue::DEFAULT_TV(),
 	         AttentionValuePtr av = AttentionValue::DEFAULT_AV());
 
-	virtual Handle do_execute(const HandleSeq&) const;
+	virtual Handle do_execute(AtomSpace*, const HandleSeq&) const;
 public:
 	MinusLink(const Handle& a, const Handle& b,
 	         TruthValuePtr tv = TruthValue::DEFAULT_TV(),


### PR DESCRIPTION
It would be better if lazy execution was used throughout; the current design uses eager execution.  

This sequence of patches starts a conversion to lazy execution, but does not finish the work.  There's a lot of work remaining, and its lower priority, and I can't really finish it at this time.  So this starts the conversion, but nothing more.