### PR TITLE
Expand support for searches that assign search results to a variable.

### DIFF
--- a/examples/aiml/README.md
+++ b/examples/aiml/README.md
@@ -8,7 +8,7 @@ Under development, very incomplete.
 # Goal
 Map AIML expressions to equivalent atomspace graphs, in such a
 way that the OpenCog pattern matcher can perform all of the same
-funcitons that AIML currently performs.
+funcitions that AIML currently performs.
 
 # Lightning reivew of AIML
 Some example sentences.

--- a/examples/aiml/recog.scm
+++ b/examples/aiml/recog.scm
@@ -144,5 +144,22 @@
 			(ConceptNode "love")
 			(GlobNode "$B"))))
 
+; Lets see if the above can be found!
+(cog-recognize adv-sent)
+
+(define constrained-adv-sent
+	(PatternLink
+		(BindLink
+			(VariableNode "$type constraints")
+			(ListLink
+				(ConceptNode "I")
+				(ConceptNode "really")
+				(ConceptNode "truly")
+				(ConceptNode "love")
+				(ConceptNode "you"))
+			(VariableNode "$impl"))))
+
+(cog-recognize constrained-adv-sent)
+
 ;-------------------------------------------------------
 *unspecified*

--- a/opencog/atoms/base/atom_types.script
+++ b/opencog/atoms/base/atom_types.script
@@ -245,6 +245,13 @@ GET_LINK <- PATTERN_LINK           // Finds all groundings, return atoms
 SATISFACTION_LINK <- PATTERN_LINK,EVALUATABLE_LINK  // Finds all groundings, return TV
 BIND_LINK <- GET_LINK              // Finds all groundings and executes
 
+// Adjoints to the GetLink and BindLink. They are "adjoint" in the sense
+// that the roles of the pattern and the grounding are reversed: given a
+// grounding, the collection of patterns that are grounded by it can be
+// searched-for.
+DUAL_GET_LINK <- PATTERN_LINK
+DUAL_BIND_LINK <- DUAL_GET_LINK
+
 // ==============================================================
 // Types and type constructors.
 

--- a/opencog/atoms/base/atom_types.script
+++ b/opencog/atoms/base/atom_types.script
@@ -58,9 +58,10 @@ EXTENSIONAL_SIMILARITY_LINK <- SIMILARITY_LINK
 INTENSIONAL_SIMILARITY_LINK <- SIMILARITY_LINK
 
 // Evaluatable link. Any link type which might be evaluated, resulting
-// in a truth-value, should inherit from this type.  It is a mixin-type,
+// in a truth-value, should inherit from this type.  This is a mixin-type,
 // it does nothing by itself, but is used to identify boolean-ish,
-// probabilisitic-TV-valued link types.
+// probabilisitic-TV-valued link types, so that they can be handled
+// properly.
 EVALUATABLE_LINK <- LINK
 
 // Boolean set operations, logical constants.

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -671,8 +671,10 @@ void PatternLink::unbundle_virtual(const OrderedHandleSet& vars,
 /* ================================================================= */
 
 /// Add dummy clauses for patterns that would otherwise not have any
-/// non-evaluatable clauses.  An example of such is
+/// non-evaluatable clauses.  One example of such is
+///
 ///    (GetLink (GreaterThan (Number 42) (Variable $x)))
+///
 /// The only clause here is the GreaterThan, and its virtual
 /// (evaluatable) so we know that in general it cannot be found in
 /// the atomspace.   Due to the pattern-matcher design, matching will
@@ -683,19 +685,24 @@ void PatternLink::unbundle_virtual(const OrderedHandleSet& vars,
 /// search results, for any variable that is not in an AbsentLink.
 /// (Always adding can harm performance, so we don't do it unless we
 /// absolutely have to.)
+///
+/// Another example is
+///
+///    (GetLink (Equal (Variable "$whole") (Implication ...)))
+///
+/// where the ImlicationLink may itself contain more variables.
+///
 void PatternLink::add_dummies()
 {
-	// XXX almost exactly the same as 0 < _fixed.size() ... right?
-	bool all_clauses_are_evaluatable = true;
+	// The below is almost but not quite the same as
+	// if (0 < _fixed.size()) return; because fixe can be
+	// non-zero, if the virtual term has only one variable
+	// in it.
 	for (const Handle& cl : _pat.clauses)
 	{
-		// if (0 < _pat.evaluatable_holders.count(cl)) continue;
-		if (0 < _pat.evaluatable_terms.count(cl)) continue;
-		all_clauses_are_evaluatable = false;
-		break;
+		// if (0 == _pat.evaluatable_holders.count(cl)) return;
+		if (0 == _pat.evaluatable_terms.count(cl)) return;
 	}
-
-	if (not all_clauses_are_evaluatable) return;
 
 	for (const Handle& v: _varlist.varseq)
 	{

--- a/opencog/atoms/pattern/PatternLink.h
+++ b/opencog/atoms/pattern/PatternLink.h
@@ -112,7 +112,7 @@ protected:
 	                      HandleSeq& virtual_clauses,
 	                      OrderedHandleSet& black_clauses);
 
-	void add_dummies();
+	bool add_dummies();
 
 	void trace_connectives(const std::set<Type>&,
 	                       const HandleSeq& clauses,

--- a/opencog/query/Pattern.h
+++ b/opencog/query/Pattern.h
@@ -153,10 +153,7 @@ struct Pattern
 };
 
 // For gdb
-static std::string oc_to_string(const Pattern& pattern)
-{
-	return pattern.to_string();
-}
+std::string oc_to_string(const Pattern&);
 
 /** @}*/
 } // namespace opencog

--- a/opencog/query/PatternMatch.cc
+++ b/opencog/query/PatternMatch.cc
@@ -426,5 +426,10 @@ bool PatternLink::satisfy(PatternMatchCallback& pmcb) const
 	                                       comp_var_gnds, comp_term_gnds);
 }
 
-/* ===================== END OF FILE ===================== */
+// For gdb
+std::string oc_to_string(const Pattern& pattern)
+{
+   return pattern.to_string();
+}
 
+/* ===================== END OF FILE ===================== */

--- a/opencog/query/Recognizer.cc
+++ b/opencog/query/Recognizer.cc
@@ -43,7 +43,6 @@ namespace opencog {
  * The file /examples/aiml/recog.scm provides a very simple example.
  * The implementation here is very minimalistic, and does many things
  * wrong:
- * -- it fails to identify the actual GetLink/BindLink that was matched.
  * -- it fails to perform any type-checking to make sure the variable
  *    constraints are satisfied.
  * -- AIML wants a left-to-right traversal, this does an omni-

--- a/tests/query/ArcanaUTest.cxxtest
+++ b/tests/query/ArcanaUTest.cxxtest
@@ -75,7 +75,7 @@ void ArcanaUTest::setUp(void)
 	as->clear();
 }
 
-#define getarity(hand) LinkCast(hand)->getArity()
+#define getarity(hand) hand->getArity()
 
 /*
  * Miscellaneous Arcana
@@ -96,8 +96,7 @@ void ArcanaUTest::test_repeats(void)
 	// Either one or two solutions are acceptable, as long as the
 	// two are identical. One solution is prefered, but seems
 	// not possible with the current algo.
-	LinkPtr lll(LinkCast(diff));
-	const HandleSeq& oset = lll->getOutgoingSet();
+	const HandleSeq& oset = diff->getOutgoingSet();
 	size_t nsol = oset.size();
 	bool pass = false;
 	if (1 == nsol) pass = true;
@@ -143,8 +142,7 @@ void ArcanaUTest::test_const(void)
 	printf("radio=%s\n", answer->toString().c_str());
 
 	TS_ASSERT_EQUALS(1, getarity(answer));
-	LinkPtr lp = LinkCast(answer);
-	Handle devel = lp->getOutgoingAtom(0);
+	Handle devel = answer->getOutgoingAtom(0);
 
 	TS_ASSERT_EQUALS(marconi, devel);
 
@@ -176,8 +174,7 @@ void ArcanaUTest::test_dummy(void)
 
 	TS_ASSERT_EQUALS(SET_LINK, answer->getType());
 	TS_ASSERT_EQUALS(1, getarity(answer));
-	LinkPtr lp = LinkCast(answer);
-	Handle num = lp->getOutgoingAtom(0);
+	Handle num = answer->getOutgoingAtom(0);
 
 	Handle fourtwo = eval->eval_h("(Number 42)");
 	TS_ASSERT_EQUALS(num, fourtwo);

--- a/tests/query/ArcanaUTest.cxxtest
+++ b/tests/query/ArcanaUTest.cxxtest
@@ -1,7 +1,7 @@
 /*
  * tests/query/ArcanaUTest.cxxtest
  *
- * Copyright (C) 2015 Linas Vepstas
+ * Copyright (C) 2015,2016 Linas Vepstas
  * All Rights Reserved
  *
  * This program is free software; you can redistribute it and/or modify
@@ -62,6 +62,7 @@ public:
 	void test_repeats(void);
 	void test_const(void);
 	void test_dummy(void);
+	void test_bigger_dummy(void);
 	void test_numeric(void);
 };
 
@@ -178,6 +179,30 @@ void ArcanaUTest::test_dummy(void)
 
 	Handle fourtwo = eval->eval_h("(Number 42)");
 	TS_ASSERT_EQUALS(num, fourtwo);
+
+	// ----
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+/*
+ * Miscellaneous Arcana
+ * This one tests addition of complicated dummy terms.
+ */
+void ArcanaUTest::test_bigger_dummy(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	eval->eval("(load-from-path \"tests/query/arcana-bigger-dummy.scm\")");
+
+	// ----
+	Handle answer = eval->eval_h("(cog-execute! bigger-dummy)");
+	printf("dummy=%s\n", answer->toString().c_str());
+
+	TS_ASSERT_EQUALS(SET_LINK, answer->getType());
+	TS_ASSERT_EQUALS(1, getarity(answer));
+
+	Handle stfu = eval->eval_h("stfu");
+	TS_ASSERT_EQUALS(answer, stfu);
 
 	// ----
 	logger().debug("END TEST: %s", __FUNCTION__);

--- a/tests/query/DisconnectedUTest.cxxtest
+++ b/tests/query/DisconnectedUTest.cxxtest
@@ -124,6 +124,7 @@ void Disconnected::test_variables(void)
 
 	eval->eval("(load-from-path \"tests/query/disco-vars.scm\")");
 
+#if DO_NOT_TEST_THIS_IS_NOW_LEGAL
 	// We expect to catch an error here. ------------------------------
 	bool caught = false;
 	try
@@ -137,9 +138,10 @@ void Disconnected::test_variables(void)
 	}
 	logger().info("Caught exception? %d\n", caught);
 	TSM_ASSERT("Failed to catch expected exception", caught);
+#endif
 
 	// We expect to catch an error here. ------------------------------
-	caught = false;
+	bool caught = false;
 	try
 	{
 		eval->eval_h("(Ba)");

--- a/tests/query/arcana-bigger-dummy.scm
+++ b/tests/query/arcana-bigger-dummy.scm
@@ -1,0 +1,35 @@
+;
+; Unit testing for addition of more complex dummy clauses
+;
+(use-modules (opencog))
+(use-modules (opencog query) (opencog exec))
+
+; Data  -- This is the answer we expect to get.
+(define stfu
+	(SetLink
+		(ListLink
+			(ImplicationLink
+				(ListLink
+					(ConceptNode "I")
+					(ConceptNode "love")
+					(ConceptNode "you"))
+				(ConceptNode "blrable"))
+			(ConceptNode "blrable"))))
+
+; Query. Should return the above.
+; Note that the query has only a single evaluatable within it.
+(define bigger-dummy
+	(GetLink
+		(VariableList
+			(TypedVariable (VariableNode "$whole") (Type "ImplicationLink"))
+			(VariableNode "$impl"))
+		(Identical
+			(VariableNode "$whole")
+			(ImplicationLink
+				(ListLink
+					(ConceptNode "I")
+					(ConceptNode "love")
+					(ConceptNode "you"))
+				(VariableNode "$impl"))
+		)
+	))

--- a/tests/query/arcana-dummy.scm
+++ b/tests/query/arcana-dummy.scm
@@ -1,5 +1,5 @@
 ;
-; Unit testing for a constant pattern
+; Unit testing for addition of "dummy" clauses into pattern.
 ;
 (use-modules (opencog))
 (use-modules (opencog query) (opencog exec))

--- a/tests/query/disco-vars.scm
+++ b/tests/query/disco-vars.scm
@@ -3,6 +3,10 @@
 ;
 ; Several patterns with ill-formed variable declarations.
 
+; The below used to be ill-formed, but the current matcher
+; accepts this and ... wastes CPU time with it.  Technically,
+; it is kind-of ill-formed, since there should be a "present"
+; search being made for it. But we punt for now.
 (define (B)
 (GetLink
    (VariableList (VariableNode "$A") (VariableNode "$B"))


### PR DESCRIPTION
It can be usefule to have the entire search result assigned to a single variable.  This fixes a bug that was preventing that.