### PR TITLE
Attempt to avoid mis-use of the cog-atom function.

### DIFF
--- a/opencog/atoms/base/Handle.cc
+++ b/opencog/atoms/base/Handle.cc
@@ -116,6 +116,7 @@ void Handle::clear_resolver(const AtomTable* tab)
 // the atom wins.  Seems to work, for now.
 inline Handle Handle::do_res(UUID uuid)
 {
+    if (INVALID_UUID == uuid) return Handle();
     for (const AtomTable* at : _resolver) {
         Handle h(at->getHandle(uuid));
         if (NULL != h) return h;

--- a/opencog/guile/SchemeSmobNew.cc
+++ b/opencog/guile/SchemeSmobNew.cc
@@ -196,7 +196,7 @@ SCM SchemeSmob::ss_atom (SCM suuid)
 
 	// SCM_RETURN_NEWSMOB (cog_uuid_tag, suuid);
 	UUID uuid = scm_to_ulong(suuid);
-	if (INVALID_UUID == uuid)
+	if (Handle::INVALID_UUID == uuid)
 		scm_wrong_type_arg_msg("cog-atom", 1, suuid, "valid opencog uuid");
 
 	return handle_to_scm(Handle(uuid));

--- a/opencog/guile/SchemeSmobNew.cc
+++ b/opencog/guile/SchemeSmobNew.cc
@@ -196,6 +196,9 @@ SCM SchemeSmob::ss_atom (SCM suuid)
 
 	// SCM_RETURN_NEWSMOB (cog_uuid_tag, suuid);
 	UUID uuid = scm_to_ulong(suuid);
+	if (INVALID_UUID == uuid)
+		scm_wrong_type_arg_msg("cog-atom", 1, suuid, "valid opencog uuid");
+
 	return handle_to_scm(Handle(uuid));
 }
 


### PR DESCRIPTION
passing a UUID of -1 to the cog-atom function leads to a crash,
the stack trace in opencog/ros-behavior-scripting#98
This attempts to avoid that crash, by throwing a user-error.