### PR TITLE
SimpleTruthValue bugfix #773

### DIFF
--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -37,7 +37,6 @@
 #include <opencog/atoms/base/Atom.h>
 #include <opencog/atoms/base/ClassServer.h>
 #include <opencog/atoms/base/Link.h>
-#include <opencog/truthvalue/SimpleTruthValue.h>
 
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/atomspace/AtomTable.h>

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -275,7 +275,7 @@ TruthValuePtr EvaluationLink::do_eval_scratch(AtomSpace* as,
 	{
 		TruthValuePtr tv(do_eval_scratch(as, evelnk->getOutgoingAtom(0), scratch));
 		return SimpleTruthValue::createTV(
-		              1.0 - tv->getMean(), tv->getCount());
+		              1.0 - tv->getMean(), tv->getConfidence());
 	}
 	else if (AND_LINK == t)
 	{

--- a/opencog/cython/opencog/atomspace.pxd
+++ b/opencog/cython/opencog/atomspace.pxd
@@ -50,7 +50,6 @@ cdef extern from "opencog/truthvalue/TruthValue.h" namespace "opencog":
 
 cdef extern from "opencog/truthvalue/SimpleTruthValue.h" namespace "opencog":
     cdef cppclass cSimpleTruthValue "opencog::SimpleTruthValue":
-        void initialize(float,float)
         cSimpleTruthValue(float, float)
         strength_t getMean()
         confidence_t getConfidence()

--- a/opencog/cython/opencog/truth_value.pyx
+++ b/opencog/cython/opencog/truth_value.pyx
@@ -16,7 +16,7 @@ cdef class TruthValue:
 
     def __cinit__(self, strength=1.0, confidence=0.0):
         # By default create a SimpleTruthValue
-        self.cobj = new tv_ptr(new cSimpleTruthValue(strength, self.confidence_to_count(confidence))) 
+        self.cobj = new tv_ptr(new cSimpleTruthValue(strength, confidence))
 
     def __dealloc__(self):
         # This deletes the *smart pointer*, not the actual pointer
@@ -41,13 +41,13 @@ cdef class TruthValue:
         return self._ptr().getCount()
 
     cdef _init(self, float mean, float confidence):
-        deref((<cSimpleTruthValue*>self._ptr())).initialize(mean, self.confidence_to_count(confidence))
+        self.cobj = new tv_ptr(new cSimpleTruthValue(mean, confidence))
 
     def __richcmp__(TruthValue h1, TruthValue h2, int op):
         " @todo support the rest of the comparison operators"
         if op == 2: # ==
             return deref(h1._ptr()) == deref(h2._ptr())
-        
+
         raise ValueError, "TruthValue does not yet support most comparison operators"
 
     cdef cTruthValue* _ptr(self):
@@ -61,14 +61,14 @@ cdef class TruthValue:
 
     def __str__(self):
         return self._ptr().toString().c_str()
-    
+
     def __repr__(self):
         return self._ptr().toString().c_str()
 
-    @staticmethod
-    def confidence_to_count(float conf):
-        return (<cSimpleTruthValue*> 0).confidenceToCount(conf)
-
-    @staticmethod
-    def count_to_confidence(float count):
-        return (<cSimpleTruthValue*> 0).countToConfidence(count)
+#    @staticmethod
+#    def confidence_to_count(float conf):
+#        return (<cSimpleTruthValue*> 0).confidenceToCount(conf)
+#
+#    @staticmethod
+#    def count_to_confidence(float count):
+#        return (<cSimpleTruthValue*> 0).countToConfidence(count)

--- a/opencog/guile/SchemeSmobTV.cc
+++ b/opencog/guile/SchemeSmobTV.cc
@@ -238,8 +238,7 @@ SCM SchemeSmob::ss_new_stv (SCM smean, SCM sconfidence)
 	double mean = scm_to_double(smean);
 	double confidence = scm_to_double(sconfidence);
 
-	float cnt = SimpleTruthValue::confidenceToCount(confidence);
-	TruthValue *tv = new SimpleTruthValue(mean, cnt);
+	TruthValue *tv = new SimpleTruthValue(mean, confidence);
 	return take_tv(tv);
 }
 

--- a/opencog/haskell/AtomSpace_CWrapper.cpp
+++ b/opencog/haskell/AtomSpace_CWrapper.cpp
@@ -165,8 +165,7 @@ int AtomSpace_setTruthValue( AtomSpace* this_ptr
     switch(type)
     {
         case SIMPLE_TRUTH_VALUE: {
-            double count = SimpleTruthValue::confidenceToCount(parameters[1]);
-            h->setTruthValue(SimpleTruthValue::createTV(parameters[0],count));
+            h->setTruthValue(SimpleTruthValue::createTV(parameters[0],parameters[1]));
             break; }
         case COUNT_TRUTH_VALUE: {
             h->setTruthValue(CountTruthValue::createTV(parameters[0]

--- a/opencog/persist/sql/odbc/ODBCAtomStorage.cc
+++ b/opencog/persist/sql/odbc/ODBCAtomStorage.cc
@@ -652,7 +652,7 @@ TruthValue* ODBCAtomStorage::getTV(int tvid)
     rp.rs->foreach_row(&Response::create_tv_cb, &rp);
     rp.rs->release();
 
-    SimpleTruthValue *stv = new SimpleTruthValue(rp.mean,rp.count);
+    SimpleTruthValue *stv = new SimpleTruthValue(rp.mean, rp.confidence);
     return stv;
 }
 
@@ -1430,7 +1430,7 @@ ODBCAtomStorage::PseudoPtr ODBCAtomStorage::makeAtom(Response &rp, UUID uuid)
 
         case SIMPLE_TRUTH_VALUE:
         {
-            TruthValuePtr stv(SimpleTruthValue::createTV(rp.mean, rp.count));
+            TruthValuePtr stv(SimpleTruthValue::createTV(rp.mean, rp.confidence));
             atom->tv = stv;
             break;
         }

--- a/opencog/persist/sql/postgres/PGAtomStorage.cc
+++ b/opencog/persist/sql/postgres/PGAtomStorage.cc
@@ -1894,7 +1894,7 @@ PGAtomStorage::PseudoPtr PGAtomStorage::make_pseudo_atom(Database &database,
         case SIMPLE_TRUTH_VALUE:
         {
             TruthValuePtr stv(SimpleTruthValue::createTV(database.mean,
-                    database.count));
+                    database.confidence));
             pseudo_atom->tv = stv;
             break;
         }

--- a/opencog/persist/zmq/atomspace/ProtocolBufferSerializer.cc
+++ b/opencog/persist/zmq/atomspace/ProtocolBufferSerializer.cc
@@ -295,7 +295,9 @@ void ProtocolBufferSerializer::serializeNullTruthValue(
 SimpleTruthValuePtr ProtocolBufferSerializer::deserializeSimpleTruthValue(
         const ZMQSingleTruthValueMessage& singleTruthValue)
 {
-	SimpleTruthValuePtr tv(new SimpleTruthValue(singleTruthValue.mean(), singleTruthValue.count()));
+	count_t cn = singleTruthValue.count();
+	confidence_t cf = cn / (cn + TruthValue::DEFAULT_K);
+	SimpleTruthValuePtr tv(new SimpleTruthValue(singleTruthValue.mean(), cf));
 	return tv;
 }
 

--- a/opencog/query/Implicator.cc
+++ b/opencog/query/Implicator.cc
@@ -22,7 +22,6 @@
  */
 
 #include <opencog/atomspace/AtomSpace.h>
-#include <opencog/truthvalue/SimpleTruthValue.h>
 #include <opencog/atoms/pattern/BindLink.h>
 
 #include "BindLinkAPI.h"

--- a/opencog/query/Satisfier.cc
+++ b/opencog/query/Satisfier.cc
@@ -22,7 +22,6 @@
  */
 
 #include <opencog/atomspace/AtomSpace.h>
-#include <opencog/truthvalue/SimpleTruthValue.h>
 #include <opencog/atoms/pattern/PatternLink.h>
 
 #include "BindLinkAPI.h"

--- a/opencog/truthvalue/SimpleTruthValue.cc
+++ b/opencog/truthvalue/SimpleTruthValue.cc
@@ -37,67 +37,74 @@
 
 using namespace opencog;
 
-#define CVAL  0.2f
-
-SimpleTruthValue::SimpleTruthValue(strength_t m, count_t c)
+SimpleTruthValue::SimpleTruthValue(strength_t m, confidence_t c)
 {
-    mean = m;
-    count = c;
+    _mean = m;
+    _confidence = c;
 }
 
 SimpleTruthValue::SimpleTruthValue(const TruthValue& source)
 {
-    mean = source.getMean();
-    count = source.getCount();
+    _mean = source.getMean();
+    _confidence = source.getConfidence();
 }
 SimpleTruthValue::SimpleTruthValue(SimpleTruthValue const& source)
 {
-    mean = source.mean;
-    count = source.count;
+    _mean = source._mean;
+    _confidence = source._confidence;
 }
 
 strength_t SimpleTruthValue::getMean() const
 {
-    return mean;
+    return _mean;
 }
 
 count_t SimpleTruthValue::getCount() const
 {
-    return count;
+    // Formula from PLN book.
+    confidence_t cf = std::min(_confidence, 0.9999998f);
+    return static_cast<count_t>(DEFAULT_K * cf / (1.0f - cf));
 }
 
 confidence_t SimpleTruthValue::getConfidence() const
 {
-    return countToConfidence(count);
+    return _confidence;
 }
 
 // This is the merge formula appropriate for PLN.
 TruthValuePtr SimpleTruthValue::merge(TruthValuePtr other,
                                       const MergeCtrl& mc) const
 {
-    switch(mc.tv_formula) {
-    case MergeCtrl::TVFormula::HIGHER_CONFIDENCE:
-        return higher_confidence_merge(other);
-    case MergeCtrl::TVFormula::PLN_BOOK_REVISION:
+    switch(mc.tv_formula)
     {
-        // Based on Section 5.10.2(A heuristic revision rule for STV)
-        // of the PLN book
-        if (other->getType() != SIMPLE_TRUTH_VALUE)
-            throw RuntimeException(TRACE_INFO,
+        case MergeCtrl::TVFormula::HIGHER_CONFIDENCE:
+            return higher_confidence_merge(other);
+
+        case MergeCtrl::TVFormula::PLN_BOOK_REVISION:
+        {
+            // Based on Section 5.10.2(A heuristic revision rule for STV)
+            // of the PLN book
+            if (other->getType() != SIMPLE_TRUTH_VALUE)
+                throw RuntimeException(TRACE_INFO,
                                    "Don't know how to merge %s into a "
                                    "SimpleTruthValue using the default style",
                                    typeid(*other).name());
-        auto count2 = other->getCount();
-        auto count_new = count + count2 - std::min(count, count2) * CVAL;
-        auto mean_new = (mean * count + other->getMean() * count2)
-            / (count + count2);
-        return std::make_shared<SimpleTruthValue>(mean_new, count_new);
-    }
-    default:
-        throw RuntimeException(TRACE_INFO,
-                               "SimpleTruthValue::merge: case not implemented");
-        return nullptr;
-    }
+
+            confidence_t cf = std::min(getConfidence(), 0.9999998f);
+            auto count = static_cast<count_t>(DEFAULT_K * cf / (1.0f - cf));
+            auto count2 = other->getCount();
+#define CVAL  0.2f
+            auto count_new = count + count2 - std::min(count, count2) * CVAL;
+            auto mean_new = (getMean() * count + other->getMean() * count2)
+                / (count + count2);
+            confidence_t confidence_new = static_cast<confidence_t>(count_new / (count_new + DEFAULT_K));
+            return std::make_shared<SimpleTruthValue>(mean_new, confidence_new);
+        }
+        default:
+            throw RuntimeException(TRACE_INFO,
+                                   "SimpleTruthValue::merge: case not implemented");
+            return nullptr;
+       }
 }
 
 std::string SimpleTruthValue::toString() const
@@ -114,34 +121,14 @@ bool SimpleTruthValue::operator==(const TruthValue& rhs) const
     const SimpleTruthValue *stv = dynamic_cast<const SimpleTruthValue *>(&rhs);
     if (NULL == stv) return false;
 
-#define FLOAT_ACCEPTABLE_MEAN_ERROR 0.000001
-    if (FLOAT_ACCEPTABLE_MEAN_ERROR < fabs(mean - stv->mean)) return false;
+#define FLOAT_ACCEPTABLE_ERROR 0.000001
+    if (FLOAT_ACCEPTABLE_ERROR < fabs(_mean - stv->_mean)) return false;
 
-// Converting from confidence to count and back again using single-precision
-// float is a real accuracy killer.  In particular, 2/802 = 0.002494 but
-// converting back gives 800*0.002494/(1.0-0.002494) = 2.000188 and so
-// comparison tests can only be accurate to about 0.000188 or
-// thereabouts.
-#define FLOAT_ACCEPTABLE_COUNT_ERROR 0.0002
-
-    if (FLOAT_ACCEPTABLE_COUNT_ERROR < fabs(1.0 - (stv->count/count))) return false;
+    if (FLOAT_ACCEPTABLE_ERROR < fabs(_confidence - stv->_confidence)) return false;
     return true;
 }
 
 TruthValueType SimpleTruthValue::getType() const
 {
     return SIMPLE_TRUTH_VALUE;
-}
-
-count_t SimpleTruthValue::confidenceToCount(confidence_t cf)
-{
-    // There are not quite 16 digits in double precision
-    // not quite 7 in single-precision float
-    cf = std::min(cf, 0.9999998f);
-    return static_cast<count_t>(DEFAULT_K * cf / (1.0f - cf));
-}
-
-confidence_t SimpleTruthValue::countToConfidence(count_t cn)
-{
-    return static_cast<confidence_t>(cn / (cn + DEFAULT_K));
 }

--- a/opencog/truthvalue/SimpleTruthValue.h
+++ b/opencog/truthvalue/SimpleTruthValue.h
@@ -38,38 +38,23 @@ namespace opencog
 class SimpleTruthValue;
 typedef std::shared_ptr<SimpleTruthValue> SimpleTruthValuePtr;
 
-//! a TruthValue that stores a mean and the number of observations (strength and confidence)
+//! a TruthValue that stores a strength and confidence.
 class SimpleTruthValue : public TruthValue
 {
 protected:
 
-    /// Mean of the strength of the TV over all observations
-    strength_t mean;
+    /// Mean of the strength of the TV over all observations.
+    strength_t _mean;
 
-    /// Total number of observations used to estimate the mean 
-    count_t count;
+    /// Estimate of confidence of the observation.
+    confidence_t _confidence;
 
 public:
-    void initialize(strength_t new_mean, count_t new_count)
-            { mean = new_mean; count = new_count; }
-
-    SimpleTruthValue(strength_t mean, count_t count);
+    SimpleTruthValue(strength_t, confidence_t);
     SimpleTruthValue(const TruthValue&);
     SimpleTruthValue(SimpleTruthValue const&);
 
     virtual bool operator==(const TruthValue& rhs) const;
-
-    /// Heuristic to compute the count given the confidence (according
-    /// to the PLN book)
-    /// count =  confidence * k / (1 - confidence)
-    /// where k is the look-ahead
-    static count_t confidenceToCount(confidence_t);
-
-    /// Heuristic to compute the confidence given the count (according
-    /// to the PLN book)
-    /// confidence = count / (count + k)
-    /// where k is the look-ahead
-    static confidence_t countToConfidence(count_t);
 
     std::string toString() const;
     TruthValueType getType() const;
@@ -88,13 +73,13 @@ public:
     TruthValuePtr merge(TruthValuePtr,
                         const MergeCtrl& mc=MergeCtrl()) const;
 
-    static SimpleTruthValuePtr createSTV(strength_t mean, count_t count)
+    static SimpleTruthValuePtr createSTV(strength_t mean, confidence_t conf)
     {
-        return std::make_shared<SimpleTruthValue>(mean, count);
+        return std::make_shared<SimpleTruthValue>(mean, conf);
     }
-    static TruthValuePtr createTV(strength_t mean, count_t count)
+    static TruthValuePtr createTV(strength_t mean, confidence_t conf)
     {
-        return std::static_pointer_cast<TruthValue>(createSTV(mean, count));
+        return std::static_pointer_cast<TruthValue>(createSTV(mean, conf));
     }
 
     TruthValuePtr clone() const

--- a/opencog/truthvalue/TruthValue.cc
+++ b/opencog/truthvalue/TruthValue.cc
@@ -23,20 +23,11 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <typeinfo>
-
 #include <stdio.h>
-#include <stdlib.h>
 
-#include <opencog/truthvalue/CountTruthValue.h>
-#include <opencog/truthvalue/IndefiniteTruthValue.h>
 #include <opencog/truthvalue/NullTruthValue.h>
 #include <opencog/truthvalue/SimpleTruthValue.h>
 #include <opencog/truthvalue/TruthValue.h>
-#include <opencog/util/platform.h>
-
-//#define DPRINTF printf
-#define DPRINTF(...)
 
 using namespace opencog;
 
@@ -52,21 +43,21 @@ TruthValuePtr TruthValue::NULL_TV()
 TruthValuePtr TruthValue::DEFAULT_TV()
 {
     // True, but no confidence.
-    static TruthValuePtr instance(std::make_shared<SimpleTruthValue>(MAX_TRUTH, 0.0));
+    static TruthValuePtr instance(std::make_shared<SimpleTruthValue>(MAX_TRUTH, 0.0f));
     return instance;
 }
 
 TruthValuePtr TruthValue::TRUE_TV()
 {
     // True, with maximum confidence.
-    static TruthValuePtr instance(std::make_shared<SimpleTruthValue>(MAX_TRUTH, 1.0e35));
+    static TruthValuePtr instance(std::make_shared<SimpleTruthValue>(MAX_TRUTH, 1.0f));
     return instance;
 }
 
 TruthValuePtr TruthValue::FALSE_TV()
 {
     // False, with maximum confidence.
-    static TruthValuePtr instance(std::make_shared<SimpleTruthValue>(0.0f, 1.0e35));
+    static TruthValuePtr instance(std::make_shared<SimpleTruthValue>(0.0f, 1.0f));
     return instance;
 }
 
@@ -88,7 +79,7 @@ bool TruthValue::isDefaultTV() const
     if (dtv.get() == this) return true;
     if (getType() == dtv->getType() and
         getMean() == dtv->getMean() and
-        getCount() == dtv->getCount())
+        getConfidence() == dtv->getConfidence())
     {
         return true;
     }
@@ -104,7 +95,7 @@ bool TruthValue::isDefinedTV() const
     if (dtv.get() == this) return true;
     if (getType() == dtv->getType() and
         getMean() == dtv->getMean() and
-        getCount() == dtv->getCount())
+        getConfidence() == dtv->getConfidence())
     {
         return true;
     }
@@ -121,7 +112,7 @@ bool TruthValue::isDefinedTV() const
     dtv = TRUE_TV();
     if (getType() == dtv->getType() and
         getMean() == dtv->getMean() and
-        getCount() == dtv->getCount())
+        getConfidence() == dtv->getConfidence())
     {
         return true;
     }
@@ -129,7 +120,7 @@ bool TruthValue::isDefinedTV() const
     dtv = FALSE_TV();
     if (getType() == dtv->getType() and
         getMean() == dtv->getMean() and
-        getCount() == dtv->getCount())
+        getConfidence() == dtv->getConfidence())
     {
         return true;
     }
@@ -137,7 +128,7 @@ bool TruthValue::isDefinedTV() const
     dtv = TRIVIAL_TV();
     if (getType() == dtv->getType() and
         getMean() == dtv->getMean() and
-        getCount() == dtv->getCount())
+        getConfidence() == dtv->getConfidence())
     {
         return true;
     }

--- a/opencog/truthvalue/TruthValue.h
+++ b/opencog/truthvalue/TruthValue.h
@@ -95,7 +95,6 @@ struct MergeCtrl
     {
         HIGHER_CONFIDENCE,  // TV with higher confidence overwrite the other
         PLN_BOOK_REVISION   // PLN book Section 5.10.2 revision rule
-
     };
 
     TVFormula tv_formula;
@@ -165,8 +164,6 @@ public:
      */
     static TruthValuePtr TRIVIAL_TV();
 
-// PURE VIRTUAL METHODS:
-
     virtual strength_t getMean()  const = 0;
     virtual confidence_t getConfidence()  const = 0;
     virtual count_t getCount()  const = 0;
@@ -184,8 +181,6 @@ public:
     virtual bool operator==(const TruthValue& rhs) const = 0;
     inline bool operator!=(const TruthValue& rhs) const
          { return !(*this == rhs); }
-
-// VIRTUAL METHODS:
 
     /**
      * Merge this TV object with the given TV object argument.
@@ -217,7 +212,8 @@ protected:
 } // namespace opencog
 
 // overload of operator<< to print TruthValue
-namespace std {
+namespace std
+{
     template<typename Out>
     Out& operator<<(Out& out, const opencog::TruthValue& tv)
     {

--- a/tests/atomspace/AtomSpaceAsyncUTest.cxxtest
+++ b/tests/atomspace/AtomSpaceAsyncUTest.cxxtest
@@ -231,7 +231,8 @@ public:
             oss << "thread " << thread_id << " node " << counter;
             counter++;
 
-            TruthValuePtr tv(SimpleTruthValue::createTV(((double) i) / ((double) N), i));
+            confidence_t cnf = ((double) i) / ((double) i + 800.0);
+            TruthValuePtr tv(SimpleTruthValue::createTV(((double) i) / ((double) N), cnf));
             atomSpace->add_node(t, oss.str())->setTruthValue(tv);
         }
     }
@@ -364,7 +365,8 @@ public:
             bogus ++;
             bogus %= N;
 
-            TruthValuePtr tv(SimpleTruthValue::createTV((double) bogus / (double) N, bogus+i));
+            confidence_t cnf = ((double) bogus+i) / ((double) (bogus+i) + 800.0);
+            TruthValuePtr tv(SimpleTruthValue::createTV((double) bogus / (double) N, cnf));
             h->setTruthValue(tv);
         }
     }
@@ -435,7 +437,8 @@ public:
             bogus ++;
             bogus %= N;
 
-            TruthValuePtr tv(SimpleTruthValue::createTV((double) bogus / (double) N, bogus+i));
+            confidence_t cnf = ((double) bogus+i) / ((double) (bogus+i) + 800.0);
+            TruthValuePtr tv(SimpleTruthValue::createTV((double) bogus / (double) N, cnf));
 
             Type t = LIST_LINK;
             hs.push_back(ha);
@@ -507,8 +510,7 @@ public:
         // Add a node to the AttentionalFocus
         Handle h = atomSpace->add_node(CONCEPT_NODE,
                                        "test");
-        h->setTruthValue(SimpleTruthValue::createTV(0.01,
-                         SimpleTruthValue::confidenceToCount(1)));
+        h->setTruthValue(SimpleTruthValue::createTV(0.01, 1));
         h->setSTI(200);
         TS_ASSERT(__testAFSignalsCounter == 1);
 
@@ -549,7 +551,8 @@ public:
 
             bogus ++;
             bogus %= N;
-            TruthValuePtr tv(SimpleTruthValue::createTV((double) bogus / (double) N, bogus+i));
+            confidence_t cnf = ((double) bogus+i) / ((double) (bogus+i) + 800.0);
+            TruthValuePtr tv(SimpleTruthValue::createTV((double) bogus / (double) N, cnf));
             atomSpace->add_link(EVALUATION_LINK, hp, hl)->setTruthValue(tv);
         }
     }

--- a/tests/atomspace/AtomSpaceImplUTest.cxxtest
+++ b/tests/atomspace/AtomSpaceImplUTest.cxxtest
@@ -286,7 +286,7 @@ public:
         Handle h[NUM_NODES];
         for (int i = 0; i < NUM_NODES; i++) {
             h[i] = atomSpace->add_node (CONCEPT_NODE, nodeNames[i]);
-            h[i]->setTruthValue(SimpleTruthValue::createTV(0.001f, SimpleTruthValue::confidenceToCount(0.99f)));
+            h[i]->setTruthValue(SimpleTruthValue::createTV(0.001f, 0.99f));
         }
         logger().debug("Nodes created\n");
 
@@ -297,7 +297,7 @@ public:
             temp[0] = h[i];
             temp[1] = h[4];
             FU[i] = atomSpace->add_link(SUBSET_LINK, temp);
-            FU[i]->setTruthValue(SimpleTruthValue::createTV(ForceUser[i], SimpleTruthValue::confidenceToCount(0.99f)));
+            FU[i]->setTruthValue(SimpleTruthValue::createTV(ForceUser[i], 0.99f));
         }
         logger().debug("ForceUser links created\n");
 
@@ -308,7 +308,7 @@ public:
             out[i].push_back(h[i]);
             out[i].push_back(h[5]);
             H[i] = atomSpace->add_link(INHERITANCE_LINK, out[i]);
-            H[i]->setTruthValue(SimpleTruthValue::createTV(Human[i], SimpleTruthValue::confidenceToCount(0.99f)));
+            H[i]->setTruthValue(SimpleTruthValue::createTV(Human[i], 0.99f));
         }
         logger().debug("Human links created\n");
 

--- a/tests/atomspace/AtomSpaceUTest.cxxtest
+++ b/tests/atomspace/AtomSpaceUTest.cxxtest
@@ -369,7 +369,7 @@ public:
         Handle h[NUM_NODES];
         for (int i = 0; i < NUM_NODES; i++) {
             h[i] = atomSpace->add_node(CONCEPT_NODE, nodeNames[i]);
-            h[i]->setTruthValue(SimpleTruthValue::createTV(0.001f, SimpleTruthValue::confidenceToCount(0.99f)));
+            h[i]->setTruthValue(SimpleTruthValue::createTV(0.001f, 0.99f));
         }
         //logger().debug("Nodes created\n");
 
@@ -380,7 +380,7 @@ public:
             temp[0] = h[i];
             temp[1] = h[4];
             FU[i] = atomSpace->add_link(SUBSET_LINK, temp);
-            FU[i]->setTruthValue(SimpleTruthValue::createTV(ForceUser[i], SimpleTruthValue::confidenceToCount(0.99f)));
+            FU[i]->setTruthValue(SimpleTruthValue::createTV(ForceUser[i], 0.99f));
         }
         //logger().debug("ForceUser links created\n");
 
@@ -391,7 +391,7 @@ public:
             out[i].push_back(h[i]);
             out[i].push_back(h[5]);
             H[i] = atomSpace->add_link(INHERITANCE_LINK, out[i]);
-            H[i]->setTruthValue(SimpleTruthValue::createTV(Human[i], SimpleTruthValue::confidenceToCount(0.99f)));
+            H[i]->setTruthValue(SimpleTruthValue::createTV(Human[i], 0.99f));
         }
         //logger().debug("Human links created\n");
 

--- a/tests/atomspace/MultiSpaceUTest.cxxtest
+++ b/tests/atomspace/MultiSpaceUTest.cxxtest
@@ -53,8 +53,8 @@ public:
 	{
 		// Create three TV's
 		TruthValuePtr tv1(SimpleTruthValue::createTV(0.5, 1.0));
-		TruthValuePtr tv2(SimpleTruthValue::createTV(0.5, 2.0));
-		TruthValuePtr tv3(SimpleTruthValue::createTV(0.5, 3.0));
+		TruthValuePtr tv2(SimpleTruthValue::createTV(0.5, 1.0/2.0));
+		TruthValuePtr tv3(SimpleTruthValue::createTV(0.5, 1.0/3.0));
 
 		// Create three atoms in three different atomspaces
 		Handle h1 = as1.add_node(CONCEPT_NODE, "1");
@@ -119,8 +119,8 @@ public:
 	{
 		// Create three TV's
 		TruthValuePtr tv1(SimpleTruthValue::createTV(0.4, 1.0));
-		TruthValuePtr tv2(SimpleTruthValue::createTV(0.4, 2.0));
-		TruthValuePtr tv3(SimpleTruthValue::createTV(0.4, 3.0));
+		TruthValuePtr tv2(SimpleTruthValue::createTV(0.4, 1.0/2.0));
+		TruthValuePtr tv3(SimpleTruthValue::createTV(0.4, 1.0/3.0));
 
 		// Create three nodes
 		NodePtr n1(createNode(CONCEPT_NODE, "uni-1"));
@@ -135,7 +135,7 @@ public:
 		Handle hnd3(n3);
 
 		// Create three links holding these three
-		TruthValuePtr tv(SimpleTruthValue::createTV(0.33, 3.0));
+		TruthValuePtr tv(SimpleTruthValue::createTV(0.33, 1.0/3.0));
 
 		// Create three copies of this link in three atomspaces
 		Handle h1 = as1.add_link(LIST_LINK, hnd1, hnd2, hnd3);
@@ -380,8 +380,8 @@ public:
 
 		// Create three TV's
 		TruthValuePtr tv1(SimpleTruthValue::createTV(0.4, 1.0));
-		TruthValuePtr tv2(SimpleTruthValue::createTV(0.4, 2.0));
-		TruthValuePtr tv3(SimpleTruthValue::createTV(0.4, 3.0));
+		TruthValuePtr tv2(SimpleTruthValue::createTV(0.4, 1.0/2.0));
+		TruthValuePtr tv3(SimpleTruthValue::createTV(0.4, 1.0/3.0));
 
 		// Create three nodes in the base atomspace
 		Handle hnd1 = nas1.add_node(CONCEPT_NODE, "nest-1");
@@ -392,7 +392,7 @@ public:
 		hnd3->setTruthValue(tv3);
 
 		// Create three links holding these three
-		TruthValuePtr tv(SimpleTruthValue::createTV(0.33, 3.0));
+		TruthValuePtr tv(SimpleTruthValue::createTV(0.33, 1.0/3.0));
 
 		// Create a link in the middle atomspace
 		Handle h2 = nas2.add_link(LIST_LINK, hnd1, hnd2, hnd3);

--- a/tests/persist/sql/odbc/BasicSaveUTest.cxxtest
+++ b/tests/persist/sql/odbc/BasicSaveUTest.cxxtest
@@ -269,19 +269,19 @@ void BasicSaveUTest::add_to_table(int idx, AtomTable *table, std::string id)
 {
     // Create an atom ...
     n1[idx] = createNode(SCHEMA_NODE, id + "fromNode");
-    TruthValuePtr stv(SimpleTruthValue::createTV(0.11, 100+idx));
+    TruthValuePtr stv(SimpleTruthValue::createTV(0.11, 1.0/(100.0+idx)));
     n1[idx]->setTruthValue(stv);
     n1[idx] = NodeCast(table->add(n1[idx], false));
     a1[idx] = n1[idx];
 
     n2[idx] = createNode(SCHEMA_NODE, id + "toNode");
-    TruthValuePtr stv2(SimpleTruthValue::createTV(0.22, 200+idx));
+    TruthValuePtr stv2(SimpleTruthValue::createTV(0.22, 1.0/(200.0+idx)));
     n2[idx]->setTruthValue(stv2);
     n2[idx] = NodeCast(table->add(n2[idx], false));
     a2[idx] = n2[idx];
 
     n3[idx] = createNode(SCHEMA_NODE, id + "third wheel");
-    TruthValuePtr stv3(SimpleTruthValue::createTV(0.33, 300+idx));
+    TruthValuePtr stv3(SimpleTruthValue::createTV(0.33, 1.0/(300.0+idx)));
     n3[idx]->setTruthValue(stv3);
     n3[idx] = NodeCast(table->add(n3[idx], false));
     a3[idx] = n3[idx];
@@ -290,7 +290,7 @@ void BasicSaveUTest::add_to_table(int idx, AtomTable *table, std::string id)
     // and should thus elicit any errors in clone uuid handling.
     char buf[40]; sprintf(buf, "%f", idx+0.14159265358979);
     n4[idx] = createNode(NUMBER_NODE, buf);
-    TruthValuePtr stv4(SimpleTruthValue::createTV(0.44, 400+idx));
+    TruthValuePtr stv4(SimpleTruthValue::createTV(0.44, 1.0/(400.0+idx)));
     n4[idx]->setTruthValue(stv4);
     n4[idx] = NodeCast(table->add(n4[idx], false));
     a4[idx] = n4[idx];

--- a/tests/persist/sql/postgres/BasicPGSQLSaveUTest.cxxtest
+++ b/tests/persist/sql/postgres/BasicPGSQLSaveUTest.cxxtest
@@ -274,19 +274,19 @@ void BasicSaveUTest::add_to_table(int idx, AtomTable *table, std::string id)
 {
     // Create an atom ...
     n1[idx] = createNode(SCHEMA_NODE, id + "fromNode");
-    TruthValuePtr stv(SimpleTruthValue::createTV(0.11, 100+idx));
+    TruthValuePtr stv(SimpleTruthValue::createTV(0.11, 1.0/(100.0+idx)));
     n1[idx]->setTruthValue(stv);
     n1[idx] = NodeCast(table->add(n1[idx], false));
     a1[idx] = n1[idx];
 
     n2[idx] = createNode(SCHEMA_NODE, id + "toNode");
-    TruthValuePtr stv2(SimpleTruthValue::createTV(0.22, 200+idx));
+    TruthValuePtr stv2(SimpleTruthValue::createTV(0.22, 1.0/(200.0+idx)));
     n2[idx]->setTruthValue(stv2);
     n2[idx] = NodeCast(table->add(n2[idx], false));
     a2[idx] = n2[idx];
 
     n3[idx] = createNode(SCHEMA_NODE, id + "third wheel");
-    TruthValuePtr stv3(SimpleTruthValue::createTV(0.33, 300+idx));
+    TruthValuePtr stv3(SimpleTruthValue::createTV(0.33, 1.0/(300.0+idx)));
     n3[idx]->setTruthValue(stv3);
     n3[idx] = NodeCast(table->add(n3[idx], false));
     a3[idx] = n3[idx];
@@ -295,7 +295,7 @@ void BasicSaveUTest::add_to_table(int idx, AtomTable *table, std::string id)
     // and should thus elicit any errors in clone uuid handling.
     char buf[40]; sprintf(buf, "%f", idx+0.14159265358979);
     n4[idx] = createNode(NUMBER_NODE, buf);
-    TruthValuePtr stv4(SimpleTruthValue::createTV(0.44, 400+idx));
+    TruthValuePtr stv4(SimpleTruthValue::createTV(0.44, 1.0/(400.0+idx)));
     n4[idx]->setTruthValue(stv4);
     n4[idx] = NodeCast(table->add(n4[idx], false));
     a4[idx] = n4[idx];

--- a/tests/persist/sql/postgres/BasicPGSQLSaveUTest.cxxtest
+++ b/tests/persist/sql/postgres/BasicPGSQLSaveUTest.cxxtest
@@ -206,7 +206,7 @@ static void atomCompare(AtomPtr a, AtomPtr b, const char* where)
             {
                 fprintf(stderr, "Error, truth value miscompare, "
                     "ma=%f mb=%f ca=%f cb=%f\n",
-                    ta->getMean(), tb->getMean(), ta->getCount(), tb->getCount());
+                    ta->getMean(), tb->getMean(), ta->getConfidence(), tb->getConfidence());
             }
         }
     }

--- a/tests/truthvalue/SimpleTruthValueUTest.cxxtest
+++ b/tests/truthvalue/SimpleTruthValueUTest.cxxtest
@@ -65,10 +65,12 @@ public:
         counts[2] = TV3_COUNT;
     }
 
+#define countToConfidence(i) ((double) (i)) /((double) (i) + 800.0)
+#define confidenceToCount(x) 800.0 * ((x) / (1.0-(x)))
     void setUp() {
         for (int i = 0; i < NUM_TVS; i++) {
-            tvs[i] = new SimpleTruthValue(means[i], counts[i]);
-            confidences[i] = SimpleTruthValue::countToConfidence(counts[i]);
+            tvs[i] = new SimpleTruthValue(means[i], countToConfidence(counts[i]));
+            confidences[i] = countToConfidence(counts[i]);
         }
     }
 
@@ -120,22 +122,22 @@ public:
     void testConfidenceToCount() {
         float testConfidences[] = {0.0f, 0.00001f, 0.1f, 0.5f, 0.9f, 0.9999999f, 1.0f};
         for (unsigned int i = 0; i < (sizeof(testConfidences) / sizeof(float)) ; i++) {
-            float count  = SimpleTruthValue::confidenceToCount(testConfidences[i]);
+            float count  = confidenceToCount(testConfidences[i]);
             TS_ASSERT(count >= 0);
         }
         for (int i = 0; i < NUM_TVS; i++) {
-            TS_ASSERT(counts[i] - SimpleTruthValue::confidenceToCount(confidences[i]) < FLOAT_ACCEPTABLE_ERROR);
+            TS_ASSERT(counts[i] - confidenceToCount(confidences[i]) < FLOAT_ACCEPTABLE_ERROR);
         }
     }
 
     void testCountToConfidence() {
         float testCounts[] = {0.0f, 0.5f, 1.0f, 5.0f, 10.0f, 1000.0f, 10000000.0f};
         for (unsigned int i = 0; i < (sizeof(testCounts) / sizeof(float)) ; i++) {
-            float confidence  = SimpleTruthValue::countToConfidence(testCounts[i]);
+            float confidence  = countToConfidence(testCounts[i]);
             TS_ASSERT(confidence >= 0 && confidence <= 1.0f);
         }
         for (int i = 0; i < NUM_TVS; i++) {
-            TS_ASSERT(confidences[i] - SimpleTruthValue::countToConfidence(counts[i]) < FLOAT_ACCEPTABLE_ERROR);
+            TS_ASSERT(confidences[i] - countToConfidence(counts[i]) < FLOAT_ACCEPTABLE_ERROR);
         }
     }
 

--- a/tests/truthvalue/TVMergeUTest.cxxtest
+++ b/tests/truthvalue/TVMergeUTest.cxxtest
@@ -66,9 +66,11 @@ private:
 public:
     TVMergeUTest()
     {
+#define countToConfidence(i) ((double) (i)) /((double) (i) + 800.0)
+#define confidenceToCount(x) 800.0 * ((x) / (1.0-(x))
         means[0] = TV1_MEAN;
         counts[0] = TV1_COUNT;
-        confidences[0] = SimpleTruthValue::countToConfidence(counts[0]);
+        confidences[0] = countToConfidence(counts[0]);
 
         TruthValuePtr tv = IndefiniteTruthValue::createITV(TV2_L, TV2_U);
         means[1] = tv->getMean();
@@ -77,14 +79,14 @@ public:
 
         means[2] = TV3_MEAN;
         counts[2] = TV3_COUNT;
-        confidences[2] = SimpleTruthValue::countToConfidence(counts[2]);
+        confidences[2] = countToConfidence(counts[2]);
     }
 
     void setUp()
     {
-        tvs[0] = SimpleTruthValue::createSTV(means[0], counts[0]);
+        tvs[0] = SimpleTruthValue::createSTV(means[0], countToConfidence(counts[0]));
         tvs[1] = IndefiniteTruthValue::createITV(TV2_L, TV2_U);
-        tvs[2] = SimpleTruthValue::createSTV(means[2], counts[2]);
+        tvs[2] = SimpleTruthValue::createSTV(means[2], countToConfidence(counts[2]));
     }
 
     void tearDown() {}
@@ -103,7 +105,7 @@ public:
         simpleCounts[1] = TV2_COUNT;
         simpleCounts[2] = TV3_COUNT;
         for (int i = 0; i < NUM_TVS; i++) {
-            simpleTvs[i] = SimpleTruthValue::createTV(simpleMeans[i], simpleCounts[i]);
+            simpleTvs[i] = SimpleTruthValue::createTV(simpleMeans[i], countToConfidence(simpleCounts[i]));
         }
 
         MergeCtrl merge_ctrl(MergeCtrl::TVFormula::PLN_BOOK_REVISION,
@@ -114,13 +116,12 @@ public:
         mergedTv = simpleTvs[0]->merge(simpleTvs[1], merge_ctrl);
         TS_ASSERT(mergedTv != simpleTvs[0]);
         TS_ASSERT(mergedTv->getMean()==0.5f);
-        TS_ASSERT(mergedTv->getCount()==1.0f);
+        TS_ASSERT_DELTA(mergedTv->getCount(), 1.0f, 0.0001f);
         mergedTv = simpleTvs[1]->merge(simpleTvs[2], merge_ctrl);
         TS_ASSERT(mergedTv != simpleTvs[1]);
         //mean=(0.5*1.0 +0.75*2.0)/(1.0+2.0)=0.6667 count=2.0+1.0-1.0*0.2=2.8
-        TS_ASSERT_DELTA(mergedTv->getMean(), 0.6667f,0.0001f);
-        TS_ASSERT_DELTA(mergedTv->getCount(),2.8f,0.01f);
-
+        TS_ASSERT_DELTA(mergedTv->getMean(), 0.6667f, 0.0001f);
+        TS_ASSERT_DELTA(mergedTv->getCount(), 2.8f, 0.0001f);
     }
 
     void testIndefiniteMerge()
@@ -138,8 +139,8 @@ public:
         simpleCounts[2] = TV3_COUNT;
         float simpleConfidences[NUM_TVS];
         for (int i = 0; i < NUM_TVS; i++) {
-            simpleTvs[i] = SimpleTruthValue::createTV(simpleMeans[i], simpleCounts[i]);
-            simpleConfidences[i] = SimpleTruthValue::countToConfidence(simpleCounts[i]);
+            simpleTvs[i] = SimpleTruthValue::createTV(simpleMeans[i], countToConfidence(simpleCounts[i]));
+            simpleConfidences[i] = countToConfidence(simpleCounts[i]);
         }
 
         TS_SKIP("Merging with IndefiniteTruthValue not implemented!");
@@ -150,7 +151,7 @@ public:
         TruthValuePtr otherTypeTv;
 
         // Merging SimpleTruthValue objects
-        otherTypeTv = SimpleTruthValue::createTV(0.333f, SimpleTruthValue::confidenceToCount(lowerConfidence));
+        otherTypeTv = SimpleTruthValue::createTV(0.333f, lowerConfidence);
         mergedTv = simpleTvs[1]->merge(otherTypeTv);
         TS_ASSERT(mergedTv != simpleTvs[1]);
         TS_ASSERT(mergedTv != otherTypeTv);
@@ -158,7 +159,7 @@ public:
         TS_ASSERT(fabs(mergedTv->getMean()  - simpleMeans[1]) <= FLOAT_ACCEPTABLE_ERROR);
         TS_ASSERT(fabs(mergedTv->getCount()  - simpleCounts[1]) <= FLOAT_ACCEPTABLE_ERROR);
         TS_ASSERT(fabs(mergedTv->getConfidence() - simpleConfidences[1]) < FLOAT_ACCEPTABLE_ERROR);
-        otherTypeTv = SimpleTruthValue::createTV(0.333f, SimpleTruthValue::confidenceToCount(upperConfidence));
+        otherTypeTv = SimpleTruthValue::createTV(0.333f, upperConfidence);
         mergedTv = simpleTvs[1]->merge(otherTypeTv);
         TS_ASSERT(mergedTv != simpleTvs[1]);
         TS_ASSERT(mergedTv != otherTypeTv);


### PR DESCRIPTION
The mis-implementation of SimpleTruthValue has caused repeated bugs over the last 7-8 years.  Fix it once and for all, by switching to a uniform probability distribution, instead of the crazy sigmoid that it used to use.  This should fix bug #773, I believe.