### PR TITLE
Add scheme binding for get_free_variables

### DIFF
--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -328,7 +328,8 @@ void SchemeSmob::register_procs()
 	// Iterators
 	register_proc("cog-map-type",          2, 0, 0, C(ss_map_type));
 
-	// Closed Atoms (no free variables)
+	// Free variables
+	register_proc("cog-free-variables",    1, 0, 0, C(ss_get_free_variables));
 	register_proc("cog-closed?",           1, 0, 0, C(ss_is_closed));
 }
 

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -172,7 +172,8 @@ private:
 	static SCM ss_set_af_boundary(SCM);
 	static SCM ss_af(void);
 
-	// Closed Atoms (no free variables)
+	// Free variables
+	static SCM ss_get_free_variables(SCM);
 	static SCM ss_is_closed(SCM);
 
 	// Callback into misc C++ code.

--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -456,6 +456,17 @@ SCM SchemeSmob::ss_subtype_p (SCM stype, SCM schild)
 	return SCM_BOOL_F;
 }
 
+SCM SchemeSmob::ss_get_free_variables(SCM satom)
+{
+	Handle h = verify_handle(satom, "cog-free-variables");
+
+	SCM list = SCM_EOL;
+	for (const Handle& fv : get_free_variables(h))
+		list = scm_cons(handle_to_scm(fv), list);
+
+	return list;
+}
+
 /**
  * Return true if the atom is closed (has no variable)
  */


### PR DESCRIPTION
Now that this has been added maybe the cog-closed? binding should be
replaced by some scheme code in utilities.scm.