### PR TITLE
Add search for gssapi_krb5 where libkrb5-dev puts it

### DIFF
--- a/lib/FindPGSQL.cmake
+++ b/lib/FindPGSQL.cmake
@@ -56,6 +56,7 @@ FIND_LIBRARY(GSSAPI_KRB5_LIBRARY
 	PATHS
 		/usr/lib
 		/usr/local/lib
+		/usr/lib/x86_64-linux-gnu/
 		/usr/lib/x86_64-linux-gnu/mit-krb5/
 		)
 


### PR DESCRIPTION
One line change to look for gssapi_krb5 in the case someone used the `libkrb5-dev ` package install for Kerberos instead of `libkrb-multidev`.