### PR TITLE
Fix CythonBindLink test

### DIFF
--- a/tests/cython/bindlink/test_bindlink.py
+++ b/tests/cython/bindlink/test_bindlink.py
@@ -30,7 +30,7 @@ class BindlinkTest(TestCase):
         self.atomspace.clear()
 
         # Initialize Python
-        initialize_opencog(self.atomspace, "")
+        initialize_opencog(self.atomspace)
         set_type_ctor_atomspace(self.atomspace)
 
         # Define several animals and something of a different type as well


### PR DESCRIPTION
This unit test was broken by #744, which removed a `.conf` file, and cause the initialization code to unsuccessfully search for the default one. It doesn't seem to need a `.conf` file, but someone should double check that. If such file is needed, parts of #744 should be reverted.