### PR TITLE
Speedup bind with a multi-threaded transient atom space cache.

### DIFF
--- a/opencog/atoms/execution/Instantiator.h
+++ b/opencog/atoms/execution/Instantiator.h
@@ -76,6 +76,18 @@ private:
 public:
 	Instantiator(AtomSpace* as) : _as(as) {}
 
+	void ready(AtomSpace* as)
+	{
+		_as = as;
+		_halt = false;
+	}
+
+	void clear()
+	{
+		_as = NULL;
+		_vmap = NULL;
+	}
+
 	Handle instantiate(const Handle& expr, const std::map<Handle, Handle> &vars);
 	Handle execute(const Handle& expr)
 	{

--- a/opencog/atomspace/AtomSpace.cc
+++ b/opencog/atomspace/AtomSpace.cc
@@ -60,9 +60,10 @@ using namespace opencog;
  * are festooned with.
  */
 AtomSpace::AtomSpace(AtomSpace* parent, bool transient) :
-    atomTable(parent? &parent->atomTable : NULL, this, transient),
-    bank(atomTable, transient),
-    backing_store(NULL)
+    _atom_table(parent? &parent->_atom_table : NULL, this, transient),
+    _bank(_atom_table, transient),
+    _backing_store(NULL),
+    _transient(transient)
 {
 }
 
@@ -70,16 +71,26 @@ AtomSpace::~AtomSpace()
 {
     // Be sure to disconnect the attention bank signals before the
     // atom table destructor runs. XXX FIXME yes this is an ugly hack.
-    bank.shutdown();
+    _bank.shutdown();
 }
 
 AtomSpace::AtomSpace(const AtomSpace&) :
-    atomTable(NULL),
-    bank(atomTable, true),
-    backing_store(NULL)
+    _atom_table(NULL),
+    _bank(_atom_table, true),
+    _backing_store(NULL)
 {
      throw opencog::RuntimeException(TRACE_INFO,
          "AtomSpace - Cannot copy an object of this class");
+}
+
+void AtomSpace::ready_transient(AtomSpace* parent)
+{
+    _atom_table.ready_transient(parent? &parent->_atom_table : NULL, this);
+}
+
+void AtomSpace::clear_transient()
+{
+    _atom_table.clear_transient();
 }
 
 AtomSpace& AtomSpace::operator=(const AtomSpace&)
@@ -93,12 +104,12 @@ AtomSpace& AtomSpace::operator=(const AtomSpace&)
 
 void AtomSpace::registerBackingStore(BackingStore *bs)
 {
-    backing_store = bs;
+    _backing_store = bs;
 }
 
 void AtomSpace::unregisterBackingStore(BackingStore *bs)
 {
-    if (bs == backing_store) backing_store = NULL;
+    if (bs == _backing_store) _backing_store = NULL;
 }
 
 // ====================================================================
@@ -108,27 +119,27 @@ Handle AtomSpace::add_atom(AtomPtr atom, bool async)
     if (nullptr == atom) return Handle();
 
     // Is this atom already in the atom table?
-    Handle hexist(atomTable.getHandle(atom));
+    Handle hexist(_atom_table.getHandle(atom));
     if (hexist) return hexist;
 
     // If we are here, the AtomTable does not yet know about this atom.
     // Maybe the backing store knows about this atom.
     Type t = atom->getType();
-    if (backing_store and not backing_store->ignoreType(t))
+    if (_backing_store and not _backing_store->ignoreType(t))
     {
         AtomPtr ba;
         NodePtr n(NodeCast(atom));
         if (n) {
-            ba = backing_store->getNode(n->getType(),
+            ba = _backing_store->getNode(n->getType(),
                                         n->getName().c_str());
         } else {
             LinkPtr l(LinkCast(atom));
             if (l)
-                 ba = backing_store->getLink(l->getType(),
+                 ba = _backing_store->getLink(l->getType(),
                                              l->getOutgoingSet());
         }
         if (ba) {
-            return atomTable.add(ba, async);
+            return _atom_table.add(ba, async);
         }
     }
 
@@ -137,12 +148,12 @@ Handle AtomSpace::add_atom(AtomPtr atom, bool async)
     // addition will fail. Deal with it.
     Handle rh;
     try {
-        rh = atomTable.add(atom, async);
+        rh = _atom_table.add(atom, async);
     }
     catch (const DeleteException& ex) {
         // Atom deletion has not been implemented in the backing store
         // This is a major to-do item.
-        if (backing_store)
+        if (_backing_store)
 // Under construction ....
 	        throw RuntimeException(TRACE_INFO, "Not implemented!!!");
     }
@@ -153,35 +164,35 @@ Handle AtomSpace::add_node(Type t, const string& name,
                            bool async)
 {
     // Is this atom already in the atom table?
-    Handle hexist(atomTable.getHandle(t, name));
+    Handle hexist(_atom_table.getHandle(t, name));
     if (hexist) return hexist;
 
     // If we are here, the AtomTable does not yet know about this atom.
     // Maybe the backing store knows about this atom.
-    if (backing_store and not backing_store->ignoreType(t))
+    if (_backing_store and not _backing_store->ignoreType(t))
     {
-        NodePtr n(backing_store->getNode(t, name.c_str()));
-        if (n) return atomTable.add(n, async);
+        NodePtr n(_backing_store->getNode(t, name.c_str()));
+        if (n) return _atom_table.add(n, async);
     }
 
     // If we are here, neither the AtomTable nor backing store know about
     // this atom. Just add it.
-    return atomTable.add(createNode(t, name), async);
+    return _atom_table.add(createNode(t, name), async);
 }
 
 Handle AtomSpace::get_node(Type t, const string& name)
 {
     // Is this atom already in the atom table?
-    Handle hexist = atomTable.getHandle(t, name);
+    Handle hexist = _atom_table.getHandle(t, name);
     if (hexist) return hexist;
 
     // If we are here, the AtomTable does not yet know about this atom.
     // Maybe the backing store knows about this atom.
-    if (backing_store and not backing_store->ignoreType(t))
+    if (_backing_store and not _backing_store->ignoreType(t))
     {
-        NodePtr n(backing_store->getNode(t, name.c_str()));
+        NodePtr n(_backing_store->getNode(t, name.c_str()));
         if (n) {
-            return atomTable.add(n, false);
+            return _atom_table.add(n, false);
         }
     }
 
@@ -193,23 +204,23 @@ Handle AtomSpace::add_link(Type t, const HandleSeq& outgoing,
                            bool async)
 {
     // Is this atom already in the atom table?
-    Handle hexist = atomTable.getHandle(t, outgoing);
+    Handle hexist = _atom_table.getHandle(t, outgoing);
     if (hexist) return hexist;
 
     // If we are here, the AtomTable does not yet know about this atom.
     // Maybe the backing store knows about this atom.
-    if (backing_store and not backing_store->ignoreType(t))
+    if (_backing_store and not _backing_store->ignoreType(t))
     {
         // If any of the outgoing set is ignorable, we will not
         // fetch the thing from the backing store.
         if (not std::any_of(outgoing.begin(), outgoing.end(),
-            [this](Handle ho) { return backing_store->ignoreAtom(ho); }))
+            [this](Handle ho) { return _backing_store->ignoreAtom(ho); }))
         {
-            LinkPtr l(backing_store->getLink(t, outgoing));
+            LinkPtr l(_backing_store->getLink(t, outgoing));
             if (l) {
                 // Put the atom into the atomtable, so it gets placed
                 // in indices, so we can find it quickly next time.
-                return atomTable.add(l, async);
+                return _atom_table.add(l, async);
             }
         }
     }
@@ -219,12 +230,12 @@ Handle AtomSpace::add_link(Type t, const HandleSeq& outgoing,
     // addition will fail. Deal with it.
     Handle rh;
     try {
-        rh = atomTable.add(createLink(t, outgoing), async);
+        rh = _atom_table.add(createLink(t, outgoing), async);
     }
     catch (const DeleteException& ex) {
         // Atom deletion has not been implemented in the backing store
         // This is a major to-do item.
-        if (backing_store)
+        if (_backing_store)
 // Under construction ....
 	        throw RuntimeException(TRACE_INFO, "Not implemented!!!");
     }
@@ -234,23 +245,23 @@ Handle AtomSpace::add_link(Type t, const HandleSeq& outgoing,
 Handle AtomSpace::get_link(Type t, const HandleSeq& outgoing)
 {
     // Is this atom already in the atom table?
-    Handle hexist = atomTable.getHandle(t, outgoing);
+    Handle hexist = _atom_table.getHandle(t, outgoing);
     if (hexist) return hexist;
 
     // If we are here, the AtomTable does not yet know about this atom.
     // Maybe the backing store knows about this atom.
-    if (backing_store and not backing_store->ignoreType(t))
+    if (_backing_store and not _backing_store->ignoreType(t))
     {
         // If any of the outgoing set is ignorable, we will not
         // fetch the thing from the backing store.
         if (not std::any_of(outgoing.begin(), outgoing.end(),
-            [this](Handle ho) { return backing_store->ignoreAtom(ho); }))
+            [this](Handle ho) { return _backing_store->ignoreAtom(ho); }))
         {
-            LinkPtr l(backing_store->getLink(t, outgoing));
+            LinkPtr l(_backing_store->getLink(t, outgoing));
             if (l) {
                 // Register the atom with the atomtable (so it
                 // gets placed in indices)
-                return atomTable.add(l, false);
+                return _atom_table.add(l, false);
             }
         }
     }
@@ -261,15 +272,15 @@ Handle AtomSpace::get_link(Type t, const HandleSeq& outgoing)
 
 void AtomSpace::store_atom(Handle h)
 {
-    if (NULL == backing_store)
+    if (NULL == _backing_store)
         throw RuntimeException(TRACE_INFO, "No backing store");
 
-    backing_store->storeAtom(h);
+    _backing_store->storeAtom(h);
 }
 
 Handle AtomSpace::fetch_atom(Handle h)
 {
-    if (NULL == backing_store)
+    if (NULL == _backing_store)
         throw RuntimeException(TRACE_INFO, "No backing store");
     if (NULL == h) return h;
 
@@ -290,8 +301,8 @@ Handle AtomSpace::fetch_atom(Handle h)
     // atomtable.
 
     // Case 1:
-    Handle hb(atomTable.getHandle(h));
-    if (atomTable.holds(hb))
+    Handle hb(_atom_table.getHandle(h));
+    if (_atom_table.holds(hb))
         return hb;
 
     // Case 2:
@@ -300,12 +311,12 @@ Handle AtomSpace::fetch_atom(Handle h)
         AtomPtr ba;
         NodePtr n(NodeCast(h));
         if (n) {
-            ba = backing_store->getNode(n->getType(),
+            ba = _backing_store->getNode(n->getType(),
                                         n->getName().c_str());
         } else {
             LinkPtr l(LinkCast(h));
             if (l)
-                 ba = backing_store->getLink(l->getType(),
+                 ba = _backing_store->getLink(l->getType(),
                                              l->getOutgoingSet());
         }
 
@@ -319,12 +330,12 @@ Handle AtomSpace::fetch_atom(Handle h)
         h = ba;
     }
 
-    return atomTable.add(h, false);
+    return _atom_table.add(h, false);
 }
 
 Handle AtomSpace::fetch_atom(UUID uuid)
 {
-    if (NULL == backing_store)
+    if (NULL == _backing_store)
         throw RuntimeException(TRACE_INFO, "No backing store");
 
     // OK, we have to handle two distinct cases.
@@ -338,13 +349,13 @@ Handle AtomSpace::fetch_atom(UUID uuid)
     //    unless all of its outgoing set already is in the atomtable.
 
     // Case 1:
-    Handle hb(atomTable.getHandle(uuid));
-    if (atomTable.holds(hb))
+    Handle hb(_atom_table.getHandle(uuid));
+    if (_atom_table.holds(hb))
         return hb;
 
     // Case 2:
     // We don't have the atom for this UUID, then go get it.
-    AtomPtr a(backing_store->getAtom(uuid));
+    AtomPtr a(_backing_store->getAtom(uuid));
 
     // If we still don't have an atom, then the requested UUID
     // was "insane", that is, unknown by either the atom table
@@ -354,12 +365,12 @@ Handle AtomSpace::fetch_atom(UUID uuid)
             "Asked backend for an unknown handle; UUID=%lu\n",
             uuid);
 
-    return atomTable.add(a, false);
+    return _atom_table.add(a, false);
 }
 
 Handle AtomSpace::fetch_incoming_set(Handle h, bool recursive)
 {
-    if (NULL == backing_store)
+    if (NULL == _backing_store)
         throw RuntimeException(TRACE_INFO, "No backing store");
 
     h = get_atom(h);
@@ -367,7 +378,7 @@ Handle AtomSpace::fetch_incoming_set(Handle h, bool recursive)
     if (nullptr == h) return Handle::UNDEFINED;
 
     // Get everything from the backing store.
-    HandleSeq iset = backing_store->getIncomingSet(h);
+    HandleSeq iset = _backing_store->getIncomingSet(h);
     size_t isz = iset.size();
     for (size_t i=0; i<isz; i++) {
         Handle hi(iset[i]);
@@ -382,20 +393,20 @@ Handle AtomSpace::fetch_incoming_set(Handle h, bool recursive)
 
 bool AtomSpace::remove_atom(Handle h, bool recursive)
 {
-    if (backing_store) {
+    if (_backing_store) {
         // Atom deletion has not been implemented in the backing store
         // This is a major to-do item.
 // Under construction ....
         throw RuntimeException(TRACE_INFO, "Not implemented!!!");
     }
-    return 0 < atomTable.extract(h, recursive).size();
+    return 0 < _atom_table.extract(h, recursive).size();
 }
 
 void AtomSpace::clear()
 {
     std::vector<Handle> allAtoms;
 
-    atomTable.getHandlesByType(back_inserter(allAtoms), ATOM, true, false);
+    _atom_table.getHandlesByType(back_inserter(allAtoms), ATOM, true, false);
 
     DPRINTF("atoms in allAtoms: %lu\n", allAtoms.size());
 
@@ -411,7 +422,7 @@ void AtomSpace::clear()
     }
 
     allAtoms.clear();
-    atomTable.getHandlesByType(back_inserter(allAtoms), ATOM, true, false);
+    _atom_table.getHandlesByType(back_inserter(allAtoms), ATOM, true, false);
     assert(allAtoms.size() == 0);
 
     // logger().set_level(save);

--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -146,6 +146,8 @@ private:
 
     // The AtomSpace that is holding us (if any). Needed for DeleteLink operation
     AtomSpace* _as;
+    bool _transient;
+
     /**
      * Override and declare copy constructor and equals operator as
      * private.  This is to prevent large object copying by mistake.
@@ -167,6 +169,10 @@ public:
     AtomTable(AtomTable* parent = NULL, AtomSpace* holder = NULL,
               bool transient = false);
     ~AtomTable();
+
+    void ready_transient(AtomTable* parent, AtomSpace* holder);
+    void clear_transient();
+
     UUID get_uuid(void) const { return _uuid; }
     AtomTable* get_environ(void) const { return _environ; }
     AtomSpace* getAtomSpace(void) const { return _as; }
@@ -203,7 +209,6 @@ public:
     AtomPtr factory(Type atom_type, AtomPtr atom);
     AtomPtr clone_factory(Type, AtomPtr);
 
-public:
     /**
      * Returns the set of atoms of a given type (subclasses optionally).
      *
@@ -273,7 +278,7 @@ public:
     /**
      * Adds an atom to the table. If the atom already is in the
      * atomtable, then the truth values and attention values of the
-     * two are merged (how, exactly? Is this doe corrrectly!?)
+     * two are merged (how, exactly? Is this done corrrectly!?)
      *
      * If the async flag is set, then the atom addition is performed
      * asynchronously; the atom might not be fully added by the time

--- a/opencog/benchmark/python_diary.txt
+++ b/opencog/benchmark/python_diary.txt
@@ -506,3 +506,127 @@ Predicates - get_predicates                     2.260µs         442,523
 Predicates - get_predicates_for                 1.909µs         523,728
 Predicates - cog-get-pred - Scheme            130.991µs           7,634
 
+
+----------------
+20 February 2016
+----------------
+
+Significant changed timings:
+----------------------------
+
+bindlink comparison
+-------------------
+Linas's changes to bindlink made it 80% faster. It was:
+
+  Bind - bindlink - Cython                      360.240µs           2,775
+
+and is now:
+
+  Bind - bindlink - Cython                      202.252µs           4,944
+
+
+Machine and Software Configuration
+----------------------------------
+As measured by Curtis on:
+  MacBook Pro - Retina, 15-inch, Early 2013
+  Intel Core i7 2.7 Ghz - Quad core
+  16GB 1600 Mhz DDR3
+
+Linux running in VirtualBox VM with boot2docker in a Docker container with:
+  docker-machine version 0.5.6, build 61388e9
+  Docker version 1.9.1, build a34a1d5
+  VirtualBox VM 5.0.14r105127
+  Ubuntu 14.04.2 LTS (trusty)
+  Python 2.7.6
+  gcc (Ubuntu 4.8.4-2ubuntu1~14.04) 4.8.4
+  guile (GNU Guile) 2.0.9
+
+(SAME configuration as last test)
+
+--- OpenCog Python Benchmark -  2016-02-20 14:49:56.407353 ---
+
+Test                                        Time per op  Ops per second
+----                                        -----------  --------------
+Add nodes - Cython                              6.305µs         158,606
+Add nodes - Cython (500K)                       6.545µs         152,790
+Add fully connected nodes                       7.979µs         125,332
+Bare atom traversal 100K - by type              0.000µs   3,104,592,153
+Resolve Handle 10K - by type                    0.188µs       5,320,722
+Resolve Handle 100K - by type                   0.104µs       9,633,795
+Resolve Handle 1M - by type                     0.101µs       9,928,881
+Get and Traverse 100K - by type                 0.691µs       1,447,246
+Yield Get and Traverse 100K - by type           0.517µs       1,935,545
+Get Outgoing                                    1.619µs         617,701
+Get Outgoing - no temporary list                1.613µs         620,017
+Bind - stub_bindlink - Cython                   0.304µs       3,287,742
+Bind - bindlink - Cython                      202.252µs           4,944
+Test scheme_eval_h(+ 2 2)                      72.558µs          13,782
+Bind - cog-bind - Scheme                      301.144µs           3,320
+Add nodes - cog-new-node - Scheme             123.117µs           8,122
+Add nodes - ConceptNode sugar - Scheme        107.173µs           9,330
+Predicates - get_predicates                     2.116µs         472,529
+Predicates - get_predicates_for                 1.740µs         574,785
+Predicates - cog-get-pred - Scheme            126.158µs           7,926
+
+
+----------------
+25 February 2016
+----------------
+
+Significant changed timings:
+----------------------------
+
+bindlink comparison
+-------------------
+Implementing a multi-threaded cache for the transient atomspaces 
+made binklink 5X faster. It was:
+
+  Bind - bindlink - Cython                      202.252µs           4,944
+
+and is now:
+
+  Bind - bindlink - Cython                       39.998µs          25,001
+
+
+Machine and Software Configuration
+----------------------------------
+As measured by Curtis on:
+  MacBook Pro - Retina, 15-inch, Early 2013
+  Intel Core i7 2.7 Ghz - Quad core
+  16GB 1600 Mhz DDR3
+
+Linux running in VirtualBox VM with boot2docker in a Docker container with:
+  docker-machine version 0.5.6, build 61388e9
+  Docker version 1.9.1, build a34a1d5
+  VirtualBox VM 5.0.14r105127
+  Ubuntu 14.04.2 LTS (trusty)
+  Python 2.7.6
+  gcc (Ubuntu 4.8.4-2ubuntu1~14.04) 4.8.4
+  guile (GNU Guile) 2.0.9
+
+(SAME configuration as last test)
+
+--- OpenCog Python Benchmark -  2016-02-25 20:27:05.746033 ---
+
+Test                                        Time per op  Ops per second
+----                                        -----------  --------------
+Add nodes - Cython                              5.829µs         171,556
+Add nodes - Cython (500K)                       5.992µs         166,878
+Add fully connected nodes                       7.583µs         131,875
+Bare atom traversal 100K - by type              0.000µs   4,048,555,984
+Resolve Handle 10K - by type                    0.130µs       7,689,607
+Resolve Handle 100K - by type                   0.108µs       9,291,273
+Resolve Handle 1M - by type                     0.102µs       9,761,448
+Get and Traverse 100K - by type                 0.702µs       1,424,480
+Yield Get and Traverse 100K - by type           0.483µs       2,070,468
+Get Outgoing                                    1.610µs         621,246
+Get Outgoing - no temporary list                1.610µs         621,106
+Bind - stub_bindlink - Cython                   0.288µs       3,469,004
+Bind - bindlink - Cython                       39.998µs          25,001
+Test scheme_eval_h(+ 2 2)                      74.616µs          13,401
+Bind - cog-bind - Scheme                      128.871µs           7,759
+Add nodes - cog-new-node - Scheme             124.144µs           8,055
+Add nodes - ConceptNode sugar - Scheme        108.928µs           9,180
+Predicates - get_predicates                     2.242µs         446,015
+Predicates - get_predicates_for                 1.784µs         560,684
+Predicates - cog-get-pred - Scheme            126.182µs           7,925

--- a/opencog/query/CMakeLists.txt
+++ b/opencog/query/CMakeLists.txt
@@ -4,6 +4,7 @@ ADD_LIBRARY(query
 	AttentionalFocusCB.cc
 	DefaultPatternMatchCB.cc
 	Implicator.cc
+	DefaultImplicator.cc
 	InitiateSearchCB.cc
 	PatternMatch.cc
 	PatternMatchEngine.cc

--- a/opencog/query/DefaultImplicator.cc
+++ b/opencog/query/DefaultImplicator.cc
@@ -1,0 +1,48 @@
+/*
+ * DefaultImplicator.cc
+ *
+ * Copyright (C) 2016 Linas Vepstas
+ *
+ * Author: Linas Vepstas <linasvepstas@gmail.com>  April 2015
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "DefaultImplicator.h"
+
+using namespace opencog;
+
+#ifdef CACHED_IMPLICATOR
+
+DefaultImplicator* CachedDefaultImplicator::_cached_implicator = NULL;
+
+CachedDefaultImplicator::CachedDefaultImplicator(AtomSpace*asp)
+{
+	// Create a new cached implicator if we need one.
+	if (!_cached_implicator)
+		_cached_implicator = new DefaultImplicator(asp);
+
+	// Ready the cached implicator for a new search on this atomspace.
+	_cached_implicator->ready(asp);
+}
+
+CachedDefaultImplicator::~CachedDefaultImplicator()
+{
+	// Clear the cached implicator for next time.
+	_cached_implicator->clear();
+}
+
+#endif

--- a/opencog/query/DefaultImplicator.h
+++ b/opencog/query/DefaultImplicator.h
@@ -44,6 +44,22 @@ class DefaultImplicator:
 			InitiateSearchCB(asp),
 			DefaultPatternMatchCB(asp) {}
 
+#ifdef CACHED_IMPLICATOR
+	virtual void ready(AtomSpace* asp)
+	{
+		Implicator::ready(asp);
+		InitiateSearchCB::ready(asp);
+		DefaultPatternMatchCB::ready(asp);
+	}
+
+	virtual void clear()
+	{
+		Implicator::clear();
+		InitiateSearchCB::clear();
+		DefaultPatternMatchCB::clear();
+	}
+#endif
+
 	virtual void set_pattern(const Variables& vars,
 	                         const Pattern& pat)
 	{
@@ -76,6 +92,16 @@ class AFImplicator:
 		DefaultPatternMatchCB::set_pattern(vars, pat);
 	}
 };
+
+#ifdef CACHED_IMPLICATOR
+class CachedDefaultImplicator {
+	static DefaultImplicator* _cached_implicator;
+	public:
+		CachedDefaultImplicator(AtomSpace*asp);
+		~CachedDefaultImplicator();
+		operator Implicator&() { return *_cached_implicator; }
+};
+#endif
 
 }; // namespace opencog
 

--- a/opencog/query/DefaultPatternMatchCB.cc
+++ b/opencog/query/DefaultPatternMatchCB.cc
@@ -36,7 +36,7 @@ const bool TRANSIENT_SPACE = true;
 const int MAX_CACHED_TRANSIENTS = 8;
 
 // Allocated storage for the transient atomspace cache static variables.
-std::mutex DefaultPatternMatchCB::_transient_cache_mutex;
+std::mutex DefaultPatternMatchCB::s_transient_cache_mutex;
 std::vector<AtomSpace*> DefaultPatternMatchCB::s_transient_cache;
 
 /* ======================================================== */
@@ -77,7 +77,7 @@ AtomSpace* DefaultPatternMatchCB::grab_transient_atomspace(AtomSpace* parent)
 	if (s_transient_cache.size() > 0)
 	{
 		// Grab the mutex lock.
-		std::unique_lock<std::mutex> cache_lock(_transient_cache_mutex);
+		std::unique_lock<std::mutex> cache_lock(s_transient_cache_mutex);
 
 		// Check to make sure the cache still has one now that we have
 		// the mutex.
@@ -107,7 +107,7 @@ void DefaultPatternMatchCB::release_transient_atomspace(AtomSpace* atomspace)
 	if (s_transient_cache.size() < MAX_CACHED_TRANSIENTS)
 	{
 		// Grab the mutex lock.
-		std::unique_lock<std::mutex> cache_lock(_transient_cache_mutex);
+		std::unique_lock<std::mutex> cache_lock(s_transient_cache_mutex);
 
 		// Check it again since we only now have the mutex locked.
 		if (s_transient_cache.size() < MAX_CACHED_TRANSIENTS)

--- a/opencog/query/DefaultPatternMatchCB.cc
+++ b/opencog/query/DefaultPatternMatchCB.cc
@@ -32,20 +32,129 @@
 
 using namespace opencog;
 
+const bool TRANSIENT_SPACE = true;
+const int MAX_CACHED_TRANSIENTS = 8;
+
+// Allocated storage for the transient atomspace cache static variables.
+std::mutex DefaultPatternMatchCB::_transient_cache_mutex;
+std::vector<AtomSpace*> DefaultPatternMatchCB::s_transient_cache;
+
 /* ======================================================== */
 
 DefaultPatternMatchCB::DefaultPatternMatchCB(AtomSpace* as) :
-	_classserver(classserver()),
-	_temp_aspace(as, true),
-	_instor(&_temp_aspace),
-	_as(as)
+	_classserver(classserver())
 {
+	_temp_aspace = grab_transient_atomspace(as);
+	_instor = new Instantiator(_temp_aspace);
+
 	_connectives.insert(SEQUENTIAL_AND_LINK);
 	_connectives.insert(SEQUENTIAL_OR_LINK);
 	_connectives.insert(AND_LINK);
 	_connectives.insert(OR_LINK);
 	_connectives.insert(NOT_LINK);
+
+	_as = as;
 }
+
+DefaultPatternMatchCB::~DefaultPatternMatchCB()
+{
+	// If we have a transient atomspace, release it.
+	if (_temp_aspace)
+	{
+		release_transient_atomspace(_temp_aspace);
+		_temp_aspace = NULL;
+	}
+
+	// Delete the instantiator.
+	delete _instor;	
+}
+
+AtomSpace* DefaultPatternMatchCB::grab_transient_atomspace(AtomSpace* parent)
+{
+	AtomSpace* transient_atomspace = NULL;
+
+	// See if the cache has one...
+	if (s_transient_cache.size() > 0)
+	{
+		// Grab the mutex lock.
+		std::unique_lock<std::mutex> cache_lock(_transient_cache_mutex);
+
+		// Check to make sure the cache still has one now that we have
+		// the mutex.
+		if (s_transient_cache.size() > 0)
+		{
+			// Pop the last transient atomspace off the cache stack.
+			transient_atomspace = s_transient_cache.back();
+			s_transient_cache.pop_back();
+
+			// Ready it for the new parent atomspace.
+			transient_atomspace->ready_transient(parent);
+		}
+	}
+
+	// If we didn't get one from the cache, then create a new one.
+	if (!transient_atomspace)
+		transient_atomspace = new AtomSpace(parent, TRANSIENT_SPACE);
+
+	return transient_atomspace;
+}
+
+void DefaultPatternMatchCB::release_transient_atomspace(AtomSpace* atomspace)
+{
+	bool atomspace_cached = false;
+
+	// If the cache is not full...
+	if (s_transient_cache.size() < MAX_CACHED_TRANSIENTS)
+	{
+		// Grab the mutex lock.
+		std::unique_lock<std::mutex> cache_lock(_transient_cache_mutex);
+
+		// Check it again since we only now have the mutex locked.
+		if (s_transient_cache.size() < MAX_CACHED_TRANSIENTS)
+		{
+			// Clear this transient atomspace.
+			atomspace->clear_transient();
+
+			// Place this transient into the cache.
+			s_transient_cache.push_back(atomspace);
+
+			// The atomspace has been cached.
+			atomspace_cached = true;
+		}
+	}
+
+	// If we didn't cache the atomspace, then delete it.
+	if (!atomspace_cached)
+		delete atomspace;
+}
+
+#ifdef CACHED_IMPLICATOR
+void DefaultPatternMatchCB::ready(AtomSpace* as)
+{
+	_temp_aspace = grab_transient_atomspace(as);
+	_instor->ready(_temp_aspace);
+
+	_as = as;
+}
+
+void DefaultPatternMatchCB::clear()
+{
+	_vars = NULL;
+	_dynamic = NULL;
+	_have_evaluatables = false;
+	_globs = NULL;
+
+	_have_variables = false;
+	_pattern_body = Handle::UNDEFINED;
+
+	release_transient_atomspace(_temp_aspace);
+	_temp_aspace = NULL;
+	_instor->clear();
+
+	_optionals_present = false;
+	_as = NULL;
+}
+#endif
 
 void DefaultPatternMatchCB::set_pattern(const Variables& vars,
                                         const Pattern& pat)
@@ -57,7 +166,6 @@ void DefaultPatternMatchCB::set_pattern(const Variables& vars,
 	_pattern_body = pat.body;
 	_globs = &pat.globby_terms;
 }
-
 
 /* ======================================================== */
 
@@ -228,8 +336,8 @@ bool DefaultPatternMatchCB::clause_match(const Handle& ptrn,
 		// which seems reasonable, except that everything else in the
 		// default callback ignores the TV on EvaluationLinks. So this
 		// is kind-of schizophrenic here.  Not sure what else to do.
-		_temp_aspace.clear();
-		TruthValuePtr tvp(EvaluationLink::do_eval_scratch(_as, grnd, &_temp_aspace));
+		_temp_aspace->clear();
+		TruthValuePtr tvp(EvaluationLink::do_eval_scratch(_as, grnd, _temp_aspace));
 
 		LAZY_LOG_FINE << "Clause_match evaluation yeilded tv"
 		              << std::endl << tvp->toString() << std::endl;
@@ -276,7 +384,7 @@ bool DefaultPatternMatchCB::eval_term(const Handle& virt,
 	// grounding might be insane.  So we put it here. This is probably
 	// not very efficient, but will do for now...
 
-	Handle gvirt(_instor.instantiate(virt, gnds));
+	Handle gvirt(_instor->instantiate(virt, gnds));
 
 	LAZY_LOG_FINE << "Enter eval_term CB with virt=" << std::endl
 	              << virt->toShortString() << std::endl;
@@ -329,10 +437,10 @@ bool DefaultPatternMatchCB::eval_term(const Handle& virt,
 	}
 	else
 	{
-		_temp_aspace.clear();
+		_temp_aspace->clear();
 		try
 		{
-			tvp = EvaluationLink::do_eval_scratch(_as, gvirt, &_temp_aspace, true);
+			tvp = EvaluationLink::do_eval_scratch(_as, gvirt, _temp_aspace, true);
 		}
 		catch (const NotEvaluatableException& ex)
 		{

--- a/opencog/query/DefaultPatternMatchCB.h
+++ b/opencog/query/DefaultPatternMatchCB.h
@@ -91,7 +91,7 @@ class DefaultPatternMatchCB : public virtual PatternMatchCallback
 	    /**
 	     * The mutex used to control access to the transient atomspace cache.
 	     */
-	    static std::mutex _transient_cache_mutex;
+	    static std::mutex s_transient_cache_mutex;
 
 	    /**
 	     * The transient atomspace cache.

--- a/opencog/query/DefaultPatternMatchCB.h
+++ b/opencog/query/DefaultPatternMatchCB.h
@@ -55,6 +55,7 @@ class DefaultPatternMatchCB : public virtual PatternMatchCallback
 {
 	public:
 		DefaultPatternMatchCB(AtomSpace*);
+		~DefaultPatternMatchCB();
 		virtual void set_pattern(const Variables&, const Pattern&);
 
 		virtual bool node_match(const Handle&, const Handle&);
@@ -87,6 +88,16 @@ class DefaultPatternMatchCB : public virtual PatternMatchCallback
 		bool optionals_present(void) { return _optionals_present; }
 	protected:
 
+	    /**
+	     * The mutex used to control access to the transient atomspace cache.
+	     */
+	    static std::mutex _transient_cache_mutex;
+
+	    /**
+	     * The transient atomspace cache.
+	     */
+		static std::vector<AtomSpace*> s_transient_cache;
+
 		ClassServer& _classserver;
 
 		const Variables* _vars = NULL;
@@ -98,9 +109,16 @@ class DefaultPatternMatchCB : public virtual PatternMatchCallback
 		Handle _pattern_body;
 
 		// Temp atomspace used for test-groundings of virtual links.
-		AtomSpace _temp_aspace;
-		Instantiator _instor;
+		AtomSpace* _temp_aspace;
+		Instantiator* _instor;
 
+		static AtomSpace* grab_transient_atomspace(AtomSpace* parent);
+		static void release_transient_atomspace(AtomSpace* atomspace);
+
+#ifdef CACHED_IMPLICATOR
+		virtual void ready(AtomSpace*);
+		virtual void clear();
+#endif
 		// Crisp-logic evaluation of evaluatable terms
 		std::set<Type> _connectives;
 		bool eval_term(const Handle& pat,

--- a/opencog/query/Implicator.cc
+++ b/opencog/query/Implicator.cc
@@ -136,8 +136,13 @@ static Handle do_imply(AtomSpace* as,
  */
 Handle bindlink(AtomSpace* as, const Handle& hbindlink)
 {
-	// Now perform the search.
+#ifdef CACHED_IMPLICATOR
+	CachedDefaultImplicator impl(as);
+#else
 	DefaultImplicator impl(as);
+#endif
+	
+	// Now perform the search.
 	return do_imply(as, hbindlink, impl);
 }
 

--- a/opencog/query/Implicator.h
+++ b/opencog/query/Implicator.h
@@ -64,6 +64,14 @@ class Implicator :
 		Handle implicand;
 		size_t max_results;
 
+#ifdef CACHED_IMPLICATOR
+		virtual void ready(AtomSpace* asp)
+		{ inst.ready(asp); max_results = SIZE_MAX; }
+
+		virtual void clear()
+		{ inst.clear(); implicand = Handle::UNDEFINED; }
+#endif
+
 		virtual bool grounding(const std::map<Handle, Handle> &var_soln,
 		                       const std::map<Handle, Handle> &term_soln);
 

--- a/opencog/query/InitiateSearchCB.cc
+++ b/opencog/query/InitiateSearchCB.cc
@@ -38,13 +38,49 @@ using namespace opencog;
 /* ======================================================== */
 
 InitiateSearchCB::InitiateSearchCB(AtomSpace* as) :
-	_classserver(classserver()),
-	_variables(NULL),
-	_pattern(NULL),
-	_dynamic(NULL),
-	_as(as)
+	_classserver(classserver())
 {
+#ifdef CACHED_IMPLICATOR
+	InitiateSearchCB::clear();
+	InitiateSearchCB::ready(as);
+#else
+	_variables = NULL;
+	_pattern = NULL;
+	_dynamic = NULL;
+	_pl = NULL;
+
+	_root = Handle::UNDEFINED;
+	_starter_term = Handle::UNDEFINED;
+
+	_curr_clause = 0;
+	_choices.clear();
+ 	_search_fail = false;
+	_as = as;
+#endif
 }
+
+#ifdef CACHED_IMPLICATOR
+void InitiateSearchCB::ready(AtomSpace* as)
+{
+	_as = as;
+}
+
+void InitiateSearchCB::clear()
+{
+	_variables = NULL;
+	_pattern = NULL;
+	_dynamic = NULL;
+	_pl = NULL;
+
+	_root = Handle::UNDEFINED;
+	_starter_term = Handle::UNDEFINED;
+
+	_curr_clause = 0;
+	_choices.clear();
+ 	_search_fail = false;
+	_as = NULL;
+}
+#endif
 
 void InitiateSearchCB::set_pattern(const Variables& vars,
                                    const Pattern& pat)

--- a/opencog/query/InitiateSearchCB.h
+++ b/opencog/query/InitiateSearchCB.h
@@ -92,6 +92,11 @@ protected:
 	virtual bool variable_search(PatternMatchEngine *);
 	virtual bool no_search(PatternMatchEngine *);
 
+#ifdef CACHED_IMPLICATOR
+	virtual void ready(AtomSpace*);
+	virtual void clear();
+#endif
+
 	AtomSpace *_as;
 };
 


### PR DESCRIPTION
Linas's prior changes to bindlink made it 80% faster. It was originally:

```
Test                                        Time per op  Ops per second
----                                        -----------  --------------
Bind - bindlink - Cython                      360.240µs           2,775
```
and after Linas's changes:
```
Test                                        Time per op  Ops per second
----                                        -----------  --------------
Bind - bindlink - Cython                      202.252µs           4,944
```

Implementing a multi-threaded cache for the transient atomspaces made binklink 5X faster. It is now:

```
Test                                        Time per op  Ops per second
----                                        -----------  --------------
Bind - bindlink - Cython                       39.998µs          25,001
```

I originally tried caching the entire DefaultImplicator but couldn't get that working for some reason and decided to check in the atomspace cache as that was the biggest likely savings. 

I've left the mostly implemented implication cache code in #ifdef CACHED_IMPLICATOR blocks and will add it back in later. But I've got more important work, at the moment.