### PR TITLE
Move ImportanceIndex to AttentionBank

### DIFF
--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -169,6 +169,7 @@ AttentionValuePtr Atom::getAttentionValue()
     return local;
 }
 
+// XXX TODO This is insane. All this needs to be moved to the attention bank.
 void Atom::setAttentionValue(AttentionValuePtr av)
 {
     // Must obtain a local copy of the AV, since there may be
@@ -193,7 +194,7 @@ void Atom::setAttentionValue(AttentionValuePtr av)
     // If the atom importance has changed its bin,
     // update the importance index.
     if (oldBin != newBin) {
-        _atomTable->updateImportanceIndex(getHandle(), oldBin);
+        _atomTable->getAtomSpace()->updateImportanceIndex(getHandle(), oldBin);
     }
 
     // Notify any interested parties that the AV changed.

--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -198,7 +198,7 @@ void Atom::setAttentionValue(AttentionValuePtr av)
     }
 
     // Notify any interested parties that the AV changed.
-    AVCHSigl& avch = _atomTable->AVChangedSignal();
+    AVCHSigl& avch = _atomTable->getAtomSpace()->getAVChangedSignal();
     avch(getHandle(), local, av);
 }
 

--- a/opencog/atomspace/AtomSpace.cc
+++ b/opencog/atomspace/AtomSpace.cc
@@ -61,7 +61,7 @@ using namespace opencog;
  */
 AtomSpace::AtomSpace(AtomSpace* parent, bool transient) :
     _atom_table(parent? &parent->_atom_table : NULL, this, transient),
-    _bank(_atom_table, transient),
+    _bank(this, transient),
     _backing_store(NULL),
     _transient(transient)
 {
@@ -76,7 +76,7 @@ AtomSpace::~AtomSpace()
 
 AtomSpace::AtomSpace(const AtomSpace&) :
     _atom_table(NULL),
-    _bank(_atom_table, true),
+    _bank(this, true),
     _backing_store(NULL)
 {
      throw opencog::RuntimeException(TRACE_INFO,

--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -31,7 +31,6 @@
 #include <vector>
 
 #include <opencog/util/exceptions.h>
-#include <opencog/truthvalue/AttentionValue.h>
 #include <opencog/truthvalue/TruthValue.h>
 
 #include <opencog/atoms/base/ClassServer.h>

--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -576,7 +576,7 @@ public:
                       AttentionValue::sti_t lowerBound,
                       AttentionValue::sti_t upperBound = AttentionValue::MAXSTI) const
     {
-        UnorderedHandleSet hs = _atom_table.getHandlesByAV(lowerBound, upperBound);
+        UnorderedHandleSet hs = _bank.getHandlesByAV(lowerBound, upperBound);
         return std::copy(hs.begin(), hs.end(), result);
     }
 
@@ -656,6 +656,8 @@ public:
 
     /** See the AttentionBank for documentation */
     void stimulate(Handle& h, double stimulus) { _bank.stimulate(h, stimulus); }
+    void updateImportanceIndex(AtomPtr a, int bin) {
+        _bank.updateImportanceIndex(a, bin); }
 
     /* ----------------------------------------------------------- */
     // ---- Signals

--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -659,6 +659,21 @@ public:
     void updateImportanceIndex(AtomPtr a, int bin) {
         _bank.updateImportanceIndex(a, bin); }
 
+    // ---- AttentionBank Signals
+    boost::signals2::connection AddAFSignal(const AFCHSigl::slot_type& function)
+    {
+        return _bank.AddAFSignal().connect(function);
+    }
+    boost::signals2::connection RemoveAFSignal(const AFCHSigl::slot_type& function)
+    {
+        return _bank.RemoveAFSignal().connect(function);
+    }
+    boost::signals2::connection AVChangedSignal(const AVCHSigl::slot_type& function)
+    {
+        return _bank.getAVChangedSignal().connect(function);
+    }
+    AVCHSigl& getAVChangedSignal() { return _bank.getAVChangedSignal(); }
+
     /* ----------------------------------------------------------- */
     // ---- Signals
 
@@ -670,21 +685,9 @@ public:
     {
         return _atom_table.removeAtomSignal().connect(function);
     }
-    boost::signals2::connection AVChangedSignal(const AVCHSigl::slot_type& function)
-    {
-        return _atom_table.AVChangedSignal().connect(function);
-    }
     boost::signals2::connection TVChangedSignal(const TVCHSigl::slot_type& function)
     {
         return _atom_table.TVChangedSignal().connect(function);
-    }
-    boost::signals2::connection AddAFSignal(const AVCHSigl::slot_type& function)
-    {
-        return _bank.AddAFSignal().connect(function);
-    }
-    boost::signals2::connection RemoveAFSignal(const AVCHSigl::slot_type& function)
-    {
-        return _bank.RemoveAFSignal().connect(function);
     }
 
     /* ----------------------------------------------------------- */

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -703,7 +703,6 @@ void AtomTable::put_atom_into_index(AtomPtr& atom)
     nodeIndex.insertAtom(pat);
     linkIndex.insertAtom(atom);
     typeIndex.insertAtom(pat);
-    importanceIndex.insertAtom(pat);
 
     // We can now unlock, since we are done. In particular, the signals
     // need to run unlocked, since they may result in more atom table
@@ -933,7 +932,6 @@ AtomPtrSet AtomTable::extract(Handle& handle, bool recursive)
             a->remove_atom(lll);
         }
     }
-    importanceIndex.removeAtom(pat);
 
     // XXX Setting the atom table causes AVChanged signals to be emitted.
     // We should really do this unlocked, but I'm too lazy to fix, and

--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -60,9 +60,6 @@ typedef std::set<AtomPtr> AtomPtrSet;
 typedef boost::signals2::signal<void (const Handle&)> AtomSignal;
 typedef boost::signals2::signal<void (const AtomPtr&)> AtomPtrSignal;
 typedef boost::signals2::signal<void (const Handle&,
-                                      const AttentionValuePtr&,
-                                      const AttentionValuePtr&)> AVCHSigl;
-typedef boost::signals2::signal<void (const Handle&,
                                       const TruthValuePtr&,
                                       const TruthValuePtr&)> TVCHSigl;
 
@@ -129,9 +126,6 @@ private:
 
     /** Signal emitted when the TV changes. */
     TVCHSigl _TVChangedSignal;
-
-    /** Signal emitted when the AV changes. */
-    AVCHSigl _AVChangedSignal;
 
     /// Parent environment for this table.  Null if top-level.
     /// This allows atomspaces to be nested; atoms in this atomspace
@@ -343,9 +337,6 @@ public:
 
     AtomSignal& addAtomSignal() { return _addAtomSignal; }
     AtomPtrSignal& removeAtomSignal() { return _removeAtomSignal; }
-
-    /** Provide ability for others to find out about AV changes */
-    AVCHSigl& AVChangedSignal() { return _AVChangedSignal; }
 
     /** Provide ability for others to find out about TV changes */
     TVCHSigl& TVChangedSignal() { return _TVChangedSignal; }

--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -35,7 +35,6 @@
 #include <opencog/util/RandGen.h>
 
 #include <opencog/truthvalue/TruthValue.h>
-#include <opencog/truthvalue/AttentionValue.h>
 
 #include <opencog/atoms/base/atom_types.h>
 #include <opencog/atoms/base/ClassServer.h>

--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -43,7 +43,6 @@
 #include <opencog/atoms/base/Node.h>
 
 #include <opencog/atomspace/FixedIntegerIndex.h>
-#include <opencog/atomspace/ImportanceIndex.h>
 #include <opencog/atomspace/LinkIndex.h>
 #include <opencog/atomspace/NodeIndex.h>
 #include <opencog/atomspace/TypeIndex.h>
@@ -110,7 +109,6 @@ private:
     TypeIndex typeIndex;
     NodeIndex nodeIndex;
     LinkIndex linkIndex;
-    ImportanceIndex importanceIndex;
 
     async_caller<AtomTable, AtomPtr> _index_queue;
     void put_atom_into_index(AtomPtr&);
@@ -261,34 +259,6 @@ public:
         { return typeIndex.begin(type, subclass); }
     TypeIndex::iterator endType(void) const
         { return typeIndex.end(); }
-
-    /**
-     * Returns the set of atoms within the given importance range.
-     *
-     * @param Importance range lower bound (inclusive).
-     * @param Importance range upper bound (inclusive).
-     * @return The set of atoms within the given importance range.
-     */
-    UnorderedHandleSet getHandlesByAV(AttentionValue::sti_t lowerBound,
-                              AttentionValue::sti_t upperBound = AttentionValue::MAXSTI) const
-    {
-        std::lock_guard<std::recursive_mutex> lck(_mtx);
-        return importanceIndex.getHandleSet(this, lowerBound, upperBound);
-    }
-
-    /**
-     * Updates the importance index for the given atom. According to the
-     * new importance of the atom, it may change importance bins.
-     *
-     * @param The atom whose importance index will be updated.
-     * @param The old importance bin where the atom originally was.
-     */
-    void updateImportanceIndex(AtomPtr a, int bin)
-    {
-        if (a->_atomTable != this) return;
-        std::lock_guard<std::recursive_mutex> lck(_mtx);
-        importanceIndex.updateImportance(a.operator->(), bin);
-    }
 
     /**
      * Adds an atom to the table. If the atom already is in the

--- a/opencog/atomspace/AttentionBank.cc
+++ b/opencog/atomspace/AttentionBank.cc
@@ -49,8 +49,10 @@ AttentionBank::AttentionBank(AtomTable& atab, bool transient)
 
     _attentionalFocusBoundary = 1;
 
+    // Subscribe to my own changes. This is insane and hacky; must move
+    // the AV stuf out of the Atom itself.  XXX FIXME.
     _AVChangedConnection =
-        atab.AVChangedSignal().connect(
+        getAVChangedSignal().connect(
             boost::bind(&AttentionBank::AVChanged, this, _1, _2, _3));
     _addAtomConnection =
         atab.addAtomSignal().connect(

--- a/opencog/atomspace/AttentionBank.h
+++ b/opencog/atomspace/AttentionBank.h
@@ -43,6 +43,10 @@ namespace opencog
 
 typedef boost::signals2::signal<void (const Handle&,
                                       const AttentionValuePtr&,
+                                      const AttentionValuePtr&)> AVCHSigl;
+
+typedef boost::signals2::signal<void (const Handle&,
+                                      const AttentionValuePtr&,
                                       const AttentionValuePtr&)> AFCHSigl;
 
 class AtomTable;
@@ -109,6 +113,9 @@ class AttentionBank
     mutable std::recursive_mutex _lock_index;
     ImportanceIndex _importanceIndex;
 
+    /** Signal emitted when the AV changes. */
+    AVCHSigl _AVChangedSignal;
+
 public:
     /** The table notifies us about AV changes */
     AttentionBank(AtomTable&, bool);
@@ -121,6 +128,9 @@ public:
      */
     AFCHSigl& AddAFSignal() { return _AddAFSignal; }
     AFCHSigl& RemoveAFSignal() { return _RemoveAFSignal; }
+
+    /** Provide ability for others to find out about AV changes */
+    AVCHSigl& getAVChangedSignal() { return _AVChangedSignal; }
 
     /**
      * Stimulate an atom.

--- a/opencog/atomspace/AttentionBank.h
+++ b/opencog/atomspace/AttentionBank.h
@@ -57,8 +57,11 @@ class AttentionBank
     bool _zombie;
 
     /** The connection by which we are notified of AV changes */
-    boost::signals2::connection AVChangedConnection;
-    void AVChanged(Handle, AttentionValuePtr, AttentionValuePtr);
+    boost::signals2::connection _AVChangedConnection;
+    void AVChanged(const Handle&, const AttentionValuePtr&, const AttentionValuePtr&);
+
+    boost::signals2::connection _addAtomConnection;
+    boost::signals2::connection _removeAtomConnection;
 
     /**
      * Boundary at which an atom is considered within the attentional
@@ -301,13 +304,13 @@ public:
         _importanceIndex.updateImportance(a.operator->(), bin);
     }
 
-    void put_atom_into_index(AtomPtr& atom)
+    void put_atom_into_index(const Handle& h)
     {
         std::lock_guard<std::recursive_mutex> lck(_lock_index);
-        _importanceIndex.insertAtom(atom.operator->());
+        _importanceIndex.insertAtom(h.operator->());
     }
 
-    void remove_atom_from_index(AtomPtr& atom)
+    void remove_atom_from_index(const AtomPtr& atom)
     {
         std::lock_guard<std::recursive_mutex> lck(_lock_index);
         _importanceIndex.removeAtom(atom.operator->());

--- a/opencog/atomspace/AttentionBank.h
+++ b/opencog/atomspace/AttentionBank.h
@@ -41,15 +41,17 @@ namespace opencog
  *  @{
  */
 
+/* Attention Value changed */
 typedef boost::signals2::signal<void (const Handle&,
                                       const AttentionValuePtr&,
                                       const AttentionValuePtr&)> AVCHSigl;
 
+/* Attentional Focus changed */
 typedef boost::signals2::signal<void (const Handle&,
                                       const AttentionValuePtr&,
                                       const AttentionValuePtr&)> AFCHSigl;
 
-class AtomTable;
+class AtomSpace;
 
 class AttentionBank
 {
@@ -118,7 +120,7 @@ class AttentionBank
 
 public:
     /** The table notifies us about AV changes */
-    AttentionBank(AtomTable&, bool);
+    AttentionBank(AtomSpace*, bool);
     ~AttentionBank();
     void shutdown(void);
 

--- a/opencog/atomspace/ImportanceIndex.cc
+++ b/opencog/atomspace/ImportanceIndex.cc
@@ -69,7 +69,6 @@ void ImportanceIndex::removeAtom(Atom* atom)
 }
 
 UnorderedHandleSet ImportanceIndex::getHandleSet(
-        const AtomTable* atomtable,
         AttentionValue::sti_t lowerBound,
         AttentionValue::sti_t upperBound) const
 {

--- a/opencog/atomspace/ImportanceIndex.h
+++ b/opencog/atomspace/ImportanceIndex.h
@@ -32,8 +32,6 @@ namespace opencog
  *  @{
  */
 
-class AtomTable;
-
 /**
  * Implements an index with additional routines needed for managing 
  * short-term importance.  This index is not thread-safe, by itself.
@@ -55,9 +53,8 @@ public:
      */
     void updateImportance(Atom*, int);
     
-    UnorderedHandleSet getHandleSet(const AtomTable*,
-                              AttentionValue::sti_t,
-                              AttentionValue::sti_t) const;
+    UnorderedHandleSet getHandleSet(AttentionValue::sti_t,
+                                    AttentionValue::sti_t) const;
 
     /**
      * This method returns which importance bin an atom with the given

--- a/tests/atomspace/AtomTableUTest.cxxtest
+++ b/tests/atomspace/AtomTableUTest.cxxtest
@@ -79,7 +79,7 @@ public:
         atomSpace->clear();
         /* load scm files with all necessary nodes and links  */
         SchemeEval* eval = SchemeEval::get_evaluator(atomSpace);
-        eval->eval("(add-to-load-path \"..\..\")");
+        eval->eval("(add-to-load-path \"../..\")");
         eval->eval("(load-from-path \"opencog/atoms/base/core_types.scm\")");
         eval->eval("(load-from-path \"tests/query/test_types.scm\")");
     }


### PR DESCRIPTION
This fulfills some of the cleanup for opencog/opencog#2333 by untangling attention-value changed signals from the AtomTable, where hey played no role, and by moving the ImportanceIndex out of the atomspace, and into the AttentionBank.  This move probably(?) fixed the thread-starvation issues explained in opencog/opencog#2333 