### PR TITLE
Removed deprecated atomspace.get_atoms_by_target_atom functions

### DIFF
--- a/opencog/cython/opencog/atomspace.pxd
+++ b/opencog/cython/opencog/atomspace.pxd
@@ -194,9 +194,6 @@ cdef extern from "opencog/atomspace/AtomSpace.h" namespace "opencog":
         # get from AttentionalFocus
         output_iterator get_handle_set_in_attentional_focus(output_iterator)
 
-        # vector[chandle].iterator get_handles_by_name(output_iterator, Type t, string name, bint subclass)
-        # vector[chandle].iterator get_handles_by_type(output_iterator, Type t, xxx bint subclass)
-
         void clear()
         bint remove_atom(cHandle h, bint recursive)
 

--- a/opencog/cython/opencog/atomspace_details.pyx
+++ b/opencog/cython/opencog/atomspace_details.pyx
@@ -328,30 +328,6 @@ cdef class AtomSpace:
             yield Atom(current_c_handle.value(),self)
             inc(c_handle_iter)
 
-    def get_atoms_by_target_atom(self, Type type, Atom target, subtype = True):
-        cdef vector[cHandle] handle_vector
-        cdef bint subt = subtype
-        cdef cAtom* atom_ptr = target.handle.atom_ptr()
-        atom_ptr.getIncomingSetByType(back_inserter(handle_vector), type, subtype)
-        return convert_handle_seq_to_python_list(handle_vector,self)
-
-    def xget_atoms_by_target_atom(self, Type type, Atom target, subtype = True):
-        cdef vector[cHandle] handle_vector
-        cdef bint subt = subtype
-        cdef cAtom* atom_ptr = target.handle.atom_ptr()
-        atom_ptr.getIncomingSetByType(back_inserter(handle_vector), type, subtype)
-
-        # This code is the same for all the x iterators but there is no
-        # way in Cython to yield out of a cdef function and no way to pass a 
-        # vector into a Python def function, so we have to repeat code. ARGGG!
-        cdef vector[cHandle].iterator c_handle_iter
-        cdef cHandle current_c_handle
-        c_handle_iter = handle_vector.begin()
-        while c_handle_iter != handle_vector.end():
-            current_c_handle = deref(c_handle_iter)
-            yield Atom(current_c_handle.value(), self)
-            inc(c_handle_iter)
-
     def get_predicates(self,
                        Atom target, 
                        Type predicate_type = types.PredicateNode,

--- a/tests/cython/atomspace/test_atomspace.py
+++ b/tests/cython/atomspace/test_atomspace.py
@@ -201,21 +201,6 @@ class AtomSpaceTest(TestCase):
         a2 = ConceptNode("test2")
         a3 = PredicateNode("test3")
 
-        # XXX atomspace functions deprecated
-
-        # test no incoming Node for a1
-        result = self.space.get_atoms_by_target_atom(types.Node, a1)
-        self.assertTrue(a1 not in result)
-
-        # now check links
-        l1 = InheritanceLink(a1, a2)
-        result = self.space.get_atoms_by_target_atom(types.Link, a1)
-        self.assertTrue(l1 in result)
-        result = self.space.get_atoms_by_target_atom(types.Link, a3)
-        self.assertTrue(l1 not in result)
-
-        # Repeat using atom functions
-
         # test no incoming Node for a1
         result = a1.incoming_by_type(types.Node)
         self.assertTrue(a1 not in result)


### PR DESCRIPTION
Merge this change after https://github.com/opencog/opencog/pull/2010 has been merged. 