### PR TITLE
Fix handling of ScopeLinks in pattern matcher -- #910

### DIFF
--- a/opencog/atoms/core/ScopeLink.h
+++ b/opencog/atoms/core/ScopeLink.h
@@ -55,7 +55,6 @@ protected:
 	/// Handle of the body of the expression.
 	Handle _body;
 
-
 	/// Variables bound in the body.
 	Variables _varlist;
 

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -305,8 +305,25 @@ bool Variables::is_equal(const Variables& other) const
 		// XXX TODO fuzzy?
 	}
 
-	// If we got toe here, everything must be OK.
+	// If we got to here, everything must be OK.
 	return true;
+}
+
+/* ================================================================= */
+
+/// Return true if the variable `othervar` in `other` is
+/// alpha-convertible to the variable `var` in this. That is,
+/// return true if they are the same variable, differing only
+/// in name.
+
+bool Variables::is_alpha_convertible(const Handle& var,
+                                     const Handle& othervar,
+                                     const Variables& other) const
+{
+	IndexMap::const_iterator idx = other.index.find(othervar);
+	if (other.index.end() == idx) return false;
+	if (varseq.at(idx->second) == var) return true;
+	return false;
 }
 
 /* ================================================================= */

--- a/opencog/atoms/core/Variables.h
+++ b/opencog/atoms/core/Variables.h
@@ -130,6 +130,14 @@ struct Variables : public FreeVariables
 	inline bool operator!=(const Variables& other) const
 	{ return not is_equal(other); }
 
+	// Return true if the variable `othervar` in `other` is
+	// alpha-convertible to the variable `var` in this. That is,
+	// return true if they are the same variable, differing only
+	// in name.
+	bool is_alpha_convertible(const Handle& var,
+	                          const Handle& othervar,
+	                          const Variables& other) const;
+
 	// Return true if we are holding a single variable, and the handle
 	// given as the argument satisfies the type restrictions (if any).
 	// Else return false.

--- a/opencog/atoms/core/Variables.h
+++ b/opencog/atoms/core/Variables.h
@@ -60,6 +60,11 @@ struct FreeVariables
 	typedef std::map<Handle, unsigned int> IndexMap;
 	IndexMap index;
 
+	/// Return true if variable `var` is in this variableset.
+	bool is_in_varset(const Handle& v) const {
+		return varset.end() != varset.find(v);
+	}
+
 	/// Create an ordered set of the free variables in the given oset.
 	///
 	/// By "ordered set" it is meant: a list of variables, in traversal

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -849,9 +849,9 @@ void PatternLink::check_satisfiability(const OrderedHandleSet& vars,
 	}
 }
 
-// Hack alert: Definitely it should not be here. Though some refactoring
+// Hack alert: The line below should not be here. Though some refactoring
 // regarding shared libraries circular dependencies (liblambda and libquery)
-// need to be done before fixing...
+// needs to be done before this becomes fixable...
 const PatternTermPtr PatternTerm::UNDEFINED(std::make_shared<PatternTerm>());
 
 void PatternLink::make_term_trees()
@@ -869,6 +869,11 @@ void PatternLink::make_term_tree_recursive(const Handle& root,
 {
 	Type t = h->getType();
 
+	// If the pattern link is a quote, then we compare the quoted
+	// contents. This is done recursively, of course.  The QuoteLink
+	// must have only one child; anything else beyond that is ignored
+	// (as its not clear what else could possibly be done).
+	//
 	// Ignore quoting and unquoting nodes in the PatternTerm
 	if ((not parent->isQuoted() and QUOTE_LINK == t)
 	    or (parent->getQuotationLevel() == 1 and UNQUOTE_LINK == t)) {

--- a/opencog/query/DefaultPatternMatchCB.h
+++ b/opencog/query/DefaultPatternMatchCB.h
@@ -88,16 +88,6 @@ class DefaultPatternMatchCB : public virtual PatternMatchCallback
 		bool optionals_present(void) { return _optionals_present; }
 	protected:
 
-	    /**
-	     * The mutex used to control access to the transient atomspace cache.
-	     */
-	    static std::mutex s_transient_cache_mutex;
-
-	    /**
-	     * The transient atomspace cache.
-	     */
-		static std::vector<AtomSpace*> s_transient_cache;
-
 		ClassServer& _classserver;
 
 		const Variables* _vars = NULL;
@@ -112,6 +102,12 @@ class DefaultPatternMatchCB : public virtual PatternMatchCallback
 		AtomSpace* _temp_aspace;
 		Instantiator* _instor;
 
+		// The transient atomspace cache. The goal here is to
+		// avoid the overhead of constantly creating/deleting
+		// the temp atomspaces above. So instead, just keep a
+		// cache of empty ones, ready to go.
+		static std::mutex s_transient_cache_mutex;
+		static std::vector<AtomSpace*> s_transient_cache;
 		static AtomSpace* grab_transient_atomspace(AtomSpace* parent);
 		static void release_transient_atomspace(AtomSpace* atomspace);
 

--- a/opencog/query/DefaultPatternMatchCB.h
+++ b/opencog/query/DefaultPatternMatchCB.h
@@ -60,6 +60,8 @@ class DefaultPatternMatchCB : public virtual PatternMatchCallback
 
 		virtual bool node_match(const Handle&, const Handle&);
 		virtual bool variable_match(const Handle&, const Handle&);
+		virtual bool scope_match(const Handle&, const Handle&);
+
 		virtual bool link_match(const Handle&, const Handle&);
 		virtual bool post_link_match(const Handle&, const Handle&);
 

--- a/opencog/query/DefaultPatternMatchCB.h
+++ b/opencog/query/DefaultPatternMatchCB.h
@@ -98,6 +98,11 @@ class DefaultPatternMatchCB : public virtual PatternMatchCallback
 		bool _have_variables;
 		Handle _pattern_body;
 
+		// Variables that should be ignored, bacause they are bound
+		// (scoped) in the current context.
+		const Variables* _pat_bound_vars;
+		const Variables* _gnd_bound_vars;
+
 		// Temp atomspace used for test-groundings of virtual links.
 		AtomSpace* _temp_aspace;
 		Instantiator* _instor;

--- a/opencog/query/PatternMatch.cc
+++ b/opencog/query/PatternMatch.cc
@@ -55,6 +55,9 @@ class PMCGroundings : public PatternMatchCallback
 		bool variable_match(const Handle& node1, const Handle& node2) {
 			return _cb.variable_match(node1, node2);
 		}
+		bool scope_match(const Handle& node1, const Handle& node2) {
+			return _cb.scope_match(node1, node2);
+		}
 		bool link_match(const Handle& link1, const Handle& link2) {
 			return _cb.link_match(link1, link2);
 		}

--- a/opencog/query/PatternMatchCallback.h
+++ b/opencog/query/PatternMatchCallback.h
@@ -68,6 +68,21 @@ class PatternMatchCallback
 		                            const Handle& grnd_node) = 0;
 
 		/**
+		 * Called when there is a variable in the template
+		 * pattern, but it is not bound into the template
+		 * itself: its just some other variable, not eligable
+		 * for handling by variable_match() above. This variable
+		 * is possibly free in the template, and it is possibly
+		 * a bound variable that the matcher has stumbled across.
+		 * If its a free variable, this callback can do as it
+		 * wishes, but if it is a bound variable, this callback
+		 * should probably respect that, and allow a match if and
+		 * only if it is alpha-convertible to the proposed grounding.
+		 */
+		virtual bool scope_match(const Handle& patt_node,
+		                         const Handle& grnd_node) = 0;
+
+		/**
 		 * Called right before link in the template pattern
 		 * is to be compared to a possibly matching link in
 		 * the atomspace. The first argument is a link from

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -92,6 +92,8 @@ static inline void logmsg(const char * msg, const Handle& h)
 /// Compare a VariableNode in the pattern to the proposed grounding.
 ///
 /// Handle hp is from the pattern clause.
+//
+// XXX the self-grounding code should maybe move to the callback ??
 bool PatternMatchEngine::variable_compare(const Handle& hp,
                                           const Handle& hg)
 {
@@ -789,12 +791,6 @@ bool PatternMatchEngine::tree_compare(const PatternTermPtr& ptm,
 {
 	const Handle& hp = ptm->getHandle();
 
-	// If the pattern link is a quote, then we compare the quoted
-	// contents. This is done recursively, of course.  The QuoteLink
-	// must have only one child; anything else beyond that is ignored
-	// (as its not clear what else could possibly be done).
-	Type tp = hp->getType();
-
 	// If the pattern link is executable, then we should execute, and
 	// use the result of that execution. (This isn't implemented yet,
 	// because all variables in an executable link need to be grounded,
@@ -803,6 +799,8 @@ bool PatternMatchEngine::tree_compare(const PatternTermPtr& ptm,
 	if (is_executable(hp))
 		throw RuntimeException(TRACE_INFO, "Not implemented!!");
 
+	Type tp = hp->getType();
+
 	// If the pattern is a DefinedSchemaNode, we need to substitute
 	// its definition. XXX TODO.
 	if (DEFINED_SCHEMA_NODE == tp)
@@ -810,10 +808,14 @@ bool PatternMatchEngine::tree_compare(const PatternTermPtr& ptm,
 
 	// Handle hp is from the pattern clause, and it might be one
 	// of the bound variables. If so, then declare a match.
-	if (not ptm->isQuoted() and
-	    _varlist->varset.end() != _varlist->varset.find(hp))
+	if (not ptm->isQuoted())
 	{
-		return variable_compare(hp, hg);
+		if (_varlist->varset.end() != _varlist->varset.find(hp))
+			return variable_compare(hp, hg);
+
+		// Report other variables that might be found.
+		if (VARIABLE_NODE == tp)
+			return _pmc.scope_match(hp, hg);
 	}
 
 	// If they're the same atom, then clearly they match.

--- a/tests/query/CMakeLists.txt
+++ b/tests/query/CMakeLists.txt
@@ -32,7 +32,7 @@ ADD_CXXTEST(Boolean2NotUTest)
 
 
 # These are NOT in alphabetical order; they are in order of
-# simpler to more complex.  Later test cses assume features
+# simpler to more complex.  Later test cases assume features
 # that are tested in earlier test cases.  DO NOT reorder this
 # list unless you are sure of what you are doing.
 IF (HAVE_GUILE)
@@ -67,6 +67,8 @@ IF (HAVE_GUILE)
 	ADD_CXXTEST(FiniteStateMachineUTest)
 	ADD_CXXTEST(AbsentUTest)
 	ADD_CXXTEST(SingleUTest)
+	ADD_CXXTEST(ScopeUTest)
+
 	ADD_CXXTEST(FirstNUTest)
 	ADD_CXXTEST(AttentionalFocusCBUTest)
 	ADD_CXXTEST(SudokuUTest)

--- a/tests/query/ScopeUTest.cxxtest
+++ b/tests/query/ScopeUTest.cxxtest
@@ -61,6 +61,7 @@ public:
 	void test_alpha_reverse(void);
 	void test_search(void);
 	void test_search_reverse(void);
+	void test_search_alt(void);
 };
 
 void ScopeUTest::tearDown(void)
@@ -144,6 +145,26 @@ void ScopeUTest::test_search_reverse(void)
 
 	Handle c1 = eval->eval_h("(content-1)");
 	Handle r1 = eval->eval_h("(cog-bind (member-to-evaluation-2-1-rule))");
+
+	TS_ASSERT_EQUALS(c1, c2);
+	TS_ASSERT_EQUALS(r1, r2);
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+/*
+ * Test search of embedded scope links, with renamed vars
+ */
+void ScopeUTest::test_search_alt(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	eval->eval("(load-from-path \"tests/query/scope-search.scm\")");
+
+	Handle c1 = eval->eval_h("(content-1)");
+	Handle r1 = eval->eval_h("(cog-bind (member-to-evaluation-2-1-alt))");
+
+	Handle c2 = eval->eval_h("(content-2)");
+	Handle r2 = eval->eval_h("(cog-bind (member-to-evaluation-2-1-rule))");
 
 	TS_ASSERT_EQUALS(c1, c2);
 	TS_ASSERT_EQUALS(r1, r2);

--- a/tests/query/ScopeUTest.cxxtest
+++ b/tests/query/ScopeUTest.cxxtest
@@ -1,0 +1,151 @@
+/*
+ * tests/query/ScopeUTest.cxxtest
+ *
+ * Copyright (C) 2016 Linas Vepstas
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/guile/SchemeEval.h>
+#include <opencog/atomspace/AtomSpace.h>
+#include <opencog/util/Logger.h>
+
+using namespace opencog;
+
+class ScopeUTest: public CxxTest::TestSuite
+{
+private:
+	AtomSpace *as;
+	SchemeEval* eval;
+
+public:
+	ScopeUTest(void)
+	{
+		logger().set_level(Logger::DEBUG);
+		logger().set_print_to_stdout_flag(true);
+
+		as = new AtomSpace();
+		eval = new SchemeEval(as);
+		eval->eval("(add-to-load-path \"..\")");
+		eval->eval("(add-to-load-path \"../../..\")");
+		eval->eval("(use-modules (opencog query))");
+	}
+
+	~ScopeUTest()
+	{
+		delete eval;
+		delete as;
+		// Erase the log file if no assertions failed.
+		if (!CxxTest::TestTracker::tracker().suiteFailed())
+			std::remove(logger().get_filename().c_str());
+	}
+
+	void setUp(void);
+	void tearDown(void);
+
+	void test_alpha(void);
+	void test_alpha_reverse(void);
+	void test_search(void);
+	void test_search_reverse(void);
+};
+
+void ScopeUTest::tearDown(void)
+{
+	as->clear();
+}
+
+void ScopeUTest::setUp(void)
+{
+	as->clear();
+	eval->eval("(load-from-path \"tests/query/test_types.scm\")");
+}
+
+/*
+ * Test alpha conversion.
+ */
+void ScopeUTest::test_alpha(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	eval->eval("(load-from-path \"tests/query/scope-search.scm\")");
+
+	Handle c1 = eval->eval_h("(content-1)");
+	Handle c2 = eval->eval_h("(content-2)");
+	printf("c2 %s\n", c2->toString().c_str());
+
+	TS_ASSERT_EQUALS(c1, c2);
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+/*
+ * Test alpha conversion.
+ */
+void ScopeUTest::test_alpha_reverse(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	eval->eval("(load-from-path \"tests/query/scope-search.scm\")");
+
+	// Reverse the order of creation
+	Handle c2 = eval->eval_h("(content-2)");
+	Handle c1 = eval->eval_h("(content-1)");
+	printf("c1 %s\n", c1->toString().c_str());
+
+	TS_ASSERT_EQUALS(c1, c2);
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+/*
+ * Test search of embedded scope links
+ */
+void ScopeUTest::test_search(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	eval->eval("(load-from-path \"tests/query/scope-search.scm\")");
+
+	Handle c1 = eval->eval_h("(content-1)");
+	Handle r1 = eval->eval_h("(cog-bind (member-to-evaluation-2-1-rule))");
+
+	Handle c2 = eval->eval_h("(content-2)");
+	Handle r2 = eval->eval_h("(cog-bind (member-to-evaluation-2-1-rule))");
+
+	TS_ASSERT_EQUALS(c1, c2);
+	TS_ASSERT_EQUALS(r1, r2);
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+/*
+ * Test search of embedded scope links.
+ * Same as above, but reversed order.
+ */
+void ScopeUTest::test_search_reverse(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	eval->eval("(load-from-path \"tests/query/scope-search.scm\")");
+
+	Handle c2 = eval->eval_h("(content-2)");
+	Handle r2 = eval->eval_h("(cog-bind (member-to-evaluation-2-1-rule))");
+
+	Handle c1 = eval->eval_h("(content-1)");
+	Handle r1 = eval->eval_h("(cog-bind (member-to-evaluation-2-1-rule))");
+
+	TS_ASSERT_EQUALS(c1, c2);
+	TS_ASSERT_EQUALS(r1, r2);
+	logger().debug("END TEST: %s", __FUNCTION__);
+}

--- a/tests/query/scope-search.scm
+++ b/tests/query/scope-search.scm
@@ -1,0 +1,100 @@
+
+(use-modules (opencog))
+(use-modules (opencog query))
+
+; (use-modules (opencog logger))
+; (cog-logger-set-level! "fine")
+; (cog-logger-set-stdout! #t)
+; (cog-logger-set-timestamp! #f)
+
+;; -----------------------------------------------------------------------------
+;; Helper functions
+
+(define (content-1)
+   (MemberLink
+      (ConceptNode "Socrates@81011e61-27a7-4001-a63b-3b569478bced")
+      (SatisfyingSetLink
+         (VariableNode "$X")
+         (EvaluationLink
+            (PredicateNode "breathe@ea723bda-70bb-47c0-8930-b344fb47a4d1")
+            (ListLink
+               (VariableNode "$X")
+               (ConceptNode "air@76357ee3-d334-4b5f-b49e-323b294310b6")
+            )
+         )
+      )
+   )
+)
+
+
+(define (content-2)
+; MemberLink having the same Variable name as rule
+   (MemberLink
+      (ConceptNode "Socrates@81011e61-27a7-4001-a63b-3b569478bced")
+      (SatisfyingSetLink
+         (VariableNode "$X-M2E")
+         (EvaluationLink
+            (PredicateNode "breathe@ea723bda-70bb-47c0-8930-b344fb47a4d1")
+            (ListLink
+               (VariableNode "$X-M2E")
+               (ConceptNode "air@76357ee3-d334-4b5f-b49e-323b294310b6")
+            )
+         )
+      )
+   )
+)
+
+
+(define (member-to-evaluation-2-1-rule)
+   (BindLink
+      (VariableList
+         (VariableNode "$B")
+         (VariableNode "$C")
+         (TypedVariableLink
+            (VariableNode "$D")
+            (TypeNode "PredicateNode")
+         )
+      )
+      (MemberLink
+         (VariableNode "$B")
+         (SatisfyingSetLink
+            (VariableNode "$X-M2E")
+            (EvaluationLink
+               (VariableNode "$D")
+               (ListLink
+                  (VariableNode "$X-M2E")
+                  (VariableNode "$C")
+               )
+            )
+         )
+      )
+      (ExecutionOutputLink
+         (GroundedSchemaNode "scm: member-to-evaluation-formula")
+         (ListLink
+            (EvaluationLink
+               (VariableNode "$D")
+               (ListLink
+                  (VariableNode "$B")
+                  (VariableNode "$C")
+               )
+            )
+            (MemberLink
+               (VariableNode "$B")
+               (SatisfyingSetLink
+                  (VariableNode "$X-M2E")
+                  (EvaluationLink
+                     (VariableNode "$D")
+                     (ListLink
+                        (VariableNode "$X-M2E")
+                        (VariableNode "$C")
+                     )
+                  )
+               )
+            )
+         )
+      )
+   )
+)
+
+(define (member-to-evaluation-formula EVAL MEM)
+   (cog-set-tv! EVAL (cog-tv MEM)))

--- a/tests/query/scope-search.scm
+++ b/tests/query/scope-search.scm
@@ -96,5 +96,58 @@
    )
 )
 
+; Same as above, but apha-renamed deduction. Should get the same
+; results.
+(define (member-to-evaluation-2-1-alt)
+   (BindLink
+      (VariableList
+         (VariableNode "$B")
+         (VariableNode "$C")
+         (TypedVariableLink
+            (VariableNode "$D")
+            (TypeNode "PredicateNode")
+         )
+      )
+      (MemberLink
+         (VariableNode "$B")
+         (SatisfyingSetLink
+            (VariableNode "$X-M2E")
+            (EvaluationLink
+               (VariableNode "$D")
+               (ListLink
+                  (VariableNode "$X-M2E")
+                  (VariableNode "$C")
+               )
+            )
+         )
+      )
+      (ExecutionOutputLink
+         (GroundedSchemaNode "scm: member-to-evaluation-formula")
+         (ListLink
+            (EvaluationLink
+               (VariableNode "$D")
+               (ListLink
+                  (VariableNode "$B")
+                  (VariableNode "$C")
+               )
+            )
+            (MemberLink
+               (VariableNode "$B")
+               (SatisfyingSetLink
+                  (VariableNode "$some-bound-var")
+                  (EvaluationLink
+                     (VariableNode "$D")
+                     (ListLink
+                        (VariableNode "$some-bound-var")
+                        (VariableNode "$C")
+                     )
+                  )
+               )
+            )
+         )
+      )
+   )
+)
+
 (define (member-to-evaluation-formula EVAL MEM)
    (cog-set-tv! EVAL (cog-tv MEM)))

--- a/tests/rule-engine/ForwardChainerUTest.cxxtest
+++ b/tests/rule-engine/ForwardChainerUTest.cxxtest
@@ -224,16 +224,16 @@ void ForwardChainerUTest::test_unify_2(void)
 		("(AndLink"
 		 "  (LambdaLink"
 		 "    (TypedVariableLink"
-		 "      (VariableNode \"$X\")"
+		 "      (VariableNode \"$Xaaaa\")"
 		 "      (TypeNode \"ConceptNode\"))"
 		 "    (PredicateNode \"P\"))"
 		 "  (LambdaLink"
 		 "    (TypedVariableLink"
-		 "      (VariableNode \"$X\")"
+		 "      (VariableNode \"$Xbee\")"
 		 "      (TypeNode \"ConceptNode\"))"
 		 "    (EvaluationLink"
 		 "      (PredicateNode \"Q\")"
-		 "      (VariableNode \"$X\"))))");
+		 "      (VariableNode \"$Xbee\"))))");
 
     Handle rbs = eval.eval_h("(ConceptNode \"PLN\")");
 


### PR DESCRIPTION
This fixes bug #910.

The current push is causing ForwardChainerUTest to fail, but I don't recall if it was failing even before I started.

I also need to add some unit tests, as well.  Merge only if you need the fix asap, and don't mind the above failure...  else wait a day.