### PR TITLE
Fix scopelink alpha equivalence

### DIFF
--- a/opencog/atoms/core/PutLink.cc
+++ b/opencog/atoms/core/PutLink.cc
@@ -104,15 +104,14 @@ void PutLink::init(void)
 		// If the body is just a single variable, and there are no
 		// type declarations for it, then ScopeLink gets confused.
 		_vardecl = Handle::UNDEFINED;
-		_body = _outgoing[0];
-		_values = _outgoing[1];
+		set_body(_outgoing[0]);
+		set_values(_outgoing[1]);
 	}
 	else
 		_values = _outgoing[2];
 
 	static_typecheck_values();
 }
-
 
 /// Check that the values in the PutLink obey the type constraints.
 /// This only performs "static" typechecking, at construction-time;
@@ -203,6 +202,17 @@ void PutLink::static_typecheck_values(void)
 			throw InvalidParamException(TRACE_INFO,
 					"PutLink bad type!");
 	}
+}
+
+void PutLink::set_values(const Handle& values)
+{
+	_values = values;
+	if (_bodies.size() == 1)
+		_bodies.push_back(values);
+	else if (_bodies.size() == 2)
+		_bodies[1] = values;
+	else OC_ASSERT(false, "There must be a bug. "
+	               "Please always set the body before the values");
 }
 
 /* ================================================================= */

--- a/opencog/atoms/core/PutLink.h
+++ b/opencog/atoms/core/PutLink.h
@@ -54,7 +54,11 @@ protected:
 	Handle _values;
 
 	void init(void);
+
 	void static_typecheck_values(void);
+
+	// Used to properly update the bodies of the underlying ScopeLink
+	void set_values(const Handle& values);
 
 	Handle do_reduce(void) const;
 

--- a/opencog/atoms/core/ScopeLink.cc
+++ b/opencog/atoms/core/ScopeLink.cc
@@ -35,6 +35,15 @@ void ScopeLink::init(void)
 	extract_variables(_outgoing);
 }
 
+void ScopeLink::set_body(const Handle& body)
+{
+	_body = body;
+	if (_bodies.empty())
+		_bodies.push_back(body);
+	else
+		_bodies[0] = body;
+}
+
 ScopeLink::ScopeLink(const HandleSeq& oset,
                      TruthValuePtr tv, AttentionValuePtr av)
 	: Link(SCOPE_LINK, oset, tv, av)
@@ -106,7 +115,7 @@ void ScopeLink::extract_variables(const HandleSeq& oset)
 	    TYPED_VARIABLE_LINK != decls and
 	    GLOB_NODE != decls)
 	{
-		_body = oset[0];
+		set_body(oset[0]);
 
 		if (classserver().isA(_body->getType(), LAMBDA_LINK))
 		{
@@ -114,7 +123,7 @@ void ScopeLink::extract_variables(const HandleSeq& oset)
 			if (nullptr == lam)
 				lam = createLambdaLink(*LinkCast(_body));
 			_varlist = lam->get_variables();
-			_body = lam->get_body();
+			set_body(lam->get_body());
 		}
 		else
 		{
@@ -131,7 +140,7 @@ void ScopeLink::extract_variables(const HandleSeq& oset)
 	// If we are here, then the first outgoing set member should be
 	// a variable declaration.
 	_vardecl = oset[0];
-	_body = oset[1];
+	set_body(oset[1]);
 
 	// Initialize _varlist with the scoped variables
 	init_scoped_variables(_vardecl);

--- a/opencog/atoms/core/ScopeLink.cc
+++ b/opencog/atoms/core/ScopeLink.cc
@@ -174,13 +174,14 @@ bool ScopeLink::is_equal(const Handle& other) const
 	// Variable declarations must match.
 	if (not _varlist.is_equal(scother->_varlist)) return false;
 
-	// Other body, with our variables in place of its variables,
-	// should be same as our body.
-	Handle altbod = scother->_varlist.substitute_nocheck(scother->_body,
-	                                                  _varlist.varseq);
-
-	// Compare bodies, they should match.
-	if (*((AtomPtr)altbod) != *((AtomPtr) _body)) return false;
+	// Other body(ies), with our variables in place of its variables,
+	// should be same as our body(ies).
+	for (size_t i = 0; i < _bodies.size(); ++i) {
+		Handle altbod = scother->_varlist.substitute_nocheck(scother->_bodies[i],
+		                                                     _varlist.varseq);
+		// Compare bodies, they should match.
+		if (*((AtomPtr)altbod) != *((AtomPtr) _bodies[i])) return false;
+	}
 
 	return true;
 }

--- a/opencog/atoms/core/ScopeLink.h
+++ b/opencog/atoms/core/ScopeLink.h
@@ -52,7 +52,8 @@ protected:
 	Handle _vardecl;
 	/// Handle of the body of the expression.
 	Handle _body;
-
+	/// HandleSeq of the bodies of the expression
+	HandleSeq _bodies;
 
 	/// Variables bound in the body.
 	Variables _varlist;
@@ -68,6 +69,9 @@ protected:
 	void init(void);
 	void extract_variables(const HandleSeq& oset);
 	void init_scoped_variables(const Handle& hvar);
+
+	// Used to properly update the bodies of the underlying ScopeLink
+	void set_body(const Handle& body);
 
 	// utility debug print
 	static void prt(const Handle& h)

--- a/opencog/atoms/pattern/BindLink.cc
+++ b/opencog/atoms/pattern/BindLink.cc
@@ -85,8 +85,8 @@ void BindLink::extract_variables(const HandleSeq& oset)
 	// declarations; extract all free variables.
 	if (2 == sz)
 	{
-		_body = oset[0];
-		_implicand = oset[1];
+		set_body(oset[0]);
+		set_implicand(oset[1]);
 		_varlist.find_variables(oset[0]);
 		return;
 	}
@@ -94,11 +94,22 @@ void BindLink::extract_variables(const HandleSeq& oset)
 	// If we are here, then the first outgoing set member should be
 	// a variable declaration.
 	_vardecl = oset[0];
-	_body = oset[1];
-	_implicand = oset[2];
+	set_body(oset[1]);
+	set_implicand(oset[2]);
 
 	// Initialize _varlist with the scoped variables
 	init_scoped_variables(oset[0]);
+}
+
+void BindLink::set_implicand(const Handle& implicand)
+{
+	_implicand = implicand;
+	if (_bodies.size() == 1)
+		_bodies.push_back(implicand);
+	else if (_bodies.size() == 2)
+		_bodies[1] = implicand;
+	else OC_ASSERT(false, "There must be a bug. "
+	               "Please always set the body before the implicand");
 }
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/pattern/BindLink.h
+++ b/opencog/atoms/pattern/BindLink.h
@@ -42,6 +42,9 @@ protected:
 	// will initialize the rewrite term _implicand.
 	void extract_variables(const HandleSeq& oset);
 
+	// Used to properly update the bodies of the underlying ScopeLink
+	void set_implicand(const Handle& implicand);
+
 	BindLink(Type, const HandleSeq&,
 	         TruthValuePtr tv = TruthValue::DEFAULT_TV(),
 	         AttentionValuePtr av = AttentionValue::DEFAULT_AV());

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -146,7 +146,7 @@ PatternLink::PatternLink(const Variables& vars, const Handle& body)
 	_pat.redex_name = "jit PatternLink";
 
 	_varlist = vars;
-	_body = body;
+	set_body(body);
 	unbundle_clauses(_body);
 	common_init();
 	setup_components();

--- a/tests/atoms/AlphaConvertUTest.cxxtest
+++ b/tests/atoms/AlphaConvertUTest.cxxtest
@@ -47,6 +47,7 @@ public:
 	void test_untyped_variable();
 	void test_variable();
 	void test_body();
+	void test_bodies();
 	void test_atomspace();
 };
 
@@ -173,7 +174,7 @@ void AlphaConvertUTest::test_variable()
 	logger().info("END TEST: %s", __FUNCTION__);
 }
 
-// Test AlphaConvert for differing bodies.
+// Test AlphaConvert for differing body.
 void AlphaConvertUTest::test_body()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
@@ -190,6 +191,35 @@ void AlphaConvertUTest::test_body()
 	Handle hscoy =
 	LB(SCOPE_LINK,
 		NB(VARIABLE_NODE, "$X"),
+		LB(OR_LINK, NB(VARIABLE_NODE, "$X")));
+
+	ScopeLinkPtr scoy(ScopeLinkCast(hscoy));
+
+	// x and y should be NOT equal
+	TS_ASSERT(not scox->is_equal(hscoy));
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// Test AlphaConvert for differing bodies.
+void AlphaConvertUTest::test_bodies()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Create ScopeLinks.
+	Handle hscox =
+	LA(BIND_LINK,
+		NA(VARIABLE_NODE, "$X"),
+		LA(AND_LINK, NA(VARIABLE_NODE, "$X")),
+		LA(AND_LINK, NA(VARIABLE_NODE, "$X")));
+
+	ScopeLinkPtr scox(ScopeLinkCast(hscox));
+	TS_ASSERT(scox != nullptr);
+
+	Handle hscoy =
+	LB(BIND_LINK,
+		NB(VARIABLE_NODE, "$X"),
+		LB(AND_LINK, NA(VARIABLE_NODE, "$X")),
 		LB(OR_LINK, NB(VARIABLE_NODE, "$X")));
 
 	ScopeLinkPtr scoy(ScopeLinkCast(hscoy));


### PR DESCRIPTION
Fix for #896 

It introduces a bit of memory overhead in the scope links (see `HandleSeq _bodies`). This overhead can be reduced by removing ScopeLink::_body, BindLink::_implicand, etc. But I've decided to let them here for now to ease the transition.