### PR TITLE
Remove deprecated atomspace functions

### DIFF
--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -237,7 +237,7 @@ public:
         setAttentionValue(new_av);
     }
 
-    /** Change the Long-term Importance */
+    /** Change the Long-Term Importance */
     void setLTI(AttentionValue::lti_t ltiValue)
     {
         AttentionValuePtr old_av = getAttentionValue();
@@ -245,6 +245,17 @@ public:
             old_av->getSTI(),
             ltiValue,
             old_av->getVLTI());
+        setAttentionValue(new_av);
+    }
+
+    /** Change the Very-Long-Term Importance */
+    void setVLTI(AttentionValue::vlti_t vltiValue)
+    {
+        AttentionValuePtr old_av = getAttentionValue();
+        AttentionValuePtr new_av = createAV(
+            old_av->getSTI(),
+            old_av->getLTI(),
+            vltiValue);
         setAttentionValue(new_av);
     }
 

--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -707,39 +707,6 @@ public:
      * XXX FIXME Lets fix cython aleady!
      */
 #ifdef DEPRECATED_CYTHON_CALLS
-    /** DEPRECATED! Do NOT USE IN NEW CODE!
-     * If you need this, just copy the code below into your app!
-     */
-    void set_TV(Handle h, TruthValuePtr tv) const {
-        h->setTruthValue(tv);
-    }
-
-    /** DEPRECATED! Do NOT USE IN NEW CODE!
-     * If you need this, just copy the code below into your app!  */
-    void set_LTI(Handle h, AttentionValue::lti_t ltiValue) const {
-        h->setLTI(ltiValue);
-    }
-
-    /** DEPRECATED! Do NOT USE IN NEW CODE!
-     * If you need this, just copy the code below into your app! */
-    AttentionValue::lti_t get_LTI(Handle h) const {
-        return h->getAttentionValue()->getLTI();
-    }
-
-    /** DEPRECATED! Do NOT USE IN NEW CODE!
-     * If you need this, just copy the code below into your app! */
-    void inc_VLTI(Handle h) const { h->incVLTI(); }
-
-    /** DEPRECATED! Do NOT USE IN NEW CODE!
-     * If you need this, just copy the code below into your app! */
-    void dec_VLTI(Handle h) const { h->decVLTI(); }
-
-    /** DEPRECATED! Do NOT USE IN NEW CODE!
-     * If you need this, just copy the code below into your app! */
-    AttentionValue::vlti_t get_VLTI(Handle h) const {
-        return h->getAttentionValue()->getVLTI();
-    }
-
     /**
      * DEPRECATED! Do NOT USE IN NEW CODE!
      * If you need this function, just copy the one-liner below.

--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -701,26 +701,6 @@ public:
         return h->getTruthValue();
     }
 #endif // DEPRECATED_ATOMSPACE_CALLS
-
-    /* ===================================================== */
-    /* Deprecated calls that only cython uses!
-     * XXX FIXME Lets fix cython aleady!
-     */
-#ifdef DEPRECATED_CYTHON_CALLS
-    /**
-     * DEPRECATED! Do NOT USE IN NEW CODE!
-     * If you need this function, just copy the one-liner below.
-     * XXX ONLY the python bindings use this. XXX kill that code.
-     */
-    template <typename OutputIterator> OutputIterator
-    get_incoming_set_by_type(OutputIterator result,
-                             Handle handle,
-                             Type type,
-                             bool subclass) const
-    {
-        return handle->getIncomingSetByType(result, type, subclass);
-    }
-#endif // DEPRECATED_CYTHON_CALLS
 };
 
 /** @}*/

--- a/opencog/cython/opencog/atom.pyx
+++ b/opencog/cython/opencog/atom.pyx
@@ -82,8 +82,8 @@ cdef class Atom(object):
             return self.type
 
     def truth_value(self, mean, count):
-        self.tv.set_value(mean, count)
-
+        self.tv = TruthValue(mean, count)
+    
     def handle_uuid(self):
         return self.value()
 

--- a/opencog/cython/opencog/atom.pyx
+++ b/opencog/cython/opencog/atom.pyx
@@ -43,15 +43,65 @@ cdef class Atom(object):
 
     property tv:
         def __get__(self):
-            return self.atomspace.get_tv(self)
-        def __set__(self,val):
-            self.atomspace.set_tv(self,val)
+            cdef cAtom* atom_ptr = self.handle.atom_ptr()
+            cdef tv_ptr tvp
+            tvp = atom_ptr.getTruthValue()
+            if (not tvp.get() or tvp.get().isNullTv()):
+                pytv = TruthValue()
+                pytv.cobj = new tv_ptr(tvp) # make copy of smart pointer
+                return pytv
+            return TruthValue(tvp.get().getMean(), tvp.get().getConfidence())
+        def __set__(self,truth_value):
+            try:
+                assert isinstance(truth_value, TruthValue)
+            except AssertionError:
+                raise TypeError("atom.av property needs a TruthValue object")
+            cdef cAtom* atom_ptr = self.handle.atom_ptr()
+            atom_ptr.setTruthValue(deref((<TruthValue>truth_value)._tvptr()))
 
     property av:
         def __get__(self):
-            return self.atomspace.get_av(self)
+            cdef cAtom* atom_ptr = self.handle.atom_ptr()
+            sti = atom_ptr.getSTI()
+            lti = atom_ptr.getLTI()
+            vlti = atom_ptr.getVLTI()
+            return { "sti": sti, "lti": lti, "vlti": vlti }
+        def __set__(self, av_dict):
+            try:
+                assert isinstance(av_dict, dict)
+            except AssertionError:
+                raise TypeError("atom.av property needs a dictionary object")
+            cdef cAtom* atom_ptr = self.handle.atom_ptr()
+            if av_dict:
+                if "sti" in av_dict: sti = av_dict["sti"]
+                if "lti" in av_dict: lti = av_dict["lti"]
+                if "vlti" in av_dict: vlti = av_dict["vlti"]
+            if sti: atom_ptr.setSTI(sti)
+            if lti: atom_ptr.setLTI(lti)
+            if vlti: atom_ptr.setVLTI(vlti)
+
+    property sti:
+        def __get__(self):
+            return self.handle.atom_ptr().getSTI()
         def __set__(self,val):
-            self.atomspace.set_av(self,av_dict=val)
+            self.handle.atom_ptr().setSTI(val)
+
+    property lti:
+        def __get__(self):
+            return self.handle.atom_ptr().getLTI()
+        def __set__(self,val):
+            self.handle.atom_ptr().setLTI(val)
+
+    property vlti:
+        def __get__(self):
+            return self.handle.atom_ptr().getVLTI()
+        def __set__(self,val):
+            self.handle.atom_ptr().setVLTI(val)
+
+    def increment_vlti(self):
+        self.handle.atom_ptr().incVLTI()
+    def decrement_vlti(self):
+        self.handle.atom_ptr().decVLTI()
 
     property out:
         def __get__(self):

--- a/opencog/cython/opencog/atom.pyx
+++ b/opencog/cython/opencog/atom.pyx
@@ -83,6 +83,7 @@ cdef class Atom(object):
 
     def truth_value(self, mean, count):
         self.tv = TruthValue(mean, count)
+        return self
     
     def handle_uuid(self):
         return self.value()

--- a/opencog/cython/opencog/atomspace.pxd
+++ b/opencog/cython/opencog/atomspace.pxd
@@ -82,11 +82,29 @@ cdef extern from "opencog/atoms/base/ClassServer.h" namespace "opencog":
 cdef extern from "opencog/atoms/base/atom_types.h" namespace "opencog":
     cdef Type NOTYPE
 
+
+# Atom
+ctypedef public short av_type
+
 cdef extern from "opencog/atoms/base/Atom.h" namespace "opencog":
     cdef cppclass cAtom "opencog::Atom":
         cAtom()
         string toString()
         string toShortString()
+
+        tv_ptr getTruthValue()
+        void setTruthValue(tv_ptr tvp)
+
+        av_type getSTI()
+        av_type getLTI()
+        av_type getVLTI()
+
+        void setSTI(av_type stiValue)
+        void setLTI(av_type ltiValue)
+        void setVLTI(av_type vltiValue)
+
+        void incVLTI()
+        void decVLTI()
 
 
 # Handle
@@ -156,20 +174,10 @@ cdef extern from "opencog/atomspace/AtomSpace.h" namespace "opencog":
         # correctly, instead of callng deprecated atomspace methods!
         string get_name(cHandle h)
         Type get_type(cHandle h)
-        tv_ptr get_TV(cHandle h)
-        void set_TV(cHandle h, tv_ptr tvn)
 
         vector[cHandle] get_outgoing(cHandle h)
         vector[cHandle] get_incoming(cHandle h)
-
-        short get_STI(cHandle h)
-        short get_LTI(cHandle h)
-        bint get_VLTI(cHandle h)
-        void set_STI(cHandle h, short)
-        void set_LTI(cHandle h, short)
-        void inc_VLTI(cHandle h)
-        void dec_VLTI(cHandle h)
-
+        
         # ==== query methods ====
         # get by type
         output_iterator get_handles_by_type(output_iterator, Type t, bint subclass)

--- a/opencog/cython/opencog/atomspace.pxd
+++ b/opencog/cython/opencog/atomspace.pxd
@@ -106,6 +106,8 @@ cdef extern from "opencog/atoms/base/Atom.h" namespace "opencog":
         void incVLTI()
         void decVLTI()
 
+        output_iterator getIncomingSetByType(output_iterator, Type type, bint subclass)
+
 
 # Handle
 ctypedef public long UUID
@@ -184,8 +186,7 @@ cdef extern from "opencog/atomspace/AtomSpace.h" namespace "opencog":
         # XXX DEPRECATED, REMOVE ASAP XXX get by name
         # Just do the right thing, here...
         output_iterator get_handles_by_name(output_iterator, string& name, Type t, bint subclass)
-        # XXX DEPRECATED, REMOVE ASAP XXX get by target handle
-        output_iterator get_incoming_set_by_type(output_iterator,cHandle& h,Type t,bint subclass)
+
         # get by STI range
         output_iterator get_handles_by_AV(output_iterator, short lowerBound, short upperBound)
         output_iterator get_handles_by_AV(output_iterator, short lowerBound)

--- a/opencog/cython/opencog/atomspace.pxd
+++ b/opencog/cython/opencog/atomspace.pxd
@@ -170,6 +170,7 @@ cdef extern from "opencog/atomspace/AtomSpace.h" namespace "opencog":
 
         bint is_valid_handle(cHandle h)
         int get_size()
+        UUID get_uuid()
 
         # these should alias the proper types for sti/lti/vlti
         # XXX DEPRECATED, REMOVE ASAP XXX just implement these

--- a/opencog/cython/opencog/atomspace_details.pyx
+++ b/opencog/cython/opencog/atomspace_details.pyx
@@ -324,18 +324,18 @@ cdef class AtomSpace:
             yield Atom(current_c_handle.value(),self)
             inc(c_handle_iter)
 
-    def get_atoms_by_target_atom(self, Type t, Atom target, subtype = True):
+    def get_atoms_by_target_atom(self, Type type, Atom target, subtype = True):
         cdef vector[cHandle] handle_vector
         cdef bint subt = subtype
-        self.atomspace.get_incoming_set_by_type(back_inserter(handle_vector),
-                                                deref(target.handle), t, subt)
+        cdef cAtom* atom_ptr = target.handle.atom_ptr()
+        atom_ptr.getIncomingSetByType(back_inserter(handle_vector), type, subtype)
         return convert_handle_seq_to_python_list(handle_vector,self)
 
-    def xget_atoms_by_target_atom(self, Type t, Atom target, subtype = True):
+    def xget_atoms_by_target_atom(self, Type type, Atom target, subtype = True):
         cdef vector[cHandle] handle_vector
         cdef bint subt = subtype
-        self.atomspace.get_incoming_set_by_type(back_inserter(handle_vector),
-                                                deref(target.handle), t, subt)
+        cdef cAtom* atom_ptr = target.handle.atom_ptr()
+        atom_ptr.getIncomingSetByType(back_inserter(handle_vector), type, subtype)
 
         # This code is the same for all the x iterators but there is no
         # way in Cython to yield out of a cdef function and no way to pass a 

--- a/opencog/cython/opencog/atomspace_details.pyx
+++ b/opencog/cython/opencog/atomspace_details.pyx
@@ -71,6 +71,10 @@ cdef class AtomSpace:
         elif op == 3: # !=
             return not is_equal
 
+    property uuid:
+        def __get__(self):
+            return self.atomspace.get_uuid()
+
     def add(self, Type t, name=None, out=None, TruthValue tv=None):
         """ add method that determines exact method to call from type """
         if is_a(t, types.Node):

--- a/opencog/cython/opencog/truth_value.pyx
+++ b/opencog/cython/opencog/truth_value.pyx
@@ -43,9 +43,6 @@ cdef class TruthValue:
     cdef _init(self, float mean, float confidence):
         deref((<cSimpleTruthValue*>self._ptr())).initialize(mean, self.confidence_to_count(confidence))
 
-    def set_value(self, mean, confidence):
-        self._init(mean, confidence)
-
     def __richcmp__(TruthValue h1, TruthValue h2, int op):
         " @todo support the rest of the comparison operators"
         if op == 2: # ==

--- a/opencog/cython/opencog/utilities.pyx
+++ b/opencog/cython/opencog/utilities.pyx
@@ -11,7 +11,8 @@ def initialize_opencog(AtomSpace atomspace, object config = None):
 
     # Avoid recursive intialization
     global is_initialized
-    if (is_initialized):
+    if is_initialized:
+        set_type_ctor_atomspace(atomspace)
         return
     is_initialized = True
 
@@ -24,7 +25,10 @@ def initialize_opencog(AtomSpace atomspace, object config = None):
     set_type_ctor_atomspace(atomspace)
 
 def finalize_opencog():
-    c_finalize_opencog()
+    global is_initialized
+    if is_initialized:
+        c_finalize_opencog()
+        
     set_type_ctor_atomspace(None)
 
 def configuration_load(object config):

--- a/tests/cython/atomspace/test_atomspace.py
+++ b/tests/cython/atomspace/test_atomspace.py
@@ -430,25 +430,25 @@ class AtomTest(TestCase):
 
         l = Link(a1, a2)
 
-        last_uuid = 95
+        space_uuid = self.space.uuid
 
         # test string representation
-        a1_expected = "(Node \"test1\") ; [{0}][{1}]\n".format(str(a1.value()), last_uuid)
+        a1_expected = "(Node \"test1\") ; [{0}][{1}]\n".format(str(a1.value()), space_uuid)
         a1_expected_long = \
             "(Node \"test1\" (stv 0.500000 0.800000)) ; [{0}][{1}]\n"\
-            .format(str(a1.value()), last_uuid)
+            .format(str(a1.value()), space_uuid)
 
-        a2_expected = "(Node \"test2\") ; [{0}][{1}]\n".format(str(a2.value()), last_uuid)
+        a2_expected = "(Node \"test2\") ; [{0}][{1}]\n".format(str(a2.value()), space_uuid)
         a2_expected_long = \
             "(Node \"test2\" (av 10 1 1) (stv 0.100000 0.300000)) ; [{0}][{1}]\n"\
-            .format(str(a2.value()), last_uuid)
+            .format(str(a2.value()), space_uuid)
 
         l_expected = \
             "(Link\n  {0}  {1}) ; [{2}][{3}]\n"\
-            .format(a1_expected, a2_expected, str(l.value()), last_uuid)
+            .format(a1_expected, a2_expected, str(l.value()), space_uuid)
         l_expected_long = \
             "(Link\n  {0}  {1}) ; [{2}][{3}]\n"\
-            .format(a1_expected_long, a2_expected_long, str(l.value()), last_uuid)
+            .format(a1_expected_long, a2_expected_long, str(l.value()), space_uuid)
 
         self.assertEqual(str(a1), a1_expected)
         self.assertEqual(a1.long_string(), a1_expected_long)

--- a/tests/cython/atomspace/test_atomspace.py
+++ b/tests/cython/atomspace/test_atomspace.py
@@ -86,6 +86,15 @@ class AtomSpaceTest(TestCase):
         self.assertTrue(tv == tv2)
         self.assertFalse(tv == tv3)
 
+        # check truth_value function of atom
+        atom = self.space.add_node(types.Node, "atom with tv")
+        default_tv = atom.tv
+        atom.truth_value(0.75, 0.9)
+        new_tv = atom.tv
+        self.assertFalse(new_tv == default_tv)
+        self.assertEqual(new_tv.mean, 0.75)
+        self.assertAlmostEqual(new_tv.confidence, 0.9, places=4)
+
     def test_get_by_name_and_type(self):
         n1 = self.space.add_node(types.Node, "test")
         n2 = self.space.add_node(types.ConceptNode, "test")
@@ -366,23 +375,25 @@ class AtomTest(TestCase):
 
         l = self.space.add_link(types.Link, [a1, a2])
 
+        last_uuid = 92
+
         # test string representation
-        a1_expected = "(Node \"test1\") ; [{0}][{1}]\n".format(str(a1.value()), 91)
+        a1_expected = "(Node \"test1\") ; [{0}][{1}]\n".format(str(a1.value()), last_uuid)
         a1_expected_long = \
             "(Node \"test1\" (stv 0.500000 0.800000)) ; [{0}][{1}]\n"\
-            .format(str(a1.value()), 91)
+            .format(str(a1.value()), last_uuid)
 
-        a2_expected = "(Node \"test2\") ; [{0}][{1}]\n".format(str(a2.value()), 91)
+        a2_expected = "(Node \"test2\") ; [{0}][{1}]\n".format(str(a2.value()), last_uuid)
         a2_expected_long = \
             "(Node \"test2\" (av 10 1 1) (stv 0.100000 0.300000)) ; [{0}][{1}]\n"\
-            .format(str(a2.value()), 91)
+            .format(str(a2.value()), last_uuid)
 
         l_expected = \
             "(Link\n  {0}  {1}) ; [{2}][{3}]\n"\
-            .format(a1_expected, a2_expected, str(l.value()), 91)
+            .format(a1_expected, a2_expected, str(l.value()), last_uuid)
         l_expected_long = \
             "(Link\n  {0}  {1}) ; [{2}][{3}]\n"\
-            .format(a1_expected_long, a2_expected_long, str(l.value()), 91)
+            .format(a1_expected_long, a2_expected_long, str(l.value()), last_uuid)
 
         self.assertEqual(str(a1), a1_expected)
         self.assertEqual(a1.long_string(), a1_expected_long)

--- a/tests/cython/atomspace/test_atomspace.py
+++ b/tests/cython/atomspace/test_atomspace.py
@@ -196,20 +196,37 @@ class AtomSpaceTest(TestCase):
         assert len(result) == 4
         assert set(result) == set([a1, a2, a3, a4])
 
-    def test_get_by_target_atom(self):
+    def test_incoming_by_type(self):
         a1 = Node("test1")
         a2 = ConceptNode("test2")
         a3 = PredicateNode("test3")
 
-        # test it doesn't apply to Nodes
+        # XXX atomspace functions deprecated
+
+        # test no incoming Node for a1
         result = self.space.get_atoms_by_target_atom(types.Node, a1)
         self.assertTrue(a1 not in result)
 
-        # links
+        # now check links
         l1 = InheritanceLink(a1, a2)
         result = self.space.get_atoms_by_target_atom(types.Link, a1)
         self.assertTrue(l1 in result)
         result = self.space.get_atoms_by_target_atom(types.Link, a3)
+        self.assertTrue(l1 not in result)
+
+        # Repeat using atom functions
+
+        # test no incoming Node for a1
+        result = a1.incoming_by_type(types.Node)
+        self.assertTrue(a1 not in result)
+
+        # now check links
+        l1 = InheritanceLink(a1, a2)
+        result = a1.incoming_by_type(types.Link)
+        self.assertTrue(l1 in result)
+        result = a2.incoming_by_type(types.Link)
+        self.assertTrue(l1 in result)
+        result = a3.incoming_by_type(types.Link)
         self.assertTrue(l1 not in result)
 
     def test_include_incoming_outgoing(self):

--- a/tests/cython/atomspace/test_atomspace.py
+++ b/tests/cython/atomspace/test_atomspace.py
@@ -3,24 +3,41 @@ from unittest import TestCase
 from opencog.atomspace import AtomSpace, TruthValue, Atom
 from opencog.atomspace import types, is_a, get_type, get_type_name
 
+from opencog.utilities import initialize_opencog, finalize_opencog
+from opencog.type_constructors import *
+
 class AtomSpaceTest(TestCase):
 
     def setUp(self):
         self.space = AtomSpace()
+        initialize_opencog(self.space)
 
     def tearDown(self):
+        finalize_opencog()
         del self.space
 
     def test_add_node(self):
 
-        a1 = self.space.add_node(types.Node, "test")
+        # Test long form atomspace node addition.
+
+        # Test node add
+        self.space.add_node(types.Node, "node" )
+
+        # Test with not a proper truthvalue
+        self.assertRaises(TypeError, self.space.add_node, types.Node, "test", 
+                0, True)
+        # Test with bad type
+        self.assertRaises(TypeError, self.space.add_node, "ConceptNode", "test", 
+                TruthValue(0.5, 0.8))
+
+        # From here on out we'll use the more compact type constructors
+        a1 = Node("test")
         self.assertTrue(a1)
         # duplicates resolve to same atom
-        a2 = self.space.add_node(types.Node, "test")
+        a2 = Node("test")
         self.assertEquals(a1, a2)
 
         # Should fail when intentionally adding bad type
-        # self.assertRaises(RuntimeError, self.space.add_node(types.Link, "test"))
         caught = False
         try:
             self.space.add_node(types.Link, "test")
@@ -28,29 +45,21 @@ class AtomSpaceTest(TestCase):
             caught = True
         self.assertEquals(caught, True)
 
-        # test adding with a truthvalue
-        a3 = self.space.add_node(types.Node, "test_w_tv", TruthValue(0.5, 0.8))
-        self.assertEquals(self.space.size(), 2)
-
-        # tests with bad parameters
-        # test with not a proper truthvalue
-        self.assertRaises(TypeError, self.space.add_node, types.Node, "test", 
-                0, True)
-        # test with bad type
-        self.assertRaises(TypeError, self.space.add_node, "ConceptNode", "test", 
-                TruthValue(0.5, 0.8))
+        # Test adding with a truthvalue
+        a3 = Node("test_w_tv").truth_value(0.5, 0.8)
+        self.assertEquals(self.space.size(), 3)
 
     def test_add_link(self):
-        n1 = self.space.add_node(types.Node, "test1")
-        n2 = self.space.add_node(types.Node, "test2")
-        l1 = self.space.add_link(types.Link, [n1, n2])
+        n1 = Node("test1")
+        n2 = Node("test2")
+        l1 = Link(n1, n2)
         self.assertTrue(l1 is not None)
-        l2 = self.space.add_link(types.Link, [n1, n2])
+        l2 = Link(n1, n2)
         self.assertTrue(l2 is not None)
         self.assertTrue(l2 == l1)
 
-        n3 = self.space.add_node(types.Node, "test3")
-        l3 = self.space.add_link(types.Link, [n1, n3], TruthValue(0.5, 0.8))
+        n3 = Node("test3")
+        l3 = Link(n1, n3).truth_value(0.5, 0.8)
         self.assertTrue(l3 is not None)
         
         # Should fail when adding an intentionally bad type
@@ -62,7 +71,7 @@ class AtomSpaceTest(TestCase):
         self.assertEquals(caught, True)
 
     def test_is_valid(self):
-        a1 = self.space.add_node(types.Node, "test1")
+        a1 = Node("test1")
         # check with Atom object
         self.assertTrue(self.space.is_valid(a1))
         # check with raw UUID
@@ -87,7 +96,7 @@ class AtomSpaceTest(TestCase):
         self.assertFalse(tv == tv3)
 
         # check truth_value function of atom
-        atom = self.space.add_node(types.Node, "atom with tv")
+        atom = Node("atom with tv")
         default_tv = atom.tv
         atom.truth_value(0.75, 0.9)
         new_tv = atom.tv
@@ -95,10 +104,34 @@ class AtomSpaceTest(TestCase):
         self.assertEqual(new_tv.mean, 0.75)
         self.assertAlmostEqual(new_tv.confidence, 0.9, places=4)
 
+    def test_attention_value(self):
+        node = Node("test")
+
+        # check values come back as assigned
+        node.sti = 1
+        node.lti = 2
+        node.vlti = 3
+        assert node.sti == 1
+        assert node.lti == 2
+        assert node.vlti == 3
+
+        # Check increment and decrement for vlti
+        node.decrement_vlti()
+        assert node.vlti == 2
+        node.increment_vlti()
+        assert node.vlti == 3
+
+        # Check dictionary setting and getting of av property.
+        node.av = {"sti": 4, "lti": 5, "vlti": 6}
+        assert node.sti == 4
+        assert node.lti == 5
+        assert node.vlti == 6
+        assert node.av == {"sti": 4, "lti": 5, "vlti": 6}
+
     def test_get_by_name_and_type(self):
-        n1 = self.space.add_node(types.Node, "test")
-        n2 = self.space.add_node(types.ConceptNode, "test")
-        n3 = self.space.add_node(types.PredicateNode, "test")
+        n1 = Node("test")
+        n2 = ConceptNode("test")
+        n3 = PredicateNode("test")
 
         # test recursive subtypes
         result = self.space.get_atoms_by_name(types.Node, "test")
@@ -117,9 +150,9 @@ class AtomSpaceTest(TestCase):
         self.assertEqual(len(result), 0)
 
     def test_get_by_type(self):
-        a1 = self.space.add_node(types.Node, "test1")
-        a2 = self.space.add_node(types.ConceptNode, "test2")
-        a3 = self.space.add_node(types.PredicateNode, "test3")
+        a1 = Node("test1")
+        a2 = ConceptNode("test2")
+        a3 = PredicateNode("test3")
 
         # test recursive subtypes
         result = self.space.get_atoms_by_type(types.Node)
@@ -128,7 +161,7 @@ class AtomSpaceTest(TestCase):
         self.assertTrue(a3 in result)
 
         # links
-        l1 = self.space.add_link(types.InheritanceLink, [a1, a2])
+        l1 = InheritanceLink(a1, a2)
         result = self.space.get_atoms_by_type(types.Link)
         self.assertTrue(l1 in result)
         
@@ -143,16 +176,16 @@ class AtomSpaceTest(TestCase):
         self.assertEqual(len(result), 0)
 
     def test_get_by_av(self):
-        a1 = self.space.add_node(types.ConceptNode, "test1")
-        a2 = self.space.add_node(types.ConceptNode, "test2")
-        a3 = self.space.add_link(types.InheritanceLink, [a1, a2])
-        a4 = self.space.add_node(types.ConceptNode, "test4")
-        a5 = self.space.add_node(types.ConceptNode, "test5")
+        a1 = ConceptNode("test1")
+        a2 = ConceptNode("test2")
+        a3 = InheritanceLink(a1, a2)
+        a4 = ConceptNode("test4")
+        a5 = ConceptNode("test5")
 
-        self.space.set_av(atom=a1, sti=10)
-        self.space.set_av(atom=a2, sti=5)
-        self.space.set_av(atom=a3, sti=4)
-        self.space.set_av(atom=a4, sti=1)
+        a1.sti = 10
+        a2.sti = 5
+        a3.sti = 4
+        a4.sti = 1
 
         result = self.space.get_atoms_by_av(4, 10)
         assert len(result) == 3
@@ -164,28 +197,28 @@ class AtomSpaceTest(TestCase):
         assert set(result) == set([a1, a2, a3, a4])
 
     def test_get_by_target_atom(self):
-        a1 = self.space.add_node(types.Node, "test1")
-        a2 = self.space.add_node(types.ConceptNode, "test2")
-        a3 = self.space.add_node(types.PredicateNode, "test3")
+        a1 = Node("test1")
+        a2 = ConceptNode("test2")
+        a3 = PredicateNode("test3")
 
         # test it doesn't apply to Nodes
         result = self.space.get_atoms_by_target_atom(types.Node, a1)
         self.assertTrue(a1 not in result)
 
         # links
-        l1 = self.space.add_link(types.InheritanceLink, [a1, a2])
+        l1 = InheritanceLink(a1, a2)
         result = self.space.get_atoms_by_target_atom(types.Link, a1)
         self.assertTrue(l1 in result)
         result = self.space.get_atoms_by_target_atom(types.Link, a3)
         self.assertTrue(l1 not in result)
 
     def test_include_incoming_outgoing(self):
-        frog = self.space.add_node(types.ConceptNode, "Frog")
-        thing = self.space.add_node(types.ConceptNode, "Thing")
-        animal = self.space.add_node(types.ConceptNode, "Animal")
-        self.space.add_node(types.ConceptNode, "SeparateThing")
-        self.space.add_link(types.InheritanceLink, [frog, animal])
-        self.space.add_link(types.InheritanceLink, [animal, thing])
+        frog = ConceptNode("Frog")
+        thing = ConceptNode("Thing")
+        animal = ConceptNode("Animal")
+        ConceptNode("SeparateThing")
+        InheritanceLink(frog, animal)
+        InheritanceLink(animal, thing)
 
         assert len(self.space.include_incoming(self.space.get_atoms_by_name(types.ConceptNode, "Frog"))) == 2
         assert len(self.space.include_incoming(self.space.get_atoms_by_type(types.ConceptNode))) == 6
@@ -194,9 +227,9 @@ class AtomSpaceTest(TestCase):
             self.space.include_incoming(self.space.get_atoms_by_name(types.ConceptNode, "Frog")))) == 3
 
     def test_remove(self):
-        a1 = self.space.add_node(types.Node, "test1")
-        a2 = self.space.add_node(types.ConceptNode, "test2")
-        a3 = self.space.add_node(types.PredicateNode, "test3")
+        a1 = Node("test1")
+        a2 = ConceptNode("test2")
+        a3 = PredicateNode("test3")
 
         self.assertTrue(a1 in self.space)
         self.assertTrue(a2 in self.space)
@@ -207,24 +240,24 @@ class AtomSpaceTest(TestCase):
         self.assertTrue(a2 in self.space)
         self.assertTrue(a3 in self.space)
 
-        l = self.space.add_link(types.SimilarityLink, [a2, a3])
+        l = SimilarityLink(a2, a3)
         self.space.remove(a2, True) # won't remove it unless recursive is True
         self.assertTrue(a2 not in self.space)
         self.assertTrue(l not in self.space)
 
     def test_clear(self):
-        a1 = self.space.add_node(types.Node, "test1")
-        a2 = self.space.add_node(types.ConceptNode, "test2")
-        a3 = self.space.add_node(types.PredicateNode, "test3")
+        a1 = Node("test1")
+        a2 = ConceptNode("test2")
+        a3 = PredicateNode("test3")
         self.space.clear()
         self.assertEquals(self.space.size(), 0) 
         self.assertEquals(len(self.space), 0) 
 
     def test_container_methods(self):
         self.assertEquals(len(self.space), 0) 
-        a1 = self.space.add_node(types.Node, "test1")
-        a2 = self.space.add_node(types.ConceptNode, "test2")
-        a3 = self.space.add_node(types.PredicateNode, "test3")
+        a1 = Node("test1")
+        a2 = ConceptNode("test2")
+        a3 = PredicateNode("test3")
         
         self.assertTrue(a1 in self.space)
         self.assertTrue(a2 in self.space)
@@ -233,17 +266,17 @@ class AtomSpaceTest(TestCase):
         self.assertEquals(len(self.space), 3)
 
     def test_get_predicates(self):
-        dog = self.space.add_node(types.ConceptNode, "dog")
-        mammal = self.space.add_node(types.ConceptNode, "mammal")
-        canine = self.space.add_node(types.ConceptNode, "canine")
-        animal = self.space.add_node(types.ConceptNode, "animal")
-        dog_mammal = self.space.add_link(types.ListLink, [dog, mammal])
-        dog_canine = self.space.add_link(types.ListLink, [dog, canine])
-        dog_animal = self.space.add_link(types.ListLink, [dog, animal])
-        isA = self.space.add_node(types.PredicateNode, "IsA")
-        dogIsAMammal = self.space.add_link(types.EvaluationLink, [isA, dog_mammal])
-        dogIsACanine = self.space.add_link(types.EvaluationLink, [isA, dog_canine])
-        dogIsAAnimal = self.space.add_link(types.EvaluationLink, [isA, dog_animal])
+        dog = ConceptNode("dog")
+        mammal = ConceptNode("mammal")
+        canine = ConceptNode("canine")
+        animal = ConceptNode("animal")
+        dog_mammal = ListLink(dog, mammal)
+        dog_canine = ListLink(dog, canine)
+        dog_animal = ListLink(dog, animal)
+        isA = PredicateNode("IsA")
+        dogIsAMammal = EvaluationLink(isA, dog_mammal)
+        dogIsACanine = EvaluationLink(isA, dog_canine)
+        dogIsAAnimal = EvaluationLink(isA, dog_animal)
 
         dog_predicates = self.space.get_predicates(dog)
         self.assertEquals(len(dog_predicates), 3)
@@ -254,22 +287,22 @@ class AtomSpaceTest(TestCase):
         self.assertEquals(count, 3)
 
     def test_get_predicates_for(self):
-        dog = self.space.add_node(types.ConceptNode, "dog")
-        mammal = self.space.add_node(types.ConceptNode, "mammal")
-        canine = self.space.add_node(types.ConceptNode, "canine")
-        animal = self.space.add_node(types.ConceptNode, "animal")
-        dog_mammal = self.space.add_link(types.ListLink, [dog, mammal])
-        dog_canine = self.space.add_link(types.ListLink, [dog, canine])
-        dog_animal = self.space.add_link(types.ListLink, [dog, animal])
-        isA = self.space.add_node(types.PredicateNode, "IsA")
-        dogIsAMammal = self.space.add_link(types.EvaluationLink, [isA, dog_mammal])
-        dogIsACanine = self.space.add_link(types.EvaluationLink, [isA, dog_canine])
-        dogIsAAnimal = self.space.add_link(types.EvaluationLink, [isA, dog_animal])
+        dog = ConceptNode("dog")
+        mammal = ConceptNode("mammal")
+        canine = ConceptNode("canine")
+        animal = ConceptNode("animal")
+        dog_mammal = ListLink(dog, mammal)
+        dog_canine = ListLink(dog, canine)
+        dog_animal = ListLink(dog, animal)
+        isA = PredicateNode("IsA")
+        dogIsAMammal = EvaluationLink(isA, dog_mammal)
+        dogIsACanine = EvaluationLink(isA, dog_canine)
+        dogIsAAnimal = EvaluationLink(isA, dog_animal)
 
-        human = self.space.add_node(types.ConceptNode, "human")
-        dog_human = self.space.add_link(types.ListLink, [dog, human])
-        loves = self.space.add_node(types.PredicateNode, "loves")
-        dogLovesHumans = self.space.add_link(types.EvaluationLink, [loves, dog_human])
+        human = ConceptNode("human")
+        dog_human = ListLink(dog, human)
+        loves = PredicateNode("loves")
+        dogLovesHumans = EvaluationLink(loves, dog_human)
 
         dog_predicates = self.space.get_predicates_for(dog, isA)
         self.assertEquals(len(dog_predicates), 3)
@@ -291,15 +324,20 @@ class AtomTest(TestCase):
 
     def setUp(self):
         self.space = AtomSpace()
+        initialize_opencog(self.space)
+
+    def tearDown(self):
+        finalize_opencog()
+        del self.space
 
     def test_creation(self):
-        a = self.space.add_node(types.Node, "test1")
+        a = Node("test1")
         self.assertEqual(a.name, "test1")
         self.assertEqual(a.tv, TruthValue(1.0, 0.0)) # default is true, no confidence
 
     def test_w_truthvalue(self):
         tv = TruthValue(0.5, 100)
-        a = self.space.add_node(types.Node, "test2", tv)
+        a = Node("test2", tv)
         self.assertEqual(a.tv, tv)
 
         # test set tv
@@ -307,7 +345,7 @@ class AtomTest(TestCase):
         self.assertEqual(a.tv, TruthValue(0.1, 10))
         
     def test_w_attention_value(self):
-        a = self.space.add_node(types.Node, "test2")
+        a = Node("test2")
 
         self.assertEqual(a.av, {'lti': 0, 'sti': 0, 'vlti': False})
 
@@ -317,28 +355,28 @@ class AtomTest(TestCase):
 
     def test_out(self):
         # test get out
-        a1 = self.space.add_node(types.Node, "test2")
+        a1 = Node("test2")
 
         self.assertEqual(a1.out, [])
 
         tv = TruthValue(0.5, 100)
-        a2 = self.space.add_node(types.Node, "test3", tv)
+        a2 = Node("test3", tv)
 
-        l = self.space.add_link(types.Link, [a1, a2])
+        l = Link(a1, a2)
         self.assertEqual(l.out, [a1, a2])
 
         # ensure out is considered immutable
         self.assertRaises(AttributeError, setattr, l, "out", [a1])
 
     def test_arity(self):
-        a1 = self.space.add_node(types.Node, "test2")
+        a1 = Node("test2")
 
         self.assertEqual(a1.arity, 0)
 
         tv = TruthValue(0.5, 100)
-        a2 = self.space.add_node(types.Node, "test3", tv)
+        a2 = Node("test3", tv)
 
-        l = self.space.add_link(types.Link, [a1, a2])
+        l = Link(a1, a2)
         self.assertEqual(l.arity, 2)
 
         # ensure arity is considered immutable
@@ -346,13 +384,13 @@ class AtomTest(TestCase):
 
     def test_type(self):
         # test get out
-        a = self.space.add_node(types.Node, "test2")
+        a = Node("test2")
 
         self.assertEqual(a.type, 1)
         self.assertEqual(a.t, 1)
 
-        a2 = self.space.add_node(types.Node, "test3")
-        l = self.space.add_link(types.Link, [a, a2])
+        a2 = Node("test3")
+        l = Link(a, a2)
         self.assertEqual(l.type, 2)
         self.assertEqual(l.t, 2)
 
@@ -367,15 +405,15 @@ class AtomTest(TestCase):
     def test_strings(self):
         # set up a link and atoms
         tv = TruthValue(0.5, 0.8)
-        a1 = self.space.add_node(types.Node, "test1", tv)
+        a1 = Node("test1", tv)
 
-        a2 = self.space.add_node(types.Node, "test2")
+        a2 = Node("test2")
         a2.av = {"sti": 10, "lti": 1, "vlti": True}
         a2.tv = TruthValue(0.1, 0.3)
 
-        l = self.space.add_link(types.Link, [a1, a2])
+        l = Link(a1, a2)
 
-        last_uuid = 92
+        last_uuid = 95
 
         # test string representation
         a1_expected = "(Node \"test1\") ; [{0}][{1}]\n".format(str(a1.value()), last_uuid)


### PR DESCRIPTION
Removed quite a few deprecated AtomSpace functions and moved them to Atom.
Updated the tests to match.

Will be removing atomspace.get_atoms_by_target_atom after this pull request is merged and I can update opencog/opencog to use the new atom.incoming_by_type in the few places where it is currently using.