### PR TITLE
Fix python block chunking

### DIFF
--- a/opencog/cython/PythonEval.cc
+++ b/opencog/cython/PythonEval.cc
@@ -1359,11 +1359,7 @@ void PythonEval::eval_expr_line(const std::string& partial_expr)
     // Ignore leading comments; don't ignore empty line.
     int c = 0;
     size_t part_size = part.size();
-    if (0 == part_size and 0 == partial_expr.size()) goto wait_for_more;
-    if (0 == part_size and
-        '\n' != partial_expr[0] and
-        '\r' != partial_expr[0])
-        goto wait_for_more;
+    if (0 == part_size and 0 < partial_expr.size()) goto wait_for_more;
 
     if (0 < part_size) c = part[0];
 

--- a/tests/cython/PythonEvalUTest.cxxtest
+++ b/tests/cython/PythonEvalUTest.cxxtest
@@ -5,6 +5,8 @@
 #include <opencog/cython/PythonEval.h>
 #include <opencog/guile/SchemeEval.h>
 
+#include <cxxtest/TestSuite.h>
+
 using std::string;
 
 using namespace opencog;
@@ -293,6 +295,35 @@ public:
         error = scheme->eval_error();
         scheme->clear_pending();
         TSM_ASSERT("Failed cog-evaluate!", !error);
+
+        // Cleanup Python.
+        global_python_finalize();
+    }
+
+    void testCodeBlockWithNewline()
+    {
+        // Initialize Python.
+        global_python_initialize();
+
+        AtomSpace *as = new AtomSpace();
+        PythonEval::create_singleton_instance(as);
+        PythonEval* python = &PythonEval::instance();
+
+        // Define python functions with newline within the code block
+        string result = python->eval(
+            "def fun(x):\n"
+            "    y = x + 1\n"
+            "\n"
+            "    return y\n"
+            "\n"
+            "fun(1)\n\n"
+            );
+
+        std::cout << "result = " << result << std::endl;
+
+        // Because results are ignored this cannot be tested as of now
+        // TS_ASSERT_EQUALS(result, "3");
+        TS_ASSERT(true);
 
         // Cleanup Python.
         global_python_finalize();


### PR DESCRIPTION
Partially revert commit https://github.com/opencog/atomspace/pull/837/commits/8dda9e4b3842b209af8355b41d49aab283de32cf so that code blocks with newlines in the middle don't get split.