### PR TITLE
#658 cog-bind-first-n, cog-satisfying-set-first-n

### DIFF
--- a/opencog/guile/SchemeModule.cc
+++ b/opencog/guile/SchemeModule.cc
@@ -19,6 +19,13 @@ FunctionWrap::FunctionWrap(Handle (f)(AtomSpace*, const Handle&),
 	define_scheme_primitive(_name, &FunctionWrap::as_wrapper_h_h, this, modname);
 }
 
+FunctionWrap::FunctionWrap(Handle (f)(AtomSpace*, unsigned int, const Handle&),
+                           const char* funcname, const char* modname)
+	: _func_h_auh(f), _name(funcname)
+{
+	define_scheme_primitive(_name, &FunctionWrap::as_wrapper_h_uh, this, modname);
+}
+
 FunctionWrap::FunctionWrap(TruthValuePtr (p)(AtomSpace*, const Handle&),
                            const char* funcname, const char* modname)
 	: _pred_ah(p), _name(funcname)
@@ -31,6 +38,13 @@ Handle FunctionWrap::as_wrapper_h_h(Handle h)
 	// XXX we should also allow opt-args to be a list of handles
 	AtomSpace *as = SchemeSmob::ss_get_env_as(_name);
 	return _func_h_ah(as, h);
+}
+
+Handle FunctionWrap::as_wrapper_h_uh(unsigned int u, Handle h)
+{
+	// XXX we should also allow opt-args to be a list of handles
+	AtomSpace *as = SchemeSmob::ss_get_env_as(_name);
+	return _func_h_auh(as, u, h);
 }
 
 TruthValuePtr FunctionWrap::as_wrapper_p_h(Handle h)

--- a/opencog/guile/SchemeModule.h
+++ b/opencog/guile/SchemeModule.h
@@ -26,7 +26,9 @@ class FunctionWrap
 
 		// These wrappers abstract the atomspace away.
 		Handle (*_func_h_ah)(AtomSpace*, const Handle&);
+		Handle (*_func_h_auh)(AtomSpace*, unsigned int, const Handle&);
 		Handle as_wrapper_h_h(Handle);
+		Handle as_wrapper_h_uh(unsigned int, Handle);
 
 		// These wrappers return a TruthValuePtr and abstract the
 		// atomspace away.
@@ -36,6 +38,8 @@ class FunctionWrap
 		const char *_name;  // scheme name of the c++ function.
 	public:
 		FunctionWrap(Handle (*)(AtomSpace*, const Handle&),
+		             const char*, const char*);
+		FunctionWrap(Handle (*)(AtomSpace*, unsigned int, const Handle&),
 		             const char*, const char*);
 		FunctionWrap(TruthValuePtr (*)(AtomSpace*, const Handle&),
 		             const char*, const char*);

--- a/opencog/guile/SchemePrimitive.h
+++ b/opencog/guile/SchemePrimitive.h
@@ -84,6 +84,7 @@ class SchemePrimitive : public PrimitiveEnviron
 			// s == string
 			// p == TruthValuePtr
 			// t == Type
+			// u == unsigned int
 			// v == void
 			// Extend the above, if required.
 
@@ -102,6 +103,7 @@ class SchemePrimitive : public PrimitiveEnviron
 			Handle (T::*h_sq)(const std::string&, const HandleSeq&);
 			Handle (T::*h_sqq)(const std::string&,
 			                   const HandleSeq&, const HandleSeq&);
+			Handle (T::*h_uh)(unsigned int, Handle);
 			HandleSeq (T::*q_h)(Handle);
 			HandleSeq (T::*q_hti)(Handle, Type, int);
 			HandleSeq (T::*q_htib)(Handle, Type, int, bool);
@@ -148,6 +150,7 @@ class SchemePrimitive : public PrimitiveEnviron
 			H_HTQ, // return handle, take handle, type, and HandleSeq
 			H_SQ,  // return handle, take string and HandleSeq
 			H_SQQ, // return handle, take string, HandleSeq and HandleSeq
+			H_UH,  // return handle, take unsigned int and handle
 			Q_H,   // return HandleSeq, take handle
 			Q_HTI, // return HandleSeq, take handle, type, and int
 			Q_HTIB,// return HandleSeq, take handle, type, and bool
@@ -302,6 +305,14 @@ class SchemePrimitive : public PrimitiveEnviron
 					HandleSeq seq2 = SchemeSmob::verify_handle_list(list2, scheme_name, 3);
 
 					Handle rh((that->*method.h_sqq)(str, seq1, seq2));
+					rc = SchemeSmob::handle_to_scm(rh);
+					break;
+				}
+				case H_UH:
+				{
+					unsigned int u = SchemeSmob::verify_uint(scm_cadr(args), scheme_name, 1);
+					Handle h(SchemeSmob::verify_handle(scm_car(args), scheme_name, 2));
+					Handle rh((that->*method.h_uh)(u,h));
 					rc = SchemeSmob::handle_to_scm(rh);
 					break;
 				}
@@ -633,6 +644,7 @@ class SchemePrimitive : public PrimitiveEnviron
 		DECLARE_CONSTR_2(H_SQ,  h_sq, Handle, const std::string&, const HandleSeq&)
 		DECLARE_CONSTR_3(H_SQQ,  h_sqq, Handle, const std::string&,
 		                                const HandleSeq&, const HandleSeq&)
+		DECLARE_CONSTR_2(H_UH, h_uh, Handle, unsigned int, Handle)
 		DECLARE_CONSTR_1(Q_H,    q_h, HandleSeq, Handle)
 		DECLARE_CONSTR_3(Q_HTI,  q_hti, HandleSeq, Handle, Type, int)
 		DECLARE_CONSTR_4(Q_HTIB, q_htib, HandleSeq, Handle, Type, int, bool)
@@ -715,6 +727,7 @@ DECLARE_DECLARE_2(Handle, Handle, int)
 DECLARE_DECLARE_2(Handle, Handle, Handle)
 DECLARE_DECLARE_2(Handle, Handle, const std::string&)
 DECLARE_DECLARE_2(Handle, const std::string&, const HandleSeq&)
+DECLARE_DECLARE_2(Handle, unsigned int, Handle)
 DECLARE_DECLARE_2(HandleSeqSeq, Handle, int)
 DECLARE_DECLARE_2(const std::string&, AtomSpace*, const std::string&)
 DECLARE_DECLARE_2(const std::string&, const std::string&, const std::string&)

--- a/opencog/guile/SchemePrimitive.h
+++ b/opencog/guile/SchemePrimitive.h
@@ -310,8 +310,8 @@ class SchemePrimitive : public PrimitiveEnviron
 				}
 				case H_UH:
 				{
-					unsigned int u = SchemeSmob::verify_uint(scm_cadr(args), scheme_name, 1);
-					Handle h(SchemeSmob::verify_handle(scm_car(args), scheme_name, 2));
+					unsigned int u = SchemeSmob::verify_uint(scm_car(args), scheme_name, 1);
+					Handle h(SchemeSmob::verify_handle(scm_cadr(args), scheme_name, 2));
 					Handle rh((that->*method.h_uh)(u,h));
 					rc = SchemeSmob::handle_to_scm(rh);
 					break;

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -200,6 +200,8 @@ private:
 	                                  const char *msg = "expecting string");
 	static int verify_int (SCM, const char *, int pos = 1,
 	                       const char *msg = "expecting integer");
+	static unsigned int verify_uint (SCM, const char *, int pos = 1,
+	                        const char *msg = "expecting unsigned integer");
 	static double verify_real (SCM, const char *, int pos = 1,
 	                           const char *msg = "expecting real number");
 

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -197,13 +197,13 @@ private:
 	static std::vector<ProtoAtomPtr> verify_protom_list (SCM, const char *,
 	                                               int pos = 1);
 	static std::string verify_string (SCM, const char *, int pos = 1,
-	                                  const char *msg = "expecting string");
+	                                  const char *msg = "string");
 	static int verify_int (SCM, const char *, int pos = 1,
-	                       const char *msg = "expecting integer");
+	                       const char *msg = "integer");
 	static unsigned int verify_uint (SCM, const char *, int pos = 1,
-	                        const char *msg = "expecting unsigned integer");
+	                        const char *msg = "unsigned integer");
 	static double verify_real (SCM, const char *, int pos = 1,
-	                           const char *msg = "expecting real number");
+	                           const char *msg = "real number");
 
 	static SCM atomspace_fluid;
 	static void ss_set_env_as(AtomSpace *);

--- a/opencog/guile/SchemeSmobNew.cc
+++ b/opencog/guile/SchemeSmobNew.cc
@@ -321,6 +321,19 @@ int SchemeSmob::verify_int (SCM sint, const char *subrname,
 	return scm_to_int(sint);
 }
 
+/**
+ * Check that the argument is an unsigned int, else throw errors.
+ * Return the unsigned int.
+ */
+unsigned int SchemeSmob::verify_uint (SCM sint, const char *subrname,
+                                      int pos, const char * msg)
+{
+	if (scm_is_unsigned_integer(sint, 0, UINT_MAX))
+		scm_wrong_type_arg_msg(subrname, pos, sint, msg);
+
+	return scm_to_uint(sint);
+}
+
 /* ============================================================== */
 /**
  * Convert argument into a list of floats.

--- a/opencog/guile/SchemeSmobNew.cc
+++ b/opencog/guile/SchemeSmobNew.cc
@@ -328,7 +328,7 @@ int SchemeSmob::verify_int (SCM sint, const char *subrname,
 unsigned int SchemeSmob::verify_uint (SCM sint, const char *subrname,
                                       int pos, const char * msg)
 {
-	if (scm_is_unsigned_integer(sint, 0, UINT_MAX))
+	if (!scm_is_unsigned_integer(sint, 0, UINT_MAX))
 		scm_wrong_type_arg_msg(subrname, pos, sint, msg);
 
 	return scm_to_uint(sint);

--- a/opencog/query/BindLinkAPI.h
+++ b/opencog/query/BindLinkAPI.h
@@ -31,9 +31,11 @@ class AtomSpace;
 
 Handle bindlink(AtomSpace*, const Handle&);
 Handle single_bindlink (AtomSpace*, const Handle&);
+Handle first_n_bindlink (AtomSpace*, unsigned int, const Handle&);
 Handle af_bindlink(AtomSpace*, const Handle&);
 TruthValuePtr satisfaction_link(AtomSpace*, const Handle&);
 Handle satisfying_set(AtomSpace*, const Handle&);
+Handle first_n_satisfying_set(AtomSpace*, unsigned int, const Handle&);
 Handle recognize(AtomSpace*, const Handle&);
 
 } // namespace opencog

--- a/opencog/query/Implicator.cc
+++ b/opencog/query/Implicator.cc
@@ -132,7 +132,7 @@ static Handle do_imply(AtomSpace* as,
  * atoms that could be a ground are found in the atomspace, then they
  * will be reported.
  *
- * See the do_bindlink function documentation for details.
+ * See the do_imply function documentation for details.
  */
 Handle bindlink(AtomSpace* as, const Handle& hbindlink)
 {
@@ -152,13 +152,29 @@ Handle bindlink(AtomSpace* as, const Handle& hbindlink)
  * Returns the first match only. Otherwise, the behavior is identical to
  * PatternMatch::bindlink above.
  *
- * See the do_bindlink function documentation for details.
+ * See the do_imply function documentation for details.
  */
 Handle single_bindlink (AtomSpace* as, const Handle& hbindlink)
 {
 	// Now perform the search.
 	DefaultImplicator impl(as);
 	impl.max_results = 1;
+	return do_imply(as, hbindlink, impl);
+}
+
+/**
+ * Evaluate an pattern and rewrite rule embedded in a BindLink
+ *
+ * Returns the first N matches. Otherwise, the behavior is identical to
+ * PatternMatch::bindlink above.
+ *
+ * See the do_imply function documentation for details.
+ */
+Handle first_n_bindlink (AtomSpace* as, unsigned int first_n, const Handle& hbindlink)
+{
+	// Now perform the search.
+	DefaultImplicator impl(as);
+	impl.max_results = first_n;
 	return do_imply(as, hbindlink, impl);
 }
 

--- a/opencog/query/Implicator.cc
+++ b/opencog/query/Implicator.cc
@@ -45,13 +45,16 @@ bool Implicator::grounding(const std::map<Handle, Handle> &var_soln,
                            const std::map<Handle, Handle> &term_soln)
 {
 	// PatternMatchEngine::print_solution(term_soln,var_soln);
+
+	// Do not accept new solution if maximum number has been already reached
+	if (_result_set.size() >= max_results)
+		return true;
+
 	Handle h = inst.instantiate(implicand, var_soln);
 	insert_result(h);
 
 	// If we found as many as we want, then stop looking for more.
-	if (_result_set.size() < max_results)
-		return false;
-	return true;
+	return (_result_set.size() >= max_results);
 }
 
 void Implicator::insert_result(const Handle& h)

--- a/opencog/query/PatternSCM.cc
+++ b/opencog/query/PatternSCM.cc
@@ -69,7 +69,7 @@ void PatternSCM::init(void)
 	// BindLink containing variables, a pattern and a rewrite rules.
 	_binders.push_back(new FunctionWrap(bindlink, "cog-bind", "query"));
 
-	// Identical to do_bindlink above, except that it only returns the
+	// Identical to bindlink above, except that it only returns the
 	// first match.
 	_binders.push_back(new FunctionWrap(single_bindlink,
 	                   "cog-bind-single", "query"));

--- a/opencog/query/PatternSCM.cc
+++ b/opencog/query/PatternSCM.cc
@@ -74,6 +74,12 @@ void PatternSCM::init(void)
 	_binders.push_back(new FunctionWrap(single_bindlink,
 	                   "cog-bind-single", "query"));
 
+	// Identical to bindlink above, except that it only returns the
+	// first N matches, assuming that N is the first argument and
+	// the second is a BindLink handle.
+	_binders.push_back(new FunctionWrap(first_n_bindlink,
+	                   "cog-bind-first-n", "query"));
+
 	// Attentional Focus function
 	_binders.push_back(new FunctionWrap(af_bindlink,
 	                   "cog-bind-af", "query"));
@@ -82,8 +88,16 @@ void PatternSCM::init(void)
 	_binders.push_back(new FunctionWrap(satisfaction_link,
 	                   "cog-satisfy", "query"));
 
+	// Finds set of all variable groundings, assuming that the argument is
+	// a handle to pattern.
 	_binders.push_back(new FunctionWrap(satisfying_set,
 	                   "cog-satisfying-set", "query"));
+
+	// Identical to satisfying_set above, except it only returns the
+	// first N matches, assuming that N is the first argument and
+	// the second is a pattern handle.
+	_binders.push_back(new FunctionWrap(first_n_satisfying_set,
+	                   "cog-satisfying-set-first-n", "query"));
 
 	// Rule recognition.
 	_binders.push_back(new FunctionWrap(recognize,

--- a/opencog/query/Satisfier.cc
+++ b/opencog/query/Satisfier.cc
@@ -90,6 +90,10 @@ bool SatisfyingSet::grounding(const std::map<Handle, Handle> &var_soln,
 {
 	// PatternMatchEngine::print_solution(var_soln, term_soln);
 
+	// Do not accept new solution if maximum number has been already reached
+	if (_satisfying_set.size() >= max_results)
+		return true;
+
 	if (1 == _varseq.size())
 	{
 		_satisfying_set.emplace(var_soln.at(_varseq[0]));

--- a/opencog/query/Satisfier.h
+++ b/opencog/query/Satisfier.h
@@ -93,9 +93,10 @@ class SatisfyingSet :
 {
 	public:
 		SatisfyingSet(AtomSpace* as) :
-			InitiateSearchCB(as), DefaultPatternMatchCB(as) {}
+			InitiateSearchCB(as), DefaultPatternMatchCB(as), max_results(SIZE_MAX) {}
 		HandleSeq _varseq;
 		std::set<Handle> _satisfying_set;
+		size_t max_results;
 
 		virtual void set_pattern(const Variables& vars,
 		                         const Pattern& pat)

--- a/tests/query/CMakeLists.txt
+++ b/tests/query/CMakeLists.txt
@@ -67,6 +67,7 @@ IF (HAVE_GUILE)
 	ADD_CXXTEST(FiniteStateMachineUTest)
 	ADD_CXXTEST(AbsentUTest)
 	ADD_CXXTEST(SingleUTest)
+	ADD_CXXTEST(FirstNUTest)
 	ADD_CXXTEST(AttentionalFocusCBUTest)
 	ADD_CXXTEST(SudokuUTest)
 	ADD_CXXTEST(EinsteinUTest)
@@ -140,6 +141,8 @@ CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/tests/query/seq-presence.scm
     ${PROJECT_BINARY_DIR}/tests/query/seq-presence.scm)
 CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/tests/query/single.scm
     ${PROJECT_BINARY_DIR}/tests/query/single.scm)
+CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/tests/query/firstn.scm
+    ${PROJECT_BINARY_DIR}/tests/query/firstn.scm)
 CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/tests/query/stackmore-o-o.scm
     ${PROJECT_BINARY_DIR}/tests/query/stackmore-o-o.scm)
 CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/tests/query/stackmore-o-u.scm

--- a/tests/query/FirstNUTest.cxxtest
+++ b/tests/query/FirstNUTest.cxxtest
@@ -121,7 +121,7 @@ void FirstNUTest::test_disconnected_satisfying_set(void)
     Handle find_0_pairs = eval->eval_h("(cog-satisfying-set-first-n 0 get-disconnected)");
     TS_ASSERT_EQUALS(0, getarity(find_0_pairs));
 
-    Handle find_2_pairs = eval->eval_h("cog-satisfying-set-first-n 2 get-disconnected)");
+    Handle find_2_pairs = eval->eval_h("(cog-satisfying-set-first-n 2 get-disconnected)");
     TS_ASSERT_EQUALS(2, getarity(find_2_pairs));
 
     Handle find_7_pairs = eval->eval_h("(cog-satisfying-set-first-n 7 get-disconnected)");
@@ -136,7 +136,7 @@ void FirstNUTest::test_wrong_args_satisfying_set(void)
 {
     logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    _test_wrong_args("cog-satisfying-set-first-n get-men");
+    _test_wrong_args("(cog-satisfying-set-first-n get-men)");
     _test_wrong_args("(cog-satisfying-set-first-n -1 get-men)");
     _test_wrong_args("(cog-satisfying-set-first-n \"blah\" get-men)");
     _test_wrong_args("(cog-satisfying-set-first-n (1 get-men))");
@@ -147,17 +147,17 @@ void FirstNUTest::test_simple_bindlink(void)
 {
     logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    Handle find_0_men = eval->eval_h("cog-bind-first-n 0 bind-men");
+    Handle find_0_men = eval->eval_h("(cog-bind-first-n 0 bind-men)");
     TS_ASSERT_EQUALS(0, getarity(find_0_men));
 
-    Handle find_1_man = eval->eval_h("cog-bind-first-n 1 bind-men");
+    Handle find_1_man = eval->eval_h("(cog-bind-first-n 1 bind-men)");
     TS_ASSERT_EQUALS(1, getarity(find_1_man));
 
-    Handle find_3_men = eval->eval_h("cog-bind-first-n 3 bind-men");
+    Handle find_3_men = eval->eval_h("(cog-bind-first-n 3 bind-men)");
     TS_ASSERT_EQUALS(3, getarity(find_3_men));
 
     // only 3 men present
-    Handle find_5_men = eval->eval_h("cog-bind-first-n 5 bind-men");
+    Handle find_5_men = eval->eval_h("(cog-bind-first-n 5 bind-men)");
     TS_ASSERT_EQUALS(3, getarity(find_3_men));
 }
 
@@ -165,17 +165,17 @@ void FirstNUTest::test_disconnected_bindlink(void)
 {
     logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    Handle find_0_pairs = eval->eval_h("cog-bind-first-n 0 bind-disconnected");
+    Handle find_0_pairs = eval->eval_h("(cog-bind-first-n 0 bind-disconnected)");
     TS_ASSERT_EQUALS(0, getarity(find_0_pairs));
 
-    Handle find_2_pairs = eval->eval_h("cog-bind-first-n 2 bind-disconnected");
+    Handle find_2_pairs = eval->eval_h("(cog-bind-first-n 2 bind-disconnected)");
     TS_ASSERT_EQUALS(2, getarity(find_2_pairs));
 
-    Handle find_7_pairs = eval->eval_h("cog-bind-first-n 7 bind-disconnected");
+    Handle find_7_pairs = eval->eval_h("(cog-bind-first-n 7 bind-disconnected)");
     TS_ASSERT_EQUALS(7, getarity(find_7_pairs));
 
     // only 9 pairs present
-    Handle find_12_pairs = eval->eval_h("cog-bind-first-n 12 bind-disconnected");
+    Handle find_12_pairs = eval->eval_h("(cog-bind-first-n 12 bind-disconnected)");
     TS_ASSERT_EQUALS(9, getarity(find_12_pairs));
 }
 
@@ -183,7 +183,7 @@ void FirstNUTest::test_wrong_args_bindlink(void)
 {
     logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    _test_wrong_args("cog-bind-first-n bind-men");
+    _test_wrong_args("(cog-bind-first-n bind-men)");
     _test_wrong_args("(cog-bind-first-n -1 bind-men)");
     _test_wrong_args("(cog-bind-first-n \"blah\" bind-men)");
     _test_wrong_args("(cog-bind-first-n (1 bind-men))");

--- a/tests/query/FirstNUTest.cxxtest
+++ b/tests/query/FirstNUTest.cxxtest
@@ -1,0 +1,191 @@
+/*
+ * tests/query/FirstNUTest.cxxtest
+ *
+ * Copyright (C) 2016 OpenCog Foundation
+ * All Rights Reserved
+ *
+ * Created by Jacek Świergocki <jswiergo@gmail.com> February 2016
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/guile/load-file.h>
+#include <opencog/guile/SchemeEval.h>
+#include <opencog/guile/SchemeSmob.h>
+#include <opencog/atomspace/AtomSpace.h>
+#include <opencog/query/BindLinkAPI.h>
+#include <opencog/util/Config.h>
+#include <opencog/util/Logger.h>
+
+using namespace opencog;
+
+class FirstNUTest: public CxxTest::TestSuite
+{
+private:
+        AtomSpace *as;
+        SchemeEval* eval;
+
+public:
+    FirstNUTest(void)
+    {
+        logger().set_level(Logger::DEBUG);
+        logger().set_print_to_stdout_flag(true);
+
+        as = new AtomSpace();
+        eval = new SchemeEval(as);
+    }
+
+    ~FirstNUTest()
+    {
+        delete eval;
+        delete as;
+        // Erase the log file if no assertions failed.
+        if (!CxxTest::TestTracker::tracker().suiteFailed())
+                std::remove(logger().get_filename().c_str());
+    }
+
+    void setUp(void);
+    void tearDown(void);
+
+    void test_simple_satisfying_set(void);
+    void test_disconnected_satisfying_set(void);
+    void test_wrong_args_satisfying_set(void);
+
+    void test_simple_bindlink(void);
+    void test_disconnected_bindlink(void);
+    void test_wrong_args_bindlink(void);
+
+    void _test_wrong_args(std::string);
+};
+
+void FirstNUTest::tearDown(void)
+{
+}
+
+void FirstNUTest::setUp(void)
+{
+    config().set("SCM_PRELOAD",
+        "opencog/atoms/base/core_types.scm, "
+        "opencog/scm/utilities.scm, "
+        "opencog/scm/opencog/query.scm, "
+        "tests/query/firstn.scm");
+
+    load_scm_files_from_config(*as);
+}
+
+#define getarity(hand) LinkCast(hand)->getArity()
+
+void FirstNUTest::_test_wrong_args(std::string command)
+{
+    eval->eval(command.c_str());
+    bool eval_err = eval->eval_error();
+    eval->clear_pending();
+    TSM_ASSERT(command + " fails to throw error", eval_err);
+}
+
+void FirstNUTest::test_simple_satisfying_set(void)
+{
+    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+    Handle find_0_men = eval->eval_h("(cog-satisfying-set-first-n 0 get-men)");
+    TS_ASSERT_EQUALS(0, getarity(find_0_men));
+
+    Handle find_1_man = eval->eval_h("(cog-satisfying-set-first-n 1 get-men)");
+    TS_ASSERT_EQUALS(1, getarity(find_1_man));
+
+    Handle find_3_men = eval->eval_h("(cog-satisfying-set-first-n 3 get-men)");
+    TS_ASSERT_EQUALS(3, getarity(find_3_men));
+
+    // only 3 men present
+    Handle find_5_men = eval->eval_h("(cog-satisfying-set-first-n 5 get-men)");
+    TS_ASSERT_EQUALS(3, getarity(find_5_men));
+}
+
+void FirstNUTest::test_disconnected_satisfying_set(void)
+{
+    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+    Handle find_0_pairs = eval->eval_h("(cog-satisfying-set-first-n 0 get-disconnected)");
+    TS_ASSERT_EQUALS(0, getarity(find_0_pairs));
+
+    Handle find_2_pairs = eval->eval_h("cog-satisfying-set-first-n 2 get-disconnected)");
+    TS_ASSERT_EQUALS(2, getarity(find_2_pairs));
+
+    Handle find_7_pairs = eval->eval_h("(cog-satisfying-set-first-n 7 get-disconnected)");
+    TS_ASSERT_EQUALS(7, getarity(find_7_pairs));
+
+    // only 9 pairs present
+    Handle find_12_pairs = eval->eval_h("(cog-satisfying-set-first-n 12 get-disconnected)");
+    TS_ASSERT_EQUALS(9, getarity(find_12_pairs));
+}
+
+void FirstNUTest::test_wrong_args_satisfying_set(void)
+{
+    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+    _test_wrong_args("cog-satisfying-set-first-n get-men");
+    _test_wrong_args("(cog-satisfying-set-first-n -1 get-men)");
+    _test_wrong_args("(cog-satisfying-set-first-n \"blah\" get-men)");
+    _test_wrong_args("(cog-satisfying-set-first-n (1 get-men))");
+    _test_wrong_args("(cog-satisfying-set-first-n get-men 1)");
+}
+
+void FirstNUTest::test_simple_bindlink(void)
+{
+    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+    Handle find_0_men = eval->eval_h("cog-bind-first-n 0 bind-men");
+    TS_ASSERT_EQUALS(0, getarity(find_0_men));
+
+    Handle find_1_man = eval->eval_h("cog-bind-first-n 1 bind-men");
+    TS_ASSERT_EQUALS(1, getarity(find_1_man));
+
+    Handle find_3_men = eval->eval_h("cog-bind-first-n 3 bind-men");
+    TS_ASSERT_EQUALS(3, getarity(find_3_men));
+
+    // only 3 men present
+    Handle find_5_men = eval->eval_h("cog-bind-first-n 5 bind-men");
+    TS_ASSERT_EQUALS(3, getarity(find_3_men));
+}
+
+void FirstNUTest::test_disconnected_bindlink(void)
+{
+    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+    Handle find_0_pairs = eval->eval_h("cog-bind-first-n 0 bind-disconnected");
+    TS_ASSERT_EQUALS(0, getarity(find_0_pairs));
+
+    Handle find_2_pairs = eval->eval_h("cog-bind-first-n 2 bind-disconnected");
+    TS_ASSERT_EQUALS(2, getarity(find_2_pairs));
+
+    Handle find_7_pairs = eval->eval_h("cog-bind-first-n 7 bind-disconnected");
+    TS_ASSERT_EQUALS(7, getarity(find_7_pairs));
+
+    // only 9 pairs present
+    Handle find_12_pairs = eval->eval_h("cog-bind-first-n 12 bind-disconnected");
+    TS_ASSERT_EQUALS(9, getarity(find_12_pairs));
+}
+
+void FirstNUTest::test_wrong_args_bindlink(void)
+{
+    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+    _test_wrong_args("cog-bind-first-n bind-men");
+    _test_wrong_args("(cog-bind-first-n -1 bind-men)");
+    _test_wrong_args("(cog-bind-first-n \"blah\" bind-men)");
+    _test_wrong_args("(cog-bind-first-n (1 bind-men))");
+    _test_wrong_args("(cog-bind-first-n bind-men 1)");
+}

--- a/tests/query/firstn.scm
+++ b/tests/query/firstn.scm
@@ -1,0 +1,73 @@
+; Socrates, Einstein, and Peirce are all men.
+(InheritanceLink
+    (ConceptNode "Socrates")
+    (ConceptNode "man"))
+
+(InheritanceLink
+    (ConceptNode "Einstein")
+    (ConceptNode "man"))
+
+(InheritanceLink
+    (ConceptNode "Peirce")
+    (ConceptNode "man"))
+
+; Cat, dog and mouse are all animal.
+(InheritanceLink
+    (ConceptNode "cat")
+    (ConceptNode "animal"))
+
+(InheritanceLink
+    (ConceptNode "dog")
+    (ConceptNode "animal"))
+
+(InheritanceLink
+    (ConceptNode "mouse")
+    (ConceptNode "animal"))
+
+; Simple GetLink
+(define get-men
+    (GetLink
+        (InheritanceLink
+            (VariableNode "$X")
+            (ConceptNode "man"))
+    ))
+
+; GetLink with disconnected clauses
+(define get-disconnected
+    (GetLink
+        (AndLink
+            (InheritanceLink
+                (VariableNode "$X")
+                (ConceptNode "man"))
+            (InheritanceLink
+                (VariableNode "$Y")
+                (ConceptNode "animal")))
+    ))
+
+; Simple BindLink
+(define bind-men
+    (BindLink
+        (VariableList (VariableNode "$X"))
+        (InheritanceLink
+            (VariableNode "$X")
+            (ConceptNode "man"))
+        (VariableNode "$X")
+    ))
+
+; BindLink with disconnected clauses
+(define bind-disconnected
+    (BindLink
+        (VariableList
+            (VariableNode "$X")
+            (VariableNode "$Y"))
+        (AndLink
+            (InheritanceLink
+                (VariableNode "$X")
+                (ConceptNode "man"))
+            (InheritanceLink
+                (VariableNode "$Y")
+                (ConceptNode "animal")))
+        (ListLink
+            (VariableNode "$X")
+            (VariableNode "$Y"))
+    ))

--- a/tests/query/firstn.scm
+++ b/tests/query/firstn.scm
@@ -1,3 +1,6 @@
+(use-modules (opencog))
+(use-modules (opencog query))
+
 ; Socrates, Einstein, and Peirce are all men.
 (InheritanceLink
     (ConceptNode "Socrates")


### PR DESCRIPTION
I have implemented functions that return first N matches. Scheme bindings are ready. I plan to add python bindings later. Unit tests contain example calls.

If you have better ideas for names or signatures of this functions let me know, I will refactor.
Not sure if previous implementation of bind-single will be still useful or should be removed, because new functions are more general. If so, I can remove the older version.