### PR TITLE
Infiinite loop detecto; SCM PRELOAD cleanup

### DIFF
--- a/opencog/guile/load-file.cc
+++ b/opencog/guile/load-file.cc
@@ -66,6 +66,8 @@ int load_scm_file (AtomSpace& as, const std::string& filename)
  * Load scheme file, with the filename specified as a relative path,
  * and the search paths prepended to the relative path.  If the search
  * paths are null, a list of defaults search paths are used.
+ *
+ * XXX FIXME DEPRECATED! -- DO NOT USE IN NEW CODE!
  */
 int load_scm_file_relative (AtomSpace& as, const std::string& filename,
                             std::vector<std::string> search_paths)
@@ -76,7 +78,6 @@ int load_scm_file_relative (AtomSpace& as, const std::string& filename,
         // XXX This is fairly tacky/broken, and needs a better fix.
         for (auto p : DEFAULT_MODULE_PATHS) {
             search_paths.push_back(p);
-            search_paths.push_back(p + "/examples/rule-engine");
             search_paths.push_back(p + "/opencog");
             search_paths.push_back(p + "/build");
             search_paths.push_back(p + "/build/opencog");
@@ -108,6 +109,8 @@ int load_scm_file_relative (AtomSpace& as, const std::string& filename,
 /**
  * Pull the names of scm files out of the config file, the SCM_PRELOAD
  * key, and try to load those, relative to the search paths.
+ *
+ * XXX FIXME DEPRECATED! -- DO NOT USE IN NEW CODE!
  */
 void load_scm_files_from_config(AtomSpace& atomSpace,
                                 std::vector<std::string> search_paths)

--- a/opencog/query/InitiateSearchCB.cc
+++ b/opencog/query/InitiateSearchCB.cc
@@ -752,6 +752,19 @@ bool InitiateSearchCB::variable_search(PatternMatchEngine *pme)
 				logger().warn("Offending variable=%s\n", var->toString().c_str());
 			for (const Handle& cl : clauses)
 				logger().warn("Offending clauses=%s\n", cl->toString().c_str());
+
+			// Terrible, terrible hack for detecting infinite loops.
+			// When the world is ready for us, we should instead just
+			// throw the hard error, as ifdef'ed above.
+			static const Pattern* prev = nullptr;
+			static unsigned int count = 0;
+			if (prev != _pattern) { prev = _pattern; count = 0; }
+			else {
+				count++;
+				if (5 < count)
+					throw RuntimeException(TRACE_INFO,
+						"Infinite Loop detected! Recursed %u times!", count);
+			}
 #endif
 		}
 

--- a/opencog/query/InitiateSearchCB.cc
+++ b/opencog/query/InitiateSearchCB.cc
@@ -736,21 +736,23 @@ bool InitiateSearchCB::variable_search(PatternMatchEngine *pme)
 	if (nullptr == _root)
 	{
 
-#if THROW_HARD_ERROR
-		throw SyntaxException(TRACE_INFO,
-			"Error: There were no type restrictions! That's infinite-recursive!");
-#else
 		if (not _variables->_deep_typemap.empty())
 		{
 			logger().warn("Warning: Full deep-type support not implemented!");
 		}
 		else
 		{
+// #define THROW_HARD_ERROR 1
+#ifdef THROW_HARD_ERROR
+			throw SyntaxException(TRACE_INFO,
+				"Error: There were no type restrictions! That's infinite-recursive!");
+#else
 			logger().warn("Warning: No type restrictions! Your code has a bug in it!");
 			for (const Handle& var: _variables->varset)
 				logger().warn("Offending variable=%s\n", var->toString().c_str());
 			for (const Handle& cl : clauses)
 				logger().warn("Offending clauses=%s\n", cl->toString().c_str());
+#endif
 		}
 
 		if (0 == clauses.size())
@@ -761,7 +763,6 @@ bool InitiateSearchCB::variable_search(PatternMatchEngine *pme)
 			return false;
 		}
 		_root = _starter_term = clauses[0];
-#endif
 	}
 
 	HandleSeq handle_set;

--- a/tests/atoms/FreeLinkUTest.cxxtest
+++ b/tests/atoms/FreeLinkUTest.cxxtest
@@ -20,12 +20,10 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/guile/load-file.h>
 #include <opencog/guile/SchemeEval.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/atoms/core/FreeLink.h>
 #include <opencog/atoms/core/VariableList.h>
-#include <opencog/util/Config.h>
 #include <opencog/util/Logger.h>
 
 using namespace opencog;
@@ -33,8 +31,8 @@ using namespace opencog;
 class FreeLinkUTest: public CxxTest::TestSuite
 {
 private:
-		AtomSpace *as;
-		SchemeEval* eval;
+	AtomSpace *as;
+	SchemeEval* eval;
 
 public:
 	FreeLinkUTest(void)
@@ -52,7 +50,7 @@ public:
 		delete eval;
 		// Erase the log file if no assertions failed.
 		if (!CxxTest::TestTracker::tracker().suiteFailed())
-				std::remove(logger().get_filename().c_str());
+			std::remove(logger().get_filename().c_str());
 	}
 
 	void setUp(void);
@@ -72,11 +70,6 @@ void FreeLinkUTest::tearDown(void)
 void FreeLinkUTest::setUp(void)
 {
 	as->clear();
-	config().set("SCM_PRELOAD",
-		"opencog/atoms/base/core_types.scm, "
-		"opencog/scm/utilities.scm");
-
-	load_scm_files_from_config(*as);
 }
 
 /*

--- a/tests/atoms/MapLinkUTest.cxxtest
+++ b/tests/atoms/MapLinkUTest.cxxtest
@@ -20,12 +20,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/guile/load-file.h>
 #include <opencog/guile/SchemeEval.h>
-#include <opencog/guile/SchemeSmob.h>
 #include <opencog/atomspace/AtomSpace.h>
-#include <opencog/query/BindLinkAPI.h>
-#include <opencog/util/Config.h>
 #include <opencog/util/Logger.h>
 
 using namespace opencog;
@@ -33,8 +29,8 @@ using namespace opencog;
 class MapLinkUTest: public CxxTest::TestSuite
 {
 private:
-        AtomSpace *as;
-        SchemeEval* eval;
+    AtomSpace *as;
+    SchemeEval* eval;
 
 public:
     MapLinkUTest(void)
@@ -44,6 +40,9 @@ public:
 
         as = new AtomSpace();
         eval = new SchemeEval(as);
+        eval->eval("(add-to-load-path \"..\")");
+        eval->eval("(add-to-load-path \"../../..\")");
+        eval->eval("(use-modules (opencog exec))");
     }
 
     ~MapLinkUTest()
@@ -52,7 +51,7 @@ public:
         delete as;
         // Erase the log file if no assertions failed.
         if (!CxxTest::TestTracker::tracker().suiteFailed())
-                std::remove(logger().get_filename().c_str());
+            std::remove(logger().get_filename().c_str());
     }
 
     void setUp(void);
@@ -72,12 +71,6 @@ void MapLinkUTest::tearDown(void)
 void MapLinkUTest::setUp(void)
 {
     as->clear();
-    config().set("SCM_PRELOAD",
-        "opencog/atoms/base/core_types.scm, "
-        "opencog/scm/utilities.scm, "
-        "opencog/scm/opencog/exec.scm");
-
-    load_scm_files_from_config(*as);
 }
 
 /*
@@ -87,8 +80,7 @@ void MapLinkUTest::test_singleton(void)
 {
     logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/atoms/maplink.scm");
-    load_scm_files_from_config(*as);
+    eval->eval("(load-from-path \"tests/atoms/maplink.scm\")");
 
     Handle result = eval->eval_h("(cog-execute! single)");
 
@@ -138,8 +130,7 @@ void MapLinkUTest::test_signature(void)
 {
     logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/atoms/maplink.scm");
-    load_scm_files_from_config(*as);
+    eval->eval("(load-from-path \"tests/atoms/maplink.scm\")");
 
     Handle result = eval->eval_h("(cog-execute! single-signature)");
 
@@ -156,8 +147,7 @@ void MapLinkUTest::test_double_set(void)
 {
     logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/atoms/maplink.scm");
-    load_scm_files_from_config(*as);
+    eval->eval("(load-from-path \"tests/atoms/maplink.scm\")");
 
     Handle result = eval->eval_h("(cog-execute! double-num-set)");
 
@@ -187,8 +177,7 @@ void MapLinkUTest::test_implication(void)
 {
     logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/atoms/maplink.scm");
-    load_scm_files_from_config(*as);
+    eval->eval("(load-from-path \"tests/atoms/maplink.scm\")");
 
     Handle result = eval->eval_h("(cog-execute! imply-map)");
 

--- a/tests/atoms/ParallelUTest.cxxtest
+++ b/tests/atoms/ParallelUTest.cxxtest
@@ -23,12 +23,8 @@
 #include <time.h>
 #include <sys/time.h>
 
-#include <opencog/guile/load-file.h>
 #include <opencog/guile/SchemeEval.h>
-#include <opencog/guile/SchemeSmob.h>
 #include <opencog/atomspace/AtomSpace.h>
-#include <opencog/query/BindLinkAPI.h>
-#include <opencog/util/Config.h>
 #include <opencog/util/Logger.h>
 
 using namespace opencog;
@@ -36,8 +32,8 @@ using namespace opencog;
 class ParallelUTest: public CxxTest::TestSuite
 {
 private:
-        AtomSpace *as;
-        SchemeEval* eval;
+    AtomSpace *as;
+    SchemeEval* eval;
 
     int robustSleep(int secs);
   
@@ -49,6 +45,8 @@ public:
 
         as = new AtomSpace();
         eval = new SchemeEval(as);
+        eval->eval("(add-to-load-path \"..\")");
+        eval->eval("(add-to-load-path \"../../..\")");
     }
 
     ~ParallelUTest()
@@ -75,12 +73,6 @@ void ParallelUTest::tearDown(void)
 void ParallelUTest::setUp(void)
 {
     as->clear();
-    config().set("SCM_PRELOAD",
-        "opencog/atoms/base/core_types.scm, "
-        "opencog/scm/utilities.scm, "
-        "opencog/scm/opencog/exec.scm");
-
-    load_scm_files_from_config(*as);
 }
 
 /*
@@ -120,8 +112,7 @@ void ParallelUTest::test_parallel(void)
 {
     logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/atoms/parallel.scm");
-    load_scm_files_from_config(*as);
+    eval->eval("(load-from-path \"tests/atoms/parallel.scm\")");
 
     // The scheme variable nnn should increment by one after 1, 3 and 5
     // seconds. If we check at 0, 2, 4, 6 seconds, we should get a clear
@@ -179,8 +170,7 @@ void ParallelUTest::test_join(void)
 {
     logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/atoms/parallel.scm");
-    load_scm_files_from_config(*as);
+    eval->eval("(load-from-path \"tests/atoms/parallel.scm\")");
 
     eval->eval("(set! nnn 0)");
 

--- a/tests/atoms/RandomUTest.cxxtest
+++ b/tests/atoms/RandomUTest.cxxtest
@@ -20,12 +20,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/guile/load-file.h>
 #include <opencog/guile/SchemeEval.h>
-#include <opencog/guile/SchemeSmob.h>
 #include <opencog/atomspace/AtomSpace.h>
-#include <opencog/query/BindLinkAPI.h>
-#include <opencog/util/Config.h>
 #include <opencog/util/Logger.h>
 
 using namespace opencog;
@@ -33,8 +29,8 @@ using namespace opencog;
 class RandomUTest: public CxxTest::TestSuite
 {
 private:
-        AtomSpace *as;
-        SchemeEval* eval;
+    AtomSpace *as;
+    SchemeEval* eval;
 
 public:
     RandomUTest(void)
@@ -44,6 +40,8 @@ public:
 
         as = new AtomSpace();
         eval = new SchemeEval(as);
+        eval->eval("(add-to-load-path \"..\")");
+        eval->eval("(add-to-load-path \"../../..\")");
     }
 
     ~RandomUTest()
@@ -52,7 +50,7 @@ public:
         delete as;
         // Erase the log file if no assertions failed.
         if (!CxxTest::TestTracker::tracker().suiteFailed())
-                std::remove(logger().get_filename().c_str());
+            std::remove(logger().get_filename().c_str());
     }
 
     void setUp(void);
@@ -70,12 +68,6 @@ void RandomUTest::tearDown(void)
 void RandomUTest::setUp(void)
 {
     as->clear();
-    config().set("SCM_PRELOAD",
-        "opencog/atoms/base/core_types.scm, "
-        "opencog/scm/utilities.scm, "
-        "opencog/scm/opencog/exec.scm");
-
-    load_scm_files_from_config(*as);
 }
 
 /*
@@ -85,8 +77,7 @@ void RandomUTest::test_weights(void)
 {
     logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/atoms/random-choice.scm");
-    load_scm_files_from_config(*as);
+    eval->eval("(load-from-path \"tests/atoms/random-choice.scm\")");
 
     eval->eval_tv("(cog-evaluate! (DefinedPredicate \"loop a lot of times\"))");
 

--- a/tests/atoms/ReductUTest.cxxtest
+++ b/tests/atoms/ReductUTest.cxxtest
@@ -20,12 +20,9 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/guile/load-file.h>
 #include <opencog/guile/SchemeEval.h>
-#include <opencog/guile/SchemeSmob.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/atoms/execution/ExecSCM.h>
-#include <opencog/util/Config.h>
 #include <opencog/util/Logger.h>
 
 using namespace opencog;
@@ -33,8 +30,8 @@ using namespace opencog;
 class ReductUTest: public CxxTest::TestSuite
 {
 private:
-		AtomSpace *as;
-		SchemeEval* eval;
+	AtomSpace *as;
+	SchemeEval* eval;
 
 public:
 	ReductUTest(void)
@@ -44,7 +41,6 @@ public:
 
 		as = new AtomSpace();
 		eval = new SchemeEval(as);
-
 		opencog_exec_init();
 	}
 
@@ -54,7 +50,7 @@ public:
 		delete eval;
 		// Erase the log file if no assertions failed.
 		if (!CxxTest::TestTracker::tracker().suiteFailed())
-				std::remove(logger().get_filename().c_str());
+			std::remove(logger().get_filename().c_str());
 	}
 
 	void setUp(void);
@@ -71,12 +67,6 @@ void ReductUTest::tearDown(void)
 void ReductUTest::setUp(void)
 {
 	as->clear();
-	config().set("SCM_PRELOAD",
-		"opencog/atoms/base/core_types.scm, "
-		"opencog/scm/opencog/exec.scm, "
-		"opencog/scm/utilities.scm");
-
-	load_scm_files_from_config(*as);
 }
 
 /*
@@ -85,9 +75,6 @@ void ReductUTest::setUp(void)
 void ReductUTest::test_arithmetic(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
-
-	// config().set("SCM_PRELOAD", "tests/atoms/arithmetic.scm");
-	// load_scm_files_from_config(*as);
 
 	// ---------
 	Handle four = eval->eval_h(

--- a/tests/cython/PythonEvalUTest.cxxtest
+++ b/tests/cython/PythonEvalUTest.cxxtest
@@ -1,12 +1,9 @@
 #include <string>
 #include <cstdio>
 
-#include <opencog/util/Config.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/cython/PythonEval.h>
 #include <opencog/guile/SchemeEval.h>
-#include <opencog/guile/SchemeSmob.h>
-#include <opencog/guile/load-file.h>
 
 using std::string;
 
@@ -14,24 +11,16 @@ using namespace opencog;
 
 const int NO_SIGNAL_HANDLERS = 0;
 
-
 class PythonEvalUTest :  public CxxTest::TestSuite
 {
-
-private:
-
-
 public:
-
     PythonEvalUTest()
     {
         logger().set_print_to_stdout_flag(true);
 
         // setup global logger
-        logger().set_filename(config()["LOG_FILE"]);
-        logger().set_level(Logger::get_level_from_string(config()["LOG_LEVEL"]));
-        logger().set_backtrace_level(Logger::get_level_from_string(config()["BACK_TRACE_LOG_LEVEL"]));
-        logger().set_print_to_stdout_flag(config().get_bool("LOG_TO_STDOUT"));
+        logger().set_level(Logger::DEBUG);
+        logger().set_print_to_stdout_flag(true);
     }
 
     ~PythonEvalUTest() {}
@@ -54,7 +43,6 @@ public:
         // Stop Python.
         Py_Finalize();
 
-
         // Try it again to make sure the Python library cleans up properly.
 
         // Start up Python.
@@ -66,7 +54,6 @@ public:
 
         // Stop Python.
         Py_Finalize();
-
 
         // And again...
 
@@ -80,8 +67,8 @@ public:
         // Stop Python.
         Py_Finalize();
 
-         logger().debug("[PythonEvalUTest] testRawPythonInitialization() DONE");
-   }
+        logger().debug("[PythonEvalUTest] testRawPythonInitialization() DONE");
+    }
 
     void testRawPythonInitializeWithGetSys()
     {
@@ -253,13 +240,9 @@ public:
         // Initialize Python.
         global_python_initialize();
 
-        config().set("SCM_PRELOAD",
-                     "opencog/atoms/base/core_types.scm, "
-		               "opencog/scm/opencog/exec.scm");
         AtomSpace *as = new AtomSpace();
         PythonEval::create_singleton_instance(as);
         PythonEval* python = &PythonEval::instance();
-        load_scm_files_from_config(*as);
 
         // Define python functions for use by scheme.
         python->eval(

--- a/tests/cython/utilities/utilities_test.conf
+++ b/tests/cython/utilities/utilities_test.conf
@@ -1,7 +1,4 @@
 #
-# This file defines configuration settings useful for a Python-script-based
-# OpenCog program that does not use or require a CogServer.
-#
 # Log to the same directory as the script.
 #
 LOG_FILE              = /tmp/utilities_test.log
@@ -9,14 +6,3 @@ LOG_FILE              = /tmp/utilities_test.log
 # Other possible log levels are "error", "warn", "info", "debug" and "fine"
 LOG_LEVEL             = info
 LOG_TO_STDOUT         = false
-
-
-# The functions in this directory will be loaded at startup for acccess by
-# Python code that runs via EvaluationLink or GroundedSchemaNode.
-PYTHON_PRELOAD_FUNCTIONS = ../../../../opencog/opencog/python/preload_functions
-
-# On buildbot and docker installs:
-# /home/opencog/src/opencog/opencog/python/preload_functions
-#
-# Full path of this file:
-# /home/opencog/src/opencog/tests/cython/utilities/utilities_test.conf

--- a/tests/persist/gearman/GearmanUTest.cxxtest
+++ b/tests/persist/gearman/GearmanUTest.cxxtest
@@ -24,11 +24,9 @@
 #include <thread>
 #include <string>
 
-#include <opencog/util/Config.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/atoms/base/Handle.h>
 #include <opencog/guile/SchemeEval.h>
-#include <opencog/guile/load-file.h>
 
 #include <opencog/persist/gearman/DistSCM.h>
 
@@ -69,10 +67,6 @@ class DistScmUTest :  public CxxTest::TestSuite
 void DistScmUTest::setUp(void)
 {
 	as->clear();
-	config().set("SCM_PRELOAD",
-	             "opencog/atoms/base/core_types.scm");
-	load_scm_files_from_config(*as);
-
 	evl->eval("(setenv \"LTDL_LIBRARY_PATH\" \"" PROJECT_BINARY_DIR
 	         "/opencog/persist/gearman:/usr/local/lib/opencog\")");
 	evl->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "/opencog/scm\")");

--- a/tests/query/AbsentUTest.cxxtest
+++ b/tests/query/AbsentUTest.cxxtest
@@ -20,12 +20,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/guile/load-file.h>
-#include <opencog/guile/SchemeEval.h>
-#include <opencog/guile/SchemeSmob.h>
 #include <opencog/atomspace/AtomSpace.h>
-#include <opencog/query/BindLinkAPI.h>
-#include <opencog/util/Config.h>
+#include <opencog/guile/SchemeEval.h>
 #include <opencog/util/Logger.h>
 
 using namespace opencog;
@@ -44,6 +40,9 @@ public:
 
 		as = new AtomSpace();
 		eval = new SchemeEval(as);
+		eval->eval("(add-to-load-path \"..\")");
+		eval->eval("(add-to-load-path \"../../..\")");
+		eval->eval("(use-modules (opencog exec) (opencog query))");
 	}
 
 	~AbsentUTest()
@@ -74,9 +73,7 @@ void AbsentUTest::tearDown(void)
 void AbsentUTest::setUp(void)
 {
 	as->clear();
-	config().set("SCM_PRELOAD", "tests/query/test_types.scm");
-	load_scm_files_from_config(*as);
-	eval->eval("(use-modules (opencog exec) (opencog query))");
+	eval->eval("(load-from-path \"tests/query/test_types.scm\")");
 }
 
 #define getarity(hand) LinkCast(hand)->getArity()
@@ -89,8 +86,7 @@ void AbsentUTest::test_single(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD", "tests/query/absent.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/absent.scm\")");
 
 	Handle empty = eval->eval_h("(ConceptNode \"room empty\")");
 	Handle full = eval->eval_h("(ConceptNode \"room nonempty\")");
@@ -141,8 +137,7 @@ void AbsentUTest::test_double(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD", "tests/query/absent-multi.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/absent-multi.scm\")");
 
 	Handle denied = eval->eval_h("(get-denied)");
 	Handle exists = eval->eval_h("(get-exists)");
@@ -231,8 +226,7 @@ void AbsentUTest::test_connect_exist(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD", "tests/query/absent-conn1.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/absent-conn1.scm\")");
 
 	Handle rtn = eval->eval_h("(cog-bind test)");
 
@@ -248,8 +242,7 @@ void AbsentUTest::test_connect_not_exist(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD", "tests/query/absent-conn2.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/absent-conn2.scm\")");
 
 	Handle rtn = eval->eval_h("(cog-bind test)");
 
@@ -265,8 +258,7 @@ void AbsentUTest::test_discon_exist(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD", "tests/query/absent-disconn1.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/absent-disconn1.scm\")");
 
 	Handle rtn = eval->eval_h("(cog-bind test)");
 
@@ -282,8 +274,7 @@ void AbsentUTest::test_discon_not_exist(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD", "tests/query/absent-disconn2.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/absent-disconn2.scm\")");
 
 	Handle rtn = eval->eval_h("(cog-bind test)");
 

--- a/tests/query/ArcanaUTest.cxxtest
+++ b/tests/query/ArcanaUTest.cxxtest
@@ -34,50 +34,50 @@ using namespace opencog;
 class ArcanaUTest: public CxxTest::TestSuite
 {
 private:
-        AtomSpace *as;
-        SchemeEval* eval;
+	AtomSpace *as;
+	SchemeEval* eval;
 
 public:
-    ArcanaUTest(void)
-    {
-        logger().set_level(Logger::DEBUG);
-        logger().set_print_to_stdout_flag(true);
+	ArcanaUTest(void)
+	{
+		logger().set_level(Logger::DEBUG);
+		logger().set_print_to_stdout_flag(true);
 
-        as = new AtomSpace();
-        eval = new SchemeEval(as);
-    }
+		as = new AtomSpace();
+		eval = new SchemeEval(as);
+	}
 
-    ~ArcanaUTest()
-    {
-        delete eval;
-        delete as;
-        // Erase the log file if no assertions failed.
-        if (!CxxTest::TestTracker::tracker().suiteFailed())
-                std::remove(logger().get_filename().c_str());
-    }
+	~ArcanaUTest()
+	{
+		delete eval;
+		delete as;
+		// Erase the log file if no assertions failed.
+		if (!CxxTest::TestTracker::tracker().suiteFailed())
+				std::remove(logger().get_filename().c_str());
+	}
 
-    void setUp(void);
-    void tearDown(void);
+	void setUp(void);
+	void tearDown(void);
 
-    void test_repeats(void);
-    void test_const(void);
-    void test_dummy(void);
-    void test_numeric(void);
+	void test_repeats(void);
+	void test_const(void);
+	void test_dummy(void);
+	void test_numeric(void);
 };
 
 void ArcanaUTest::tearDown(void)
 {
-    as->clear();
+	as->clear();
 }
 
 void ArcanaUTest::setUp(void)
 {
-    as->clear();
-    config().set("SCM_PRELOAD",
-        "tests/query/test_types.scm, "
-        "opencog/scm/opencog/query.scm");
-    load_scm_files_from_config(*as);
-    eval->eval("(use-modules (opencog query))");
+	as->clear();
+	config().set("SCM_PRELOAD",
+		"tests/query/test_types.scm, "
+		"opencog/scm/opencog/query.scm");
+	load_scm_files_from_config(*as);
+	eval->eval("(use-modules (opencog query))");
 }
 
 #define getarity(hand) LinkCast(hand)->getArity()
@@ -88,48 +88,48 @@ void ArcanaUTest::setUp(void)
  */
 void ArcanaUTest::test_repeats(void)
 {
-    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/arcana-repeat.scm");
-    load_scm_files_from_config(*as);
+	config().set("SCM_PRELOAD", "tests/query/arcana-repeat.scm");
+	load_scm_files_from_config(*as);
 
-    Handle same = eval->eval_h("(cog-bind (repeat-same))");
-    printf("same, num solutions=%d\n", getarity(same));
-    TS_ASSERT_EQUALS(1, getarity(same));
+	Handle same = eval->eval_h("(cog-bind (repeat-same))");
+	printf("same, num solutions=%d\n", getarity(same));
+	TS_ASSERT_EQUALS(1, getarity(same));
 
-    Handle diff = eval->eval_h("(cog-bind (repeat-different))");
+	Handle diff = eval->eval_h("(cog-bind (repeat-different))");
 
-    // Either one or two solutions are acceptable, as long as the
-    // two are identical. One solution is prefered, but seems
-    // not possible with the current algo.
-    LinkPtr lll(LinkCast(diff));
-    const HandleSeq& oset = lll->getOutgoingSet();
-    size_t nsol = oset.size();
-    bool pass = false;
-    if (1 == nsol) pass = true;
-    if (2 == nsol and oset[0] == oset[1]) pass = true;
-    printf("diff, num solutions=%zu\n", nsol);
-    if (1 <= nsol)
-        printf("Solution 1:\n%s\n", oset[0]->toShortString().c_str());
-    if (2 == nsol)
-        printf("Solution 2:\n%s\n", oset[0]->toShortString().c_str());
-    TS_ASSERT_EQUALS(true, pass);
+	// Either one or two solutions are acceptable, as long as the
+	// two are identical. One solution is prefered, but seems
+	// not possible with the current algo.
+	LinkPtr lll(LinkCast(diff));
+	const HandleSeq& oset = lll->getOutgoingSet();
+	size_t nsol = oset.size();
+	bool pass = false;
+	if (1 == nsol) pass = true;
+	if (2 == nsol and oset[0] == oset[1]) pass = true;
+	printf("diff, num solutions=%zu\n", nsol);
+	if (1 <= nsol)
+		printf("Solution 1:\n%s\n", oset[0]->toShortString().c_str());
+	if (2 == nsol)
+		printf("Solution 2:\n%s\n", oset[0]->toShortString().c_str());
+	TS_ASSERT_EQUALS(true, pass);
 
-    Handle d3d = eval->eval_h("(cog-bind (repeat-diff-thrice))");
-    printf("d3d, num solutions=%d\n", getarity(d3d));
-    TS_ASSERT(1 <= getarity(d3d));
-    TS_ASSERT(getarity(d3d) <= 3);
+	Handle d3d = eval->eval_h("(cog-bind (repeat-diff-thrice))");
+	printf("d3d, num solutions=%d\n", getarity(d3d));
+	TS_ASSERT(1 <= getarity(d3d));
+	TS_ASSERT(getarity(d3d) <= 3);
 
-    Handle thrice = eval->eval_h("(cog-bind (repeat-thrice))");
-    printf("thrice, num solutions=%d\n", getarity(thrice));
-    TS_ASSERT_EQUALS(1, getarity(thrice));
+	Handle thrice = eval->eval_h("(cog-bind (repeat-thrice))");
+	printf("thrice, num solutions=%d\n", getarity(thrice));
+	TS_ASSERT_EQUALS(1, getarity(thrice));
 
-    Handle once = eval->eval_h("(cog-bind (repeat-once))");
-    printf("once, num solutions=%d\n", getarity(once));
-    TS_ASSERT_EQUALS(1, getarity(once));
+	Handle once = eval->eval_h("(cog-bind (repeat-once))");
+	printf("once, num solutions=%d\n", getarity(once));
+	TS_ASSERT_EQUALS(1, getarity(once));
 
-    // ----
-    logger().debug("END TEST: %s", __FUNCTION__);
+	// ----
+	logger().debug("END TEST: %s", __FUNCTION__);
 }
 
 /*
@@ -138,33 +138,33 @@ void ArcanaUTest::test_repeats(void)
  */
 void ArcanaUTest::test_const(void)
 {
-    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/arcana-const.scm");
-    load_scm_files_from_config(*as);
+	config().set("SCM_PRELOAD", "tests/query/arcana-const.scm");
+	load_scm_files_from_config(*as);
 
-    // ----
-    Handle marconi = eval->eval_h("marconi");
+	// ----
+	Handle marconi = eval->eval_h("marconi");
 
-    Handle answer = eval->eval_h("(cog-bind who)");
-    printf("radio=%s\n", answer->toString().c_str());
+	Handle answer = eval->eval_h("(cog-bind who)");
+	printf("radio=%s\n", answer->toString().c_str());
 
-    TS_ASSERT_EQUALS(1, getarity(answer));
-    LinkPtr lp = LinkCast(answer);
-    Handle devel = lp->getOutgoingAtom(0);
+	TS_ASSERT_EQUALS(1, getarity(answer));
+	LinkPtr lp = LinkCast(answer);
+	Handle devel = lp->getOutgoingAtom(0);
 
-    TS_ASSERT_EQUALS(marconi, devel);
+	TS_ASSERT_EQUALS(marconi, devel);
 
-    // ----
-    // Test DefinedSchemaNode as an answer.
-    Handle defans = eval->eval_h("(cog-bind whodfn)");
-    printf("defined radio=%s\n", defans->toString().c_str());
+	// ----
+	// Test DefinedSchemaNode as an answer.
+	Handle defans = eval->eval_h("(cog-bind whodfn)");
+	printf("defined radio=%s\n", defans->toString().c_str());
 
-    TS_ASSERT_EQUALS(1, getarity(defans));
-    TS_ASSERT_EQUALS(defans, answer);
+	TS_ASSERT_EQUALS(1, getarity(defans));
+	TS_ASSERT_EQUALS(defans, answer);
 
-    // ----
-    logger().debug("END TEST: %s", __FUNCTION__);
+	// ----
+	logger().debug("END TEST: %s", __FUNCTION__);
 }
 
 /*
@@ -173,25 +173,25 @@ void ArcanaUTest::test_const(void)
  */
 void ArcanaUTest::test_dummy(void)
 {
-    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/arcana-dummy.scm");
-    load_scm_files_from_config(*as);
+	config().set("SCM_PRELOAD", "tests/query/arcana-dummy.scm");
+	load_scm_files_from_config(*as);
 
-    // ----
-    Handle answer = eval->eval_h("(cog-execute! dummy)");
-    printf("dummy=%s\n", answer->toString().c_str());
+	// ----
+	Handle answer = eval->eval_h("(cog-execute! dummy)");
+	printf("dummy=%s\n", answer->toString().c_str());
 
-    TS_ASSERT_EQUALS(SET_LINK, answer->getType());
-    TS_ASSERT_EQUALS(1, getarity(answer));
-    LinkPtr lp = LinkCast(answer);
-    Handle num = lp->getOutgoingAtom(0);
+	TS_ASSERT_EQUALS(SET_LINK, answer->getType());
+	TS_ASSERT_EQUALS(1, getarity(answer));
+	LinkPtr lp = LinkCast(answer);
+	Handle num = lp->getOutgoingAtom(0);
 
-    Handle fourtwo = eval->eval_h("(Number 42)");
-    TS_ASSERT_EQUALS(num, fourtwo);
+	Handle fourtwo = eval->eval_h("(Number 42)");
+	TS_ASSERT_EQUALS(num, fourtwo);
 
-    // ----
-    logger().debug("END TEST: %s", __FUNCTION__);
+	// ----
+	logger().debug("END TEST: %s", __FUNCTION__);
 }
 
 /*
@@ -200,28 +200,28 @@ void ArcanaUTest::test_dummy(void)
  */
 void ArcanaUTest::test_numeric(void)
 {
-    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/arcana-numeric.scm");
-    load_scm_files_from_config(*as);
+	config().set("SCM_PRELOAD", "tests/query/arcana-numeric.scm");
+	load_scm_files_from_config(*as);
 
-    // ----
-    Handle sl = eval->eval_h("(StateLink"
-                             "   (SchemaNode \"start-interaction-timestamp\")"
-                             "   (TimeLink))");
-    Instantiator(as).execute(sl);
+	// ----
+	Handle sl = eval->eval_h("(StateLink"
+							 "   (SchemaNode \"start-interaction-timestamp\")"
+							 "   (TimeLink))");
+	Instantiator(as).execute(sl);
   
-    TruthValuePtr too_soon = eval->eval_tv(
-        "(cog-evaluate! (DefinedPredicateNode \"Time to change expression\"))");
+	TruthValuePtr too_soon = eval->eval_tv(
+		"(cog-evaluate! (DefinedPredicateNode \"Time to change expression\"))");
 
-    TS_ASSERT_LESS_THAN_EQUALS(too_soon->getMean(), 0.5);
+	TS_ASSERT_LESS_THAN_EQUALS(too_soon->getMean(), 0.5);
 
-    // The TV needs to change after 2 seconds.... sleep 4 to be safe.
-    sleep(4);
-    TruthValuePtr too_late = eval->eval_tv(
-        "(cog-evaluate! (DefinedPredicateNode \"Time to change expression\"))");
-    TS_ASSERT_LESS_THAN_EQUALS(0.5, too_late->getMean());
+	// The TV needs to change after 2 seconds.... sleep 4 to be safe.
+	sleep(4);
+	TruthValuePtr too_late = eval->eval_tv(
+		"(cog-evaluate! (DefinedPredicateNode \"Time to change expression\"))");
+	TS_ASSERT_LESS_THAN_EQUALS(0.5, too_late->getMean());
 
-    // ----
-    logger().debug("END TEST: %s", __FUNCTION__);
+	// ----
+	logger().debug("END TEST: %s", __FUNCTION__);
 }

--- a/tests/query/ArcanaUTest.cxxtest
+++ b/tests/query/ArcanaUTest.cxxtest
@@ -20,13 +20,9 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/guile/load-file.h>
-#include <opencog/guile/SchemeEval.h>
-#include <opencog/guile/SchemeSmob.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/atoms/execution/Instantiator.h>
-#include <opencog/query/BindLinkAPI.h>
-#include <opencog/util/Config.h>
+#include <opencog/guile/SchemeEval.h>
 #include <opencog/util/Logger.h>
 
 using namespace opencog;
@@ -45,6 +41,10 @@ public:
 
 		as = new AtomSpace();
 		eval = new SchemeEval(as);
+		eval->eval("(add-to-load-path \"..\")");
+		eval->eval("(add-to-load-path \"../../..\")");
+		eval->eval("(use-modules (opencog query))");
+		eval->eval("(load-from-path \"tests/query/test_types.scm\")");
 	}
 
 	~ArcanaUTest()
@@ -53,7 +53,7 @@ public:
 		delete as;
 		// Erase the log file if no assertions failed.
 		if (!CxxTest::TestTracker::tracker().suiteFailed())
-				std::remove(logger().get_filename().c_str());
+			std::remove(logger().get_filename().c_str());
 	}
 
 	void setUp(void);
@@ -73,11 +73,6 @@ void ArcanaUTest::tearDown(void)
 void ArcanaUTest::setUp(void)
 {
 	as->clear();
-	config().set("SCM_PRELOAD",
-		"tests/query/test_types.scm, "
-		"opencog/scm/opencog/query.scm");
-	load_scm_files_from_config(*as);
-	eval->eval("(use-modules (opencog query))");
 }
 
 #define getarity(hand) LinkCast(hand)->getArity()
@@ -90,8 +85,7 @@ void ArcanaUTest::test_repeats(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD", "tests/query/arcana-repeat.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/arcana-repeat.scm\")");
 
 	Handle same = eval->eval_h("(cog-bind (repeat-same))");
 	printf("same, num solutions=%d\n", getarity(same));
@@ -140,8 +134,7 @@ void ArcanaUTest::test_const(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD", "tests/query/arcana-const.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/arcana-const.scm\")");
 
 	// ----
 	Handle marconi = eval->eval_h("marconi");
@@ -175,8 +168,7 @@ void ArcanaUTest::test_dummy(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD", "tests/query/arcana-dummy.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/arcana-dummy.scm\")");
 
 	// ----
 	Handle answer = eval->eval_h("(cog-execute! dummy)");
@@ -202,13 +194,12 @@ void ArcanaUTest::test_numeric(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD", "tests/query/arcana-numeric.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/arcana-numeric.scm\")");
 
 	// ----
 	Handle sl = eval->eval_h("(StateLink"
-							 "   (SchemaNode \"start-interaction-timestamp\")"
-							 "   (TimeLink))");
+	                         "   (SchemaNode \"start-interaction-timestamp\")"
+	                         "   (TimeLink))");
 	Instantiator(as).execute(sl);
   
 	TruthValuePtr too_soon = eval->eval_tv(

--- a/tests/query/AttentionalFocusCBUTest.cxxtest
+++ b/tests/query/AttentionalFocusCBUTest.cxxtest
@@ -20,12 +20,9 @@
  * Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-#include <opencog/guile/load-file.h>
 #include <opencog/guile/SchemeEval.h>
-#include <opencog/guile/SchemeSmob.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/query/BindLinkAPI.h>
-#include <opencog/util/Config.h>
 #include <opencog/util/Logger.h>
 
 using namespace opencog;
@@ -42,6 +39,8 @@ public:
 
 		as = new AtomSpace();
 		eval = new SchemeEval(as);
+		eval->eval("(add-to-load-path \"..\")");
+		eval->eval("(add-to-load-path \"../../..\")");
 	}
 
 	~AttentionalFocusCBUTest()
@@ -71,8 +70,8 @@ void AttentionalFocusCBUTest::test_af_bindlink(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 	as->set_attentional_focus_boundary(20); //for test purpose
-	config().set("SCM_PRELOAD", "tests/query/af-filtering-test.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/af-filtering-test.scm\")");
+
 	Handle findMan = eval->eval_h("find-man");
 	// Test PatternMatch::af_bindlink, which should only return the
 	// first match

--- a/tests/query/BuggyEqualUTest.cxxtest
+++ b/tests/query/BuggyEqualUTest.cxxtest
@@ -20,11 +20,9 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/guile/load-file.h>
+#include <opencog/atomspace/AtomSpace.h>
 #include <opencog/guile/SchemeEval.h>
-#include <opencog/guile/SchemeSmob.h>
 #include <opencog/query/BindLinkAPI.h>
-#include <opencog/util/Config.h>
 #include <opencog/util/Logger.h>
 
 using namespace opencog;
@@ -44,6 +42,9 @@ class BuggyEqual :  public CxxTest::TestSuite
 
 			as = new AtomSpace();
 			eval = new SchemeEval(as);
+			eval->eval("(use-modules (opencog query))");
+			eval->eval("(add-to-load-path \"..\")");
+			eval->eval("(add-to-load-path \"../../..\")");
 		}
 
 		~BuggyEqual()
@@ -66,11 +67,10 @@ class BuggyEqual :  public CxxTest::TestSuite
 void BuggyEqual::setUp(void)
 {
 	as->clear();
-	eval->eval("(use-modules (opencog query))");
 }
 
 #define getlink(hand,pos) hand->getOutgoingAtom(pos)
-#define getarity(hand) LinkCast(hand)->getArity()
+#define getarity(hand) hand->getArity()
 
 /*
  * NotLink causing weird trouble.
@@ -79,8 +79,7 @@ void BuggyEqual::test_bugeq(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD", "tests/query/buggy-equal.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/buggy-equal.scm\")");
 
 	Handle pln = eval->eval_h("(cog-bind pln-rule-deduction)");
 	printf("Deduction results:\n%s\n", pln->toShortString().c_str());
@@ -95,8 +94,7 @@ void BuggyEqual::test_bugalt(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD", "tests/query/buggy-equal.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/buggy-equal.scm\")");
 
 	Handle alt = eval->eval_h("(cog-bind pln-alt)");
 	printf("Alt results:\n%s\n", alt->toShortString().c_str());

--- a/tests/query/BuggyLinkUTest.cxxtest
+++ b/tests/query/BuggyLinkUTest.cxxtest
@@ -20,12 +20,9 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/guile/load-file.h>
 #include <opencog/guile/SchemeEval.h>
-#include <opencog/guile/SchemeSmob.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/query/BindLinkAPI.h>
-#include <opencog/util/Config.h>
 #include <opencog/util/Logger.h>
 
 using namespace opencog;
@@ -44,6 +41,8 @@ public:
 
         as = new AtomSpace();
         eval = new SchemeEval(as);
+        eval->eval("(add-to-load-path \"..\")");
+        eval->eval("(add-to-load-path \"../../..\")");
     }
 
     ~BuggyLinkUTest()
@@ -74,7 +73,7 @@ void BuggyLinkUTest::setUp(void)
 
 /*
  * BuggyLink unit test.  Test binding to unquoted links.
- * This test explicitly tests the bug described in 
+ * This test explicitly tests the bug described in
  * https://github.com/opencog/opencog/issues/1025
  * The old pattern matcher would crash with a null-pointer deref.
  * The current one works great.
@@ -83,8 +82,7 @@ void BuggyLinkUTest::test_link(void)
 {
     logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/buggy-link.scm");
-    load_scm_files_from_config(*as);
+    eval->eval("(load-from-path \"tests/query/buggy-link.scm\")");
 
     Handle bindy = eval->eval_h("bindy");
     TSM_ASSERT("Failed to load test data", Handle::UNDEFINED != bindy);
@@ -94,4 +92,3 @@ void BuggyLinkUTest::test_link(void)
 
     TS_ASSERT_EQUALS(1, getarity(lily));
 }
-

--- a/tests/query/BuggyNotUTest.cxxtest
+++ b/tests/query/BuggyNotUTest.cxxtest
@@ -20,11 +20,10 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/guile/load-file.h>
+#include <opencog/atomspace/AtomSpace.h>
 #include <opencog/guile/SchemeEval.h>
 #include <opencog/guile/SchemeSmob.h>
 #include <opencog/query/BindLinkAPI.h>
-#include <opencog/util/Config.h>
 #include <opencog/util/Logger.h>
 
 #include "test-types.h"
@@ -35,6 +34,7 @@ class BuggyNot :  public CxxTest::TestSuite
 {
 	private:
 		AtomSpace *as;
+		SchemeEval* eval;
 
 	public:
 
@@ -44,6 +44,9 @@ class BuggyNot :  public CxxTest::TestSuite
 			logger().set_print_to_stdout_flag(true);
 
 			as = new AtomSpace();
+			eval = new SchemeEval(as);
+			eval->eval("(add-to-load-path \"..\")");
+			eval->eval("(add-to-load-path \"../../..\")");
 		}
 
 		~BuggyNot()
@@ -66,15 +69,13 @@ class BuggyNot :  public CxxTest::TestSuite
  */
 #define an as->addNode
 #define al as->addLink
-#define getarity(hand) LinkCast(hand)->getArity()
-#define getlink(hand,pos) LinkCast(hand)->getOutgoingAtom(pos)
+#define getarity(hand) hand->getArity()
+#define getlink(hand,pos) hand->getOutgoingAtom(pos)
 
 void BuggyNot::setUp(void)
 {
 	as->clear();
-
-	config().set("SCM_PRELOAD", "tests/query/test_types.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/test_types.scm\")");
 }
 
 /*
@@ -84,11 +85,9 @@ void BuggyNot::test_bugnot(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD", "tests/query/buggy-not.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/buggy-not.scm\")");
 
 	// Create an implication link that will be tested.
-	SchemeEval* eval = new SchemeEval(as);
 	Handle same_rule = eval->apply("is-same-rule", Handle::UNDEFINED);
 	Handle trans_rule = eval->apply("transitive-rule", Handle::UNDEFINED);
 	delete eval;

--- a/tests/query/BuggyQuoteUTest.cxxtest
+++ b/tests/query/BuggyQuoteUTest.cxxtest
@@ -20,12 +20,9 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/guile/load-file.h>
 #include <opencog/guile/SchemeEval.h>
-#include <opencog/guile/SchemeSmob.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/query/BindLinkAPI.h>
-#include <opencog/util/Config.h>
 #include <opencog/util/Logger.h>
 
 using namespace opencog;
@@ -44,6 +41,8 @@ public:
 
         as = new AtomSpace();
         eval = new SchemeEval(as);
+        eval->eval("(add-to-load-path \"..\")");
+        eval->eval("(add-to-load-path \"../../..\")");
     }
 
     ~BuggyQuoteUTest()
@@ -51,7 +50,7 @@ public:
         delete as;
         // Erase the log file if no assertions failed.
         if (!CxxTest::TestTracker::tracker().suiteFailed())
-                std::remove(logger().get_filename().c_str());
+            std::remove(logger().get_filename().c_str());
     }
 
     void setUp(void);
@@ -86,8 +85,7 @@ void BuggyQuoteUTest::test_bad_quote(void)
 {
     logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/buggy-crime.scm");
-    load_scm_files_from_config(*as);
+    eval->eval("(load-from-path \"tests/query/buggy-crime.scm\")");
 
     // This should throw an exception from scheme.
     // Disable logging so as to avoid the hopeless spew of errors.
@@ -115,8 +113,7 @@ void BuggyQuoteUTest::test_good_form(void)
 {
     logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/buggy-crime.scm");
-    load_scm_files_from_config(*as);
+    eval->eval("(load-from-path \"tests/query/buggy-crime.scm\")");
 
     Handle qrule = eval->eval_h("query_rule_good");
     TSM_ASSERT("Failed to load test data", Handle::UNDEFINED != qrule);

--- a/tests/query/BuggySelfGroundUTest.cxxtest
+++ b/tests/query/BuggySelfGroundUTest.cxxtest
@@ -22,12 +22,9 @@
  * Created by Jacek Świergocki <jswiergo@gmail.com> August 2015
  */
 
-#include <opencog/guile/load-file.h>
 #include <opencog/guile/SchemeEval.h>
-#include <opencog/guile/SchemeSmob.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/query/BindLinkAPI.h>
-#include <opencog/util/Config.h>
 #include <opencog/util/Logger.h>
 
 using namespace opencog;
@@ -35,8 +32,8 @@ using namespace opencog;
 class BuggySelfGroundUTest: public CxxTest::TestSuite
 {
 private:
-        AtomSpace *as;
-        SchemeEval* eval;
+    AtomSpace *as;
+    SchemeEval* eval;
 
 public:
     BuggySelfGroundUTest(void)
@@ -46,6 +43,8 @@ public:
 
         as = new AtomSpace();
         eval = new SchemeEval(as);
+        eval->eval("(add-to-load-path \"..\")");
+        eval->eval("(add-to-load-path \"../../..\")");
     }
 
     ~BuggySelfGroundUTest()
@@ -54,7 +53,7 @@ public:
         delete as;
         // Erase the log file if no assertions failed.
         if (!CxxTest::TestTracker::tracker().suiteFailed())
-                std::remove(logger().get_filename().c_str());
+            std::remove(logger().get_filename().c_str());
     }
 
     void setUp(void);
@@ -79,8 +78,7 @@ void BuggySelfGroundUTest::test_crash(void)
 {
     logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/buggy-selfgnd.scm");
-    load_scm_files_from_config(*as);
+    eval->eval("(load-from-path \"tests/query/buggy-selfgnd.scm\")");
 
     Handle hbnd = eval->eval_h("bnd");
     TSM_ASSERT("Failed to load test data", Handle::UNDEFINED != hbnd);

--- a/tests/query/BuggyStackUTest.cxxtest
+++ b/tests/query/BuggyStackUTest.cxxtest
@@ -20,11 +20,10 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/guile/load-file.h>
+#include <opencog/atomspace/AtomSpace.h>
 #include <opencog/guile/SchemeEval.h>
 #include <opencog/guile/SchemeSmob.h>
 #include <opencog/query/BindLinkAPI.h>
-#include <opencog/util/Config.h>
 #include <opencog/util/Logger.h>
 
 #include "test-types.h"
@@ -64,25 +63,21 @@ class BuggyStackUTest :  public CxxTest::TestSuite
  */
 #define an as->add_node
 #define al as->add_link
-#define getarity(hand) LinkCast(hand)->getArity()
-#define getlink(hand,pos) LinkCast(hand)->getOutgoingAtom(pos)
+#define getarity(hand) hand->getArity()
+#define getlink(hand,pos) hand->getOutgoingAtom(pos)
 
 void BuggyStackUTest::setUp(void)
 {
 	as = new AtomSpace();
+	SchemeEval* eval = new SchemeEval(as);
+	eval->eval("(add-to-load-path \"..\")");
+	eval->eval("(add-to-load-path \"../../..\")");
+	eval->eval("(load-from-path \"tests/query/test_types.scm\")");
+	eval->eval("(load-from-path \"tests/query/buggy-stack.scm\")");
 
-	config().set("SCM_PRELOAD",
-      "tests/query/test_types.scm, "
-		"tests/query/buggy-stack.scm");
-
-	load_scm_files_from_config(*as);
-
-#ifdef HAVE_GUILE
 	// Create an implication link that will be tested.
-	SchemeEval* ev = new SchemeEval(as);
-	restrict = ev->apply("impy", Handle::UNDEFINED);
-	delete ev;
-#endif /* HAVE_GUILE */
+	restrict = eval->apply("impy", Handle::UNDEFINED);
+	delete eval;
 }
 
 /*

--- a/tests/query/ChoiceLinkUTest.cxxtest
+++ b/tests/query/ChoiceLinkUTest.cxxtest
@@ -40,6 +40,8 @@ public:
 
 		as = new AtomSpace();
 		eval = new SchemeEval(as);
+		eval->eval("(add-to-load-path \"..\")");
+		eval->eval("(add-to-load-path \"../../..\")");
 	}
 
 	~ChoiceLinkUTest()
@@ -87,8 +89,7 @@ void ChoiceLinkUTest::test_basic_or(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD", "tests/query/choice-link.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/choice-link.scm\")");
 
 	Handle items = eval->eval_h("(cog-bind (basic))");
 
@@ -102,8 +103,7 @@ void ChoiceLinkUTest::test_embed_or(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD", "tests/query/choice-embed.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/choice-embed.scm\")");
 
 	Handle items = eval->eval_h("(cog-bind (embed))");
 
@@ -117,8 +117,7 @@ void ChoiceLinkUTest::test_nest_or(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD", "tests/query/choice-nest.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/choice-nest.scm\")");
 
 	Handle items = eval->eval_h("(cog-bind (nest))");
 
@@ -133,8 +132,7 @@ void ChoiceLinkUTest::test_top_nest_or(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD", "tests/query/choice-top-nest.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/choice-top-nest.scm\")");
 
 	Handle items = eval->eval_h("(cog-bind (top-nest))");
 
@@ -149,8 +147,7 @@ void ChoiceLinkUTest::test_nest_bad_or(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD", "tests/query/choice-nest.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/choice-nest.scm\")");
 
 	Handle items = eval->eval_h("(cog-bind (nest-bad))");
 
@@ -165,8 +162,7 @@ void ChoiceLinkUTest::test_top_nest_bad_or(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD", "tests/query/choice-top-nest.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/choice-top-nest.scm\")");
 
 	Handle items = eval->eval_h("(cog-bind (top-nest-bad))");
 
@@ -181,8 +177,7 @@ void ChoiceLinkUTest::test_top_disco(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD", "tests/query/choice-disconnected.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/choice-dicsonnected.scm\")");
 
 	Handle items = eval->eval_h("(cog-bind (top-disco))");
 
@@ -203,8 +198,7 @@ void ChoiceLinkUTest::test_embed_disco(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD", "tests/query/choice-embed-disco.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/choice-embed-disco.scm\")");
 
 	Handle items = eval->eval_h("(cog-bind (embed-disco))");
 
@@ -219,8 +213,7 @@ void ChoiceLinkUTest::test_double_or(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD", "tests/query/choice-double.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/choice-double.scm\")");
 
 	Handle items = eval->eval_h("(cog-bind (double))");
 
@@ -234,8 +227,7 @@ void ChoiceLinkUTest::test_unary(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD", "tests/query/choice-unary.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/choice-unary.scm\")");
 
 	// Needed to define cog-execute!
 	eval->eval("(use-modules (opencog exec))");
@@ -258,8 +250,7 @@ void ChoiceLinkUTest::test_typed(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD", "tests/query/choice-typed.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/choice-typed.scm\")");
 
 	// Needed to define cog-execute!
 	eval->eval("(use-modules (opencog exec))");

--- a/tests/query/ChoiceLinkUTest.cxxtest
+++ b/tests/query/ChoiceLinkUTest.cxxtest
@@ -20,12 +20,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/guile/load-file.h>
 #include <opencog/guile/SchemeEval.h>
-#include <opencog/guile/SchemeSmob.h>
 #include <opencog/atomspace/AtomSpace.h>
-#include <opencog/query/BindLinkAPI.h>
-#include <opencog/util/Config.h>
 #include <opencog/util/Logger.h>
 
 using namespace opencog;
@@ -33,53 +29,53 @@ using namespace opencog;
 class ChoiceLinkUTest: public CxxTest::TestSuite
 {
 private:
-        AtomSpace *as;
-        SchemeEval* eval;
+	AtomSpace *as;
+	SchemeEval* eval;
 
 public:
-    ChoiceLinkUTest(void)
-    {
-        logger().set_level(Logger::DEBUG);
-        logger().set_print_to_stdout_flag(true);
+	ChoiceLinkUTest(void)
+	{
+		logger().set_level(Logger::DEBUG);
+		logger().set_print_to_stdout_flag(true);
 
-        as = new AtomSpace();
-        eval = new SchemeEval(as);
-    }
+		as = new AtomSpace();
+		eval = new SchemeEval(as);
+	}
 
-    ~ChoiceLinkUTest()
-    {
-        delete eval;
-        delete as;
-        // Erase the log file if no assertions failed.
-        if (!CxxTest::TestTracker::tracker().suiteFailed())
-                std::remove(logger().get_filename().c_str());
-    }
+	~ChoiceLinkUTest()
+	{
+		delete eval;
+		delete as;
+		// Erase the log file if no assertions failed.
+		if (!CxxTest::TestTracker::tracker().suiteFailed())
+				std::remove(logger().get_filename().c_str());
+	}
 
-    void setUp(void);
-    void tearDown(void);
+	void setUp(void);
+	void tearDown(void);
 
-    void test_basic_or(void);
-    void test_embed_or(void);
-    void test_nest_or(void);
-    void test_top_nest_or(void);
-    void test_nest_bad_or(void);
-    void test_top_nest_bad_or(void);
-    void test_top_disco(void);
-    void test_embed_disco(void);
-    void test_double_or(void);
-    void test_unary(void);
-    void test_typed(void);
+	void test_basic_or(void);
+	void test_embed_or(void);
+	void test_nest_or(void);
+	void test_top_nest_or(void);
+	void test_nest_bad_or(void);
+	void test_top_nest_bad_or(void);
+	void test_top_disco(void);
+	void test_embed_disco(void);
+	void test_double_or(void);
+	void test_unary(void);
+	void test_typed(void);
 };
 
 void ChoiceLinkUTest::tearDown(void)
 {
-    as->clear();
+	as->clear();
 }
 
 void ChoiceLinkUTest::setUp(void)
 {
-    as->clear();
-    eval->eval("(use-modules (opencog query))");
+	as->clear();
+	eval->eval("(use-modules (opencog query))");
 }
 
 #define getarity(hand) LinkCast(hand)->getArity()
@@ -89,14 +85,14 @@ void ChoiceLinkUTest::setUp(void)
  */
 void ChoiceLinkUTest::test_basic_or(void)
 {
-    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/choice-link.scm");
-    load_scm_files_from_config(*as);
+	config().set("SCM_PRELOAD", "tests/query/choice-link.scm");
+	load_scm_files_from_config(*as);
 
-    Handle items = eval->eval_h("(cog-bind (basic))");
+	Handle items = eval->eval_h("(cog-bind (basic))");
 
-    TS_ASSERT_EQUALS(2, getarity(items));
+	TS_ASSERT_EQUALS(2, getarity(items));
 }
 
 /*
@@ -104,14 +100,14 @@ void ChoiceLinkUTest::test_basic_or(void)
  */
 void ChoiceLinkUTest::test_embed_or(void)
 {
-    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/choice-embed.scm");
-    load_scm_files_from_config(*as);
+	config().set("SCM_PRELOAD", "tests/query/choice-embed.scm");
+	load_scm_files_from_config(*as);
 
-    Handle items = eval->eval_h("(cog-bind (embed))");
+	Handle items = eval->eval_h("(cog-bind (embed))");
 
-    TS_ASSERT_EQUALS(2, getarity(items));
+	TS_ASSERT_EQUALS(2, getarity(items));
 }
 
 /*
@@ -119,15 +115,15 @@ void ChoiceLinkUTest::test_embed_or(void)
  */
 void ChoiceLinkUTest::test_nest_or(void)
 {
-    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/choice-nest.scm");
-    load_scm_files_from_config(*as);
+	config().set("SCM_PRELOAD", "tests/query/choice-nest.scm");
+	load_scm_files_from_config(*as);
 
-    Handle items = eval->eval_h("(cog-bind (nest))");
+	Handle items = eval->eval_h("(cog-bind (nest))");
 
-    printf ("Nest found:\n%s\n", items->toShortString().c_str());
-    TS_ASSERT_EQUALS(5, getarity(items));
+	printf ("Nest found:\n%s\n", items->toShortString().c_str());
+	TS_ASSERT_EQUALS(5, getarity(items));
 }
 
 /*
@@ -135,15 +131,15 @@ void ChoiceLinkUTest::test_nest_or(void)
  */
 void ChoiceLinkUTest::test_top_nest_or(void)
 {
-    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/choice-top-nest.scm");
-    load_scm_files_from_config(*as);
+	config().set("SCM_PRELOAD", "tests/query/choice-top-nest.scm");
+	load_scm_files_from_config(*as);
 
-    Handle items = eval->eval_h("(cog-bind (top-nest))");
+	Handle items = eval->eval_h("(cog-bind (top-nest))");
 
-    printf ("Top-nest found:\n%s\n", items->toShortString().c_str());
-    TS_ASSERT_EQUALS(5, getarity(items));
+	printf ("Top-nest found:\n%s\n", items->toShortString().c_str());
+	TS_ASSERT_EQUALS(5, getarity(items));
 }
 
 /*
@@ -151,15 +147,15 @@ void ChoiceLinkUTest::test_top_nest_or(void)
  */
 void ChoiceLinkUTest::test_nest_bad_or(void)
 {
-    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/choice-nest.scm");
-    load_scm_files_from_config(*as);
+	config().set("SCM_PRELOAD", "tests/query/choice-nest.scm");
+	load_scm_files_from_config(*as);
 
-    Handle items = eval->eval_h("(cog-bind (nest-bad))");
+	Handle items = eval->eval_h("(cog-bind (nest-bad))");
 
-    printf ("Nest-bad found:\n%s\n", items->toShortString().c_str());
-    TS_ASSERT_EQUALS(4, getarity(items));
+	printf ("Nest-bad found:\n%s\n", items->toShortString().c_str());
+	TS_ASSERT_EQUALS(4, getarity(items));
 }
 
 /*
@@ -167,15 +163,15 @@ void ChoiceLinkUTest::test_nest_bad_or(void)
  */
 void ChoiceLinkUTest::test_top_nest_bad_or(void)
 {
-    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/choice-top-nest.scm");
-    load_scm_files_from_config(*as);
+	config().set("SCM_PRELOAD", "tests/query/choice-top-nest.scm");
+	load_scm_files_from_config(*as);
 
-    Handle items = eval->eval_h("(cog-bind (top-nest-bad))");
+	Handle items = eval->eval_h("(cog-bind (top-nest-bad))");
 
-    printf ("Top-nest-bad found:\n%s\n", items->toShortString().c_str());
-    TS_ASSERT_EQUALS(4, getarity(items));
+	printf ("Top-nest-bad found:\n%s\n", items->toShortString().c_str());
+	TS_ASSERT_EQUALS(4, getarity(items));
 }
 
 /*
@@ -183,20 +179,20 @@ void ChoiceLinkUTest::test_top_nest_bad_or(void)
  */
 void ChoiceLinkUTest::test_top_disco(void)
 {
-    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/choice-disconnected.scm");
-    load_scm_files_from_config(*as);
+	config().set("SCM_PRELOAD", "tests/query/choice-disconnected.scm");
+	load_scm_files_from_config(*as);
 
-    Handle items = eval->eval_h("(cog-bind (top-disco))");
+	Handle items = eval->eval_h("(cog-bind (top-disco))");
 
-    printf ("Top-disco found:\n%s\n", items->toShortString().c_str());
-    TS_ASSERT_EQUALS(2, getarity(items));
+	printf ("Top-disco found:\n%s\n", items->toShortString().c_str());
+	TS_ASSERT_EQUALS(2, getarity(items));
 
-    Handle wrap = eval->eval_h("(cog-bind (wrapped-disco))");
+	Handle wrap = eval->eval_h("(cog-bind (wrapped-disco))");
 
-    printf ("Top-wrapped-disco found:\n%s\n", wrap->toShortString().c_str());
-    TS_ASSERT_EQUALS(2, getarity(wrap));
+	printf ("Top-wrapped-disco found:\n%s\n", wrap->toShortString().c_str());
+	TS_ASSERT_EQUALS(2, getarity(wrap));
 }
 
 /*
@@ -205,15 +201,15 @@ void ChoiceLinkUTest::test_top_disco(void)
  */
 void ChoiceLinkUTest::test_embed_disco(void)
 {
-    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/choice-embed-disco.scm");
-    load_scm_files_from_config(*as);
+	config().set("SCM_PRELOAD", "tests/query/choice-embed-disco.scm");
+	load_scm_files_from_config(*as);
 
-    Handle items = eval->eval_h("(cog-bind (embed-disco))");
+	Handle items = eval->eval_h("(cog-bind (embed-disco))");
 
-    printf ("Embed pseudo-disco found:\n%s\n", items->toShortString().c_str());
-    TS_ASSERT_EQUALS(2, getarity(items));
+	printf ("Embed pseudo-disco found:\n%s\n", items->toShortString().c_str());
+	TS_ASSERT_EQUALS(2, getarity(items));
 }
 
 /*
@@ -221,14 +217,14 @@ void ChoiceLinkUTest::test_embed_disco(void)
  */
 void ChoiceLinkUTest::test_double_or(void)
 {
-    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/choice-double.scm");
-    load_scm_files_from_config(*as);
+	config().set("SCM_PRELOAD", "tests/query/choice-double.scm");
+	load_scm_files_from_config(*as);
 
-    Handle items = eval->eval_h("(cog-bind (double))");
+	Handle items = eval->eval_h("(cog-bind (double))");
 
-    TS_ASSERT_EQUALS(3, getarity(items));
+	TS_ASSERT_EQUALS(3, getarity(items));
 }
 
 /*
@@ -236,23 +232,23 @@ void ChoiceLinkUTest::test_double_or(void)
  */
 void ChoiceLinkUTest::test_unary(void)
 {
-    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/choice-unary.scm");
-    load_scm_files_from_config(*as);
+	config().set("SCM_PRELOAD", "tests/query/choice-unary.scm");
+	load_scm_files_from_config(*as);
 
-    // Needed to define cog-execute!
-    eval->eval("(use-modules (opencog exec))");
+	// Needed to define cog-execute!
+	eval->eval("(use-modules (opencog exec))");
 
-    Handle doors = eval->eval_h("(cog-execute! (get-a))");
+	Handle doors = eval->eval_h("(cog-execute! (get-a))");
 
-    printf("unary door-a found:\n%s\n", doors->toString().c_str());
-    TS_ASSERT_EQUALS(1, getarity(doors));
+	printf("unary door-a found:\n%s\n", doors->toString().c_str());
+	TS_ASSERT_EQUALS(1, getarity(doors));
 
-    doors = eval->eval_h("(cog-execute! (get-bc))");
+	doors = eval->eval_h("(cog-execute! (get-bc))");
 
-    printf("unary door-bc found:\n%s\n", doors->toString().c_str());
-    TS_ASSERT_EQUALS(4, getarity(doors));
+	printf("unary door-bc found:\n%s\n", doors->toString().c_str());
+	TS_ASSERT_EQUALS(4, getarity(doors));
 }
 
 /*
@@ -260,16 +256,16 @@ void ChoiceLinkUTest::test_unary(void)
  */
 void ChoiceLinkUTest::test_typed(void)
 {
-    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/choice-typed.scm");
-    load_scm_files_from_config(*as);
+	config().set("SCM_PRELOAD", "tests/query/choice-typed.scm");
+	load_scm_files_from_config(*as);
 
-    // Needed to define cog-execute!
-    eval->eval("(use-modules (opencog exec))");
+	// Needed to define cog-execute!
+	eval->eval("(use-modules (opencog exec))");
 
-    Handle rules = eval->eval_h("(cog-execute! get-nodes1)");
+	Handle rules = eval->eval_h("(cog-execute! get-nodes1)");
 
-    printf("typed get-nodes found:\n%s\n", rules->toString().c_str());
-    TS_ASSERT_EQUALS(2, getarity(rules));
+	printf("typed get-nodes found:\n%s\n", rules->toString().c_str());
+	TS_ASSERT_EQUALS(2, getarity(rules));
 }

--- a/tests/query/ChoiceLinkUTest.cxxtest
+++ b/tests/query/ChoiceLinkUTest.cxxtest
@@ -177,7 +177,7 @@ void ChoiceLinkUTest::test_top_disco(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	eval->eval("(load-from-path \"tests/query/choice-dicsonnected.scm\")");
+	eval->eval("(load-from-path \"tests/query/choice-disconnected.scm\")");
 
 	Handle items = eval->eval_h("(cog-bind (top-disco))");
 

--- a/tests/query/DeepTypeUTest.cxxtest
+++ b/tests/query/DeepTypeUTest.cxxtest
@@ -20,12 +20,9 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/guile/load-file.h>
+#include <opencog/util/Logger.h>
 #include <opencog/guile/SchemeEval.h>
 #include <opencog/atomspace/AtomSpace.h>
-#include <opencog/query/BindLinkAPI.h>
-#include <opencog/util/Config.h>
-#include <opencog/util/Logger.h>
 #include <cxxtest/TestSuite.h>
 
 using namespace opencog;
@@ -46,6 +43,8 @@ public:
 		as = new AtomSpace();
 		eval = new SchemeEval(as);
 		eval->eval("(use-modules (opencog exec) (opencog query))");
+		eval->eval("(add-to-load-path \"..\")");
+		eval->eval("(add-to-load-path \"../../..\")");
 	}
 
 	~DeepTypeUTest()
@@ -84,8 +83,7 @@ void DeepTypeUTest::test_is_type(void)
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
 	as->clear();
-	config().set("SCM_PRELOAD", "tests/query/deep-types.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/deep-types.scm\")");
 
 	std::string rv = eval->eval(
 		"(cog-value-is-type? "
@@ -468,8 +466,7 @@ void DeepTypeUTest::test_get_signature(void)
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
 	as->clear();
-	config().set("SCM_PRELOAD", "tests/query/deep-types.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/deep-types.scm\")");
 
 	Handle hgnd = eval->eval_h("(cog-execute! get-foo)");
 	Handle hans = eval->eval_h(
@@ -527,8 +524,7 @@ void DeepTypeUTest::test_unbundle_defined_type_node(void)
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD", "tests/query/deep-types.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/deep-types.scm\")");
 
 	Handle result = eval->eval_h("(cog-execute! predicate-search-typed)");
 	Handle result_expected = eval->eval_h(

--- a/tests/query/DefineUTest.cxxtest
+++ b/tests/query/DefineUTest.cxxtest
@@ -20,12 +20,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/guile/load-file.h>
 #include <opencog/guile/SchemeEval.h>
-#include <opencog/guile/SchemeSmob.h>
 #include <opencog/atomspace/AtomSpace.h>
-#include <opencog/query/BindLinkAPI.h>
-#include <opencog/util/Config.h>
 #include <opencog/util/Logger.h>
 
 using namespace opencog;
@@ -44,6 +40,9 @@ public:
 
 		as = new AtomSpace();
 		eval = new SchemeEval(as);
+		eval->eval("(add-to-load-path \"..\")");
+		eval->eval("(add-to-load-path \"../../..\")");
+		eval->eval("(use-modules (opencog query))");
 	}
 
 	~DefineLinkUTest()
@@ -70,7 +69,6 @@ void DefineLinkUTest::tearDown(void)
 void DefineLinkUTest::setUp(void)
 {
 	as->clear();
-	eval->eval("(use-modules (opencog query))");
 }
 
 #define getarity(hand) LinkCast(hand)->getArity()
@@ -82,8 +80,7 @@ void DefineLinkUTest::test_basic(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD", "tests/query/define.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/define.scm\")");
 
 	Handle items = eval->eval_h("(cog-execute! get-elect)");
 	TS_ASSERT_EQUALS(2, getarity(items));
@@ -103,8 +100,7 @@ void DefineLinkUTest::test_schema(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD", "tests/query/define-schema.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/define-schema.scm\")");
 
 	Handle timestamp = eval->eval_h(
 		"(cog-execute! (DefinedSchemaNode \"set timestamp\"))");

--- a/tests/query/DefineUTest.cxxtest
+++ b/tests/query/DefineUTest.cxxtest
@@ -33,44 +33,44 @@ using namespace opencog;
 class DefineLinkUTest: public CxxTest::TestSuite
 {
 private:
-        AtomSpace *as;
-        SchemeEval* eval;
+	AtomSpace *as;
+	SchemeEval* eval;
 
 public:
-    DefineLinkUTest(void)
-    {
-        logger().set_level(Logger::DEBUG);
-        logger().set_print_to_stdout_flag(true);
+	DefineLinkUTest(void)
+	{
+		logger().set_level(Logger::DEBUG);
+		logger().set_print_to_stdout_flag(true);
 
-        as = new AtomSpace();
-        eval = new SchemeEval(as);
-    }
+		as = new AtomSpace();
+		eval = new SchemeEval(as);
+	}
 
-    ~DefineLinkUTest()
-    {
-        delete eval;
-        delete as;
-        // Erase the log file if no assertions failed.
-        if (!CxxTest::TestTracker::tracker().suiteFailed())
-                std::remove(logger().get_filename().c_str());
-    }
+	~DefineLinkUTest()
+	{
+		delete eval;
+		delete as;
+		// Erase the log file if no assertions failed.
+		if (!CxxTest::TestTracker::tracker().suiteFailed())
+				std::remove(logger().get_filename().c_str());
+	}
 
-    void setUp(void);
-    void tearDown(void);
+	void setUp(void);
+	void tearDown(void);
 
-    void test_basic(void);
-    void test_schema(void);
+	void test_basic(void);
+	void test_schema(void);
 };
 
 void DefineLinkUTest::tearDown(void)
 {
-    as->clear();
+	as->clear();
 }
 
 void DefineLinkUTest::setUp(void)
 {
-    as->clear();
-    eval->eval("(use-modules (opencog query))");
+	as->clear();
+	eval->eval("(use-modules (opencog query))");
 }
 
 #define getarity(hand) LinkCast(hand)->getArity()
@@ -80,19 +80,19 @@ void DefineLinkUTest::setUp(void)
  */
 void DefineLinkUTest::test_basic(void)
 {
-    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/define.scm");
-    load_scm_files_from_config(*as);
+	config().set("SCM_PRELOAD", "tests/query/define.scm");
+	load_scm_files_from_config(*as);
 
-    Handle items = eval->eval_h("(cog-execute! get-elect)");
-    TS_ASSERT_EQUALS(2, getarity(items));
+	Handle items = eval->eval_h("(cog-execute! get-elect)");
+	TS_ASSERT_EQUALS(2, getarity(items));
 
-    items = eval->eval_h("(cog-execute! get-elect-bound)");
-    TS_ASSERT_EQUALS(2, getarity(items));
+	items = eval->eval_h("(cog-execute! get-elect-bound)");
+	TS_ASSERT_EQUALS(2, getarity(items));
 
-    items = eval->eval_h("(cog-execute! get-parts)");
-    TS_ASSERT_EQUALS(2, getarity(items));
+	items = eval->eval_h("(cog-execute! get-parts)");
+	TS_ASSERT_EQUALS(2, getarity(items));
 }
 
 /*
@@ -101,32 +101,32 @@ void DefineLinkUTest::test_basic(void)
  */
 void DefineLinkUTest::test_schema(void)
 {
-    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/define-schema.scm");
-    load_scm_files_from_config(*as);
+	config().set("SCM_PRELOAD", "tests/query/define-schema.scm");
+	load_scm_files_from_config(*as);
 
-    Handle timestamp = eval->eval_h(
-        "(cog-execute! (DefinedSchemaNode \"set timestamp\"))");
-    TS_ASSERT_EQUALS(2, getarity(timestamp));
+	Handle timestamp = eval->eval_h(
+		"(cog-execute! (DefinedSchemaNode \"set timestamp\"))");
+	TS_ASSERT_EQUALS(2, getarity(timestamp));
 
-    // Executing the above should return something like this:
-    // (EvaluationLink
-    //     (PredicateNode "start-interaction-timestamp")
-    //     (ListLink
-    //         (NumberNode "1442342173.000000")))
-    // We need to check explicitly for the NumberNode, as a bogus
-    // return would provide a VariableNode instead, and that would
-    // be wrong.
+	// Executing the above should return something like this:
+	// (EvaluationLink
+	//	 (PredicateNode "start-interaction-timestamp")
+	//	 (ListLink
+	//		 (NumberNode "1442342173.000000")))
+	// We need to check explicitly for the NumberNode, as a bogus
+	// return would provide a VariableNode instead, and that would
+	// be wrong.
 
-    LinkPtr lp = LinkCast(timestamp);
-    Handle pred = lp->getOutgoingAtom(0);
-    TS_ASSERT_EQUALS(PREDICATE_NODE, pred->getType());
+	LinkPtr lp = LinkCast(timestamp);
+	Handle pred = lp->getOutgoingAtom(0);
+	TS_ASSERT_EQUALS(PREDICATE_NODE, pred->getType());
 
-    Handle list = lp->getOutgoingAtom(1);
-    TS_ASSERT_EQUALS(LIST_LINK, list->getType());
+	Handle list = lp->getOutgoingAtom(1);
+	TS_ASSERT_EQUALS(LIST_LINK, list->getType());
 
-    LinkPtr ll = LinkCast(list);
-    Handle num = ll->getOutgoingAtom(0);
-    TS_ASSERT_EQUALS(NUMBER_NODE, num->getType());
+	LinkPtr ll = LinkCast(list);
+	Handle num = ll->getOutgoingAtom(0);
+	TS_ASSERT_EQUALS(NUMBER_NODE, num->getType());
 }

--- a/tests/query/DisconnectedUTest.cxxtest
+++ b/tests/query/DisconnectedUTest.cxxtest
@@ -20,11 +20,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/guile/load-file.h>
 #include <opencog/guile/SchemeEval.h>
-#include <opencog/guile/SchemeSmob.h>
 #include <opencog/query/BindLinkAPI.h>
-#include <opencog/util/Config.h>
 #include <opencog/util/Logger.h>
 
 #include "test-types.h"
@@ -70,8 +67,9 @@ void Disconnected::setUp(void)
 	as = new AtomSpace();
 	eval = new SchemeEval(as);
 
-	config().set("SCM_PRELOAD", "tests/query/test_types.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(add-to-load-path \"..\")");
+	eval->eval("(add-to-load-path \"../../..\")");
+	eval->eval("(load-from-path \"tests/query/test_types.scm\")");
 }
 
 void Disconnected::tearDown(void)
@@ -89,9 +87,7 @@ void Disconnected::test_components(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD",
-		"tests/query/disconnected.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/disconnected.scm\")");
 
 	Handle bindlinkh = eval->apply("get-bindlink", Handle::UNDEFINED);
 	// Make sure the scheme file actually loaded!
@@ -125,9 +121,7 @@ void Disconnected::test_variables(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD",
-		"tests/query/disco-vars.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/disco-vars.scm\")");
 
 	// We expect to catch an error here. ------------------------------
 	bool caught = false;

--- a/tests/query/DisconnectedUTest.cxxtest
+++ b/tests/query/DisconnectedUTest.cxxtest
@@ -20,6 +20,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <opencog/atomspace/AtomSpace.h>
 #include <opencog/guile/SchemeEval.h>
 #include <opencog/query/BindLinkAPI.h>
 #include <opencog/util/Logger.h>

--- a/tests/query/EinsteinUTest.cxxtest
+++ b/tests/query/EinsteinUTest.cxxtest
@@ -20,11 +20,10 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/guile/load-file.h>
+#include <opencog/atomspace/AtomSpace.h>
 #include <opencog/guile/SchemeEval.h>
 #include <opencog/guile/SchemeSmob.h>
 #include <opencog/query/BindLinkAPI.h>
-#include <opencog/util/Config.h>
 #include <opencog/util/Logger.h>
 
 #include "test-types.h"
@@ -47,6 +46,9 @@ class EinsteinPuzzle :  public CxxTest::TestSuite
 
 			as = new AtomSpace();
 			eval = new SchemeEval(as);
+			eval->eval("(add-to-load-path \"..\")");
+			eval->eval("(add-to-load-path \"../../..\")");
+			eval->eval("(load-from-path \"tests/query/test_types.scm\")");
 		}
 
 		~EinsteinPuzzle()
@@ -72,15 +74,12 @@ class EinsteinPuzzle :  public CxxTest::TestSuite
  */
 #define an as->add_node
 #define al as->add_link
-#define getarity(hand) LinkCast(hand)->getArity()
-#define getlink(hand,pos) LinkCast(hand)->getOutgoingAtom(pos)
+#define getarity(hand) hand->getArity()
+#define getlink(hand,pos) hand->getOutgoingAtom(pos)
 
 void EinsteinPuzzle::setUp(void)
 {
 	as->clear();
-
-	config().set("SCM_PRELOAD", "tests/query/test_types.scm");
-	load_scm_files_from_config(*as);
 }
 
 /* ========================================================================
@@ -90,10 +89,8 @@ void EinsteinPuzzle::test_trivial_deduct(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD",
-		"tests/query/deduct-trivial.scm, "
-		"tests/query/deduct-rules.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/deduct-trivial.scm\")");
+	eval->eval("(load-from-path \"tests/query/deduct-rules.scm\")");
 
 	// Create an implication link that will be tested.
 	Handle puzzle_rules = eval->apply("is-same-rule", Handle::UNDEFINED);
@@ -124,11 +121,9 @@ void EinsteinPuzzle::test_trivial_keep(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD",
-	             "tests/query/deduct-trivial.scm, "
-	             "tests/query/deduct-rules.scm, "
-	             "tests/query/deduct-keep.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/deduct-trivial.scm\")");
+	eval->eval("(load-from-path \"tests/query/deduct-rules.scm\")");
+	eval->eval("(load-from-path \"tests/query/deduct-keep.scm\")");
 
 	// Create an implication link that will be tested.
 	Handle same_rule = eval->apply("is-same-rule", Handle::UNDEFINED);
@@ -176,10 +171,8 @@ void EinsteinPuzzle::test_full(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD",
-	             "tests/query/deduct-einstein.scm, "
-	             "tests/query/deduct-rules.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/deduct-einstein.scm\")");
+	eval->eval("(load-from-path \"tests/query/deduct-rules.scm\")");
 
 	// Create an implication link that will be tested.
 	Handle same_rule = eval->apply("is-same-rule", Handle::UNDEFINED);

--- a/tests/query/EvaluationUTest.cxxtest
+++ b/tests/query/EvaluationUTest.cxxtest
@@ -20,12 +20,9 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/guile/load-file.h>
 #include <opencog/guile/SchemeEval.h>
-#include <opencog/guile/SchemeSmob.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/query/BindLinkAPI.h>
-#include <opencog/util/Config.h>
 #include <opencog/util/Logger.h>
 
 using namespace opencog;
@@ -73,9 +70,11 @@ void EvaluationUTest::setUp(void)
 	as->clear();
 	eval->eval("(use-modules (opencog exec))");
 	eval->eval("(use-modules (opencog query))");
+	eval->eval("(add-to-load-path \"..\")");
+	eval->eval("(add-to-load-path \"../../..\")");
 }
 
-#define getarity(hand) LinkCast(hand)->getArity()
+#define getarity(hand) hand->getArity()
 
 /*
  * Evaluation most basic unit test.
@@ -84,8 +83,7 @@ void EvaluationUTest::test_eval(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD", "tests/query/evaluation.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/evaluation.scm\")");
 
 	Handle five = eval->eval_h("(cog-execute! (five-arcs))");
 	printf ("five: found:\n%s\n", five->toShortString().c_str());
@@ -121,8 +119,7 @@ void EvaluationUTest::test_logic(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD", "tests/query/evaluation.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/evaluation.scm\")");
 
 	Handle four = eval->eval_h("(cog-execute! (four-not))");
 	printf ("four-not: found:\n%s\n", four->toShortString().c_str());
@@ -154,8 +151,7 @@ void EvaluationUTest::test_varval(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD", "tests/query/eval-var.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/eval-var.scm\")");
 
 	Handle do_things = eval->eval_h("(do-things)");
 	Handle do_things_results = bindlink(as, do_things);

--- a/tests/query/FiniteStateMachineUTest.cxxtest
+++ b/tests/query/FiniteStateMachineUTest.cxxtest
@@ -20,12 +20,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/guile/load-file.h>
 #include <opencog/guile/SchemeEval.h>
-#include <opencog/guile/SchemeSmob.h>
 #include <opencog/atomspace/AtomSpace.h>
-#include <opencog/query/BindLinkAPI.h>
-#include <opencog/util/Config.h>
 #include <opencog/util/Logger.h>
 
 using namespace opencog;
@@ -44,6 +40,9 @@ public:
 
 		as = new AtomSpace();
 		eval = new SchemeEval(as);
+		eval->eval("(use-modules (opencog query))");
+		eval->eval("(add-to-load-path \"..\")");
+		eval->eval("(add-to-load-path \"../../..\")");
 	}
 
 	~FiniteStateMachineUTest()
@@ -52,7 +51,7 @@ public:
 		delete as;
 		// Erase the log file if no assertions failed.
 		if (!CxxTest::TestTracker::tracker().suiteFailed())
-				std::remove(logger().get_filename().c_str());
+			std::remove(logger().get_filename().c_str());
 	}
 
 	void setUp(void);
@@ -70,16 +69,15 @@ void FiniteStateMachineUTest::tearDown(void)
 void FiniteStateMachineUTest::setUp(void)
 {
 	as->clear();
-	eval->eval("(use-modules (opencog query))");
 }
 
-#define getarity(hand) LinkCast(hand)->getArity()
+#define getarity(hand) hand->getArity()
 
 Handle FiniteStateMachineUTest::get_state(Handle set_link)
 {
-	Handle and_link = LinkCast(set_link)->getOutgoingAtom(0);
-	Handle list_link = LinkCast(and_link)->getOutgoingAtom(0);
-	return LinkCast(list_link)->getOutgoingAtom(1);
+	Handle and_link = set_link->getOutgoingAtom(0);
+	Handle list_link = and_link->getOutgoingAtom(0);
+	return list_link->getOutgoingAtom(1);
 }
 
 /*
@@ -89,8 +87,7 @@ void FiniteStateMachineUTest::test_basic(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD", "tests/query/finite-state-machine.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/finite-state-machine.scm\")");
 
 	// We expect the incoming set to have an arity of 3: once for the
 	// real, actual state, and once for each of the two VariableNodes.

--- a/tests/query/FirstNUTest.cxxtest
+++ b/tests/query/FirstNUTest.cxxtest
@@ -22,12 +22,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/guile/load-file.h>
 #include <opencog/guile/SchemeEval.h>
-#include <opencog/guile/SchemeSmob.h>
 #include <opencog/atomspace/AtomSpace.h>
-#include <opencog/query/BindLinkAPI.h>
-#include <opencog/util/Config.h>
 #include <opencog/util/Logger.h>
 
 using namespace opencog;
@@ -46,6 +42,8 @@ public:
 
         as = new AtomSpace();
         eval = new SchemeEval(as);
+        eval->eval("(add-to-load-path \"..\")");
+        eval->eval("(add-to-load-path \"../../..\")");
     }
 
     ~FirstNUTest()
@@ -77,9 +75,8 @@ void FirstNUTest::tearDown(void)
 
 void FirstNUTest::setUp(void)
 {
-    config().set("SCM_PRELOAD", "tests/query/firstn.scm");
-    load_scm_files_from_config(*as);
     eval->eval("(use-modules (opencog exec) (opencog query))");
+    eval->eval("(load-from-path \"tests/query/firstn.scm\")");
 }
 
 #define getarity(hand) LinkCast(hand)->getArity()

--- a/tests/query/GetLinkUTest.cxxtest
+++ b/tests/query/GetLinkUTest.cxxtest
@@ -20,12 +20,10 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/guile/load-file.h>
 #include <opencog/guile/SchemeEval.h>
 #include <opencog/truthvalue/SimpleTruthValue.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/query/BindLinkAPI.h>
-#include <opencog/util/Config.h>
 #include <opencog/util/Logger.h>
 #include <cxxtest/TestSuite.h>
 
@@ -49,6 +47,8 @@ public:
 		as = new AtomSpace();
 		eval = new SchemeEval(as);
 		eval->eval("(use-modules (opencog exec) (opencog query))");
+		eval->eval("(add-to-load-path \"..\")");
+		eval->eval("(add-to-load-path \"../../..\")");
 	}
 
 	~GetLinkUTest()
@@ -88,8 +88,7 @@ void GetLinkUTest::test_unary_get(void)
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
 	as->clear();
-	config().set("SCM_PRELOAD", "tests/query/get-link.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/get-link.scm\")");
 
 	Handle hgnd = eval->eval_h("(cog-satisfying-set is-human)");
 	Handle hans = eval->eval_h(
@@ -111,8 +110,7 @@ void GetLinkUTest::test_binary_get(void)
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
 	as->clear();
-	config().set("SCM_PRELOAD", "tests/query/get-link.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/get-link.scm\")");
 
 	Handle hgnd = eval->eval_h("(cog-satisfying-set is-something)");
 	Handle hans = eval->eval_h(
@@ -136,8 +134,7 @@ void GetLinkUTest::test_free_bound(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD", "tests/query/get-link.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/get-link.scm\")");
 
 	Handle hgnd = eval->eval_h("(cog-satisfying-set is-query)");
 
@@ -159,8 +156,7 @@ void GetLinkUTest::test_eval_clause(void)
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
 	as->clear();
-	config().set("SCM_PRELOAD", "tests/query/get-link-eval.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/get-link-eval.scm\")");
 
 	Handle hgnd = eval->eval_h("(cog-satisfying-set get)");
 
@@ -188,8 +184,7 @@ void GetLinkUTest::test_disconnected_binary_get(void)
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
 	as->clear();
-	config().set("SCM_PRELOAD", "tests/query/get-link.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/get-link.scm\")");
 
 	Handle g_take_contain = eval->eval_h("g-take-contain");
 	Handle hgnd = satisfying_set(as, g_take_contain);

--- a/tests/query/GlobUTest.cxxtest
+++ b/tests/query/GlobUTest.cxxtest
@@ -20,12 +20,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/guile/load-file.h>
 #include <opencog/guile/SchemeEval.h>
-#include <opencog/guile/SchemeSmob.h>
 #include <opencog/atomspace/AtomSpace.h>
-#include <opencog/query/BindLinkAPI.h>
-#include <opencog/util/Config.h>
 #include <opencog/util/Logger.h>
 
 using namespace opencog;
@@ -33,8 +29,8 @@ using namespace opencog;
 class GlobUTest: public CxxTest::TestSuite
 {
 private:
-        AtomSpace *as;
-        SchemeEval* eval;
+    AtomSpace *as;
+    SchemeEval* eval;
 
 public:
     GlobUTest(void)
@@ -44,6 +40,9 @@ public:
 
         as = new AtomSpace();
         eval = new SchemeEval(as);
+        eval->eval("(add-to-load-path \"..\")");
+        eval->eval("(add-to-load-path \"../../..\")");
+        eval->eval("(use-modules (opencog query))");
     }
 
     ~GlobUTest()
@@ -70,9 +69,7 @@ void GlobUTest::tearDown(void)
 void GlobUTest::setUp(void)
 {
     as->clear();
-    config().set("SCM_PRELOAD", "tests/query/test_types.scm");
-    load_scm_files_from_config(*as);
-    eval->eval("(use-modules (opencog query))");
+    eval->eval("(load-from-path \"tests/query/test_types.scm\")");
 }
 
 /*
@@ -82,8 +79,7 @@ void GlobUTest::test_glob_middle(void)
 {
     logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/glob-basic.scm");
-    load_scm_files_from_config(*as);
+    eval->eval("(load-from-path \"tests/query/glob-basic.scm\")");
 
     Handle love = eval->eval_h("(cog-bind glob-you)");
     printf("glob-you %s\n", love->toString().c_str());
@@ -117,8 +113,7 @@ void GlobUTest::test_glob_final(void)
 {
     logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/glob-basic.scm");
-    load_scm_files_from_config(*as);
+    eval->eval("(load-from-path \"tests/query/glob-basic.scm\")");
 
     Handle love = eval->eval_h("(cog-bind love-glob)");
     printf("love-glob %s\n", love->toString().c_str());

--- a/tests/query/GlobUTest.cxxtest
+++ b/tests/query/GlobUTest.cxxtest
@@ -11,7 +11,7 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
@@ -29,47 +29,47 @@ using namespace opencog;
 class GlobUTest: public CxxTest::TestSuite
 {
 private:
-    AtomSpace *as;
-    SchemeEval* eval;
+	AtomSpace *as;
+	SchemeEval* eval;
 
 public:
-    GlobUTest(void)
-    {
-        logger().set_level(Logger::DEBUG);
-        logger().set_print_to_stdout_flag(true);
+	GlobUTest(void)
+	{
+		logger().set_level(Logger::DEBUG);
+		logger().set_print_to_stdout_flag(true);
 
-        as = new AtomSpace();
-        eval = new SchemeEval(as);
-        eval->eval("(add-to-load-path \"..\")");
-        eval->eval("(add-to-load-path \"../../..\")");
-        eval->eval("(use-modules (opencog query))");
-    }
+		as = new AtomSpace();
+		eval = new SchemeEval(as);
+		eval->eval("(add-to-load-path \"..\")");
+		eval->eval("(add-to-load-path \"../../..\")");
+		eval->eval("(use-modules (opencog query))");
+	}
 
-    ~GlobUTest()
-    {
-        delete eval;
-        delete as;
-        // Erase the log file if no assertions failed.
-        if (!CxxTest::TestTracker::tracker().suiteFailed())
-                std::remove(logger().get_filename().c_str());
-    }
+	~GlobUTest()
+	{
+		delete eval;
+		delete as;
+		// Erase the log file if no assertions failed.
+		if (!CxxTest::TestTracker::tracker().suiteFailed())
+			std::remove(logger().get_filename().c_str());
+	}
 
-    void setUp(void);
-    void tearDown(void);
+	void setUp(void);
+	void tearDown(void);
 
-    void test_glob_middle(void);
-    void test_glob_final(void);
+	void test_glob_middle(void);
+	void test_glob_final(void);
 };
 
 void GlobUTest::tearDown(void)
 {
-    as->clear();
+	as->clear();
 }
 
 void GlobUTest::setUp(void)
 {
-    as->clear();
-    eval->eval("(load-from-path \"tests/query/test_types.scm\")");
+	as->clear();
+	eval->eval("(load-from-path \"tests/query/test_types.scm\")");
 }
 
 /*
@@ -77,33 +77,33 @@ void GlobUTest::setUp(void)
  */
 void GlobUTest::test_glob_middle(void)
 {
-    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    eval->eval("(load-from-path \"tests/query/glob-basic.scm\")");
+	eval->eval("(load-from-path \"tests/query/glob-basic.scm\")");
 
-    Handle love = eval->eval_h("(cog-bind glob-you)");
-    printf("glob-you %s\n", love->toString().c_str());
-    TS_ASSERT_EQUALS(2, love->getArity());
+	Handle love = eval->eval_h("(cog-bind glob-you)");
+	printf("glob-you %s\n", love->toString().c_str());
+	TS_ASSERT_EQUALS(2, love->getArity());
 
-    Handle response = eval->eval_h(
-       "(SetLink"
-       "  (ListLink"
-       "    (ConceptNode \"I\")"
-       "    (ConceptNode \"love\")"
-       "    (ConceptNode \"you\")"
-       "    (ConceptNode \"too\"))"
-       "  (ListLink"
-       "    (ConceptNode \"I\")"
-       "    (ConceptNode \"really\")"
-       "    (ConceptNode \"totally\")"
-       "    (ConceptNode \"need\")"
-       "    (ConceptNode \"you\")"
-       "    (ConceptNode \"too\")))"
-    );
-    TS_ASSERT_EQUALS(love, response);
+	Handle response = eval->eval_h(
+		"(SetLink"
+		"  (ListLink"
+		"    (ConceptNode \"I\")"
+		"    (ConceptNode \"love\")"
+		"    (ConceptNode \"you\")"
+		"    (ConceptNode \"too\"))"
+		"  (ListLink"
+		"    (ConceptNode \"I\")"
+		"    (ConceptNode \"really\")"
+		"    (ConceptNode \"totally\")"
+		"    (ConceptNode \"need\")"
+		"    (ConceptNode \"you\")"
+		"    (ConceptNode \"too\")))"
+	);
+	TS_ASSERT_EQUALS(love, response);
 
-    // ----
-    logger().debug("END TEST: %s", __FUNCTION__);
+	// ----
+	logger().debug("END TEST: %s", __FUNCTION__);
 }
 
 /*
@@ -111,34 +111,34 @@ void GlobUTest::test_glob_middle(void)
  */
 void GlobUTest::test_glob_final(void)
 {
-    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    eval->eval("(load-from-path \"tests/query/glob-basic.scm\")");
+	eval->eval("(load-from-path \"tests/query/glob-basic.scm\")");
 
-    Handle love = eval->eval_h("(cog-bind love-glob)");
-    printf("love-glob %s\n", love->toString().c_str());
-    TS_ASSERT_EQUALS(2, love->getArity());
+	Handle love = eval->eval_h("(cog-bind love-glob)");
+	printf("love-glob %s\n", love->toString().c_str());
+	TS_ASSERT_EQUALS(2, love->getArity());
 
-    Handle response = eval->eval_h(
-       "(SetLink"
-       "  (ListLink"
-       "    (ConceptNode \"Hey!\")"
-       "    (ConceptNode \"I\")"
-       "    (ConceptNode \"like\")"
-       "    (ConceptNode \"you\")"
-       "    (ConceptNode \"also\"))"
-       "  (ListLink"
-       "    (ConceptNode \"Hey!\")"
-       "    (ConceptNode \"I\")"
-       "    (ConceptNode \"like\")"
-       "    (ConceptNode \"teddy\")"
-       "    (ConceptNode \"bears\")"
-       "    (ConceptNode \"a\")"
-       "    (ConceptNode \"lot\")"
-       "    (ConceptNode \"also\")))"
-    );
-    TS_ASSERT_EQUALS(love, response);
+	Handle response = eval->eval_h(
+		"(SetLink"
+		"  (ListLink"
+		"    (ConceptNode \"Hey!\")"
+		"    (ConceptNode \"I\")"
+		"    (ConceptNode \"like\")"
+		"    (ConceptNode \"you\")"
+		"    (ConceptNode \"also\"))"
+		"  (ListLink"
+		"    (ConceptNode \"Hey!\")"
+		"    (ConceptNode \"I\")"
+		"    (ConceptNode \"like\")"
+		"    (ConceptNode \"teddy\")"
+		"    (ConceptNode \"bears\")"
+		"    (ConceptNode \"a\")"
+		"    (ConceptNode \"lot\")"
+		"    (ConceptNode \"also\")))"
+	);
+	TS_ASSERT_EQUALS(love, response);
 
-    // ----
-    logger().debug("END TEST: %s", __FUNCTION__);
+	// ----
+	logger().debug("END TEST: %s", __FUNCTION__);
 }

--- a/tests/query/GreaterComputeUTest.cxxtest
+++ b/tests/query/GreaterComputeUTest.cxxtest
@@ -20,12 +20,9 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/guile/load-file.h>
 #include <opencog/guile/SchemeEval.h>
-#include <opencog/guile/SchemeSmob.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/query/BindLinkAPI.h>
-#include <opencog/util/Config.h>
 #include <opencog/util/Logger.h>
 
 using namespace opencog;
@@ -44,6 +41,9 @@ public:
 
         as = new AtomSpace();
         eval = new SchemeEval(as);
+        eval->eval("(use-modules (opencog exec))");
+        eval->eval("(add-to-load-path \"..\")");
+        eval->eval("(add-to-load-path \"../../..\")");
     }
 
     ~GreaterComputeUTest()
@@ -66,7 +66,6 @@ void GreaterComputeUTest::tearDown(void)
 
 void GreaterComputeUTest::setUp(void)
 {
-    eval->eval("(use-modules (opencog exec))");
 }
 
 #define getarity(hand) LinkCast(hand)->getArity()
@@ -79,8 +78,7 @@ void GreaterComputeUTest::test_computation(void)
 {
     logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/greater-compute.scm");
-    load_scm_files_from_config(*as);
+    eval->eval("(load-from-path \"tests/query/greater-compute.scm\")");
 
     Handle try_out = eval->eval_h("(threshold)");
 

--- a/tests/query/GreaterThanUTest.cxxtest
+++ b/tests/query/GreaterThanUTest.cxxtest
@@ -20,12 +20,9 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/guile/load-file.h>
 #include <opencog/guile/SchemeEval.h>
-#include <opencog/guile/SchemeSmob.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/query/BindLinkAPI.h>
-#include <opencog/util/Config.h>
 #include <opencog/util/Logger.h>
 
 using namespace opencog;
@@ -44,6 +41,8 @@ public:
 
 		as = new AtomSpace();
 		eval = new SchemeEval(as);
+		eval->eval("(add-to-load-path \"..\")");
+		eval->eval("(add-to-load-path \"../../..\")");
 	}
 
 	~GreaterThanUTest()
@@ -51,7 +50,7 @@ public:
 		delete as;
 		// Erase the log file if no assertions failed.
 		if (!CxxTest::TestTracker::tracker().suiteFailed())
-				std::remove(logger().get_filename().c_str());
+			std::remove(logger().get_filename().c_str());
 	}
 
 	void setUp(void);
@@ -81,8 +80,7 @@ void GreaterThanUTest::test_numeric_greater(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD", "tests/query/greater_than.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/greater_than.scm\")");
 
 	Handle richer_than_george = eval->eval_h("(richer-than-george)");
 	Handle richer_than_susan = eval->eval_h("(richer-than-susan)");
@@ -115,8 +113,7 @@ void GreaterThanUTest::test_scm_greater(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD", "tests/query/greater_than.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/greater_than.scm\")");
 
 	Handle richer_than_george = eval->eval_h("(scm-than-george)");
 	Handle richer_than_susan = eval->eval_h("(scm-than-susan)");
@@ -138,8 +135,7 @@ void GreaterThanUTest::test_builtin_greater(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD", "tests/query/greater_than.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/greater_than.scm\")");
 
 	Handle richer_than_george = eval->eval_h("(builtin-than-george)");
 	Handle richer_than_susan = eval->eval_h("(builtin-than-susan)");

--- a/tests/query/GreaterThanUTest.cxxtest
+++ b/tests/query/GreaterThanUTest.cxxtest
@@ -33,33 +33,33 @@ using namespace opencog;
 class GreaterThanUTest: public CxxTest::TestSuite
 {
 private:
-        AtomSpace *as;
-        SchemeEval* eval;
+	AtomSpace *as;
+	SchemeEval* eval;
 
 public:
-    GreaterThanUTest(void)
-    {
-        logger().set_level(Logger::DEBUG);
-        logger().set_print_to_stdout_flag(true);
+	GreaterThanUTest(void)
+	{
+		logger().set_level(Logger::DEBUG);
+		logger().set_print_to_stdout_flag(true);
 
-        as = new AtomSpace();
-        eval = new SchemeEval(as);
-    }
+		as = new AtomSpace();
+		eval = new SchemeEval(as);
+	}
 
-    ~GreaterThanUTest()
-    {
-        delete as;
-        // Erase the log file if no assertions failed.
-        if (!CxxTest::TestTracker::tracker().suiteFailed())
-                std::remove(logger().get_filename().c_str());
-    }
+	~GreaterThanUTest()
+	{
+		delete as;
+		// Erase the log file if no assertions failed.
+		if (!CxxTest::TestTracker::tracker().suiteFailed())
+				std::remove(logger().get_filename().c_str());
+	}
 
-    void setUp(void);
-    void tearDown(void);
+	void setUp(void);
+	void tearDown(void);
 
-    void test_numeric_greater(void);
-    void test_scm_greater(void);
-    void test_builtin_greater(void);
+	void test_numeric_greater(void);
+	void test_scm_greater(void);
+	void test_builtin_greater(void);
 };
 
 void GreaterThanUTest::tearDown(void)
@@ -79,80 +79,80 @@ void GreaterThanUTest::setUp(void)
  */
 void GreaterThanUTest::test_numeric_greater(void)
 {
-    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/greater_than.scm");
-    load_scm_files_from_config(*as);
+	config().set("SCM_PRELOAD", "tests/query/greater_than.scm");
+	load_scm_files_from_config(*as);
 
-    Handle richer_than_george = eval->eval_h("(richer-than-george)");
-    Handle richer_than_susan = eval->eval_h("(richer-than-susan)");
-    Handle richer_than_obama = eval->eval_h("(richer-than-obama)");
-    Handle richer_than_gates = eval->eval_h("(richer-than-gates)");
+	Handle richer_than_george = eval->eval_h("(richer-than-george)");
+	Handle richer_than_susan = eval->eval_h("(richer-than-susan)");
+	Handle richer_than_obama = eval->eval_h("(richer-than-obama)");
+	Handle richer_than_gates = eval->eval_h("(richer-than-gates)");
 
-    TSM_ASSERT("Failed to load test data", richer_than_george);
-    TSM_ASSERT("Failed to load test data", richer_than_susan);
-    TSM_ASSERT("Failed to load test data", richer_than_obama);
-    TSM_ASSERT("Failed to load test data", richer_than_gates);
+	TSM_ASSERT("Failed to load test data", richer_than_george);
+	TSM_ASSERT("Failed to load test data", richer_than_susan);
+	TSM_ASSERT("Failed to load test data", richer_than_obama);
+	TSM_ASSERT("Failed to load test data", richer_than_gates);
 
-    Handle people_richer_than_george = bindlink(as, richer_than_george);
-    Handle people_richer_than_susan = bindlink(as, richer_than_susan);
-    Handle people_richer_than_obama = bindlink(as, richer_than_obama);
-    Handle people_richer_than_gates = bindlink(as, richer_than_gates);
+	Handle people_richer_than_george = bindlink(as, richer_than_george);
+	Handle people_richer_than_susan = bindlink(as, richer_than_susan);
+	Handle people_richer_than_obama = bindlink(as, richer_than_obama);
+	Handle people_richer_than_gates = bindlink(as, richer_than_gates);
 
-    TSM_ASSERT("Failed to run test", people_richer_than_george);
-    TSM_ASSERT("Failed to run test", people_richer_than_susan);
-    TSM_ASSERT("Failed to run test", people_richer_than_obama);
-    TSM_ASSERT("Failed to run test", people_richer_than_gates);
+	TSM_ASSERT("Failed to run test", people_richer_than_george);
+	TSM_ASSERT("Failed to run test", people_richer_than_susan);
+	TSM_ASSERT("Failed to run test", people_richer_than_obama);
+	TSM_ASSERT("Failed to run test", people_richer_than_gates);
 
-    TS_ASSERT_EQUALS(0, getarity(people_richer_than_gates));
-    TS_ASSERT_EQUALS(1, getarity(people_richer_than_obama));
-    TS_ASSERT_EQUALS(2, getarity(people_richer_than_george));
-    TS_ASSERT_EQUALS(3, getarity(people_richer_than_susan));
+	TS_ASSERT_EQUALS(0, getarity(people_richer_than_gates));
+	TS_ASSERT_EQUALS(1, getarity(people_richer_than_obama));
+	TS_ASSERT_EQUALS(2, getarity(people_richer_than_george));
+	TS_ASSERT_EQUALS(3, getarity(people_richer_than_susan));
 }
 
 // Same test as above, but using a scheme func for the compares
 void GreaterThanUTest::test_scm_greater(void)
 {
-    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/greater_than.scm");
-    load_scm_files_from_config(*as);
+	config().set("SCM_PRELOAD", "tests/query/greater_than.scm");
+	load_scm_files_from_config(*as);
 
-    Handle richer_than_george = eval->eval_h("(scm-than-george)");
-    Handle richer_than_susan = eval->eval_h("(scm-than-susan)");
-    Handle richer_than_obama = eval->eval_h("(scm-than-obama)");
-    Handle richer_than_gates = eval->eval_h("(scm-than-gates)");
+	Handle richer_than_george = eval->eval_h("(scm-than-george)");
+	Handle richer_than_susan = eval->eval_h("(scm-than-susan)");
+	Handle richer_than_obama = eval->eval_h("(scm-than-obama)");
+	Handle richer_than_gates = eval->eval_h("(scm-than-gates)");
 
-    Handle people_richer_than_george = bindlink(as, richer_than_george);
-    Handle people_richer_than_susan = bindlink(as, richer_than_susan);
-    Handle people_richer_than_obama = bindlink(as, richer_than_obama);
-    Handle people_richer_than_gates = bindlink(as, richer_than_gates);
+	Handle people_richer_than_george = bindlink(as, richer_than_george);
+	Handle people_richer_than_susan = bindlink(as, richer_than_susan);
+	Handle people_richer_than_obama = bindlink(as, richer_than_obama);
+	Handle people_richer_than_gates = bindlink(as, richer_than_gates);
 
-    TS_ASSERT_EQUALS(0, getarity(people_richer_than_gates));
-    TS_ASSERT_EQUALS(1, getarity(people_richer_than_obama));
-    TS_ASSERT_EQUALS(2, getarity(people_richer_than_george));
-    TS_ASSERT_EQUALS(3, getarity(people_richer_than_susan));
+	TS_ASSERT_EQUALS(0, getarity(people_richer_than_gates));
+	TS_ASSERT_EQUALS(1, getarity(people_richer_than_obama));
+	TS_ASSERT_EQUALS(2, getarity(people_richer_than_george));
+	TS_ASSERT_EQUALS(3, getarity(people_richer_than_susan));
 }
 // Same test as above, but using the built-in GreaterThanLink
 void GreaterThanUTest::test_builtin_greater(void)
 {
-    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/greater_than.scm");
-    load_scm_files_from_config(*as);
+	config().set("SCM_PRELOAD", "tests/query/greater_than.scm");
+	load_scm_files_from_config(*as);
 
-    Handle richer_than_george = eval->eval_h("(builtin-than-george)");
-    Handle richer_than_susan = eval->eval_h("(builtin-than-susan)");
-    Handle richer_than_obama = eval->eval_h("(builtin-than-obama)");
-    Handle richer_than_gates = eval->eval_h("(builtin-than-gates)");
+	Handle richer_than_george = eval->eval_h("(builtin-than-george)");
+	Handle richer_than_susan = eval->eval_h("(builtin-than-susan)");
+	Handle richer_than_obama = eval->eval_h("(builtin-than-obama)");
+	Handle richer_than_gates = eval->eval_h("(builtin-than-gates)");
 
-    Handle people_richer_than_george = bindlink(as, richer_than_george);
-    Handle people_richer_than_susan = bindlink(as, richer_than_susan);
-    Handle people_richer_than_obama = bindlink(as, richer_than_obama);
-    Handle people_richer_than_gates = bindlink(as, richer_than_gates);
+	Handle people_richer_than_george = bindlink(as, richer_than_george);
+	Handle people_richer_than_susan = bindlink(as, richer_than_susan);
+	Handle people_richer_than_obama = bindlink(as, richer_than_obama);
+	Handle people_richer_than_gates = bindlink(as, richer_than_gates);
 
-    TS_ASSERT_EQUALS(0, getarity(people_richer_than_gates));
-    TS_ASSERT_EQUALS(1, getarity(people_richer_than_obama));
-    TS_ASSERT_EQUALS(2, getarity(people_richer_than_george));
-    TS_ASSERT_EQUALS(3, getarity(people_richer_than_susan));
+	TS_ASSERT_EQUALS(0, getarity(people_richer_than_gates));
+	TS_ASSERT_EQUALS(1, getarity(people_richer_than_obama));
+	TS_ASSERT_EQUALS(2, getarity(people_richer_than_george));
+	TS_ASSERT_EQUALS(3, getarity(people_richer_than_susan));
 }

--- a/tests/query/MatchLinkUTest.cxxtest
+++ b/tests/query/MatchLinkUTest.cxxtest
@@ -22,9 +22,7 @@
 
 #include <opencog/guile/SchemeEval.h>
 #include <opencog/guile/SchemeSmob.h>
-#include <opencog/guile/load-file.h>
 #include <opencog/query/BindLinkAPI.h>
-#include <opencog/util/Config.h>
 #include <opencog/util/Logger.h>
 
 #include "test-types.h"
@@ -72,14 +70,13 @@ void MatchLink::setUp(void)
 {
 	as = new AtomSpace();
 
-	config().set("SCM_PRELOAD",
-      "tests/query/test_types.scm, "
-		"tests/query/match-link.scm");
-
-	load_scm_files_from_config(*as);
+	SchemeEval* eval = new SchemeEval(as);
+	eval->eval("(add-to-load-path \"..\")");
+	eval->eval("(add-to-load-path \"../../..\")");
+	eval->eval("(load-from-path \"tests/query/test_types.scm\")");
+	eval->eval("(load-from-path \"tests/query/match-link.scm\")");
 
 	// Create an implication link that will be tested.
-	SchemeEval* eval = new SchemeEval(as);
 	untyped_link_match = eval->apply("untyped-link-match", Handle::UNDEFINED);
 	typed_link_match = eval->apply("typed-link-match", Handle::UNDEFINED);
 	untyped_any_match = eval->apply("untyped-any-match", Handle::UNDEFINED);

--- a/tests/query/QuoteUTest.cxxtest
+++ b/tests/query/QuoteUTest.cxxtest
@@ -20,12 +20,9 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/guile/load-file.h>
-#include <opencog/guile/SchemeEval.h>
-#include <opencog/guile/SchemeSmob.h>
 #include <opencog/atomspace/AtomSpace.h>
+#include <opencog/guile/SchemeEval.h>
 #include <opencog/query/BindLinkAPI.h>
-#include <opencog/util/Config.h>
 #include <opencog/util/Logger.h>
 #include <cxxtest/TestSuite.h>
 
@@ -45,6 +42,8 @@ public:
 
         as = new AtomSpace();
         eval = new SchemeEval(as);
+        eval->eval("(add-to-load-path \"..\")");
+        eval->eval("(add-to-load-path \"../../..\")");
     }
 
     ~QuoteUTest()
@@ -91,8 +90,7 @@ void QuoteUTest::test_quoted_variable(void)
 {
     logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/quote-var.scm");
-    load_scm_files_from_config(*as);
+    eval->eval("(load-from-path \"tests/query/quote-var.scm\")");
 
     Handle bindy = eval->eval_h("bindy");
 
@@ -135,8 +133,7 @@ void QuoteUTest::test_nest(void)
 {
     logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/quote-nest.scm");
-    load_scm_files_from_config(*as);
+    eval->eval("(load-from-path \"tests/query/quote-nest.scm\")");
 
     Handle bindy = eval->eval_h("bindy");
 
@@ -187,8 +184,7 @@ void QuoteUTest::test_gpn(void)
 {
     logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/quote-gpn.scm");
-    load_scm_files_from_config(*as);
+    eval->eval("(load-from-path \"tests/query/quote-gpn.scm\")");
 
     Handle bindy = eval->eval_h("bindy");
 
@@ -209,8 +205,7 @@ void QuoteUTest::test_double_quote(void)
 {
     logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/quote-quote.scm");
-    load_scm_files_from_config(*as);
+    eval->eval("(load-from-path \"tests/query/quote-quote.scm\")");
 
     Handle bindy = eval->eval_h("bindy");
 
@@ -229,8 +224,7 @@ void QuoteUTest::test_impossible(void)
 {
     logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/quote-impossible.scm");
-    load_scm_files_from_config(*as);
+    eval->eval("(load-from-path \"tests/query/quote-impossible.scm\")");
 
     Handle imp = eval->eval_h("imp");
 
@@ -253,8 +247,7 @@ void QuoteUTest::test_numeric_greater(void)
 {
     logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/quote-greater.scm");
-    load_scm_files_from_config(*as);
+    eval->eval("(load-from-path \"tests/query/quote-greater.scm\")");
 
     Handle richer_than_george = eval->eval_h("(richer-than-george)");
     Handle richer_than_susan = eval->eval_h("(richer-than-susan)");
@@ -278,9 +271,7 @@ void QuoteUTest::test_crash(void)
 {
     logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/quote-crash.scm");
-
-    load_scm_files_from_config(*as);
+    eval->eval("(load-from-path \"tests/query/quote-crash.scm\")");
 
     // If we can execute this without crashing, the test is succesful.
     Handle cr = eval->eval_h("(cog-bind crasher)");
@@ -307,8 +298,7 @@ void QuoteUTest::test_exec_getlink(void)
 {
     logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/quote-exec-getlink.scm");
-    load_scm_files_from_config(*as);
+    eval->eval("(load-from-path \"tests/query/quote-exec-getlink.scm\")");
 
     Handle exe = eval->eval_h("(cog-execute! z-get)");
     TS_ASSERT_EQUALS(1, getarity(exe));

--- a/tests/query/SequenceUTest.cxxtest
+++ b/tests/query/SequenceUTest.cxxtest
@@ -34,35 +34,35 @@ using namespace opencog;
 class SequenceUTest: public CxxTest::TestSuite
 {
 private:
-        AtomSpace *as;
-        SchemeEval* eval;
+		AtomSpace *as;
+		SchemeEval* eval;
 
 public:
-    SequenceUTest(void)
-    {
-        logger().set_level(Logger::DEBUG);
-        logger().set_print_to_stdout_flag(true);
+	SequenceUTest(void)
+	{
+		logger().set_level(Logger::DEBUG);
+		logger().set_print_to_stdout_flag(true);
 
-        as = new AtomSpace();
-        eval = new SchemeEval(as);
-    }
+		as = new AtomSpace();
+		eval = new SchemeEval(as);
+	}
 
-    ~SequenceUTest()
-    {
-        delete as;
-        // Erase the log file if no assertions failed.
-        if (!CxxTest::TestTracker::tracker().suiteFailed())
-                std::remove(logger().get_filename().c_str());
-    }
+	~SequenceUTest()
+	{
+		delete as;
+		// Erase the log file if no assertions failed.
+		if (!CxxTest::TestTracker::tracker().suiteFailed())
+				std::remove(logger().get_filename().c_str());
+	}
 
-    void setUp(void);
-    void tearDown(void);
+	void setUp(void);
+	void tearDown(void);
 
-    void test_sequence(void);
-    void test_presence(void);
-    void test_fallback(void);
-    void test_pass_presence(void);
-    void test_or_put(void);
+	void test_sequence(void);
+	void test_presence(void);
+	void test_fallback(void);
+	void test_pass_presence(void);
+	void test_or_put(void);
 };
 
 void SequenceUTest::tearDown(void)
@@ -71,7 +71,7 @@ void SequenceUTest::tearDown(void)
 
 void SequenceUTest::setUp(void)
 {
-    eval->eval("(use-modules (opencog query))");
+	eval->eval("(use-modules (opencog query))");
 }
 
 /*
@@ -79,83 +79,83 @@ void SequenceUTest::setUp(void)
  */
 void SequenceUTest::test_sequence(void)
 {
-    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/sequence.scm");
-    load_scm_files_from_config(*as);
+	config().set("SCM_PRELOAD", "tests/query/sequence.scm");
+	load_scm_files_from_config(*as);
 
-    // This should throw an exception from scheme.
-    // Disable logging so as to avoid the hopeless spew of errors.
-    logger().set_level(Logger::NONE);
-    bool caught_exception = false;
-    try
-    {
-        eval->eval_tv("(cog-satisfy (off-road))");
-    }
-    catch (const RuntimeException &e)
-    {
-        caught_exception = true;
-    }
-    TS_ASSERT_EQUALS(true, caught_exception);
-    logger().set_level(Logger::INFO);
+	// This should throw an exception from scheme.
+	// Disable logging so as to avoid the hopeless spew of errors.
+	logger().set_level(Logger::NONE);
+	bool caught_exception = false;
+	try
+	{
+		eval->eval_tv("(cog-satisfy (off-road))");
+	}
+	catch (const RuntimeException &e)
+	{
+		caught_exception = true;
+	}
+	TS_ASSERT_EQUALS(true, caught_exception);
+	logger().set_level(Logger::INFO);
 
-    // This should not throw any exceptions.
-    TruthValuePtr tv = eval->eval_tv("(cog-satisfy (traffic-lights))");
-    TS_ASSERT_LESS_THAN_EQUALS(tv->getMean(), 0.5);
+	// This should not throw any exceptions.
+	TruthValuePtr tv = eval->eval_tv("(cog-satisfy (traffic-lights))");
+	TS_ASSERT_LESS_THAN_EQUALS(tv->getMean(), 0.5);
 
-    // Check the number of green lights and red lights that were
-    // evaluated. The pattern has two green lights and one red
-    // light... The GPN's count how many times these are hit, and
-    // the counts should be correct.
-    std::string sngreen = eval->eval("num-green");
-    std::string snred = eval->eval("num-red");
-    int ngreen = atoi(sngreen.c_str());
-    int nred = atoi(snred.c_str());
-    TS_ASSERT_EQUALS(2, ngreen);
-    TS_ASSERT_EQUALS(1, nred);
+	// Check the number of green lights and red lights that were
+	// evaluated. The pattern has two green lights and one red
+	// light... The GPN's count how many times these are hit, and
+	// the counts should be correct.
+	std::string sngreen = eval->eval("num-green");
+	std::string snred = eval->eval("num-red");
+	int ngreen = atoi(sngreen.c_str());
+	int nred = atoi(snred.c_str());
+	TS_ASSERT_EQUALS(2, ngreen);
+	TS_ASSERT_EQUALS(1, nred);
 
-    // ----------------------------------------------------------
-    // There are two green lights here; the TV should be "true".
-    tv = eval->eval_tv("(cog-satisfy (all-green))");
-    TS_ASSERT_LESS_THAN(0.5, tv->getMean());
+	// ----------------------------------------------------------
+	// There are two green lights here; the TV should be "true".
+	tv = eval->eval_tv("(cog-satisfy (all-green))");
+	TS_ASSERT_LESS_THAN(0.5, tv->getMean());
 
-    // Should have seen two more green lights, and no reds.
-    sngreen = eval->eval("num-green");
-    snred = eval->eval("num-red");
-    ngreen = atoi(sngreen.c_str());
-    nred = atoi(snred.c_str());
-    TS_ASSERT_EQUALS(4, ngreen);
-    TS_ASSERT_EQUALS(1, nred);
+	// Should have seen two more green lights, and no reds.
+	sngreen = eval->eval("num-green");
+	snred = eval->eval("num-red");
+	ngreen = atoi(sngreen.c_str());
+	nred = atoi(snred.c_str());
+	TS_ASSERT_EQUALS(4, ngreen);
+	TS_ASSERT_EQUALS(1, nred);
 
-    // ----------------------------------------------------------
-    // There are four green lights here; the third one is wrapped
-    // by a NotLink.  That should halt the pregression, and return
-    // false.
-    tv = eval->eval_tv("(cog-satisfy (anti-green))");
-    TS_ASSERT_LESS_THAN(tv->getMean(), 0.5);
+	// ----------------------------------------------------------
+	// There are four green lights here; the third one is wrapped
+	// by a NotLink.  That should halt the pregression, and return
+	// false.
+	tv = eval->eval_tv("(cog-satisfy (anti-green))");
+	TS_ASSERT_LESS_THAN(tv->getMean(), 0.5);
 
-    // Should have seen three more green lights, and no reds.
-    sngreen = eval->eval("num-green");
-    snred = eval->eval("num-red");
-    ngreen = atoi(sngreen.c_str());
-    nred = atoi(snred.c_str());
-    TS_ASSERT_EQUALS(7, ngreen);
-    TS_ASSERT_EQUALS(1, nred);
+	// Should have seen three more green lights, and no reds.
+	sngreen = eval->eval("num-green");
+	snred = eval->eval("num-red");
+	ngreen = atoi(sngreen.c_str());
+	nred = atoi(snred.c_str());
+	TS_ASSERT_EQUALS(7, ngreen);
+	TS_ASSERT_EQUALS(1, nred);
 
-    logger().debug("END TEST: %s", __FUNCTION__);
+	logger().debug("END TEST: %s", __FUNCTION__);
 }
 
 void SequenceUTest::test_presence(void)
 {
-    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/seq-presence.scm");
-    load_scm_files_from_config(*as);
+	config().set("SCM_PRELOAD", "tests/query/seq-presence.scm");
+	load_scm_files_from_config(*as);
 
-    TruthValuePtr tv = eval->eval_tv("(cog-satisfy empty-sequence)");
-    TS_ASSERT_LESS_THAN_EQUALS(0.5, tv->getMean());
+	TruthValuePtr tv = eval->eval_tv("(cog-satisfy empty-sequence)");
+	TS_ASSERT_LESS_THAN_EQUALS(0.5, tv->getMean());
 
-    logger().debug("END TEST: %s", __FUNCTION__);
+	logger().debug("END TEST: %s", __FUNCTION__);
 }
 
 /*
@@ -163,144 +163,144 @@ void SequenceUTest::test_presence(void)
  */
 void SequenceUTest::test_fallback(void)
 {
-    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/sequence.scm");
-    load_scm_files_from_config(*as);
+	config().set("SCM_PRELOAD", "tests/query/sequence.scm");
+	load_scm_files_from_config(*as);
 
-    // This should not throw any exceptions.
-    TruthValuePtr tv = eval->eval_tv("(cog-satisfy drag-race)");
-    TS_ASSERT_LESS_THAN_EQUALS(0.5, tv->getMean());
+	// This should not throw any exceptions.
+	TruthValuePtr tv = eval->eval_tv("(cog-satisfy drag-race)");
+	TS_ASSERT_LESS_THAN_EQUALS(0.5, tv->getMean());
 
-    // Check the number of green lights and red lights that were
-    // evaluated. The pattern has two green lights and one red
-    // light... The GPN's count how many times these are hit, and
-    // the counts should be correct.
-    std::string sngreen = eval->eval("num-green");
-    std::string snred = eval->eval("num-red");
-    int ngreen = atoi(sngreen.c_str());
-    int nred = atoi(snred.c_str());
-    TS_ASSERT_EQUALS(1, ngreen);
-    TS_ASSERT_EQUALS(3, nred);
+	// Check the number of green lights and red lights that were
+	// evaluated. The pattern has two green lights and one red
+	// light... The GPN's count how many times these are hit, and
+	// the counts should be correct.
+	std::string sngreen = eval->eval("num-green");
+	std::string snred = eval->eval("num-red");
+	int ngreen = atoi(sngreen.c_str());
+	int nred = atoi(snred.c_str());
+	TS_ASSERT_EQUALS(1, ngreen);
+	TS_ASSERT_EQUALS(3, nred);
 
-    logger().debug("END TEST: %s", __FUNCTION__);
+	logger().debug("END TEST: %s", __FUNCTION__);
 }
 
 void SequenceUTest::test_pass_presence(void)
 {
-    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/seq-absence.scm");
-    load_scm_files_from_config(*as);
+	config().set("SCM_PRELOAD", "tests/query/seq-absence.scm");
+	load_scm_files_from_config(*as);
 
-    TruthValuePtr tv = eval->eval_tv("(cog-satisfy or-presence)");
-    TS_ASSERT_LESS_THAN_EQUALS(0.5, tv->getMean());
+	TruthValuePtr tv = eval->eval_tv("(cog-satisfy or-presence)");
+	TS_ASSERT_LESS_THAN_EQUALS(0.5, tv->getMean());
 
-    std::string sntrig = eval->eval("trig");
-    int ntrig = atoi(sntrig.c_str());
-    TS_ASSERT_EQUALS(1, ntrig);
+	std::string sntrig = eval->eval("trig");
+	int ntrig = atoi(sntrig.c_str());
+	TS_ASSERT_EQUALS(1, ntrig);
 
-    // -------------------------------------------------------
-    tv = eval->eval_tv("(cog-satisfy and-absence)");
-    TS_ASSERT_LESS_THAN_EQUALS(0.5, tv->getMean());
+	// -------------------------------------------------------
+	tv = eval->eval_tv("(cog-satisfy and-absence)");
+	TS_ASSERT_LESS_THAN_EQUALS(0.5, tv->getMean());
 
-    sntrig = eval->eval("trig");
-    ntrig = atoi(sntrig.c_str());
-    TS_ASSERT_EQUALS(2, ntrig);
+	sntrig = eval->eval("trig");
+	ntrig = atoi(sntrig.c_str());
+	TS_ASSERT_EQUALS(2, ntrig);
 
-    // -------------------------------------------------------
-    tv = eval->eval_tv("(cog-satisfy and-not-present)");
-    TS_ASSERT_LESS_THAN_EQUALS(0.5, tv->getMean());
+	// -------------------------------------------------------
+	tv = eval->eval_tv("(cog-satisfy and-not-present)");
+	TS_ASSERT_LESS_THAN_EQUALS(0.5, tv->getMean());
 
-    sntrig = eval->eval("trig");
-    ntrig = atoi(sntrig.c_str());
-    TS_ASSERT_EQUALS(3, ntrig);
+	sntrig = eval->eval("trig");
+	ntrig = atoi(sntrig.c_str());
+	TS_ASSERT_EQUALS(3, ntrig);
 
-    // -------------------------------------------------------
-    tv = eval->eval_tv("(cog-satisfy or-not-absent)");
-    TS_ASSERT_LESS_THAN_EQUALS(0.5, tv->getMean());
+	// -------------------------------------------------------
+	tv = eval->eval_tv("(cog-satisfy or-not-absent)");
+	TS_ASSERT_LESS_THAN_EQUALS(0.5, tv->getMean());
 
-    sntrig = eval->eval("trig");
-    ntrig = atoi(sntrig.c_str());
-    TS_ASSERT_EQUALS(4, ntrig);
+	sntrig = eval->eval("trig");
+	ntrig = atoi(sntrig.c_str());
+	TS_ASSERT_EQUALS(4, ntrig);
 
-    // -------------------------------------------------------
-    // and now, all the above should fail...
-    eval->eval_h("(EvaluationLink (PredicateNode \"visible\")"
-                 "(ListLink (ConceptNode \"yes it is\")))");
+	// -------------------------------------------------------
+	// and now, all the above should fail...
+	eval->eval_h("(EvaluationLink (PredicateNode \"visible\")"
+				 "(ListLink (ConceptNode \"yes it is\")))");
 
-    int no_change = 4;
+	int no_change = 4;
 
-    // ----
-    eval->eval_tv("(cog-satisfy or-presence)");
-    TS_ASSERT_LESS_THAN_EQUALS(0.5, tv->getMean()); // return true
+	// ----
+	eval->eval_tv("(cog-satisfy or-presence)");
+	TS_ASSERT_LESS_THAN_EQUALS(0.5, tv->getMean()); // return true
 
-    ntrig = atoi(eval->eval("trig").c_str());
-    TS_ASSERT_EQUALS(no_change, ntrig);
+	ntrig = atoi(eval->eval("trig").c_str());
+	TS_ASSERT_EQUALS(no_change, ntrig);
 
-    // ----
-    tv = eval->eval_tv("(cog-satisfy and-absence)");
-    TS_ASSERT_LESS_THAN_EQUALS(tv->getMean(), 0.5);  // return false
+	// ----
+	tv = eval->eval_tv("(cog-satisfy and-absence)");
+	TS_ASSERT_LESS_THAN_EQUALS(tv->getMean(), 0.5);  // return false
 
-    ntrig = atoi(eval->eval("trig").c_str());
-    TS_ASSERT_EQUALS(no_change, ntrig);
+	ntrig = atoi(eval->eval("trig").c_str());
+	TS_ASSERT_EQUALS(no_change, ntrig);
 
 #if BROKEN_FIXME_XXX
 // The below is a valid test, and it should pass; however, the
 // pattern matcher fails on these two. Since I'm too lazy to fix,
 // just right now, I'm just gonna stub these out instead.
-    // ----
-    tv = eval->eval_tv("(cog-satisfy and-not-present)");
-    TS_ASSERT_LESS_THAN_EQUALS(tv->getMean(), 0.5); // return false
+	// ----
+	tv = eval->eval_tv("(cog-satisfy and-not-present)");
+	TS_ASSERT_LESS_THAN_EQUALS(tv->getMean(), 0.5); // return false
 
-    ntrig = atoi(eval->eval("trig").c_str());
-    TS_ASSERT_EQUALS(no_change, ntrig);
+	ntrig = atoi(eval->eval("trig").c_str());
+	TS_ASSERT_EQUALS(no_change, ntrig);
 
-    // ----
-    tv = eval->eval_tv("(cog-satisfy or-not-absent)");
-    TS_ASSERT_LESS_THAN_EQUALS(0.5, tv->getMean()); // return true
+	// ----
+	tv = eval->eval_tv("(cog-satisfy or-not-absent)");
+	TS_ASSERT_LESS_THAN_EQUALS(0.5, tv->getMean()); // return true
 
-    ntrig = atoi(eval->eval("trig").c_str());
-    TS_ASSERT_EQUALS(no_change, ntrig);
+	ntrig = atoi(eval->eval("trig").c_str());
+	TS_ASSERT_EQUALS(no_change, ntrig);
 #endif
 
-    // ----
-    logger().debug("END TEST: %s", __FUNCTION__);
+	// ----
+	logger().debug("END TEST: %s", __FUNCTION__);
 }
 
 // This is an interesting test case .. the PutLink writes atoms to the
 // main atomspace, instead of a temporary scratch space!
 void SequenceUTest::test_or_put(void)
 {
-    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/seq-absence.scm");
-    load_scm_files_from_config(*as);
+	config().set("SCM_PRELOAD", "tests/query/seq-absence.scm");
+	load_scm_files_from_config(*as);
 
-    // ----
-    // Insert eval link to prevent it from tripping.
-    eval->eval_h(
-        "(EvaluationLink (PredicateNode \"yes-visible\")"
-        "    (ListLink (ConceptNode \"is-vis\")))");
-    TruthValuePtr tv = eval->eval_tv("(cog-satisfy or-visible-put)");
-    TS_ASSERT_LESS_THAN_EQUALS(0.5, tv->getMean());
+	// ----
+	// Insert eval link to prevent it from tripping.
+	eval->eval_h(
+		"(EvaluationLink (PredicateNode \"yes-visible\")"
+		"	(ListLink (ConceptNode \"is-vis\")))");
+	TruthValuePtr tv = eval->eval_tv("(cog-satisfy or-visible-put)");
+	TS_ASSERT_LESS_THAN_EQUALS(0.5, tv->getMean());
 
-    // Check the state. Should have a list of length 1,
-    // with a variable only; that is, the state was NOT set.
-    Handle iset = eval->eval_h(
-          "(cdr (cog-incoming-set (AnchorNode \"state\")))");
-    TS_ASSERT_EQUALS(iset, Handle::UNDEFINED);
+	// Check the state. Should have a list of length 1,
+	// with a variable only; that is, the state was NOT set.
+	Handle iset = eval->eval_h(
+		  "(cdr (cog-incoming-set (AnchorNode \"state\")))");
+	TS_ASSERT_EQUALS(iset, Handle::UNDEFINED);
 
-    // ----
-    tv = eval->eval_tv("(cog-satisfy or-put)");
-    TS_ASSERT_LESS_THAN_EQUALS(0.5, tv->getMean());
+	// ----
+	tv = eval->eval_tv("(cog-satisfy or-put)");
+	TS_ASSERT_LESS_THAN_EQUALS(0.5, tv->getMean());
 
-    // Check the state.
-    Handle not_viz = eval->eval_h("(ConceptNode \"not-vis\")");
-    Handle stateh = eval->eval_h("(AnchorNode \"state\")");
-    Handle state = StateLink::get_state(stateh);
-    TS_ASSERT_EQUALS(state, not_viz);
+	// Check the state.
+	Handle not_viz = eval->eval_h("(ConceptNode \"not-vis\")");
+	Handle stateh = eval->eval_h("(AnchorNode \"state\")");
+	Handle state = StateLink::get_state(stateh);
+	TS_ASSERT_EQUALS(state, not_viz);
 
-    // ----
-    logger().debug("END TEST: %s", __FUNCTION__);
+	// ----
+	logger().debug("END TEST: %s", __FUNCTION__);
 }

--- a/tests/query/SequenceUTest.cxxtest
+++ b/tests/query/SequenceUTest.cxxtest
@@ -20,13 +20,10 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/guile/load-file.h>
 #include <opencog/guile/SchemeEval.h>
-#include <opencog/guile/SchemeSmob.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/atoms/core/StateLink.h>
-#include <opencog/query/BindLinkAPI.h>
-#include <opencog/util/Config.h>
+// #include <opencog/query/BindLinkAPI.h>
 #include <opencog/util/Logger.h>
 
 using namespace opencog;
@@ -34,8 +31,8 @@ using namespace opencog;
 class SequenceUTest: public CxxTest::TestSuite
 {
 private:
-		AtomSpace *as;
-		SchemeEval* eval;
+	AtomSpace *as;
+	SchemeEval* eval;
 
 public:
 	SequenceUTest(void)
@@ -45,6 +42,9 @@ public:
 
 		as = new AtomSpace();
 		eval = new SchemeEval(as);
+		eval->eval("(add-to-load-path \"..\")");
+		eval->eval("(add-to-load-path \"../../..\")");
+		eval->eval("(use-modules (opencog query))");
 	}
 
 	~SequenceUTest()
@@ -52,7 +52,7 @@ public:
 		delete as;
 		// Erase the log file if no assertions failed.
 		if (!CxxTest::TestTracker::tracker().suiteFailed())
-				std::remove(logger().get_filename().c_str());
+			std::remove(logger().get_filename().c_str());
 	}
 
 	void setUp(void);
@@ -71,7 +71,6 @@ void SequenceUTest::tearDown(void)
 
 void SequenceUTest::setUp(void)
 {
-	eval->eval("(use-modules (opencog query))");
 }
 
 /*
@@ -81,8 +80,7 @@ void SequenceUTest::test_sequence(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD", "tests/query/sequence.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/sequence.scm\")");
 
 	// This should throw an exception from scheme.
 	// Disable logging so as to avoid the hopeless spew of errors.
@@ -149,8 +147,7 @@ void SequenceUTest::test_presence(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD", "tests/query/seq-presence.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/seq-presence.scm\")");
 
 	TruthValuePtr tv = eval->eval_tv("(cog-satisfy empty-sequence)");
 	TS_ASSERT_LESS_THAN_EQUALS(0.5, tv->getMean());
@@ -165,8 +162,7 @@ void SequenceUTest::test_fallback(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD", "tests/query/sequence.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/sequence.scm\")");
 
 	// This should not throw any exceptions.
 	TruthValuePtr tv = eval->eval_tv("(cog-satisfy drag-race)");
@@ -190,8 +186,7 @@ void SequenceUTest::test_pass_presence(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD", "tests/query/seq-absence.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/seq-absence.scm\")");
 
 	TruthValuePtr tv = eval->eval_tv("(cog-satisfy or-presence)");
 	TS_ASSERT_LESS_THAN_EQUALS(0.5, tv->getMean());
@@ -274,8 +269,7 @@ void SequenceUTest::test_or_put(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD", "tests/query/seq-absence.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/seq-absence.scm\")");
 
 	// ----
 	// Insert eval link to prevent it from tripping.

--- a/tests/query/SequenceUTest.cxxtest
+++ b/tests/query/SequenceUTest.cxxtest
@@ -23,7 +23,6 @@
 #include <opencog/guile/SchemeEval.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/atoms/core/StateLink.h>
-// #include <opencog/query/BindLinkAPI.h>
 #include <opencog/util/Logger.h>
 
 using namespace opencog;

--- a/tests/query/SingleUTest.cxxtest
+++ b/tests/query/SingleUTest.cxxtest
@@ -20,12 +20,9 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/guile/load-file.h>
 #include <opencog/guile/SchemeEval.h>
-#include <opencog/guile/SchemeSmob.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/query/BindLinkAPI.h>
-#include <opencog/util/Config.h>
 #include <opencog/util/Logger.h>
 
 using namespace opencog;
@@ -33,8 +30,8 @@ using namespace opencog;
 class SingleUTest: public CxxTest::TestSuite
 {
 private:
-        AtomSpace *as;
-        SchemeEval* eval;
+    AtomSpace *as;
+    SchemeEval* eval;
 
 public:
     SingleUTest(void)
@@ -44,6 +41,9 @@ public:
 
         as = new AtomSpace();
         eval = new SchemeEval(as);
+        eval->eval("(use-modules (opencog exec) (opencog query))");
+        eval->eval("(add-to-load-path \"..\")");
+        eval->eval("(add-to-load-path \"../../..\")");
     }
 
     ~SingleUTest()
@@ -52,7 +52,7 @@ public:
         delete as;
         // Erase the log file if no assertions failed.
         if (!CxxTest::TestTracker::tracker().suiteFailed())
-                std::remove(logger().get_filename().c_str());
+            std::remove(logger().get_filename().c_str());
     }
 
     void setUp(void);
@@ -67,7 +67,6 @@ void SingleUTest::tearDown(void)
 
 void SingleUTest::setUp(void)
 {
-    eval->eval("(use-modules (opencog exec) (opencog query))");
 }
 
 #define getarity(hand) LinkCast(hand)->getArity()
@@ -82,8 +81,7 @@ void SingleUTest::test_single_bindlink(void)
 {
     logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    config().set("SCM_PRELOAD", "tests/query/single.scm");
-    load_scm_files_from_config(*as);    
+    eval->eval("(load-from-path \"tests/query/single.scm\")");
 
     // First, get all the solutions. There should be 3 of them:
     // Socrates, Einstein and Peirce all inherit from man

--- a/tests/query/StackMoreUTest.cxxtest
+++ b/tests/query/StackMoreUTest.cxxtest
@@ -20,11 +20,9 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/guile/load-file.h>
 #include <opencog/guile/SchemeEval.h>
 #include <opencog/guile/SchemeSmob.h>
 #include <opencog/query/BindLinkAPI.h>
-#include <opencog/util/Config.h>
 #include <opencog/util/Logger.h>
 
 #include "test-types.h"
@@ -74,21 +72,20 @@ class StackMoreUTest :  public CxxTest::TestSuite
 void StackMoreUTest::setUp(void)
 {
 	as = new AtomSpace();
+	SchemeEval* eval = new SchemeEval(as);
 
-	config().set("SCM_PRELOAD",
-      "tests/query/test_types.scm, "
-		"tests/query/stackmore-o-o.scm, "
-		"tests/query/stackmore-o-u.scm, "
-		"tests/query/stackmany-o-u.scm, "
-		"tests/query/stackmore-o-uu.scm, "
-		"tests/query/stackmore-u-o.scm, "
-		"tests/query/stackmore-u-u.scm, "
-		"tests/query/stackmore-u-uu.scm");
-
-	load_scm_files_from_config(*as);
+	eval->eval("(add-to-load-path \"..\")");
+	eval->eval("(add-to-load-path \"../../..\")");
+	eval->eval("(load-from-path \"tests/query/test_types.scm\")");
+	eval->eval("(load-from-path \"tests/query/stackmore-o-o.scm\")");
+	eval->eval("(load-from-path \"tests/query/stackmore-o-u.scm\")");
+	eval->eval("(load-from-path \"tests/query/stackmany-o-u.scm\")");
+	eval->eval("(load-from-path \"tests/query/stackmore-o-uu.scm\")");
+	eval->eval("(load-from-path \"tests/query/stackmore-u-o.scm\")");
+	eval->eval("(load-from-path \"tests/query/stackmore-u-u.scm\")");
+	eval->eval("(load-from-path \"tests/query/stackmore-u-uu.scm\")");
 
 	// Create an implication link that will be tested.
-	SchemeEval* eval = new SchemeEval(as);
 	bind_oo = eval->apply("bind_oo", Handle::UNDEFINED);
 	bind_ou = eval->apply("bind_ou", Handle::UNDEFINED);
 	many_ou = eval->apply("many_ou", Handle::UNDEFINED);

--- a/tests/query/SubstitutionUTest.cxxtest
+++ b/tests/query/SubstitutionUTest.cxxtest
@@ -20,12 +20,9 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/guile/load-file.h>
 #include <opencog/guile/SchemeEval.h>
-#include <opencog/guile/SchemeSmob.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/atoms/core/VariableList.h>
-#include <opencog/util/Config.h>
 #include <opencog/util/exceptions.h>
 #include <opencog/util/Logger.h>
 
@@ -45,9 +42,9 @@ public:
 
 		as = new AtomSpace();
 		eval = new SchemeEval(as);
-
-		config().set("SCM_PRELOAD", "tests/query/substitution.scm");
-		load_scm_files_from_config(*as);
+		eval->eval("(add-to-load-path \"..\")");
+		eval->eval("(add-to-load-path \"../../..\")");
+		eval->eval("(load-from-path \"tests/query/substitution.scm\")");
 	}
 
 	~SubstitutionUTest()

--- a/tests/query/SudokuUTest.cxxtest
+++ b/tests/query/SudokuUTest.cxxtest
@@ -21,6 +21,7 @@
  */
 
 #include <opencog/guile/SchemeEval.h>
+#include <opencog/guile/SchemeSmob.h>
 #include <opencog/query/BindLinkAPI.h>
 #include <opencog/util/Logger.h>
 

--- a/tests/query/SudokuUTest.cxxtest
+++ b/tests/query/SudokuUTest.cxxtest
@@ -20,11 +20,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/guile/load-file.h>
 #include <opencog/guile/SchemeEval.h>
-#include <opencog/guile/SchemeSmob.h>
 #include <opencog/query/BindLinkAPI.h>
-#include <opencog/util/Config.h>
 #include <opencog/util/Logger.h>
 
 #include "test-types.h"
@@ -46,6 +43,9 @@ class SudokuPuzzle :  public CxxTest::TestSuite
 
 			as = new AtomSpace();
 			eval = new SchemeEval(as);
+			eval->eval("(add-to-load-path \"..\")");
+			eval->eval("(add-to-load-path \"../../..\")");
+			eval->eval("(use-modules (opencog query))");
 		}
 
 		~SudokuPuzzle()
@@ -76,8 +76,6 @@ class SudokuPuzzle :  public CxxTest::TestSuite
 void SudokuPuzzle::setUp(void)
 {
 	as->clear();
-
-	eval->eval("(use-modules (opencog query))");
 }
 
 #define getlink(hand,pos) LinkCasts(hand)->getOutgoingAtom(pos)
@@ -90,9 +88,7 @@ void SudokuPuzzle::test_2x2_puzzle(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD",
-		"tests/query/sudoku-simple.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/sudoku-simple.scm\")");
 
 	// Create an implication link that will be tested.
 	Handle puzzle = eval->eval_h("(x2-puzzle)");
@@ -119,9 +115,7 @@ void SudokuPuzzle::xtest_2x2_any(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD",
-		"tests/query/sudoku-simple.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/sudoku-simple.scm\")");
 
 	// Create an implication link that will be tested.
 	Handle puzzle = eval->eval_h("(x2-any)");
@@ -146,9 +140,7 @@ void SudokuPuzzle::test_3x3_puzzle(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD",
-		"tests/query/sudoku-simple.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/sudoku-simple.scm\")");
 
 	// Create an implication link that will be tested.
 	Handle puzzle = eval->eval_h("(x3-puzzle)");
@@ -174,10 +166,8 @@ void SudokuPuzzle::xxx_borken_test_puzzle(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	config().set("SCM_PRELOAD",
-		"tests/query/sudoku-rules.scm, "
-		"tests/query/sudoku-puzzle.scm");
-	load_scm_files_from_config(*as);
+	eval->eval("(load-from-path \"tests/query/sudoku-rules.scm\")");
+	eval->eval("(load-from-path \"tests/query/sudoku-puzzle.scm\")");
 
 	// Create an implication link that will be tested.
 	Handle puzzle = eval->eval_h("(puzzle)");

--- a/tests/query/UnorderedUTest.cxxtest
+++ b/tests/query/UnorderedUTest.cxxtest
@@ -20,11 +20,9 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/guile/load-file.h>
 #include <opencog/guile/SchemeEval.h>
 #include <opencog/guile/SchemeSmob.h>
 #include <opencog/query/BindLinkAPI.h>
-#include <opencog/util/Config.h>
 #include <opencog/util/Logger.h>
 
 #include "test-types.h"
@@ -79,17 +77,15 @@ class UnorderedUTest :  public CxxTest::TestSuite
 void UnorderedUTest::setUp(void)
 {
 	as = new AtomSpace();
-
-	config().set("SCM_PRELOAD",
-		"tests/query/test_types.scm, "
-		"tests/query/unordered.scm, "
-		"tests/query/unordered-more.scm, "
-		"tests/query/unordered-exhaust.scm");
-
-	load_scm_files_from_config(*as);
+	SchemeEval* eval = new SchemeEval(as);
+	eval->eval("(add-to-load-path \"..\")");
+	eval->eval("(add-to-load-path \"../../..\")");
+	eval->eval("(load-from-path \"tests/query/test_types.scm\")");
+	eval->eval("(load-from-path \"tests/query/unordered.scm\")");
+	eval->eval("(load-from-path \"tests/query/unordered-more.scm\")");
+	eval->eval("(load-from-path \"tests/query/unordered-exhaust.scm\")");
 
 	// Create an implication link that will be tested.
-	SchemeEval* eval = new SchemeEval(as);
 	pair = eval->apply("pair", Handle::UNDEFINED);
 	disorder = eval->apply("blink", Handle::UNDEFINED);
 	disordered = eval->apply("blinker", Handle::UNDEFINED);

--- a/tests/query/VarTypeNotUTest.cxxtest
+++ b/tests/query/VarTypeNotUTest.cxxtest
@@ -20,11 +20,9 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/guile/load-file.h>
 #include <opencog/guile/SchemeEval.h>
 #include <opencog/guile/SchemeSmob.h>
 #include <opencog/query/BindLinkAPI.h>
-#include <opencog/util/Config.h>
 #include <opencog/util/Logger.h>
 
 #include "test-types.h"
@@ -35,6 +33,7 @@ class VarTypeNot :  public CxxTest::TestSuite
 {
 	private:
 		AtomSpace *as;
+		SchemeEval* eval;
 		Handle vscope_good, vscope_bad;
 
 	public:
@@ -66,12 +65,11 @@ class VarTypeNot :  public CxxTest::TestSuite
 void VarTypeNot::setUp(void)
 {
 	as = new AtomSpace();
-
-	config().set("SCM_PRELOAD",
-		"tests/query/test_types.scm, "
-		"tests/query/var-type-not.scm");
-
-	load_scm_files_from_config(*as);
+	eval = new SchemeEval(as);
+	eval->eval("(add-to-load-path \"..\")");
+	eval->eval("(add-to-load-path \"../../..\")");
+	eval->eval("(load-from-path \"tests/query/test_types.scm\")");
+	eval->eval("(load-from-path \"tests/query/var-type-not.scm\")");
 }
 
 void VarTypeNot::tearDown(void)
@@ -89,8 +87,7 @@ void VarTypeNot::test_exec(void)
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
 	// Create an implication link that will be tested.
-	SchemeEval* evaluator = new SchemeEval(as);
-	vscope_good = evaluator->apply("rule-good", Handle::UNDEFINED);
+	vscope_good = eval->apply("rule-good", Handle::UNDEFINED);
 
 	// This should throw an exception.
 	// Disable logging so as to avoid the hopeless spew of errors.
@@ -101,7 +98,7 @@ void VarTypeNot::test_exec(void)
 	bool caught = false;
 	try
 	{
-		vscope_bad = evaluator->apply("rule-bad", Handle::UNDEFINED);
+		vscope_bad = eval->apply("rule-bad", Handle::UNDEFINED);
 	}
    catch (const RuntimeException& ex)
    {
@@ -110,7 +107,6 @@ void VarTypeNot::test_exec(void)
        caught = true;
    }
    TSM_ASSERT("Failed to catch expected exception", caught);
-	delete evaluator;
 
 	logger().set_level(Logger::INFO);
 
@@ -121,7 +117,7 @@ void VarTypeNot::test_exec(void)
 
 /*****************
 	In the good old days, it was the pattern matcher that threw the exception
-	for the bad variable type. Now, it is thown much earlier, by the
+	for the bad variable type. Now, it is thrown much earlier, by the
 	atomspace, so the remainder of this test is irrelevant.
 
 	TSM_ASSERT("Failed to load test data", Handle::UNDEFINED != vscope_bad);

--- a/tests/rule-engine/BackwardChainerUTest.cxxtest
+++ b/tests/rule-engine/BackwardChainerUTest.cxxtest
@@ -53,10 +53,6 @@ void BackwardChainerUTest::setUp()
 	eval_.eval("(add-to-load-path \"../../..\")");
 	eval_.eval("(use-modules (opencog))");
 	// eval_.eval("(use-modules (opencog rule-engine))");
-
-	// This is toally nuts, but deleting this one line causes this
-	// unit test to fail.  I'm completely stumped by this.
-	SchemeEval evo2(&as_);
 }
 
 void BackwardChainerUTest::tearDown()
@@ -239,6 +235,9 @@ void BackwardChainerUTest::test_tvq_impossible_bc()
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
+	// This is toally nuts, but deleting this one line causes the
+	// NEXT unit test to fail!  I'm completely stumped by this.
+	SchemeEval evo2(&as_);
 	as_.clear();
 
 	eval_.eval("(load-from-path \"tests/rule-engine/bc-modus-ponens-config.scm\")");

--- a/tests/rule-engine/BackwardChainerUTest.cxxtest
+++ b/tests/rule-engine/BackwardChainerUTest.cxxtest
@@ -11,10 +11,6 @@
 #include <opencog/atoms/pattern/PatternLink.h>
 #include <opencog/util/mt19937ar.h>
 
-// Dead include files
-#include <opencog/util/Config.h>
-#include <opencog/guile/load-file.h>
-
 using namespace opencog;
 //#define DEBUG 1
 
@@ -58,9 +54,9 @@ void BackwardChainerUTest::setUp()
 	eval_.eval("(use-modules (opencog))");
 	// eval_.eval("(use-modules (opencog rule-engine))");
 
-	// This is crazy...
-	config().set("SCM_PRELOAD", "tests/rule-engine/empty-file.scm");
-	load_scm_files_from_config(as_);
+	// This is toally nuts, but deleting this one line causes this
+	// unit test to fail.  I'm completely stumped by this.
+	SchemeEval evo2(&as_);
 }
 
 void BackwardChainerUTest::tearDown()

--- a/tests/rule-engine/BackwardChainerUTest.cxxtest
+++ b/tests/rule-engine/BackwardChainerUTest.cxxtest
@@ -235,9 +235,11 @@ void BackwardChainerUTest::test_tvq_impossible_bc()
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	// This is toally nuts, but deleting this one line causes the
-	// NEXT unit test to fail!  I'm completely stumped by this.
-	SchemeEval evo2(&as_);
+	// This is kind of crazy, but ... but deleting the forced garbage
+	// collection below causes the NEXT unit test to fail!  I don't
+	// understand what's at the root of this bug. Some weird
+	// indeterminism?
+	eval_.eval("(gc)");
 	as_.clear();
 
 	eval_.eval("(load-from-path \"tests/rule-engine/bc-modus-ponens-config.scm\")");

--- a/tests/rule-engine/BackwardChainerUTest.cxxtest
+++ b/tests/rule-engine/BackwardChainerUTest.cxxtest
@@ -7,12 +7,9 @@
 #include <opencog/rule-engine/backwardchainer/BackwardChainer.h>
 #include <opencog/rule-engine/backwardchainer/BackwardChainerPMCB.h>
 #include <opencog/guile/SchemeEval.h>
-#include <opencog/guile/SchemeSmob.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/atoms/pattern/PatternLink.h>
-#include <opencog/util/Config.h>
 #include <opencog/util/mt19937ar.h>
-#include <opencog/guile/load-file.h>
 
 using namespace opencog;
 //#define DEBUG 1
@@ -52,11 +49,8 @@ public:
 
 void BackwardChainerUTest::setUp()
 {
-	config().set("SCM_PRELOAD",
-	             "opencog/atoms/base/core_types.scm, "
-	             "opencog/scm/utilities.scm, "
-	             "opencog/scm/av-tv.scm");
-	load_scm_files_from_config(as_);
+	eval_.eval("(add-to-load-path \"..\")");
+	eval_.eval("(add-to-load-path \"../../..\")");
 }
 
 void BackwardChainerUTest::tearDown()
@@ -70,10 +64,8 @@ void BackwardChainerUTest::test_1_rule_bc_modus_ponens()
 
 	as_.clear();
 
-	config().set("SCM_PRELOAD",
-	             "tests/rule-engine/bc-modus-ponens-config.scm,"
-	             "tests/rule-engine/bc-animals.scm");
-	load_scm_files_from_config(as_);
+	eval_.eval("(load-from-path \"tests/rule-engine/bc-modus-ponens-config.scm\")");
+	eval_.eval("(load-from-path \"tests/rule-engine/bc-animals.scm\")");
 	randGen().seed(0);
 
 	// load 1 modus ponens rule
@@ -82,9 +74,9 @@ void BackwardChainerUTest::test_1_rule_bc_modus_ponens()
 
 	Handle target_var = eval_.eval_h("(VariableNode \"$what\")");
 	Handle target =
-	    eval_.eval_h("(InheritanceLink"
-	                  "   (VariableNode \"$what\")"
-					  "   (ConceptNode \"green\"))");
+		eval_.eval_h("(InheritanceLink"
+		             "   (VariableNode \"$what\")"
+		             "   (ConceptNode \"green\"))");
 	Handle soln = eval_.eval_h("(ConceptNode \"Fritz\")");
 
 	bc.set_target(target);
@@ -105,10 +97,8 @@ void BackwardChainerUTest::test_1_rule_bc_deduction()
 
 	as_.clear();
 
-	config().set("SCM_PRELOAD",
-	             "tests/rule-engine/bc-deduction-config.scm,"
-	             "tests/rule-engine/bc-transitive-closure.scm");
-	load_scm_files_from_config(as_);
+	eval_.eval("(load-from-path \"tests/rule-engine/bc-deduction-config.scm\")");
+	eval_.eval("(load-from-path \"tests/rule-engine/bc-transitive-closure.scm\")");
 	randGen().seed(0);
 
 	// load 1 deduction rule
@@ -143,10 +133,8 @@ void BackwardChainerUTest::test_1_rule_impossible_bc()
 
 	as_.clear();
 
-	config().set("SCM_PRELOAD",
-	             "tests/rule-engine/bc-modus-ponens-config.scm,"
-	             "tests/rule-engine/bc-criminal.scm");
-	load_scm_files_from_config(as_);
+	eval_.eval("(load-from-path \"tests/rule-engine/bc-modus-ponens-config.scm\")");
+	eval_.eval("(load-from-path \"tests/rule-engine/bc-criminal.scm\")");
 	randGen().seed(0);
 
 	// load modus ponens rule
@@ -181,10 +169,8 @@ void BackwardChainerUTest::test_2_rules_bc()
 
 	as_.clear();
 
-	config().set("SCM_PRELOAD",
-	             "tests/rule-engine/bc-config.scm,"
-	             "tests/rule-engine/bc-criminal.scm");
-	load_scm_files_from_config(as_);
+	eval_.eval("(load-from-path \"tests/rule-engine/bc-config.scm\")");
+	eval_.eval("(load-from-path \"tests/rule-engine/bc-criminal.scm\")");
 	randGen().seed(500);
 
 	// load modus ponens & deduction rules
@@ -218,10 +204,8 @@ void BackwardChainerUTest::test_tvq_bc()
 
 	as_.clear();
 
-	config().set("SCM_PRELOAD",
-	             "tests/rule-engine/bc-modus-ponens-config.scm,"
-	             "tests/rule-engine/bc-animals.scm");
-	load_scm_files_from_config(as_);
+	eval_.eval("(load-from-path \"tests/rule-engine/bc-modus-ponens-config.scm\")");
+	eval_.eval("(load-from-path \"tests/rule-engine/bc-animals.scm\")");
 	randGen().seed(500);
 
 	// load modus ponens
@@ -251,10 +235,8 @@ void BackwardChainerUTest::test_tvq_impossible_bc()
 
 	as_.clear();
 
-	config().set("SCM_PRELOAD",
-	             "tests/rule-engine/bc-modus-ponens-config.scm,"
-	             "tests/rule-engine/bc-animals.scm");
-	load_scm_files_from_config(as_);
+	eval_.eval("(load-from-path \"tests/rule-engine/bc-modus-ponens-config.scm\")");
+	eval_.eval("(load-from-path \"tests/rule-engine/bc-animals.scm\")");
 	randGen().seed(0);
 
 	// load modus ponens
@@ -294,10 +276,8 @@ void BackwardChainerUTest::test_focus_set()
 
 	as_.clear();
 
-	config().set("SCM_PRELOAD",
-	             "tests/rule-engine/bc-modus-ponens-config.scm,"
-	             "tests/rule-engine/bc-animals.scm");
-	load_scm_files_from_config(as_);
+	eval_.eval("(load-from-path \"tests/rule-engine/bc-modus-ponens-config.scm\")");
+	eval_.eval("(load-from-path \"tests/rule-engine/bc-animals.scm\")");
 	randGen().seed(0);
 
 	// load 1 modus ponens rule

--- a/tests/rule-engine/BackwardChainerUTest.cxxtest
+++ b/tests/rule-engine/BackwardChainerUTest.cxxtest
@@ -11,6 +11,10 @@
 #include <opencog/atoms/pattern/PatternLink.h>
 #include <opencog/util/mt19937ar.h>
 
+// Dead include files
+#include <opencog/util/Config.h>
+#include <opencog/guile/load-file.h>
+
 using namespace opencog;
 //#define DEBUG 1
 
@@ -51,6 +55,12 @@ void BackwardChainerUTest::setUp()
 {
 	eval_.eval("(add-to-load-path \"..\")");
 	eval_.eval("(add-to-load-path \"../../..\")");
+	eval_.eval("(use-modules (opencog))");
+	// eval_.eval("(use-modules (opencog rule-engine))");
+
+	// This is crazy...
+	config().set("SCM_PRELOAD", "tests/rule-engine/empty-file.scm");
+	load_scm_files_from_config(as_);
 }
 
 void BackwardChainerUTest::tearDown()
@@ -179,9 +189,9 @@ void BackwardChainerUTest::test_2_rules_bc()
 
 	Handle target_var = eval_.eval_h("(VariableNode \"$who\")");
 	Handle target =
-	    eval_.eval_h("(InheritanceLink"
-	                  "   (VariableNode \"$who\")"
-					  "   (ConceptNode \"criminal\"))");
+		eval_.eval_h("(InheritanceLink"
+		             "   (VariableNode \"$who\")"
+		             "   (ConceptNode \"criminal\"))");
 	Handle soln = eval_.eval_h("(ConceptNode \"West\")");
 
 	bc.set_target(target);

--- a/tests/rule-engine/ChainerUtilsUTest.cxxtest
+++ b/tests/rule-engine/ChainerUtilsUTest.cxxtest
@@ -23,11 +23,8 @@
 #include <cxxtest/TestSuite.h>
 
 #include <opencog/util/Logger.h>
-#include <opencog/util/Config.h>
-
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/guile/SchemeEval.h>
-#include <opencog/guile/load-file.h>
 #include <opencog/rule-engine/ChainerUtils.h>
 
 using namespace opencog;
@@ -76,11 +73,6 @@ void ChainerUtilsUTest::test_get_outgoing_nodes()
 void ChainerUtilsUTest::test_are_similar()
 {
     AtomSpace as;
-    config().set("SCM_PRELOAD", "opencog/atoms/base/core_types.scm, "
-                 "opencog/scm/utilities.scm, "
-                 "opencog/scm/av-tv.scm");
-    load_scm_files_from_config(as);
-
     SchemeEval eval(&as);
 
     Handle h1 = eval.eval_h("(EvaluationLink "

--- a/tests/rule-engine/ForwardChainerUTest.cxxtest
+++ b/tests/rule-engine/ForwardChainerUTest.cxxtest
@@ -6,9 +6,7 @@
  */
 #include <boost/range/algorithm/find.hpp>
 
-#include <opencog/util/Config.h>
 #include <opencog/atomspace/AtomSpace.h>
-#include <opencog/guile/load-file.h>
 #include <opencog/guile/SchemeEval.h>
 
 #include <opencog/rule-engine/forwardchainer/ForwardChainer.h>
@@ -39,39 +37,22 @@ public:
 
 		// Disable the AF mechanism during testing!
 		_as.set_attentional_focus_boundary(AttentionValue::MINSTI);
-		config().set("SCM_PRELOAD",
-		             "opencog/atoms/base/core_types.scm, "
-		             "opencog/scm/utilities.scm, "
-		             "opencog/scm/av-tv.scm");
-		load_scm_files_from_config(_as);
 
+		eval.eval("(add-to-load-path \"..\")");
+		eval.eval("(add-to-load-path \"../../..\")");
 		eval.eval("(use-modules (opencog))");
-		CHKERR;
-
 		eval.eval("(use-modules (opencog rule-engine))");
 		CHKERR;
 
-		// add the following so that utilities.scm and av-tv.scm are
-		// correctly loaded from crisp-deduction.scm
-		eval.eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "/opencog/scm\")");
-		CHKERR;
-
-		// Load utilities.scm and rule-engine-utils.scm. Apparently
-		// the modules' functions are not loaded
-		eval.eval("(load-from-path \"utilities.scm\")");
-		CHKERR;
-		eval.eval("(load-from-path \"opencog/rule-engine/rule-engine-utils.scm\")");
-		CHKERR;
-
 		// Load the simple deduction example to test it
-		eval.eval("(load-from-path \"" PROJECT_SOURCE_DIR
-		          "/tests/rule-engine/crisp-deduction.scm\")");
-		eval.eval("(load-from-path \"" PROJECT_SOURCE_DIR
-		          "/tests/rule-engine/crisp-deduction-config.scm\")");
+		eval.eval("(load-from-path \""
+		          "tests/rule-engine/crisp-deduction.scm\")");
+		eval.eval("(load-from-path \""
+		          "tests/rule-engine/crisp-deduction-config.scm\")");
 		CHKERR;
 
-		eval.eval("(load-from-path \"" PROJECT_SOURCE_DIR
-		          "/tests/rule-engine/bc-config.scm\")");
+		eval.eval("(load-from-path \""
+		          "tests/rule-engine/bc-config.scm\")");
 	}
 	void test_do_chain();
 	void test_choose_rule();
@@ -87,10 +68,11 @@ void ForwardChainerUTest::test_do_chain()
 {
 	// Test simple deduction
 	//
-	// InheritanceLink A B
-	// InheritanceLink B C
-	// |-
-	// InheritanceLink A C
+	//   InheritanceLink A B
+	//   InheritanceLink B C
+	//   |-
+	//   InheritanceLink A C
+	//
 	Handle A = eval.eval_h("(PredicateNode \"A\" (stv 1 1))"),
 		B = eval.eval_h("(PredicateNode \"B\" (stv 1 1))"),
 		C = eval.eval_h("(PredicateNode \"C\" (stv 1 1))"),
@@ -134,10 +116,7 @@ void ForwardChainerUTest::test_apply_rule(void)
 {
 	// Apply rule x and see if all the inferences made
 	// are a direct result of source being part of input/premise
-	config().set(
-		"SCM_PRELOAD",
-		"tests/rule-engine/simple-assertions.scm");
-	load_scm_files_from_config(_as);
+	eval.eval("(load-from-path \"tests/rule-engine/simple-assertions.scm\")");
 
 	Handle rule_handle = eval.eval_h("(MemberLink"
 	                                 "   bc-deduction-rule-name"
@@ -165,9 +144,7 @@ void ForwardChainerUTest::test_apply_rule(void)
 
 void ForwardChainerUTest::test_substitute_rule_part(void)
 {
-	config().set("SCM_PRELOAD",
-	             "tests/rule-engine/dfc-tests.scm");
-	load_scm_files_from_config(_as);
+	eval.eval("(load-from-path \"tests/rule-engine/dfc-tests.scm\")");
 
 	Handle rule_handle = eval.eval_h("bc-deduction-rule");
 
@@ -232,8 +209,7 @@ void ForwardChainerUTest::test_unify_1(void)
 
 void ForwardChainerUTest::test_unify_2(void)
 {
-	config().set("SCM_PRELOAD", "tests/rule-engine/rules/pln-implication-and-lambda-factorization-rule.scm");
-	load_scm_files_from_config(_as);
+	eval.eval("(load-from-path \"tests/rule-engine/rules/pln-implication-and-lambda-factorization-rule.scm\")");
 
 	Handle source = eval.eval_h
 		("(AndLink"
@@ -266,9 +242,8 @@ void ForwardChainerUTest::test_unify_2(void)
 
 void ForwardChainerUTest::test_derive_rules_1(void)
 {
-	config().set("SCM_PRELOAD", "tests/rule-engine/rules/bc-deduction.scm,"
-	             "tests/rule-engine/simple-assertions.scm");
-	load_scm_files_from_config(_as);
+	eval.eval("(load-from-path \"tests/rule-engine/rules/bc-deduction.scm\")");
+	eval.eval("(load-from-path \"tests/rule-engine/rules/simple-assertions.scm\")");
 
 	Handle rule_handle = eval.eval_h("(MemberLink"
 	                                 "   bc-deduction-rule-name"
@@ -294,9 +269,7 @@ void ForwardChainerUTest::test_derive_rules_2()
 {
 	_as.clear();
 
-	config().set("SCM_PRELOAD",
-	             "tests/rule-engine/rules/implication-construction-rule.scm");
-	load_scm_files_from_config(_as);
+	eval.eval("(load-from-path \"tests/rule-engine/rules/implication-construction-rule.scm\")");
 
 	Handle source = eval.eval_h("(LambdaLink"
 	                            "   (TypedVariableLink"

--- a/tests/rule-engine/URECommonsUTest.cxxtest
+++ b/tests/rule-engine/URECommonsUTest.cxxtest
@@ -7,10 +7,8 @@
 
 #include <opencog/rule-engine/URECommons.h>
 #include <opencog/guile/SchemeEval.h>
-#include <opencog/guile/SchemeSmob.h>
 #include <opencog/atomspace/AtomSpace.h>
-#include <opencog/util/Config.h>
-#include <opencog/guile/load-file.h>
+
 //TODO test choose_target
 using namespace opencog;
 class URECommonsUTest: public CxxTest::TestSuite {
@@ -28,18 +26,17 @@ public:
 
 };
 
-void URECommonsUTest::setUp() {
-	config().set("SCM_PRELOAD", "opencog/atoms/base/core_types.scm, "
-			"opencog/scm/utilities.scm, "
-			"opencog/python/pln_old/examples/deduction/atomspace_contents.scm");
-	load_scm_files_from_config(as_);
+void URECommonsUTest::setUp()
+{
 }
 
-void URECommonsUTest::tearDown() {
+void URECommonsUTest::tearDown()
+{
 	as_.clear();
 }
 
-void URECommonsUTest::test_get_root_links(void) {
+void URECommonsUTest::test_get_root_links(void)
+{
 	string bindlink =
 			"(BindLink"
 					"   (VariableList"
@@ -85,8 +82,9 @@ void URECommonsUTest::test_get_root_links(void) {
 	TS_ASSERT_EQUALS(1, rootsx.size());
 }
 
-void URECommonsUTest::test_create_bindLink() {
-//TODO expand this test
+void URECommonsUTest::test_create_bindLink()
+{
+	//TODO expand this test
 	Handle himplicant = eval_.eval_h("(InheritanceLink"
 	                                 "   (VariableNode \"$var-rich\")"
 	                                 "   (ConceptNode \"happy\"))");
@@ -94,4 +92,3 @@ void URECommonsUTest::test_create_bindLink() {
 
 	TS_ASSERT_EQUALS(BIND_LINK, h->getType());
 }
-

--- a/tests/rule-engine/UREConfigReaderUTest.cxxtest
+++ b/tests/rule-engine/UREConfigReaderUTest.cxxtest
@@ -1,7 +1,5 @@
 #include <opencog/atomspace/AtomSpace.h>
-#include <opencog/guile/load-file.h>
 #include <opencog/guile/SchemeEval.h>
-#include <opencog/util/Config.h>
 
 #include <opencog/rule-engine/UREConfigReader.h>
 
@@ -15,14 +13,14 @@ private:
 public:
 	UREConfigReaderUTest() : _eval(&_as)
 	{
-		config().set("SCM_PRELOAD",
-		             "opencog/atoms/base/core_types.scm");
-		load_scm_files_from_config(_as);
-
 		// Module loading is borked from the C++ environment, so
 		// add the following paths so that utilities.scm is found.
 		_eval.eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "/opencog/scm\")");
 		_eval.eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "/opencog/scm/opencog\")");
+
+		_eval.eval("(add-to-load-path \"..\")");
+		_eval.eval("(add-to-load-path \"../../..\")");
+		_eval.eval("(use-modules (opencog) (opencog query))");
 
 		// Load the simple crisp system example to test it
 		string eval_output =

--- a/tests/scm/MultiAtomSpaceUTest.cxxtest
+++ b/tests/scm/MultiAtomSpaceUTest.cxxtest
@@ -20,10 +20,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/guile/load-file.h>
+#include <opencog/atomspace/AtomSpace.h>
 #include <opencog/guile/SchemeEval.h>
-#include <opencog/guile/SchemeSmob.h>
-#include <opencog/util/Config.h>
 #include <opencog/util/Logger.h>
 
 using namespace opencog;
@@ -72,11 +70,8 @@ void MultiAtomSpace::setUp(void)
 {
 	main_as = new AtomSpace();
 	evaluator = new SchemeEval(main_as);
-
-	config().set("SCM_PRELOAD",
-		"opencog/atoms/base/core_types.scm");
-
-	load_scm_files_from_config(*main_as);
+	evaluator->eval("(add-to-load-path \"..\")");
+	evaluator->eval("(add-to-load-path \"../../..\")");
 }
 
 void MultiAtomSpace::tearDown(void)
@@ -217,19 +212,10 @@ void MultiAtomSpace::test_load(void)
 	AtomSpace* as1 = new AtomSpace();
 	AtomSpace* as2 = new AtomSpace();
 
-	config().set("SCM_PRELOAD",
-		"opencog/atomspace/core_types.scm, "
-		"opencog/nlp/types/nlp_types.scm, "
-		"opencog/scm/utilities.scm, "
-		"tests/scm/utils-test.scm");
-
-	load_scm_files_from_config(*as1);
-	load_scm_files_from_config(*as2);
-	// load_scm_file(*as1, "tests/scm/utils-test.scm");
-	// load_scm_file(*as2, "tests/scm/utils-test.scm");
-
 	SchemeEval* ev1 = new SchemeEval(as1);
 	SchemeEval* ev2 = new SchemeEval(as2);
+	ev1->eval("(load-from-path \"tests/scm/utils-test.scm\")");
+	ev2->eval("(load-from-path \"tests/scm/utils-test.scm\")");
 
 	// The below is a complicated multi-atom-space version of part of 
 	// the SCMUtilsUTest suite.  Different atoms in different spaces...
@@ -324,9 +310,8 @@ void MultiAtomSpace::test_nest(void)
 	TSM_ASSERT("Expect one link in local atomspace", 1 == locas->get_num_links());
 
 	// The outgoing set should not be copied, but should be the original.
-	LinkPtr lll(LinkCast(hl));
-	TSM_ASSERT("Expect atom a in position 0", ha == lll->getOutgoingAtom(0));
-	TSM_ASSERT("Expect atom b in position 1", hb == lll->getOutgoingAtom(1));
+	TSM_ASSERT("Expect atom a in position 0", ha == hl->getOutgoingAtom(0));
+	TSM_ASSERT("Expect atom b in position 1", hb == hl->getOutgoingAtom(1));
 
 	delete lev;
 	delete locas;
@@ -336,10 +321,10 @@ void MultiAtomSpace::test_nest(void)
 	TSM_ASSERT("Still two nodes in main atomspace", 2 == main_as->get_num_nodes());
 	TSM_ASSERT("Still zero links in main atomspace", 0 == main_as->get_num_links());
 
-	// The pointer lll should still be alive, even though the atomspace
+	// The pointer hl should still be alive, even though the atomspace
 	// is gone.
-	TSM_ASSERT("Still atom a in position 0", ha == lll->getOutgoingAtom(0));
-	TSM_ASSERT("Still atom b in position 1", hb == lll->getOutgoingAtom(1));
+	TSM_ASSERT("Still atom a in position 0", ha == hl->getOutgoingAtom(0));
+	TSM_ASSERT("Still atom b in position 1", hb == hl->getOutgoingAtom(1));
 }
 
 void MultiAtomSpace::test_nest_scm(void)

--- a/tests/scm/MultiThreadUTest.cxxtest
+++ b/tests/scm/MultiThreadUTest.cxxtest
@@ -20,10 +20,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/guile/load-file.h>
+#include <opencog/atomspace/AtomSpace.h>
 #include <opencog/guile/SchemeEval.h>
-#include <opencog/guile/SchemeSmob.h>
-#include <opencog/util/Config.h>
 #include <opencog/util/Logger.h>
 
 using namespace opencog;
@@ -63,8 +61,6 @@ class MultiThreadUTest :  public CxxTest::TestSuite
 #define al as->add_link
 void MultiThreadUTest::setUp(void)
 {
-	config().set("SCM_PRELOAD",
-		"opencog/atoms/base/core_types.scm");
 }
 
 void MultiThreadUTest::tearDown(void)
@@ -84,7 +80,6 @@ void MultiThreadUTest::test_three_evals_one_thread(void)
 
 	// Three evaluators all touching one atomspace.
 	as = new AtomSpace();
-	load_scm_files_from_config(*as);
 	SchemeEval* ev1 = new SchemeEval(as);
 	SchemeEval* ev2 = new SchemeEval(as);
 	SchemeEval* ev3 = new SchemeEval(as);
@@ -133,7 +128,6 @@ void MultiThreadUTest::test_three_evals_one_thread(void)
 // Use a unique evaluator for this thread.
 void MultiThreadUTest::threadedAdd(int thread_id, int N)
 {
-	load_scm_files_from_config(*as);
 	SchemeEval* ev = new SchemeEval(as);
 	int counter = 0;
 	for (int i = 0; i < N; i++) {
@@ -160,7 +154,6 @@ void MultiThreadUTest::test_multi_threads(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 	as = new AtomSpace();
-	load_scm_files_from_config(*as);
 	as->clear();
 
 	std::vector<std::thread> thread_pool;

--- a/tests/scm/SCMExecutionOutputUTest.cxxtest
+++ b/tests/scm/SCMExecutionOutputUTest.cxxtest
@@ -80,6 +80,7 @@ void SCMExecutionOutputUTest::setUp(void)
 {
 	as = new AtomSpace();
 	eval = new SchemeEval(as);
+	eval->eval("(use-modules (opencog exec))");
 }
 
 void SCMExecutionOutputUTest::tearDown(void)

--- a/tests/scm/SCMExecutionOutputUTest.cxxtest
+++ b/tests/scm/SCMExecutionOutputUTest.cxxtest
@@ -47,7 +47,6 @@ class SCMExecutionOutputUTest :  public CxxTest::TestSuite
 	{
 		logger().set_level(Logger::DEBUG);
 		logger().set_print_to_stdout_flag(true);
-		opencog_exec_init();
 	}
 
 	~SCMExecutionOutputUTest()

--- a/tests/scm/SCMExecutionOutputUTest.cxxtest
+++ b/tests/scm/SCMExecutionOutputUTest.cxxtest
@@ -24,12 +24,10 @@
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/atoms/base/Link.h>
 #include <opencog/atoms/base/Node.h>
-#include <opencog/guile/load-file.h>
 #include <opencog/guile/SchemeSmob.h>
 #include <opencog/guile/SchemeEval.h>
 #include <opencog/guile/SchemePrimitive.h>
 #include <opencog/util/Logger.h>
-#include <opencog/util/Config.h>
 #include <opencog/atoms/execution/ExecutionOutputLink.h>
 #include <opencog/atoms/execution/EvaluationLink.h>
 #include <opencog/atoms/execution/ExecSCM.h>
@@ -49,9 +47,6 @@ class SCMExecutionOutputUTest :  public CxxTest::TestSuite
 	{
 		logger().set_level(Logger::DEBUG);
 		logger().set_print_to_stdout_flag(true);
-
-		config().set("SCM_PRELOAD", "opencog/atoms/base/core_types.scm, "
-		                            "opencog/scm/opencog/exec.scm");
 		opencog_exec_init();
 	}
 
@@ -84,7 +79,6 @@ class SCMExecutionOutputUTest :  public CxxTest::TestSuite
 void SCMExecutionOutputUTest::setUp(void)
 {
 	as = new AtomSpace();
-	load_scm_files_from_config(*as);
 	eval = new SchemeEval(as);
 }
 

--- a/tests/scm/SCMUtilsUTest.cxxtest
+++ b/tests/scm/SCMUtilsUTest.cxxtest
@@ -20,10 +20,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/guile/load-file.h>
+#include <opencog/atomspace/AtomSpace.h>
 #include <opencog/guile/SchemeEval.h>
-#include <opencog/guile/SchemeSmob.h>
-#include <opencog/util/Config.h>
 #include <opencog/util/Logger.h>
 
 #include "../query/test-types.h"
@@ -69,14 +67,10 @@ void SCMUtilsUTest::setUp(void)
 {
 	as = new AtomSpace();
 	evaluator = new SchemeEval(as);
-
-	config().set("SCM_PRELOAD",
-		"opencog/atoms/base/core_types.scm, "
-		"tests/query/test_types.scm, "
-		"opencog/scm/utilities.scm, "
-		"tests/scm/utils-test.scm");
-
-	load_scm_files_from_config(*as);
+	evaluator->eval("(add-to-load-path \"..\")");
+	evaluator->eval("(add-to-load-path \"../../..\")");
+	evaluator->eval("(load-from-path \"tests/query/test_types.scm\")");
+	evaluator->eval("(load-from-path \"tests/scm/utils-test.scm\")");
 }
 
 void SCMUtilsUTest::tearDown(void)


### PR DESCRIPTION
The third commit - ad410f5be002f89b56e7dda7285ae1eba4d7815c -  adds a cheesy infinite-loop detector, for pull req #763 

Te rest is a whole-sale removal of the SCM PRELOAD mechanism from all of the unit tests that used it.