### PR TITLE
a fix for gcc 5.2 warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.a
+*.so
 *.log
 .vagrant
 .DS_Store

--- a/tests/atomspaceutils/CMakeLists.txt
+++ b/tests/atomspaceutils/CMakeLists.txt
@@ -1,4 +1,4 @@
-LINK_LIBRARIES(AtomSpaceUtilsUTest
+LINK_LIBRARIES(
 	atomspaceutils
 	atomspace
 )


### PR DESCRIPTION
also ignore shared objects created by haskell test builds