### PR TITLE
skip some initialization of transient atomspaces.

### DIFF
--- a/opencog/atomspace/AtomSpace.cc
+++ b/opencog/atomspace/AtomSpace.cc
@@ -51,9 +51,17 @@ using namespace opencog;
 
 // ====================================================================
 
+/**
+ * Transient atomspaces skip some of the initialization steps,
+ * so that they can be constructed more quickly.  Transient atomspaces
+ * are typically used as scratch spaces, to hold temporary results
+ * during evaluation, pattern matching and inference. Such temporary
+ * spaces don't need some of the heavier-weight crud that atomspaces
+ * are festooned with.
+ */
 AtomSpace::AtomSpace(AtomSpace* parent, bool transient) :
     atomTable(parent? &parent->atomTable : NULL, this, transient),
-    bank(atomTable),
+    bank(atomTable, transient),
     backing_store(NULL)
 {
 }
@@ -67,7 +75,7 @@ AtomSpace::~AtomSpace()
 
 AtomSpace::AtomSpace(const AtomSpace&) :
     atomTable(NULL),
-    bank(atomTable),
+    bank(atomTable, true),
     backing_store(NULL)
 {
      throw opencog::RuntimeException(TRACE_INFO,

--- a/opencog/atomspace/AtomSpace.cc
+++ b/opencog/atomspace/AtomSpace.cc
@@ -51,8 +51,8 @@ using namespace opencog;
 
 // ====================================================================
 
-AtomSpace::AtomSpace(AtomSpace* parent) :
-    atomTable(parent? &parent->atomTable : NULL, this),
+AtomSpace::AtomSpace(AtomSpace* parent, bool transient) :
+    atomTable(parent? &parent->atomTable : NULL, this, transient),
     bank(atomTable),
     backing_store(NULL)
 {

--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -84,7 +84,7 @@ protected:
     void unregisterBackingStore(BackingStore *);
 
 public:
-    AtomSpace(AtomSpace* parent = NULL);
+    AtomSpace(AtomSpace* parent = NULL, bool transient = false);
     ~AtomSpace();
 
     /// Get the environment that this atomspace was created in.

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -65,8 +65,8 @@ using namespace opencog;
 
 std::recursive_mutex AtomTable::_mtx;
 
-AtomTable::AtomTable(AtomTable* parent, AtomSpace* holder)
-    : _index_queue(this, &AtomTable::put_atom_into_index)
+AtomTable::AtomTable(AtomTable* parent, AtomSpace* holder, bool transient)
+    : _index_queue(this, &AtomTable::put_atom_into_index, transient?0:4)
 {
     _as = holder;
     _environ = parent;

--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -156,8 +156,15 @@ public:
 
     /**
      * Constructor and destructor for this class.
+     *
+     * If 'transient' is true, then some non-essential initialization
+     * is skipped.  This makes the constructor run faster. This is
+     * useful when the AtomTable is being used only for holding
+     * temporary, scratch results, e.g. as a result of evaluation
+     * or inference.
      */
-    AtomTable(AtomTable* parent = NULL, AtomSpace* holder = NULL);
+    AtomTable(AtomTable* parent = NULL, AtomSpace* holder = NULL,
+              bool transient = false);
     ~AtomTable();
     UUID get_uuid(void) const { return _uuid; }
     AtomTable* get_environ(void) const { return _environ; }

--- a/opencog/atomspace/AttentionBank.h
+++ b/opencog/atomspace/AttentionBank.h
@@ -46,6 +46,12 @@ class AtomTable;
 
 class AttentionBank
 {
+    /** If true, then this AttentionBank is not being used.
+     * Yes, this is totally bogus, but is needed, due to design
+     * flaws related to attention allocation.
+     */
+    bool _zombie;
+
     /** The connection by which we are notified of AV changes */
     boost::signals2::connection AVChangedConnection;
     void AVChanged(Handle, AttentionValuePtr, AttentionValuePtr);
@@ -79,7 +85,7 @@ class AttentionBank
 
 public:
     /** The table notifies us about AV changes */
-    AttentionBank(AtomTable&);
+    AttentionBank(AtomTable&, bool);
     ~AttentionBank();
     void shutdown(void);
 

--- a/opencog/query/DefaultPatternMatchCB.cc
+++ b/opencog/query/DefaultPatternMatchCB.cc
@@ -36,7 +36,7 @@ using namespace opencog;
 
 DefaultPatternMatchCB::DefaultPatternMatchCB(AtomSpace* as) :
 	_classserver(classserver()),
-	_temp_aspace(as),
+	_temp_aspace(as, true),
 	_instor(&_temp_aspace),
 	_as(as)
 {


### PR DESCRIPTION
The temporary atomspaces used as scratch space during evaluation do not need to do a full initialization.  This should make things run a little bit faster.