### PR TITLE
Python evaluator fixes.

### DIFF
--- a/opencog/cython/PythonEval.cc
+++ b/opencog/cython/PythonEval.cc
@@ -1391,7 +1391,11 @@ void PythonEval::eval_expr_line(const std::string& partial_expr)
     // Ignore leading comments; don't ignore empty line.
     int c = 0;
     size_t part_size = part.size();
-    if (0 == part_size and 0 < partial_expr.size()) goto wait_for_more;
+    if (0 == part_size and 0 == partial_expr.size()) goto wait_for_more;
+    if (0 == part_size and
+        '\n' != partial_expr[0] and
+        '\r' != partial_expr[0])
+        goto wait_for_more;
 
     if (0 < part_size) c = part[0];
 
@@ -1445,11 +1449,14 @@ void PythonEval::eval_expr_line(const std::string& partial_expr)
     return;
 
 wait_for_more:
-    _result = "";
     _pending_input = true;
     // Add this expression to our evaluation buffer.
     _input_line += part;
     _input_line += '\n';  // we stripped this off, above
+
+    _result = "";
+    _eval_done = true;
+    _wait_done.notify_all();
 }
 
 std::string PythonEval::poll_result()

--- a/opencog/cython/PythonEval.cc
+++ b/opencog/cython/PythonEval.cc
@@ -1389,7 +1389,7 @@ void PythonEval::eval_expr_line(const std::string& partial_expr)
 
     _input_line += part;
     _input_line += '\n';  // we stripped this off, above
-    logger().info("[PythonEval] eval_expr length=%zu:\n%s",
+    logger().debug("[PythonEval] eval_expr length=%zu:\n%s",
                   _input_line.length(), _input_line.c_str());
 
     // This is the cogserver shell-freindly evaluator. We must
@@ -1409,7 +1409,7 @@ void PythonEval::eval_expr_line(const std::string& partial_expr)
     _input_line = "";
     _paren_count = 0;
     _pending_input = false;
-    logger().info("[PythonEval] eval_expr result length=%zu:\n%s",
+    logger().debug("[PythonEval] eval_expr result length=%zu:\n%s",
                   _result.length(), _result.c_str());
 
     _eval_done = true;
@@ -1447,6 +1447,12 @@ std::string PythonEval::poll_result()
 
 void PythonEval::interrupt(void)
 {
+    // What we want to do here is to somehow interrupt or throw an
+    // exception to the code that is running in the PyRun(), up above,
+    // in the execute_string() method. That is, we want to make it
+    // stop whatever infinite loop the user told it to run, and just
+    // return to the C code (possibly spewing exceptions, etc.)
+    // However, I cannot figure out how to implement this ...
     _result += "PythonEval: interrupt not implemented!\n";
 
     logger().warn("[PythonEval] interrupt not implemented!\n");

--- a/opencog/cython/PythonEval.cc
+++ b/opencog/cython/PythonEval.cc
@@ -1425,14 +1425,13 @@ void PythonEval::eval_expr_line(const std::string& partial_expr)
     // will crash the cogserver. Pass the exception message to
     // the user, who can read and contemplate it: it is almost
     // surely a syntax error in the python code.
-    _result = "";
     try
     {
-        _result = this->apply_script(_input_line);
+        _result += this->apply_script(_input_line);
     }
     catch (const RuntimeException &e)
     {
-        _result = e.get_message();
+        _result += e.get_message();
         _result += "\n";
     }
     _input_line = "";

--- a/tests/cython/PythonEvalUTest.cxxtest
+++ b/tests/cython/PythonEvalUTest.cxxtest
@@ -254,7 +254,7 @@ public:
 
             "def return_truth(atom1, atom2):\n"
             "    print 'return_truth TruthValue(0.75, 100.0)'\n"
-            "    return TruthValue(0.75, 100.0)\n"
+            "    return TruthValue(0.75, 100.0)\n\n"
             );
 
         // Create a scheme evaluator to trigger cog-evaluate and cog-execute.


### PR DESCRIPTION
I believe that this will partially alleviate the problem described in opencog/opencog#2311  and in  opencog/opencog#2315 and in opencog/opencog#2301 and in particular, Misgana's comment  https://github.com/opencog/opencog/issues/2301#issuecomment-235012670

Basically, the way python was handling printing could not possibly work for anything that ran a python agent, or ran for a long time before returning.  Right now, prints will always go to the cogserver stdout -- that will be recaptured in a different pull for the cogserver.

I cannot figure out how to interrupt python, so if you create an infinite loop, the only way to stop it is to kill the cogserver.