### PR TITLE
small fix on eg

### DIFF
--- a/examples/guile/basic.scm
+++ b/examples/guile/basic.scm
@@ -30,7 +30,7 @@
 
 ; Run the following REPL commands
 ; * Print a list of all (currently loaded) opencog functions.
-; ,apropos "cog"
+; ,apropos cog
 
 ; * Get the documentation of a a given function
 ; ,describe cog-new-node

--- a/examples/guile/basic.scm
+++ b/examples/guile/basic.scm
@@ -28,9 +28,10 @@
 ; Access an atom that does not exist.
 (cog-node 'ConceptNode "qwerty")
 
-; Print a list of all (currently loaded) opencog functions.
-,apropos cog
+; Run the following REPL commands
+; * Print a list of all (currently loaded) opencog functions.
+; ,apropos "cog"
 
-;
-,describe cog-new-node
-,describe cog-node
+; * Get the documentation of a a given function
+; ,describe cog-new-node
+; ,describe cog-node


### PR DESCRIPTION
Prevent the following
```
scheme@(guile-user) [1]> (load "basic.scm")
Syntax error:
/home/user/opencog/atomspace/examples/guile/basic.scm:32:0: unquote: expression not valid outside of quasiquote in form (unquote apropos)
```

