### PR TITLE
Bug-fix a crazy crash

### DIFF
--- a/opencog/scm/opencog.scm
+++ b/opencog/scm/opencog.scm
@@ -14,7 +14,9 @@
 
 ; libsmob won't be found unless we setenv where to find it!
 (setenv "LTDL_LIBRARY_PATH"
-	(string-append (getenv "LTDL_LIBRARY_PATH") "/usr/local/lib/opencog"))
+	(if (getenv "LTDL_LIBRARY_PATH")
+		(string-append (getenv "LTDL_LIBRARY_PATH") ":/usr/local/lib/opencog")
+		"/usr/local/lib/opencog"))
 
 ; Work-around another common usability issue...
 (add-to-load-path "/usr/local/share/opencog/scm")

--- a/opencog/scm/opencog.scm
+++ b/opencog/scm/opencog.scm
@@ -13,7 +13,8 @@
 (setlocale LC_CTYPE "")
 
 ; libsmob won't be found unless we setenv where to find it!
-(setenv "LTDL_LIBRARY_PATH" "/usr/local/lib/opencog")
+(setenv "LTDL_LIBRARY_PATH"
+	(string-append (getenv "LTDL_LIBRARY_PATH") "/usr/local/lib/opencog"))
 
 ; Work-around another common usability issue...
 (add-to-load-path "/usr/local/share/opencog/scm")

--- a/opencog/scm/opencog/query.scm
+++ b/opencog/scm/opencog/query.scm
@@ -5,7 +5,8 @@
 (define-module (opencog query))
 
 ; The atomspace libraries are located in /usr/local/lib/opencog
-(setenv "LTDL_LIBRARY_PATH" "/usr/local/lib/opencog")
+(setenv "LTDL_LIBRARY_PATH"
+	(string-append (getenv "LTDL_LIBRARY_PATH") "/usr/local/lib/opencog"))
 
 ; This is also loaded by (opencog exec) We need it here,
 ; else we get undefined symbols in libquery.

--- a/opencog/scm/opencog/query.scm
+++ b/opencog/scm/opencog/query.scm
@@ -6,7 +6,9 @@
 
 ; The atomspace libraries are located in /usr/local/lib/opencog
 (setenv "LTDL_LIBRARY_PATH"
-	(string-append (getenv "LTDL_LIBRARY_PATH") "/usr/local/lib/opencog"))
+	(if (getenv "LTDL_LIBRARY_PATH")
+		(string-append (getenv "LTDL_LIBRARY_PATH") ":/usr/local/lib/opencog")
+		"/usr/local/lib/opencog"))
 
 ; This is also loaded by (opencog exec) We need it here,
 ; else we get undefined symbols in libquery.


### PR DESCRIPTION
Fix for bug #587 

Without this, some executables run from the build directory  (for example, the unit tests)  will crash with a "double free or corruption" error.
