### PR TITLE
Allow DefinedPredicateNodes in EvaluationLinks.

### DIFF
--- a/opencog/atoms/core/LambdaLink.h
+++ b/opencog/atoms/core/LambdaLink.h
@@ -61,12 +61,10 @@ public:
 	// Take the list of values `vals`, and substitute them in for the
 	// variables in the body of this lambda. The values must satisfy all
 	// type restrictions, else an exception will be thrown.
-/*
 	Handle substitute(const HandleSeq& vals) const
 	{
-		return VariableList::substitute(_body, vals);
+		return get_variables().substitute(_body, vals);
 	}
-*/
 };
 
 typedef std::shared_ptr<LambdaLink> LambdaLinkPtr;

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -188,9 +188,16 @@ static void thread_eval_tv(AtomSpace* as,
 	*tv = EvaluationLink::do_eval_scratch(as, evelnk, scratch, silent);
 }
 
-/// do_evaluate -- evaluate the GroundedPredicateNode of the EvaluationLink
+/// do_evaluate -- evaluate any Node or Link types that can meaningfully
+/// result in a truth value.
 ///
-/// Expects the argument to be an EvaluationLink, which should have the
+/// For example, evaluating a TrueLink returns TruthValue::TRUE_TV, and
+/// evaluating a FalseLink returns TruthValue::FALSE_TV.  Evaluating
+/// AndLink, OrLink returns the boolean and, or of their respective
+/// arguments.  A wide variety of Link types are evaluatable, this
+/// handles them all.
+///
+/// If the argument to be an EvaluationLink, it should have the
 /// following structure:
 ///
 ///     EvaluationLink
@@ -471,25 +478,36 @@ TruthValuePtr EvaluationLink::do_evaluate(AtomSpace* as, const HandleSeq& sna)
 
 /// do_evaluate -- evaluate the GroundedPredicateNode of the EvaluationLink
 ///
-/// Expects "gsn" to be a GroundedPredicateNode
+/// Expects "pn" to be a GroundedPredicateNode or a DefinedPredicateNode
 /// Expects "args" to be a ListLink
 /// Executes the GroundedPredicateNode, supplying the args as argument
 ///
 TruthValuePtr EvaluationLink::do_evaluate(AtomSpace* as,
-                                    const Handle& gsn, const Handle& args)
+                                    const Handle& pn, const Handle& args)
 {
-	if (GROUNDED_PREDICATE_NODE != gsn->getType())
+	Type pntype = pn->getType();
+	if (DEFINED_PREDICATE_NODE == pntype)
 	{
-		// Throw a silent exception; this is called in some try..catch blocks.
-		throw NotEvaluatableException();
+printf("duuuude hola %s\n", pn->toString().c_str());
+		Handle defn = DefineLink::get_definition(pn);
+printf("duuuude defn %s\n", defn->toString().c_str());
+
+return TruthValue::TRUE_TV();
 	}
+
 	if (LIST_LINK != args->getType())
 	{
 		throw RuntimeException(TRACE_INFO, "Expecting arguments to EvaluationLink!");
 	}
 
+	if (GROUNDED_PREDICATE_NODE != pntype)
+	{
+		// Throw a silent exception; this is called in some try..catch blocks.
+		throw NotEvaluatableException();
+	}
+
 	// Get the schema name.
-	const std::string& schema = NodeCast(gsn)->getName();
+	const std::string& schema = pn->getName();
 	// printf ("Grounded schema name: %s\n", schema.c_str());
 
 	// A very special-case C++ comparison.

--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -147,7 +147,8 @@ SCM SchemeSmob::equalp_misc(SCM a, SCM b)
 
 /* ============================================================== */
 
-void SchemeSmob::throw_exception(const char *msg, const char * func)
+[[ noreturn ]] void SchemeSmob::throw_exception(const char *msg,
+                                                const char * func)
 {
 	if (msg and msg[0] != 0)
 	{
@@ -166,6 +167,7 @@ void SchemeSmob::throw_exception(const char *msg, const char * func)
 	}
 	else
 	{
+		logger().error("Guile caught unknown C++ exception");
 		// scm_misc_error(fe->get_name(), "unknown C++ exception", SCM_EOL);
 		scm_error_scm(
 			scm_from_utf8_symbol("C++ exception"),
@@ -173,8 +175,11 @@ void SchemeSmob::throw_exception(const char *msg, const char * func)
 			scm_from_utf8_string("unknown C++ exception"),
 			SCM_EOL,
 			SCM_EOL);
-		logger().error("Guile caught unknown C++ exception");
+		// Hmm. scm_error never returns.
 	}
+
+	// The scm functions never return, so this throw can never occur.
+	throw "Impossible, this can't happen";
 }
 
 /* ============================================================== */

--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -149,7 +149,8 @@ SCM SchemeSmob::equalp_misc(SCM a, SCM b)
 
 void SchemeSmob::throw_exception(const char *msg, const char * func)
 {
-	if (msg) {
+	if (msg and msg[0] != 0)
+	{
 		// Should we even bother to log this?  Probably not ...
 		logger().info("Guile caught C++ exception: %s", msg);
 


### PR DESCRIPTION
Behaves similarly to GroundedPredicateNodes: the definition is expanded before being used.