### PR TITLE
Add deterministic atoms less

### DIFF
--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -417,6 +417,13 @@ public:
      * @return true if the atoms are different, false otherwise.
      */
     virtual bool operator!=(const Atom&) const = 0;
+
+    /** Returns whether this atom is less than the given atom.
+     *
+     * @return true if this atom is less than the given one, false otherwise.
+     */
+    virtual bool operator<(const Atom&) const = 0;
+
 };
 
 /** @}*/

--- a/opencog/atoms/base/Handle.cc
+++ b/opencog/atoms/base/Handle.cc
@@ -76,6 +76,21 @@ bool Handle::atoms_less(const Atom* a, const Atom* b)
     return a < b;
 }
 
+bool Handle::deterministic_atoms_less(const Atom* a, const Atom* b)
+{
+    if (a == b) return false;
+    if (nullptr == a) return true;
+    if (nullptr == b) return false;
+    UUID ua = a->getUUID();
+    UUID ub = b->getUUID();
+    if (INVALID_UUID != ua or INVALID_UUID != ub) return ua < ub;
+
+    // If both UUID's are invalid, we compare them by content. This is
+    // expensive but useful when you really want a deterministic
+    // comparison.
+    return a->operator<(*b);
+}
+
 // ===================================================
 // Handle resolution stuff.
 

--- a/opencog/atoms/base/Handle.h
+++ b/opencog/atoms/base/Handle.h
@@ -131,16 +131,16 @@ public:
         return _ptr.get() != h._ptr.get();
     }
     inline bool operator< (const Handle& h) const noexcept {
-       return atoms_less(_ptr.get(), h._ptr.get());
+       return deterministic_atoms_less(_ptr.get(), h._ptr.get());
     }
     inline bool operator> (const Handle& h) const noexcept {
-       return atoms_less(h._ptr.get(), _ptr.get());
+       return deterministic_atoms_less(h._ptr.get(), _ptr.get());
     }
     inline bool operator<=(const Handle& h) const noexcept {
-       return not atoms_less(h._ptr.get(), _ptr.get());
+       return not deterministic_atoms_less(h._ptr.get(), _ptr.get());
     }
     inline bool operator>=(const Handle& h) const noexcept {
-       return not atoms_less(_ptr.get(), h._ptr.get());
+       return not deterministic_atoms_less(_ptr.get(), h._ptr.get());
     }
 
     /**

--- a/opencog/atoms/base/Handle.h
+++ b/opencog/atoms/base/Handle.h
@@ -130,18 +130,20 @@ public:
     inline bool operator!=(const Handle& h) const noexcept {
         return _ptr.get() != h._ptr.get();
     }
+#define DEFAULT_ATOMS_LESS deterministic_atoms_less
     inline bool operator< (const Handle& h) const noexcept {
-       return deterministic_atoms_less(_ptr.get(), h._ptr.get());
+       return DEFAULT_ATOMS_LESS(_ptr.get(), h._ptr.get());
     }
     inline bool operator> (const Handle& h) const noexcept {
-       return deterministic_atoms_less(h._ptr.get(), _ptr.get());
+       return DEFAULT_ATOMS_LESS(h._ptr.get(), _ptr.get());
     }
     inline bool operator<=(const Handle& h) const noexcept {
-       return not deterministic_atoms_less(h._ptr.get(), _ptr.get());
+       return not DEFAULT_ATOMS_LESS(h._ptr.get(), _ptr.get());
     }
     inline bool operator>=(const Handle& h) const noexcept {
-       return not deterministic_atoms_less(_ptr.get(), h._ptr.get());
+       return not DEFAULT_ATOMS_LESS(_ptr.get(), h._ptr.get());
     }
+#undef DEFAULT_ATOMS_LESS
 
     /**
      * Returns a negative value, zero or a positive value if the first

--- a/opencog/atoms/base/Handle.h
+++ b/opencog/atoms/base/Handle.h
@@ -59,6 +59,7 @@ private:
     AtomPtr _ptr;
 
     static bool atoms_less(const Atom*, const Atom*);
+    static bool deterministic_atoms_less(const Atom*, const Atom*);
     static AtomPtr do_res(UUID);
     static std::vector<const AtomTable*> _resolver;
 

--- a/opencog/atoms/base/Link.cc
+++ b/opencog/atoms/base/Link.cc
@@ -155,3 +155,26 @@ bool Link::operator!=(const Atom& other) const
     return !(*this == other);
 }
 
+bool Link::operator<(const Atom& other) const
+{
+    if (getType() == other.getType()) {
+        const HandleSeq& outgoing = getOutgoingSet();
+        const HandleSeq& other_outgoing = other.getOutgoingSet();
+        Arity arity = outgoing.size();
+        Arity other_arity = other_outgoing.size();
+        if (arity == other_arity) {
+            Arity i = 0;
+            while (i < arity) {
+                Handle ll = outgoing[i];
+                Handle rl = other_outgoing[i];
+                if (ll == rl)
+                    i++;
+                else
+                    return ll->operator<(*rl.atom_ptr());
+            }
+            return false;
+        } else
+            return arity < other_arity;
+    } else
+        return getType() < other.getType();
+}

--- a/opencog/atoms/base/Link.h
+++ b/opencog/atoms/base/Link.h
@@ -222,6 +222,16 @@ public:
      * @return true if they are different, false otherwise.
      */
     virtual bool operator!=(const Atom&) const;
+
+    /**
+     * Returns whether this atom is less than the given atom.
+     *
+     * WARNING: the comparison is based on content, and therefore
+     * potentially expensive.
+     *
+     * @return true if this atom is less than the given one, false otherwise.
+     */
+    virtual bool operator<(const Atom&) const;
 };
 
 static inline LinkPtr LinkCast(const Handle& h)

--- a/opencog/atoms/base/Node.cc
+++ b/opencog/atoms/base/Node.cc
@@ -102,3 +102,11 @@ bool Node::operator!=(const Atom& other) const
 {
     return not (*this == other);
 }
+
+bool Node::operator<(const Atom& other) const
+{
+    if (getType() == other.getType())
+        return getName() < other.getName();
+    else
+        return getType() < other.getType();
+}

--- a/opencog/atoms/base/Node.h
+++ b/opencog/atoms/base/Node.h
@@ -112,6 +112,15 @@ public:
      * @return true if they are different, false otherwise.
      */
     virtual bool operator!=(const Atom&) const;
+
+    /** Returns whether this atom is less than the given atom.
+     *
+     * WARNING: the comparison is based on content, and therefore
+     * potentially expensive.
+     *
+     * @return true if this atom is less than the given one, false otherwise.
+     */
+	virtual bool operator<(const Atom&) const;
 };
 
 typedef std::shared_ptr<Node> NodePtr;

--- a/scripts/benchmark_utests.sh
+++ b/scripts/benchmark_utests.sh
@@ -1,0 +1,46 @@
+# Small script to test the performance of the AtomSpace and its tools
+# (pattern matcher, URE, etc). It merely runs all the unit tests a
+# certain number of times and output statistics about it.
+
+# This script relies on https://github.com/nferraz/st
+
+# Check unbound variables
+set -u
+
+# # Debug trace
+# set -x
+
+# Number of times to run the unit tests
+N=30
+
+# Name of the build directory
+BUILD_DIR_NAME=build
+
+# Get the script directory
+PRG_PATH="$(readlink -f "$0")"
+PRG_DIR="$(dirname "$PRG_PATH")"
+UTEST_DIR="$PRG_DIR/../$BUILD_DIR_NAME"
+
+#############
+# Functions #
+#############
+
+# Get the real time in second (given the output of time command)
+get_real_time() {
+    grep "real" | cut -d' ' -f2
+}
+
+# Run all query unit tests
+run_utests() {
+    cd "$UTEST_DIR";
+    make test ARGS=-j2
+    cd -
+}
+
+########
+# Main #
+########
+
+for i in $(seq 1 $N); do
+    time -p run_utests 
+done |& get_real_time | st | column -t


### PR DESCRIPTION
This is not to merge immediately. I'm still working on it (mostly benchmarking). But I'm putting this already to get some feedback.

# Overview
This implements a deterministic less than operator for Handle. Deterministic in the sense that if the Handles are undefined it computes the less_than relationship based on contents rather than pointers.

It has the main advantage that it makes unit tests reproducible, assuming of course that the atoms are added in a deterministic manner. For instance map<Handle, float> will behave the same way every time.

Obviously the main drawback is that it has more overhead than comparing pointers, however, according to my understanding this should not compromise the performances of the AtomSpace  because the indexes Handles always have UUIDs, so never resorts to content comparison. So the overhead should only occurs when manipulating atoms that not in any atomspaces.

I tried to estimate that but couldn't precisely, ultimately it depends on the size of the atoms, what proportion isn't in any atomspaces, etc. I find it very hard to get a realistic figure of that.

So what I've merely done is to compare the performances of the atomspace repository unit tests, 20 times and average, I found no significant performance drop. Then, to be sure that there was at least some non negligible usages of comparison by content I intentionally introduced inefficiencies (time waster) in the comparison. Here are the results.

# Performances

## Pointer based atom less than

```
N   min   max    sum      mean     stddev
20  69.3  71.43  1411.99  70.5995  0.591648
```

## Content based atom less than

```
N   min    max    sum      mean     stddev
20  69.56  72.06  1416.01  70.8005  0.677266
```

## Content based atom less than + loop of 50K printing some short message (it's rederected to /dev/null I think, but I just wanted to be sure gcc doesn't optimize it away)

```
N   min     max     sum      mean     stddev
20  108.87  113.03  2214.56  110.728  1.21169
```

## Content based atom less than + loop of 100K printing some short message

```
N   min     max     sum      mean     stddev
20  155.64  171.82  3234.69  161.734  3.94332
```

I tried to work out some math to extract more information about the overhead but I ended with more variables than equations and I couldn't solve it. In other words the only way to probe deeper is gonna be run a real benchmarking tool. But again I don't know what is supposed to be realistically meaningful. I guess running the FC on some real world inference could give a meaningful answer.