### PR TITLE
Remove UUID abuse

### DIFF
--- a/opencog/atoms/base/Handle.cc
+++ b/opencog/atoms/base/Handle.cc
@@ -85,13 +85,9 @@ bool Handle::content_based_atoms_less(const Atom* a, const Atom* b)
     if (a == b) return false;
     if (nullptr == a) return true;
     if (nullptr == b) return false;
-    UUID ua = a->getUUID();
-    UUID ub = b->getUUID();
-    if (INVALID_UUID != ua or INVALID_UUID != ub) return ua < ub;
 
-    // If both UUID's are invalid, we compare them by content. This is
-    // expensive but useful when you really want a deterministic
-    // comparison.
+    // Otherwise we compare them by content. This is expensive but
+    // useful when you really want a deterministic comparison.
     return a->operator<(*b);
 }
 


### PR DESCRIPTION
Not really an abuse, but if we're to compare by content and we're not
that concerned about performances, then it's even better to not use UUID
at all as the comparison will then even be independent of the order of
atom creation.