### PR TITLE
Exponentiall Importance index

### DIFF
--- a/opencog/atomspace/ImportanceIndex.cc
+++ b/opencog/atomspace/ImportanceIndex.cc
@@ -28,6 +28,8 @@
 #include <opencog/atoms/base/Atom.h>
 #include <opencog/atomspace/AtomTable.h>
 
+#include <boost/range/adaptor/reversed.hpp>
+
 using namespace opencog;
 
 //! Each bin has STI range of 32 means 2048 importance bins.
@@ -122,4 +124,36 @@ UnorderedHandleSet ImportanceIndex::getHandleSet(
 	std::transform(set.begin(), set.end(), inserter(ret),
 	               [](Atom* atom)->Handle { return atom->getHandle(); });
 	return ret;
+}
+
+UnorderedHandleSet ImportanceIndex::getMaxBinContents()
+{
+    UnorderedHandleSet ret;
+    for (AtomSet s : boost::adaptors::reverse(idx))
+    {
+        if (s.size() > 0)
+        {
+	        std::transform(s.begin(), s.end(), inserter(ret),
+	               [](Atom* atom)->Handle { return atom->getHandle(); });
+	        return ret;
+        }
+    }
+
+    return ret;
+}
+
+UnorderedHandleSet ImportanceIndex::getMinBinContents()
+{
+    UnorderedHandleSet ret;
+    for (AtomSet s : idx)
+    {
+        if (s.size() > 0)
+        {
+	        std::transform(s.begin(), s.end(), inserter(ret),
+	               [](Atom* atom)->Handle { return atom->getHandle(); });
+	        return ret;
+        }
+    }
+
+    return ret;
 }

--- a/opencog/atomspace/ImportanceIndex.cc
+++ b/opencog/atomspace/ImportanceIndex.cc
@@ -32,41 +32,44 @@
 
 using namespace opencog;
 
-//! Each bin has STI range of 32 means 2048 importance bins.
-#define IMPORTANCE_INDEX_SIZE   104 //(12*8)+8
+/**
+ * This formula is used to calculate the GROUP_NUM given the GROUP_SIZE
+ * 32768 = (sum 2^b , b = 0 to (GROUP_NUM-1)) * GROUP_SIZE + GROUP_SIZE
+ * for a GROUP_SIZE of 8 we get:
+ * 32768 = (sum 2^b , b = 0 to 11) * 8 + 8
+ * This means we have 12 groups with 8 bins each
+ * The range of each groups bins is double the previous (2^b) and starts at 1
+ * We have to add 8 since [2^c - 1 = sum 2^b , b = 0 to (c-1)] and we have 8
+ * such groups
+ */
+#define GROUP_SIZE 8
+#define GROUP_NUM 12
+#define IMPORTANCE_INDEX_SIZE (GROUP_NUM*GROUP_SIZE)+GROUP_NUM //104
 
 ImportanceIndex::ImportanceIndex(void)
 {
 	resize(IMPORTANCE_INDEX_SIZE);
 }
 
-/**
- * The following formula is used to calculate the ammount of bins
- * 32768 = (sum 2^b , b = 0 to x) * 8 + 8
- * This means we have x groups with 8 bins each
- * The range of each groups bin is doulbe the previous (2^b) and starts at 1
- * We have to add 8 since 2^c - 1 = sum 2^b , b = 0 to (c-1) and we have 8
- * such groups
- */
 unsigned int ImportanceIndex::importanceBin(short importance)
 {
-    if (importance <= 15)
+    if (importance < 2*GROUP_SIZE)
         return importance;
 
-    short imp = std::ceil((importance - 8.0) / 8.0);
+    short imp = std::ceil((importance - GROUP_SIZE) / GROUP_SIZE);
 
     int sum = 0;
     int i;
-    for (i = 0; i <= 11; i++)
+    for (i = 0; i <= GROUP_NUM; i++)
     {
         if (sum >= imp)
             break;
         sum = sum + std::pow(2,i);
     }
 
-    int ad = 8 - std::ceil(importance / std::pow(2,(i-1)));
+    int ad = GROUP_SIZE - std::ceil(importance / std::pow(2,(i-1)));
 
-    unsigned int bin = ((i * 8) - ad);
+    unsigned int bin = ((i * GROUP_SIZE) - ad);
     assert(bin <= IMPORTANCE_INDEX_SIZE);
     return bin;
 }

--- a/opencog/atomspace/ImportanceIndex.h
+++ b/opencog/atomspace/ImportanceIndex.h
@@ -65,6 +65,16 @@ public:
      * should be placed.
      */
     static unsigned int importanceBin(short);
+
+    /**
+     * Get the highest bin which containsAtoms
+     */
+    UnorderedHandleSet getMaxBinContents();
+
+    /**
+     * Get the lowest bin which containsAtoms
+     */
+    UnorderedHandleSet getMinBinContents();
 };
 
 /** @}*/


### PR DESCRIPTION
This changes the Importance Index to have an exponentially growing bin Size where each size is part of a group of 8 bins that all have this size. (To avoid bins that get too big)

This is done for 2 reasons.
Firstly Most Atom will have a low STI so the bin sizes for these should be smaller so that all bins contain similar amounts of Atoms.
Secondly @misgeatgit and I discussed that initializing new Atoms with a small random STI (range [0,15]) which would lead to the Atom entering different bins could improve performance.

The downside to this is that figuring out the index of the bin is not a bit slower. 
At low STI values, the Atom might jump quite frequently between bins.
And the new Index can no longer handle negative STI values which is no issue with the current system.