### PR TITLE
Add dummy clauses to simplify search.

### DIFF
--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -41,7 +41,7 @@ void PatternLink::common_init(void)
 
 	// If there are any defines in the pattern, then all bets are off
 	// as to whether it is connected or not, what's virtual, what isn't.
-	// The analysis will have to be performed at run-time, so we can
+	// The analysis will have to be performed at run-time, so we will
 	// skip doing it here.
 	if (0 < _pat.defined_terms.size())
 	{

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -57,6 +57,8 @@ void PatternLink::common_init(void)
 	                 _fixed, _virtual, _pat.black);
 	_num_virts = _virtual.size();
 
+	add_dummies();
+
 	// unbundle_virtual does not handle connectives. Here, we assume that
 	// we are being run with the DefaultPatternMatchCB, and so we assume
 	// that the logical connectives are AndLink, OrLink and NotLink.
@@ -669,6 +671,43 @@ void PatternLink::unbundle_virtual(const std::set<Handle>& vars,
 
 		if (is_black)
 			black_clauses.insert(clause);
+	}
+}
+
+/* ================================================================= */
+
+/// Add dummy clauses for patterns that would otherwise not have any
+/// non-evaluatable clauses.  An example of such is
+///    (GetLink (GreaterThan (Number 42) (Variable $x)))
+/// The only clause here is the GreaterThan, and its virtual
+/// (evaluatable) so we know that in general it cannot be found in
+/// the atomspace.   Due to the pattern-matcher design, matching will
+/// fail unless there is at least one PresentLink/AbsentLink clause.
+/// We can infer, from the above, that the Variable $x must be in the
+/// atomspace, so we just add it here, as a dummy clause that can be
+/// trivially satisfied.  This can be done generically, without changing
+/// search results, for any variable that is not in an AbsentLink.
+/// (Always adding can harm performance, so we don't do it unless we
+/// absolutely have to.)
+void PatternLink::add_dummies()
+{
+	// XXX almost exactly the same as 0 < _fixed.size() ... right?
+	bool all_clauses_are_evaluatable = true;
+	for (const Handle& cl : _pat.clauses)
+	{
+		// if (0 < _pat.evaluatable_holders.count(cl)) continue;
+		if (0 < _pat.evaluatable_terms.count(cl)) continue;
+		all_clauses_are_evaluatable = false;
+		break;
+	}
+
+	if (not all_clauses_are_evaluatable) return;
+
+	for (const Handle& v: _varlist.varseq)
+	{
+		_pat.clauses.emplace_back(v);
+		_pat.cnf_clauses.emplace_back(v);
+		_pat.mandatory.emplace_back(v);
 	}
 }
 

--- a/opencog/atoms/pattern/PatternLink.h
+++ b/opencog/atoms/pattern/PatternLink.h
@@ -112,6 +112,8 @@ protected:
 	                      HandleSeq& virtual_clauses,
 	                      std::set<Handle>& black_clauses);
 
+	void add_dummies();
+
 	void trace_connectives(const std::set<Type>&,
 	                       const HandleSeq& clauses,
 	                       int quotation_level = 0);

--- a/opencog/guile/SchemePrimitive.cc
+++ b/opencog/guile/SchemePrimitive.cc
@@ -159,8 +159,14 @@ SCM PrimitiveEnviron::do_call(SCM sfe, SCM arglist)
 
 PrimitiveEnviron * PrimitiveEnviron::verify_pe(SCM spe, const char *subrname)
 {
-	if (!SCM_SMOB_PREDICATE(SchemeSmob::cog_misc_tag, spe))
+	if (not SCM_SMOB_PREDICATE(SchemeSmob::cog_misc_tag, spe))
+{
+printf("duude aieeeee %p\n", subrname);
+printf("duude aieeeee >>%s\n", subrname);
+scm_display(spe, scm_current_output_port ());
+fflush (stdout);
 		scm_wrong_type_arg_msg(subrname, 1, spe, "opencog primitive function");
+}
 
 	scm_t_bits misctype = SCM_SMOB_FLAGS(spe);
 	if (SchemeSmob::COG_EXTEND != misctype)

--- a/opencog/guile/SchemePrimitive.cc
+++ b/opencog/guile/SchemePrimitive.cc
@@ -160,13 +160,7 @@ SCM PrimitiveEnviron::do_call(SCM sfe, SCM arglist)
 PrimitiveEnviron * PrimitiveEnviron::verify_pe(SCM spe, const char *subrname)
 {
 	if (not SCM_SMOB_PREDICATE(SchemeSmob::cog_misc_tag, spe))
-{
-printf("duude aieeeee %p\n", subrname);
-printf("duude aieeeee >>%s\n", subrname);
-scm_display(spe, scm_current_output_port ());
-fflush (stdout);
 		scm_wrong_type_arg_msg(subrname, 1, spe, "opencog primitive function");
-}
 
 	scm_t_bits misctype = SCM_SMOB_FLAGS(spe);
 	if (SchemeSmob::COG_EXTEND != misctype)

--- a/opencog/query/InitiateSearchCB.cc
+++ b/opencog/query/InitiateSearchCB.cc
@@ -666,7 +666,7 @@ bool InitiateSearchCB::variable_search(PatternMatchEngine *pme)
 				// Evaluatables don't exist in the atomspace, in general.
 				// Therefore, we cannot start a search with them. Unless
 				// they are all evaluatable, in which case we pick a clause
-				// that hase a variable with the narrowest type-membership.
+				// that has a variable with the narrowest type-membership.
 				if (not all_clauses_are_evaluatable and
 				    0 < _pattern->evaluatable_holders.count(cl)) continue;
 
@@ -687,7 +687,7 @@ bool InitiateSearchCB::variable_search(PatternMatchEngine *pme)
 					_root = cl;
 					_starter_term = *fa.least_holders.begin();
 					if (all_clauses_are_evaluatable)
-						_starter_term = cl;
+						_starter_term = var;
 					count = num;
 					ptypes = typeset;
 					LAZY_LOG_FINE << "New minimum count of "

--- a/opencog/query/InitiateSearchCB.cc
+++ b/opencog/query/InitiateSearchCB.cc
@@ -627,7 +627,7 @@ bool InitiateSearchCB::variable_search(PatternMatchEngine *pme)
 #ifdef _IMPLMENT_ME_LATER
 		// XXX TODO FIXME --- if there is a deep type in the mix, that
 		// will offer a far-superior place to start the search.
-		// Unfortunately, implementing this will rquire a bit more work,
+		// Unfortunately, implementing this will require a bit more work,
 		// so we punt for now, as there are no users ....
 		auto dit = _variables->_deep_typemap.find(var);
 		if (_variables->_deep_typemap.end() != dit)
@@ -637,7 +637,7 @@ bool InitiateSearchCB::variable_search(PatternMatchEngine *pme)
 		auto tit = _variables->_simple_typemap.find(var);
 		if (_variables->_simple_typemap.end() == tit) continue;
 		const std::set<Type>& typeset = tit->second;
-		LAZY_LOG_FINE << "Type-restictions set size = "
+		LAZY_LOG_FINE << "Type-restriction set size = "
 		              << typeset.size();
 
 		// Calculate the total number of atoms of typeset

--- a/opencog/query/InitiateSearchCB.cc
+++ b/opencog/query/InitiateSearchCB.cc
@@ -613,6 +613,17 @@ bool InitiateSearchCB::variable_search(PatternMatchEngine *pme)
 {
 	const HandleSeq& clauses = _pattern->mandatory;
 
+	// Some search patterns simply do not have any groundable
+	// clauses in them. This is one common reason why a variable-
+	// based search is being performed.
+	bool all_clauses_are_evaluatable = true;
+	for (const Handle& cl : clauses)
+	{
+		if (0 < _pattern->evaluatable_holders.count(cl)) continue;
+		all_clauses_are_evaluatable = false;
+		break;
+	}
+
 	// Find the rarest variable type;
 	size_t count = SIZE_MAX;
 	std::set<Type> ptypes;
@@ -653,10 +664,12 @@ bool InitiateSearchCB::variable_search(PatternMatchEngine *pme)
 			for (const Handle& cl : clauses)
 			{
 				// Evaluatables don't exist in the atomspace, in general.
-				// Cannot start a search with them.
-				if (0 < _pattern->evaluatable_holders.count(cl)) continue;
-				FindAtoms fa(var);
-				fa.search_set(cl);
+				// Therefore, we cannot start a search with them. Unless
+				// they are all evaluatable, in which case we pick a clause
+				// that hase a variable with the narrowest type-membership.
+				if (not all_clauses_are_evaluatable and
+				    0 < _pattern->evaluatable_holders.count(cl)) continue;
+
 				if (cl == var)
 				{
 					_root = cl;
@@ -666,14 +679,19 @@ bool InitiateSearchCB::variable_search(PatternMatchEngine *pme)
 					LAZY_LOG_FINE << "New minimum count of " << count;
 					break;
 				}
+
+				FindAtoms fa(var);
+				fa.search_set(cl);
 				if (0 < fa.least_holders.size())
 				{
 					_root = cl;
 					_starter_term = *fa.least_holders.begin();
+					if (all_clauses_are_evaluatable)
+						_starter_term = cl;
 					count = num;
 					ptypes = typeset;
 					LAZY_LOG_FINE << "New minimum count of "
-					              << count << "(nonroot)";
+					              << count << " (nonroot)";
 					break;
 				}
 			}
@@ -683,10 +701,10 @@ bool InitiateSearchCB::variable_search(PatternMatchEngine *pme)
 	// There were no type restrictions!
 	if (nullptr == _root)
 	{
-		logger().fine("There were no type restrictions! That must be wrong!");
+		logger().info("Warning: There were no type restrictions! That must be wrong!");
 		if (0 == clauses.size())
 		{
-			// This is kind-of weird, it can happen if all clauses
+			// This is kind-of weird, but it can happen if all clauses
 			// are optional.
 			_search_fail = true;
 			return false;

--- a/opencog/query/InitiateSearchCB.cc
+++ b/opencog/query/InitiateSearchCB.cc
@@ -619,7 +619,7 @@ bool InitiateSearchCB::variable_search(PatternMatchEngine *pme)
 	bool all_clauses_are_evaluatable = true;
 	for (const Handle& cl : clauses)
 	{
-		if (0 < _pattern->evaluatable_holders.count(cl)) continue;
+		if (0 < _pattern->evaluatable_terms.count(cl)) continue;
 		all_clauses_are_evaluatable = false;
 		break;
 	}
@@ -668,7 +668,7 @@ bool InitiateSearchCB::variable_search(PatternMatchEngine *pme)
 				// they are all evaluatable, in which case we pick a clause
 				// that has a variable with the narrowest type-membership.
 				if (not all_clauses_are_evaluatable and
-				    0 < _pattern->evaluatable_holders.count(cl)) continue;
+				    0 < _pattern->evaluatable_terms.count(cl)) continue;
 
 				if (cl == var)
 				{

--- a/opencog/scm/opencog/logger.scm
+++ b/opencog/scm/opencog/logger.scm
@@ -6,11 +6,8 @@
 
 (define-module (opencog logger))
 
-; libsmob won't be found unless we setenv where to find it!
-(setenv "LTDL_LIBRARY_PATH"
-	(if (getenv "LTDL_LIBRARY_PATH")
-		(string-append (getenv "LTDL_LIBRARY_PATH") ":/usr/local/lib/opencog")
-		"/usr/local/lib/opencog"))
+; We need this to set the LTDL_LIBRARY_PATH
+(use-modules (opencog))
 
 (load-extension "libsmob" "opencog_logger_init")
 

--- a/opencog/scm/opencog/logger.scm
+++ b/opencog/scm/opencog/logger.scm
@@ -6,6 +6,12 @@
 
 (define-module (opencog logger))
 
+; libsmob won't be found unless we setenv where to find it!
+(setenv "LTDL_LIBRARY_PATH"
+	(if (getenv "LTDL_LIBRARY_PATH")
+		(string-append (getenv "LTDL_LIBRARY_PATH") ":/usr/local/lib/opencog")
+		"/usr/local/lib/opencog"))
+
 (load-extension "libsmob" "opencog_logger_init")
 
 ; Documentation for the functions implemented as C++ code

--- a/tests/query/ArcanaUTest.cxxtest
+++ b/tests/query/ArcanaUTest.cxxtest
@@ -61,6 +61,7 @@ public:
 
     void test_repeats(void);
     void test_const(void);
+    void test_dummy(void);
     void test_numeric(void);
 };
 
@@ -163,6 +164,33 @@ void ArcanaUTest::test_const(void)
 
     TS_ASSERT_EQUALS(1, getarity(defans));
     TS_ASSERT_EQUALS(defans, answer);
+
+    // ----
+    logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+/*
+ * Miscellaneous Arcana
+ * This one tests addition of mandatory dummy terms.
+ */
+void ArcanaUTest::test_dummy(void)
+{
+    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+    config().set("SCM_PRELOAD", "tests/query/arcana-dummy.scm");
+    load_scm_files_from_config(*as);
+
+    // ----
+    Handle answer = eval->eval_h("(cog-execute! dummy)");
+    printf("dummy=%s\n", answer->toString().c_str());
+
+    TS_ASSERT_EQUALS(SET_LINK, answer->getType());
+    TS_ASSERT_EQUALS(1, getarity(answer));
+    LinkPtr lp = LinkCast(answer);
+    Handle num = lp->getOutgoingAtom(0);
+
+    Handle fourtwo = eval->eval_h("(Number 42)");
+    TS_ASSERT_EQUALS(num, fourtwo);
 
     // ----
     logger().debug("END TEST: %s", __FUNCTION__);

--- a/tests/query/arcana-dummy.scm
+++ b/tests/query/arcana-dummy.scm
@@ -1,0 +1,15 @@
+;
+; Unit testing for a constant pattern
+;
+(use-modules (opencog))
+(use-modules (opencog query) (opencog exec))
+
+; Data
+(Number 42)
+(Number 3003)
+
+; Query. Should return only "42"
+(define dummy
+	(GetLink
+		(TypedVariable (Variable "$x") (Type "NumberNode"))
+		(GreaterThan (Number 88) (Variable "$x"))))


### PR DESCRIPTION
This avoids a common usage error -- failure to explicitly specify a searchable clause.