### PR TITLE
Fixed speed problem with EinsteinUTest

### DIFF
--- a/opencog/atomspace/AtomSpace.cc
+++ b/opencog/atomspace/AtomSpace.cc
@@ -408,32 +408,6 @@ std::string AtomSpace::to_string()
 	return ss.str();
 }
 
-void AtomSpace::clear()
-{
-    std::vector<Handle> allAtoms;
-
-    _atom_table.getHandlesByType(back_inserter(allAtoms), ATOM, true, false);
-
-    DPRINTF("atoms in allAtoms: %lu\n", allAtoms.size());
-
-    // Uncomment to turn on logging at DEBUG level.
-    // Logger::Level save = logger().get_level();
-    // logger().set_level(Logger::DEBUG);
-
-    // XXX FIXME TODO This is a stunningly inefficient way to clear the
-    // atomspace! This will take minutes on any decent-sized atomspace!
-    std::vector<Handle>::iterator i;
-    for (i = allAtoms.begin(); i != allAtoms.end(); ++i) {
-        purge_atom(*i, true);
-    }
-
-    allAtoms.clear();
-    _atom_table.getHandlesByType(back_inserter(allAtoms), ATOM, true, false);
-    assert(allAtoms.size() == 0);
-
-    // logger().set_level(save);
-}
-
 namespace std {
 
 ostream& operator<<(ostream& out, const opencog::AtomSpace& as) {

--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -110,7 +110,8 @@ public:
     inline UUID get_uuid(void) const { return _atom_table.get_uuid(); }
 
     //! Clear the atomspace, remove all atoms
-    void clear();
+    void clear()
+        { _atom_table.clear(); }
 
     /**
      * Add an atom to the Atom Table.  If the atom already exists

--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -173,6 +173,9 @@ public:
     void ready_transient(AtomTable* parent, AtomSpace* holder);
     void clear_transient();
 
+    void clear_all_atoms();
+    void clear();
+
     UUID get_uuid(void) const { return _uuid; }
     AtomTable* get_environ(void) const { return _environ; }
     AtomSpace* getAtomSpace(void) const { return _as; }


### PR DESCRIPTION
Moved the `clear` code for atom space to the atom table since it was using only atom table methods anyway. 

Then special-cased `clear` to use the faster `clear` for transient atom spaces. Also moved the guts of `clear_transient` out into a separate function `clear_all_atoms` that is used for both `clear` and `clear_transient`.