### PR TITLE
General cleanup to the attention-bank code.

### DIFF
--- a/opencog/atomspace/AtomSpace.cc
+++ b/opencog/atomspace/AtomSpace.cc
@@ -552,18 +552,6 @@ std::string AtomSpace::to_string()
 	return ss.str();
 }
 
-void AtomSpace::stimulate(Handle& h, double stimulus)
-{
-    int sti = h->getAttentionValue()->getSTI();
-    int lti = h->getAttentionValue()->getLTI();
-    int stiWage = _bank.calculateSTIWage() * stimulus;
-    int ltiWage = _bank.calculateLTIWage() * stimulus;
-
-    h->setSTI(sti + stiWage);
-    h->setLTI(lti + ltiWage);
-}
-
-
 namespace std {
 
 ostream& operator<<(ostream& out, const opencog::AtomSpace& as) {

--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -654,14 +654,9 @@ public:
     long get_STI_funds() const { return _bank.getSTIFunds(); }
     long get_LTI_funds() const { return _bank.getLTIFunds(); }
 
-    /**
-     * Stimulate an atom.
-     *
-     * @warning Should only be used by attention allocation system.
-     * @param  h Handle to be stimulated
-     * @param stimulus stimulus amount
-     */
-    void stimulate(Handle& h, double stimulus);
+    /** See the AttentionBank for documentation */
+    void stimulate(Handle& h, double stimulus) { _bank.stimulate(h, stimulus); }
+
     /* ----------------------------------------------------------- */
     // ---- Signals
 

--- a/opencog/atomspace/AttentionBank.cc
+++ b/opencog/atomspace/AttentionBank.cc
@@ -119,13 +119,11 @@ long AttentionBank::getTotalLTI() const
 
 long AttentionBank::getSTIFunds() const
 {
-    std::lock_guard<std::mutex> lock(_lock_funds);
     return fundsSTI;
 }
 
 long AttentionBank::getLTIFunds() const
 {
-    std::lock_guard<std::mutex> lock(_lock_funds);
     return fundsLTI;
 }
 

--- a/opencog/atomspace/AttentionBank.cc
+++ b/opencog/atomspace/AttentionBank.cc
@@ -105,38 +105,6 @@ void AttentionBank::stimulate(Handle& h, double stimulus)
     h->setLTI(lti + ltiWage);
 }
 
-long AttentionBank::getTotalSTI() const
-{
-    std::lock_guard<std::mutex> lock(_lock_funds);
-    return startingFundsSTI - fundsSTI;
-}
-
-long AttentionBank::getTotalLTI() const
-{
-    std::lock_guard<std::mutex> lock(_lock_funds);
-    return startingFundsLTI - fundsLTI;
-}
-
-long AttentionBank::getSTIFunds() const
-{
-    return fundsSTI;
-}
-
-long AttentionBank::getLTIFunds() const
-{
-    return fundsLTI;
-}
-
-long AttentionBank::updateSTIFunds(AttentionValue::sti_t diff)
-{
-    return fundsSTI += diff;
-}
-
-long AttentionBank::updateLTIFunds(AttentionValue::lti_t diff)
-{
-    return fundsLTI += diff;
-}
-
 void AttentionBank::updateMaxSTI(AttentionValue::sti_t m)
 {
     std::lock_guard<std::mutex> lock(_lock_maxSTI);

--- a/opencog/atomspace/AttentionBank.cc
+++ b/opencog/atomspace/AttentionBank.cc
@@ -38,14 +38,14 @@ AttentionBank::AttentionBank(AtomTable& atab, bool transient)
     if (transient) { _zombie = true; return; }
     _zombie = false;
 
-    startingFundsSTI = fundsSTI = config().get_int("STARTING_STI_FUNDS",100000);
-    startingFundsLTI = fundsLTI = config().get_int("STARTING_LTI_FUNDS",100000);
-    stiFundsBuffer = config().get_int("STI_FUNDS_BUFFER",10000);
-    ltiFundsBuffer = config().get_int("LTI_FUNDS_BUFFER",10000);
-    targetLTI = config().get_int("TARGET_LTI_FUNDS",10000);
-    targetSTI = config().get_int("TARGET_STI_FUNDS",10000);
-    STIAtomWage = config().get_int("ECAN_STARTING_ATOM_STI_WAGE",10);
-    LTIAtomWage = config().get_int("ECAN_STARTING_ATOM_LTI_WAGE",10);
+    startingFundsSTI = fundsSTI = config().get_int("STARTING_STI_FUNDS", 100000);
+    startingFundsLTI = fundsLTI = config().get_int("STARTING_LTI_FUNDS", 100000);
+    stiFundsBuffer = config().get_int("STI_FUNDS_BUFFER", 10000);
+    ltiFundsBuffer = config().get_int("LTI_FUNDS_BUFFER", 10000);
+    targetLTI = config().get_int("TARGET_LTI_FUNDS", 10000);
+    targetSTI = config().get_int("TARGET_STI_FUNDS", 10000);
+    STIAtomWage = config().get_int("ECAN_STARTING_ATOM_STI_WAGE", 10);
+    LTIAtomWage = config().get_int("ECAN_STARTING_ATOM_LTI_WAGE", 10);
 
     attentionalFocusBoundary = 1;
 
@@ -107,57 +107,57 @@ void AttentionBank::stimulate(Handle& h, double stimulus)
 
 long AttentionBank::getTotalSTI() const
 {
-    std::lock_guard<std::mutex> lock(lock_funds);
+    std::_lock_guard<std::mutex> lock(_lock_funds);
     return startingFundsSTI - fundsSTI;
 }
 
 long AttentionBank::getTotalLTI() const
 {
-    std::lock_guard<std::mutex> lock(lock_funds);
+    std::_lock_guard<std::mutex> lock(_lock_funds);
     return startingFundsLTI - fundsLTI;
 }
 
 long AttentionBank::getSTIFunds() const
 {
-    std::lock_guard<std::mutex> lock(lock_funds);
+    std::_lock_guard<std::mutex> lock(_lock_funds);
     return fundsSTI;
 }
 
 long AttentionBank::getLTIFunds() const
 {
-    std::lock_guard<std::mutex> lock(lock_funds);
+    std::_lock_guard<std::mutex> lock(_lock_funds);
     return fundsLTI;
 }
 
 long AttentionBank::updateSTIFunds(AttentionValue::sti_t diff)
 {
-    std::lock_guard<std::mutex> lock(lock_funds);
+    std::_lock_guard<std::mutex> lock(_lock_funds);
     fundsSTI += diff;
     return fundsSTI;
 }
 
 long AttentionBank::updateLTIFunds(AttentionValue::lti_t diff)
 {
-    std::lock_guard<std::mutex> lock(lock_funds);
+    std::_lock_guard<std::mutex> lock(_lock_funds);
     fundsLTI += diff;
     return fundsLTI;
 }
 
 void AttentionBank::updateMaxSTI(AttentionValue::sti_t m)
 {
-    std::lock_guard<std::mutex> lock(lock_maxSTI);
+    std::_lock_guard<std::mutex> lock(_lock_maxSTI);
     maxSTI.update(m);
 }
 
 void AttentionBank::updateMinSTI(AttentionValue::sti_t m)
 {
-    std::lock_guard<std::mutex> lock(lock_minSTI);
+    std::_lock_guard<std::mutex> lock(_lock_minSTI);
     minSTI.update(m);
 }
 
 AttentionValue::sti_t AttentionBank::getMaxSTI(bool average) const
 {
-    std::lock_guard<std::mutex> lock(lock_maxSTI);
+    std::_lock_guard<std::mutex> lock(_lock_maxSTI);
     if (average) {
         return (AttentionValue::sti_t) maxSTI.recent;
     } else {
@@ -167,7 +167,7 @@ AttentionValue::sti_t AttentionBank::getMaxSTI(bool average) const
 
 AttentionValue::sti_t AttentionBank::getMinSTI(bool average) const
 {
-    std::lock_guard<std::mutex> lock(lock_minSTI);
+    std::_lock_guard<std::mutex> lock(_lock_minSTI);
     if (average) {
         return (AttentionValue::sti_t) minSTI.recent;
     } else {

--- a/opencog/atomspace/AttentionBank.cc
+++ b/opencog/atomspace/AttentionBank.cc
@@ -140,10 +140,10 @@ AttentionValue::sti_t AttentionBank::getMinSTI(bool average) const
 AttentionValue::sti_t AttentionBank::calculateSTIWage()
 {
     long funds = getSTIFunds();
-    float diff  = funds - targetSTI;
-    float ndiff = diff / stiFundsBuffer;
-    ndiff = std::min(ndiff,1.0f);
-    ndiff = std::max(ndiff,-1.0f);
+    double diff  = funds - targetSTI;
+    double ndiff = diff / stiFundsBuffer;
+    ndiff = std::min(ndiff, 1.0);
+    ndiff = std::max(ndiff, -1.0);
 
     return STIAtomWage + (STIAtomWage * ndiff);
 }
@@ -151,10 +151,10 @@ AttentionValue::sti_t AttentionBank::calculateSTIWage()
 AttentionValue::lti_t AttentionBank::calculateLTIWage()
 {
     long funds = getLTIFunds();
-    float diff  = funds - targetLTI;
-    float ndiff = diff / ltiFundsBuffer;
-    ndiff = std::min(ndiff,1.0f);
-    ndiff = std::max(ndiff,-1.0f);
+    double diff  = funds - targetLTI;
+    double ndiff = diff / ltiFundsBuffer;
+    ndiff = std::min(ndiff, 1.0);
+    ndiff = std::max(ndiff, -1.0);
 
     return LTIAtomWage + (LTIAtomWage * ndiff);
 }
@@ -170,33 +170,27 @@ AttentionValue::sti_t AttentionBank::setAttentionalFocusBoundary(AttentionValue:
     return boundary;
 }
 
-float AttentionBank::getNormalisedSTI(AttentionValuePtr av, bool average, bool clip) const
+double AttentionBank::getNormalisedSTI(AttentionValuePtr av,
+                                   bool average, bool clip) const
 {
+    double val;
     // get normalizer (maxSTI - attention boundary)
-    int normaliser;
-    float val;
     AttentionValue::sti_t s = av->getSTI();
     if (s > getAttentionalFocusBoundary()) {
-        normaliser = (int) getMaxSTI(average) - getAttentionalFocusBoundary();
-        if (normaliser == 0) {
-            return 0.0f;
-        }
-        val = (s - getAttentionalFocusBoundary()) / (float) normaliser;
+        int normaliser = (int) getMaxSTI(average) - getAttentionalFocusBoundary();
+        if (normaliser == 0) return 0.0;
+        val = (s - getAttentionalFocusBoundary()) / (double) normaliser;
     } else {
-        normaliser = -((int) getMinSTI(average) + getAttentionalFocusBoundary());
-        if (normaliser == 0) {
-            return 0.0f;
-        }
-        val = (s + getAttentionalFocusBoundary()) / (float) normaliser;
+        int normaliser = -((int) getMinSTI(average) + getAttentionalFocusBoundary());
+        if (normaliser == 0) return 0.0;
+        val = (s + getAttentionalFocusBoundary()) / (double) normaliser;
     }
-    if (clip) {
-        return std::max(-1.0f, std::min(val,1.0f));
-    } else {
-        return val;
-    }
+
+    if (clip) return std::max(-1.0, std::min(val, 1.0));
+    return val;
 }
 
-float AttentionBank::getNormalisedSTI(AttentionValuePtr av) const
+double AttentionBank::getNormalisedSTI(AttentionValuePtr av) const
 {
     AttentionValue::sti_t s = av->getSTI();
     auto normaliser =
@@ -205,19 +199,14 @@ float AttentionBank::getNormalisedSTI(AttentionValuePtr av) const
     return (s / normaliser);
 }
 
-float AttentionBank::getNormalisedZeroToOneSTI(AttentionValuePtr av, bool average, bool clip) const
+double AttentionBank::getNormalisedZeroToOneSTI(AttentionValuePtr av,
+                                    bool average, bool clip) const
 {
-    int normaliser;
-    float val;
     AttentionValue::sti_t s = av->getSTI();
-    normaliser = getMaxSTI(average) - getMinSTI(average);
-    if (normaliser == 0) {
-        return 0.0f;
-    }
-    val = (s - getMinSTI(average)) / (float) normaliser;
-    if (clip) {
-        return std::max(0.0f, std::min(val,1.0f));
-    } else {
-        return val;
-    }
+    int normaliser = getMaxSTI(average) - getMinSTI(average);
+    if (normaliser == 0) return 0.0;
+
+    double val = (s - getMinSTI(average)) / (double) normaliser;
+    if (clip) return std::max(0.0, std::min(val, 1.0));
+    return val;
 }

--- a/opencog/atomspace/AttentionBank.cc
+++ b/opencog/atomspace/AttentionBank.cc
@@ -107,71 +107,71 @@ void AttentionBank::stimulate(Handle& h, double stimulus)
 
 long AttentionBank::getTotalSTI() const
 {
-    std::_lock_guard<std::mutex> lock(_lock_funds);
+    std::lock_guard<std::mutex> lock(_lock_funds);
     return startingFundsSTI - fundsSTI;
 }
 
 long AttentionBank::getTotalLTI() const
 {
-    std::_lock_guard<std::mutex> lock(_lock_funds);
+    std::lock_guard<std::mutex> lock(_lock_funds);
     return startingFundsLTI - fundsLTI;
 }
 
 long AttentionBank::getSTIFunds() const
 {
-    std::_lock_guard<std::mutex> lock(_lock_funds);
+    std::lock_guard<std::mutex> lock(_lock_funds);
     return fundsSTI;
 }
 
 long AttentionBank::getLTIFunds() const
 {
-    std::_lock_guard<std::mutex> lock(_lock_funds);
+    std::lock_guard<std::mutex> lock(_lock_funds);
     return fundsLTI;
 }
 
 long AttentionBank::updateSTIFunds(AttentionValue::sti_t diff)
 {
-    std::_lock_guard<std::mutex> lock(_lock_funds);
+    std::lock_guard<std::mutex> lock(_lock_funds);
     fundsSTI += diff;
     return fundsSTI;
 }
 
 long AttentionBank::updateLTIFunds(AttentionValue::lti_t diff)
 {
-    std::_lock_guard<std::mutex> lock(_lock_funds);
+    std::lock_guard<std::mutex> lock(_lock_funds);
     fundsLTI += diff;
     return fundsLTI;
 }
 
 void AttentionBank::updateMaxSTI(AttentionValue::sti_t m)
 {
-    std::_lock_guard<std::mutex> lock(_lock_maxSTI);
-    maxSTI.update(m);
+    std::lock_guard<std::mutex> lock(_lock_maxSTI);
+    _maxSTI.update(m);
 }
 
 void AttentionBank::updateMinSTI(AttentionValue::sti_t m)
 {
-    std::_lock_guard<std::mutex> lock(_lock_minSTI);
-    minSTI.update(m);
+    std::lock_guard<std::mutex> lock(_lock_minSTI);
+    _minSTI.update(m);
 }
 
 AttentionValue::sti_t AttentionBank::getMaxSTI(bool average) const
 {
-    std::_lock_guard<std::mutex> lock(_lock_maxSTI);
+    std::lock_guard<std::mutex> lock(_lock_maxSTI);
     if (average) {
-        return (AttentionValue::sti_t) maxSTI.recent;
+        return (AttentionValue::sti_t) _maxSTI.recent;
     } else {
-        return maxSTI.val;
+        return _maxSTI.val;
     }
 }
 
 AttentionValue::sti_t AttentionBank::getMinSTI(bool average) const
 {
-    std::_lock_guard<std::mutex> lock(_lock_minSTI);
+    std::lock_guard<std::mutex> lock(_lock_minSTI);
     if (average) {
-        return (AttentionValue::sti_t) minSTI.recent;
+        return (AttentionValue::sti_t) _minSTI.recent;
     } else {
-        return minSTI.val;
+        return _minSTI.val;
     }
 }
 

--- a/opencog/atomspace/AttentionBank.cc
+++ b/opencog/atomspace/AttentionBank.cc
@@ -94,6 +94,17 @@ void AttentionBank::AVChanged(Handle h, AttentionValuePtr old_av,
     }
 }
 
+void AttentionBank::stimulate(Handle& h, double stimulus)
+{
+    int sti = h->getAttentionValue()->getSTI();
+    int lti = h->getAttentionValue()->getLTI();
+    int stiWage = calculateSTIWage() * stimulus;
+    int ltiWage = calculateLTIWage() * stimulus;
+
+    h->setSTI(sti + stiWage);
+    h->setLTI(lti + ltiWage);
+}
+
 long AttentionBank::getTotalSTI() const
 {
     std::lock_guard<std::mutex> lock(lock_funds);

--- a/opencog/atomspace/AttentionBank.cc
+++ b/opencog/atomspace/AttentionBank.cc
@@ -129,16 +129,12 @@ long AttentionBank::getLTIFunds() const
 
 long AttentionBank::updateSTIFunds(AttentionValue::sti_t diff)
 {
-    std::lock_guard<std::mutex> lock(_lock_funds);
-    fundsSTI += diff;
-    return fundsSTI;
+    return fundsSTI += diff;
 }
 
 long AttentionBank::updateLTIFunds(AttentionValue::lti_t diff)
 {
-    std::lock_guard<std::mutex> lock(_lock_funds);
-    fundsLTI += diff;
-    return fundsLTI;
+    return fundsLTI += diff;
 }
 
 void AttentionBank::updateMaxSTI(AttentionValue::sti_t m)

--- a/opencog/atomspace/AttentionBank.h
+++ b/opencog/atomspace/AttentionBank.h
@@ -230,7 +230,8 @@ public:
     /** Change the Very-Long-Term Importance of an attention value holder */
     //void setVLTI(AttentionValueHolderPtr avh, AttentionValue::vlti_t);
 
-    /** Retrieve the doubly normalised Short-Term Importance between -1..1
+    /**
+     * Retrieve the doubly normalised Short-Term Importance between -1..1
      * for a given AttentionValue. STI above and below threshold
      * normalised separately and linearly.
      *
@@ -241,13 +242,15 @@ public:
      *        Outside this range can be return if average=true
      * @return normalised STI between -1..1
      */
-    float getNormalisedSTI(AttentionValuePtr, bool average, bool clip) const;
+    double getNormalisedSTI(AttentionValuePtr, bool average, bool clip) const;
 
     /**
      * @see getNormalisedSTI()
      */
-    float getNormalisedSTI(AttentionValuePtr) const;
-    /** Retrieve the linearly normalised Short-Term Importance between 0..1
+    double getNormalisedSTI(AttentionValuePtr) const;
+
+    /**
+     * Retrieve the linearly normalised Short-Term Importance between 0..1
      * for a given AttentionValue.
      *
      * @param h The attention value holder to get STI for
@@ -257,7 +260,7 @@ public:
      *        Outside this range can be return if average=true
      * @return normalised STI between 0..1
      */
-    float getNormalisedZeroToOneSTI(AttentionValuePtr, bool average, bool clip) const;
+    double getNormalisedZeroToOneSTI(AttentionValuePtr, bool average, bool clip) const;
 };
 
 /** @}*/

--- a/opencog/atomspace/AttentionBank.h
+++ b/opencog/atomspace/AttentionBank.h
@@ -46,7 +46,8 @@ class AtomTable;
 
 class AttentionBank
 {
-    /** If true, then this AttentionBank is not being used.
+    /**
+     * If true, then this AttentionBank is not being used.
      * Yes, this is totally bogus, but is needed, due to design
      * flaws related to attention allocation.
      */
@@ -59,11 +60,14 @@ class AttentionBank
     /**
      * Boundary at which an atom is considered within the attentional
      * focus of opencog. Atom's with STI less than this value are
-     * not charged STI rent 
+     * not charged STI rent.
      */
     AttentionValue::sti_t attentionalFocusBoundary;
 
-    /** Signal emitted when an atom crosses in or out of the AttentionalFocus */
+    /**
+     * Signal emitted when an atom crosses in or out of the
+     * AttentionalFocus.
+     */
     AFCHSigl _AddAFSignal;
     AFCHSigl _RemoveAFSignal;
 
@@ -161,8 +165,8 @@ public:
     /**
      * Get the maximum STI observed in the AtomSpace.
      *
-     * @param average If true, return an exponentially decaying average of
-     * maximum STI, otherwise return the actual maximum.
+     * @param average If true, return an exponentially decaying
+     * average of maximum STI, otherwise return the actual maximum.
      * @return Maximum STI
      */
     AttentionValue::sti_t getMaxSTI(bool average=true) const;
@@ -170,8 +174,8 @@ public:
     /**
      * Get the minimum STI observed in the AtomSpace.
      *
-     * @param average If true, return an exponentially decaying average of
-     * minimum STI, otherwise return the actual maximum.
+     * @param average If true, return an exponentially decaying
+     * average of minimum STI, otherwise return the actual maximum.
      * @return Minimum STI
      */
     AttentionValue::sti_t getMinSTI(bool average=true) const;
@@ -181,9 +185,10 @@ public:
     AttentionValue::sti_t calculateLTIWage(void);
 
     /**
-     * Update the minimum STI observed in the connected AtomSpace. Min/max are not updated
-     * on setSTI because average is calculate by lobe cycle, although this could
-     * potentially also be handled by the cogServer.
+     * Update the minimum STI observed in the connected AtomSpace.
+     * Min/max are not updated on setSTI because average is calculate
+     * by lobe cycle, although this could potentially also be handled
+     * by the cogServer.
      *
      * @warning Should only be used by attention allocation system.
      * @param m New minimum STI
@@ -191,9 +196,10 @@ public:
     void updateMinSTI(AttentionValue::sti_t m);
 
     /**
-     * Update the maximum STI observed in the connected AtomSpace. Min/max are not updated
-     * on setSTI because average is calculate by lobe cycle, although this could
-     * potentially also be handled by the cogServer.
+     * Update the maximum STI observed in the connected AtomSpace.
+     * Min/max are not updated on setSTI because average is calculate
+     * by lobe cycle, although this could potentially also be handled
+     * by the cogServer.
      *
      * @warning Should only be used by attention allocation system.
      * @param m New maximum STI
@@ -208,10 +214,10 @@ public:
      * normalised separately and linearly.
      *
      * @param h The attention value holder to get STI for
-     * @param average Should the recent average max/min STI be used, or the
-     * exact min/max?
-     * @param clip Should the returned value be clipped to -1..1? Outside this
-     * range can be return if average=true
+     * @param average Should the recent average max/min STI be used,
+     *        or the exact min/max?
+     * @param clip Should the returned value be clipped to -1..1?
+     *        Outside this range can be return if average=true
      * @return normalised STI between -1..1
      */
     float getNormalisedSTI(AttentionValuePtr, bool average, bool clip) const;
@@ -224,10 +230,10 @@ public:
      * for a given AttentionValue.
      *
      * @param h The attention value holder to get STI for
-     * @param average Should the recent average max/min STI be used, or the
-     * exact min/max?
-     * @param clip Should the returned value be clipped to 0..1? Outside this
-     * range can be return if average=true
+     * @param average Should the recent average max/min STI be used,
+     *        or the exact min/max?
+     * @param clip Should the returned value be clipped to 0..1?
+     *        Outside this range can be return if average=true
      * @return normalised STI between 0..1
      */
     float getNormalisedZeroToOneSTI(AttentionValuePtr, bool average, bool clip) const;

--- a/opencog/atomspace/AttentionBank.h
+++ b/opencog/atomspace/AttentionBank.h
@@ -25,6 +25,7 @@
 #ifndef _OPENCOG_ATTENTION_BANK_H
 #define _OPENCOG_ATTENTION_BANK_H
 
+#include <atomic>
 #include <mutex>
 
 #include <boost/signals2.hpp>
@@ -80,10 +81,12 @@ class AttentionBank
     mutable std::mutex _lock_maxSTI;
     mutable std::mutex _lock_minSTI;
 
-    /* These indicate the amount importance funds available in the
-     * AtomSpace */
-    long fundsSTI;
-    long fundsLTI;
+    /**
+     * The amount importance funds available in the AttentionBank.
+     * Atomic, so that updates don't need a lock.
+     */
+    std::atomic_long fundsSTI;
+    std::atomic_long fundsLTI;
 
     long startingFundsSTI;
     long startingFundsLTI;
@@ -96,8 +99,6 @@ class AttentionBank
 
     AttentionValue::sti_t STIAtomWage;
     AttentionValue::lti_t LTIAtomWage;
-
-    mutable std::mutex _lock_funds;
 
 public:
     /** The table notifies us about AV changes */

--- a/opencog/atomspace/AttentionBank.h
+++ b/opencog/atomspace/AttentionBank.h
@@ -63,7 +63,7 @@ class AttentionBank
      * focus of opencog. Atom's with STI less than this value are
      * not charged STI rent.
      */
-    AttentionValue::sti_t attentionalFocusBoundary;
+    AttentionValue::sti_t _attentionalFocusBoundary;
 
     /**
      * Signal emitted when an atom crosses in or out of the
@@ -171,7 +171,9 @@ public:
      *
      * @return Short Term Importance threshold value
      */
-    AttentionValue::sti_t getAttentionalFocusBoundary() const;
+    AttentionValue::sti_t getAttentionalFocusBoundary() const {
+        return _attentionalFocusBoundary;
+    }
 
     /**
      * Change the attentional focus boundary. Some situations
@@ -181,7 +183,11 @@ public:
      * @return Short Term Importance threshold value
      */
     AttentionValue::sti_t setAttentionalFocusBoundary(
-        AttentionValue::sti_t s);
+        AttentionValue::sti_t s)
+    {
+        _attentionalFocusBoundary = s;
+        return s;
+    }
 
     /**
      * Get the maximum STI observed in the AtomSpace.

--- a/opencog/atomspace/AttentionBank.h
+++ b/opencog/atomspace/AttentionBank.h
@@ -74,8 +74,8 @@ class AttentionBank
     opencog::recent_val<AttentionValue::sti_t> maxSTI;
     opencog::recent_val<AttentionValue::sti_t> minSTI;
 
-    mutable std::mutex lock_maxSTI;
-    mutable std::mutex lock_minSTI;
+    mutable std::mutex _lock_maxSTI;
+    mutable std::mutex _lock_minSTI;
 
     /* These indicate the amount importance funds available in the
      * AtomSpace */
@@ -94,7 +94,7 @@ class AttentionBank
     AttentionValue::sti_t STIAtomWage;
     AttentionValue::lti_t LTIAtomWage;
 
-    mutable std::mutex lock_funds;
+    mutable std::mutex _lock_funds;
 
 public:
     /** The table notifies us about AV changes */

--- a/opencog/atomspace/AttentionBank.h
+++ b/opencog/atomspace/AttentionBank.h
@@ -110,6 +110,15 @@ public:
     AFCHSigl& RemoveAFSignal() { return _RemoveAFSignal; }
 
     /**
+     * Stimulate an atom.
+     *
+     * @warning Should only be used by attention allocation system.
+     * @param  h Handle to be stimulated
+     * @param stimulus stimulus amount
+     */
+    void stimulate(Handle&, double stimulus);
+
+    /**
      * Get the total amount of STI in the AtomSpace, sum of
      * STI across all atoms.
      *

--- a/opencog/atomspace/AttentionBank.h
+++ b/opencog/atomspace/AttentionBank.h
@@ -71,8 +71,11 @@ class AttentionBank
     AFCHSigl _AddAFSignal;
     AFCHSigl _RemoveAFSignal;
 
-    opencog::recent_val<AttentionValue::sti_t> maxSTI;
-    opencog::recent_val<AttentionValue::sti_t> minSTI;
+    /**
+     * Running average min and max STI, together with locks to pretect updates.
+     */
+    opencog::recent_val<AttentionValue::sti_t> _maxSTI;
+    opencog::recent_val<AttentionValue::sti_t> _minSTI;
 
     mutable std::mutex _lock_maxSTI;
     mutable std::mutex _lock_minSTI;

--- a/opencog/atomspace/AttentionBank.h
+++ b/opencog/atomspace/AttentionBank.h
@@ -128,7 +128,9 @@ public:
      *
      * @return total STI in AtomSpace
      */
-    long getTotalSTI() const;
+    long getTotalSTI() const {
+        return startingFundsSTI - fundsSTI;
+    }
 
     /**
      * Get the total amount of LTI in the AtomSpace, sum of
@@ -136,25 +138,31 @@ public:
      *
      * @return total LTI in AtomSpace
      */
-    long getTotalLTI() const;
+    long getTotalLTI() const {
+        return startingFundsLTI - fundsLTI;
+    }
 
     /**
      * Get the STI funds available in the AtomSpace pool.
      *
      * @return STI funds available
      */
-    long getSTIFunds() const;
+    long getSTIFunds() const { return fundsSTI; }
 
     /**
      * Get the LTI funds available in the AtomSpace pool.
      *
      * @return LTI funds available
-
      */
-    long getLTIFunds() const;
+    long getLTIFunds() const { return fundsLTI; }
 
-    long updateSTIFunds(AttentionValue::sti_t diff);
-    long updateLTIFunds(AttentionValue::lti_t diff);
+    long updateSTIFunds(AttentionValue::sti_t diff) {
+        return fundsSTI += diff;
+    }
+
+    long updateLTIFunds(AttentionValue::lti_t diff) {
+        return fundsLTI += diff;
+    }
 
     /**
      * Get attentional focus boundary, generally atoms below


### PR DESCRIPTION
Its a bit old, wasteful, inefficient, sloppy. Avoid rounding errors.