### PR TITLE
Fix degenerate link load case with caching

### DIFF
--- a/opencog/persist/sql/postgres/PGAtomStorage.h
+++ b/opencog/persist/sql/postgres/PGAtomStorage.h
@@ -185,6 +185,11 @@ class PGAtomStorage : public AtomStorage
 
         std::unordered_map<UUID, std::vector<UUID>> _edge_cache;
 
+        // Atom Caching for getAtom optimization...
+        std::unordered_map<UUID, AtomPtr> _atom_cache;
+        void cache_atom(UUID uuid, AtomPtr atom);
+        AtomPtr get_cached_atom(UUID uuid);
+
     public:
         PGAtomStorage(const std::string& dbname, 
                     const std::string& username,

--- a/tests/persist/sql/postgres/PersistPGSQLUTest.cxxtest
+++ b/tests/persist/sql/postgres/PersistPGSQLUTest.cxxtest
@@ -45,7 +45,7 @@
 using namespace opencog;
 
 #define HUGE_LINK_SIZE  100000
-#define DEEP_LINK_SIZE  5
+#define DEEP_LINK_SIZE  20
 
 class PersistUTest :  public CxxTest::TestSuite
 {


### PR DESCRIPTION
Implemented a cache to fix issue #698 which was causing crashes for links of depth 20 or more. The number of queries is now as expected. If you have 10 links and 2 nodes, there will 10 x 2 + 2 queries, two per link, one for the link, and one for the edges, and one per node.

Bumped up the test to 20. There is still an analogous problem with AtomSpace::add_link that makes adding links of high depth very slow. 