### PR TITLE
Bug-fix a lazy/eager execution breakage.

### DIFF
--- a/tests/atoms/random-choice.scm
+++ b/tests/atoms/random-choice.scm
@@ -5,14 +5,51 @@
 ; -- DefinedPredicate ad DefinedSchema
 ; -- DivideLink
 ; -- Tail recursion optimization in the SequentialAndLink
+; -- Lazy/Eager execution of FunctionLink arguments.
 ;
 (use-modules (opencog) (opencog exec))
 
 ; Pick A with 70% probability, pick B with 30% probability
-(Define (DefinedSchema "randy")
+(Define (DefinedSchema "rand-transpose")
    (RandomChoice
       (List (Number 0.7) (Number 0.3))
       (List (Concept "A") (Concept "B"))))
+
+; Pick A with 70% probability, pick B with 30% probability
+(Define (DefinedSchema "rand-set-choice")
+   (RandomChoice
+      (SetLink
+         (List (Number 0.7) (Concept "A"))
+         (List (Number 0.3) (Concept "B")))))
+
+; Pick A with 70% probability, pick B with 30% probability
+; Use a Getlink to fish out the probabilities, isntead of
+; hard-coding them, as above. This forces the lazy/eager
+; evaluation subsystem to "do the right thing" -- to evaluate
+; the GetLink before running the RandomChoice.
+(Define (DefinedSchema "randy")
+   (RandomChoice
+      (GetLink
+         (VariableList (VariableNode "$prob") (VariableNode "$expr"))
+         (AndLink
+            (EvaluationLink
+               (PredicateNode "Emotion-expression")
+               (ListLink (ConceptNode "wake-up") (VariableNode "$expr")))
+            (StateLink
+               (ListLink
+                  (ConceptNode "wake-up")
+                  (VariableNode "$expr"))
+               (VariableNode "$prob"))))
+      ))
+
+; Data to allow the GetLink above to find the needed data.
+(Evaluation (Predicate "Emotion-expression")
+   (ListLink (Concept "wake-up") (Concept "A")))
+(State (ListLink (ConceptNode "wake-up") (Concept "A")) (Number 0.7))
+
+(Evaluation (Predicate "Emotion-expression")
+   (ListLink (Concept "wake-up") (Concept "B")))
+(State (ListLink (ConceptNode "wake-up") (Concept "B")) (Number 0.3))
 
 ; Initialize counts to zero.
 (State (Anchor "sum-A") (Number 0))


### PR DESCRIPTION
This is needed to get ros-behavior-scripting to work again.
Earlier changes tried to do more lazy evaluation, wherever possible, but these broke the ros-behavior-scripting code, and there was no unit test to spot the breakage.  So fix that.