### PR TITLE
Extend rule format

### DIFF
--- a/opencog/rule-engine/Rule.cc
+++ b/opencog/rule-engine/Rule.cc
@@ -192,6 +192,7 @@ HandleSeq Rule::get_premises(const Handle& conclusion) const
 
     return hs;
 }
+
 /**
  * Get the conclusion (output) of the rule.  defined in a BindLink.
  *
@@ -216,48 +217,61 @@ Handle Rule::get_forward_conclusion() const
  */
 HandleSeq Rule::get_conclusion_seq() const
 {
-	// if the rule's handle has not been set yet
+	// If the rule's handle has not been set yet
 	if (forward_rule_handle_ == Handle::UNDEFINED)
 		return HandleSeq();
 
-	Handle implicand = BindLinkCast(forward_rule_handle_)->get_implicand();
-
-	std::queue<Handle> pre_output;
-	HandleSeq final_output;
-
-	// skip the top level ListLink
-	if (implicand->getType() == LIST_LINK)
+	// If no backward rule then extract the conclusions from the
+	// forward rule
+	if (backward_rule_handle_ == Handle::UNDEFINED)
 	{
-		for (const Handle& h : implicand->getOutgoingSet())
-			pre_output.push(h);
-	}
-	else
-	{
-		pre_output.push(implicand);
-	}
+		Handle implicand = BindLinkCast(forward_rule_handle_)->get_implicand();
 
-	// check all output of ExecutionOutputLink
-	while (not pre_output.empty())
-	{
-		Handle hfront = pre_output.front();
-		pre_output.pop();
+		std::queue<Handle> pre_output;
+		HandleSeq final_output;
 
-		if (hfront->getType() == EXECUTION_OUTPUT_LINK)
+		// skip the top level ListLink
+		if (implicand->getType() == LIST_LINK)
 		{
-			// get the ListLink containing the arguments of the ExecutionOutputLink
-			Handle harg = hfront->getOutgoingSet()[1];
-
-			for (const Handle& h : harg->getOutgoingSet())
+			for (const Handle& h : implicand->getOutgoingSet())
 				pre_output.push(h);
-
-			continue;
+		}
+		else
+		{
+			pre_output.push(implicand);
 		}
 
-		// if not an ExecutionOutputLink, it is a final output
-		final_output.push_back(hfront);
-	}
+		// check all output of ExecutionOutputLink
+		while (not pre_output.empty())
+		{
+			Handle hfront = pre_output.front();
+			pre_output.pop();
 
-	return final_output;
+			if (hfront->getType() == EXECUTION_OUTPUT_LINK)
+			{
+				// get the ListLink containing the arguments of the
+				// ExecutionOutputLink
+				Handle harg = hfront->getOutgoingSet()[1];
+
+				for (const Handle& h : harg->getOutgoingSet())
+					pre_output.push(h);
+
+				continue;
+			}
+
+			// if not an ExecutionOutputLink, it is a final output
+			final_output.push_back(hfront);
+		}
+
+		return final_output;
+	}
+	// The is a backward rule so return directly its body
+	else
+	{
+		Type t = backward_rule_handle_->getType();
+		OC_ASSERT(t == BIND_LINK or t == GET_LINK);
+		return { backward_rule_handle_->getOutgoingSet()[1] };
+	}
 }
 
 void Rule::set_weight(float p)

--- a/opencog/rule-engine/Rule.cc
+++ b/opencog/rule-engine/Rule.cc
@@ -118,7 +118,7 @@ void Rule::set_forward_handle(const Handle& h)
 	forward_rule_handle_ = h;
 }
 
-Handle Rule::get_forward_handle() const
+Handle Rule::get_forward_rule() const
 {
 	return forward_rule_handle_;
 }

--- a/opencog/rule-engine/Rule.cc
+++ b/opencog/rule-engine/Rule.cc
@@ -251,12 +251,13 @@ HandleSeq Rule::get_conclusion_seq() const
 			if (hfront->getType() == EXECUTION_OUTPUT_LINK)
 			{
 				// get the ListLink containing the arguments of the
-				// ExecutionOutputLink. WARNING: only the *first*
+				// ExecutionOutputLink. WARNING: only the last
 				// argument is to be used to represent the conclusion
 				// pattern.
 				Handle list_h = hfront->getOutgoingAtom(1);
-				OC_ASSERT(list_h->getType() == LIST_LINK);
-				pre_output.push(list_h->getOutgoingAtom(0));
+				OC_ASSERT(list_h->getType() == LIST_LINK
+				          and list_h->getArity() > 0);
+				pre_output.push(list_h->getOutgoingAtom(list_h->getArity()-1));
 				continue;
 			}
 

--- a/opencog/rule-engine/Rule.cc
+++ b/opencog/rule-engine/Rule.cc
@@ -197,7 +197,7 @@ HandleSeq Rule::get_premises(const Handle& conclusion) const
  *
  * @return the Handle of the implicand
  */
-Handle Rule::get_conclusion() const
+Handle Rule::get_forward_conclusion() const
 {
 	// if the rule's handle has not been set yet
 	if (forward_rule_handle_ == Handle::UNDEFINED)

--- a/opencog/rule-engine/Rule.h
+++ b/opencog/rule-engine/Rule.h
@@ -137,7 +137,7 @@ public:
 	}
 
 	// Modifiers
-	void set_handle(const Handle& h /* Member <rule alias> <rbs> */);
+	void set_forward_handle(const Handle& h);
 	void set_name(const string& name);
 	void set_category(const string& name);
 	void set_weight(float p);
@@ -147,7 +147,7 @@ public:
 	const string& get_name() const;
 	string& get_category();
 	const string& get_category() const;
-	Handle get_handle() const;
+	Handle get_forward_handle() const;
 	Handle get_alias() const;
 	Handle get_forward_vardecl() const;
 	Handle get_backward_vardecl() const;

--- a/opencog/rule-engine/Rule.h
+++ b/opencog/rule-engine/Rule.h
@@ -124,7 +124,7 @@ public:
 	Rule(const Handle& rule);
 	Rule(const Handle& rule_alias, const Handle& rbs);
 
-	void init(Handle rule);
+	void init(const Handle& rule);
 	
 	// Comparison
 	bool operator==(const Rule& r) const {
@@ -160,11 +160,16 @@ public:
 	 */
 	HandleSeq get_premises(const Handle& conclusion = Handle::UNDEFINED) const;
 	Handle get_conclusion() const;
-	HandleSeq get_conclusion_seq() const; float get_weight() const;
+	HandleSeq get_conclusion_seq() const;
+	float get_weight() const;
 
 	Rule gen_standardize_apart(AtomSpace* as);
 
 private:
+	// // Rule handle, a BindLink or a ListLink of forward and backward rule
+	// Maybe not useful
+	// Handle rule_handle_;
+
 	// Forward rule handle, typically a BindLink
 	Handle forward_rule_handle_;
 

--- a/opencog/rule-engine/Rule.h
+++ b/opencog/rule-engine/Rule.h
@@ -159,7 +159,17 @@ public:
 	 * computed based on the backward rule.
 	 */
 	HandleSeq get_premises(const Handle& conclusion = Handle::UNDEFINED) const;
+
+	/**
+	 * Return the conclusion on the forward rule. Used for applying a
+	 * forward step.
+	 */
 	Handle get_forward_conclusion() const;
+
+	/**
+	 * Return the list of conclusion patterns. Used for finding out is
+	 * the rule matches a certain target.
+	 */
 	HandleSeq get_conclusion_seq() const;
 	float get_weight() const;
 

--- a/opencog/rule-engine/Rule.h
+++ b/opencog/rule-engine/Rule.h
@@ -138,7 +138,7 @@ public:
 	const string& get_name() const;
 	string& get_category();
 	const string& get_category() const;
-	Handle get_forward_handle() const;
+	Handle get_forward_rule() const;
 	Handle get_alias() const;
 	Handle get_forward_vardecl() const;
 	HandleSeq get_backward_vardecls() const;

--- a/opencog/rule-engine/Rule.h
+++ b/opencog/rule-engine/Rule.h
@@ -159,7 +159,7 @@ public:
 	 * computed based on the backward rule.
 	 */
 	HandleSeq get_premises(const Handle& conclusion = Handle::UNDEFINED) const;
-	Handle get_conclusion() const;
+	Handle get_forward_conclusion() const;
 	HandleSeq get_conclusion_seq() const;
 	float get_weight() const;
 

--- a/opencog/rule-engine/Rule.h
+++ b/opencog/rule-engine/Rule.h
@@ -58,7 +58,10 @@ using namespace std;
  *
  * <conclusion> may represent explicitly the conclusion pattern, or
  * (most of the cases) it may be obfuscated in a grounded schema
- * node. In the such a case one the following format may be used.
+ * node. In the such a case one the following format may be used. Note
+ * that if the rule uses a GroundedSchema and no backward form in used
+ * (as described below) then the last argument of the GroundedSchema
+ * will represent the rule's conclusion pattern.
  *
  * 2. A list starting with a forward format and optionally 1 or more
  * backward forms. The backward forms allow to easily obtain

--- a/opencog/rule-engine/UREConfigReader.h
+++ b/opencog/rule-engine/UREConfigReader.h
@@ -93,7 +93,7 @@ private:
 		const Rule& get_rule(const Handle& h) const
 		{
 			for (const auto& rule : rules) {
-				if (rule.get_handle() == h)
+				if (rule.get_forward_handle() == h)
 					return rule;
 			}
 

--- a/opencog/rule-engine/UREConfigReader.h
+++ b/opencog/rule-engine/UREConfigReader.h
@@ -93,7 +93,7 @@ private:
 		const Rule& get_rule(const Handle& h) const
 		{
 			for (const auto& rule : rules) {
-				if (rule.get_forward_handle() == h)
+				if (rule.get_forward_rule() == h)
 					return rule;
 			}
 

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.cc
@@ -252,7 +252,7 @@ void BackwardChainer::process_target(Target& target)
 
 	bc_logger().debug("Selected rule %s", selected_rule.get_name().c_str());
 	LAZY_BC_LOG_DEBUG << "Standardized rule:" << std::endl
-	                  << standardized_rule.get_forward_handle()->toShortString();
+	                  << standardized_rule.get_forward_rule()->toShortString();
 	bc_logger().debug("Found %d implicand's output unifiable",
 	                  all_implicand_to_target_mappings.size());
 
@@ -506,7 +506,7 @@ HandleSeq BackwardChainer::match_knowledge_base(Handle hpattern,
 			// don't want matched clause that is part of a rule
 			auto& rules = _configReader.get_rules();
 			if (std::any_of(rules.begin(), rules.end(), [&](Rule& r) {
-						return is_atom_in_tree(r.get_forward_handle(), p.second);
+						return is_atom_in_tree(r.get_forward_rule(), p.second);
 					}))
 			{
 				bc_logger().debug("matched clause in rule");
@@ -515,7 +515,7 @@ HandleSeq BackwardChainer::match_knowledge_base(Handle hpattern,
 
 			// don't want matched stuff with some part of a rule inside
 			if (std::any_of(rules.begin(), rules.end(), [&](Rule& r) {
-						return is_atom_in_tree(p.second, r.get_forward_handle());
+						return is_atom_in_tree(p.second, r.get_forward_rule());
 					}))
 			{
 				bc_logger().debug("matched clause wrapping rule");

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.cc
@@ -252,7 +252,7 @@ void BackwardChainer::process_target(Target& target)
 
 	bc_logger().debug("Selected rule %s", selected_rule.get_name().c_str());
 	LAZY_BC_LOG_DEBUG << "Standardized rule:" << std::endl
-	                  << standardized_rule.get_handle()->toShortString();
+	                  << standardized_rule.get_forward_handle()->toShortString();
 	bc_logger().debug("Found %d implicand's output unifiable",
 	                  all_implicand_to_target_mappings.size());
 
@@ -368,6 +368,9 @@ void BackwardChainer::process_target(Target& target)
 			// apply it by using the mapping to ground the target, and add
 			// it to _as since this is not garbage; this should generate
 			// all the outputs of the rule, and execute any evaluatable
+			//
+			// In other words apply forward chaining for that
+			// grounded conclusion.
 			//
 			// XXX TODO the TV of the original "Variable Fullfillment" target
 			// need to be changed here... right?
@@ -503,7 +506,8 @@ HandleSeq BackwardChainer::match_knowledge_base(Handle hpattern,
 			// don't want matched clause that is part of a rule
 			auto& rules = _configReader.get_rules();
 			if (std::any_of(rules.begin(), rules.end(), [&](Rule& r) {
-						return is_atom_in_tree(r.get_handle(), p.second); }))
+						return is_atom_in_tree(r.get_forward_handle(), p.second);
+					}))
 			{
 				bc_logger().debug("matched clause in rule");
 				break;
@@ -511,7 +515,8 @@ HandleSeq BackwardChainer::match_knowledge_base(Handle hpattern,
 
 			// don't want matched stuff with some part of a rule inside
 			if (std::any_of(rules.begin(), rules.end(), [&](Rule& r) {
-						return is_atom_in_tree(p.second, r.get_handle()); }))
+						return is_atom_in_tree(p.second, r.get_forward_handle());
+					}))
 			{
 				bc_logger().debug("matched clause wrapping rule");
 				break;

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.cc
@@ -323,7 +323,7 @@ void BackwardChainer::process_target(Target& target)
 		// Adding to _garbage_superspace because the mapping are from within
 		// the garbage space.
 		Handle output_grounded =
-			garbage_substitute(standardized_rule.get_conclusion(),
+			garbage_substitute(standardized_rule.get_forward_conclusion(),
 			                   implicand_mapping);
 		LAZY_BC_LOG_DEBUG << "Output reverse grounded step 1 as:" << std::endl
 		                  << output_grounded->toShortString();

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.cc
@@ -300,7 +300,7 @@ void BackwardChainer::process_target(Target& target)
 		target.store_step(selected_rule, { hrule_implicant_reverse_grounded });
 		_targets_set.emplace(hrule_implicant_reverse_grounded,
 		                     gen_sub_varlist(hrule_implicant_reverse_grounded,
-		                                     standardized_rule.get_vardecl(),
+		                                     standardized_rule.get_forward_vardecl(),
 		                                     additional_free_var));
 		return;
 	}
@@ -323,7 +323,7 @@ void BackwardChainer::process_target(Target& target)
 		// Adding to _garbage_superspace because the mapping are from within
 		// the garbage space.
 		Handle output_grounded =
-			garbage_substitute(standardized_rule.get_implicand(),
+			garbage_substitute(standardized_rule.get_conclusion(),
 			                   implicand_mapping);
 		LAZY_BC_LOG_DEBUG << "Output reverse grounded step 1 as:" << std::endl
 		                  << output_grounded->toShortString();
@@ -332,7 +332,7 @@ void BackwardChainer::process_target(Target& target)
 		                  << output_grounded->toShortString();
 
 		HandleSeq output_grounded_seq;
-		for (const auto& h : standardized_rule.get_implicand_seq())
+		for (const auto& h : standardized_rule.get_conclusion_seq())
 			output_grounded_seq.push_back(
 				garbage_substitute(garbage_substitute(h, implicand_mapping), vm));
 
@@ -573,8 +573,8 @@ HandleSeq BackwardChainer::find_premises(const Rule& standardized_rule,
                                          Handle& hrule_implicant_reverse_grounded,
                                          HandleMapSeq& premises_vmap_list)
 {
-	Handle hrule_implicant = standardized_rule.get_implicant();
-	Handle hrule_vardecl = standardized_rule.get_vardecl();
+	Handle hrule_implicant = standardized_rule.get_forward_implicant();
+	Handle hrule_vardecl = standardized_rule.get_forward_vardecl();
 
 	// Reverse ground the implicant with the grounding we found from
 	// unifying the implicand
@@ -881,8 +881,8 @@ bool BackwardChainer::select_rule(const Target& target,
 		selected_rule = rules[index];
 		standardized_rule = selected_rule.gen_standardize_apart(&_garbage_superspace);
 
-		Handle hrule_vardecl = standardized_rule.get_vardecl();
-		HandleSeq output = standardized_rule.get_implicand_seq();
+		Handle hrule_vardecl = standardized_rule.get_forward_vardecl();
+		HandleSeq output = standardized_rule.get_conclusion_seq();
 
 		all_implicand_to_target_mappings.clear();
 

--- a/opencog/rule-engine/forwardchainer/ForwardChainer.cc
+++ b/opencog/rule-engine/forwardchainer/ForwardChainer.cc
@@ -154,7 +154,7 @@ bool ForwardChainer::termination()
 void ForwardChainer::apply_all_rules()
 {
     for (Rule* rule : _rules) {
-        HandleSeq hs = apply_rule(rule->get_forward_handle());
+        HandleSeq hs = apply_rule(rule->get_forward_rule());
 
         // Update
         _fcstat.add_inference_record(Handle::UNDEFINED, rule,
@@ -456,7 +456,7 @@ UnorderedHandleSet ForwardChainer::derive_rules(const Handle& source,
 
             fv.search_set(it.first);
 
-            Handle rhandle = rule->get_forward_handle();
+            Handle rhandle = rule->get_forward_rule();
             HandleSeq new_candidate_rules = substitute_rule_part(
                 temp_pm_as, temp_pm_as.add_atom(rhandle), fv.varset,
                 gcb.var_groundings);

--- a/opencog/rule-engine/forwardchainer/ForwardChainer.cc
+++ b/opencog/rule-engine/forwardchainer/ForwardChainer.cc
@@ -258,7 +258,7 @@ Rule* ForwardChainer::choose_rule(const Handle& hsource)
                          temp->get_name().c_str());
 
         bool unified = false;
-        HandleSeq hs = temp->get_implicant_seq();
+        HandleSeq hs = temp->get_conclusion_seq();
         for (Handle premise_pat : hs) {
             if (unify(hsource, premise_pat, temp)) {
                 rule = temp;
@@ -415,7 +415,7 @@ UnorderedHandleSet ForwardChainer::derive_rules(const Handle& source,
     AtomSpace temp_pm_as;
     Handle hcpy = temp_pm_as.add_atom(pattern);
     Handle implicant_vardecl = temp_pm_as.add_atom(
-        gen_sub_varlist(pattern, rule->get_vardecl()));
+        gen_sub_varlist(pattern, rule->get_forward_vardecl()));
     Handle sourcecpy = temp_pm_as.add_atom(source);
 
     Handle h = temp_pm_as.add_link(BIND_LINK, implicant_vardecl, hcpy, hcpy);
@@ -491,7 +491,7 @@ UnorderedHandleSet ForwardChainer::derive_rules(const Handle& source,
         derived_rules.insert(result.begin(), result.end());
     };
 
-    for (Handle premise_pat : rule->get_implicant_seq())
+    for (const Handle& premise_pat : rule->get_premises())
         add_result(derive_rules(source, premise_pat, rule));
 
     return derived_rules;
@@ -647,7 +647,7 @@ bool ForwardChainer::unify(const Handle& source, const Handle& pattern,
     AtomSpace tmp_as;
     Handle pattern_cpy = tmp_as.add_atom(pattern);
     Handle pattern_vardecl =
-	    tmp_as.add_atom(gen_sub_varlist(pattern, rule->get_vardecl()));
+	    tmp_as.add_atom(gen_sub_varlist(pattern, rule->get_forward_vardecl()));
     Handle source_cpy = tmp_as.add_atom(source);
 
     Handle bl =

--- a/opencog/rule-engine/forwardchainer/ForwardChainer.cc
+++ b/opencog/rule-engine/forwardchainer/ForwardChainer.cc
@@ -258,8 +258,7 @@ Rule* ForwardChainer::choose_rule(const Handle& hsource)
                          temp->get_name().c_str());
 
         bool unified = false;
-        HandleSeq hs = temp->get_conclusion_seq();
-        for (Handle premise_pat : hs) {
+        for (Handle premise_pat : temp->get_premises()) {
             if (unify(hsource, premise_pat, temp)) {
                 rule = temp;
                 unified = true;

--- a/opencog/rule-engine/forwardchainer/ForwardChainer.cc
+++ b/opencog/rule-engine/forwardchainer/ForwardChainer.cc
@@ -154,7 +154,7 @@ bool ForwardChainer::termination()
 void ForwardChainer::apply_all_rules()
 {
     for (Rule* rule : _rules) {
-        HandleSeq hs = apply_rule(rule->get_handle());
+        HandleSeq hs = apply_rule(rule->get_forward_handle());
 
         // Update
         _fcstat.add_inference_record(Handle::UNDEFINED, rule,
@@ -457,7 +457,7 @@ UnorderedHandleSet ForwardChainer::derive_rules(const Handle& source,
 
             fv.search_set(it.first);
 
-            Handle rhandle = rule->get_handle();
+            Handle rhandle = rule->get_forward_handle();
             HandleSeq new_candidate_rules = substitute_rule_part(
                 temp_pm_as, temp_pm_as.add_atom(rhandle), fv.varset,
                 gcb.var_groundings);

--- a/opencog/scm/opencog/rule-engine/rule-engine-utils.scm
+++ b/opencog/scm/opencog/rule-engine/rule-engine-utils.scm
@@ -153,6 +153,13 @@
     rbs
 )
 
+(define-public (ure-get-forward-rule rule)
+"
+  Given a rule return the forward form
+"
+  (let ((rule-type (cog-type rule)))
+    (if (eq? rule-type 'ListLink) (gar rule) rule))
+)
 
 (define (export-rule-engine-utils)
   (export ure-add-rule
@@ -160,5 +167,6 @@
           ure-set-num-parameter
           ure-set-fuzzy-bool-parameter
           ure-define-rbs
+          ure-get-forward-rule
           export-rule-engine-utils)
 )

--- a/opencog/scm/opencog/rule-engine/rule-engine-utils.scm
+++ b/opencog/scm/opencog/rule-engine/rule-engine-utils.scm
@@ -24,9 +24,11 @@
 (use-modules (opencog))
 (use-modules (opencog query))
 
-(define-public (ure-add-rule rbs rule-name rule weight)
+(define-public (ure-define-add-rule rbs rule-name rule weight)
 "
-  Adds a rule to a rulebase and sets its weight and returns the rule node.
+
+  Associate a rule name and a rule content, and adds it to a rulebase
+  with a given weight and returns the rule alias (DefinedSchemaNode <rule-name>).
 
   rbs: The ConceptNode that represents a rulebase.
 
@@ -49,6 +51,19 @@
     )
 )
 
+(define-public (ure-add-rule rbs rule-alias weight)
+"
+  Adds a rule to a rulebase and sets its weight.
+
+  rbs: The ConceptNode that represents a rulebase.
+
+  rule-alias : A string that names the rule.
+
+  weight: A number that is used to represent the priority of the rule.
+"
+    (MemberLink (stv weight 1) rule-alias rbs)
+)
+
 (define-public (ure-add-rules rbs rules)
 "
   Given a rbs and a list of pairs (rule-alias weight) create for each rule
@@ -64,11 +79,8 @@
 "
   (define (expand-pair weighted-rule)
     (let* ((rule-alias (car weighted-rule))
-           (rule-name (cog-name rule-alias))
-           ; Assuming a rule is a BindLink
-           (rule (car (cog-chase-link 'DefineLink 'BindLink rule-alias)))
            (weight (cadr weighted-rule)))
-        (ure-add-rule rbs rule-name rule weight)
+        (ure-add-rule rbs rule-alias weight)
     )
   )
   (for-each expand-pair rules)

--- a/tests/rule-engine/BackwardChainerUTest.cxxtest
+++ b/tests/rule-engine/BackwardChainerUTest.cxxtest
@@ -116,7 +116,7 @@ void BackwardChainerUTest::test_1_rule_bc_deduction()
 	Handle D = eval_.eval_h("(Concept \"D\")");
 
 	bc.set_target(target);
-	bc.get_config().set_maximum_iterations(200);
+	bc.get_config().set_maximum_iterations(100);
 	bc.do_chain();
 
 	HandleMultimap results = bc.get_chaining_result();
@@ -355,8 +355,8 @@ void BackwardChainerUTest::test_focus_set()
  * (InheritanceLink
  *  (ConceptNode "A")
  *   (ConceptNode "B")
- * )
- *
+ * )/
+*
  * (InheritanceLink
  *   (ConceptNode "A")
  *   (VariableNode "$X")

--- a/tests/rule-engine/rules/bc-deduction-rule.scm
+++ b/tests/rule-engine/rules/bc-deduction-rule.scm
@@ -40,7 +40,8 @@
             (ListLink
                 (InheritanceLink
                     (VariableNode "$A")
-                    (VariableNode "$B"))
+                    (VariableNode "$B")
+                )
                 (InheritanceLink
                     (VariableNode "$B")
                     (VariableNode "$C")

--- a/tests/rule-engine/rules/bc-modus-ponens-rule.scm
+++ b/tests/rule-engine/rules/bc-modus-ponens-rule.scm
@@ -17,10 +17,10 @@
         (ExecutionOutputLink
             (GroundedSchemaNode "scm: bc-modus-ponens-formula")
             (ListLink
-                (VariableNode "$B")
                 (ImplicationLink
                     (VariableNode "$A")
-                    (VariableNode "$B"))))))
+                    (VariableNode "$B"))
+                (VariableNode "$B")))))
 
 ; -----------------------------------------------------------------------------
 ; Modus Ponens Formula
@@ -30,7 +30,7 @@
 ; Side-effect: TruthValue of AC may be updated
 ; -----------------------------------------------------------------------------
 
-(define (bc-modus-ponens-formula B AB)
+(define (bc-modus-ponens-formula AB B)
     (cog-set-tv!
         B
         (bc-modus-ponens-side-effect-free-formula

--- a/tests/rule-engine/rules/crisp-modus-ponens-rule.scm
+++ b/tests/rule-engine/rules/crisp-modus-ponens-rule.scm
@@ -19,10 +19,10 @@
         (ExecutionOutputLink
             (GroundedSchemaNode "scm: crisp-modus-ponens-formula")
             (ListLink
+                (VariableNode "$A")
                 (ImplicationLink
                     (VariableNode "$A")
                     (VariableNode "$B"))
-                (VariableNode "$A")
                 (VariableNode "$B")))))
 
 ; -----------------------------------------------------------------------------
@@ -32,7 +32,7 @@
 ; the TV of B to (stv 1 1)
 ; -----------------------------------------------------------------------------
 
-(define (crisp-modus-ponens-formula AB A B)
+(define (crisp-modus-ponens-formula A AB B)
     (let (  (sA (cog-stv-strength A))
             (cA (cog-stv-confidence A))
             (sAB (cog-stv-strength AB))

--- a/tests/rule-engine/rules/implication-construction-rule.scm
+++ b/tests/rule-engine/rules/implication-construction-rule.scm
@@ -9,7 +9,7 @@
 ;;    Q
 ;;
 ;; To properly deal with this we should support deep type and infer
-;; that P and Q are over the same domain.
+;; that P and Q have non empty intersection.
 ;;
 ;; Overlaps:
 ;;


### PR DESCRIPTION
Fix for #119, see http://wiki.opencog.org/wikihome/index.php/URE_Configuration_Format#Rule for the specification of the new format. Note that it is backward compatible with the old one so you don't need to worry about it as long as you don't use the backward chainer.