### PR TITLE
Set number of counts to detect infinit loop to 100

### DIFF
--- a/opencog/query/InitiateSearchCB.cc
+++ b/opencog/query/InitiateSearchCB.cc
@@ -761,7 +761,7 @@ bool InitiateSearchCB::variable_search(PatternMatchEngine *pme)
 			if (prev != _pattern) { prev = _pattern; count = 0; }
 			else {
 				count++;
-				if (5 < count)
+				if (100 < count)
 					throw RuntimeException(TRACE_INFO,
 						"Infinite Loop detected! Recursed %u times!", count);
 			}


### PR DESCRIPTION
Obviously looking at _pattern alone isn't enough. But since it is a
temporary workaround anyway it's OK. I set it to 100 so that the BC unit
test can pass.