### PR TITLE
remove LinkPtr from the pattern matcher API

### DIFF
--- a/opencog/query/AttentionalFocusCB.cc
+++ b/opencog/query/AttentionalFocusCB.cc
@@ -37,10 +37,15 @@ bool AttentionalFocusCB::node_match(const Handle& node1, const Handle& node2)
 		node2->getSTI() > _as->get_attentional_focus_boundary();
 }
 
-bool AttentionalFocusCB::link_match(const LinkPtr& lpat, const LinkPtr& lsoln)
+bool AttentionalFocusCB::link_match(const Handle& lpat, const Handle& lsoln)
 {
 	return DefaultPatternMatchCB::link_match(lpat, lsoln)
 		and lsoln->getSTI() > _as->get_attentional_focus_boundary();
+}
+
+static bool compare_sti(const LinkPtr& lptr1, const LinkPtr& lptr2)
+{
+	return lptr1->getSTI() > lptr2->getSTI();
 }
 
 IncomingSet AttentionalFocusCB::get_incoming_set(const Handle& h)

--- a/opencog/query/AttentionalFocusCB.h
+++ b/opencog/query/AttentionalFocusCB.h
@@ -29,11 +29,6 @@ namespace opencog {
 
 class AttentionalFocusCB: public virtual DefaultPatternMatchCB
 {
-private:
-	static bool compare_sti(LinkPtr lptr1, LinkPtr lptr2)
-	{
-		return lptr1->getSTI() > lptr2->getSTI();
-	}
 public:
 	AttentionalFocusCB(AtomSpace*);
 
@@ -41,7 +36,7 @@ public:
 	bool node_match(const Handle&, const Handle&);
 
 	// Only match links if they are in the attentional focus
-	bool link_match(const LinkPtr&, const LinkPtr&);
+	bool link_match(const Handle&, const Handle&);
 
 	// Only get incoming sets that are in the attentional focus
 	IncomingSet get_incoming_set(const Handle&);

--- a/opencog/query/DefaultPatternMatchCB.cc
+++ b/opencog/query/DefaultPatternMatchCB.cc
@@ -222,8 +222,8 @@ bool DefaultPatternMatchCB::variable_match(const Handle& npat_h,
  * By default, the search continues if the link
  * arity and the link types match.
  */
-bool DefaultPatternMatchCB::link_match(const LinkPtr& lpat,
-                                       const LinkPtr& lsoln)
+bool DefaultPatternMatchCB::link_match(const Handle& lpat,
+                                       const Handle& lsoln)
 {
 	// If the pattern is exactly the same link as the proposed
 	// grounding, then its a perfect match.
@@ -239,7 +239,7 @@ bool DefaultPatternMatchCB::link_match(const LinkPtr& lpat,
 	if (pattype != soltype) return false;
 
 	// Reject mis-sized compares, unless the pattern has a glob in it.
-	if (0 == _globs->count(lpat->getHandle()))
+	if (0 == _globs->count(lpat))
 	{ 
 		if (lpat->getArity() != lsoln->getArity()) return false;
 	}
@@ -252,8 +252,8 @@ bool DefaultPatternMatchCB::link_match(const LinkPtr& lpat,
 	return true;
 }
 
-bool DefaultPatternMatchCB::post_link_match(const LinkPtr& lpat,
-                                            const LinkPtr& lgnd)
+bool DefaultPatternMatchCB::post_link_match(const Handle& lpat,
+                                            const Handle& lgnd)
 {
 	// The if (STATE_LINK) thing is a temp hack until we get a nicer
 	// solution, viz, get around to implementing executable terms in

--- a/opencog/query/DefaultPatternMatchCB.h
+++ b/opencog/query/DefaultPatternMatchCB.h
@@ -60,8 +60,8 @@ class DefaultPatternMatchCB : public virtual PatternMatchCallback
 
 		virtual bool node_match(const Handle&, const Handle&);
 		virtual bool variable_match(const Handle&, const Handle&);
-		virtual bool link_match(const LinkPtr&, const LinkPtr&);
-		virtual bool post_link_match(const LinkPtr&, const LinkPtr&);
+		virtual bool link_match(const Handle&, const Handle&);
+		virtual bool post_link_match(const Handle&, const Handle&);
 
 		virtual bool clause_match(const Handle&, const Handle&);
 		/**

--- a/opencog/query/PatternMatch.cc
+++ b/opencog/query/PatternMatch.cc
@@ -55,10 +55,10 @@ class PMCGroundings : public PatternMatchCallback
 		bool variable_match(const Handle& node1, const Handle& node2) {
 			return _cb.variable_match(node1, node2);
 		}
-		bool link_match(const LinkPtr& link1, const LinkPtr& link2) {
+		bool link_match(const Handle& link1, const Handle& link2) {
 			return _cb.link_match(link1, link2);
 		}
-		bool post_link_match(const LinkPtr& link1, const LinkPtr& link2) {
+		bool post_link_match(const Handle& link1, const Handle& link2) {
 			return _cb.post_link_match(link1, link2);
 		}
 		bool fuzzy_match(const Handle& h1, const Handle& h2) {

--- a/opencog/query/PatternMatchCallback.h
+++ b/opencog/query/PatternMatchCallback.h
@@ -92,8 +92,8 @@ class PatternMatchCallback
 		 * type, and to proceed with the search, or cut it
 		 * off, based on these values.
 		 */
-		virtual bool link_match(const LinkPtr& patt_link,
-		                        const LinkPtr& grnd_link) = 0;
+		virtual bool link_match(const Handle& patt_link,
+		                        const Handle& grnd_link) = 0;
 
 		/**
 		 * Called after a candidate grounding has been found
@@ -111,8 +111,8 @@ class PatternMatchCallback
 		 * The first link is from the pattern, the second is
 		 * from the proposed grounding.
 		 */
-		virtual bool post_link_match(const LinkPtr& patt_link,
-		                             const LinkPtr& grnd_link)
+		virtual bool post_link_match(const Handle& patt_link,
+		                             const Handle& grnd_link)
 		{
 			return true; // Accept the match, by default.
 		}

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -198,12 +198,10 @@ bool PatternMatchEngine::node_compare(const Handle& hp,
 /// If the two links are both ordered, its enough to compare
 /// them "side-by-side".
 bool PatternMatchEngine::ordered_compare(const PatternTermPtr& ptm,
-                                         const Handle& hg,
-                                         const LinkPtr& lp,
-                                         const LinkPtr& lg)
+                                         const Handle& hg)
 {
 	PatternTermSeq osp = ptm->getOutgoingSet();
-	const HandleSeq &osg = lg->getOutgoingSet();
+	const HandleSeq &osg = hg->getOutgoingSet();
 
 	size_t osg_size = osg.size();
 	size_t osp_size = osp.size();
@@ -228,7 +226,7 @@ bool PatternMatchEngine::ordered_compare(const PatternTermPtr& ptm,
 	// kind of fuzzy matching). If there are no globs, and the arity is
 	// mis-matched, then perform fuzzy matching.
 	bool match = true;
-	if (0 == _pat->globby_terms.count(lp->getHandle()))
+	if (0 == _pat->globby_terms.count(ptm->getHandle()))
 	{
 		// If the arities are mis-matched, do a fuzzy compare instead.
 		if (osp_size != osg_size)
@@ -349,9 +347,7 @@ bool PatternMatchEngine::ordered_compare(const PatternTermPtr& ptm,
 /// the ChoiceLink as a whole can be considered to be grounded.
 ///
 bool PatternMatchEngine::choice_compare(const PatternTermPtr& ptm,
-                                        const Handle& hg,
-                                        const LinkPtr& lp,
-                                        const LinkPtr& lg)
+                                        const Handle& hg)
 {
 	const Handle& hp = ptm->getHandle();
 	PatternTermSeq osp = ptm->getOutgoingSet();
@@ -582,12 +578,10 @@ they call compare_tree.
 ******************************************************************/
 
 bool PatternMatchEngine::unorder_compare(const PatternTermPtr& ptm,
-                                         const Handle& hg,
-                                         const LinkPtr& lp,
-                                         const LinkPtr& lg)
+                                         const Handle& hg)
 {
 	const Handle& hp = ptm->getHandle();
-	const HandleSeq& osg = lg->getOutgoingSet();
+	const HandleSeq& osg = hg->getOutgoingSet();
 	PatternTermSeq osp = ptm->getOutgoingSet();
 	size_t arity = osp.size();
 
@@ -842,8 +836,6 @@ bool PatternMatchEngine::tree_compare(const PatternTermPtr& ptm,
 	if (not (hp->isLink() and hg->isLink())) return _pmc.fuzzy_match(hp, hg);
 
 	// Let the callback perform basic checking.
-	LinkPtr lp(LinkCast(hp));
-	LinkPtr lg(LinkCast(hg));
 	bool match = _pmc.link_match(hp, hg);
 	if (not match) return false;
 
@@ -856,15 +848,15 @@ bool PatternMatchEngine::tree_compare(const PatternTermPtr& ptm,
 	// the ChoiceLink as a whole can be considered to be grounded.
 	//
 	if (CHOICE_LINK == tp)
-		return choice_compare(ptm, hg, lp, lg);
+		return choice_compare(ptm, hg);
 
 	// If the two links are both ordered, its enough to compare
 	// them "side-by-side".
-	if (2 > lp->getArity() or _classserver.isA(tp, ORDERED_LINK))
-		return ordered_compare(ptm, hg, lp, lg);
+	if (2 > hp->getArity() or _classserver.isA(tp, ORDERED_LINK))
+		return ordered_compare(ptm, hg);
 
 	// If we are here, we are dealing with an unordered link.
-	return unorder_compare(ptm, hg, lp, lg);
+	return unorder_compare(ptm, hg);
 }
 
 /* ======================================================== */

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -329,11 +329,11 @@ bool PatternMatchEngine::ordered_compare(const PatternTermPtr& ptm,
 
 	// If we've found a grounding, lets see if the
 	// post-match callback likes this grounding.
-	match = _pmc.post_link_match(lp, lg);
+	const Handle &hp = ptm->getHandle();
+	match = _pmc.post_link_match(hp, hg);
 	if (not match) return false;
 
 	// If we've found a grounding, record it.
-	const Handle &hp = ptm->getHandle();
 	if (hp != hg) var_grounding[hp] = hg;
 
 	return true;
@@ -388,7 +388,7 @@ bool PatternMatchEngine::choice_compare(const PatternTermPtr& ptm,
 		{
 			// If we've found a grounding, lets see if the
 			// post-match callback likes this grounding.
-			match = _pmc.post_link_match(lp, lg);
+			match = _pmc.post_link_match(hp, hg);
 			if (match)
 			{
 				// Even the stack, *without* erasing the discovered grounding.
@@ -658,7 +658,7 @@ bool PatternMatchEngine::unorder_compare(const PatternTermPtr& ptm,
 		{
 			// If we've found a grounding, lets see if the
 			// post-match callback likes this grounding.
-			match = _pmc.post_link_match(lp, lg);
+			match = _pmc.post_link_match(hp, hg);
 			if (match)
 			{
 				// Even the stack, *without* erasing the discovered grounding.
@@ -844,7 +844,7 @@ bool PatternMatchEngine::tree_compare(const PatternTermPtr& ptm,
 	// Let the callback perform basic checking.
 	LinkPtr lp(LinkCast(hp));
 	LinkPtr lg(LinkCast(hg));
-	bool match = _pmc.link_match(lp, lg);
+	bool match = _pmc.link_match(hp, hg);
 	if (not match) return false;
 
 	LAZY_LOG_FINE << "depth=" << depth;

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -188,12 +188,9 @@ private:
 	bool variable_compare(const Handle&, const Handle&);
 	bool self_compare(const PatternTermPtr&);
 	bool node_compare(const Handle&, const Handle&);
-	bool choice_compare(const PatternTermPtr&, const Handle&,
-	                    const LinkPtr&, const LinkPtr&);
-	bool ordered_compare(const PatternTermPtr&, const Handle&,
-	                     const LinkPtr&, const LinkPtr&);
-	bool unorder_compare(const PatternTermPtr&, const Handle&,
-	                     const LinkPtr&, const LinkPtr&);
+	bool choice_compare(const PatternTermPtr&, const Handle&);
+	bool ordered_compare(const PatternTermPtr&, const Handle&);
+	bool unorder_compare(const PatternTermPtr&, const Handle&);
 	bool clause_compare(const PatternTermPtr&, const Handle&);
 
 	// -------------------------------------------

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -188,7 +188,6 @@ private:
 	bool variable_compare(const Handle&, const Handle&);
 	bool self_compare(const PatternTermPtr&);
 	bool node_compare(const Handle&, const Handle&);
-	bool redex_compare(const LinkPtr&, const LinkPtr&);
 	bool choice_compare(const PatternTermPtr&, const Handle&,
 	                    const LinkPtr&, const LinkPtr&);
 	bool ordered_compare(const PatternTermPtr&, const Handle&,

--- a/opencog/query/Recognizer.cc
+++ b/opencog/query/Recognizer.cc
@@ -78,7 +78,7 @@ class Recognizer :
 
 		virtual bool initiate_search(PatternMatchEngine*);
 		virtual bool node_match(const Handle&, const Handle&);
-		virtual bool link_match(const LinkPtr&, const LinkPtr&);
+		virtual bool link_match(const Handle&, const Handle&);
 		virtual bool fuzzy_match(const Handle&, const Handle&);
 		virtual bool grounding(const HandleMap &var_soln,
 		                       const HandleMap &term_soln);
@@ -156,7 +156,7 @@ bool Recognizer::node_match(const Handle& npat_h, const Handle& nsoln_h)
 	return false;
 }
 
-bool Recognizer::link_match(const LinkPtr& lpat, const LinkPtr& lsoln)
+bool Recognizer::link_match(const Handle& lpat, const Handle& lsoln)
 {
 	// Self-compares always proceed.
 	if (lpat == lsoln) return true;


### PR DESCRIPTION
This provides a minor performance boost, by avoiding a very costly cast; it also simplifies the API slightly.