### PR TITLE
Benchmark random fix

### DIFF
--- a/opencog/benchmark/AtomSpaceBenchmark.h
+++ b/opencog/benchmark/AtomSpaceBenchmark.h
@@ -59,10 +59,8 @@ class AtomSpaceBenchmark
     PythonEval* pyev;
 #endif
 
-    MT19937RandGen* rng;
-
-    std::default_random_engine randgen;
-    std::poisson_distribution<unsigned> *prg;
+    MT19937RandGen* randomGenerator;
+    std::poisson_distribution<unsigned> *poissonDistribution;
 
     Type randomType(Type t);
     Type numberOfTypes;


### PR DESCRIPTION
The random link generation code was using a poisson distribution that wasn't using the same random number generator as the rest of the code, it was using a separate `std::default_random_engine`. This meant that the arity of outgoing for atoms wasn't deterministic with the same randseed value since `std::default_random_engine` used the default randseed initializer in all cases.

This pull request removes the extra random engine so they all use the Mersenne Twister generator which can use a randseed value from the command line for repeatability.