### PR TITLE
Fix unintentionally small sized index.

### DIFF
--- a/opencog/atomspace/ImportanceIndex.cc
+++ b/opencog/atomspace/ImportanceIndex.cc
@@ -31,7 +31,7 @@
 using namespace opencog;
 
 //! Each bin has STI range of 32 means 2048 importance bins.
-#define IMPORTANCE_INDEX_BIN_SIZE   (1 << 5)
+#define IMPORTANCE_INDEX_BIN_SIZE   32
 #define IMPORTANCE_INDEX_SIZE       2048
 
 ImportanceIndex::ImportanceIndex(void)
@@ -44,7 +44,7 @@ unsigned int ImportanceIndex::importanceBin(short importance)
 	// STI is in range of [-32768, 32767] so adding 32768 puts it in
 	// [0, 65535]
 	unsigned int bin = (importance + 32768) / IMPORTANCE_INDEX_BIN_SIZE;
-	assert (bin <= 2048-1);
+	assert (bin < IMPORTANCE_INDEX_SIZE);
 	return bin;
 }
 

--- a/opencog/atomspace/ImportanceIndex.cc
+++ b/opencog/atomspace/ImportanceIndex.cc
@@ -30,19 +30,22 @@
 
 using namespace opencog;
 
-//! 4092 importance bins means each bin has STI range of 32
-#define IMPORTANCE_INDEX_SIZE   (1 << 11)
+//! Each bin has STI range of 32 means 2048 importance bins.
+#define IMPORTANCE_INDEX_BIN_SIZE   (1 << 5)
+#define IMPORTANCE_INDEX_SIZE       2048
 
 ImportanceIndex::ImportanceIndex(void)
 {
-	resize(IMPORTANCE_INDEX_SIZE+1);
+	resize(IMPORTANCE_INDEX_SIZE);
 }
 
 unsigned int ImportanceIndex::importanceBin(short importance)
 {
 	// STI is in range of [-32768, 32767] so adding 32768 puts it in
 	// [0, 65535]
-	return (importance + 32768) / IMPORTANCE_INDEX_SIZE;
+	unsigned int bin = (importance + 32768) / IMPORTANCE_INDEX_BIN_SIZE;
+	assert (bin <= 2048-1);
+	return bin;
 }
 
 void ImportanceIndex::updateImportance(Atom* atom, int bin)


### PR DESCRIPTION
A lot of atoms were falling in the same bin since the number of bins was only 32, which seems unintentional according to the comment left in the code. The actual intention was to have 2048 bins  holding atoms with STI range of 32 where 2048 bin size is the result of dividing 2^sizeof(short) by 32 assuming size of short is 2 bytes. So, the fix is based on my above understanding.