### PR TITLE
Unordered link unify support

### DIFF
--- a/opencog/atomutils/Unify.cc
+++ b/opencog/atomutils/Unify.cc
@@ -96,50 +96,50 @@ UnificationSolutionSet mkvarsol(const Handle& lhs, const Handle& rhs,
 	}
 }
 
-UnificationSolutionSet merge(const UnificationSolutionSet& lhs,
-                             const UnificationSolutionSet& rhs)
+UnificationSolutionSet join(const UnificationSolutionSet& lhs,
+                            const UnificationSolutionSet& rhs)
 {
-	// No need to merge if one of them is invalid
+	// No need to join if one of them is invalid
 	if (not lhs.satisfiable or not rhs.satisfiable)
 		return UnificationSolutionSet(false);
 
-	// No need to merge if one of them is empty
+	// No need to join if one of them is empty
 	if (rhs.partitions.empty())
 		return lhs;
 	if (lhs.partitions.empty())
 		return rhs;
 
-	// Merge
+	// Join
 	UnificationSolutionSet result;
 	for (const UnificationPartition& rp : rhs.partitions) {
-		UnificationPartitions sol(merge(lhs.partitions, rp));
+		UnificationPartitions sol(join(lhs.partitions, rp));
 		result.partitions.insert(sol.begin(), sol.end());
 	}
 
-	// If we get an empty merge whereas the inputs where not empty
-	// then the merge has failed
+	// If we get an empty join whereas the inputs where not empty
+	// then the join has failed
 	result.satisfiable = (not result.partitions.empty()) or
 		(lhs.partitions.empty() and rhs.partitions.empty());
 
 	return result;
 }
 
-UnificationPartitions merge(const UnificationPartitions& lhs,
-                            const UnificationPartition& rhs)
+UnificationPartitions join(const UnificationPartitions& lhs,
+                           const UnificationPartition& rhs)
 {
 	UnificationPartitions result;
 	if (lhs.empty())
 		result.insert(rhs);
 	else {
 		for (const auto& par : lhs) {
-			result.insert(merge(par, rhs));
+			result.insert(join(par, rhs));
 		}
 	}
 	return result;
 }
 
-UnificationPartition merge(const UnificationPartition& lhs,
-                           const UnificationPartition& rhs)
+UnificationPartition join(const UnificationPartition& lhs,
+                          const UnificationPartition& rhs)
 {
 	// Don't bother merging if one of them is empty
 	if (lhs.empty())
@@ -155,8 +155,8 @@ UnificationPartition merge(const UnificationPartition& lhs,
 				// Merely insert this independent block
 				result.insert(typed_block);
 			} else {
-				// Merge the 2 equality related blocks
-				UnificationBlock m_typed_block = merge(typed_block, *it);
+				// Join the 2 equality related blocks
+				UnificationBlock m_typed_block = join(typed_block, *it);
 				// If the resulting block is valid then replace *it
 				if (is_valid(m_typed_block)) {
 					result.erase(it);
@@ -173,7 +173,7 @@ UnificationPartition merge(const UnificationPartition& lhs,
 	return result;
 }
 
-UnificationBlock merge(const UnificationBlock& lhs, const UnificationBlock& rhs)
+UnificationBlock join(const UnificationBlock& lhs, const UnificationBlock& rhs)
 {
 	return {set_union(lhs.first, rhs.first),
 			type_intersection(lhs.second, rhs.second)};

--- a/opencog/atomutils/Unify.cc
+++ b/opencog/atomutils/Unify.cc
@@ -207,7 +207,7 @@ UnificationPartition join(const UnificationPartition& lhs,
 				UnificationBlock m_typed_block = join(typed_block, *it);
 				// If the resulting block is valid then replace *it
 				if (is_valid(m_typed_block)) {
-					result.erase(it);
+					result.erase(it->first);
 					result.insert(m_typed_block);
 				}
 				// If the resulting block is invalid then the partition is
@@ -229,7 +229,7 @@ UnificationBlock join(const UnificationBlock& lhs, const UnificationBlock& rhs)
 
 bool is_valid(const UnificationBlock& block)
 {
-	return block.second == Handle::UNDEFINED;
+	return block.second != Handle::UNDEFINED;
 }
 
 // TODO: very limited type intersection, should support structural
@@ -308,9 +308,8 @@ bool inherit(const Handle& lhs, const Handle& rhs,
 	if (VARIABLE_NODE == lhs->getType() and VARIABLE_NODE == rhs->getType())
 		return inherit(get_union_type(lhs, lhs_vardecl),
 		               get_union_type(rhs, rhs_vardecl));
-	// It that necessary?
-	// else if (lhs == rhs)
-	// 	return true;
+	else if (lhs == rhs)
+		return true;
 	else
 		return gen_varlist(rhs, rhs_vardecl)->is_type(rhs, lhs);
 }

--- a/opencog/atomutils/Unify.cc
+++ b/opencog/atomutils/Unify.cc
@@ -77,10 +77,13 @@ UnificationSolutionSet unify(const Handle& lhs, const Handle& rhs,
 	for (const auto& perm : gen_permutations(lhs)) {
 		UnificationSolutionSet perm_sol;
 		for (Arity i = 0; i < lhs_arity; ++i) {
+			std::cout << "perm[" << i << "] = " << perm[i] << std::endl;
 			auto rs = unify(lhs->getOutgoingAtom(perm[i]),
 			                rhs->getOutgoingAtom(i),
 			                lhs_vardecl, rhs_vardecl);
+			std::cout << "rs = " << oc_to_string(rs);
 			perm_sol = join(perm_sol, rs);
+			std::cout << "perm_sol = " << oc_to_string(perm_sol);
 			if (not perm_sol.satisfiable)     // Stop if unification has failed
 				break;
 		}
@@ -370,6 +373,14 @@ std::string oc_to_string(const BoolHandleMapSetPair& bhmsp)
 	std::stringstream ss;
 	ss << "success: " << bhmsp.first << std::endl
 	   << "mappings: " << oc_to_string(bhmsp.second);
+	return ss.str();
+}
+
+std::string oc_to_string(const UnificationBlock& ub)
+{
+	std::stringstream ss;
+	ss << "block:" << std::endl << oc_to_string(ub.first)
+	   << "type:" << std::endl << oc_to_string(ub.second);
 	return ss.str();
 }
 

--- a/opencog/atomutils/Unify.h
+++ b/opencog/atomutils/Unify.h
@@ -44,11 +44,6 @@ typedef std::map<OrderedHandleSet, Handle> UnificationPartition;
 typedef UnificationPartition::value_type UnificationBlock;
 typedef std::set<UnificationPartition> UnificationPartitions;
 
-// Bool represents whether the mapping is valid
-typedef std::pair<bool, HandleMap> BoolHandleMapPair;
-typedef std::pair<bool, HandleMapSet> BoolHandleMapSetPair;
-typedef std::pair<bool, UnificationPartition> BoolUnificationPartitionPair;
-
 struct UnificationSolutionSet :
 		public boost::equality_comparable<UnificationSolutionSet>
 {
@@ -75,15 +70,76 @@ struct UnificationSolutionSet :
  * This algorithm perform unification by recursively
  *
  * 1. Generate all equality partitions
- * 2. Check that each partition is satisfiable
  *
- * To solve 2., for each partition block, it computes the type that
+ * 2. Decorate partition blocks with types
+ *
+ * 3. Check that each partition is satisfiable
+ *
+ * For now the types in 2. are represented by the substitutions, for
+ * instance the typed block {{X, A}, A} means that X is A. Later one
+ * we will replace that by deep types as to represents things like
+ * {{X, Y}, ConceptNode} meaning that X and Y must be concept nodes is
+ * order to be satisfiable, of course the deep will still need to
+ * capture grounds such as {{X, A}, A}, it's not clear excatly how,
+ * maybe Linas deep type implementation can already do that.
+ *
+ * To solve 3, for each partition block, it computes the type that
  * intersects all its elements and repeat till a fixed point is
  * reached. To do that efficiently we would need to build a dependency
- * DAG, but at first we just compute type intersections is random
- * order.
+ * DAG, but at first we can afford to compute type intersections is
+ * random order.
  *
- * TODO: Improve comments, adding the old unify comments
+ * Also, permutations are supported though very slow.
+ *
+ * Examples:
+ *
+ * 1.
+ *
+ * unify((Variable "$X"), (Concept "A"))
+ * ->
+ * {{<{(Variable "$X"), (Concept "A")}, (Concept "A")>}}
+ *
+ * meaning that the partition block {(Variable "$X"), (Concept "A")}
+ * has type (Concept "A"), and there is only one partition in the
+ * solution set.
+ *
+ * 2.
+ *
+ * unify((Concept "A"), (Concept "$X"))
+ * ->
+ * {{<{(Variable "$X"), (Concept "A")}, (Concept "A")>}}
+ *
+ * 3.
+ *
+ * unify((Inheritance (Concept "A") (Concept "B")), (Variable "$X"))
+ * ->
+ * {{<{(Variable "$X"), (Inheritance (Concept "A") (Concept "B"))},
+ *    (Inheritance (Concept "A") (Concept "B"))>}}
+ *
+ * 4.
+ *
+ * unify((Inheritance (Concept "A") (Variable "$Y")),
+ *       (Inheritance (Variable "$X") (Concept "B"))
+ * ->
+ * {{<{(Variable "$X"), (Concept "A")}, (Concept "A")>,
+ *   <{(Variable "$Y"), (Concept "B")}, (Concept "B")>}}
+ *
+ * 5.
+ *
+ * unify((And (Concept "A") (Concept "B")),
+ *       (And (Variable "$X") (Variable "$Y"))
+ * ->
+ * {
+ *  {<{(Variable "$X"), (Concept "A")}, (Concept "A")>,
+ *   <{(Variable "$Y"), (Concept "B")}, (Concept "B")>},
+ *
+ *  {<{(Variable "$X"), (Concept "B")}, (Concept "B")>,
+ *   <{(Variable "$Y"), (Concept "A")}, (Concept "A")>}
+ * }
+ *
+ * mean that the solution set has 2 partitions, one where X unifies to
+ * A and Y unifies to B, and another one where X unifies to B and Y
+ * unifies to A.
  */
 UnificationSolutionSet unify(const Handle& lhs, const Handle& rhs,
                              const Handle& lhs_vardecl = Handle::UNDEFINED,
@@ -130,14 +186,14 @@ UnificationPartitions join(const UnificationPartitions& lhs,
                             const UnificationPartition& rhs);
 
 /**
- * Join 2 partitions. If the resulting partition is invalid then the
- * empty partition is returned.
+ * Join 2 partitions. If the resulting partition is satisfiable then
+ * the empty partition is returned.
  */
 UnificationPartition join(const UnificationPartition& lhs,
                            const UnificationPartition& rhs);
 
 /**
- * Join 2 blocks (supposedly valid).
+ * Join 2 blocks (supposedly satisfiable).
  *
  * That is compute their type intersection and if defined, then build
  * the block as the union of the 2 blocks, typed with their type
@@ -146,10 +202,10 @@ UnificationPartition join(const UnificationPartition& lhs,
 UnificationBlock join(const UnificationBlock& lhs, const UnificationBlock& rhs);
 
 /**
- * Return true if a unification block is valid. A unification block is
- * invalid if it's type is undefined (bottom).
+ * Return true if a unification block is satisfiable. A unification
+ * block is non satisfiable if it's type is undefined (bottom).
  */
-bool is_valid(const UnificationBlock& block);
+bool is_satisfiable(const UnificationBlock& block);
 
 /**
  * TODO: adjust this comment to reflect the new implementation.
@@ -290,7 +346,6 @@ VariableListPtr gen_varlist(const Handle& h);
  */
 VariableListPtr gen_varlist(const Handle& h, const Handle& vardecl);
 
-std::string oc_to_string(const BoolHandleMapSetPair& bhmsp);
 std::string oc_to_string(const UnificationPartition& hshm);
 std::string oc_to_string(const UnificationBlock& ub);
 std::string oc_to_string(const UnificationPartitions& par);

--- a/opencog/atomutils/Unify.h
+++ b/opencog/atomutils/Unify.h
@@ -292,6 +292,7 @@ VariableListPtr gen_varlist(const Handle& h, const Handle& vardecl);
 
 std::string oc_to_string(const BoolHandleMapSetPair& bhmsp);
 std::string oc_to_string(const UnificationPartition& hshm);
+std::string oc_to_string(const UnificationBlock& ub);
 std::string oc_to_string(const UnificationPartitions& par);
 std::string oc_to_string(const UnificationSolutionSet& sol);
 	

--- a/opencog/atomutils/Unify.h
+++ b/opencog/atomutils/Unify.h
@@ -98,33 +98,33 @@ UnificationSolutionSet mkvarsol(const Handle& lhs, const Handle& rhs,
                                 const Handle& rhs_vardecl);
 
 /**
- * Merge 2 solution sets. Generate the product of all consistent
+ * Join 2 solution sets. Generate the product of all consistent
  * solutions (with partitions so that all blocks are typed with a
  * defined Handle).
  */
-UnificationSolutionSet merge(const UnificationSolutionSet& lhs,
+UnificationSolutionSet join(const UnificationSolutionSet& lhs,
                              const UnificationSolutionSet& rhs);
 
 // TODO: add comment. Possibly return UnificationPartitions instead of
 // UnificationSolutionSet.
-UnificationPartitions merge(const UnificationPartitions& lhs,
+UnificationPartitions join(const UnificationPartitions& lhs,
                             const UnificationPartition& rhs);
 
 /**
- * Merge 2 partitions. If the resulting partition is invalid then the
+ * Join 2 partitions. If the resulting partition is invalid then the
  * empty partition is returned.
  */
-UnificationPartition merge(const UnificationPartition& lhs,
+UnificationPartition join(const UnificationPartition& lhs,
                            const UnificationPartition& rhs);
 
 /**
- * Merge 2 blocks (supposedly valid).
+ * Join 2 blocks (supposedly valid).
  *
  * That is compute their type intersection and if defined, then build
  * the block as the union of the 2 blocks, typed with their type
  * intersection.
  */
-UnificationBlock merge(const UnificationBlock& lhs, const UnificationBlock& rhs);
+UnificationBlock join(const UnificationBlock& lhs, const UnificationBlock& rhs);
 
 /**
  * Return true if a unification block is valid. A unification block is

--- a/opencog/atomutils/Unify.h
+++ b/opencog/atomutils/Unify.h
@@ -90,6 +90,25 @@ UnificationSolutionSet unify(const Handle& lhs, const Handle& rhs,
                              const Handle& rhs_vardecl = Handle::UNDEFINED);
 
 /**
+ * Return if the atom is an unordered link.
+ */
+bool is_unordered(const Handle& h);
+
+/**
+ * Generate set of all index permutations if h is unordered, otherwise
+ * return the singleton with {[0..h->getArity()]}.
+ */
+std::set<std::vector<Arity>> gen_permutations(const Handle& h);
+
+/**
+ * Generate the set of all permutations of size n.
+ *
+ * TODO: Add a conditional to ignore dead-end permutations to save
+ * lots of computations.
+ */
+std::set<std::vector<Arity>> gen_permutations(Arity n);
+
+/**
  * Build elementary solution set between 2 atoms given that at least
  * one of them is a variable.
  */

--- a/tests/atomutils/UnifyUTest.cxxtest
+++ b/tests/atomutils/UnifyUTest.cxxtest
@@ -33,8 +33,9 @@ class UnifyUTest :  public CxxTest::TestSuite
 private:
 	AtomSpace _as;
 	Handle X, Y, Z, W, V, A, B, AB, XB, AY, XY, AZ, AW, AV,
-		AndAB, AndXA, AndXY,
+		AndAB, AndAY, AndXB, AndXY,
 		AndAABB, AndXYAB, AndAAABBB, AndXXYYAB, AndAAAABBBB, AndXXXYYYAB,
+		AndAAAAABBBBB, AndXXXXYYYYAB,
 		CT, PT, CPT,
 		X_vardecl, Y_vardecl, Z_vardecl, W_vardecl, V_vardecl,
 		XY_vardecl;
@@ -43,6 +44,8 @@ public:
 	UnifyUTest() {}
 
 	void setUp();
+
+	void test_join_1();
 
 	void test_unify_without_var_1();
 	void test_unify_without_var_2();
@@ -73,8 +76,10 @@ public:
 	void test_unify_unordered_1();
 	void test_unify_unordered_2();
 	void test_unify_unordered_3();
-	// void test_unify_unordered_4();
-	// void test_unify_unordered_5();
+	void test_unify_unordered_4();
+	void test_unify_unordered_5();
+	void test_unify_unordered_6();
+	void test_unify_unordered_7();
 };
 
 void UnifyUTest::setUp(void)
@@ -97,7 +102,8 @@ void UnifyUTest::setUp(void)
 	AW = al(INHERITANCE_LINK, A, W);
 	AV = al(INHERITANCE_LINK, A, V);
 	AndAB = al(AND_LINK, A, B);
-	AndXA = al(AND_LINK, X, A);
+	AndAY = al(AND_LINK, A, Y);
+	AndXB = al(AND_LINK, X, B);
 	AndXY = al(AND_LINK, X, Y);
 	AndAABB = al(AND_LINK, {A, A, B, B});
 	AndXYAB = al(AND_LINK, {X, Y, A, B});
@@ -105,6 +111,8 @@ void UnifyUTest::setUp(void)
 	AndXXYYAB = al(AND_LINK, {X, X, Y, Y, A, B});
 	AndAAAABBBB = al(AND_LINK, {A, A, A, A, B, B, B, B});
 	AndXXXYYYAB = al(AND_LINK, {X, X, X, Y, Y, Y, A, B});
+	AndAAAAABBBBB = al(AND_LINK, {A, A, A, A, A, B, B, B, B, B});
+	AndXXXXYYYYAB = al(AND_LINK, {X, X, X, X, Y, Y, Y, Y, A, B});
 	CT = an(TYPE_NODE, "ConceptNode");
 	PT = an(TYPE_NODE, "PredicateNode");
 	CPT = al(TYPE_CHOICE, CT, PT);
@@ -119,6 +127,19 @@ void UnifyUTest::setUp(void)
 
 #undef al
 #undef an
+}
+
+void UnifyUTest::test_join_1()
+{
+	UnificationSolutionSet s1 = UnificationSolutionSet(true, {{{{X, A}, A}}}),
+		s2 = UnificationSolutionSet(true, {{{{X, B}, B}}}),
+		result = join(s1, s2),
+		expected = UnificationSolutionSet(false);
+
+	std::cout << "result = " << oc_to_string(result) << std::endl;
+	std::cout << "expected = " << oc_to_string(expected) << std::endl;
+
+	TS_ASSERT_EQUALS(result, expected);
 }
 
 void UnifyUTest::test_unify_without_var_1()
@@ -328,9 +349,9 @@ void UnifyUTest::test_gen_permutations_3()
 
 void UnifyUTest::test_unify_unordered_1()
 {
-	UnificationSolutionSet result = unify(AndAB, AndXA,
-	                                      Handle::UNDEFINED, X_vardecl),
-		expected = UnificationSolutionSet(true, {{{{X, B}, B}}});
+	UnificationSolutionSet result = unify(AndAB, AndAY,
+	                                      Handle::UNDEFINED, Y_vardecl),
+		expected = UnificationSolutionSet(true, {{{{Y, B}, B}}});
 
 	std::cout << "result = " << oc_to_string(result) << std::endl;
 	std::cout << "expected = " << oc_to_string(expected) << std::endl;
@@ -339,6 +360,18 @@ void UnifyUTest::test_unify_unordered_1()
 }
 
 void UnifyUTest::test_unify_unordered_2()
+{
+	UnificationSolutionSet result = unify(AndAY, AndXB),
+		expected = UnificationSolutionSet(true,
+		                                  {{{{X, A}, A}, {{Y, B}, B}}});
+
+	std::cout << "result = " << oc_to_string(result) << std::endl;
+	std::cout << "expected = " << oc_to_string(expected) << std::endl;
+
+	TS_ASSERT_EQUALS(result, expected);
+}
+
+void UnifyUTest::test_unify_unordered_3()
 {
 	UnificationSolutionSet result = unify(AndAB, AndXY,
 	                                      Handle::UNDEFINED, XY_vardecl),
@@ -350,7 +383,7 @@ void UnifyUTest::test_unify_unordered_2()
 	std::cout << "expected = " << oc_to_string(expected) << std::endl;
 }
 
-void UnifyUTest::test_unify_unordered_3()
+void UnifyUTest::test_unify_unordered_4()
 {
 	UnificationSolutionSet result = unify(AndAABB, AndXYAB),
 		expected = UnificationSolutionSet(true,
@@ -363,28 +396,41 @@ void UnifyUTest::test_unify_unordered_3()
 	TS_ASSERT_EQUALS(result, expected);
 }
 
-// void UnifyUTest::test_unify_unordered_4()
-// {
-// 	UnificationSolutionSet result = unify(AndAAABBB, AndXXYYAB),
-// 		expected = UnificationSolutionSet(true,
-// 		                                  {{{{X, A}, A}, {{Y, B}, B}},
-// 			                               {{{Y, A}, A}, {{X, B}, B}}});
+void UnifyUTest::test_unify_unordered_5()
+{
+	UnificationSolutionSet result = unify(AndAAABBB, AndXXYYAB),
+		expected = UnificationSolutionSet(true,
+		                                  {{{{X, A}, A}, {{Y, B}, B}},
+			                               {{{Y, A}, A}, {{X, B}, B}}});
 
-// 	std::cout << "result = " << oc_to_string(result) << std::endl;
-// 	std::cout << "expected = " << oc_to_string(expected) << std::endl;
+	std::cout << "result = " << oc_to_string(result) << std::endl;
+	std::cout << "expected = " << oc_to_string(expected) << std::endl;
 
-// 	TS_ASSERT_EQUALS(result, expected);
-// }
+	TS_ASSERT_EQUALS(result, expected);
+}
 
-// void UnifyUTest::test_unify_unordered_5()
-// {
-// 	UnificationSolutionSet result = unify(AndAAAABBBB, AndXXXYYYAB),
-// 		expected = UnificationSolutionSet(true,
-// 		                                  {{{{X, A}, A}, {{Y, B}, B}},
-// 			                               {{{Y, A}, A}, {{X, B}, B}}});
+void UnifyUTest::test_unify_unordered_6()
+{
+	UnificationSolutionSet result = unify(AndAAAABBBB, AndXXXYYYAB),
+		expected = UnificationSolutionSet(true,
+		                                  {{{{X, A}, A}, {{Y, B}, B}},
+			                               {{{Y, A}, A}, {{X, B}, B}}});
 
-// 	std::cout << "result = " << oc_to_string(result) << std::endl;
-// 	std::cout << "expected = " << oc_to_string(expected) << std::endl;
+	std::cout << "result = " << oc_to_string(result) << std::endl;
+	std::cout << "expected = " << oc_to_string(expected) << std::endl;
 
-// 	TS_ASSERT_EQUALS(result, expected);
-// }
+	TS_ASSERT_EQUALS(result, expected);
+}
+
+void UnifyUTest::test_unify_unordered_7()
+{
+	UnificationSolutionSet result = unify(AndAAAAABBBBB, AndXXXXYYYYAB),
+		expected = UnificationSolutionSet(true,
+		                                  {{{{X, A}, A}, {{Y, B}, B}},
+			                               {{{Y, A}, A}, {{X, B}, B}}});
+
+	std::cout << "result = " << oc_to_string(result) << std::endl;
+	std::cout << "expected = " << oc_to_string(expected) << std::endl;
+
+	TS_ASSERT_EQUALS(result, expected);
+}

--- a/tests/atomutils/UnifyUTest.cxxtest
+++ b/tests/atomutils/UnifyUTest.cxxtest
@@ -33,7 +33,8 @@ class UnifyUTest :  public CxxTest::TestSuite
 private:
 	AtomSpace _as;
 	Handle X, Y, Z, W, V, A, B, AB, XB, AY, XY, AZ, AW, AV,
-		AndAB, AndXA, AndXY, AndABABABABAB, AndXXXXYYYYAB,
+		AndAB, AndXA, AndXY,
+		AndAABB, AndXYAB, AndAAABBB, AndXXYYAB, AndAAAABBBB, AndXXXYYYAB,
 		CT, PT, CPT,
 		X_vardecl, Y_vardecl, Z_vardecl, W_vardecl, V_vardecl,
 		XY_vardecl;
@@ -67,9 +68,13 @@ public:
 
 	// Unordered link
 	void test_gen_permutations_1();
+	void test_gen_permutations_2();
+	void test_gen_permutations_3();
 	void test_unify_unordered_1();
 	void test_unify_unordered_2();
-	// void test_unify_unordered_3();
+	void test_unify_unordered_3();
+	// void test_unify_unordered_4();
+	// void test_unify_unordered_5();
 };
 
 void UnifyUTest::setUp(void)
@@ -94,8 +99,12 @@ void UnifyUTest::setUp(void)
 	AndAB = al(AND_LINK, A, B);
 	AndXA = al(AND_LINK, X, A);
 	AndXY = al(AND_LINK, X, Y);
-	AndABABABABAB = al(AND_LINK, {A, B, A, B, A, B, A, B, A, B});
-	AndXXXXYYYYAB = al(AND_LINK, {X, X, X, X, Y, Y, Y, Y, A, B});
+	AndAABB = al(AND_LINK, {A, A, B, B});
+	AndXYAB = al(AND_LINK, {X, Y, A, B});
+	AndAAABBB = al(AND_LINK, {A, A, A, B, B, B});
+	AndXXYYAB = al(AND_LINK, {X, X, Y, Y, A, B});
+	AndAAAABBBB = al(AND_LINK, {A, A, A, A, B, B, B, B});
+	AndXXXYYYAB = al(AND_LINK, {X, X, X, Y, Y, Y, A, B});
 	CT = an(TYPE_NODE, "ConceptNode");
 	PT = an(TYPE_NODE, "PredicateNode");
 	CPT = al(TYPE_CHOICE, CT, PT);
@@ -296,6 +305,27 @@ void UnifyUTest::test_gen_permutations_1()
 	TS_ASSERT_EQUALS(result, expected);
 }
 
+void UnifyUTest::test_gen_permutations_2()
+{
+	std::set<std::vector<Arity>> result = gen_permutations(6);
+
+	for (const auto& perm : result) {
+		for (const auto& el: perm) {
+			std::cout << el << " ";
+		}
+		std::cout << std::endl;
+	}
+
+	TS_ASSERT_EQUALS(result.size(), 720);
+}
+
+void UnifyUTest::test_gen_permutations_3()
+{
+	std::set<std::vector<Arity>> result = gen_permutations(8);
+
+	TS_ASSERT_EQUALS(result.size(), 40320);
+}
+
 void UnifyUTest::test_unify_unordered_1()
 {
 	UnificationSolutionSet result = unify(AndAB, AndXA,
@@ -318,13 +348,37 @@ void UnifyUTest::test_unify_unordered_2()
 
 	std::cout << "result = " << oc_to_string(result) << std::endl;
 	std::cout << "expected = " << oc_to_string(expected) << std::endl;
+}
+
+void UnifyUTest::test_unify_unordered_3()
+{
+	UnificationSolutionSet result = unify(AndAABB, AndXYAB),
+		expected = UnificationSolutionSet(true,
+		                                  {{{{X, A}, A}, {{Y, B}, B}},
+			                               {{{Y, A}, A}, {{X, B}, B}}});
+
+	std::cout << "result = " << oc_to_string(result) << std::endl;
+	std::cout << "expected = " << oc_to_string(expected) << std::endl;
 
 	TS_ASSERT_EQUALS(result, expected);
 }
 
-// void UnifyUTest::test_unify_unordered_3()
+// void UnifyUTest::test_unify_unordered_4()
 // {
-// 	UnificationSolutionSet result = unify(AndABABABABAB, AndXXXXYYYYAB),
+// 	UnificationSolutionSet result = unify(AndAAABBB, AndXXYYAB),
+// 		expected = UnificationSolutionSet(true,
+// 		                                  {{{{X, A}, A}, {{Y, B}, B}},
+// 			                               {{{Y, A}, A}, {{X, B}, B}}});
+
+// 	std::cout << "result = " << oc_to_string(result) << std::endl;
+// 	std::cout << "expected = " << oc_to_string(expected) << std::endl;
+
+// 	TS_ASSERT_EQUALS(result, expected);
+// }
+
+// void UnifyUTest::test_unify_unordered_5()
+// {
+// 	UnificationSolutionSet result = unify(AndAAAABBBB, AndXXXYYYAB),
 // 		expected = UnificationSolutionSet(true,
 // 		                                  {{{{X, A}, A}, {{Y, B}, B}},
 // 			                               {{{Y, A}, A}, {{X, B}, B}}});

--- a/tests/atomutils/UnifyUTest.cxxtest
+++ b/tests/atomutils/UnifyUTest.cxxtest
@@ -33,6 +33,7 @@ class UnifyUTest :  public CxxTest::TestSuite
 private:
 	AtomSpace _as;
 	Handle X, Y, Z, W, V, A, B, AB, XB, AY, XY, AZ, AW, AV,
+		AndAB, AndXA, AndXY, AndABABABABAB, AndXXXXYYYYAB,
 		CT, PT, CPT,
 		X_vardecl, Y_vardecl, Z_vardecl, W_vardecl, V_vardecl,
 		XY_vardecl;
@@ -42,20 +43,33 @@ public:
 
 	void setUp();
 
-	void test_unify_1();
-	void test_unify_2();
-	void test_unify_3();
-	void test_unify_4();
-	void test_unify_5();
-	void test_unify_6();
-	void test_unify_7();
-	void test_unify_8();
-	void test_unify_9();
-	void test_unify_10();
-	void test_unify_11();
-	void test_unify_12();
-	void test_unify_13();
-	void test_unify_14();
+	void test_unify_without_var_1();
+	void test_unify_without_var_2();
+
+	void test_unify_basic_1();
+	void test_unify_basic_2();
+	void test_unify_basic_3();
+	void test_unify_basic_4();
+	void test_unify_basic_5();
+	void test_unify_basic_6();
+	void test_unify_basic_7();
+	void test_unify_basic_8();
+
+	// Variable declaration
+	void test_unify_vardecl_1();
+	void test_unify_vardecl_2();
+	void test_unify_vardecl_3();
+	void test_unify_vardecl_4();
+	void test_unify_vardecl_5();
+
+	// Type union
+	void test_unify_type_union_1();
+
+	// Unordered link
+	void test_gen_permutations_1();
+	void test_unify_unordered_1();
+	void test_unify_unordered_2();
+	// void test_unify_unordered_3();
 };
 
 void UnifyUTest::setUp(void)
@@ -77,6 +91,11 @@ void UnifyUTest::setUp(void)
 	AZ = al(INHERITANCE_LINK, A, Z);
 	AW = al(INHERITANCE_LINK, A, W);
 	AV = al(INHERITANCE_LINK, A, V);
+	AndAB = al(AND_LINK, A, B);
+	AndXA = al(AND_LINK, X, A);
+	AndXY = al(AND_LINK, X, Y);
+	AndABABABABAB = al(AND_LINK, {A, B, A, B, A, B, A, B, A, B});
+	AndXXXXYYYYAB = al(AND_LINK, {X, X, X, X, Y, Y, Y, Y, A, B});
 	CT = an(TYPE_NODE, "ConceptNode");
 	PT = an(TYPE_NODE, "PredicateNode");
 	CPT = al(TYPE_CHOICE, CT, PT);
@@ -93,7 +112,29 @@ void UnifyUTest::setUp(void)
 #undef an
 }
 
-void UnifyUTest::test_unify_1()
+void UnifyUTest::test_unify_without_var_1()
+{
+	UnificationSolutionSet result = unify(AB, A),
+		expected(false);
+
+	std::cout << "result = " << oc_to_string(result) << std::endl;
+	std::cout << "expected = " << oc_to_string(expected) << std::endl;
+
+	TS_ASSERT_EQUALS(result, expected);
+}
+
+void UnifyUTest::test_unify_without_var_2()
+{
+	UnificationSolutionSet result = unify(AB, AB),
+		expected(true);
+
+	std::cout << "result = " << oc_to_string(result) << std::endl;
+	std::cout << "expected = " << oc_to_string(expected) << std::endl;
+
+	TS_ASSERT_EQUALS(result, expected);
+}
+
+void UnifyUTest::test_unify_basic_1()
 {
 	UnificationSolutionSet result = unify(X, A),
 		expected = UnificationSolutionSet(true, {{{{X, A}, A}}});
@@ -104,7 +145,7 @@ void UnifyUTest::test_unify_1()
 	TS_ASSERT_EQUALS(result, expected);
 }
 
-void UnifyUTest::test_unify_2()
+void UnifyUTest::test_unify_basic_2()
 {
 	UnificationSolutionSet result = unify(A, X),
 		expected = UnificationSolutionSet(true, {{{{X, A}, A}}});
@@ -115,7 +156,7 @@ void UnifyUTest::test_unify_2()
 	TS_ASSERT_EQUALS(result, expected);
 }
 
-void UnifyUTest::test_unify_3()
+void UnifyUTest::test_unify_basic_3()
 {
 	UnificationSolutionSet result = unify(X, AB),
 		expected = UnificationSolutionSet(true, {{{{X, AB}, AB}}});
@@ -126,7 +167,7 @@ void UnifyUTest::test_unify_3()
 	TS_ASSERT_EQUALS(result, expected);
 }
 
-void UnifyUTest::test_unify_4()
+void UnifyUTest::test_unify_basic_4()
 {
 	UnificationSolutionSet result = unify(XB, AY),
 		expected = UnificationSolutionSet(true, {{{{X, A}, A}, {{Y, B}, B}}});
@@ -137,7 +178,7 @@ void UnifyUTest::test_unify_4()
 	TS_ASSERT_EQUALS(result, expected);
 }
 
-void UnifyUTest::test_unify_5()
+void UnifyUTest::test_unify_basic_5()
 {
 	UnificationSolutionSet result = unify(XY, AY),
 		expected = UnificationSolutionSet(true, {{{{X, A}, A}, {{Y, Y}, Y}}});
@@ -148,7 +189,7 @@ void UnifyUTest::test_unify_5()
 	TS_ASSERT_EQUALS(result, expected);
 }
 
-void UnifyUTest::test_unify_6()
+void UnifyUTest::test_unify_basic_6()
 {
 	// This one is supposed to fail
 	UnificationSolutionSet result = unify(A, B);
@@ -158,7 +199,7 @@ void UnifyUTest::test_unify_6()
 	TS_ASSERT(not result.satisfiable);
 }
 
-void UnifyUTest::test_unify_7()
+void UnifyUTest::test_unify_basic_7()
 {
 	// This one is supposed to fail
 	UnificationSolutionSet result = unify(XB, B);
@@ -166,7 +207,7 @@ void UnifyUTest::test_unify_7()
 	TS_ASSERT(not result.satisfiable);
 }
 
-void UnifyUTest::test_unify_8()
+void UnifyUTest::test_unify_basic_8()
 {
 	UnificationSolutionSet result = unify(XY, AZ),
 		expected = UnificationSolutionSet(true, {{{{X, A}, A}, {{Y, Z}, Y}}});
@@ -177,7 +218,7 @@ void UnifyUTest::test_unify_8()
 	TS_ASSERT_EQUALS(result, expected);
 }
 
-void UnifyUTest::test_unify_9()
+void UnifyUTest::test_unify_vardecl_1()
 {
 	UnificationSolutionSet result = unify(X, A, X_vardecl),
 		expected = UnificationSolutionSet(true, {{{{X, A}, A}}});
@@ -188,7 +229,7 @@ void UnifyUTest::test_unify_9()
 	TS_ASSERT_EQUALS(result, expected);
 }
 
-void UnifyUTest::test_unify_10()
+void UnifyUTest::test_unify_vardecl_2()
 {
 	UnificationSolutionSet result = unify(XY, AY, XY_vardecl, Y_vardecl),
 		expected = UnificationSolutionSet(true, {{{{X, A}, A}, {{Y}, Y}}});
@@ -199,7 +240,7 @@ void UnifyUTest::test_unify_10()
 	TS_ASSERT_EQUALS(result, expected);
 }
 
-void UnifyUTest::test_unify_11()
+void UnifyUTest::test_unify_vardecl_3()
 {
 	UnificationSolutionSet result = unify(XB, AY, X_vardecl, Y_vardecl),
 		expected = UnificationSolutionSet(true, {{{{X, A}, A}, {{Y, B}, B}}});
@@ -207,7 +248,7 @@ void UnifyUTest::test_unify_11()
 	TS_ASSERT_EQUALS(result, expected);
 }
 
-void UnifyUTest::test_unify_12()
+void UnifyUTest::test_unify_vardecl_4()
 {
 	UnificationSolutionSet result = unify(XY, AZ, XY_vardecl, Z_vardecl),
 		expected = UnificationSolutionSet(true, {{{{X, A}, A}, {{Y, Z}, Y}}});
@@ -218,7 +259,7 @@ void UnifyUTest::test_unify_12()
 	TS_ASSERT_EQUALS(result, expected);
 }
 
-void UnifyUTest::test_unify_13()
+void UnifyUTest::test_unify_vardecl_5()
 {
 	// This one is supposed to fail as the types of Y and W have empty
 	// intersection.
@@ -229,7 +270,7 @@ void UnifyUTest::test_unify_13()
 	TS_ASSERT(not result.satisfiable);
 }
 
-void UnifyUTest::test_unify_14()
+void UnifyUTest::test_unify_type_union_1()
 {
 	UnificationSolutionSet result = unify(XY, AV, XY_vardecl, V_vardecl),
 		expected = UnificationSolutionSet(true, {{{{X, A}, A}, {{Y, V}, Y}}});
@@ -239,3 +280,57 @@ void UnifyUTest::test_unify_14()
 
 	TS_ASSERT_EQUALS(result, expected);
 }
+
+void UnifyUTest::test_gen_permutations_1()
+{
+	std::set<std::vector<Arity>> result = gen_permutations(3),
+		expected{{0,1,2},{0,2,1},{1,0,2},{1,2,0},{2,0,1},{2,1,0}};
+
+	for (const auto& perm : result) {
+		for (const auto& el: perm) {
+			std::cout << el << " ";
+		}
+		std::cout << std::endl;
+	}
+
+	TS_ASSERT_EQUALS(result, expected);
+}
+
+void UnifyUTest::test_unify_unordered_1()
+{
+	UnificationSolutionSet result = unify(AndAB, AndXA,
+	                                      Handle::UNDEFINED, X_vardecl),
+		expected = UnificationSolutionSet(true, {{{{X, B}, B}}});
+
+	std::cout << "result = " << oc_to_string(result) << std::endl;
+	std::cout << "expected = " << oc_to_string(expected) << std::endl;
+
+	TS_ASSERT_EQUALS(result, expected);
+}
+
+void UnifyUTest::test_unify_unordered_2()
+{
+	UnificationSolutionSet result = unify(AndAB, AndXY,
+	                                      Handle::UNDEFINED, XY_vardecl),
+		expected = UnificationSolutionSet(true,
+		                                  {{{{X, A}, A}, {{Y, B}, B}},
+			                               {{{Y, A}, A}, {{X, B}, B}}});
+
+	std::cout << "result = " << oc_to_string(result) << std::endl;
+	std::cout << "expected = " << oc_to_string(expected) << std::endl;
+
+	TS_ASSERT_EQUALS(result, expected);
+}
+
+// void UnifyUTest::test_unify_unordered_3()
+// {
+// 	UnificationSolutionSet result = unify(AndABABABABAB, AndXXXXYYYYAB),
+// 		expected = UnificationSolutionSet(true,
+// 		                                  {{{{X, A}, A}, {{Y, B}, B}},
+// 			                               {{{Y, A}, A}, {{X, B}, B}}});
+
+// 	std::cout << "result = " << oc_to_string(result) << std::endl;
+// 	std::cout << "expected = " << oc_to_string(expected) << std::endl;
+
+// 	TS_ASSERT_EQUALS(result, expected);
+// }


### PR DESCRIPTION
Add support for unordered link in #874

It's unoptimized, the unit test `test_unify_unordered_7` takes a minute to run, while is should take less than a second. The algorithm is to be blamed, the permutation generator should ignore permutations that will not obviously work. Coming next...