### PR TITLE
Async Atom addition/removal for ImportanceIndex

### DIFF
--- a/opencog/atomspace/AttentionBank.cc
+++ b/opencog/atomspace/AttentionBank.cc
@@ -48,6 +48,8 @@ AttentionBank::AttentionBank(AtomSpace *asp, bool transient)
     STIAtomWage = config().get_int("ECAN_STARTING_ATOM_STI_WAGE", 10);
     LTIAtomWage = config().get_int("ECAN_STARTING_ATOM_LTI_WAGE", 10);
 
+    bool async = config().get_bool("AttentionBank_Async",true);
+
     _attentionalFocusBoundary = 1;
 
     // Subscribe to my own changes. This is insane and hacky; must move
@@ -55,14 +57,24 @@ AttentionBank::AttentionBank(AtomSpace *asp, bool transient)
     _AVChangedConnection =
         _AVChangedSignal.connect(
             boost::bind(&AttentionBank::AVChanged, this, _1, _2, _3));
-    _addAtomConnection =
+
+    if (async) {
+     _addAtomConnection =
         asp->addAtomSignal(
             boost::bind(&AttentionBank::add_atom_to_indexInsertQueue, this, _1));
-          //boost::bind(&AttentionBank::put_atom_into_index, this, _1));
     _removeAtomConnection =
         asp->removeAtomSignal(
             boost::bind(&AttentionBank::add_atom_to_indexRemoveQueue, this, _1));
-          //boost::bind(&AttentionBank::remove_atom_from_index, this, _1));
+    }
+    else {
+     _addAtomConnection =
+        asp->addAtomSignal(
+            boost::bind(&AttentionBank::put_atom_into_index, this, _1));
+    _removeAtomConnection =
+        asp->removeAtomSignal(
+            boost::bind(&AttentionBank::remove_atom_from_index, this, _1));
+
+    }
 }
 
 /// This must be called before the AtomTable is destroyed. Which

--- a/opencog/atomspace/AttentionBank.cc
+++ b/opencog/atomspace/AttentionBank.cc
@@ -32,6 +32,8 @@
 using namespace opencog;
 
 AttentionBank::AttentionBank(AtomSpace *asp, bool transient)
+    : _index_insert_queue(this, &AttentionBank::put_atom_into_index, transient?0:4)
+    , _index_remove_queue(this, &AttentionBank::remove_atom_from_index, transient?0:4)
 {
     /* Do not boether with initialization, if this is transient */
     if (transient) { _zombie = true; return; }
@@ -55,10 +57,12 @@ AttentionBank::AttentionBank(AtomSpace *asp, bool transient)
             boost::bind(&AttentionBank::AVChanged, this, _1, _2, _3));
     _addAtomConnection =
         asp->addAtomSignal(
-            boost::bind(&AttentionBank::put_atom_into_index, this, _1));
+            boost::bind(&AttentionBank::add_atom_to_indexInsertQueue, this, _1));
+          //boost::bind(&AttentionBank::put_atom_into_index, this, _1));
     _removeAtomConnection =
         asp->removeAtomSignal(
-            boost::bind(&AttentionBank::remove_atom_from_index, this, _1));
+            boost::bind(&AttentionBank::add_atom_to_indexRemoveQueue, this, _1));
+          //boost::bind(&AttentionBank::remove_atom_from_index, this, _1));
 }
 
 /// This must be called before the AtomTable is destroyed. Which

--- a/opencog/atomspace/AttentionBank.h
+++ b/opencog/atomspace/AttentionBank.h
@@ -31,7 +31,7 @@
 
 #include <boost/signals2.hpp>
 
-#include "async_method_caller_const.h"
+#include <opencog/util/async_method_caller.h>
 #include <opencog/util/recent_val.h>
 
 #include <opencog/truthvalue/AttentionValue.h>
@@ -117,8 +117,8 @@ class AttentionBank
     mutable std::mutex _lock_index;
     ImportanceIndex _importanceIndex;
 
-    async_caller_const<AttentionBank,Handle> _index_insert_queue;
-    async_caller_const<AttentionBank,AtomPtr> _index_remove_queue;
+    async_caller<AttentionBank,Handle> _index_insert_queue;
+    async_caller<AttentionBank,AtomPtr> _index_remove_queue;
 
     /** Signal emitted when the AV changes. */
     AVCHSigl _AVChangedSignal;

--- a/opencog/atomspace/AttentionBank.h
+++ b/opencog/atomspace/AttentionBank.h
@@ -31,7 +31,9 @@
 
 #include <boost/signals2.hpp>
 
+#include "async_method_caller_const.h"
 #include <opencog/util/recent_val.h>
+
 #include <opencog/truthvalue/AttentionValue.h>
 #include <opencog/atomspace/ImportanceIndex.h>
 
@@ -114,6 +116,9 @@ class AttentionBank
     /** The importance index, and it's lock. */
     mutable std::recursive_mutex _lock_index;
     ImportanceIndex _importanceIndex;
+
+    async_caller_const<AttentionBank,Handle> _index_insert_queue;
+    async_caller_const<AttentionBank,AtomPtr> _index_remove_queue;
 
     /** Signal emitted when the AV changes. */
     AVCHSigl _AVChangedSignal;
@@ -316,6 +321,16 @@ public:
         _importanceIndex.updateImportance(a.operator->(), bin);
     }
 
+    void add_atom_to_indexInsertQueue(const Handle& h)
+    {
+        _index_insert_queue.enqueue(h);
+    }
+
+    void add_atom_to_indexRemoveQueue(const AtomPtr& atom)
+    {
+        _index_remove_queue.enqueue(atom);
+    }
+
     void put_atom_into_index(const Handle& h)
     {
         std::lock_guard<std::recursive_mutex> lck(_lock_index);
@@ -327,6 +342,7 @@ public:
         std::lock_guard<std::recursive_mutex> lck(_lock_index);
         _importanceIndex.removeAtom(atom.operator->());
     }
+
 };
 
 /** @}*/

--- a/tests/atomspace/UseCountUTest.cxxtest
+++ b/tests/atomspace/UseCountUTest.cxxtest
@@ -149,6 +149,9 @@ public:
         anchor = atomSpace->add_node(ANCHOR_NODE, "*** The Anchor ***");
         __totalAdded++;
 
+        //ImportanceIndex is asynchronos give it some time
+        sleep(1);
+
         long int initial_use_count = AtomPtr(anchor).use_count();
         std::cout << std::endl;
         std::cout << "Initial anchor use count=" << initial_use_count << std::endl;
@@ -170,6 +173,9 @@ public:
 
         // Wait for it all to come together.
         for (std::thread& t : thread_pool) t.join();
+
+        //ImportanceIndex is asynchronos give it some time
+        sleep(1);
 
         long int final_use_count = AtomPtr(anchor).use_count();
         std::cout << "Final anchor use count=" << final_use_count << std::endl;

--- a/tests/cython/atomspace/test_atomspace.py
+++ b/tests/cython/atomspace/test_atomspace.py
@@ -6,6 +6,8 @@ from opencog.atomspace import types, is_a, get_type, get_type_name
 from opencog.utilities import initialize_opencog, finalize_opencog
 from opencog.type_constructors import *
 
+from time import sleep
+
 class AtomSpaceTest(TestCase):
 
     def setUp(self):
@@ -165,6 +167,9 @@ class AtomSpaceTest(TestCase):
         a2.sti = 5
         a3.sti = 4
         a4.sti = 1
+
+        #ImportanceIndex is Asynchronus give it some time
+        sleep(1)
 
         result = self.space.get_atoms_by_av(4, 10)
         assert len(result) == 3


### PR DESCRIPTION
This requires a change in the cog utils namely an async_caller which accepts functions that take a "const" argument. Haven't found a nice way to do that without a lot of duplicate code.

@linas please take a look at this. If it's okay I can merge this once I have the changes to cog utils merged.
The code is basically a mirror of what already exists for the AtomTable.