### PR TITLE
gcc5 in ubuntu xenial requires the --no-as-needed flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,10 @@ IF (CMAKE_COMPILER_IS_GNUCXX)
 		# SET(CMAKE_C_FLAGS "-Wl,--copy-dt-needed-entries")
 		SET(CMAKE_C_FLAGS_DEBUG "-ggdb3 -fstack-protector")
 		SET(CMAKE_C_FLAGS_PROFILE "-O2 -g3 -fstack-protector -pg")
-		SET(CMAKE_C_FLAGS_RELEASE "-O3 -g -fstack-protector -flto")
+		# -flto is good for performance, but wow is it slow to link...
+		# XXX disable for now ... its just to painful, in daily life.
+		# SET(CMAKE_C_FLAGS_RELEASE "-O3 -g -fstack-protector -flto")
+		SET(CMAKE_C_FLAGS_RELEASE "-O3 -g -fstack-protector")
 		LINK_LIBRARIES(pthread)
 
 		# Workaround for circular dependencies problem. This causes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,8 +82,8 @@ IF (CMAKE_COMPILER_IS_GNUCXX)
 		SET(CMAKE_C_FLAGS_PROFILE "-O2 -g3 -fstack-protector -pg")
 		# -flto is good for performance, but wow is it slow to link...
 		# XXX disable for now ... its just to painful, in daily life.
-		# SET(CMAKE_C_FLAGS_RELEASE "-O3 -g -fstack-protector -flto")
-		SET(CMAKE_C_FLAGS_RELEASE "-O3 -g -fstack-protector")
+		# SET(CMAKE_C_FLAGS_RELEASE "-O3 -g -fstack-protector")
+		SET(CMAKE_C_FLAGS_RELEASE "-O3 -g -fstack-protector -flto")
 		LINK_LIBRARIES(pthread)
 
 		# Workaround for circular dependencies problem. This causes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,8 +100,8 @@ IF (CMAKE_COMPILER_IS_GNUCXX)
 	#
 	# 2) -fopenmp for multithreading support
 	#
-	# 3) -std=gnu++0x for C++0x and GNU extensions support
-	SET(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -Wno-variadic-macros -fopenmp -std=gnu++0x")
+	# 3) -std=gnu++11 for C++11 and GNU extensions support
+	SET(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -Wno-variadic-macros -fopenmp -std=gnu++11")
 
 	SET(CMAKE_CXX_FLAGS_DEBUG ${CMAKE_C_FLAGS_DEBUG})
 	SET(CMAKE_CXX_FLAGS_PROFILE ${CMAKE_C_FLAGS_PROFILE})

--- a/opencog/atomspace/CMakeLists.txt
+++ b/opencog/atomspace/CMakeLists.txt
@@ -24,11 +24,13 @@ ADD_LIBRARY (atomspace
 ADD_DEPENDENCIES(atomspace opencog_atom_types)
 
 TARGET_LINK_LIBRARIES(atomspace
+	-Wl,--no-as-needed
 	atomcore
 	lambda
 	clearbox
+	atomutils
 	atombase
-	truthvalue  
+	truthvalue
 	${COGUTIL_LIBRARY}
 	${Boost_THREAD_LIBRARY}
 )


### PR DESCRIPTION
The default behavior for gcc5 changed, we need this flag, now.