### PR TITLE
Fix for opencog/ros-behavior-scripting/issues/108

### DIFF
--- a/opencog/cython/PythonEval.cc
+++ b/opencog/cython/PythonEval.cc
@@ -34,6 +34,7 @@
 
 #include <opencog/atoms/base/Atom.h>
 #include <opencog/atoms/base/Link.h>
+#include <opencog/atomspace/AtomSpace.h>
 
 #include "PythonEval.h"
 
@@ -441,13 +442,25 @@ PythonEval& PythonEval::instance(AtomSpace* atomspace)
 #define CHECK_SINGLETON
 #ifdef CHECK_SINGLETON
         if (nullptr != singletonInstance->_atomspace)
+        {
             // Someone is trying to initialize the Python interpreter on a
             // different AtomSpace.  Because of the singleton design of the
             // the CosgServer+AtomSpace, there is no easy way to support this...
+            // logger().error() will print a stack tace to tell use who
+            // is doing this.
+            logger().error("PythonEval: ",
+                "Trying to re-initialize python interpreter with different\n"
+                "AtomSpace ptr! Current ptr=%p uuid=%d "
+                "New ptr=%p uuid=%d\n",
+                singletonInstance->_atomspace,
+                singletonInstance->_atomspace->get_uuid(),
+                atomspace, atomspace?atomspace->get_uuid():0);
+
             throw RuntimeException(TRACE_INFO,
                 "Trying to re-initialize python interpreter with different\n"
                 "AtomSpace ptr! Current ptr=%p New ptr=%p\n",
                 singletonInstance->_atomspace, atomspace);
+        }
 #else
         // We need to be able to call the python interpreter with
         // different atomspaces; for example, we need to use temporary

--- a/opencog/cython/PythonEval.cc
+++ b/opencog/cython/PythonEval.cc
@@ -489,6 +489,8 @@ void PythonEval::initialize_python_objects_and_imports(void)
     PyObject* pyAtomSpaceObject = this->atomspace_py_object(_atomspace);
     PyDict_SetItemString(pyRootDictionary, "ATOMSPACE", pyAtomSpaceObject);
     Py_DECREF(pyAtomSpaceObject);
+    if (nullptr == _atomspace)
+        logger().warn("Python evaluator initialized with null atomspace!");
 
     // PyModule_GetDict returns a borrowed reference, so don't do this:
     // Py_DECREF(pyRootDictionary);
@@ -1086,7 +1088,6 @@ void PythonEval::add_to_sys_path(std::string path)
     Py_DECREF(pyPathString);
 }
 
-
 const int ABSOLUTE_IMPORTS_ONLY = 0;
 
 void PythonEval::import_module(const boost::filesystem::path &file,
@@ -1127,6 +1128,9 @@ void PythonEval::import_module(const boost::filesystem::path &file,
         // This decrement is needed because PyDict_SetItemString does
         // not "steal" the reference, unlike PyList_SetItem.
         Py_DECREF(pyAtomSpaceObject);
+        if (nullptr == _atomspace)
+            logger().warn("Python module initialized with null atomspace!");
+
 
         // We need to increment the pyModule reference because
         // PyModule_AddObject "steals" it and we're keeping a copy

--- a/opencog/cython/PythonEval.h
+++ b/opencog/cython/PythonEval.h
@@ -137,7 +137,7 @@ class PythonEval : public GenericEval
         bool _eval_done;
         std::mutex _poll_mtx;
         std::mutex _eval_mutex;
-	    std::condition_variable _wait_done;
+        std::condition_variable _wait_done;
 
         PyObject* _pyGlobal;
         PyObject* _pyLocal;

--- a/opencog/cython/PythonEval.h
+++ b/opencog/cython/PythonEval.h
@@ -56,24 +56,6 @@
 namespace opencog {
 
 class AtomSpace;
-class CogServer;
-
-/**
- * Each call of the embedded python code could be easily locked by object of this class
- */
-class PythonThreadLocker
-{
-    private:
-        PyGILState_STATE state;
-
-    public:
-        PythonThreadLocker() : state(PyGILState_Ensure())
-        {}
-
-        ~PythonThreadLocker() {
-            PyGILState_Release(state);
-        }
-};
 
 /**
  * Singleton class used to initialize python interpreter in the main thread.

--- a/opencog/cython/PythonSCM.cc
+++ b/opencog/cython/PythonSCM.cc
@@ -78,6 +78,10 @@ void* PythonSCM::init_in_guile(void* self)
 #ifdef HAVE_GUILE
 	scm_c_define_module("opencog python", init_in_module, self);
 	scm_c_use_module("opencog python");
+
+	// Make sure that guile and python are using the same atomspace.
+	// This will avoid assorted confusion.
+	PythonEval::instance(SchemeSmob::ss_get_env_as("python-eval"));
 #endif
 	return NULL;
 }

--- a/opencog/cython/opencog/Utilities.cc
+++ b/opencog/cython/opencog/Utilities.cc
@@ -12,31 +12,11 @@ using namespace opencog;
 
 void opencog::initialize_opencog(AtomSpace* atomSpace, const char* configFile)
 {
-    std::string logFile;
-    std::string logLevelString;
-    Logger::Level logLevel;
-    std::string backtraceLevelString;
-    Logger::Level backtraceLevel;
-    bool logToStdOut;
-    
     // Load the config file if one was passed in.
     if (configFile)
     {
         // Load the config file.
         config().load(configFile);
-
-        // Setup the logger to match the log settings from the Config file.
-        logFile = config()["LOG_FILE"];
-        logLevelString = config()["LOG_LEVEL"];
-        logLevel = Logger::get_level_from_string(logLevelString);
-        backtraceLevelString = config()["BACK_TRACE_LOG_LEVEL"];
-        backtraceLevel = Logger::get_level_from_string(backtraceLevelString);
-        logToStdOut = config().get_bool("LOG_TO_STDOUT");
-        logger().set_filename(logFile);
-        logger().set_level(logLevel);
-        logger().set_backtrace_level(backtraceLevel);
-        logger().set_print_to_stdout_flag(logToStdOut);
-
         logger().debug("initialize_opencog - config file loaded");
     }
 


### PR DESCRIPTION
The root bug was that python was being used without first setting the atomspace it should use.