### PR TITLE
Alpha conversion

### DIFF
--- a/opencog/atoms/core/ScopeLink.cc
+++ b/opencog/atoms/core/ScopeLink.cc
@@ -166,7 +166,8 @@ bool ScopeLink::is_equal(const Handle& other) const
 	ScopeLinkPtr scother(ScopeLinkCast(other));
 
 	// Variable declarations must match.
-	if (not _varlist.is_equal(scother->_varlist)) return false;
+	if (scother == nullptr or not _varlist.is_equal(scother->_varlist))
+		return false;
 
 	// Other body, with our variables in place of its variables,
 	// should be same as our body.

--- a/opencog/atoms/core/ScopeLink.cc
+++ b/opencog/atoms/core/ScopeLink.cc
@@ -176,6 +176,12 @@ bool ScopeLink::is_equal(const Handle& other) const
 	return true;
 }
 
+Handle ScopeLink::alpha_conversion() const
+{
+	// TODO
+	return Handle::UNDEFINED;
+}
+
 bool ScopeLink::operator==(const Atom& ac) const
 {
 	Atom& a = (Atom&) ac; // cast away constness, for smart ptr.

--- a/opencog/atoms/core/ScopeLink.cc
+++ b/opencog/atoms/core/ScopeLink.cc
@@ -179,19 +179,26 @@ bool ScopeLink::is_equal(const Handle& other) const
 	return true;
 }
 
+inline std::string rand_hex_str()
+{
+	int rnd_id = randGen().randint();
+	std::stringstream ss;
+	ss << std::hex << rnd_id;
+	return ss.str();
+}
+
 Handle ScopeLink::alpha_conversion() const
 {
 	// Generate new variable names
 	HandleSeq new_vars;
 	for (const Handle& h : _varlist.varseq) {
-		int rnd_uuid = randGen().randint();
-		std::string new_var_name = h->getName() + "-" + std::to_string(rnd_uuid);
+		std::string new_var_name = h->getName() + "-" + rand_hex_str();
 		new_vars.emplace_back(createNode(VARIABLE_NODE, new_var_name));
 	}
 	HandleSeq hs;
 	for (size_t i = 0; i < getArity(); ++i)
 		hs.push_back(_varlist.substitute_nocheck(getOutgoingAtom(i),
-		                                         _varlist.varseq));
+		                                         new_vars));
 	return Handle(createLink(getType(), hs));
 }
 

--- a/opencog/atoms/core/ScopeLink.cc
+++ b/opencog/atoms/core/ScopeLink.cc
@@ -205,7 +205,7 @@ Handle ScopeLink::alpha_conversion() const
 	for (size_t i = 0; i < getArity(); ++i)
 		hs.push_back(_varlist.substitute_nocheck(getOutgoingAtom(i),
 		                                         new_vars));
-	return Handle(createLink(getType(), hs));
+	return Handle(factory(getType(), hs));
 }
 
 bool ScopeLink::operator==(const Atom& ac) const

--- a/opencog/atoms/core/ScopeLink.cc
+++ b/opencog/atoms/core/ScopeLink.cc
@@ -28,6 +28,11 @@
 #include <opencog/atoms/TypeNode.h>
 #include <opencog/atoms/core/FreeLink.h>
 #include <opencog/atoms/core/LambdaLink.h>
+#include <opencog/atoms/core/PutLink.h>
+#include <opencog/atoms/core/ImplicationLink.h>
+#include <opencog/atoms/pattern/PatternLink.h>
+#include <opencog/atoms/pattern/DualLink.h>
+#include <opencog/atoms/pattern/BindLink.h>
 
 #include "ScopeLink.h"
 
@@ -212,6 +217,39 @@ bool ScopeLink::operator==(const Atom& ac) const
 bool ScopeLink::operator!=(const Atom& a) const
 {
 	return not operator==(a);
+}
+
+ScopeLinkPtr ScopeLink::factory(const Handle& h)
+{
+	return factory(h->getType(), h->getOutgoingSet());
+}
+
+ScopeLinkPtr ScopeLink::factory(Type t, const HandleSeq& seq)
+{
+	if (SCOPE_LINK == t)
+		return createScopeLink(seq);
+
+	if (PUT_LINK == t)
+		return createPutLink(seq);
+
+	if (LAMBDA_LINK == t)
+		return createLambdaLink(seq);
+
+	if (IMPLICATION_LINK == t)
+		return createImplicationLink(seq);
+
+	if (PATTERN_LINK == t)
+		return createPatternLink(seq);
+
+	if (DUAL_LINK == t)
+		return createDualLink(seq);
+
+	if (BIND_LINK == t)
+		return createBindLink(seq);
+
+	throw SyntaxException(TRACE_INFO,
+		"ScopeLink is not a factory for %s",
+		classserver().getTypeName(t).c_str());
 }
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/core/ScopeLink.cc
+++ b/opencog/atoms/core/ScopeLink.cc
@@ -21,6 +21,9 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <string>
+
+#include <opencog/util/mt19937ar.h>
 #include <opencog/atoms/base/ClassServer.h>
 #include <opencog/atoms/TypeNode.h>
 #include <opencog/atoms/core/FreeLink.h>
@@ -178,8 +181,18 @@ bool ScopeLink::is_equal(const Handle& other) const
 
 Handle ScopeLink::alpha_conversion() const
 {
-	// TODO
-	return Handle::UNDEFINED;
+	// Generate new variable names
+	HandleSeq new_vars;
+	for (const Handle& h : _varlist.varseq) {
+		int rnd_uuid = randGen().randint();
+		std::string new_var_name = h->getName() + "-" + std::to_string(rnd_uuid);
+		new_vars.emplace_back(createNode(VARIABLE_NODE, new_var_name));
+	}
+	HandleSeq hs;
+	for (size_t i = 0; i < getArity(); ++i)
+		hs.push_back(_varlist.substitute_nocheck(getOutgoingAtom(i),
+		                                         _varlist.varseq));
+	return Handle(createLink(getType(), hs));
 }
 
 bool ScopeLink::operator==(const Atom& ac) const

--- a/opencog/atoms/core/ScopeLink.h
+++ b/opencog/atoms/core/ScopeLink.h
@@ -95,6 +95,11 @@ public:
 	// up to a renaming of the bound variables.
 	bool is_equal(const Handle&) const;
 
+	// Return an alpha converted copy of the given handle. The new
+	// variables names correspond to the old names appened with a
+	// random string.
+	Handle alpha_conversion() const;
+
 	// Overload equality check!
 	virtual bool operator==(const Atom&) const;
 	virtual bool operator!=(const Atom&) const;

--- a/opencog/atoms/core/ScopeLink.h
+++ b/opencog/atoms/core/ScopeLink.h
@@ -45,6 +45,8 @@ namespace opencog
 /// the point of unpacked variables is to act as a memo or cache,
 /// speeding up later calculations.
 ///
+class ScopeLink;
+typedef std::shared_ptr<ScopeLink> ScopeLinkPtr;
 class ScopeLink : public Link
 {
 protected:
@@ -103,9 +105,11 @@ public:
 	// Overload equality check!
 	virtual bool operator==(const Atom&) const;
 	virtual bool operator!=(const Atom&) const;
+
+	static ScopeLinkPtr factory(const Handle&);
+	static ScopeLinkPtr factory(Type, const HandleSeq&);
 };
 
-typedef std::shared_ptr<ScopeLink> ScopeLinkPtr;
 static inline ScopeLinkPtr ScopeLinkCast(const Handle& h)
 	{ return std::dynamic_pointer_cast<ScopeLink>(AtomCast(h)); }
 static inline ScopeLinkPtr ScopeLinkCast(const AtomPtr& a)

--- a/opencog/atoms/core/ScopeLink.h
+++ b/opencog/atoms/core/ScopeLink.h
@@ -96,7 +96,7 @@ public:
 	bool is_equal(const Handle&) const;
 
 	// Return an alpha converted copy of the given handle. The new
-	// variables names correspond to the old names appened with a
+	// variables names correspond to the old names appended with a
 	// random string.
 	Handle alpha_conversion() const;
 

--- a/tests/atoms/AlphaConvertUTest.cxxtest
+++ b/tests/atoms/AlphaConvertUTest.cxxtest
@@ -48,6 +48,7 @@ public:
 	void test_variable();
 	void test_body();
 	void test_atomspace();
+	void test_alpha_conversion();
 };
 
 #define NA _asa.add_node
@@ -253,6 +254,24 @@ void AlphaConvertUTest::test_atomspace()
 	// x and t should be equal
 	TS_ASSERT(scox->is_equal(hscot));
 #endif
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// Test ScopeLink::alpha_conversion
+void AlphaConvertUTest::test_alpha_conversion()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Test simple ScopeLink
+	Handle hsc =
+	LA(SCOPE_LINK,
+		NA(VARIABLE_NODE, "$X"),
+		LA(AND_LINK, NA(VARIABLE_NODE, "$X")));
+
+	ScopeLinkPtr sc(ScopeLinkCast(hsc));
+	Handle scac = sc->alpha_conversion();
+	TS_ASSERT(sc->is_equal(scac));
 
 	logger().info("END TEST: %s", __FUNCTION__);
 }


### PR DESCRIPTION
@linas please have a look at this PR.

It implements `ScopeLink::alpha_conversion` that performs alpha-conversion with randomly generated new variables (maybe I should name it `rand_alpha_conversion`).

You may look in particular at `ScopeLink::factory`. I'm a bit unconfident about it as it's somewhat redundant with `AtomTable::factory` and I'm not sure how all this is supposed to work together. I would say perhaps `AtomTable::factory` could be decomposed into `FunctionLink::factory`, `ScopeLink::factory`, etc, but I'm really not sure, and it's another issue anyway, if it is at all.