### PR TITLE
Fix for '$' suffix of prefix in node names.

### DIFF
--- a/opencog/persist/sql/odbc/ODBCAtomStorage.cc
+++ b/opencog/persist/sql/odbc/ODBCAtomStorage.cc
@@ -848,9 +848,9 @@ void ODBCAtomStorage::do_store_single_atom(AtomPtr atom, int aheight)
         {
             // Use postgres $-quoting to make unicode strings
             // easier to deal with.
-            std::string qname = " $$";
+            std::string qname = " $ocp$";
             qname += n->getName();
-            qname += "$$ ";
+            qname += "$ocp$ ";
 
             // The Atoms table has a UNIQUE constraint on the
             // node name.  If a node name is too long, a postgres

--- a/tests/persist/sql/odbc/BasicSaveUTest.cxxtest
+++ b/tests/persist/sql/odbc/BasicSaveUTest.cxxtest
@@ -342,6 +342,7 @@ void BasicSaveUTest::test_single_atom(void)
     single_atom_save_restore("ccc ");
     single_atom_save_restore("ddd ");
     single_atom_save_restore("eee ");
+    single_atom_save_restore("$$$ ");
 
     logger().debug("END TEST: %s", __FUNCTION__);
 }


### PR DESCRIPTION
The parser for PostgreSQL does a linear search for $$ rather than an outward-in search so it fails when there are $$ next to another $ for the [PostgreSQL dollar escaping](http://www.postgresql.org/docs/current/interactive/sql-syntax-lexical.html#SQL-SYNTAX-DOLLAR-QUOTING). Reverting to the more verbose $ocp$ escaping mechanism as $ocp$ is not likely to be in a node name.