### PR TITLE
New `IdenticalLink` link, for syntactic equality.

### DIFF
--- a/opencog/atoms/base/atom_types.script
+++ b/opencog/atoms/base/atom_types.script
@@ -379,6 +379,12 @@ QUANTITY_LINK <- ORDERED_LINK
 // link type.)
 VIRTUAL_LINK <- EVALUATION_LINK
 GREATER_THAN_LINK <- VIRTUAL_LINK
+
+// IdenticalLink tests for syntactic equality.  It does NOT execute its
+// arguments; it true only if both sides are the same atom.
+// EqualLink tests for semantic equality: the two sides are equal, if,
+// after execution, they evaluate to the same atom.
+IDENTICAL_LINK <- VIRTUAL_LINK
 EQUAL_LINK <- VIRTUAL_LINK
 
 // --------------------------------------------------------------

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -122,6 +122,21 @@ static TruthValuePtr greater(AtomSpace* as, const Handle& h)
 		return TruthValue::FALSE_TV();
 }
 
+/// Check for syntactic equality
+static TruthValuePtr identical(const Handle& h)
+{
+	const HandleSeq& oset = h->getOutgoingSet();
+	if (2 != oset.size())
+		throw RuntimeException(TRACE_INFO,
+		     "IdenticalLink expects two arguments");
+
+	if (oset[0] == oset[1])
+		return TruthValue::TRUE_TV();
+	else
+		return TruthValue::FALSE_TV();
+}
+
+/// Check for semantic equality
 static TruthValuePtr equal(AtomSpace* as, const Handle& h)
 {
 	const HandleSeq& oset = h->getOutgoingSet();
@@ -241,6 +256,10 @@ TruthValuePtr EvaluationLink::do_eval_scratch(AtomSpace* as,
 		Handle args(inst.execute(sna.at(1)));
 
 		return do_evaluate(scratch, sna.at(0), args);
+	}
+	else if (IDENTICAL_LINK == t)
+	{
+		return identical(evelnk);
 	}
 	else if (EQUAL_LINK == t)
 	{

--- a/tests/atoms/CMakeLists.txt
+++ b/tests/atoms/CMakeLists.txt
@@ -21,6 +21,9 @@ TARGET_LINK_LIBRARIES(DefineLinkUTest atomspace)
 ADD_CXXTEST(DeleteLinkUTest)
 TARGET_LINK_LIBRARIES(DeleteLinkUTest execution atomspace)
 
+ADD_CXXTEST(EqualLinkUTest)
+TARGET_LINK_LIBRARIES(EqualLinkUTest execution atomspace)
+
 ADD_CXXTEST(PutLinkUTest)
 TARGET_LINK_LIBRARIES(PutLinkUTest execution atomspace)
 

--- a/tests/atoms/EqualLinkUTest.cxxtest
+++ b/tests/atoms/EqualLinkUTest.cxxtest
@@ -55,13 +55,51 @@ void EqualLinkUTest::test_equality()
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
 	Handle thing_a = N(CONCEPT_NODE, "thing A");
+	Handle thing_b = N(CONCEPT_NODE, "thing B");
 	Handle semantic_a =
 		L(PUT_LINK, N(VARIABLE_NODE, "$x"), thing_a);
 
-	Handle ident_aa = L(IDENTICAL_LINK, thing_a, thing_a);
+	Handle semantic_b =
+		L(PUT_LINK, N(VARIABLE_NODE, "$x"), thing_b);
 
-	TruthValuePtr iyes = EvaluationLink::do_evaluate(&_as, ident_aa);
-	TS_ASSERT_LESS_THAN(0.5, iyes->getMean());
+	Handle ident_aa = L(IDENTICAL_LINK, thing_a, thing_a);
+	Handle ident_asa = L(IDENTICAL_LINK, thing_a, semantic_a);
+
+	Handle ident_ab = L(IDENTICAL_LINK, thing_a, thing_b);
+	Handle ident_asb = L(IDENTICAL_LINK, thing_a, semantic_b);
+
+	// -------
+	Handle equal_aa = L(EQUAL_LINK, thing_a, thing_a);
+	Handle equal_asa = L(EQUAL_LINK, thing_a, semantic_a);
+
+	Handle equal_ab = L(EQUAL_LINK, thing_a, thing_b);
+	Handle equal_asb = L(EQUAL_LINK, thing_a, semantic_b);
+
+	// -------
+	TruthValuePtr tv = EvaluationLink::do_evaluate(&_as, ident_aa);
+	TS_ASSERT_LESS_THAN(0.5, tv->getMean());  // true
+
+	tv = EvaluationLink::do_evaluate(&_as, ident_asa);
+	TS_ASSERT_LESS_THAN(tv->getMean(), 0.5); // false
+
+	tv = EvaluationLink::do_evaluate(&_as, ident_ab);
+	TS_ASSERT_LESS_THAN(tv->getMean(), 0.5); // false
+
+	tv = EvaluationLink::do_evaluate(&_as, ident_asb);
+	TS_ASSERT_LESS_THAN(tv->getMean(), 0.5); // false
+
+	// -------
+	tv = EvaluationLink::do_evaluate(&_as, equal_aa);
+	TS_ASSERT_LESS_THAN(0.5, tv->getMean());  // true
+
+	tv = EvaluationLink::do_evaluate(&_as, equal_asa);
+	TS_ASSERT_LESS_THAN(0.5, tv->getMean());  // true
+
+	tv = EvaluationLink::do_evaluate(&_as, equal_ab);
+	TS_ASSERT_LESS_THAN(tv->getMean(), 0.5); // false
+
+	tv = EvaluationLink::do_evaluate(&_as, equal_asb);
+	TS_ASSERT_LESS_THAN(tv->getMean(), 0.5); // false
 
 	logger().info("END TEST: %s", __FUNCTION__);
 }

--- a/tests/atoms/EqualLinkUTest.cxxtest
+++ b/tests/atoms/EqualLinkUTest.cxxtest
@@ -1,0 +1,67 @@
+/*
+ * tests/atoms/EqualUTest.cxxtest
+ *
+ * Copyright (C) 2016 Linas Vepstas
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/atoms/base/Atom.h>
+#include <opencog/atomspace/AtomSpace.h>
+#include <opencog/atoms/execution/EvaluationLink.h>
+
+using namespace opencog;
+
+// Test the EqualLink.
+//
+class EqualLinkUTest :  public CxxTest::TestSuite
+{
+private:
+	AtomSpace _as;
+
+public:
+	EqualLinkUTest()
+	{
+		logger().set_print_to_stdout_flag(true);
+	}
+
+	void setUp() {}
+
+	void tearDown() {}
+
+	void test_equality();
+};
+
+#define N _as.add_node
+#define L _as.add_link
+
+// Test equality vs. identity
+void EqualLinkUTest::test_equality()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle thing_a = N(CONCEPT_NODE, "thing A");
+	Handle semantic_a =
+		L(PUT_LINK, N(VARIABLE_NODE, "$x"), thing_a);
+
+	Handle ident_aa = L(IDENTICAL_LINK, thing_a, thing_a);
+
+	TruthValuePtr iyes = EvaluationLink::do_evaluate(&_as, ident_aa);
+	TS_ASSERT_LESS_THAN(0.5, iyes->getMean());
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}

--- a/tests/query/buggy-equal.scm
+++ b/tests/query/buggy-equal.scm
@@ -1,12 +1,10 @@
 ;
 ; buggy-equal.scm
 ;
-; Unit test for github bug report #1520
+; Unit test for github bug report opencog/opencog#1520
 ;
 (use-modules (opencog))
 (use-modules (opencog query))
-
-; (load-from-path "utilities.scm")
 
 ; --------------------------------------------------------------------
 ; First, some data to populate the atomspace
@@ -24,7 +22,7 @@
 
 
 ; --------------------------------------------------------------------
-;; The Bindlink from bug #1520, with one change:
+;; The Bindlink from bug opencog/opencog#1520, with one change:
 ;; Use NotLink instead of AbsentLink.
 ;;
 ;; Absence is looking for the lack of a pattern.
@@ -137,7 +135,7 @@
             )
             ; To avoid matching (Inheritance A B) and (Inheritance B A)
             (NotLink
-                (EqualLink
+                (IdenticalLink
                     (VariableNode "$A")
                     (VariableNode "$C")
                 )

--- a/tests/query/buggy-selfgnd.scm
+++ b/tests/query/buggy-selfgnd.scm
@@ -1,5 +1,6 @@
-; In this case instatiator tried to instantiate and add new BindLink
-; atom to Atomspace throwing exception. More details here:
+;
+; In this case, the instatiator tried to instantiate and add a new
+; BindLink atom to Atomspace, throwing exception. More details here:
 ; https://github.com/opencog/atomspace/issues/210
 
 (EvaluationLink
@@ -11,6 +12,11 @@
     (ConceptNode "glib")
     (ConceptNode "blab"))
 
+; This is a kind-of-ish poorly-formed expression.
+; When the EqualLink is evaluated, its arguments are executed first.
+; If $lnk was bound to the BindLink (which it could be, because there
+; is no type restriction on $lnk), this causes the BindLink to be run
+; again .. and again .. infinite regress.
 (define bnd
     (BindLink
         (AndLink

--- a/tests/query/buggy-selfgnd.scm
+++ b/tests/query/buggy-selfgnd.scm
@@ -17,6 +17,8 @@
 ; If $lnk was bound to the BindLink (which it could be, because there
 ; is no type restriction on $lnk), this causes the BindLink to be run
 ; again .. and again .. infinite regress.
+;
+; To avoid infinite regress, use IdenticalLink instead of EqualLink.
 (define bnd
     (BindLink
         (AndLink
@@ -24,7 +26,8 @@
             (EvaluationLink
                 (VariableNode "$a")
                 (VariableNode "$b"))
-            (EqualLink
+            ; (EqualLink
+            (IdenticalLink
                 (VariableNode "$lnk")
                 (EvaluationLink
                     (VariableNode "$a")

--- a/tests/query/evaluation.scm
+++ b/tests/query/evaluation.scm
@@ -59,7 +59,7 @@
 (define (one-arc-one)
 	(wrapper
 		(list one->x x->one
-			(EqualLink (VariableNode "$x") (ConceptNode "idea one"))
+			(IdenticalLink (VariableNode "$x") (ConceptNode "idea one"))
 		)
 	)
 )
@@ -67,7 +67,7 @@
 (define (one-arc-three)
 	(wrapper
 		(list one->x x->one
-			(EqualLink (VariableNode "$x") (ConceptNode "idea three"))
+			(IdenticalLink (VariableNode "$x") (ConceptNode "idea three"))
 		)
 	)
 )
@@ -76,8 +76,8 @@
 (define (zero-arcs)
 	(wrapper
 		(list one->x x->one
-			(EqualLink (VariableNode "$x") (ConceptNode "idea three"))
-			(EqualLink (VariableNode "$x") (ConceptNode "idea four"))
+			(IdenticalLink (VariableNode "$x") (ConceptNode "idea three"))
+			(IdenticalLink (VariableNode "$x") (ConceptNode "idea four"))
 		)
 	)
 )
@@ -87,7 +87,7 @@
 	(wrapper
 		(list one->x x->one
 			(AbsentLink
-				(EqualLink (VariableNode "$x") (ConceptNode "idea three"))
+				(IdenticalLink (VariableNode "$x") (ConceptNode "idea three"))
 			)
 		)
 	)
@@ -98,13 +98,13 @@
 	(wrapper
 		(list one->x x->one
 			(AbsentLink
-				(EqualLink (VariableNode "$x") (ConceptNode "idea three"))
+				(IdenticalLink (VariableNode "$x") (ConceptNode "idea three"))
 			)
 			(AbsentLink
-				(EqualLink (VariableNode "$x") (ConceptNode "idea four"))
+				(IdenticalLink (VariableNode "$x") (ConceptNode "idea four"))
 			)
 			(AbsentLink
-				(EqualLink (VariableNode "$x") (ConceptNode "idea five"))
+				(IdenticalLink (VariableNode "$x") (ConceptNode "idea five"))
 			)
 		)
 	)
@@ -118,7 +118,7 @@
 	(wrapper
 		(list one->x x->one
 			(NotLink
-				(EqualLink (VariableNode "$x") (ConceptNode "idea one"))
+				(IdenticalLink (VariableNode "$x") (ConceptNode "idea one"))
 			)
 		)
 	)
@@ -129,8 +129,8 @@
 	(wrapper
 		(list one->x x->one
 			(OrLink
-				(EqualLink (VariableNode "$x") (ConceptNode "idea one"))
-				(EqualLink (VariableNode "$x") (ConceptNode "idea two"))
+				(IdenticalLink (VariableNode "$x") (ConceptNode "idea one"))
+				(IdenticalLink (VariableNode "$x") (ConceptNode "idea two"))
 			)
 		)
 	)
@@ -142,8 +142,8 @@
 		(list one->x x->one
 			(NotLink
 				(OrLink
-					(EqualLink (VariableNode "$x") (ConceptNode "idea one"))
-					(EqualLink (VariableNode "$x") (ConceptNode "idea two"))
+					(IdenticalLink (VariableNode "$x") (ConceptNode "idea one"))
+					(IdenticalLink (VariableNode "$x") (ConceptNode "idea two"))
 				)
 			)
 		)
@@ -156,12 +156,12 @@
 		(list one->x x->one
 			(AndLink
 				(NotLink
-					(EqualLink (VariableNode "$x") (ConceptNode "idea three"))
+					(IdenticalLink (VariableNode "$x") (ConceptNode "idea three"))
 				)
 				(NotLink
 					(OrLink
-						(EqualLink (VariableNode "$x") (ConceptNode "idea four"))
-						(EqualLink (VariableNode "$x") (ConceptNode "idea five"))
+						(IdenticalLink (VariableNode "$x") (ConceptNode "idea four"))
+						(IdenticalLink (VariableNode "$x") (ConceptNode "idea five"))
 					)
 				)
 			)

--- a/tests/rule-engine/bc-deduction.scm
+++ b/tests/rule-engine/bc-deduction.scm
@@ -29,7 +29,7 @@
             )
             ;; To avoid matching (Inheritance A B) and (Inheritance B A)
             (NotLink
-                (EqualLink
+                (IdenticalLink
                     (VariableNode "$A")
                     (VariableNode "$C")
                 )

--- a/tests/rule-engine/dfc-tests.scm
+++ b/tests/rule-engine/dfc-tests.scm
@@ -12,7 +12,7 @@
             )
             ; To avoid matching (Inheritance A B) and (Inheritance B A)
             (NotLink
-                (EqualLink
+                (IdenticalLink
                     (ConceptNode "Cat")
                     (VariableNode "$C")
                 )
@@ -51,7 +51,7 @@
             )
             ; To avoid matching (Inheritance A B) and (Inheritance B A)
             (NotLink
-                (EqualLink
+                (IdenticalLink
                     (VariableNode "$A")
                     (ConceptNode  "Animal")
                 )

--- a/tests/rule-engine/implication-construction-rule.scm
+++ b/tests/rule-engine/implication-construction-rule.scm
@@ -35,7 +35,7 @@
      (VariableNode "$P")
      (VariableNode "$Q")
      (NotLink
-        (EqualLink
+        (IdenticalLink
            (VariableNode "$P")
            (VariableNode "$Q")))))
 

--- a/tests/rule-engine/rules/crisp-deduction-rule.scm
+++ b/tests/rule-engine/rules/crisp-deduction-rule.scm
@@ -27,7 +27,7 @@
             )
             ;; To avoid matching (Implication A B) and (Implication B A)
             (NotLink
-                (EqualLink
+                (IdenticalLink
                     (VariableNode "$A")
                     (VariableNode "$C")
                 )


### PR DESCRIPTION
Using the EqualLink can cause infinite recursion during equality tests. The IdenticalLink can be used to test for syntactic equality, avoiding infinite regress (and its faster, too).  Needed for bug #705