### PR TITLE
Optimize unify

### DIFF
--- a/opencog/atomutils/Unify.cc
+++ b/opencog/atomutils/Unify.cc
@@ -151,37 +151,6 @@ HandleSeq cp_erase(const HandleSeq& hs, Arity i)
 	return hs_cp;
 }
 
-std::set<std::vector<Arity>> gen_permutations(const Handle& h)
-{
-	Arity n = h->getArity();
-	if (is_unordered(h)) {
-		return gen_permutations(n);
-	} else {
-		std::vector<Arity> zero2n;
-		for (Arity i = 0; i < n; ++i)
-			zero2n.push_back(i);
-		return {zero2n};
-	}
-}
-
-std::set<std::vector<Arity>> gen_permutations(Arity n)
-{
-	// Base case
-	if (n == 0)
-		return {{}};
-
-	// Recursive case
-	std::set<std::vector<Arity>> result;
-	for (const std::vector<Arity>& perm : gen_permutations(n - 1)) {
-		for (Arity i = 0; i < n; ++i) {
-			std::vector<Arity> cpy(perm);
-			cpy.insert(cpy.begin() + i, n - 1);
-			result.insert(cpy);
-		}
-	}
-	return result;
-}
-
 UnificationSolutionSet mkvarsol(const Handle& lhs, const Handle& rhs,
                                 const Handle& lhs_vardecl,
                                 const Handle& rhs_vardecl)

--- a/opencog/atomutils/Unify.h
+++ b/opencog/atomutils/Unify.h
@@ -144,10 +144,6 @@ struct UnificationSolutionSet :
 UnificationSolutionSet unify(const Handle& lhs, const Handle& rhs,
                              const Handle& lhs_vardecl = Handle::UNDEFINED,
                              const Handle& rhs_vardecl = Handle::UNDEFINED);
-UnificationSolutionSet unify(bool unordered,
-                             const HandleSeq& lhs, const HandleSeq& rhs,
-                             const Handle& lhs_vardecl,
-                             const Handle& rhs_vardecl);
 UnificationSolutionSet unordered_unify(const HandleSeq& lhs,
                                        const HandleSeq& rhs,
                                        const Handle& lhs_vardecl,
@@ -161,6 +157,11 @@ UnificationSolutionSet ordered_unify(const HandleSeq& lhs,
  * Return if the atom is an unordered link.
  */
 bool is_unordered(const Handle& h);
+
+/**
+ * Return a copy of a HandleSeq with the ith element removed.
+ */
+HandleSeq cp_erase(const HandleSeq& hs, Arity i);
 
 /**
  * Generate set of all index permutations if h is unordered, otherwise

--- a/opencog/atomutils/Unify.h
+++ b/opencog/atomutils/Unify.h
@@ -144,6 +144,18 @@ struct UnificationSolutionSet :
 UnificationSolutionSet unify(const Handle& lhs, const Handle& rhs,
                              const Handle& lhs_vardecl = Handle::UNDEFINED,
                              const Handle& rhs_vardecl = Handle::UNDEFINED);
+UnificationSolutionSet unify(bool unordered,
+                             const HandleSeq& lhs, const HandleSeq& rhs,
+                             const Handle& lhs_vardecl,
+                             const Handle& rhs_vardecl);
+UnificationSolutionSet unordered_unify(const HandleSeq& lhs,
+                                       const HandleSeq& rhs,
+                                       const Handle& lhs_vardecl,
+                                       const Handle& rhs_vardecl);
+UnificationSolutionSet ordered_unify(const HandleSeq& lhs,
+                                     const HandleSeq& rhs,
+                                     const Handle& lhs_vardecl,
+                                     const Handle& rhs_vardecl);
 
 /**
  * Return if the atom is an unordered link.

--- a/opencog/atomutils/Unify.h
+++ b/opencog/atomutils/Unify.h
@@ -164,20 +164,6 @@ bool is_unordered(const Handle& h);
 HandleSeq cp_erase(const HandleSeq& hs, Arity i);
 
 /**
- * Generate set of all index permutations if h is unordered, otherwise
- * return the singleton with {[0..h->getArity()]}.
- */
-std::set<std::vector<Arity>> gen_permutations(const Handle& h);
-
-/**
- * Generate the set of all permutations of size n.
- *
- * TODO: Add a conditional to ignore dead-end permutations to save
- * lots of computations.
- */
-std::set<std::vector<Arity>> gen_permutations(Arity n);
-
-/**
  * Build elementary solution set between 2 atoms given that at least
  * one of them is a variable.
  */

--- a/tests/atomutils/UnifyUTest.cxxtest
+++ b/tests/atomutils/UnifyUTest.cxxtest
@@ -33,7 +33,7 @@ class UnifyUTest :  public CxxTest::TestSuite
 private:
 	AtomSpace _as;
 	Handle X, Y, Z, W, V, A, B, AB, XB, AY, XY, AZ, AW, AV,
-		AndAB, AndAY, AndXB, AndXY,
+		AndAA, AndAB, AndAY, AndXB, AndXY,
 		AndAABB, AndXYAB, AndAAABBB, AndXXYYAB, AndAAAABBBB, AndXXXYYYAB,
 		AndAAAAABBBBB, AndXXXXYYYYAB,
 		CT, PT, CPT,
@@ -80,6 +80,7 @@ public:
 	void test_unify_unordered_5();
 	void test_unify_unordered_6();
 	void test_unify_unordered_7();
+	void test_unify_unordered_8();
 };
 
 void UnifyUTest::setUp(void)
@@ -101,6 +102,7 @@ void UnifyUTest::setUp(void)
 	AZ = al(INHERITANCE_LINK, A, Z);
 	AW = al(INHERITANCE_LINK, A, W);
 	AV = al(INHERITANCE_LINK, A, V);
+	AndAA = al(AND_LINK, A, A);
 	AndAB = al(AND_LINK, A, B);
 	AndAY = al(AND_LINK, A, Y);
 	AndXB = al(AND_LINK, X, B);
@@ -349,6 +351,15 @@ void UnifyUTest::test_gen_permutations_3()
 
 void UnifyUTest::test_unify_unordered_1()
 {
+	UnificationSolutionSet result = unify(AndAA, AndAB);
+
+	std::cout << "result = " << oc_to_string(result) << std::endl;
+
+	TS_ASSERT(not result.satisfiable);
+}
+
+void UnifyUTest::test_unify_unordered_2()
+{
 	UnificationSolutionSet result = unify(AndAB, AndAY,
 	                                      Handle::UNDEFINED, Y_vardecl),
 		expected = UnificationSolutionSet(true, {{{{Y, B}, B}}});
@@ -359,7 +370,7 @@ void UnifyUTest::test_unify_unordered_1()
 	TS_ASSERT_EQUALS(result, expected);
 }
 
-void UnifyUTest::test_unify_unordered_2()
+void UnifyUTest::test_unify_unordered_3()
 {
 	UnificationSolutionSet result = unify(AndAY, AndXB),
 		expected = UnificationSolutionSet(true,
@@ -371,7 +382,7 @@ void UnifyUTest::test_unify_unordered_2()
 	TS_ASSERT_EQUALS(result, expected);
 }
 
-void UnifyUTest::test_unify_unordered_3()
+void UnifyUTest::test_unify_unordered_4()
 {
 	UnificationSolutionSet result = unify(AndAB, AndXY,
 	                                      Handle::UNDEFINED, XY_vardecl),
@@ -383,7 +394,7 @@ void UnifyUTest::test_unify_unordered_3()
 	std::cout << "expected = " << oc_to_string(expected) << std::endl;
 }
 
-void UnifyUTest::test_unify_unordered_4()
+void UnifyUTest::test_unify_unordered_5()
 {
 	UnificationSolutionSet result = unify(AndAABB, AndXYAB),
 		expected = UnificationSolutionSet(true,
@@ -396,7 +407,7 @@ void UnifyUTest::test_unify_unordered_4()
 	TS_ASSERT_EQUALS(result, expected);
 }
 
-void UnifyUTest::test_unify_unordered_5()
+void UnifyUTest::test_unify_unordered_6()
 {
 	UnificationSolutionSet result = unify(AndAAABBB, AndXXYYAB),
 		expected = UnificationSolutionSet(true,
@@ -409,7 +420,7 @@ void UnifyUTest::test_unify_unordered_5()
 	TS_ASSERT_EQUALS(result, expected);
 }
 
-void UnifyUTest::test_unify_unordered_6()
+void UnifyUTest::test_unify_unordered_7()
 {
 	UnificationSolutionSet result = unify(AndAAAABBBB, AndXXXYYYAB),
 		expected = UnificationSolutionSet(true,
@@ -422,7 +433,7 @@ void UnifyUTest::test_unify_unordered_6()
 	TS_ASSERT_EQUALS(result, expected);
 }
 
-void UnifyUTest::test_unify_unordered_7()
+void UnifyUTest::test_unify_unordered_8()
 {
 	UnificationSolutionSet result = unify(AndAAAAABBBBB, AndXXXXYYYYAB),
 		expected = UnificationSolutionSet(true,

--- a/tests/atomutils/UnifyUTest.cxxtest
+++ b/tests/atomutils/UnifyUTest.cxxtest
@@ -70,9 +70,6 @@ public:
 	void test_unify_type_union_1();
 
 	// Unordered link
-	void test_gen_permutations_1();
-	void test_gen_permutations_2();
-	void test_gen_permutations_3();
 	void test_unify_unordered_1();
 	void test_unify_unordered_2();
 	void test_unify_unordered_3();
@@ -311,42 +308,6 @@ void UnifyUTest::test_unify_type_union_1()
 	std::cout << "expected = " << oc_to_string(expected) << std::endl;
 
 	TS_ASSERT_EQUALS(result, expected);
-}
-
-void UnifyUTest::test_gen_permutations_1()
-{
-	std::set<std::vector<Arity>> result = gen_permutations(3),
-		expected{{0,1,2},{0,2,1},{1,0,2},{1,2,0},{2,0,1},{2,1,0}};
-
-	for (const auto& perm : result) {
-		for (const auto& el: perm) {
-			std::cout << el << " ";
-		}
-		std::cout << std::endl;
-	}
-
-	TS_ASSERT_EQUALS(result, expected);
-}
-
-void UnifyUTest::test_gen_permutations_2()
-{
-	std::set<std::vector<Arity>> result = gen_permutations(6);
-
-	for (const auto& perm : result) {
-		for (const auto& el: perm) {
-			std::cout << el << " ";
-		}
-		std::cout << std::endl;
-	}
-
-	TS_ASSERT_EQUALS(result.size(), 720);
-}
-
-void UnifyUTest::test_gen_permutations_3()
-{
-	std::set<std::vector<Arity>> result = gen_permutations(8);
-
-	TS_ASSERT_EQUALS(result.size(), 40320);
 }
 
 void UnifyUTest::test_unify_unordered_1()


### PR DESCRIPTION
Optimization for #874. Unfortunately `test_unify_unordered_8` (formerly `test_unify_unordered_7`) is only 2x or so faster, going from 1min to 20sec.

I don't think I can do better on the algorithmic side. I might be able to speed that up further by doing C++ optimizations but I'll only look into that if it is a problem in practice.

Something that I might do is add a `unifiable` function that only test satisfiability as opposed to finding all possible unifications. This should save a lot of time, but again better do that based on real use cases.