### PR TITLE
Remove many LinkCasts and NodeCasts

### DIFF
--- a/opencog/atoms/base/atom_types.script
+++ b/opencog/atoms/base/atom_types.script
@@ -280,7 +280,7 @@ SIGNATURE_LINK <- ORDERED_LINK
 FUZZY_LINK <- SIGNATURE_LINK
 
 // A type binder: it binds a type to a VariableNode. Always arity-2,
-// the first position must be a Variablenode, the second must be a type.
+// the first position must be a VariableNode, the second must be a type.
 // Note that this is always scoped, i.e. used in lambdas and places
 // where variables are not free. Thus, unlike TypedAtomLink, this is
 // never globally unique.

--- a/opencog/atomspace/AtomSpace.cc
+++ b/opencog/atomspace/AtomSpace.cc
@@ -278,15 +278,11 @@ Handle AtomSpace::add_atom(AtomPtr atom, bool async)
     if (_backing_store and not _backing_store->ignoreType(t))
     {
         AtomPtr ba;
-        NodePtr n(NodeCast(atom));
-        if (n) {
-            ba = _backing_store->getNode(n->getType(),
-                                        n->getName().c_str());
+        if (atom->isNode()) {
+            ba = _backing_store->getNode(t, atom->getName().c_str());
         } else {
-            LinkPtr l(LinkCast(atom));
-            if (l)
-                 ba = _backing_store->getLink(l->getType(),
-                                             l->getOutgoingSet());
+            if (atom->isLink())
+                 ba = _backing_store->getLink(t, atom->getOutgoingSet());
         }
         if (ba) {
             return _atom_table.add(ba, async);
@@ -458,15 +454,13 @@ Handle AtomSpace::fetch_atom(Handle h)
     // This atom is not yet in any (this??) atomspace; go get it.
     if (NULL == h->getAtomTable()) {
         AtomPtr ba;
-        NodePtr n(NodeCast(h));
-        if (n) {
-            ba = _backing_store->getNode(n->getType(),
-                                        n->getName().c_str());
+        if (h->isNode()) {
+            ba = _backing_store->getNode(h->getType(),
+                                         h->getName().c_str());
         } else {
-            LinkPtr l(LinkCast(h));
-            if (l)
-                 ba = _backing_store->getLink(l->getType(),
-                                             l->getOutgoingSet());
+            if (h->isLink())
+                 ba = _backing_store->getLink(h->getType(),
+                                              h->getOutgoingSet());
         }
 
         // If we still don't have an atom, then the requested UUID

--- a/opencog/atomspace/BackingStore.cc
+++ b/opencog/atomspace/BackingStore.cc
@@ -35,29 +35,27 @@ std::string s_indent("");
 int s_ignore_count = 0;
 #endif
 
-bool BackingStore::ignoreAtom(Handle h) const
+bool BackingStore::ignoreAtom(const Handle& h) const
 {
 #if DEBUG_IGNORE
-    fprintf(stderr, "%signoreAtom(%lu) %d\n", s_indent.c_str(), h->getUUID(),
-    		s_ignore_count++);
+	fprintf(stderr, "%signoreAtom(%lu) %d\n", s_indent.c_str(), h->getUUID(),
+	        s_ignore_count++);
 #endif
 
 	// If the handle is a uuid only, and no atom, we can't ignore it.
-	AtomPtr a(h);
-	if (NULL == a) return false;
+	if (nullptr == h) return false;
 
 	// If the atom is of an ignoreable type, then ignore.
-	if (ignoreType(a->getType())) return true;
+	if (ignoreType(h->getType())) return true;
 
 	// If its a link, then scan the outgoing set.
-	LinkPtr l(LinkCast(a));
-	if (NULL == l) return false;
+	if (not h->isLink()) return false;
 
 #if DEBUG_IGNORE
-    s_indent += "  ";
+	s_indent += "  ";
 #endif
-    bool should_ignore = false;
-	const HandleSeq& hs = l->getOutgoingSet();
+	bool should_ignore = false;
+	const HandleSeq& hs = h->getOutgoingSet();
 	if (std::any_of(hs.begin(), hs.end(), [this](Handle ho) { return ignoreAtom(ho); }))
 		should_ignore = true;
 #if DEBUG_IGNORE

--- a/opencog/atomspace/BackingStore.h
+++ b/opencog/atomspace/BackingStore.h
@@ -111,7 +111,7 @@ class BackingStore
 		 * either because it is of an ignorable type, or is a link
 		 * which contains an atom that is of an ignorable type.
 		 */
-		virtual bool ignoreAtom(Handle) const;
+		virtual bool ignoreAtom(const Handle&) const;
 
 		/**
 		 * The set of ignored atom types.

--- a/opencog/atomspace/IncomingIndex.cc
+++ b/opencog/atomspace/IncomingIndex.cc
@@ -36,15 +36,11 @@ void IncomingIndex::resize()
 
 void IncomingIndex::insertAtom(const AtomPtr& a)
 {
-	LinkPtr l(LinkCast(a));
-	if (NULL == l) return;
+	if (not a->isLink()) return;
 
 	Handle hin = a->getHandle();
-	const std::vector<Handle>& oset = l->getOutgoingSet();
-	for (std::vector<Handle>::const_iterator it = oset.begin(); it != oset.end(); ++it)
+	for (const Handle& h : a->getOutgoingSet())
 	{
-		Handle h = *it;
-		
 		const UnorderedHandleSet& oldset = idx.get(h);
 
 		// Check to see if h is already listed; it should not be...
@@ -69,15 +65,11 @@ void IncomingIndex::insertAtom(const AtomPtr& a)
 
 void IncomingIndex::removeAtom(const AtomPtr& a)
 {
-	LinkPtr l(LinkCast(a));
-	if (NULL == l) return;
+	if (not a->isLink()) return;
 
 	Handle hin = a->getHandle();
-	const std::vector<Handle>& oset = l->getOutgoingSet();
-	for (std::vector<Handle>::const_iterator it = oset.begin(); it != oset.end(); ++it)
+	for (const Handle& h: a->getOutgoingSet())
 	{
-		Handle h = *it;
-		
 		const UnorderedHandleSet& oldset = idx.get(h);
 		UnorderedHandleSet inset = oldset;
 

--- a/opencog/atomspaceutils/AtomSpaceUtils.cc
+++ b/opencog/atomspaceutils/AtomSpaceUtils.cc
@@ -46,17 +46,18 @@ Handle add_prefixed_node(AtomSpace& as, Type t, const std::string& prefix)
     return as.add_node(t, name);
 }
 
-bool remove_hypergraph(AtomSpace& as, Handle h)
+/// Return true if all of h was removed.
+bool remove_hypergraph(AtomSpace& as, const Handle& h)
 {
-    LinkPtr link(LinkCast(h));
-
     // Recursive case
-    if (link) {
-        HandleSeq oset = link->getOutgoingSet();
+    if (h->isLink()) {
+        HandleSeq oset = h->getOutgoingSet();
         bool success = as.remove_atom(h);
-        if (success)
+        if (success) {
+            // Return true only if entire subgraph was removed.
             for (const Handle& oh : oset)
-                success &= remove_hypergraph(as, oh);
+                if (not remove_hypergraph(as, oh)) success = false;
+        }
         return success;
     }
     // Base case

--- a/opencog/atomspaceutils/AtomSpaceUtils.h
+++ b/opencog/atomspaceutils/AtomSpaceUtils.h
@@ -57,7 +57,7 @@ Handle add_prefixed_node(AtomSpace&, Type, const std::string& prefix = "");
  *
  * will remove the InheritanceLink, ConceptNode "A" and ConceptNode "B".
  */
-bool remove_hypergraph(AtomSpace& as, Handle h);
+bool remove_hypergraph(AtomSpace& as, const Handle& h);
 
 /** @}*/
 }

--- a/opencog/atomutils/FindUtils.cc
+++ b/opencog/atomutils/FindUtils.cc
@@ -88,12 +88,11 @@ FindAtoms::Loco FindAtoms::find_rec(const Handle& h, int quotation_level)
 		if (classserver().isA(t, stopper)) return NOPE;
 	}
 
-	LinkPtr l(LinkCast(h));
-	if (l)
+	if (h->isLink())
 	{
 		bool held = false;
 		bool imm = false;
-		for (const Handle& oh : l->getOutgoingSet())
+		for (const Handle& oh : h->getOutgoingSet())
 		{
 			Loco where = find_rec(oh, quotation_level);
 			if (NOPE != where) held = true;
@@ -112,11 +111,10 @@ FindAtoms::Loco FindAtoms::find_rec(const Handle& h, int quotation_level)
 bool is_atom_in_tree(const Handle& tree, const Handle& atom)
 {
 	if (tree == atom) return true;
-	LinkPtr ltree(LinkCast(tree));
-	if (NULL == ltree) return false;
+	if (not tree->isLink()) return false;
 
 	// Recurse downwards...
-	for (const Handle h: ltree->getOutgoingSet()) {
+	for (const Handle& h: tree->getOutgoingSet()) {
 		if (is_atom_in_tree(h, atom)) return true;
 	}
 	return false;
@@ -138,14 +136,13 @@ int min_quotation_level(const Handle& tree,
 {
 	// Base case
 	if (tree == atom) return level_from_root;
-	LinkPtr ltree(LinkCast(tree));
-	if (nullptr == ltree) return std::numeric_limits<int>::max();
+	if (not tree->isLink()) return std::numeric_limits<int>::max();
 
 	// Recursive case
 	if (tree->getType() == QUOTE_LINK) level_from_root++;
 	else if (tree->getType() == UNQUOTE_LINK) level_from_root--;
 	int result = std::numeric_limits<int>::max();
-	for (const Handle& h : ltree->getOutgoingSet())
+	for (const Handle& h : tree->getOutgoingSet())
 		result = std::min(result, min_quotation_level(h, atom, level_from_root));
 	return result;
 }
@@ -156,14 +153,13 @@ int max_quotation_level(const Handle& tree,
 {
 	// Base case
 	if (tree == atom) return level_from_root;
-	LinkPtr ltree(LinkCast(tree));
-	if (nullptr == ltree) return std::numeric_limits<int>::min();
+	if (not tree->isLink()) return std::numeric_limits<int>::min();
 
 	// Recursive case
 	if (tree->getType() == QUOTE_LINK) level_from_root++;
 	else if (tree->getType() == UNQUOTE_LINK) level_from_root--;
 	int result = std::numeric_limits<int>::min();
-	for (const Handle& h : ltree->getOutgoingSet())
+	for (const Handle& h : tree->getOutgoingSet())
 		result = std::max(result, max_quotation_level(h, atom, level_from_root));
 	return result;
 }
@@ -172,8 +168,7 @@ bool is_unscoped_in_tree(const Handle& tree, const Handle& atom)
 {
 	// Base cases
 	if (tree == atom) return true;
-	LinkPtr ltree(LinkCast(tree));
-	if (nullptr == ltree) return false;
+	if (not tree->isLink()) return false;
 	ScopeLinkPtr stree(ScopeLinkCast(tree));
 	if (nullptr != stree) {
 		const std::set<Handle>& varset = stree->get_variables().varset;
@@ -182,7 +177,7 @@ bool is_unscoped_in_tree(const Handle& tree, const Handle& atom)
 	}
 
 	// Recursive case
-	for (const Handle& h : ltree->getOutgoingSet())
+	for (const Handle& h : tree->getOutgoingSet())
 		if (is_unscoped_in_tree(h, atom))
 			return true;
 	return false;
@@ -260,10 +255,9 @@ bool contains_atomtype(const Handle& clause, Type atom_type)
 	if (QUOTE_LINK == clause_type) return false;
 	// if (classserver().isA(clause_type, SCOPE_LINK)) return false;
 
-	LinkPtr lc(LinkCast(clause));
-	if (not lc) return false;
+	if (not clause->isLink()) return false;
 
-	for (const Handle& subclause: lc->getOutgoingSet())
+	for (const Handle& subclause: clause->getOutgoingSet())
 	{
 		if (contains_atomtype(subclause, atom_type)) return true;
 	}
@@ -302,10 +296,9 @@ HandleSeq get_free_vars_in_tree(const Handle& tree)
 		    //      or h->getArity() == 3))
 			return;
 
-		LinkPtr l(LinkCast(h));
-		if (l)
+		if (h->isLink())
 		{
-			for (const Handle& oh : l->getOutgoingSet())
+			for (const Handle& oh : h->getOutgoingSet())
 				find_rec(oh);
 		}
 	};

--- a/opencog/atomutils/FollowLink.h
+++ b/opencog/atomutils/FollowLink.h
@@ -79,8 +79,7 @@ private:
 
 		cnt = -1;
 		to_atom = Handle::UNDEFINED;
-		LinkPtr l(LinkCast(h));
-		if (l) l->foreach_outgoing(&FollowLink::pursue_link, this);
+		if (h->isLink()) h->foreach_outgoing(&FollowLink::pursue_link, this);
 		if (to_atom) return true;
 		return false;
 	}

--- a/opencog/atomutils/ForeachChaseLink.h
+++ b/opencog/atomutils/ForeachChaseLink.h
@@ -193,7 +193,7 @@ private:
 		cnt = -1;
 		to_atom = Handle::UNDEFINED;
 		// foreach_outgoing_handle(link_h, PrivateUseOnlyChaseLink::endpoint_matcher, this);
-		LinkCast(link_h)->foreach_outgoing(endpoint_matcher, this);
+		link_h->foreach_outgoing(endpoint_matcher, this);
 
 		bool rc = false;
 		if (to_atom)

--- a/opencog/atomutils/FuzzyMatch.cc
+++ b/opencog/atomutils/FuzzyMatch.cc
@@ -74,9 +74,8 @@ void FuzzyMatch::find_starters(const Handle& hp)
 
 	// Proposed start was not accepted. Look farther down, at it's
 	// sub-trees.
-	LinkPtr lp(LinkCast(hp));
-	if (lp) {
-		for (const Handle& h : lp->getOutgoingSet()) {
+	if (hp->isLink()) {
+		for (const Handle& h : hp->getOutgoingSet()) {
 			find_starters(h);
 		}
 	}

--- a/opencog/atomutils/FuzzyMatchBasic.cc
+++ b/opencog/atomutils/FuzzyMatchBasic.cc
@@ -71,9 +71,7 @@ void FuzzyMatchBasic::start_search(const Handle& trg)
  */
 bool FuzzyMatchBasic::accept_starter(const Handle& hp)
 {
-	NodePtr np(NodeCast(hp));
-	if (nullptr == np) return false;
-
+	if (hp->isLink()) return false;
 	return true;
 }
 

--- a/opencog/atomutils/FuzzyMatchBasic.cc
+++ b/opencog/atomutils/FuzzyMatchBasic.cc
@@ -39,15 +39,17 @@ static void get_all_atoms(const Handle& h, HandleSeq& nlist, HandleSeq& alist)
 {
 	alist.emplace_back(h);
 
-	LinkPtr lll(LinkCast(h));
-	if (nullptr == lll)
+	if (h->isNode())
 	{
 		nlist.emplace_back(h);
 		return;
 	}
 
-	for (const Handle& o : lll->getOutgoingSet())
-		get_all_atoms(o, nlist, alist);
+	if (h->isLink())
+	{
+		for (const Handle& o : h->getOutgoingSet())
+			get_all_atoms(o, nlist, alist);
+	}
 }
 
 /**

--- a/opencog/atomutils/Neighbors.cc
+++ b/opencog/atomutils/Neighbors.cc
@@ -105,9 +105,8 @@ static void get_distant_neighbors_rec(const Handle& h,
                 get_distant_neighbors_rec(in_h, res, dist - 1);
         }
         // 2. Fetch outgoings
-        LinkPtr link = LinkCast(h);
-        if (link) {
-            for (const Handle& out_h : link->getOutgoingSet()) {
+        if (h->isLink()) {
+            for (const Handle& out_h : h->getOutgoingSet()) {
                 if (res.find(out_h) == res.cend()) // Do not re-explore
                     get_distant_neighbors_rec(out_h, res, dist - 1);
             }

--- a/opencog/atomutils/Substitutor.h
+++ b/opencog/atomutils/Substitutor.h
@@ -58,15 +58,12 @@ private:
 		if (vmap.end() != it )
 			return it->second;
 
-		LinkPtr lexpr(LinkCast(expr));
-
 		// If not a link, and not mapped, just return it.
-		if (not lexpr)
-			return Handle(expr);
+		if (not expr->isLink()) return expr;
 
 		HandleSeq oset_results;
 		bool changed = false;
-		for (const Handle& h : lexpr->getOutgoingSet())
+		for (const Handle& h : expr->getOutgoingSet())
 		{
 			Handle hg = walk_tree(vmap, h);
 			if (hg != h) changed = true;

--- a/opencog/guile/SchemeSmobNew.cc
+++ b/opencog/guile/SchemeSmobNew.cc
@@ -63,12 +63,11 @@ std::string SchemeSmob::handle_to_string(Handle h, int indent)
 	// to file, and then restored, as needed.
 	std::string ret = "";
 	for (int i=0; i< indent; i++) ret += "   ";
-	NodePtr nnn(NodeCast(h));
-	if (nnn) {
+	if (h->isNode()) {
 		ret += "(";
 		ret += classserver().getTypeName(h->getType());
 		ret += " \"";
-		ret += nnn->getName();
+		ret += h->getName();
 		ret += "\"";
 
 		// Print the truth value only after the node name
@@ -88,8 +87,7 @@ std::string SchemeSmob::handle_to_string(Handle h, int indent)
 		return ret;
 	}
 
-	LinkPtr lll(LinkCast(h));
-	if (lll) {
+	if (h->isLink()) {
 		ret += "(";
 		ret += classserver().getTypeName(h->getType());
 
@@ -109,7 +107,7 @@ std::string SchemeSmob::handle_to_string(Handle h, int indent)
 
 		// print the outgoing link set.
 		ret += "\n";
-		std::vector<Handle> oset = lll->getOutgoingSet();
+		const HandleSeq& oset = h->getOutgoingSet();
 		unsigned int arity = oset.size();
 		for (unsigned int i=0; i<arity; i++) {
 			//ret += " ";

--- a/opencog/rule-engine/ChainerUtils.cc
+++ b/opencog/rule-engine/ChainerUtils.cc
@@ -34,17 +34,16 @@ void get_outgoing_nodes(const Handle& hinput,
                         UnorderedHandleSet& node_set,
                         Type type)
 {
-    LinkPtr link(LinkCast(hinput));
     // Recursive case
-    if (link) {
-        for (const Handle& h : link->getOutgoingSet())
+    if (hinput->isLink()) {
+        for (const Handle& h : hinput->getOutgoingSet())
             get_outgoing_nodes(h, node_set, type);
         return;
     }
 
     // Base case
     if (NODE == type or // Empty means all kinds of nodes
-        NodeCast(hinput)->getType() == type)
+        hinput->getType() == type)
     {
         node_set.insert(hinput);
     }
@@ -69,27 +68,24 @@ bool are_similar(const Handle& h1, const Handle& h2, bool strict_type_match)
     if (h1 == h2)
         return true;
 
-    if (NodeCast(h1) and NodeCast(h2))
+    if (h1->isNode() and h2->isNode())
         return !strict_type_match or h1->getType() == h2->getType();
 
-    LinkPtr lh1(LinkCast(h1));
-    LinkPtr lh2(LinkCast(h2));
-
-    if (lh1 and lh2) {
-        if (strict_type_match and (lh1->getType() != lh2->getType()))
+    if (h1->isLink() and h2->isLink()) {
+        if (strict_type_match and (h1->getType() != h2->getType()))
             return false;
 
-        HandleSeq hseqh1 = lh1->getOutgoingSet();
-        HandleSeq hseqh2 = lh2->getOutgoingSet();
+        const HandleSeq& hseqh1 = h1->getOutgoingSet();
+        HandleSeq hseqh2 = h2->getOutgoingSet();
 
         if (hseqh1.size() != hseqh2.size())
             return false;
 
         // Unordered links should be treated in a special way
-        if (classserver().isA(lh1->getType(), UNORDERED_LINK) or classserver().isA(
-                lh2->getType(), UNORDERED_LINK)) {
-
-            for (const auto& h1 : hseqh1) {
+        if (classserver().isA(h1->getType(), UNORDERED_LINK) or
+            classserver().isA(h2->getType(), UNORDERED_LINK))
+        {
+            for (const Handle& h1 : hseqh1) {
                 for (auto it = hseqh2.begin(); it != hseqh2.end(); ++it) {
                     if (are_similar(h1, h2, strict_type_match)) {
                         hseqh2.erase(it);

--- a/opencog/rule-engine/InferenceSCM.cc
+++ b/opencog/rule-engine/InferenceSCM.cc
@@ -69,7 +69,7 @@ Handle InferenceSCM::do_forward_chaining(Handle hsource,
     HandleSeq focus_set = {};
 
     if (hfocus_set->getType() == SET_LINK)
-        focus_set = LinkCast(hfocus_set)->getOutgoingSet();
+        focus_set = hfocus_set->getOutgoingSet();
     else
         throw RuntimeException(
                 TRACE_INFO,

--- a/opencog/rule-engine/Rule.cc
+++ b/opencog/rule-engine/Rule.cc
@@ -56,12 +56,12 @@ void Rule::init(Handle rule)
 		                                "Rule '%s' is expected to be a MemberLink",
 		                                rule->toString().c_str());
 
-		rule_alias_ = LinkCast(rule)->getOutgoingAtom(0);
-		Handle rbs = LinkCast(rule)->getOutgoingAtom(1);
+		rule_alias_ = rule->getOutgoingAtom(0);
+		Handle rbs = rule->getOutgoingAtom(1);
 
 		rule_handle_ = DefineLink::get_definition(rule_alias_);
-		name_ = NodeCast(rule_alias_)->getName();
-		category_ = NodeCast(rbs)->getName();
+		name_ = rule_alias_->getName();
+		category_ = rbs->getName();
 		weight_ = rule->getTruthValue()->getMean();
 	}
 }
@@ -126,7 +126,7 @@ Handle Rule::get_vardecl() const
 	if (rule_handle_ == Handle::UNDEFINED)
 		return Handle::UNDEFINED;
 
-	return LinkCast(rule_handle_)->getOutgoingAtom(0);
+	return rule_handle_->getOutgoingAtom(0);
 }
 
 /**
@@ -160,7 +160,7 @@ HandleSeq Rule::get_implicant_seq() const
     HandleSeq hs;
 
     if (t == AND_LINK or t == OR_LINK)
-        hs = LinkCast(implicant)->getOutgoingSet();
+        hs = implicant->getOutgoingSet();
     else
         hs.push_back(implicant);
 
@@ -202,7 +202,7 @@ HandleSeq Rule::get_implicand_seq() const
 	// skip the top level ListLink
 	if (implicand->getType() == LIST_LINK)
 	{
-		for (Handle h : LinkCast(implicand)->getOutgoingSet())
+		for (const Handle& h : implicand->getOutgoingSet())
 			pre_output.push(h);
 	}
 	else
@@ -219,9 +219,9 @@ HandleSeq Rule::get_implicand_seq() const
 		if (hfront->getType() == EXECUTION_OUTPUT_LINK)
 		{
 			// get the ListLink containing the arguments of the ExecutionOutputLink
-			Handle harg = LinkCast(hfront)->getOutgoingSet()[1];
+			Handle harg = hfront->getOutgoingSet()[1];
 
-			for (Handle h : LinkCast(harg)->getOutgoingSet())
+			for (const Handle& h : harg->getOutgoingSet())
 				pre_output.push(h);
 
 			continue;
@@ -283,9 +283,9 @@ Rule Rule::gen_standardize_apart(AtomSpace* as)
 Handle Rule::standardize_helper(AtomSpace* as, const Handle& h,
                                 std::map<Handle, Handle>& dict)
 {
-	if (LinkCast(h))
+	if (h->isLink())
 	{
-		HandleSeq old_outgoing = LinkCast(h)->getOutgoingSet();
+		HandleSeq old_outgoing = h->getOutgoingSet();
 		HandleSeq new_outgoing;
 
 		for (auto ho : old_outgoing)
@@ -303,7 +303,7 @@ Handle Rule::standardize_helper(AtomSpace* as, const Handle& h,
 	// want to generate a completely unique variable
 	if (dict.count(h) == 0)
 	{
-		std::string new_name = NodeCast(h)->getName() + "-" + to_string(boost::uuids::random_generator()());
+		std::string new_name = h->getName() + "-" + to_string(boost::uuids::random_generator()());
 		Handle hcpy = as->add_atom(createNode(h->getType(), new_name, h->getTruthValue()));
 
 		dict[h] = hcpy;
@@ -315,7 +315,7 @@ Handle Rule::standardize_helper(AtomSpace* as, const Handle& h,
 	if (dict.at(h) != Handle::UNDEFINED)
 		return dict[h];
 
-	std::string new_name = NodeCast(h)->getName() + "-" + name_;
+	std::string new_name = h->getName() + "-" + name_;
 	Handle hcpy = as->add_atom(createNode(h->getType(), new_name, h->getTruthValue()));
 
 	dict[h] = hcpy;

--- a/opencog/rule-engine/UREConfigReader.cc
+++ b/opencog/rule-engine/UREConfigReader.cc
@@ -102,7 +102,7 @@ HandleSeq UREConfigReader::fetch_rule_names(Handle rbs)
 	// longer useful
 	remove_hypergraph(_as, gl);
 
-	return LinkCast(rule_names)->getOutgoingSet();
+	return rule_names->getOutgoingSet();
 }
 
 HandleSeq UREConfigReader::fetch_execution_outputs(Handle schema,
@@ -132,7 +132,7 @@ HandleSeq UREConfigReader::fetch_execution_outputs(Handle schema,
 	// longer useful
 	remove_hypergraph(_as, gl);
 
-	return LinkCast(outputs)->getOutgoingSet();
+	return outputs->getOutgoingSet();
 }
 
 double UREConfigReader::fetch_num_param(const string& schema_name, Handle input,

--- a/opencog/rule-engine/UREConfigReader.cc
+++ b/opencog/rule-engine/UREConfigReader.cc
@@ -141,7 +141,7 @@ double UREConfigReader::fetch_num_param(const string& schema_name, Handle input,
 	Handle param_schema = _as.add_node(SCHEMA_NODE, schema_name);
 	HandleSeq outputs = fetch_execution_outputs(param_schema, input, NUMBER_NODE);
 	{
-		string input_name = NodeCast(input)->getName();
+		string input_name = input->getName();
 		Type input_type = input->getType();
 		string input_str =
 			classserver().getTypeName(input_type) + " \"" + input_name + "\"";

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.cc
@@ -762,11 +762,11 @@ bool BackwardChainer::unify(const Handle& hsource,
 	Handle temp_hsource_vardecl = temp_space.add_atom(hsource_vardecl);
 	Handle temp_hmatch_vardecl = temp_space.add_atom(hmatch_vardecl);
 
-	FindAtoms fv(VARIABLE_NODE);
-	fv.search_set(hsource);
-
 	if (temp_hsource_vardecl == Handle::UNDEFINED)
 	{
+		FindAtoms fv(VARIABLE_NODE);
+		fv.search_set(hsource);
+
 		HandleSeq vars;
 		for (const Handle& h : fv.varset)
 			vars.push_back(h);

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.cc
@@ -835,11 +835,9 @@ static void get_all_unique_atoms(const Handle& h, UnorderedHandleSet& atom_set)
 {
     atom_set.insert(h);
 
-/*
     if (h->isLink())
         for (const Handle& o : h->getOutgoingSet())
             get_all_unique_atoms(o, atom_set);
-*/
 }
 
 /**

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.cc
@@ -837,12 +837,8 @@ static void get_all_unique_atoms(const Handle& h, UnorderedHandleSet& atom_set)
 {
     atom_set.insert(h);
 
-    LinkPtr lll(LinkCast(h));
-    if (not lll)
-    {
-        for (const Handle& o : lll->getOutgoingSet())
-            get_all_unique_atoms(o, atom_set);
-    }
+    for (const Handle& o : h->getOutgoingSet())
+        get_all_unique_atoms(o, atom_set);
 }
 
 /**

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.cc
@@ -813,7 +813,7 @@ bool BackwardChainer::unify(const Handle& hsource,
 		return false;
 
 	// Change the mapping from temp_atomspace to current atomspace
-	for (auto& p : good_map)
+	for (const auto& p : good_map)
 	{
 		Handle var = p.first;
 		Handle grn = p.second;

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.cc
@@ -60,11 +60,9 @@ void BackwardChainer::set_target(const Handle& init_target,
 	_targets_set.emplace(_init_target, gen_varlist(_init_target));
 
 	// get the stuff under the SetLink
-	LinkPtr lll(LinkCast(focus_link));
-
-	if (lll)
+	if (focus_link->isLink())
 	{
-		HandleSeq focus_set = lll->getOutgoingSet();
+		HandleSeq focus_set = focus_link->getOutgoingSet();
 		for (const auto& h : focus_set)
 			_focus_space.add_atom(h);
 
@@ -175,7 +173,7 @@ void BackwardChainer::process_target(Target& target)
 	if (_logical_link_types.count(htarget->getType()) == 1)
 	{
 		bool all_virtual = true;
-		for (const Handle& h : LinkCast(htarget)->getOutgoingSet())
+		for (const Handle& h : htarget->getOutgoingSet())
 		{
 			if (classserver().isA(h->getType(), VIRTUAL_LINK))
 				continue;
@@ -230,7 +228,7 @@ void BackwardChainer::process_target(Target& target)
 	{
 		bc_logger().debug("Breaking into sub-targets");
 
-		HandleSeq sub_premises = LinkCast(htarget)->getOutgoingSet();
+		HandleSeq sub_premises = htarget->getOutgoingSet();
 
 		for (Handle& h : sub_premises)
 			_targets_set.emplace(h, gen_sub_varlist(h, htarget_vardecl,
@@ -410,7 +408,7 @@ void BackwardChainer::process_target(Target& target)
 		bc_logger().debug("Before breaking apart into sub-premises");
 
 		// Else break out any logical link and add to targets
-		HandleSeq sub_premises = LinkCast(hp)->getOutgoingSet();
+		HandleSeq sub_premises = hp->getOutgoingSet();
 		target.store_step(selected_rule, sub_premises);
 
 		for (Handle& s : sub_premises)
@@ -671,7 +669,7 @@ HandleSeq BackwardChainer::ground_premises(const Handle& hpremise,
 	if (_logical_link_types.count(premises->getType()) == 1)
 	{
 		HandleSeq sub_premises;
-		HandleSeq oset = LinkCast(hpremise)->getOutgoingSet();
+		HandleSeq oset = hpremise->getOutgoingSet();
 
 		for (const Handle& h : oset)
 		{
@@ -977,8 +975,8 @@ Handle BackwardChainer::gen_sub_varlist(const Handle& parent,
 	fv.search_set(parent);
 
 	HandleSeq oset;
-	if (LinkCast(parent_varlist))
-		oset = LinkCast(parent_varlist)->getOutgoingSet();
+	if (parent_varlist->isLink())
+		oset = parent_varlist->getOutgoingSet();
 	else
 		oset.push_back(parent_varlist);
 
@@ -994,10 +992,10 @@ Handle BackwardChainer::gen_sub_varlist(const Handle& parent,
 			additional_free_varset.erase(h);
 		}
 		else if (TYPED_VARIABLE_LINK == t
-			     and fv.varset.count(LinkCast(h)->getOutgoingSet()[0]) == 1)
+			     and fv.varset.count(h->getOutgoingSet()[0]) == 1)
 		{
 			final_oset.push_back(h);
-			additional_free_varset.erase(LinkCast(h)->getOutgoingSet()[0]);
+			additional_free_varset.erase(h->getOutgoingSet()[0]);
 		}
 	}
 

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.cc
@@ -60,7 +60,7 @@ void BackwardChainer::set_target(const Handle& init_target,
 	_targets_set.emplace(_init_target, gen_varlist(_init_target));
 
 	// get the stuff under the SetLink
-	if (focus_link->isLink())
+	if (focus_link and focus_link->isLink())
 	{
 		HandleSeq focus_set = focus_link->getOutgoingSet();
 		for (const auto& h : focus_set)
@@ -835,8 +835,11 @@ static void get_all_unique_atoms(const Handle& h, UnorderedHandleSet& atom_set)
 {
     atom_set.insert(h);
 
-    for (const Handle& o : h->getOutgoingSet())
-        get_all_unique_atoms(o, atom_set);
+/*
+    if (h->isLink())
+        for (const Handle& o : h->getOutgoingSet())
+            get_all_unique_atoms(o, atom_set);
+*/
 }
 
 /**

--- a/opencog/rule-engine/backwardchainer/UnifyPMCB.cc
+++ b/opencog/rule-engine/backwardchainer/UnifyPMCB.cc
@@ -76,7 +76,7 @@ bool UnifyPMCB::grounding(const std::map<Handle, Handle> &var_soln,
 	std::map<Handle, Handle> true_var_soln;
 
 	// get rid of non-var mapping
-	for (auto& p : var_soln)
+	for (const auto& p : var_soln)
 	{
 		if (_int_vars->get_variables().varset.count(p.first) == 1)
 		{

--- a/opencog/rule-engine/forwardchainer/ForwardChainer.cc
+++ b/opencog/rule-engine/forwardchainer/ForwardChainer.cc
@@ -67,7 +67,7 @@ void ForwardChainer::init(const Handle& hsource, const HandleSeq& focus_set)
 
     // Accept set of initial sources wrapped in a SET_LINK.
     if (hsource->getType() == SET_LINK) {
-        init_sources = LinkCast(hsource)->getOutgoingSet();
+        init_sources = hsource->getOutgoingSet();
     } else {
         init_sources.push_back(hsource);
     }
@@ -185,9 +185,8 @@ Handle ForwardChainer::choose_source()
 		// remain a hack anyway.
 		if (biased_randbool(0.01)) {
 			for (const Handle& h : _selected_sources) {
-				LinkPtr l = LinkCast(h);
-				if (l) {
-					const HandleSeq& outgoings = l->getOutgoingSet();
+				if (h->isLink()) {
+					const HandleSeq& outgoings = h->getOutgoingSet();
 					update_potential_sources(outgoings);
 				}
 			}
@@ -318,7 +317,7 @@ HandleSeq ForwardChainer::apply_rule(const Handle& rhandle)
         Handle implicant = BindLinkCast(rhandle)->get_body();
         HandleSeq hs;
         if (implicant->getType() == AND_LINK or implicant->getType() == OR_LINK)
-            hs = LinkCast(implicant)->getOutgoingSet();
+            hs = implicant->getOutgoingSet();
         else
             hs.push_back(implicant);
         // Actual checking here.
@@ -331,7 +330,7 @@ HandleSeq ForwardChainer::apply_rule(const Handle& rhandle)
         }
 
         Instantiator inst(&_as);
-        Handle houtput = LinkCast(rhandle)->getOutgoingSet().back();
+        Handle houtput = rhandle->getOutgoingSet().back();
         LAZY_FC_LOG_DEBUG << "Instantiating " << houtput->toShortString();
 
         result.push_back(inst.instantiate(houtput, {}));
@@ -535,11 +534,9 @@ void ForwardChainer::validate(const Handle& hsource, const HandleSeq& hfocus_set
 static void get_all_unique_atoms(const Handle& h, UnorderedHandleSet& atom_set)
 {
     atom_set.insert(h);
-
-    LinkPtr lll(LinkCast(h));
-    if (lll)
+    if (h->isLink())
     {
-        for (const Handle& o : lll->getOutgoingSet())
+        for (const Handle& o : h->getOutgoingSet())
             get_all_unique_atoms(o, atom_set);
     }
 }
@@ -618,7 +615,7 @@ HandleSeq ForwardChainer::substitute_rule_part(
         // generate varlist from himplicant.
         Handle hvarlist = as.add_atom(
             gen_sub_varlist(himplicant,
-                            LinkCast(hrule)->getOutgoingAtom(0)));
+                            hrule->getOutgoingAtom(0)));
 
         // Create a simplified implicand without constant clauses
         Handle hsimplicant = remove_constant_clauses(hvarlist, himplicant);
@@ -656,7 +653,7 @@ bool ForwardChainer::unify(const Handle& source, const Handle& pattern,
     Handle bl =
         tmp_as.add_link(BIND_LINK, pattern_vardecl, pattern_cpy, pattern_cpy);
     Handle result = bindlink(&tmp_as, bl);
-    HandleSeq results = LinkCast(result)->getOutgoingSet();
+    HandleSeq results = result->getOutgoingSet();
 
     return std::find(results.begin(), results.end(), source_cpy) != results.end();
 }
@@ -668,8 +665,8 @@ Handle ForwardChainer::gen_sub_varlist(const Handle& parent,
     fv.search_set(parent);
 
     HandleSeq oset;
-    if (LinkCast(parent_varlist))
-        oset = LinkCast(parent_varlist)->getOutgoingSet();
+    if (parent_varlist->isLink())
+        oset = parent_varlist->getOutgoingSet();
     else
         oset.push_back(parent_varlist);
 
@@ -681,7 +678,7 @@ Handle ForwardChainer::gen_sub_varlist(const Handle& parent,
 
         if ((VARIABLE_NODE == t and fv.varset.count(h) == 1)
             or (TYPED_VARIABLE_LINK == t
-                and fv.varset.count(LinkCast(h)->getOutgoingSet()[0]) == 1))
+                and fv.varset.count(h->getOutgoingAtom(0)) == 1))
             final_oset.push_back(h);
     }
 


### PR DESCRIPTION
It turns out that LinkCast, NodeCast are slow.  With the newer virtual methods, they are also un-needed.  So remove them.

NOTE: This also fixes a bug in the BackwardChainer, which seemed to have reversed a boolean by accident.