### PR TITLE
temporary fix for race bug, root cause not known

### DIFF
--- a/opencog/guile/SchemeSmobAS.cc
+++ b/opencog/guile/SchemeSmobAS.cc
@@ -65,6 +65,7 @@ SCM SchemeSmob::make_as (AtomSpace *as)
 void SchemeSmob::release_as (AtomSpace *as)
 {
 	std::unique_lock<std::mutex> lck(as_mtx);
+	if (as==nullptr) return;//mandeep
 	auto has = deleteable_as.find(as);
 	if (deleteable_as.end() == has) return;
 	deleteable_as[as] --;

--- a/opencog/guile/SchemeSmobNew.cc
+++ b/opencog/guile/SchemeSmobNew.cc
@@ -363,7 +363,7 @@ SCM SchemeSmob::ss_new_node (SCM stype, SCM sname, SCM kv_pairs)
 	if (NULL == atomspace) atomspace = ss_get_env_as("cog-new-node");
 
 	Handle h;
-
+	if (NULL== atomspace) return handle_to_scm(h);//mandeep: null atomspace returned sometimes
 	try
 	{
 		// Now, create the actual node... in the actual atom space.


### PR DESCRIPTION
This fixes crash, but might break adding of a node randomly since i do not know why its unable to find an atomspace. The reasons are related to netcat spawning threads and executing scheme eval to add a node 