### PR TITLE
Schemepremitive support for signature of type void (Handle, short)

### DIFF
--- a/opencog/guile/SchemePrimitive.h
+++ b/opencog/guile/SchemePrimitive.h
@@ -123,6 +123,7 @@ class SchemePrimitive : public PrimitiveEnviron
 			UUID (T::*u_ssb)(const std::string&, const std::string&, bool);
 			void (T::*v_b)(bool);
 			void (T::*v_h)(Handle);
+			void (T::*v_hs)(Handle, short);
 			void (T::*v_s)(const std::string&);
 			void (T::*v_sa)(const std::string&, AtomSpace*);
 			void (T::*v_ss)(const std::string&,
@@ -132,7 +133,6 @@ class SchemePrimitive : public PrimitiveEnviron
 			                 const std::string&);
 			void (T::*v_t)(Type);
 			void (T::*v_ti)(Type, int);
-                	void (T::*v_hs)(Handle, short);
 			void (T::*v_tidi)(Type, int, double, int);
 			void (T::*v_v)(void);
 		} method;
@@ -169,13 +169,13 @@ class SchemePrimitive : public PrimitiveEnviron
 			U_SSB, // return UUID, take string,string,boolean
 			V_B,   // return void, take bool
 			V_H,   // return void, take Handle
+			V_HS,  // return void, take Handle and short
 			V_S,   // return void, take string
 			V_SA,  // return void, take string, Atomspace
 			V_SS,  // return void, take two strings
 			V_SSS, // return void, take three strings
 			V_T,   // return void, take Type
 			V_TI,  // return void, take Type and int
-                	V_HS,  // return void, take Handle and short
 			V_TIDI,// return void, take Type, int, double, and int
 			V_V    // return void, take void
 		} signature;
@@ -515,6 +515,14 @@ class SchemePrimitive : public PrimitiveEnviron
 					Handle h(SchemeSmob::verify_handle(scm_car(args), scheme_name));
 					(that->*method.v_h)(h);
 					break;
+				} 
+				case V_HS:
+				{
+					Handle h = SchemeSmob::verify_handle(scm_car(args), scheme_name, 1);
+					short s = SchemeSmob::verify_int(scm_cadr(args), scheme_name, 2);
+
+					(that->*method.v_hs)(h, s);
+					break;
 				}
 				case V_S:
 				{
@@ -566,15 +574,6 @@ class SchemePrimitive : public PrimitiveEnviron
 					int i = SchemeSmob::verify_int(scm_cadr(args), scheme_name, 2);
 
 					(that->*method.v_ti)(t, i);
-					break;
-				}
-                                case V_HS:
-				{
-					Handle h = SchemeSmob::verify_handle(scm_car(args), scheme_name, 1);
-
-					short s = SchemeSmob::verify_int(scm_cadr(args), scheme_name, 2);
-
-					(that->*method.v_hs)(h, s);
 					break;
 				}
 				case V_TIDI:
@@ -696,6 +695,7 @@ class SchemePrimitive : public PrimitiveEnviron
 		DECLARE_CONSTR_3(U_SSB,  u_ssb, UUID,const std::string&,const std::string&, bool)
 		DECLARE_CONSTR_1(V_B,    v_b,  void, bool)
 		DECLARE_CONSTR_1(V_H,    v_h,  void, Handle)
+		DECLARE_CONSTR_2(V_HS,   v_hs, void, Handle, short)
 		DECLARE_CONSTR_1(V_S,    v_s,  void, const std::string&)
 		DECLARE_CONSTR_2(V_SA,   v_sa, void, const std::string&,
 		                               AtomSpace*)
@@ -705,7 +705,6 @@ class SchemePrimitive : public PrimitiveEnviron
 		                               const std::string&, const std::string&)
 		DECLARE_CONSTR_1(V_T,    v_t,  void, Type)
 		DECLARE_CONSTR_2(V_TI,   v_ti, void, Type, int)
-        	DECLARE_CONSTR_2(V_HS,   v_hs, void, Handle, short)
 		DECLARE_CONSTR_4(V_TIDI, v_tidi, void, Type, int, double, int)
 
 		DECLARE_CONSTR_0(V_V,    v_v,  void);

--- a/opencog/guile/SchemePrimitive.h
+++ b/opencog/guile/SchemePrimitive.h
@@ -132,6 +132,7 @@ class SchemePrimitive : public PrimitiveEnviron
 			                 const std::string&);
 			void (T::*v_t)(Type);
 			void (T::*v_ti)(Type, int);
+                	void (T::*v_hs)(Handle, short);
 			void (T::*v_tidi)(Type, int, double, int);
 			void (T::*v_v)(void);
 		} method;
@@ -174,6 +175,7 @@ class SchemePrimitive : public PrimitiveEnviron
 			V_SSS, // return void, take three strings
 			V_T,   // return void, take Type
 			V_TI,  // return void, take Type and int
+                	V_HS,  // return void, take Handle and short
 			V_TIDI,// return void, take Type, int, double, and int
 			V_V    // return void, take void
 		} signature;
@@ -566,6 +568,15 @@ class SchemePrimitive : public PrimitiveEnviron
 					(that->*method.v_ti)(t, i);
 					break;
 				}
+                                case V_HS:
+				{
+					Handle h = SchemeSmob::verify_handle(scm_car(args), scheme_name, 1);
+
+					short s = SchemeSmob::verify_int(scm_cadr(args), scheme_name, 2);
+
+					(that->*method.v_hs)(h, s);
+					break;
+				}
 				case V_TIDI:
 				{
 					Type t = SchemeSmob::verify_atom_type(scm_car(args), scheme_name, 1);
@@ -694,6 +705,7 @@ class SchemePrimitive : public PrimitiveEnviron
 		                               const std::string&, const std::string&)
 		DECLARE_CONSTR_1(V_T,    v_t,  void, Type)
 		DECLARE_CONSTR_2(V_TI,   v_ti, void, Type, int)
+        	DECLARE_CONSTR_2(V_HS,   v_hs, void, Handle, short)
 		DECLARE_CONSTR_4(V_TIDI, v_tidi, void, Type, int, double, int)
 
 		DECLARE_CONSTR_0(V_V,    v_v,  void);
@@ -759,6 +771,7 @@ DECLARE_DECLARE_2(const std::string&, const std::string&, const std::string&)
 DECLARE_DECLARE_2(void, const std::string&, AtomSpace*)
 DECLARE_DECLARE_2(void, const std::string&, const std::string&)
 DECLARE_DECLARE_2(void, Type, int)
+DECLARE_DECLARE_2(void, Handle, short)
 DECLARE_DECLARE_3(double, Handle, Handle, Type)
 DECLARE_DECLARE_3(Handle, Handle, Type, const HandleSeq&)
 DECLARE_DECLARE_3(Handle, const std::string&, const HandleSeq&, const HandleSeq&)


### PR DESCRIPTION
Needed for stimulating a handle with some stimulus value from a scheme code.