### PR TITLE
Use extract_atom instead of remove_atom in UREConfigReader

### DIFF
--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -279,8 +279,8 @@ public:
      * from the (local, in-RAM) AtomSpace (in this process); any copies
      * of the atom in persistent storage orin other address spaces are
      * unaffected.  To also delete from persistant storage, use the
-     * removeAtom() method. Of course, the AtomSpace must be connected
-     * to storage in order for removeAtom() to reach out that far; if
+     * remove_atom() method. Of course, the AtomSpace must be connected
+     * to storage in order for remove_atom() to reach out that far; if
      * the AtomSpace is not connected to a backend, there is no
      * difference between remove and extract.
      *

--- a/opencog/atomspaceutils/AtomSpaceUtils.cc
+++ b/opencog/atomspaceutils/AtomSpaceUtils.cc
@@ -47,23 +47,33 @@ Handle add_prefixed_node(AtomSpace& as, Type t, const std::string& prefix)
 }
 
 /// Return true if all of h was removed.
-bool remove_hypergraph(AtomSpace& as, const Handle& h)
+bool do_hypergraph_removal(AtomSpace& as, const Handle& h, bool from_storage)
 {
     // Recursive case
     if (h->isLink()) {
         HandleSeq oset = h->getOutgoingSet();
-        bool success = as.remove_atom(h);
+        bool success = (from_storage)? as.remove_atom(h) : as.extract_atom(h);
         if (success) {
             // Return true only if entire subgraph was removed.
             for (const Handle& oh : oset)
-                if (not remove_hypergraph(as, oh)) success = false;
+                if (not do_hypergraph_removal(as, oh, from_storage))
+                    success = false;
         }
         return success;
     }
     // Base case
     else {
-        return as.remove_atom(h);
+        return (from_storage)? as.remove_atom(h) : as.extract_atom(h);
     }
 }
 
+bool remove_hypergraph(AtomSpace& as, const Handle& h)
+{
+    return do_hypergraph_removal(as, h, true);
+}
+
+bool extract_hypergraph(AtomSpace& as, const Handle& h)
+{
+    return do_hypergraph_removal(as, h, false);
+}
 } // namespace opencog

--- a/opencog/atomspaceutils/AtomSpaceUtils.h
+++ b/opencog/atomspaceutils/AtomSpaceUtils.h
@@ -59,6 +59,12 @@ Handle add_prefixed_node(AtomSpace&, Type, const std::string& prefix = "");
  */
 bool remove_hypergraph(AtomSpace& as, const Handle& h);
 
+/**
+ * Similar to remove_hypergraph(), but only remove the hypergraph from
+ * atomspace (local, in RAM) but not in any persistent storage.
+ */
+bool extract_hypergraph(AtomSpace& as, const Handle& h);
+
 /** @}*/
 }
 

--- a/opencog/rule-engine/UREConfigReader.cc
+++ b/opencog/rule-engine/UREConfigReader.cc
@@ -101,7 +101,7 @@ HandleSeq UREConfigReader::fetch_rule_names(const Handle& rbs)
 
 	// Remove the GetLink pattern and other no longer useful atoms
 	// from the AtomSpace
-	remove_hypergraph(_as, gl);
+	extract_hypergraph(_as, gl);
 	_as.extract_atom(results);
 
 	return rule_names;
@@ -133,7 +133,7 @@ HandleSeq UREConfigReader::fetch_execution_outputs(const Handle& schema,
 
 	// Remove the GetLink pattern and other no longer useful atoms
 	// from the AtomSpace
-	remove_hypergraph(_as, gl);
+	extract_hypergraph(_as, gl);
 	_as.extract_atom(results);
 
 	return outputs;

--- a/opencog/rule-engine/UREConfigReader.cc
+++ b/opencog/rule-engine/UREConfigReader.cc
@@ -102,8 +102,8 @@ HandleSeq UREConfigReader::fetch_rule_names(const Handle& rbs)
 	// Remove the GetLink pattern and other no longer useful atoms
 	// from the AtomSpace
 	remove_hypergraph(_as, gl);
-	_as.remove_atom(results);
-		
+	_as.extract_atom(results);
+
 	return rule_names;
 }
 
@@ -134,7 +134,7 @@ HandleSeq UREConfigReader::fetch_execution_outputs(const Handle& schema,
 	// Remove the GetLink pattern and other no longer useful atoms
 	// from the AtomSpace
 	remove_hypergraph(_as, gl);
-	_as.remove_atom(results);
+	_as.extract_atom(results);
 
 	return outputs;
 }


### PR DESCRIPTION
The only difference is that "extract" only removes an atom from the atomspace in RAM while "remove" removes it from the persistence storage as well. Since removing atoms from the persistence storage is not supported at this moment, and looks like URE is only storing those atoms locally, I suggest to use extract_atom for now to prevent getting runtime exceptions if we have the DB opened