### PR TITLE
Constify atomspace

### DIFF
--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -110,7 +110,7 @@ void Atom::setTruthValue(TruthValuePtr newTV)
     }
 }
 
-TruthValuePtr Atom::getTruthValue()
+TruthValuePtr Atom::getTruthValue() const
 {
     // OK. The atomic thread-safety of shared-pointers is subtle. See
     // http://www.boost.org/doc/libs/1_53_0/libs/smart_ptr/shared_ptr.htm#ThreadSafety

--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -152,7 +152,7 @@ void Atom::merge(TruthValuePtr tvn, const MergeCtrl& mc)
 
 // ==============================================================
 
-AttentionValuePtr Atom::getAttentionValue()
+AttentionValuePtr Atom::getAttentionValue() const
 {
     // OK. The atomic thread-safety of shared-pointers is subtle. See
     // http://www.boost.org/doc/libs/1_53_0/libs/smart_ptr/shared_ptr.htm#ThreadSafety

--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -317,7 +317,7 @@ void Atom::remove_atom(LinkPtr a)
     _incoming_set->_iset.erase(a);
 }
 
-size_t Atom::getIncomingSetSize()
+size_t Atom::getIncomingSetSize() const
 {
     if (NULL == _incoming_set) return 0;
     std::lock_guard<std::mutex> lck (_mtx);

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -223,7 +223,7 @@ public:
      * @return The pointer to the AttentionValue object
      * of the atom.
      */
-    AttentionValuePtr getAttentionValue();
+    AttentionValuePtr getAttentionValue() const;
 
     //! Sets the AttentionValue object of the atom.
     void setAttentionValue(AttentionValuePtr);

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -404,7 +404,7 @@ public:
      * @return A string representation of the node.
      * cannot be const, because observing the TV and AV requires a lock.
      */
-    virtual std::string toString(const std::string& indent) = 0;
+    virtual std::string toString(const std::string& indent) const = 0;
     virtual std::string toShortString(const std::string& indent) = 0;
 
     // Work around gdb's incapability to build a string on the fly,

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -229,17 +229,17 @@ public:
     void setAttentionValue(AttentionValuePtr);
 
     /// Handy-dandy convenience getters for attention values.
-    AttentionValue::sti_t getSTI()
+    AttentionValue::sti_t getSTI() const
     {
         return getAttentionValue()->getSTI();
     }
 
-    AttentionValue::lti_t getLTI()
+    AttentionValue::lti_t getLTI() const
     {
         return getAttentionValue()->getLTI();
     }
 
-    AttentionValue::vlti_t getVLTI()
+    AttentionValue::vlti_t getVLTI() const
     {
         return getAttentionValue()->getVLTI();
     }

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -405,7 +405,7 @@ public:
      * cannot be const, because observing the TV and AV requires a lock.
      */
     virtual std::string toString(const std::string& indent) const = 0;
-    virtual std::string toShortString(const std::string& indent) = 0;
+    virtual std::string toShortString(const std::string& indent) const = 0;
 
     // Work around gdb's incapability to build a string on the fly,
     // see http://stackoverflow.com/questions/16734783 for more

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -307,7 +307,7 @@ public:
     }
 
     //! Get the size of the incoming set.
-    size_t getIncomingSetSize();
+    size_t getIncomingSetSize() const;
 
     //! Return the incoming set of this atom.
     //! If the AtomSpace pointer is non-null, then only those atoms

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -107,7 +107,7 @@ protected:
     // but there seemed to be too much contention for it, so instead,
     // we are using a lock-per-atom, even though this makes the atom
     // kind-of fat.
-    std::mutex _mtx;
+    mutable std::mutex _mtx;
 
     /**
      * Constructor for this class. Protected; no user should call this
@@ -288,7 +288,7 @@ public:
      *
      * @return The const referent to the TruthValue object of the atom.
      */
-    TruthValuePtr getTruthValue();
+    TruthValuePtr getTruthValue() const;
 
     //! Sets the TruthValue object of the atom.
     void setTruthValue(TruthValuePtr);

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -410,8 +410,8 @@ public:
     // Work around gdb's incapability to build a string on the fly,
     // see http://stackoverflow.com/questions/16734783 for more
     // explanation.
-    std::string toString() { return toString(""); }
-    std::string toShortString() { return toShortString(""); }
+    std::string toString() const { return toString(""); }
+    std::string toShortString() const { return toShortString(""); }
 
     /** Returns whether two atoms are equal.
      *

--- a/opencog/atoms/base/FloatValue.cc
+++ b/opencog/atoms/base/FloatValue.cc
@@ -32,7 +32,7 @@ bool FloatValue::operator==(const ProtoAtom& other) const
 
 // ==============================================================
 
-std::string FloatValue::toString(const std::string& indent)
+std::string FloatValue::toString(const std::string& indent) const
 {
 	std::string rv = indent + "(FloatValue";
 	for (double v :_value)

--- a/opencog/atoms/base/FloatValue.h
+++ b/opencog/atoms/base/FloatValue.h
@@ -55,7 +55,7 @@ public:
 
 	/** Returns a string representation of the value.  */
 	virtual std::string toString(const std::string& indent) const;
-	virtual std::string toShortString(const std::string& indent)
+	virtual std::string toShortString(const std::string& indent) const
 	{ return toString(indent); }
 
 	/** Returns true if two atoms are equal.  */

--- a/opencog/atoms/base/FloatValue.h
+++ b/opencog/atoms/base/FloatValue.h
@@ -54,7 +54,7 @@ public:
 	void setValue(double v) { _value = std::vector<double>({v}); }
 
 	/** Returns a string representation of the value.  */
-	virtual std::string toString(const std::string& indent);
+	virtual std::string toString(const std::string& indent) const;
 	virtual std::string toShortString(const std::string& indent)
 	{ return toString(indent); }
 

--- a/opencog/atoms/base/Link.cc
+++ b/opencog/atoms/base/Link.cc
@@ -68,7 +68,7 @@ Link::~Link()
     DPRINTF("Deleting link:\n%s\n", this->toString().c_str());
 }
 
-std::string Link::toShortString(const std::string& indent)
+std::string Link::toShortString(const std::string& indent) const
 {
     std::stringstream answer;
     std::string more_indent = indent + "  ";

--- a/opencog/atoms/base/Link.cc
+++ b/opencog/atoms/base/Link.cc
@@ -97,7 +97,7 @@ std::string Link::toShortString(const std::string& indent)
     return answer.str();
 }
 
-std::string Link::toString(const std::string& indent)
+std::string Link::toString(const std::string& indent) const
 {
     std::string answer = indent;
     std::string more_indent = indent + "  ";

--- a/opencog/atoms/base/Link.h
+++ b/opencog/atoms/base/Link.h
@@ -205,7 +205,7 @@ public:
      *
      * @return A short string representation of the link.
      */
-    std::string toShortString(const std::string& indent);
+    std::string toShortString(const std::string& indent) const;
 
 	// Work around gdb's incapability to build a string on the fly,
 	// see http://stackoverflow.com/questions/16734783 and

--- a/opencog/atoms/base/Link.h
+++ b/opencog/atoms/base/Link.h
@@ -195,7 +195,7 @@ public:
      *
      * @return A string representation of the link.
      */
-    std::string toString(const std::string& indent);
+    std::string toString(const std::string& indent) const;
 
     /**
      * Returns a short string representation of the link.

--- a/opencog/atoms/base/LinkValue.cc
+++ b/opencog/atoms/base/LinkValue.cc
@@ -32,7 +32,7 @@ bool LinkValue::operator==(const ProtoAtom& other) const
 
 // ==============================================================
 
-std::string LinkValue::toString(const std::string& indent)
+std::string LinkValue::toString(const std::string& indent) const
 {
 	std::string rv = indent + "(LinkValue\n";
 	for (ProtoAtomPtr v :_value)

--- a/opencog/atoms/base/LinkValue.h
+++ b/opencog/atoms/base/LinkValue.h
@@ -54,7 +54,7 @@ public:
 
 	/** Returns a string representation of the value.  */
 	virtual std::string toString(const std::string& indent) const;
-	virtual std::string toShortString(const std::string& indent)
+	virtual std::string toShortString(const std::string& indent) const
 	{ return toString(indent); }
 
 	/** Returns true if the two atoms are equal, else false.  */

--- a/opencog/atoms/base/LinkValue.h
+++ b/opencog/atoms/base/LinkValue.h
@@ -53,7 +53,7 @@ public:
 	void setValue(const std::vector<ProtoAtomPtr>& v) { _value = v; }
 
 	/** Returns a string representation of the value.  */
-	virtual std::string toString(const std::string& indent);
+	virtual std::string toString(const std::string& indent) const;
 	virtual std::string toShortString(const std::string& indent)
 	{ return toString(indent); }
 

--- a/opencog/atoms/base/Node.cc
+++ b/opencog/atoms/base/Node.cc
@@ -62,7 +62,7 @@ std::string Node::toShortString(const std::string& indent)
     return nam;
 }
 
-std::string Node::toString(const std::string& indent)
+std::string Node::toString(const std::string& indent) const
 {
     std::string tmpname = _name;
     if (_name == "")

--- a/opencog/atoms/base/Node.cc
+++ b/opencog/atoms/base/Node.cc
@@ -43,7 +43,7 @@ void Node::init(const std::string& cname)
     _name = cname;
 }
 
-std::string Node::toShortString(const std::string& indent)
+std::string Node::toShortString(const std::string& indent) const
 {
     std::string tmpname = _name;
     if (_name == "")

--- a/opencog/atoms/base/Node.h
+++ b/opencog/atoms/base/Node.h
@@ -92,7 +92,7 @@ public:
      *
      * @return A string representation of the node.
      */
-    std::string toString(const std::string& indent);
+    std::string toString(const std::string& indent) const;
     std::string toShortString(const std::string& indent);
 
 	// Work around gdb's incapability to build a string on the fly,

--- a/opencog/atoms/base/Node.h
+++ b/opencog/atoms/base/Node.h
@@ -93,7 +93,7 @@ public:
      * @return A string representation of the node.
      */
     std::string toString(const std::string& indent) const;
-    std::string toShortString(const std::string& indent);
+    std::string toShortString(const std::string& indent) const;
 
 	// Work around gdb's incapability to build a string on the fly,
 	// see http://stackoverflow.com/questions/16734783 and

--- a/opencog/atoms/base/ProtoAtom.h
+++ b/opencog/atoms/base/ProtoAtom.h
@@ -71,7 +71,7 @@ public:
 	 * @return A string representation of the node.
 	 * cannot be const, because observing the TV and AV requires a lock.
 	 */
-	virtual std::string toString(const std::string& indent) = 0;
+	virtual std::string toString(const std::string& indent) const = 0;
 	virtual std::string toShortString(const std::string& indent) = 0;
 
 	// Work around gdb's inability to build a string on the fly,

--- a/opencog/atoms/base/ProtoAtom.h
+++ b/opencog/atoms/base/ProtoAtom.h
@@ -77,8 +77,8 @@ public:
 	// Work around gdb's inability to build a string on the fly,
 	// see http://stackoverflow.com/questions/16734783 for more
 	// explanation.
-	std::string toString() { return toString(""); }
-	std::string toShortString() { return toShortString(""); }
+	std::string toString() const { return toString(""); }
+	std::string toShortString() const { return toShortString(""); }
 
 	/** Returns whether two atoms are equal.
 	 *

--- a/opencog/atoms/base/ProtoAtom.h
+++ b/opencog/atoms/base/ProtoAtom.h
@@ -72,7 +72,7 @@ public:
 	 * cannot be const, because observing the TV and AV requires a lock.
 	 */
 	virtual std::string toString(const std::string& indent) const = 0;
-	virtual std::string toShortString(const std::string& indent) = 0;
+	virtual std::string toShortString(const std::string& indent) const = 0;
 
 	// Work around gdb's inability to build a string on the fly,
 	// see http://stackoverflow.com/questions/16734783 for more

--- a/opencog/atoms/base/StringValue.cc
+++ b/opencog/atoms/base/StringValue.cc
@@ -32,7 +32,7 @@ bool StringValue::operator==(const ProtoAtom& other) const
 
 // ==============================================================
 
-std::string StringValue::toString(const std::string& indent)
+std::string StringValue::toString(const std::string& indent) const
 {
 	std::string rv = indent + "(StringValue";
 	for (std::string v :_value)

--- a/opencog/atoms/base/StringValue.h
+++ b/opencog/atoms/base/StringValue.h
@@ -57,7 +57,7 @@ public:
 
 
 	/** Returns a string representation of the value.  */
-	virtual std::string toString(const std::string& indent);
+	virtual std::string toString(const std::string& indent) const;
 	virtual std::string toShortString(const std::string& indent)
 	{ return toString(indent); }
 

--- a/opencog/atoms/base/StringValue.h
+++ b/opencog/atoms/base/StringValue.h
@@ -58,7 +58,7 @@ public:
 
 	/** Returns a string representation of the value.  */
 	virtual std::string toString(const std::string& indent) const;
-	virtual std::string toShortString(const std::string& indent)
+	virtual std::string toShortString(const std::string& indent) const
 	{ return toString(indent); }
 
 	/** Returns true if the two atoms are equal.  */


### PR DESCRIPTION
Constify the atomspace API, partially addressing issue #114 . There is more to do but it's good enough for now to for instance print a `const Link&` while debugging (was my main motivation to get into that).