### PR TITLE
Revert "Add utest failing ScopeLink::is_equal"

### DIFF
--- a/tests/atoms/AlphaConvertUTest.cxxtest
+++ b/tests/atoms/AlphaConvertUTest.cxxtest
@@ -44,17 +44,16 @@ public:
 
 	void tearDown() {}
 
-	// void test_untyped_variable();
-	// void test_variable();
-	// void test_body();
-	// void test_atomspace();
-	// void test_bindlink();
-	// void test_rand_alpha_conversion();
-	// void test_names_alpha_conversion();
-	// void test_vardecl_alpha_conversion();
-	// void test_vardecl_bindlink_alpha_conversion();
-	// void test_values_alpha_conversion();
-	void test_unordered();
+	void test_untyped_variable();
+	void test_variable();
+	void test_body();
+	void test_atomspace();
+	void test_bindlink();
+	void test_rand_alpha_conversion();
+	void test_names_alpha_conversion();
+	void test_vardecl_alpha_conversion();
+	void test_vardecl_bindlink_alpha_conversion();
+	void test_values_alpha_conversion();
 };
 
 #define NA _asa.add_node
@@ -63,402 +62,366 @@ public:
 #define NB _asb.add_node
 #define LB _asb.add_link
 
-// // Test AlphaConvert over an untyped variable.
-// void AlphaConvertUTest::test_untyped_variable()
-// {
-// 	logger().info("BEGIN TEST: %s", __FUNCTION__);
-
-// 	// Create ScopeLinks.
-// 	Handle hscox =
-// 	LA(SCOPE_LINK,
-// 		NA(VARIABLE_NODE, "$X"),
-// 		LA(AND_LINK, NA(VARIABLE_NODE, "$X")));
-
-// 	ScopeLinkPtr scox(ScopeLinkCast(hscox));
-// 	TS_ASSERT(scox != nullptr);
-
-// 	Handle hscoy =
-// 	LB(SCOPE_LINK,
-// 		NB(VARIABLE_NODE, "$Y"),
-// 		LB(AND_LINK, NB(VARIABLE_NODE, "$Y")));
-
-// 	ScopeLinkPtr scoy(ScopeLinkCast(hscoy));
-
-// 	// x and y should be equal
-// 	TS_ASSERT(scox->is_equal(hscoy));
-
-// 	_asb.clear();
-// 	Handle hscoz =
-// 	LB(SCOPE_LINK,
-// 		LB(VARIABLE_LIST, NB(VARIABLE_NODE, "$Z")),
-// 		LB(AND_LINK, NB(VARIABLE_NODE, "$Z")));
-
-// 	// x and z should be equal
-// 	TS_ASSERT(scox->is_equal(hscoz));
-
-// 	// Constraining something to be "type Atom" is not a constraint.
-// 	_asb.clear();
-// 	Handle hscow =
-// 	LB(SCOPE_LINK,
-// 		LB(TYPED_VARIABLE_LINK,
-// 			NB(VARIABLE_NODE, "$W"), NB(TYPE_NODE, "Atom")),
-// 		LB(AND_LINK, NB(VARIABLE_NODE, "$W")));
-
-// 	// x and w should be equal
-// 	TS_ASSERT(scox->is_equal(hscow));
-
-// 	_asb.clear();
-// 	Handle hscot =
-// 	LB(SCOPE_LINK,
-// 		LB(TYPED_VARIABLE_LINK,
-// 			NB(VARIABLE_NODE, "$T"),
-// 			LB(TYPE_CHOICE, NB(TYPE_NODE, "Atom"))),
-// 		LB(AND_LINK, NB(VARIABLE_NODE, "$T")));
-
-// 	// x and t should be equal
-// 	TS_ASSERT(scox->is_equal(hscot));
-
-// 	logger().info("END TEST: %s", __FUNCTION__);
-// }
-
-// // Test AlphaConvert over an variable types as ConceptNode.
-// void AlphaConvertUTest::test_variable()
-// {
-// 	logger().info("BEGIN TEST: %s", __FUNCTION__);
-
-// 	// Create ScopeLinks.
-// 	Handle hscox =
-// 	LA(SCOPE_LINK,
-// 		LA(TYPED_VARIABLE_LINK,
-// 			NA(VARIABLE_NODE, "$X"), NA(TYPE_NODE, "ConceptNode")),
-// 		LA(AND_LINK, NA(VARIABLE_NODE, "$X")));
-
-// 	ScopeLinkPtr scox(ScopeLinkCast(hscox));
-// 	TS_ASSERT(scox != nullptr);
-
-// 	Handle hscoy =
-// 	LB(SCOPE_LINK,
-// 		NB(VARIABLE_NODE, "$Y"),
-// 		LB(AND_LINK, NB(VARIABLE_NODE, "$Y")));
-
-// 	ScopeLinkPtr scoy(ScopeLinkCast(hscoy));
-
-// 	// x and y should be not equal
-// 	TS_ASSERT(not scox->is_equal(hscoy));
-
-// 	_asb.clear();
-// 	Handle hscoz =
-// 	LB(SCOPE_LINK,
-// 		LB(VARIABLE_LIST, NB(VARIABLE_NODE, "$Z")),
-// 		LB(AND_LINK, NB(VARIABLE_NODE, "$Z")));
-
-// 	// x and z should be not equal
-// 	TS_ASSERT(not scox->is_equal(hscoz));
-
-// 	// Constraining should work.
-// 	_asb.clear();
-// 	Handle hscow =
-// 	LB(SCOPE_LINK,
-// 		LB(TYPED_VARIABLE_LINK,
-// 			NB(VARIABLE_NODE, "$W"), NB(TYPE_NODE, "ConceptNode")),
-// 		LB(AND_LINK, NB(VARIABLE_NODE, "$W")));
-
-// 	// x and w should be equal
-// 	TS_ASSERT(scox->is_equal(hscow));
-
-// 	_asb.clear();
-// 	Handle hscot =
-// 	LB(SCOPE_LINK,
-// 		LB(TYPED_VARIABLE_LINK,
-// 			NB(VARIABLE_NODE, "$T"),
-// 			LB(TYPE_CHOICE, NB(TYPE_NODE, "Atom"), NB(TYPE_NODE, "ConceptNode"))),
-// 		LB(AND_LINK, NB(VARIABLE_NODE, "$T")));
-
-// 	// x and t should be equal
-// 	TS_ASSERT(scox->is_equal(hscot));
-
-// 	logger().info("END TEST: %s", __FUNCTION__);
-// }
-
-// // Test AlphaConvert for differing bodies.
-// void AlphaConvertUTest::test_body()
-// {
-// 	logger().info("BEGIN TEST: %s", __FUNCTION__);
-
-// 	// Create ScopeLinks.
-// 	Handle hscox =
-// 	LA(SCOPE_LINK,
-// 		NA(VARIABLE_NODE, "$X"),
-// 		LA(AND_LINK, NA(VARIABLE_NODE, "$X")));
-
-// 	ScopeLinkPtr scox(ScopeLinkCast(hscox));
-// 	TS_ASSERT(scox != nullptr);
-
-// 	Handle hscoy =
-// 	LB(SCOPE_LINK,
-// 		NB(VARIABLE_NODE, "$X"),
-// 		LB(OR_LINK, NB(VARIABLE_NODE, "$X")));
-
-// 	ScopeLinkPtr scoy(ScopeLinkCast(hscoy));
-
-// 	// x and y should be NOT equal
-// 	TS_ASSERT(not scox->is_equal(hscoy));
-
-// 	logger().info("END TEST: %s", __FUNCTION__);
-// }
-
-// // Test alpha conversion in the atomspace.
-// void AlphaConvertUTest::test_atomspace()
-// {
-// 	logger().info("BEGIN TEST: %s", __FUNCTION__);
-
-// 	// Create ScopeLinks.
-// 	Handle hscox =
-// 	LA(SCOPE_LINK,
-// 		NA(VARIABLE_NODE, "$X"),
-// 		LA(AND_LINK, NA(VARIABLE_NODE, "$X")));
-
-// 	Handle hscoy =
-// 	LA(SCOPE_LINK,
-// 		NA(VARIABLE_NODE, "$Y"),
-// 		LA(AND_LINK, NA(VARIABLE_NODE, "$Y")));
-
-// 	// x and y should be equal
-// 	// TS_ASSERT(hscox == hscoy);
-
-// 	printf("Expecting same atom: x=%s vs y=%s\n",
-// 		hscox->toString().c_str(), hscoy->toString().c_str());
-
-// #if 0
-// 	Handle hscoz =
-// 	LA(SCOPE_LINK,
-// 		LA(VARIABLE_LIST, NA(VARIABLE_NODE, "$Z")),
-// 		LA(AND_LINK, NA(VARIABLE_NODE, "$Z")));
-
-// 	// x and z should be equal
-// 	TS_ASSERT(scox->is_equal(hscoz));
-
-// 	// Constraining something to be "type Atom" is not a constraint.
-// 	_asb.clear();
-// 	Handle hscow =
-// 	LA(SCOPE_LINK,
-// 		LA(TYPED_VARIABLE_LINK,
-// 			NA(VARIABLE_NODE, "$W"), NA(TYPE_NODE, "Atom")),
-// 		LA(AND_LINK, NA(VARIABLE_NODE, "$W")));
-
-// 	// x and w should be equal
-// 	TS_ASSERT(scox->is_equal(hscow));
-
-// 	_asb.clear();
-// 	Handle hscot =
-// 	LA(SCOPE_LINK,
-// 		LA(TYPED_VARIABLE_LINK,
-// 			NA(VARIABLE_NODE, "$T"),
-// 			LA(TYPE_CHOICE, NA(TYPE_NODE, "Atom"))),
-// 		LA(AND_LINK, NA(VARIABLE_NODE, "$T")));
-
-// 	// x and t should be equal
-// 	TS_ASSERT(scox->is_equal(hscot));
-// #endif
-
-// 	logger().info("END TEST: %s", __FUNCTION__);
-// }
-
-// // Test is_equal for BindLink.
-// void AlphaConvertUTest::test_bindlink()
-// {
-// 	logger().info("BEGIN TEST: %s", __FUNCTION__);
-
-// 	// Create BindLink
-// 	Handle hscox =
-// 	LA(BIND_LINK,
-// 		NA(VARIABLE_NODE, "$X"),
-// 		LA(OR_LINK, NA(VARIABLE_NODE, "$X")),
-// 		LA(AND_LINK, NA(VARIABLE_NODE, "$X")));
-
-// 	ScopeLinkPtr scox(ScopeLinkCast(hscox));
-// 	TS_ASSERT(scox != nullptr);
-
-// 	_asb.clear();
-// 	Handle hscoy =
-// 	LB(BIND_LINK,
-// 		NB(VARIABLE_NODE, "$X"),
-// 		LB(OR_LINK, NB(VARIABLE_NODE, "$X")),
-// 		LB(AND_LINK, NB(VARIABLE_NODE, "$X")));
-
-// 	// x and y should be equal
-// 	TS_ASSERT(scox->is_equal(hscoy));
-
-// 	_asb.clear();
-// 	hscoy =
-// 	LB(BIND_LINK,
-// 		LB(OR_LINK, NB(VARIABLE_NODE, "$X")),
-// 		LB(AND_LINK, NB(VARIABLE_NODE, "$X")));
-
-// 	// x and y should be equal
-// 	TS_ASSERT(scox->is_equal(hscoy));
-
-// 	_asb.clear();
-// 	hscoy =
-// 	LB(BIND_LINK,
-// 		NB(VARIABLE_NODE, "$X"),
-// 		LB(OR_LINK, NA(VARIABLE_NODE, "$X")),
-// 		LB(OR_LINK, NB(VARIABLE_NODE, "$X")));
-
-// 	// x and y should be NOT equal because their implicants are not
-// 	// alpha-equivalent.
-// 	TS_ASSERT(not scox->is_equal(hscoy));
-
-// 	logger().info("END TEST: %s", __FUNCTION__);
-// }
-
-// // Test ScopeLink::alpha_conversion with no arguments
-// void AlphaConvertUTest::test_rand_alpha_conversion()
-// {
-// 	logger().info("BEGIN TEST: %s", __FUNCTION__);
-
-// 	// Test simple ScopeLink
-// 	Handle hsc =
-// 	LA(SCOPE_LINK,
-// 		NA(VARIABLE_NODE, "$X"),
-// 		LA(AND_LINK, NA(VARIABLE_NODE, "$X")));
-
-// 	ScopeLinkPtr sc(ScopeLinkCast(hsc));
-// 	Handle scac = sc->alpha_conversion();
-// 	TS_ASSERT(sc->is_equal(scac));
-
-// 	logger().info("END TEST: %s", __FUNCTION__);
-// }
-
-// // Test ScopeLink::alpha_conversion with provided variable names
-// void AlphaConvertUTest::test_names_alpha_conversion()
-// {
-// 	logger().info("BEGIN TEST: %s", __FUNCTION__);
-
-// 	// Test simple ScopeLink
-// 	Handle X = NA(VARIABLE_NODE, "$X"),
-// 		Y = NA(VARIABLE_NODE, "$Y"),
-// 		hsc = LA(SCOPE_LINK, X, LA(AND_LINK, X)),
-// 		expected = LA(SCOPE_LINK, Y, LA(AND_LINK, Y));
-
-// 	ScopeLinkPtr sc(ScopeLinkCast(hsc));
-// 	Handle result = _asa.add_atom(sc->alpha_conversion({Y}));
-
-// 	std::cout << "result = " << oc_to_string(result);
-// 	std::cout << "expected = " << oc_to_string(expected);
-
-// 	TS_ASSERT_EQUALS(result, expected);
-
-// 	logger().info("END TEST: %s", __FUNCTION__);
-// }
-
-// // Test ScopeLink::alpha_conversion with provided variable names and vardecl
-// void AlphaConvertUTest::test_vardecl_alpha_conversion()
-// {
-// 	logger().info("BEGIN TEST: %s", __FUNCTION__);
-
-// 	// Test simple ScopeLink
-// 	Handle X = NA(VARIABLE_NODE, "$X"),
-// 		Y = NA(VARIABLE_NODE, "$Y"),
-// 		CT = NA(TYPE_NODE, "ConceptNode"),
-// 		Y_vardecl = LA(TYPED_VARIABLE_LINK, Y, CT),
-// 		hsc = LA(SCOPE_LINK, X, LA(AND_LINK, X)),
-// 		expected = LA(SCOPE_LINK, Y_vardecl, LA(AND_LINK, Y));
-
-// 	ScopeLinkPtr sc(ScopeLinkCast(hsc));
-// 	Handle result = _asa.add_atom(sc->alpha_conversion({Y}, Y_vardecl));
-
-// 	std::cout << "result = " << oc_to_string(result);
-// 	std::cout << "expected = " << oc_to_string(expected);
-
-// 	TS_ASSERT_EQUALS(result, expected);
-
-// 	logger().info("END TEST: %s", __FUNCTION__);
-// }
-
-// // Like test_vardecl_bindlink_alpha_conversion but using a BindLink
-// // instead of a ScopeLink
-// void AlphaConvertUTest::test_vardecl_bindlink_alpha_conversion()
-// {
-// 	logger().info("BEGIN TEST: %s", __FUNCTION__);
-
-// 	// Test simple ScopeLink
-// 	Handle X = NA(VARIABLE_NODE, "$X"),
-// 		Y = NA(VARIABLE_NODE, "$Y"),
-// 		CT = NA(TYPE_NODE, "ConceptNode"),
-// 		Y_vardecl = LA(TYPED_VARIABLE_LINK, Y, CT),
-// 		hsc = LA(BIND_LINK, LA(AND_LINK, X), LA(OR_LINK, X)),
-// 		expected = LA(BIND_LINK, Y_vardecl,
-// 		              LA(AND_LINK, Y), LA(OR_LINK, Y));
-
-// 	ScopeLinkPtr sc(ScopeLinkCast(hsc));
-// 	Handle result = _asa.add_atom(sc->alpha_conversion({Y}, Y_vardecl));
-
-// 	std::cout << "result = " << oc_to_string(result);
-// 	std::cout << "expected = " << oc_to_string(expected);
-
-// 	TS_ASSERT_EQUALS(result, expected);
-
-// 	logger().info("END TEST: %s", __FUNCTION__);
-// }
-
-// // Test ScopeLink::alpha_conversion with provided values instead of variable
-// void AlphaConvertUTest::test_values_alpha_conversion()
-// {
-// 	logger().info("BEGIN TEST: %s", __FUNCTION__);
-
-// 	// Test simple ScopeLink
-// 	Handle X = NA(VARIABLE_NODE, "$X"),
-// 		Y = NA(VARIABLE_NODE, "$Y"),
-// 		A = NA(CONCEPT_NODE, "A"),
-// 		CT = NA(TYPE_NODE, "ConceptNode"),
-// 		Y_vardecl = LA(TYPED_VARIABLE_LINK, Y, CT),
-// 		hsc = LA(SCOPE_LINK, X, LA(AND_LINK, X)),
-// 		expected = LA(SCOPE_LINK, LA(AND_LINK, A));
-
-// 	ScopeLinkPtr sc(ScopeLinkCast(hsc));
-// 	Handle result = _asa.add_atom(sc->alpha_conversion({A}, Y_vardecl));
-
-// 	std::cout << "result = " << oc_to_string(result);
-// 	std::cout << "expected = " << oc_to_string(expected);
-
-// 	TS_ASSERT_EQUALS(result, expected);
-
-// 	logger().info("END TEST: %s", __FUNCTION__);
-// }
-
-// Test ScopeLink::is_equal with undordered links
-void AlphaConvertUTest::test_unordered()
+// Test AlphaConvert over an untyped variable.
+void AlphaConvertUTest::test_untyped_variable()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
-	Handle
-		X = NA(VARIABLE_NODE, "$X"),
+	// Create ScopeLinks.
+	Handle hscox =
+	LA(SCOPE_LINK,
+		NA(VARIABLE_NODE, "$X"),
+		LA(AND_LINK, NA(VARIABLE_NODE, "$X")));
+
+	ScopeLinkPtr scox(ScopeLinkCast(hscox));
+	TS_ASSERT(scox != nullptr);
+
+	Handle hscoy =
+	LB(SCOPE_LINK,
+		NB(VARIABLE_NODE, "$Y"),
+		LB(AND_LINK, NB(VARIABLE_NODE, "$Y")));
+
+	ScopeLinkPtr scoy(ScopeLinkCast(hscoy));
+
+	// x and y should be equal
+	TS_ASSERT(scox->is_equal(hscoy));
+
+	_asb.clear();
+	Handle hscoz =
+	LB(SCOPE_LINK,
+		LB(VARIABLE_LIST, NB(VARIABLE_NODE, "$Z")),
+		LB(AND_LINK, NB(VARIABLE_NODE, "$Z")));
+
+	// x and z should be equal
+	TS_ASSERT(scox->is_equal(hscoz));
+
+	// Constraining something to be "type Atom" is not a constraint.
+	_asb.clear();
+	Handle hscow =
+	LB(SCOPE_LINK,
+		LB(TYPED_VARIABLE_LINK,
+			NB(VARIABLE_NODE, "$W"), NB(TYPE_NODE, "Atom")),
+		LB(AND_LINK, NB(VARIABLE_NODE, "$W")));
+
+	// x and w should be equal
+	TS_ASSERT(scox->is_equal(hscow));
+
+	_asb.clear();
+	Handle hscot =
+	LB(SCOPE_LINK,
+		LB(TYPED_VARIABLE_LINK,
+			NB(VARIABLE_NODE, "$T"),
+			LB(TYPE_CHOICE, NB(TYPE_NODE, "Atom"))),
+		LB(AND_LINK, NB(VARIABLE_NODE, "$T")));
+
+	// x and t should be equal
+	TS_ASSERT(scox->is_equal(hscot));
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// Test AlphaConvert over an variable types as ConceptNode.
+void AlphaConvertUTest::test_variable()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Create ScopeLinks.
+	Handle hscox =
+	LA(SCOPE_LINK,
+		LA(TYPED_VARIABLE_LINK,
+			NA(VARIABLE_NODE, "$X"), NA(TYPE_NODE, "ConceptNode")),
+		LA(AND_LINK, NA(VARIABLE_NODE, "$X")));
+
+	ScopeLinkPtr scox(ScopeLinkCast(hscox));
+	TS_ASSERT(scox != nullptr);
+
+	Handle hscoy =
+	LB(SCOPE_LINK,
+		NB(VARIABLE_NODE, "$Y"),
+		LB(AND_LINK, NB(VARIABLE_NODE, "$Y")));
+
+	ScopeLinkPtr scoy(ScopeLinkCast(hscoy));
+
+	// x and y should be not equal
+	TS_ASSERT(not scox->is_equal(hscoy));
+
+	_asb.clear();
+	Handle hscoz =
+	LB(SCOPE_LINK,
+		LB(VARIABLE_LIST, NB(VARIABLE_NODE, "$Z")),
+		LB(AND_LINK, NB(VARIABLE_NODE, "$Z")));
+
+	// x and z should be not equal
+	TS_ASSERT(not scox->is_equal(hscoz));
+
+	// Constraining should work.
+	_asb.clear();
+	Handle hscow =
+	LB(SCOPE_LINK,
+		LB(TYPED_VARIABLE_LINK,
+			NB(VARIABLE_NODE, "$W"), NB(TYPE_NODE, "ConceptNode")),
+		LB(AND_LINK, NB(VARIABLE_NODE, "$W")));
+
+	// x and w should be equal
+	TS_ASSERT(scox->is_equal(hscow));
+
+	_asb.clear();
+	Handle hscot =
+	LB(SCOPE_LINK,
+		LB(TYPED_VARIABLE_LINK,
+			NB(VARIABLE_NODE, "$T"),
+			LB(TYPE_CHOICE, NB(TYPE_NODE, "Atom"), NB(TYPE_NODE, "ConceptNode"))),
+		LB(AND_LINK, NB(VARIABLE_NODE, "$T")));
+
+	// x and t should be equal
+	TS_ASSERT(scox->is_equal(hscot));
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// Test AlphaConvert for differing bodies.
+void AlphaConvertUTest::test_body()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Create ScopeLinks.
+	Handle hscox =
+	LA(SCOPE_LINK,
+		NA(VARIABLE_NODE, "$X"),
+		LA(AND_LINK, NA(VARIABLE_NODE, "$X")));
+
+	ScopeLinkPtr scox(ScopeLinkCast(hscox));
+	TS_ASSERT(scox != nullptr);
+
+	Handle hscoy =
+	LB(SCOPE_LINK,
+		NB(VARIABLE_NODE, "$X"),
+		LB(OR_LINK, NB(VARIABLE_NODE, "$X")));
+
+	ScopeLinkPtr scoy(ScopeLinkCast(hscoy));
+
+	// x and y should be NOT equal
+	TS_ASSERT(not scox->is_equal(hscoy));
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// Test alpha conversion in the atomspace.
+void AlphaConvertUTest::test_atomspace()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Create ScopeLinks.
+	Handle hscox =
+	LA(SCOPE_LINK,
+		NA(VARIABLE_NODE, "$X"),
+		LA(AND_LINK, NA(VARIABLE_NODE, "$X")));
+
+	Handle hscoy =
+	LA(SCOPE_LINK,
+		NA(VARIABLE_NODE, "$Y"),
+		LA(AND_LINK, NA(VARIABLE_NODE, "$Y")));
+
+	// x and y should be equal
+	// TS_ASSERT(hscox == hscoy);
+
+	printf("Expecting same atom: x=%s vs y=%s\n",
+		hscox->toString().c_str(), hscoy->toString().c_str());
+
+#if 0
+	Handle hscoz =
+	LA(SCOPE_LINK,
+		LA(VARIABLE_LIST, NA(VARIABLE_NODE, "$Z")),
+		LA(AND_LINK, NA(VARIABLE_NODE, "$Z")));
+
+	// x and z should be equal
+	TS_ASSERT(scox->is_equal(hscoz));
+
+	// Constraining something to be "type Atom" is not a constraint.
+	_asb.clear();
+	Handle hscow =
+	LA(SCOPE_LINK,
+		LA(TYPED_VARIABLE_LINK,
+			NA(VARIABLE_NODE, "$W"), NA(TYPE_NODE, "Atom")),
+		LA(AND_LINK, NA(VARIABLE_NODE, "$W")));
+
+	// x and w should be equal
+	TS_ASSERT(scox->is_equal(hscow));
+
+	_asb.clear();
+	Handle hscot =
+	LA(SCOPE_LINK,
+		LA(TYPED_VARIABLE_LINK,
+			NA(VARIABLE_NODE, "$T"),
+			LA(TYPE_CHOICE, NA(TYPE_NODE, "Atom"))),
+		LA(AND_LINK, NA(VARIABLE_NODE, "$T")));
+
+	// x and t should be equal
+	TS_ASSERT(scox->is_equal(hscot));
+#endif
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// Test is_equal for BindLink.
+void AlphaConvertUTest::test_bindlink()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Create BindLink
+	Handle hscox =
+	LA(BIND_LINK,
+		NA(VARIABLE_NODE, "$X"),
+		LA(OR_LINK, NA(VARIABLE_NODE, "$X")),
+		LA(AND_LINK, NA(VARIABLE_NODE, "$X")));
+
+	ScopeLinkPtr scox(ScopeLinkCast(hscox));
+	TS_ASSERT(scox != nullptr);
+
+	_asb.clear();
+	Handle hscoy =
+	LB(BIND_LINK,
+		NB(VARIABLE_NODE, "$X"),
+		LB(OR_LINK, NB(VARIABLE_NODE, "$X")),
+		LB(AND_LINK, NB(VARIABLE_NODE, "$X")));
+
+	// x and y should be equal
+	TS_ASSERT(scox->is_equal(hscoy));
+
+	_asb.clear();
+	hscoy =
+	LB(BIND_LINK,
+		LB(OR_LINK, NB(VARIABLE_NODE, "$X")),
+		LB(AND_LINK, NB(VARIABLE_NODE, "$X")));
+
+	// x and y should be equal
+	TS_ASSERT(scox->is_equal(hscoy));
+
+	_asb.clear();
+	hscoy =
+	LB(BIND_LINK,
+		NB(VARIABLE_NODE, "$X"),
+		LB(OR_LINK, NA(VARIABLE_NODE, "$X")),
+		LB(OR_LINK, NB(VARIABLE_NODE, "$X")));
+
+	// x and y should be NOT equal because their implicants are not
+	// alpha-equivalent.
+	TS_ASSERT(not scox->is_equal(hscoy));
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// Test ScopeLink::alpha_conversion with no arguments
+void AlphaConvertUTest::test_rand_alpha_conversion()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Test simple ScopeLink
+	Handle hsc =
+	LA(SCOPE_LINK,
+		NA(VARIABLE_NODE, "$X"),
+		LA(AND_LINK, NA(VARIABLE_NODE, "$X")));
+
+	ScopeLinkPtr sc(ScopeLinkCast(hsc));
+	Handle scac = sc->alpha_conversion();
+	TS_ASSERT(sc->is_equal(scac));
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// Test ScopeLink::alpha_conversion with provided variable names
+void AlphaConvertUTest::test_names_alpha_conversion()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Test simple ScopeLink
+	Handle X = NA(VARIABLE_NODE, "$X"),
 		Y = NA(VARIABLE_NODE, "$Y"),
-		Z = NA(VARIABLE_NODE, "$Z"),
-		and1 = LA(AND_LINK, X, Y),
-		and2 = LA(AND_LINK, Z, Y),
-		vardecl = LA(VARIABLE_LIST, X, Y, Z),
-		body = LA(OR_LINK, and1, and2),
-		sc = LA(SCOPE_LINK, vardecl, body);
+		hsc = LA(SCOPE_LINK, X, LA(AND_LINK, X)),
+		expected = LA(SCOPE_LINK, Y, LA(AND_LINK, Y));
 
-	ScopeLinkPtr sc_p(ScopeLinkCast(sc));
-	TS_ASSERT(sc_p != nullptr);
+	ScopeLinkPtr sc(ScopeLinkCast(hsc));
+	Handle result = _asa.add_atom(sc->alpha_conversion({Y}));
 
-	Handle
-		alpha_X = NA(VARIABLE_NODE, "$X-alpha"),
-		alpha_Y = NA(VARIABLE_NODE, "$Y-alpha"),
-		alpha_Z = NA(VARIABLE_NODE, "$Z-alpha"),
-		alpha_and2 = LA(AND_LINK, alpha_Z, alpha_Y),
-		alpha_and1 = LA(AND_LINK, alpha_X, alpha_Y),
-		alpha_vardecl = LA(VARIABLE_LIST, alpha_X, alpha_Y, alpha_Z),
-		alpha_body = LA(OR_LINK, alpha_and1, alpha_and2),
-		alpha_sc = LA(SCOPE_LINK, alpha_vardecl, alpha_body);
+	std::cout << "result = " << oc_to_string(result);
+	std::cout << "expected = " << oc_to_string(expected);
 
-	std::cout << "sc = " << oc_to_string(sc);
-	std::cout << "alpha_sc = " << oc_to_string(alpha_sc);
-	
-	TS_ASSERT(sc_p->is_equal(alpha_sc));
+	TS_ASSERT_EQUALS(result, expected);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// Test ScopeLink::alpha_conversion with provided variable names and vardecl
+void AlphaConvertUTest::test_vardecl_alpha_conversion()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Test simple ScopeLink
+	Handle X = NA(VARIABLE_NODE, "$X"),
+		Y = NA(VARIABLE_NODE, "$Y"),
+		CT = NA(TYPE_NODE, "ConceptNode"),
+		Y_vardecl = LA(TYPED_VARIABLE_LINK, Y, CT),
+		hsc = LA(SCOPE_LINK, X, LA(AND_LINK, X)),
+		expected = LA(SCOPE_LINK, Y_vardecl, LA(AND_LINK, Y));
+
+	ScopeLinkPtr sc(ScopeLinkCast(hsc));
+	Handle result = _asa.add_atom(sc->alpha_conversion({Y}, Y_vardecl));
+
+	std::cout << "result = " << oc_to_string(result);
+	std::cout << "expected = " << oc_to_string(expected);
+
+	TS_ASSERT_EQUALS(result, expected);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// Like test_vardecl_bindlink_alpha_conversion but using a BindLink
+// instead of a ScopeLink
+void AlphaConvertUTest::test_vardecl_bindlink_alpha_conversion()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Test simple ScopeLink
+	Handle X = NA(VARIABLE_NODE, "$X"),
+		Y = NA(VARIABLE_NODE, "$Y"),
+		CT = NA(TYPE_NODE, "ConceptNode"),
+		Y_vardecl = LA(TYPED_VARIABLE_LINK, Y, CT),
+		hsc = LA(BIND_LINK, LA(AND_LINK, X), LA(OR_LINK, X)),
+		expected = LA(BIND_LINK, Y_vardecl,
+		              LA(AND_LINK, Y), LA(OR_LINK, Y));
+
+	ScopeLinkPtr sc(ScopeLinkCast(hsc));
+	Handle result = _asa.add_atom(sc->alpha_conversion({Y}, Y_vardecl));
+
+	std::cout << "result = " << oc_to_string(result);
+	std::cout << "expected = " << oc_to_string(expected);
+
+	TS_ASSERT_EQUALS(result, expected);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// Test ScopeLink::alpha_conversion with provided values instead of variable
+void AlphaConvertUTest::test_values_alpha_conversion()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Test simple ScopeLink
+	Handle X = NA(VARIABLE_NODE, "$X"),
+		Y = NA(VARIABLE_NODE, "$Y"),
+		A = NA(CONCEPT_NODE, "A"),
+		CT = NA(TYPE_NODE, "ConceptNode"),
+		Y_vardecl = LA(TYPED_VARIABLE_LINK, Y, CT),
+		hsc = LA(SCOPE_LINK, X, LA(AND_LINK, X)),
+		expected = LA(SCOPE_LINK, LA(AND_LINK, A));
+
+	ScopeLinkPtr sc(ScopeLinkCast(hsc));
+	Handle result = _asa.add_atom(sc->alpha_conversion({A}, Y_vardecl));
+
+	std::cout << "result = " << oc_to_string(result);
+	std::cout << "expected = " << oc_to_string(expected);
+
+	TS_ASSERT_EQUALS(result, expected);
 
 	logger().info("END TEST: %s", __FUNCTION__);
 }


### PR DESCRIPTION
Reverts opencog/atomspace#917

Forgot to re-enable the other tests...