### PR TITLE
Avoid smart-pointer casts, where possible

### DIFF
--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -51,6 +51,9 @@ namespace opencog
 
 class AtomSpace;
 
+//! arity of Links, represented as short integer (16 bits)
+typedef unsigned short Arity;
+
 class Link;
 typedef std::shared_ptr<Link> LinkPtr;
 typedef std::vector<LinkPtr> IncomingSet; // use vector; see below.
@@ -173,11 +176,6 @@ public:
 
     virtual ~Atom();
 
-    virtual const std::string& getName() const {
-        static std::string empty_string("");
-        return empty_string;
-    }
-
     //! Returns the AtomTable in which this Atom is inserted.
     AtomSpace* getAtomSpace() const;
 
@@ -189,6 +187,10 @@ public:
 
     virtual bool isNode() const = 0;
     virtual bool isLink() const = 0;
+
+    virtual const std::string& getName() const {
+        throw RuntimeException(TRACE_INFO, "Not a node!");
+    }
 
     virtual Arity getArity() const {
         throw RuntimeException(TRACE_INFO, "Not a link!");

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -187,14 +187,16 @@ public:
      */
     inline Type getType() const { return _type; }
 
+    virtual bool isNode() const = 0;
+    virtual bool isLink() const = 0;
+
     /** Returns the outgoing set.
      *
      * @return The outgoing set.
      */
-    virtual inline const HandleSeq& getOutgoingSet() const
+    virtual const HandleSeq& getOutgoingSet() const
     {
-        static HandleSeq no_atoms;
-        return no_atoms;
+        throw RuntimeException(TRACE_INFO, "Not a link!");
     }
 
     /** Returns the handle of the atom.

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -190,12 +190,15 @@ public:
     virtual bool isNode() const = 0;
     virtual bool isLink() const = 0;
 
-    /** Returns the outgoing set.
-     *
-     * @return The outgoing set.
-     */
-    virtual const HandleSeq& getOutgoingSet() const
-    {
+    virtual Arity getArity() const {
+        throw RuntimeException(TRACE_INFO, "Not a link!");
+    }
+
+    virtual const HandleSeq& getOutgoingSet() const {
+        throw RuntimeException(TRACE_INFO, "Not a link!");
+    }
+
+    virtual Handle getOutgoingAtom(Arity) const {
         throw RuntimeException(TRACE_INFO, "Not a link!");
     }
 

--- a/opencog/atoms/base/Link.h
+++ b/opencog/atoms/base/Link.h
@@ -142,6 +142,9 @@ public:
      */
     ~Link();
 
+    virtual bool isNode() const { return false; }
+    virtual bool isLink() const { return true; }
+
     inline Arity getArity() const {
         return _outgoing.size();
     }

--- a/opencog/atoms/base/Link.h
+++ b/opencog/atoms/base/Link.h
@@ -86,8 +86,9 @@ public:
          AttentionValuePtr av = AttentionValue::DEFAULT_AV())
         : Atom(t, tv, av)
     {
-        HandleSeq oset;
-        oset.emplace_back(h);
+        // reserve+assign is 2x faster than push_back()/emplace_back()
+        HandleSeq oset(1);
+        oset[0] = h;
         init(oset);
     }
 
@@ -96,9 +97,10 @@ public:
          AttentionValuePtr av = AttentionValue::DEFAULT_AV())
         : Atom(t, tv, av)
     {
-        HandleSeq oset;
-        oset.emplace_back(ha);
-        oset.emplace_back(hb);
+        // reserve+assign is 2x faster than push_back()/emplace_back()
+        HandleSeq oset(2);
+        oset[0] = ha;
+        oset[1] = hb;
         init(oset);
     }
 
@@ -107,10 +109,11 @@ public:
          AttentionValuePtr av = AttentionValue::DEFAULT_AV())
         : Atom(t, tv, av)
     {
-        HandleSeq oset;
-        oset.emplace_back(ha);
-        oset.emplace_back(hb);
-        oset.emplace_back(hc);
+        // reserve+assign is 2x faster than push_back()/emplace_back()
+        HandleSeq oset(3);
+        oset[0] = ha;
+        oset[1] = hb;
+        oset[3] = hc;
         init(oset);
     }
     Link(Type t, const Handle& ha, const Handle &hb,
@@ -119,11 +122,12 @@ public:
          AttentionValuePtr av = AttentionValue::DEFAULT_AV())
         : Atom(t, tv, av)
     {
-        HandleSeq oset;
-        oset.emplace_back(ha);
-        oset.emplace_back(hb);
-        oset.emplace_back(hc);
-        oset.emplace_back(hd);
+        // reserve+assign is 2x faster than push_back()/emplace_back()
+        HandleSeq oset(4);
+        oset[0] = ha;
+        oset[1] = hb;
+        oset[2] = hc;
+        oset[3] = hd;
         init(oset);
     }
 

--- a/opencog/atoms/base/Link.h
+++ b/opencog/atoms/base/Link.h
@@ -36,14 +36,11 @@ class AtomTable;
  *  @{
  */
 
-//! arity of Links, represented as short integer (16 bits)
-typedef unsigned short Arity;
-
 /**
- * Nodes in OpenCog are connected to each other by links. Each link embodies
- * one of the basic inter-node relationships. Links do not necessarily
- * describe a binary relationship between two entities. Links may describe
- * relationships between more than two entities at once. Finally, links
+ * Atoms in OpenCog are connected to each other by links. Each link
+ * embodies a basic inter-atom relationship. Links do not necessarily
+ * describe a binary relationship between two atoms. Links may describe
+ * relationships between more than two atoms at once. Finally, links
  * describe relationships not only between nodes, but also higher-order
  * relationships between links, and between nodes and links.
  */

--- a/opencog/atoms/base/Link.h
+++ b/opencog/atoms/base/Link.h
@@ -145,7 +145,7 @@ public:
     virtual bool isNode() const { return false; }
     virtual bool isLink() const { return true; }
 
-    inline Arity getArity() const {
+    virtual Arity getArity() const {
         return _outgoing.size();
     }
 
@@ -155,20 +155,21 @@ public:
      *
      * @return A const reference to this atom's outgoing set.
      */
-    inline const HandleSeq& getOutgoingSet() const
+    virtual const HandleSeq& getOutgoingSet() const
     {
         return _outgoing;
     }
+
     /**
      * Returns a specific Handle in the outgoing set.
      *
      * @param The position of the handle in the array.
      * @return A specific handle in the outgoing set.
      */
-    inline Handle getOutgoingAtom(Arity pos) const
+    virtual Handle getOutgoingAtom(Arity pos) const
     {
         // Checks for a valid position
-        if (pos < getArity()) {
+        if (pos < _outgoing.size()) {
             return _outgoing[pos];
         } else {
             throw RuntimeException(TRACE_INFO, "invalid outgoing set index %d", pos);
@@ -182,7 +183,7 @@ public:
     template<class T>
     inline bool foreach_outgoing(bool (T::*cb)(const Handle&), T *data)
     {
-        for (const Handle& out_h : getOutgoingSet()) {
+        for (const Handle& out_h : _outgoing) {
             if ((data->*cb)(out_h)) return true;
         }
         return false;

--- a/opencog/atoms/base/Node.h
+++ b/opencog/atoms/base/Node.h
@@ -85,7 +85,7 @@ public:
      *
      * @return The name of the node.
      */
-    inline const std::string& getName() const { return _name; }
+    virtual const std::string& getName() const { return _name; }
 
     /**
      * Returns a string representation of the node.

--- a/opencog/atoms/base/Node.h
+++ b/opencog/atoms/base/Node.h
@@ -77,6 +77,9 @@ public:
         init(n._name);
     }
 
+    virtual bool isNode() const { return true; }
+    virtual bool isLink() const { return false; }
+
     /**
      * Gets the name of the node.
      *

--- a/opencog/benchmark/AtomSpaceBenchmark.cc
+++ b/opencog/benchmark/AtomSpaceBenchmark.cc
@@ -216,86 +216,92 @@ void AtomSpaceBenchmark::setMethod(std::string methodToTest)
 
     if (methodToTest == "all" or methodToTest == "noop") {
         methodsToTest.push_back( &AtomSpaceBenchmark::bm_noop);
-        methodNames.push_back( "noop");
+        methodNames.push_back("noop");
         foundMethod = true;
     }
     if (methodToTest == "all" or methodToTest == "getType") {
         methodsToTest.push_back( &AtomSpaceBenchmark::bm_getType);
-        methodNames.push_back( "getType");
+        methodNames.push_back("getType");
         foundMethod = true;
     }
 
     if (methodToTest == "all" or methodToTest == "getTruthValue") {
         methodsToTest.push_back( &AtomSpaceBenchmark::bm_getTruthValue);
-        methodNames.push_back( "getTruthValue");
+        methodNames.push_back("getTruthValue");
         foundMethod = true;
     }
 
 #ifdef ZMQ_EXPERIMENT
     if (methodToTest == "all" or methodToTest == "getTruthValueZMQ") {
         methodsToTest.push_back( &AtomSpaceBenchmark::bm_getTruthValueZmq);
-        methodNames.push_back( "getTruthValueZMQ");
+        methodNames.push_back("getTruthValueZMQ");
         foundMethod = true;
     }
 #endif
 
     if (methodToTest == "all" or methodToTest == "setTruthValue") {
         methodsToTest.push_back( &AtomSpaceBenchmark::bm_setTruthValue);
-        methodNames.push_back( "setTruthValue");
+        methodNames.push_back("setTruthValue");
         foundMethod = true;
     }
 
-    if (methodToTest == "all" or methodToTest == "getOutgoingSet") {
-        methodsToTest.push_back( &AtomSpaceBenchmark::bm_getOutgoingSet);
-        methodNames.push_back( "getOutgoingSet");
+    if (methodToTest == "all" or methodToTest == "pointerCast") {
+        methodsToTest.push_back( &AtomSpaceBenchmark::bm_pointerCast);
+        methodNames.push_back("pointerCast");
         foundMethod = true;
     }
 
     if (methodToTest == "all" or methodToTest == "getIncomingSet") {
         methodsToTest.push_back( &AtomSpaceBenchmark::bm_getIncomingSet);
-        methodNames.push_back( "getIncomingSet");
+        methodNames.push_back("getIncomingSet");
+        foundMethod = true;
+    }
+
+    if (methodToTest == "all" or methodToTest == "getOutgoingSet") {
+        methodsToTest.push_back( &AtomSpaceBenchmark::bm_getOutgoingSet);
+        methodNames.push_back("getOutgoingSet");
         foundMethod = true;
     }
 
     if (methodToTest == "all" or methodToTest == "addNode") {
         methodsToTest.push_back( &AtomSpaceBenchmark::bm_addNode);
-        methodNames.push_back( "addNode");
+        methodNames.push_back("addNode");
         foundMethod = true;
     }
 
     if (methodToTest == "all" or methodToTest == "addLink") {
         methodsToTest.push_back( &AtomSpaceBenchmark::bm_addLink);
-        methodNames.push_back( "addLink");
+        methodNames.push_back("addLink");
         foundMethod = true;
     }
 
     if (methodToTest == "all" or methodToTest == "removeAtom") {
         methodsToTest.push_back( &AtomSpaceBenchmark::bm_rmAtom);
-        methodNames.push_back( "removeAtom");
+        methodNames.push_back("removeAtom");
         foundMethod = true;
     }
 
     if (methodToTest == "all" or methodToTest == "getHandlesByType") {
         methodsToTest.push_back( &AtomSpaceBenchmark::bm_getHandlesByType);
-        methodNames.push_back( "getHandlesByType");
+        methodNames.push_back("getHandlesByType");
         foundMethod = true;
     }
 
     if (methodToTest == "all" or methodToTest == "push_back") {
         methodsToTest.push_back( &AtomSpaceBenchmark::bm_push_back);
-        methodNames.push_back( "push_back");
+        methodNames.push_back("push_back");
         foundMethod = true;
     }
 
     if (methodToTest == "all" or methodToTest == "emplace_back") {
         methodsToTest.push_back( &AtomSpaceBenchmark::bm_emplace_back);
-        methodNames.push_back( "emplace_back");
+        methodNames.push_back("emplace_back");
         foundMethod = true;
     }
 
     if (methodToTest == "all" or methodToTest == "reserve") {
         methodsToTest.push_back( &AtomSpaceBenchmark::bm_reserve);
-        methodNames.push_back( "reserve");
+        methodNames.push_back("reserve");
         foundMethod = true;
     }
 
@@ -981,8 +987,8 @@ timepair_t AtomSpaceBenchmark::bm_getType()
     switch (testKind) {
 #if HAVE_CYTHON
     case BENCH_PYTHON: {
-#if HAVE_CYTHONX
         OC_ASSERT(1 == Nloops, "Looping not supported for python");
+#if HAVE_CYTHONX
         std::ostringstream dss;
         for (unsigned int i=0; i<Nloops; i++) {
             dss << "aspace.get_type(Handle(" << h.value() << "))\n";
@@ -1166,62 +1172,6 @@ timepair_t AtomSpaceBenchmark::bm_setTruthValue()
     return timepair_t(0,0);
 }
 
-timepair_t AtomSpaceBenchmark::bm_getOutgoingSet()
-{
-    Handle hs[Nclock];
-    for (unsigned int i=0; i<Nclock; i++)
-        hs[i] = getRandomHandle();
-
-    switch (testKind) {
-#if HAVE_CYTHON
-    case BENCH_PYTHON: {
-#if HAVE_CYTHONX
-        OC_ASSERT(1 == Nloops, "Looping not supported for python");
-        std::ostringstream dss;
-        dss << "out = Atom(" << h.value() << ", aspace).out\n";
-        std::string ps = dss.str();
-        clock_t t_begin = clock();
-        pyev->eval(ps);
-        return clock() - t_begin;
-#endif /* HAVE_CYTHON */
-    }
-#endif /* HAVE_CYTHON */
-#if HAVE_GUILE
-    case BENCH_SCM: {
-        std::string gsa[Nclock];
-        for (unsigned int i=0; i<Nclock; i++)
-        {
-            Handle h = hs[i];
-            std::ostringstream ss;
-            for (unsigned int i=0; i<Nloops; i++) {
-                ss << "(cog-outgoing-set (cog-atom " << h.value() << "))\n";
-                h = getRandomHandle();
-            }
-            std::string gs = memoize_or_compile(ss.str());
-            gsa[i] = gs;
-        }
-        clock_t t_begin = clock();
-        for (unsigned int i=0; i<Nclock; i++)
-           scm->eval(gsa[i]);
-        clock_t time_taken = clock() - t_begin;
-        return timepair_t(time_taken,0);
-    }
-#endif /* HAVE_GUILE */
-    case BENCH_AS:
-    case BENCH_TABLE: {
-        clock_t t_begin = clock();
-        for (unsigned int i=0; i<Nclock; i++)
-        {
-            LinkPtr l(LinkCast(hs[i]));
-            if (l) l->getOutgoingSet();
-        }
-        clock_t time_taken = clock() - t_begin;
-        return timepair_t(time_taken,0);
-    }
-    }
-    return timepair_t(0,0);
-}
-
 timepair_t AtomSpaceBenchmark::bm_getIncomingSet()
 {
     Handle hs[Nclock];
@@ -1268,6 +1218,110 @@ timepair_t AtomSpaceBenchmark::bm_getIncomingSet()
         clock_t t_begin = clock();
         for (unsigned int i=0; i<Nclock; i++)
             hs[i]->getIncomingSet();
+        clock_t time_taken = clock() - t_begin;
+        return timepair_t(time_taken,0);
+    }
+    }
+    return timepair_t(0,0);
+}
+
+// How long does it take to cast?
+timepair_t AtomSpaceBenchmark::bm_pointerCast()
+{
+    Handle hs[Nclock];
+    for (unsigned int i=0; i<Nclock; i++)
+        hs[i] = getRandomHandle();
+
+    switch (testKind) {
+#if HAVE_CYTHON
+    case BENCH_PYTHON: {
+        return timepair_t(0,0);
+    }
+#endif /* HAVE_CYTHON */
+#if HAVE_GUILE
+    case BENCH_SCM: {
+        return timepair_t(0,0);
+    }
+#endif /* HAVE_GUILE */
+    case BENCH_AS:
+    case BENCH_TABLE: {
+        // Summing prevents the optimizer from optimizing away.
+        // We want to measure how long it takes to perform a cast.
+        // To avoid the optimizer from playing tricks, we hav to do
+        // something with the resulting pointer.  We already know that
+        // getType() is very fast -- a method call, so we treat that as
+        // a lind-of no-op.
+        int sum = 0;
+        clock_t t_begin = clock();
+        for (unsigned int i=0; i<Nclock; i++)
+        {
+#ifdef MEASURE_LINKS
+            LinkPtr l(LinkCast(hs[i]));
+            if (l)
+               sum += l->getType();
+#else
+            NodePtr n(NodeCast(hs[i]));
+            if (n)
+               sum += n->getType();
+#endif
+        }
+        clock_t time_taken = clock() - t_begin;
+        global += sum;
+        return timepair_t(time_taken,0);
+    }
+    }
+    return timepair_t(0,0);
+}
+
+timepair_t AtomSpaceBenchmark::bm_getOutgoingSet()
+{
+    Handle hs[Nclock];
+    for (unsigned int i=0; i<Nclock; i++)
+        hs[i] = getRandomHandle();
+
+    switch (testKind) {
+#if HAVE_CYTHON
+    case BENCH_PYTHON: {
+        OC_ASSERT(1 == Nloops, "Looping not supported for python");
+#if HAVE_CYTHONX
+        std::ostringstream dss;
+        dss << "out = Atom(" << h.value() << ", aspace).out\n";
+        std::string ps = dss.str();
+        clock_t t_begin = clock();
+        pyev->eval(ps);
+        return clock() - t_begin;
+#endif /* HAVE_CYTHON */
+    }
+#endif /* HAVE_CYTHON */
+#if HAVE_GUILE
+    case BENCH_SCM: {
+        std::string gsa[Nclock];
+        for (unsigned int i=0; i<Nclock; i++)
+        {
+            Handle h = hs[i];
+            std::ostringstream ss;
+            for (unsigned int i=0; i<Nloops; i++) {
+                ss << "(cog-outgoing-set (cog-atom " << h.value() << "))\n";
+                h = getRandomHandle();
+            }
+            std::string gs = memoize_or_compile(ss.str());
+            gsa[i] = gs;
+        }
+        clock_t t_begin = clock();
+        for (unsigned int i=0; i<Nclock; i++)
+           scm->eval(gsa[i]);
+        clock_t time_taken = clock() - t_begin;
+        return timepair_t(time_taken,0);
+    }
+#endif /* HAVE_GUILE */
+    case BENCH_AS:
+    case BENCH_TABLE: {
+        clock_t t_begin = clock();
+        for (unsigned int i=0; i<Nclock; i++)
+        {
+            LinkPtr l(LinkCast(hs[i]));
+            if (l) l->getOutgoingSet();
+        }
         clock_t time_taken = clock() - t_begin;
         return timepair_t(time_taken,0);
     }

--- a/opencog/benchmark/AtomSpaceBenchmark.cc
+++ b/opencog/benchmark/AtomSpaceBenchmark.cc
@@ -1255,6 +1255,7 @@ timepair_t AtomSpaceBenchmark::bm_pointerCast()
         clock_t t_begin = clock();
         for (unsigned int i=0; i<Nclock; i++)
         {
+#define MEASURE_LINKS
 #ifdef MEASURE_LINKS
             LinkPtr l(LinkCast(hs[i]));
             if (l)

--- a/opencog/benchmark/AtomSpaceBenchmark.cc
+++ b/opencog/benchmark/AtomSpaceBenchmark.cc
@@ -1320,8 +1320,8 @@ timepair_t AtomSpaceBenchmark::bm_getOutgoingSet()
         clock_t t_begin = clock();
         for (unsigned int i=0; i<Nclock; i++)
         {
-            LinkPtr l(LinkCast(hs[i]));
-            if (l) l->getOutgoingSet();
+            if (hs[i]->isLink())
+                hs[i]->getOutgoingSet();
         }
         clock_t time_taken = clock() - t_begin;
         return timepair_t(time_taken,0);

--- a/opencog/benchmark/AtomSpaceBenchmark.h
+++ b/opencog/benchmark/AtomSpaceBenchmark.h
@@ -133,15 +133,8 @@ public:
     void setTestAllMethods() { setMethod("all"); }
 
     timepair_t bm_noop();
-    timepair_t bm_addNode();
-    timepair_t bm_addLink();
-    timepair_t bm_rmAtom();
 
     timepair_t bm_getType();
-    timepair_t bm_getHandlesByType();
-    timepair_t bm_getOutgoingSet();
-    timepair_t bm_getIncomingSet();
-
     // Get and set TV and AV
     float chanceUseDefaultTV; // if set, this will use default TV for new atoms and bm_setTruthValue
     timepair_t bm_getTruthValue();
@@ -150,6 +143,15 @@ public:
 #ifdef ZMQ_EXPERIMENT
     timepair_t bm_getTruthValueZmq();
 #endif
+
+    timepair_t bm_pointerCast();
+    timepair_t bm_getIncomingSet();
+    timepair_t bm_getOutgoingSet();
+    timepair_t bm_getHandlesByType();
+
+    timepair_t bm_addNode();
+    timepair_t bm_addLink();
+    timepair_t bm_rmAtom();
 
     timepair_t bm_push_back();
     timepair_t bm_emplace_back();

--- a/opencog/benchmark/diary.txt
+++ b/opencog/benchmark/diary.txt
@@ -1056,6 +1056,7 @@ gets removed now. The change in addNode and addLink is unclear.
 
 How fast is std::vector<Handle>, really?
 
+atomspace_bm -
 
    count             1            2           3            4
    rate           M-ops/sec    M-ops/sec   M-ops/sec    M-ops/sec
@@ -1104,3 +1105,32 @@ ProtoAtom*:     using bool atoms_less(const ProtAtom*, etc...)
 
 Conclude: switching to * from Ptr for handle compares helps. But AddLink
    still hurts; it hurts just a bit less.
+
+======================================================================
+
+4 Feb 2016
+----------
+ProtoAtom work .. how much does a cast really cost?
+i.e. a cast from Handle to NodePtr or LinkPtr ?
+
+atomspace_bm -m noop m- getType -m pointerCast -m getOutgoingSet
+
+                  previous      NodeCast        LinkCast
+   name           K-ops/sec     K-ops/sec      K-ops/sec
+   ----           ---------     ---------      ---------
+  noop              1e6         889K             864K
+  getType          75.5K         72.0K            72.0K
+  pointerCast                     6375             7354
+  getOutgoingSet    7555          7646             7797
+
+previous: copied column from above.
+
+NodeCast: perform NodeCast only.
+
+LinkCast: perform LinkCast only.
+
+Comments: we expect the pointerCast and the getOutgoingSet values to be
+nearly identical, since getOutgoingSet is just a cast, followed by a
+very simple method call.  The NodeCast and Link Cast numbers might
+differ, but not much, due to the different ratios of links and nodes in
+the sample set.

--- a/opencog/benchmark/diary.txt
+++ b/opencog/benchmark/diary.txt
@@ -1113,14 +1113,14 @@ Conclude: switching to * from Ptr for handle compares helps. But AddLink
 ProtoAtom work .. how much does a cast really cost?
 i.e. a cast from Handle to NodePtr or LinkPtr ?
 
-atomspace_bm -m noop m- getType -m pointerCast -m getOutgoingSet
+atomspace_bm -m noop -m getType -m pointerCast -m getOutgoingSet
 
                   previous      NodeCast        LinkCast
    name           K-ops/sec     K-ops/sec      K-ops/sec
    ----           ---------     ---------      ---------
   noop              1e6         889K             864K
   getType          75.5K         72.0K            72.0K
-  pointerCast                     6375             7354
+  pointerCast        -            6375             7354
   getOutgoingSet    7555          7646             7797
 
 previous: copied column from above.
@@ -1134,3 +1134,6 @@ nearly identical, since getOutgoingSet is just a cast, followed by a
 very simple method call.  The NodeCast and Link Cast numbers might
 differ, but not much, due to the different ratios of links and nodes in
 the sample set.
+
+Ergo, the cost of getOutgoingSet is dominated by the LinkCast!  If we
+get rid of it, then what happens?  It goes up to 44.1M-ops/sec! Woww!

--- a/opencog/benchmark/diary.txt
+++ b/opencog/benchmark/diary.txt
@@ -1041,11 +1041,12 @@ fixed column: measured with the fixed benchmark.
 Comments:
 The get* numbers are much much higher, because the old test was
 mis-measuring these; they were under a microsecond, so the call to
-clock() was given spurious measurements. The actual performance is
+clock() was giving spurious measurements. The actual performance is
 now revealed. Its roughly equal to what one would get from the
-broken column, if one took reciprocal, subtracted the "noop",
-and took reciprocal, again. So the "broken" numbers had been failing
-to be correctly normalized.
+broken column, if one took the reciprocal, subtracted the "noop",
+and took the reciprocal, again. Basically, the "broken" numbers had
+included a hefty overhead from calling clock(), an had not been
+correctly normalized.
 
 The removeAtom numbers are faster, because only 3/4ths the atomspace
 gets removed now. The change in addNode and addLink is unclear.
@@ -1055,13 +1056,25 @@ gets removed now. The change in addNode and addLink is unclear.
 
 How fast is std::vector<Handle>, really?
 
- 
+
    count             1            2           3            4
    rate           M-ops/sec    M-ops/sec   M-ops/sec    M-ops/sec
    ----           ---------    ---------   ---------    ---------
   push_back         7.54         3.27        1.96         1.88
   emplace_back      7.26         3.35        1.96         1.87
   reserve           7.66         6.01        4.75         4.13
+
+count: the number of handles that are pushed/emplaced back.
+
+push_back: call the push-back method
+     example: HandleSeq oset; oset.push_back(ha); oset.push_back(hb);
+
+emplace-back: call the emplace_back method
+
+reserve: create vector of fixed size, then assign directly.
+     example: HandleSeq oset(2); oset[0] = ha; oset[1] = hb;
+
+Looks like direct assignment is a winner!
 
 ======================================================================
  15 Oct 2015

--- a/opencog/benchmark/diary.txt
+++ b/opencog/benchmark/diary.txt
@@ -1101,7 +1101,7 @@ Again, ProtoAtom.
 AtomPtr column: copied from above
 Atom* column:   using bool atoms_less(const Atom*, const Atom*); in
                 Handle.h (used to be AtomPtr)
-ProtoAtom*:     using bool atoms_less(const ProtAtom*, etc...)
+ProtoAtom*:     using bool atoms_less(const ProtoAtom*, etc...)
 
 Conclude: switching to * from Ptr for handle compares helps. But AddLink
    still hurts; it hurts just a bit less.

--- a/opencog/cython/opencog/atom.pyx
+++ b/opencog/cython/opencog/atom.pyx
@@ -116,7 +116,8 @@ cdef class Atom(object):
     property out:
         def __get__(self):            
             if self._outgoing is None:
-                if self.isLink():
+                atom_ptr = self.handle.atom_ptr()
+                if atom_ptr.isLink():
                      self._outgoing = self.get_out()
                 else:
                      self._outgoing = []

--- a/opencog/cython/opencog/atom.pyx
+++ b/opencog/cython/opencog/atom.pyx
@@ -40,7 +40,10 @@ cdef class Atom(object):
             cdef cAtom* atom_ptr
             if self._name is None:
                 atom_ptr = self.handle.atom_ptr()
-                self._name = atom_ptr.getName()
+                if atom_ptr.isNode():
+                    self._name = atom_ptr.getName()
+                else:
+                    self._name = ""
             return self._name
 
     property tv:
@@ -113,7 +116,10 @@ cdef class Atom(object):
     property out:
         def __get__(self):            
             if self._outgoing is None:
-                self._outgoing = self.get_out()
+                if self.isLink():
+                     self._outgoing = self.get_out()
+                else:
+                     self._outgoing = []
             return self._outgoing
 
     property arity:

--- a/opencog/cython/opencog/atomspace.pxd
+++ b/opencog/cython/opencog/atomspace.pxd
@@ -91,12 +91,12 @@ cdef extern from "opencog/atoms/base/Atom.h" namespace "opencog":
         cAtom()
 
         Type getType()
-        string getName()
+        int isNode()
+        int isLink()
 
         string toString()
         string toShortString()
 
-        vector[cHandle] getOutgoingSet()
         output_iterator getIncomingSet(output_iterator)
 
         tv_ptr getTruthValue()
@@ -114,6 +114,10 @@ cdef extern from "opencog/atoms/base/Atom.h" namespace "opencog":
         void decVLTI()
 
         output_iterator getIncomingSetByType(output_iterator, Type type, bint subclass)
+
+        # Conditionally-valid methods. Not defined for all atoms.
+        string getName()
+        vector[cHandle] getOutgoingSet()
 
 
 # Handle

--- a/opencog/guile/SchemeEval.cc
+++ b/opencog/guile/SchemeEval.cc
@@ -1028,7 +1028,7 @@ SCM SchemeEval::do_apply_scm(const std::string& func, const Handle& varargs )
 	SCM expr = SCM_EOL;
 
 	// If there were args, pass the args to the function.
-	if (varargs->isLink())
+	if (varargs and varargs->isLink())
 	{
 		const std::vector<Handle> &oset = varargs->getOutgoingSet();
 

--- a/opencog/guile/SchemeEval.cc
+++ b/opencog/guile/SchemeEval.cc
@@ -1028,10 +1028,9 @@ SCM SchemeEval::do_apply_scm(const std::string& func, const Handle& varargs )
 	SCM expr = SCM_EOL;
 
 	// If there were args, pass the args to the function.
-	LinkPtr lvar(LinkCast(varargs));
-	if (lvar)
+	if (varargs->isLink())
 	{
-		const std::vector<Handle> &oset = lvar->getOutgoingSet();
+		const std::vector<Handle> &oset = varargs->getOutgoingSet();
 
 		// Iterate in reverse, because cons chains in reverse.
 		size_t sz = oset.size();

--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -52,8 +52,7 @@ SCM SchemeSmob::ss_name (SCM satom)
 {
 	std::string name;
 	Handle h = verify_handle(satom, "cog-name");
-	NodePtr nnn(NodeCast(h));
-	if (nnn) name = nnn->getName();
+	if (h->isNode()) name = h->getName();
 	SCM str = scm_from_utf8_string(name.c_str());
 	return str;
 }

--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -159,10 +159,9 @@ SCM SchemeSmob::ss_outgoing_set (SCM satom)
 {
 	Handle h = verify_handle(satom, "cog-outgoing-set");
 
-	LinkPtr lll(LinkCast(h));
-	if (NULL == lll) return SCM_EOL;
+	if (not h->isLink()) return SCM_EOL;
 
-	const HandleSeq& oset = lll->getOutgoingSet();
+	const HandleSeq& oset = h->getOutgoingSet();
 
 	SCM list = SCM_EOL;
 	for (int i = oset.size()-1; i >= 0; i--)

--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -73,8 +73,7 @@ SCM SchemeSmob::ss_arity (SCM satom)
 {
 	Handle h = verify_handle(satom, "cog-arity");
 	Arity ari = 0;
-	LinkPtr lll(LinkCast(h));
-	if (lll) ari = lll->getArity();
+	if (h->isLink()) ari = h->getArity();
 
 	/* Arity is currently an unsigned short */
 	SCM sari = scm_from_ushort(ari);

--- a/opencog/guile/SchemeSmobNew.cc
+++ b/opencog/guile/SchemeSmobNew.cc
@@ -208,7 +208,7 @@ SCM SchemeSmob::ss_node_p (SCM s)
 	if (nullptr == h)
 		return SCM_BOOL_F;
 
-	if (NodeCast(h)) return SCM_BOOL_T;
+	if (h->isNode()) return SCM_BOOL_T;
 
 	return SCM_BOOL_F;
 }
@@ -222,7 +222,7 @@ SCM SchemeSmob::ss_link_p (SCM s)
 	if (nullptr == h)
 		return SCM_BOOL_F;
 
-	if (LinkCast(h)) return SCM_BOOL_T;
+	if (h->isLink()) return SCM_BOOL_T;
 	return SCM_BOOL_F;
 }
 

--- a/opencog/query/DefaultPatternMatchCB.cc
+++ b/opencog/query/DefaultPatternMatchCB.cc
@@ -215,9 +215,8 @@ bool DefaultPatternMatchCB::clause_match(const Handle& ptrn,
 	// It is tested by EvaluationUTest.
 	if (ptrn->getType() == VARIABLE_NODE and
 	    grnd->getType() == EVALUATION_LINK and
-	    0 < LinkCast(grnd)->getArity() and
-	    LinkCast(grnd)->getOutgoingAtom(0)->getType() ==
-	                                     GROUNDED_PREDICATE_NODE)
+	    0 < grnd->getArity() and
+	    grnd->getOutgoingAtom(0)->getType() == GROUNDED_PREDICATE_NODE)
 	{
 		LAZY_LOG_FINE << "Evaluate the grounding clause=" << std::endl
 		              << grnd->toShortString() << std::endl;
@@ -383,13 +382,12 @@ bool DefaultPatternMatchCB::eval_sentence(const Handle& top,
 		return eval_term(top, gnds);
 	}
 
-	LinkPtr ltop(LinkCast(top));
-	if (NULL == ltop)
+	if (not top->isLink())
 		throw InvalidParamException(TRACE_INFO,
 	            "Not expecting a Node, here %s\n",
 	            top->toShortString().c_str());
 
-	const HandleSeq& oset = ltop->getOutgoingSet();
+	const HandleSeq& oset = top->getOutgoingSet();
 	if (0 == oset.size())
 		throw InvalidParamException(TRACE_INFO,
 		   "Expecting logical connective to have at least one child!");

--- a/opencog/query/InitiateSearchCB.cc
+++ b/opencog/query/InitiateSearchCB.cc
@@ -156,8 +156,7 @@ InitiateSearchCB::find_starter_recursive(const Handle& h, size_t& depth,
 	Handle hdeepest(Handle::UNDEFINED);
 	size_t thinnest = SIZE_MAX;
 
-	LinkPtr ll(LinkCast(h));
-	for (Handle hunt : ll->getOutgoingSet())
+	for (Handle hunt : h->getOutgoingSet())
 	{
 		size_t brdepth = depth + 1;
 		size_t brwid = SIZE_MAX;
@@ -165,7 +164,7 @@ InitiateSearchCB::find_starter_recursive(const Handle& h, size_t& depth,
 
 		// Blow past the QuoteLinks, since they just screw up the search start.
 		if (QUOTE_LINK == hunt->getType())
-			hunt = LinkCast(hunt)->getOutgoingAtom(0);
+			hunt = hunt->getOutgoingAtom(0);
 
 		Handle s(find_starter_recursive(hunt, brdepth, sbr, brwid));
 
@@ -507,8 +506,7 @@ void InitiateSearchCB::find_rarest(const Handle& clause,
 	// Base case
 	if ((quotation_level < 1) and (CHOICE_LINK == t)) return;
 
-	LinkPtr lll(LinkCast(clause));
-	if (nullptr == lll) return;
+	if (not clause->isLink()) return;
 
 	if ((QUOTE_LINK == t and quotation_level > 0)
 	    or (UNQUOTE_LINK == t and quotation_level > 1)
@@ -526,7 +524,7 @@ void InitiateSearchCB::find_rarest(const Handle& clause,
 	if (QUOTE_LINK == t) quotation_level++;
 	else if (UNQUOTE_LINK == t) quotation_level--;
 
-	const HandleSeq& oset = lll->getOutgoingSet();
+	const HandleSeq& oset = clause->getOutgoingSet();
 	for (const Handle& h : oset)
 		find_rarest(h, rarest, count, quotation_level);
 }

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -114,8 +114,7 @@ bool PatternMatchEngine::variable_compare(const Handle& hp,
 
 	// VariableNode had better be an actual node!
 	// If it's not then we are very very confused ...
-	NodePtr np(NodeCast(hp));
-	OC_ASSERT (NULL != np,
+	OC_ASSERT (hp->isNode(),
 	           "ERROR: expected variable to be a node, got this: %s\n",
 	           hp->toShortString().c_str());
 
@@ -706,7 +705,7 @@ bool PatternMatchEngine::clause_compare(const PatternTermPtr& ptm,
 {
 	return ptm->getHandle() == clause
 		or (clause->getType() == QUOTE_LINK
-		    and ptm->getHandle() == LinkCast(clause)->getOutgoingAtom(0));
+		    and ptm->getHandle() == clause->getOutgoingAtom(0));
 }
 
 /// Return the saved unordered-link permutation for this
@@ -837,17 +836,15 @@ bool PatternMatchEngine::tree_compare(const PatternTermPtr& ptm,
 		return self_compare(ptm);
 
 	// If both are nodes, compare them as such.
-	NodePtr np(NodeCast(hp));
-	NodePtr ng(NodeCast(hg));
-	if (np and ng)
+	if (hp->isNode() and hg->isNode())
 		return node_compare(hp, hg);
 
 	// If they're not both links, then it is clearly a mismatch.
-	LinkPtr lp(LinkCast(hp));
-	LinkPtr lg(LinkCast(hg));
-	if (not (lp and lg)) return _pmc.fuzzy_match(hp, hg);
+	if (not (hp->isLink() and hg->isLink())) return _pmc.fuzzy_match(hp, hg);
 
 	// Let the callback perform basic checking.
+	LinkPtr lp(LinkCast(hp));
+	LinkPtr lg(LinkCast(hg));
 	bool match = _pmc.link_match(lp, lg);
 	if (not match) return false;
 

--- a/opencog/query/Recognizer.cc
+++ b/opencog/query/Recognizer.cc
@@ -103,13 +103,12 @@ using namespace opencog;
 
 bool Recognizer::do_search(PatternMatchEngine* pme, const Handle& top)
 {
-	LinkPtr ltop(LinkCast(top));
-	if (ltop)
+	if (top->isLink())
 	{
 		// Recursively drill down and explore every possible node as
 		// a search starting point. This is needed, as the patterns we
 		// compare against might not be connected.
-		for (const Handle& h : ltop->getOutgoingSet())
+		for (const Handle& h : top->getOutgoingSet())
 		{
 			_starter_term = top;
 			bool found = do_search(pme, h);
@@ -181,7 +180,7 @@ bool Recognizer::loose_match(const Handle& npat_h, const Handle& nsoln_h)
 
 	// Strict match for link types
 	if (npat_h->getType() != gtype) return false;
-	if (nullptr == NodeCast(npat_h)) return true;
+	if (not npat_h->isNode()) return true;
 
 	// if we are here, we know we have nodes. Ask for a strick match.
 	if (npat_h != nsoln_h) return false;
@@ -195,11 +194,9 @@ bool Recognizer::fuzzy_match(const Handle& npat_h, const Handle& nsoln_h)
 	// if we are too rigorouos here, and have a bug, we may fail to find
 	// a good pattern.
 
-	LinkPtr lpat(LinkCast(npat_h));
-	LinkPtr lsoln(LinkCast(nsoln_h));
-	if (nullptr == lpat or nullptr == lsoln) return false;
+	if (not npat_h->isLink() or not nsoln_h->isLink()) return false;
 
-	const HandleSeq &osg = lsoln->getOutgoingSet();
+	const HandleSeq &osg = nsoln_h->getOutgoingSet();
 	size_t osg_size = osg.size();
 
 	// Lets not waste time, if there's no glob there.
@@ -214,7 +211,7 @@ bool Recognizer::fuzzy_match(const Handle& npat_h, const Handle& nsoln_h)
 	}
 	if (not have_glob) return false;
 
-	const HandleSeq &osp = lpat->getOutgoingSet();
+	const HandleSeq &osp = npat_h->getOutgoingSet();
 	size_t osp_size = osp.size();
 	size_t max_size = std::max(osg_size, osp_size);
 

--- a/opencog/rule-engine/Rule.cc
+++ b/opencog/rule-engine/Rule.cc
@@ -51,7 +51,7 @@ void Rule::init(Handle rule)
 		rule_handle_ = Handle::UNDEFINED;
 	else
 	{
-		if (!rule->isType(MEMBER_LINK, true))
+		if (not classserver().isA(rule->getType(), MEMBER_LINK))
 			throw InvalidParamException(TRACE_INFO,
 		                                "Rule '%s' is expected to be a MemberLink",
 		                                rule->toString().c_str());

--- a/tests/query/test-types.h
+++ b/tests/query/test-types.h
@@ -21,6 +21,8 @@ Type LEMMA_LINK
 	= classserver().addType(LINK, "LemmaLink");
 Type LEMMA_NODE
 	= classserver().addType(NODE, "LemmaNode");
+Type LG_CONNECTOR_NODE
+	= classserver().addType(NODE, "LgConnectorNode");
 Type PARSE_LINK
 	= classserver().addType(LINK, "ParseLink");
 Type PARSE_NODE

--- a/tests/query/test_types.scm
+++ b/tests/query/test_types.scm
@@ -40,6 +40,9 @@
 (define (LemmaNode . x)
 	(apply cog-new-node (append (list 'LemmaNode) x)))
 
+(define (LgConnectorNode . x)
+   (apply cog-new-node (append (list 'LgConnectorNode) x)))
+
 (define (ParseNode . x)
 	(apply cog-new-node (append (list 'ParseNode) x)))
 


### PR DESCRIPTION
Per discussion in issue #513.

Measured the performance of the cast; its large and dominates the cost of getOutgoingSet().