### PR TITLE
Rename purge to extract.

### DIFF
--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -275,12 +275,18 @@ public:
     void store_atom(Handle h);
 
     /**
-     * Purge an atom from the atomspace.  This only removes the atom
-     * from the AtomSpace; it may still remain in persistent storage.
-     * To also delete from persistant storage, use the removeAtom()
-     * method.  The atom remains valid as long as there are Handles
-     * or AtomPtr's that reference it; it is deleted only when the
-     * last reference goes away.
+     * Extract an atom from the atomspace.  This only removes the atom
+     * from the (local, in-RAM) AtomSpace (in this process); any copies
+     * of the atom in persistent storage orin other address spaces are
+     * unaffected.  To also delete from persistant storage, use the
+     * removeAtom() method. Of course, the AtomSpace must be connected
+     * to storage in order for removeAtom() to reach out that far; if
+     * the AtomSpace is not connected to a backend, there is no
+     * difference between remove and extract.
+     *
+     * The atom itself remains valid as long as there are Handles or
+     * AtomPtr's that reference it; the RAM associated with the atom is
+     * freed only when the last reference goes away.
      *
      * @param h The Handle of the atom to be removed.
      * @param recursive Recursive-removal flag. If the flag is set,
@@ -292,7 +298,7 @@ public:
      * @return True if the Atom for the given Handle was successfully
      *         removed. False, otherwise.
      */
-    bool purge_atom(Handle h, bool recursive = false) {
+    bool extract_atom(Handle h, bool recursive = false) {
         return 0 < _atom_table.extract(h, recursive).size();
     }
 

--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -254,8 +254,8 @@ void SchemeSmob::register_procs()
 	register_proc("cog-link",              1, 0, 1, C(ss_link));
 	register_proc("cog-delete",            1, 0, 1, C(ss_delete));
 	register_proc("cog-delete-recursive",  1, 0, 1, C(ss_delete_recursive));
-	register_proc("cog-purge",             1, 0, 1, C(ss_purge));
-	register_proc("cog-purge-recursive",   1, 0, 1, C(ss_purge_recursive));
+	register_proc("cog-extract",           1, 0, 1, C(ss_extract));
+	register_proc("cog-extract-recursive", 1, 0, 1, C(ss_extract_recursive));
 	register_proc("cog-value?",            1, 0, 1, C(ss_value_p));
 	register_proc("cog-atom?",             1, 0, 1, C(ss_atom_p));
 	register_proc("cog-node?",             1, 0, 1, C(ss_node_p));

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -81,8 +81,8 @@ private:
 	static SCM ss_link(SCM, SCM);
 	static SCM ss_delete(SCM, SCM);
 	static SCM ss_delete_recursive(SCM, SCM);
-	static SCM ss_purge(SCM, SCM);
-	static SCM ss_purge_recursive(SCM, SCM);
+	static SCM ss_extract(SCM, SCM);
+	static SCM ss_extract_recursive(SCM, SCM);
 	static SCM ss_value_p(SCM);
 	static SCM ss_atom_p(SCM);
 	static SCM ss_node_p(SCM);

--- a/opencog/guile/SchemeSmobNew.cc
+++ b/opencog/guile/SchemeSmobNew.cc
@@ -703,29 +703,25 @@ SCM SchemeSmob::ss_delete_recursive (SCM satom, SCM kv_pairs)
 
 /* ============================================================== */
 /**
- * Purge the atom from the atomspace, but only if it has no incoming links.
- * Return SCM_BOOL_T if the atom was deleted, else return SCM_BOOL_F
- * This does NOT remove the atom from any attached backing store, only
- * from the atomspace.
+ * Extract the atom from the atomspace, but only if it has no incoming
+ * links. Return `SCM_BOOL_T` if the atom was successfully extracted,
+ * else return `SCM_BOOL_F`.  This does NOT remove the atom from any
+ * attached backing store/persistant storage, only from the (local,
+ * in-RAM) atomspace.
  */
-SCM SchemeSmob::ss_purge (SCM satom, SCM kv_pairs)
+SCM SchemeSmob::ss_extract (SCM satom, SCM kv_pairs)
 {
-	Handle h = verify_handle(satom, "cog-purge");
+	Handle h = verify_handle(satom, "cog-extract");
 
-	// It can happen that the atom has already been purged, but we're
-	// still holding on to its UUID.  This is rare... but possible. So
-	// don't crash when it happens. XXX Is it really possible? How?
-	if (NULL == h.operator->()) return SCM_BOOL_F;
-
-	// The purge will fail/log warning if the incoming set isn't null.
+	// The extract will fail/log warning if the incoming set isn't null.
 	if (h->getIncomingSetSize() > 0) return SCM_BOOL_F;
 
 	AtomSpace* atomspace = get_as_from_list(kv_pairs);
-	if (NULL == atomspace) atomspace = ss_get_env_as("cog-purge");
+	if (NULL == atomspace) atomspace = ss_get_env_as("cog-extract");
 
-	// AtomSpace::purgeAtom() returns true if atom was purged,
+	// AtomSpace::extract_atom() returns true if atom was extracted,
 	// else returns false
-	bool rc = atomspace->purge_atom(h, false);
+	bool rc = atomspace->extract_atom(h, false);
 
 	// Clobber the handle, too.
 	*((Handle *) SCM_SMOB_DATA(satom)) = Handle::UNDEFINED;
@@ -738,18 +734,18 @@ SCM SchemeSmob::ss_purge (SCM satom, SCM kv_pairs)
 
 /* ============================================================== */
 /**
- * Purge the atom, and everything pointing to it.
+ * Extract the atom, and everything pointing to it.
  * This does NOT remove the atom from any attached backing store, only
  * from the atomspace.
  */
-SCM SchemeSmob::ss_purge_recursive (SCM satom, SCM kv_pairs)
+SCM SchemeSmob::ss_extract_recursive (SCM satom, SCM kv_pairs)
 {
-	Handle h = verify_handle(satom, "cog-purge-recursive");
+	Handle h = verify_handle(satom, "cog-extract-recursive");
 
 	AtomSpace* atomspace = get_as_from_list(kv_pairs);
-	if (NULL == atomspace) atomspace = ss_get_env_as("cog-purge-recursive");
+	if (NULL == atomspace) atomspace = ss_get_env_as("cog-extract-recursive");
 
-	bool rc = atomspace->purge_atom(h, true);
+	bool rc = atomspace->extract_atom(h, true);
 
 	// Clobber the handle, too.
 	*((Handle *) SCM_SMOB_DATA(satom)) = Handle::UNDEFINED;

--- a/opencog/persist/sql/README.md
+++ b/opencog/persist/sql/README.md
@@ -661,7 +661,7 @@ be slow.
 Once stored, the atom may be deleted from the AtomSpace; it will
 remain in storage, and can be recreated at will:
 ```
-    guile> (cog-purge y)
+    guile> (cog-extract y)
     #t
     guile> y
     #<Invalid handle>
@@ -673,7 +673,7 @@ Notice, in the above, that the truth value is the same as it was before.
 That is because the truth value was fetched from the database when the
 atom is recreated.
 
-The UUID associated with the atom will NOT change between purges
+The UUID associated with the atom will NOT change between extracts
 and server restarts. This can be verified with the cog-handle command,
 which returns the UUID:
 ```
@@ -681,24 +681,25 @@ which returns the UUID:
     2
 ```
 
-Purging vs. Deletion
---------------------
-There are four related but distinct concepts of atom deletion: purge and
-delete, each of which may also be done recursively. "Purge" with remove
-the atom from the atomspace; it will NOT remove it from the database!
-"Delete" will remove the atom from both the atomspace, and from the
-database; thus, deletion is permanent!  (Well, if there are two
-cogservers attached to one database, and one cogserver deletes the atom
-from the database, it will still not be deleted from the second
-cogserver, and so that second cogserver could still save that atom.
-There is currently no way to broadcast a distributed system-wide
-delete message. Its not even obvious that such a broadcast is evn a good
-idea.)
+Extraction vs. Deletion
+-----------------------
+There are four related but distinct concepts of atom deletion: extract
+and delete, each of which may also be done recursively. "Extract" will
+remove the atom from the (local, in-RAM) atomspace; it will NOT remove
+it from the database!  "Delete" will remove the atom from both the
+atomspace, and from the database; thus, deletion is permanent!
+(Caution: there are pathological situations. For example, if there are
+two atomspaces attached to one database, and delete is used in one
+atomspace (thus deleting the atom in the database), there may still be
+a copy in the second atomspace.  If the second atomspace stores that
+atom, it will be re-created in the database.  There is no way to
+broadcast a distributed system-wide delete message.  Such a message
+does not seem to be a good idea, anyway.)
 
-Atoms can also be deleted or purged recusrively. Thus, normally, a
-purge/delete will succeed only if the atom has no incoming set.
-The recursive forms, `cog-purge-recursive` and `cog-delete-recursive`
-purge/delete the atom and avery link that contains that atom, and so
+Atoms can also be extracted or deleted recusrively. Thus, normally, a
+extract/delete will succeed only if the atom has no incoming set.
+The recursive forms, `cog-extract-recursive` and `cog-delete-recursive`
+extract/delete the atom and avery link that contains that atom, and so
 on.
 
 

--- a/opencog/scm/opencog/rule-engine/rule-engine-utils.scm
+++ b/opencog/scm/opencog/rule-engine/rule-engine-utils.scm
@@ -105,7 +105,7 @@
        ; Delete any previous value for that parameter
        (cog-bind del-prev-val)
        ; Delete pattern to not create to much junk in the atomspace
-       (purge-hypergraph del-prev-val)
+       (extract-hypergraph del-prev-val)
   )
 
   ; Set new value for that parameter

--- a/opencog/scm/utilities.scm
+++ b/opencog/scm/utilities.scm
@@ -13,9 +13,9 @@
 ; -- simple traversal of outgoing set (gar, gdr, etc.)
 ; -- for-each-except loop.
 ; -- cog-atom-incr --  Increment count truth value on "atom" by "cnt".
-; -- purge-hypergraph -- purge a hypergraph and everything "under" it.
-; -- purge-type -- purge all atoms of type 'atom-type'.
-; -- clear -- purge all atoms in the atomspace.
+; -- extract-hypergraph -- extract a hypergraph and everything "under" it.
+; -- extract-type -- extract all atoms of type 'atom-type'.
+; -- clear -- extract all atoms in the atomspace.
 ; -- count-all -- Return the total number of atoms in the atomspace.
 ; -- cog-get-atoms -- Return a list of all atoms of type 'atom-type'
 ; -- cog-prt-atomspace -- Prints all atoms in the atomspace
@@ -178,38 +178,38 @@
 )
 
 ; --------------------------------------------------------------------
-(define-public (purge-hypergraph atom)
+(define-public (extract-hypergraph atom)
 "
-  purge-hypergraph -- purge a hypergraph and everything under it
+  extract-hypergraph -- extract a hypergraph and everything under it
 
-  If the indicated atom has no incoming links, then purge it. Repeat
+  If the indicated atom has no incoming links, then extract it. Repeat
   recursively downwards, following the *outgoing* set of any links
   encountered.  This only removes the atoms from the atomspace, it
   does NOT remove it from the backingstore, if attached!
 "
 	(if (cog-node? atom)
-		(cog-purge atom)
+		(cog-extract atom)
 		(let* ((oset (cog-outgoing-set atom))
-				(flg (cog-purge atom))
+				(flg (cog-extract atom))
 			)
-			(if flg ;; halt recursion if link was not purge-able
-				(for-each purge-hypergraph oset)
+			(if flg ;; halt recursion if link was not extract-able
+				(for-each extract-hypergraph oset)
 			)
 		)
 	)
 )
 
 ; --------------------------------------------------------------------
-(define-public (purge-type atom-type)
+(define-public (extract-type atom-type)
 "
-  purge-type -- purge all atoms of type 'atom-type'
+  extract-type -- extract all atoms of type 'atom-type'
 
   If any atoms of that type have incoming links, those links will be
-  purged, and so on recursively.  This only removes the atoms from the
+  extractd, and so on recursively.  This only removes the atoms from the
   atomspace, it does NOT remove it from the backingstore, if attached!
 "
 	(cog-map-type
-		(lambda (x) (cog-purge-recursive x) #f)
+		(lambda (x) (cog-extract-recursive x) #f)
 		atom-type
 	)
 )
@@ -217,12 +217,12 @@
 ; --------------------------------------------------------------------
 (define-public (clear)
 "
-  clear -- purge all atoms in the atomspace.  This only removes the
+  clear -- extract all atoms in the atomspace.  This only removes the
   atoms from the atomspace, it does NOT remove it from the backingstore,
   if attached!
 "
 	(for-each
-		purge-type
+		extract-type
 		(cog-get-types)
 	)
 )
@@ -1163,8 +1163,8 @@
 'gdddr
 'for-each-except
 'cog-atom-incr
-'purge-hypergraph
-'purge-type
+'extract-hypergraph
+'extract-type
 'clear
 'count-all
 'cog-get-atoms

--- a/tests/atomspace/AtomSpaceAsyncUTest.cxxtest
+++ b/tests/atomspace/AtomSpaceAsyncUTest.cxxtest
@@ -172,7 +172,7 @@ public:
         TS_ASSERT(atomSpace->get_size() == 1);
 
         logger().debug("before atom remove, table size = %u", atomSpace->get_size());
-        atomSpace->purge_atom(wnHandle, true);
+        atomSpace->extract_atom(wnHandle, true);
         TS_ASSERT(__testSignalsCounter == 111111);
         TS_ASSERT(atomSpace->get_size() == 0);
 
@@ -184,7 +184,7 @@ public:
         wnHandle = atomSpace->add_node(NUMBER_NODE, "1.41421356");
         atomSpace->add_node(NUMBER_NODE, "1.41421356");
         TS_ASSERT(__testSignalsCounter == 10);
-        atomSpace->purge_atom(wnHandle, true);
+        atomSpace->extract_atom(wnHandle, true);
         TS_ASSERT(__testSignalsCounter == 100010);
 
         __testSignalsCounter = 0;
@@ -194,7 +194,7 @@ public:
         wnHandle = atomSpace->add_node(NUMBER_NODE, "1.41421356");
         atomSpace->add_node(NUMBER_NODE, "1.41421356");
         TS_ASSERT(__testSignalsCounter == 0);
-        atomSpace->purge_atom(wnHandle, true);
+        atomSpace->extract_atom(wnHandle, true);
         TS_ASSERT(__testSignalsCounter == 0);
     }
 
@@ -291,7 +291,7 @@ public:
             TS_ASSERT_EQUALS(hs.size(), 1);
             if (hs.size() != 0) {
                 //std::cout << " handle " << hs[0] << std::endl;
-                atomSpace->purge_atom(hs[0], true);
+                atomSpace->extract_atom(hs[0], true);
             }
         }
     }
@@ -591,7 +591,7 @@ public:
             // size_t j = (i+111*thread_id) % nc;
             size_t j = (i+11*thread_id) % nc;
             // size_t j = i;
-            atomSpace->purge_atom((*seq)[j], true);
+            atomSpace->extract_atom((*seq)[j], true);
         }
     }
 
@@ -657,7 +657,7 @@ public:
             TS_ASSERT(h != Handle::UNDEFINED);
             if (h) {
                 //std::cout << " handle " << h << std::endl;
-                atomSpace->purge_atom(h, true);
+                atomSpace->extract_atom(h, true);
             }
         }
     }

--- a/tests/persist/sql/odbc/PersistUTest.cxxtest
+++ b/tests/persist/sql/odbc/PersistUTest.cxxtest
@@ -360,9 +360,9 @@ void PersistUTest::test_atomspace(void)
     /* Push all atoms out to the SQL DB */
     _pm->do_store();
 
-    /* Purge atoms from the AtomSpace. This does not delete them from
+    /* Extract atoms from the AtomSpace. This does not delete them from
      * the SQL storage, though; to do that, they must be deleted, not
-    * purged.
+     * extractd.
      */
     _as->barrier();
     _as->clear();

--- a/tests/persist/sql/postgres/PersistPGSQLUTest.cxxtest
+++ b/tests/persist/sql/postgres/PersistPGSQLUTest.cxxtest
@@ -386,9 +386,9 @@ void PersistUTest::test_atomspace()
     /* Push all atoms out to the SQL DB */
     _pm->do_store();
 
-    /* Purge atoms from the AtomSpace. This does not delete them from
+    /* Extract atoms from the AtomSpace. This does not delete them from
      * the SQL storage, though; to do that, they must be deleted, not
-    * purged.
+     * extractd.
      */
     _as->barrier();
     _as->clear();


### PR DESCRIPTION
Maybe this will lessen the continuing confusion, as seen on the mailing list?

Naming it "purge" seems to have been a mistake, as that seems to conflict with common database usage. 