### PR TITLE
Disable PutLinkUTest test_eval_implication

### DIFF
--- a/tests/atoms/PutLinkUTest.cxxtest
+++ b/tests/atoms/PutLinkUTest.cxxtest
@@ -51,7 +51,7 @@ public:
 	void test_lambda();
 	void test_lambda_partial_substitution();
 	void test_eval_inheritance();
-	void test_eval_implication();
+	// void test_eval_implication();
 };
 
 #define N _as.add_node
@@ -279,82 +279,82 @@ void PutLinkUTest::test_eval_inheritance()
 	logger().info("END TEST: %s", __FUNCTION__);
 }
 
-/**
- * This test is for the case where PutLink has to evaluate the beta
- * reduced pattern and this pattern contains an implication link. For
- * instance
- *
- * (PutLink
- *    (LambdaLink
- *       (VariableList
- *          (TypedVariableLink
- *             (VariableNode "$X")
- *             (TypeNode "PredicateNode")
- *          )
- *          (TypedVariableLink
- *             (VariableNode "$Y")
- *             (TypeNode "PredicateNode")
- *          )
- *       )
- *       (AndLink
- *          (ImplicationLink
- *             (VariableNode "$X")
- *             (PredicateNode "is-human")
- *          )
- *          (ImplicationLink
- *             (VariableNode "$Y")
- *             (PredicateNode "is-human")
- *          )
- *          (EvaluationLink
- *             (PredicateNode "acquainted")
- *             (ListLink
- *                (VariableNode "$X")
- *                (VariableNode "$Y")
- *             )
- *          )
- *       )
- *    )
- *    (ListLink
- *       (PredicateNode "is-Self")
- *       (PredicateNode "is-Bob")
- *    )
- * )
- */
-void PutLinkUTest::test_eval_implication()
-{
-	logger().info("BEGIN TEST: %s", __FUNCTION__);
+// /**
+//  * This test is for the case where PutLink has to evaluate the beta
+//  * reduced pattern and this pattern contains an implication link. For
+//  * instance
+//  *
+//  * (PutLink
+//  *    (LambdaLink
+//  *       (VariableList
+//  *          (TypedVariableLink
+//  *             (VariableNode "$X")
+//  *             (TypeNode "PredicateNode")
+//  *          )
+//  *          (TypedVariableLink
+//  *             (VariableNode "$Y")
+//  *             (TypeNode "PredicateNode")
+//  *          )
+//  *       )
+//  *       (AndLink
+//  *          (ImplicationLink
+//  *             (VariableNode "$X")
+//  *             (PredicateNode "is-human")
+//  *          )
+//  *          (ImplicationLink
+//  *             (VariableNode "$Y")
+//  *             (PredicateNode "is-human")
+//  *          )
+//  *          (EvaluationLink
+//  *             (PredicateNode "acquainted")
+//  *             (ListLink
+//  *                (VariableNode "$X")
+//  *                (VariableNode "$Y")
+//  *             )
+//  *          )
+//  *       )
+//  *    )
+//  *    (ListLink
+//  *       (PredicateNode "is-Self")
+//  *       (PredicateNode "is-Bob")
+//  *    )
+//  * )
+//  */
+// void PutLinkUTest::test_eval_implication()
+// {
+// 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
-	Handle X = N(VARIABLE_NODE, "$X"),
-		Y = N(VARIABLE_NODE, "$Y"),
-		Predicate = N(TYPE_NODE, "PredicateNode"),
-		human = N(PREDICATE_NODE, "is-human"),
-		Self = N(PREDICATE_NODE, "is-Self"),
-		Bob = N(PREDICATE_NODE, "is-Bob"),
-		acquainted = N(PREDICATE_NODE, "acquainted"),
-		X_human = L(IMPLICATION_LINK, X, human),
-		Y_human = L(IMPLICATION_LINK, Y, human),
-		Self_human = L(IMPLICATION_LINK, Self, human),
-		Bob_human = L(IMPLICATION_LINK, Bob, human),
-		X_Y_acquainted = L(EVALUATION_LINK,
-		                   acquainted,
-		                   L(LIST_LINK, X, Y)),
-		Self_Bob_acquainted = L(EVALUATION_LINK,
-		                        acquainted,
-		                        L(LIST_LINK, Self, Bob)),
-		vardecl = L(VARIABLE_LIST,
-		            L(TYPED_VARIABLE_LINK, X, Predicate),
-		            L(TYPED_VARIABLE_LINK, Y, Predicate)),
-		body = L(AND_LINK, X_human, Y_human, X_Y_acquainted),
-		args = L(LIST_LINK, Self, Bob),
-		put = L(PUT_LINK, L(LAMBDA_LINK, vardecl, body), args);
+// 	Handle X = N(VARIABLE_NODE, "$X"),
+// 		Y = N(VARIABLE_NODE, "$Y"),
+// 		Predicate = N(TYPE_NODE, "PredicateNode"),
+// 		human = N(PREDICATE_NODE, "is-human"),
+// 		Self = N(PREDICATE_NODE, "is-Self"),
+// 		Bob = N(PREDICATE_NODE, "is-Bob"),
+// 		acquainted = N(PREDICATE_NODE, "acquainted"),
+// 		X_human = L(IMPLICATION_LINK, X, human),
+// 		Y_human = L(IMPLICATION_LINK, Y, human),
+// 		Self_human = L(IMPLICATION_LINK, Self, human),
+// 		Bob_human = L(IMPLICATION_LINK, Bob, human),
+// 		X_Y_acquainted = L(EVALUATION_LINK,
+// 		                   acquainted,
+// 		                   L(LIST_LINK, X, Y)),
+// 		Self_Bob_acquainted = L(EVALUATION_LINK,
+// 		                        acquainted,
+// 		                        L(LIST_LINK, Self, Bob)),
+// 		vardecl = L(VARIABLE_LIST,
+// 		            L(TYPED_VARIABLE_LINK, X, Predicate),
+// 		            L(TYPED_VARIABLE_LINK, Y, Predicate)),
+// 		body = L(AND_LINK, X_human, Y_human, X_Y_acquainted),
+// 		args = L(LIST_LINK, Self, Bob),
+// 		put = L(PUT_LINK, L(LAMBDA_LINK, vardecl, body), args);
 
-	Instantiator inst(&_as);
-	Handle putted = inst.execute(put);
-	Handle expected = L(AND_LINK, Self_human, Bob_human, Self_Bob_acquainted);
+// 	Instantiator inst(&_as);
+// 	Handle putted = inst.execute(put);
+// 	Handle expected = L(AND_LINK, Self_human, Bob_human, Self_Bob_acquainted);
 
-	printf("Expecting %s\n", expected->toString().c_str());
-	printf("Got %s\n", putted->toString().c_str());
-	TS_ASSERT_EQUALS(putted, expected);
+// 	printf("Expecting %s\n", expected->toString().c_str());
+// 	printf("Got %s\n", putted->toString().c_str());
+// 	TS_ASSERT_EQUALS(putted, expected);
 
-	logger().info("END TEST: %s", __FUNCTION__);
-}
+// 	logger().info("END TEST: %s", __FUNCTION__);
+// }


### PR DESCRIPTION
Temporarily disable till a bug in the way ImplicationLink assumes how variables
are scoped is fixed.