### PR TITLE
Send an atomspace from scheme to python.

### DIFF
--- a/opencog/cython/PythonEval.cc
+++ b/opencog/cython/PythonEval.cc
@@ -516,7 +516,7 @@ PyObject* PythonEval::atomspace_py_object(AtomSpace* atomspace)
     // The py_atomspace function pointer will be NULL if the
     // opencopg.atomspace cython module failed to load. Avert
     // a hard-to-debug crash on null-pointer-deref, and replace
-    // it by a hard-to-debug error message.
+    // it by a slightly less hard-to-debug error message.
     if (NULL == py_atomspace) {
         logger().error("PythonEval::%s Failed to load the"
                        "opencog.atomspace module", __FUNCTION__);
@@ -756,8 +756,7 @@ PyObject* PythonEval::call_user_function(const std::string& moduleFunction,
         throw RuntimeException(TRACE_INFO,
             "Expecting arguments to be a ListLink!");
     }
-    LinkPtr linkArguments(LinkCast(arguments));
-    int actualArgumentCount = linkArguments->getArity();
+    int actualArgumentCount = arguments->getArity();
 
     // Now make sure the expected count matches the actual argument count.
     if (expectedArgumentCount != actualArgumentCount) {
@@ -772,7 +771,7 @@ PyObject* PythonEval::call_user_function(const std::string& moduleFunction,
     // atoms for each of the atoms in the link arguments.
     PyObject* pyArguments = PyTuple_New(actualArgumentCount);
     PyObject* pyAtomSpace = this->atomspace_py_object(_atomspace);
-    const HandleSeq& argumentHandles = linkArguments->getOutgoingSet();
+    const HandleSeq& argumentHandles = arguments->getOutgoingSet();
     int tupleItem = 0;
     for (HandleSeq::const_iterator it = argumentHandles.begin();
         it != argumentHandles.end(); ++it) {
@@ -917,6 +916,119 @@ TruthValuePtr PythonEval::apply_tv(AtomSpace *as, const std::string& func, Handl
     // Release the GIL. No Python API allowed beyond this point.
     PyGILState_Release(gstate);
     return tvp;
+}
+
+/**
+ * Call the user defined function with the provide atomspace argument.
+ * This is a cut-n-paste of PythonEval::call_user_function but with
+ * assorted hacks to handle the different argument type.
+ *
+ * On error throws an exception.
+ */
+void PythonEval::apply_as(const std::string& moduleFunction,
+                          AtomSpace* as)
+{
+    std::lock_guard<std::recursive_mutex> lck(_mtx);
+
+    PyObject *pyError, *pyModule, *pyUserFunc;
+    PyObject *pyDict;
+    std::string functionName;
+    std::string errorString;
+
+    // Grab the GIL.
+    PyGILState_STATE gstate;
+    gstate = PyGILState_Ensure();
+
+    // Get the module and stripped function name.
+    pyModule = this->module_for_function(moduleFunction, functionName);
+
+    // If we can't find that module then throw an exception.
+    if (!pyModule) {
+        PyGILState_Release(gstate);
+        logger().error("Python module for '%s' not found!", moduleFunction.c_str());
+        throw RuntimeException(TRACE_INFO,
+            "Python module for '%s' not found!",
+            moduleFunction.c_str());
+    }
+
+    // Get a reference to the user function.
+    pyDict = PyModule_GetDict(pyModule);
+    pyUserFunc = PyDict_GetItemString(pyDict, functionName.c_str());
+
+    // PyModule_GetDict returns a borrowed reference, so don't do this:
+    // Py_DECREF(pyDict);
+
+    // If we can't find that function then throw an exception.
+    if (!pyUserFunc) {
+        PyGILState_Release(gstate);
+        throw RuntimeException(TRACE_INFO,
+            "Python function '%s' not found!",
+            moduleFunction.c_str());
+    }
+
+    // Promote the borrowed reference for pyUserFunc since it will
+    // be passed to a Python C API function later that "steals" it.
+    Py_INCREF(pyUserFunc);
+
+    // Make sure the function is callable.
+    if (!PyCallable_Check(pyUserFunc)) {
+        Py_DECREF(pyUserFunc);
+        PyGILState_Release(gstate);
+        throw RuntimeException(TRACE_INFO,
+            "Python function '%s' not callable!", moduleFunction.c_str());
+    }
+
+    // Get the expected argument count.
+    int expectedArgumentCount = this->argument_count(pyUserFunc);
+    if (expectedArgumentCount == MISSING_FUNC_CODE) {
+        PyGILState_Release(gstate);
+        throw RuntimeException(TRACE_INFO,
+            "Python function '%s' error missing 'func_code'!",
+            moduleFunction.c_str());
+    }
+
+    // Make sure the argument count is 1 (just the atomspace)
+    if (1 != expectedArgumentCount) {
+        PyGILState_Release(gstate);
+        throw RuntimeException(TRACE_INFO,
+            "Python function '%s' which expects '%d arguments,"
+            " should have one atomspace argument!",
+            moduleFunction.c_str(), expectedArgumentCount);
+    }
+
+    // Create the Python tuple for the function call with python
+    // atomspace.
+    PyObject* pyArguments = PyTuple_New(1);
+    PyObject* pyAtomSpace = this->atomspace_py_object(_atomspace);
+
+    PyTuple_SetItem(pyArguments, 0, pyAtomSpace);
+    // Py_DECREF(pyAtomSpace);
+
+    // Execute the user function.
+    PyObject_CallObject(pyUserFunc, pyArguments);
+
+    // Cleanup the reference counts for Python objects we no longer reference.
+    // Since we promoted the borrowed pyExecuteUserFunc reference, we need
+    // to decrement it here. Do this before error checking below since we'll
+    // need to decrement these references even if there is an error.
+    Py_DECREF(pyUserFunc);
+    Py_DECREF(pyArguments);
+
+    // Check for errors.
+    pyError = PyErr_Occurred();
+    if (pyError) {
+
+        // Construct the error message and throw an exception.
+        this->build_python_error_message(moduleFunction.c_str(), errorString);
+        PyGILState_Release(gstate);
+        throw RuntimeException(TRACE_INFO, "%s", errorString.c_str());
+
+        // PyErr_Occurred returns a borrowed reference, so don't do this:
+        // Py_DECREF(pyError);
+    }
+
+    // Release the GIL. No Python API allowed beyond this point.
+    PyGILState_Release(gstate);
 }
 
 std::string PythonEval::apply_script(const std::string& script)

--- a/opencog/cython/PythonEval.cc
+++ b/opencog/cython/PythonEval.cc
@@ -447,13 +447,14 @@ PythonEval& PythonEval::instance(AtomSpace* atomspace)
 
 #define CHECK_SINGLETON
 #ifdef CHECK_SINGLETON
-        // Someone is trying to initialize the Python interpreter on a
-        // different AtomSpace.  Because of the singleton design of the
-        // the CosgServer+AtomSpace, there is no easy way to support this...
-        throw RuntimeException(TRACE_INFO,
-            "Trying to re-initialize python interpreter with different\n"
-            "AtomSpace ptr! Current ptr=%p New ptr=%p\n",
-            singletonInstance->_atomspace, atomspace);
+        if (nullptr != singletonInstance->_atomspace)
+            // Someone is trying to initialize the Python interpreter on a
+            // different AtomSpace.  Because of the singleton design of the
+            // the CosgServer+AtomSpace, there is no easy way to support this...
+            throw RuntimeException(TRACE_INFO,
+                "Trying to re-initialize python interpreter with different\n"
+                "AtomSpace ptr! Current ptr=%p New ptr=%p\n",
+                singletonInstance->_atomspace, atomspace);
 #else
         // We need to be able to call the python interpreter with
         // different atomspaces; for example, we need to use temporary
@@ -514,7 +515,7 @@ void PythonEval::initialize_python_objects_and_imports(void)
 PyObject* PythonEval::atomspace_py_object(AtomSpace* atomspace)
 {
     // The py_atomspace function pointer will be NULL if the
-    // opencopg.atomspace cython module failed to load. Avert
+    // opencog.atomspace cython module failed to load. Avert
     // a hard-to-debug crash on null-pointer-deref, and replace
     // it by a slightly less hard-to-debug error message.
     if (NULL == py_atomspace) {
@@ -574,8 +575,8 @@ void PythonEval::print_dictionary(PyObject* obj)
  *
  * Only call this when PyErr_Occurred() returns a non-null PyObject*.
  */
-void PythonEval::build_python_error_message(    const char* function_name,
-                                                std::string& errorMessage)
+void PythonEval::build_python_error_message(const char* function_name,
+                                            std::string& errorMessage)
 {
     PyObject *pyErrorType, *pyError, *pyTraceback, *pyErrorString;
     std::stringstream errorStringStream;

--- a/opencog/cython/PythonEval.cc
+++ b/opencog/cython/PythonEval.cc
@@ -926,7 +926,7 @@ TruthValuePtr PythonEval::apply_tv(AtomSpace *as, const std::string& func, Handl
  * On error throws an exception.
  */
 void PythonEval::apply_as(const std::string& moduleFunction,
-                          AtomSpace* as)
+                          AtomSpace* as_argument)
 {
     std::lock_guard<std::recursive_mutex> lck(_mtx);
 
@@ -999,7 +999,7 @@ void PythonEval::apply_as(const std::string& moduleFunction,
     // Create the Python tuple for the function call with python
     // atomspace.
     PyObject* pyArguments = PyTuple_New(1);
-    PyObject* pyAtomSpace = this->atomspace_py_object(_atomspace);
+    PyObject* pyAtomSpace = this->atomspace_py_object(as_argument);
 
     PyTuple_SetItem(pyArguments, 0, pyAtomSpace);
     // Py_DECREF(pyAtomSpace);

--- a/opencog/cython/PythonEval.h
+++ b/opencog/cython/PythonEval.h
@@ -178,14 +178,22 @@ class PythonEval : public GenericEval
         std::string apply_script(const std::string& script);
 
         /**
-         * Calls the Python function passed in 'func' returning a Handle.
+         * Calls the Python function passed in `func`, passing it
+         * the `varargs` as an argument, and returning a Handle.
          */
         Handle apply(AtomSpace*, const std::string& func, Handle varargs);
 
         /**
-         * Calls the Python function passed in 'func' returning a TruthValuePtr.
+         * Calls the Python function passed in `func`, passing it
+         * the `varargs` as an argument, returning a TruthValuePtr.
          */
         TruthValuePtr apply_tv(AtomSpace*, const std::string& func, Handle varargs);
+
+        /**
+         * Calls the Python function passed in `func`, passing it
+         * the AtomSpace as an argument, returning void.
+         */
+        void apply_as(const std::string& func, AtomSpace*);
 
         /**
          *

--- a/opencog/cython/PythonSCM.cc
+++ b/opencog/cython/PythonSCM.cc
@@ -26,6 +26,7 @@
 #define _OPENCOG_PYTHON_SCM_H
 
 #include <string>
+#include <opencog/atomspace/AtomSpace.h>
 
 namespace opencog
 {
@@ -42,7 +43,7 @@ private:
 public:
 	PythonSCM();
 	const std::string& eval(const std::string&);
-	void apply_as(const std::string&);
+	void apply_as(const std::string&, AtomSpace*);
 }; // class
 
 /** @}*/
@@ -108,11 +109,11 @@ const std::string& PythonSCM::eval(const std::string& pystr)
 	return rv;
 }
 
-void PythonSCM::apply_as(const std::string& pystr)
+void PythonSCM::apply_as(const std::string& pystr, AtomSpace* as)
 {
 	static PythonEval& pyev = PythonEval::instance();
 
-	pyev.apply_as(pystr, NULL);
+	pyev.apply_as(pystr, as);
 }
 
 void opencog_python_init(void)

--- a/opencog/cython/PythonSCM.cc
+++ b/opencog/cython/PythonSCM.cc
@@ -42,6 +42,7 @@ private:
 public:
 	PythonSCM();
 	const std::string& eval(const std::string&);
+	void apply_as(const std::string&);
 }; // class
 
 /** @}*/
@@ -90,6 +91,7 @@ void PythonSCM::init(void)
 {
 #ifdef HAVE_GUILE
 	define_scheme_primitive("python-eval", &PythonSCM::eval, this, "python");
+	define_scheme_primitive("python-call-with-as", &PythonSCM::apply_as, this, "python");
 #endif
 }
 
@@ -97,13 +99,20 @@ const std::string& PythonSCM::eval(const std::string& pystr)
 {
 	static PythonEval& pyev = PythonEval::instance();
 
-	// Because we are returning a refernce to string (!!) we need to
+	// Because we are returning a reference to string(!!), we need to
 	// keep a thread-local copy of it around, for the caller to fetch.
 	// Note that PythonEval appears to be thread-safe, so we don't
 	// need any locks here.
 	thread_local std::string rv;
 	rv = pyev.eval(pystr);
 	return rv;
+}
+
+void PythonSCM::apply_as(const std::string& pystr)
+{
+	static PythonEval& pyev = PythonEval::instance();
+
+	pyev.apply_as(pystr, NULL);
 }
 
 void opencog_python_init(void)

--- a/opencog/guile/SchemePrimitive.h
+++ b/opencog/guile/SchemePrimitive.h
@@ -117,10 +117,11 @@ class SchemePrimitive : public PrimitiveEnviron
 			                               const std::string&);
 			const std::string& (T::*s_v)(void);
 			TruthValuePtr (T::*p_h)(Handle);
-			UUID (T::*u_ssb)(const std::string&,const std::string&,bool);
+			UUID (T::*u_ssb)(const std::string&, const std::string&, bool);
 			void (T::*v_b)(bool);
 			void (T::*v_h)(Handle);
 			void (T::*v_s)(const std::string&);
+			void (T::*v_sa)(const std::string&, AtomSpace*);
 			void (T::*v_ss)(const std::string&,
 			                const std::string&);
 			void (T::*v_sss)(const std::string&,
@@ -163,6 +164,7 @@ class SchemePrimitive : public PrimitiveEnviron
 			V_B,   // return void, take bool
 			V_H,   // return void, take Handle
 			V_S,   // return void, take string
+			V_SA,  // return void, take string, Atomspace
 			V_SS,  // return void, take two strings
 			V_SSS, // return void, take three strings
 			V_T,   // return void, take Type
@@ -500,6 +502,16 @@ class SchemePrimitive : public PrimitiveEnviron
 					(that->*method.v_s)(str);
 					break;
 				}
+				case V_SA:
+				{
+					// First argument is a string
+					std::string str(SchemeSmob::verify_string(scm_car(args), scheme_name, 1));
+
+					// Second argument is an AtomSpace
+					AtomSpace* as = SchemeSmob::verify_atomspace(scm_car(args), scheme_name, 2);
+					(that->*method.v_sa)(str,as);
+					break;
+				}
 				case V_SS:
 				{
 					// All args are strings
@@ -652,6 +664,8 @@ class SchemePrimitive : public PrimitiveEnviron
 		DECLARE_CONSTR_1(V_B,    v_b,  void, bool)
 		DECLARE_CONSTR_1(V_H,    v_h,  void, Handle)
 		DECLARE_CONSTR_1(V_S,    v_s,  void, const std::string&)
+		DECLARE_CONSTR_2(V_SA,   v_sa, void, const std::string&,
+		                               AtomSpace*)
 		DECLARE_CONSTR_2(V_SS,   v_ss, void, const std::string&,
 		                               const std::string&)
 		DECLARE_CONSTR_3(V_SSS,  v_sss,void, const std::string&,
@@ -718,6 +732,7 @@ DECLARE_DECLARE_2(Handle, const std::string&, const HandleSeq&)
 DECLARE_DECLARE_2(HandleSeqSeq, Handle, int)
 DECLARE_DECLARE_2(const std::string&, AtomSpace*, const std::string&)
 DECLARE_DECLARE_2(const std::string&, const std::string&, const std::string&)
+DECLARE_DECLARE_2(void, const std::string&, AtomSpace*)
 DECLARE_DECLARE_2(void, const std::string&, const std::string&)
 DECLARE_DECLARE_2(void, Type, int)
 DECLARE_DECLARE_3(double, Handle, Handle, Type)

--- a/opencog/guile/SchemePrimitive.h
+++ b/opencog/guile/SchemePrimitive.h
@@ -508,7 +508,7 @@ class SchemePrimitive : public PrimitiveEnviron
 					std::string str(SchemeSmob::verify_string(scm_car(args), scheme_name, 1));
 
 					// Second argument is an AtomSpace
-					AtomSpace* as = SchemeSmob::verify_atomspace(scm_car(args), scheme_name, 2);
+					AtomSpace* as = SchemeSmob::verify_atomspace(scm_cadr(args), scheme_name, 2);
 					(that->*method.v_sa)(str,as);
 					break;
 				}

--- a/opencog/scm/opencog/python.scm
+++ b/opencog/scm/opencog/python.scm
@@ -8,3 +8,12 @@
 (use-modules (opencog))
 
 (load-extension "libPythonSCM" "opencog_python_init")
+
+(set-procedure-property! python-eval 'documentation
+"
+ python-eval STRING
+    Evaluate the STRING within the current python evaluator. The STRING
+    argument can be any valid python code.
+
+    Example: (python-eval "print ('hello! ' + str(2+2))")
+")

--- a/opencog/scm/opencog/python.scm
+++ b/opencog/scm/opencog/python.scm
@@ -28,4 +28,16 @@
 
     Example:
       (python-call-with-as \"set_type_ctor_atomspace\" (cog-atomspace))
+
+    A more complicated example:
+      (python-eval \"
+      from opencog.atomspace import AtomSpace, TruthValue
+      from opencog.atomspace import types
+
+      def foo(asp):
+          TV = TruthValue(0.42, 0.69)
+          asp.add_node(types.ConceptNode, 'Apple', TV)
+      \")
+      (python-call-with-as \"foo\" (cog-atomspace))
+      (cog-node 'ConceptNode \"Apple\")
 ")

--- a/opencog/scm/opencog/python.scm
+++ b/opencog/scm/opencog/python.scm
@@ -15,5 +15,5 @@
     Evaluate the STRING within the current python evaluator. The STRING
     argument can be any valid python code.
 
-    Example: (python-eval "print ('hello! ' + str(2+2))")
+    Example: (python-eval \"print ('hello! ' + str(2+2))\")
 ")

--- a/opencog/scm/opencog/python.scm
+++ b/opencog/scm/opencog/python.scm
@@ -17,3 +17,15 @@
 
     Example: (python-eval \"print ('hello! ' + str(2+2))\")
 ")
+
+(set-procedure-property! python-call-with-as 'documentation
+"
+ python-call-with-as FUNC ATOMSPACE
+    Call the python function FUNC, passing the ATOMSPACE as an argument.
+    The FUNC should be a scheme string.  This is meant to allow both
+    scheme and python to share a common atomspace, by using the example
+    below.
+
+    Example:
+      (python-call-with-as \"set_type_ctor_atomspace\" (cog-atomspace))
+")


### PR DESCRIPTION
In order to get rid of the cogserver once and for all, there needs to be a way to share the atomspace between guile and python.  This provides that technique.