### PR TITLE
Additional work on the ScopeLink

### DIFF
--- a/opencog/atoms/core/ScopeLink.cc
+++ b/opencog/atoms/core/ScopeLink.cc
@@ -170,7 +170,7 @@ void ScopeLink::init_scoped_variables(const Handle& hvar)
 /// Compare other ScopeLink, return true if it is equal to this one,
 /// up to an alpha-conversion of variables.
 ///
-bool ScopeLink::is_equal(const Handle& other) const
+bool ScopeLink::is_equal(const Handle& other, bool silent) const
 {
 	if (other == this) return true;
 	if (other->getType() != _type) return false;
@@ -198,7 +198,8 @@ bool ScopeLink::is_equal(const Handle& other) const
 	for (Arity i = 0; i < n_scoped_terms; ++i) {
 		Handle h = getOutgoingAtom(i + vardecl_offset);
 		Handle other_h = other->getOutgoingAtom(i + other_vardecl_offset);
-		other_h = scother->_varlist.substitute_nocheck(other_h, _varlist.varseq);
+		other_h = scother->_varlist.substitute_nocheck(other_h,
+		                                         _varlist.varseq, silent);
  		// Compare them, they should match.
 		if (*((AtomPtr)h) != *((AtomPtr) other_h)) return false;
  	}

--- a/opencog/atoms/core/ScopeLink.h
+++ b/opencog/atoms/core/ScopeLink.h
@@ -93,7 +93,7 @@ public:
 	// Return true if the other Handle is equal to this one,
 	// i.e. is the same, up to alpha conversion. i.e. is the same,
 	// up to a renaming of the bound variables.
-	bool is_equal(const Handle&) const;
+	bool is_equal(const Handle&, bool silent=false) const;
 
 	/**
 	 * Return an alpha converted copy of itself. One can provide in

--- a/opencog/atoms/core/Variables.h
+++ b/opencog/atoms/core/Variables.h
@@ -94,9 +94,9 @@ struct FreeVariables
 	// for the variables.  "nocheck" == no type checking is done.
 	// This performs an almost pure, syntactic beta-reduction; its
 	// almost-pure because it does honour the semantics of QuoteLink.
-	Handle substitute_nocheck(const Handle&, const HandleSeq&) const;
+	Handle substitute_nocheck(const Handle&, const HandleSeq&, bool silent=false) const;
 protected:
-	Handle substitute_scoped(const Handle&, const HandleSeq&,
+	Handle substitute_scoped(const Handle&, const HandleSeq&, bool,
 	                         const IndexMap&, int) const;
 };
 

--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -200,10 +200,10 @@ public:
      */
     Handle getHandle(Type, const std::string&) const;
     Handle getHandle(Type, const HandleSeq&) const;
-    Handle getLinkHandle(AtomPtr&) const;
-    Handle getHandle(AtomPtr&) const;
-    Handle getHandle(const Handle& h) const {
-        AtomPtr a(h); return getHandle(a);
+    Handle getLinkHandle(AtomPtr&, int=0) const;
+    Handle getHandle(AtomPtr&, int=0) const;
+    Handle getHandle(const Handle& h, int quotelevel=0) const {
+        AtomPtr a(h); return getHandle(a, quotelevel);
     }
     Handle getHandle(UUID) const;
 

--- a/tests/query/ScopeUTest.cxxtest
+++ b/tests/query/ScopeUTest.cxxtest
@@ -63,6 +63,7 @@ public:
 	void test_search_reverse(void);
 	void test_search_alt(void);
 	void test_pushpop(void);
+	void test_quote(void);
 };
 
 void ScopeUTest::tearDown(void)
@@ -194,5 +195,27 @@ void ScopeUTest::test_pushpop(void)
 	Handle c2 = em->getOutgoingAtom(0);
 
 	TS_ASSERT_EQUALS(c1, c2);
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+/*
+ * Test search of embedded scope links.
+ * The search pattern inculdes QuoteLinks that have to be navigated
+ * correctly, in order for thins to work.
+ */
+void ScopeUTest::test_quote(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	eval->eval("(load-from-path \"tests/query/scope-quote.scm\")");
+
+	Handle list = eval->eval_h("(cog-bind blist)");
+	Handle andl = eval->eval_h("(cog-bind bland)");
+
+	Handle elist = eval->eval_h("(SetLink (OrderedLink p-lamb q-lamb)) ");
+	Handle eandl = eval->eval_h("(SetLink (UnorderedLink p-lamb q-lamb)) ");
+
+	TS_ASSERT_EQUALS(list, elist);
+	TS_ASSERT_EQUALS(andl, eandl);
 	logger().debug("END TEST: %s", __FUNCTION__);
 }

--- a/tests/query/scope-quote.scm
+++ b/tests/query/scope-quote.scm
@@ -20,13 +20,14 @@
 
 
 ; Sample data
-; The ListLink variant
-(ListLink
+(define p-lamb
   (LambdaLink
     (TypedVariableLink
       (VariableNode "$Xaaaa")
       (TypeNode "ConceptNode"))
-    (PredicateNode "P"))
+    (PredicateNode "P")))
+
+(define q-lamb
   (LambdaLink
     (TypedVariableLink
       (VariableNode "$Xbee")
@@ -34,22 +35,12 @@
     (EvaluationLink
       (PredicateNode "Q")
       (VariableNode "$Xbee"))))
+
+; The ListLink variant
+(ListLink p-lamb q-lamb)
 
 ; The AndLink variant -- same as above, except uses AndLink.
-(AndLink
-  (LambdaLink
-    (TypedVariableLink
-      (VariableNode "$Xaaaa")
-      (TypeNode "ConceptNode"))
-    (PredicateNode "P"))
-  (LambdaLink
-    (TypedVariableLink
-      (VariableNode "$Xbee")
-      (TypeNode "ConceptNode"))
-    (EvaluationLink
-      (PredicateNode "Q")
-      (VariableNode "$Xbee"))))
-
+(AndLink p-lamb q-lamb)
 
 ; The pattern matcher, looks for the List variant
 (define blist
@@ -85,7 +76,7 @@
           (UnquoteLink
             (VariableNode "$A2")))))
     ; result
-    (ListLink
+    (OrderedLink
       (LambdaLink
         (VariableNode "$TyVs-one")
         (VariableNode "$A1"))
@@ -129,7 +120,7 @@
           (UnquoteLink
             (VariableNode "$A2")))))
     ; output result
-    (AndLink
+    (UnorderedLink
       (LambdaLink
         (VariableNode "$TyVs-one")
         (VariableNode "$A1"))

--- a/tests/query/scope-quote.scm
+++ b/tests/query/scope-quote.scm
@@ -18,7 +18,24 @@
 (use-modules (opencog))
 (use-modules (opencog query))
 
+
 ; Sample data
+; The ListLink variant
+(ListLink
+  (LambdaLink
+    (TypedVariableLink
+      (VariableNode "$Xaaaa")
+      (TypeNode "ConceptNode"))
+    (PredicateNode "P"))
+  (LambdaLink
+    (TypedVariableLink
+      (VariableNode "$Xbee")
+      (TypeNode "ConceptNode"))
+    (EvaluationLink
+      (PredicateNode "Q")
+      (VariableNode "$Xbee"))))
+
+; The AndLink variant -- same as above, except uses AndLink.
 (AndLink
   (LambdaLink
     (TypedVariableLink
@@ -34,6 +51,51 @@
       (VariableNode "$Xbee"))))
 
 
+; The pattern matcher, looks for the List variant
+(define blist
+  (BindLink
+    (VariableList
+      (TypedVariableLink
+        (VariableNode "$TyVs-one")
+        (TypeChoice
+          (TypeNode "TypedVariableLink")
+          (TypeNode "VariableNode")
+          (TypeNode "VariableList")))
+      (TypedVariableLink
+        (VariableNode "$TyVs-two")
+        (TypeChoice
+          (TypeNode "TypedVariableLink")
+          (TypeNode "VariableNode")
+          (TypeNode "VariableList")))
+      (VariableNode "$A1")
+      (VariableNode "$A2")
+    )
+    ; pattern
+    (ListLink
+      (QuoteLink
+        (LambdaLink
+          (UnquoteLink
+            (VariableNode "$TyVs-one"))
+          (UnquoteLink
+            (VariableNode "$A1"))))
+      (QuoteLink
+        (LambdaLink
+          (UnquoteLink
+            (VariableNode "$TyVs-two"))
+          (UnquoteLink
+            (VariableNode "$A2")))))
+    ; result
+    (ListLink
+      (LambdaLink
+        (VariableNode "$TyVs-one")
+        (VariableNode "$A1"))
+      (LambdaLink
+        (VariableNode "$TyVs-two")
+        (VariableNode "$A2"))))
+)
+
+; The pattern matcher, looks for the And variant. Notice that
+; the quoting is different from the above.
 (define bland
   (BindLink
     ; Variable declaration

--- a/tests/query/scope-quote.scm
+++ b/tests/query/scope-quote.scm
@@ -1,0 +1,77 @@
+;
+; scope-quote.scm
+;
+; The current ForwardChainerUTest creates some bindlinks that are
+; very similar to this. These search for a combination of AndLinks
+; and LambdaLinks, and hope to match the variable names that appear
+; inside of them.  The extra quoting places some extra pressures
+; and complexity on handling the ScopeLinks correctly. This tests
+; that.
+;
+; There are two variants in here: one with an AndLink, and one
+; without.  The issue is that the AndLink has a special meaning for
+; the BindLink, as opposed to PLN, and thus must be quoted. Also,
+; it is an unordered link, so takes a different path through the
+; pattern matcher.  Thus, the second variant uses a ListLink instead,
+; to simplify debugging, in case there is a bug.
+
+(use-modules (opencog))
+(use-modules (opencog query))
+
+; Sample data
+(AndLink
+  (LambdaLink
+    (TypedVariableLink
+      (VariableNode "$Xaaaa")
+      (TypeNode "ConceptNode"))
+    (PredicateNode "P"))
+  (LambdaLink
+    (TypedVariableLink
+      (VariableNode "$Xbee")
+      (TypeNode "ConceptNode"))
+    (EvaluationLink
+      (PredicateNode "Q")
+      (VariableNode "$Xbee"))))
+
+
+(define bland
+  (BindLink
+    ; Variable declaration
+    (VariableList
+      (TypedVariableLink
+        (VariableNode "$TyVs-one")
+        (TypeChoice
+          (TypeNode "TypedVariableLink")
+          (TypeNode "VariableNode")
+          (TypeNode "VariableList")))
+      (TypedVariableLink
+        (VariableNode "$TyVs-two")
+        (TypeChoice
+          (TypeNode "TypedVariableLink")
+          (TypeNode "VariableNode")
+          (TypeNode "VariableList")))
+      (VariableNode "$A1")
+      (VariableNode "$A2")
+    )
+    ; pattern to match
+    (QuoteLink
+      (AndLink
+        (LambdaLink
+          (UnquoteLink
+            (VariableNode "$TyVs-one"))
+          (UnquoteLink
+            (VariableNode "$A1")))
+        (LambdaLink
+          (UnquoteLink
+            (VariableNode "$TyVs-two"))
+          (UnquoteLink
+            (VariableNode "$A2")))))
+    ; output result
+    (AndLink
+      (LambdaLink
+        (VariableNode "$TyVs-one")
+        (VariableNode "$A1"))
+      (LambdaLink
+        (VariableNode "$TyVs-two")
+        (VariableNode "$A2"))))
+)


### PR DESCRIPTION
The forward-chainer (or at least, the ForwardChainerUTest) uses some "interesting" LambdaLink constructions that have some rather subtle interpretations in terms of semantics. Thw work here is to make sure that those get handled correctly in most(?) cases.

Please note how Quote and UnquoteLink are being used, at the bottom of `scope-quote.scm` in the test directory.  If you are working on FC or BC rules, and they aren't behaving correctly, you may need to use QuoteLinks in the same fashion.

This pull req requires  https://github.com/opencog/cogutils/pull/61 in order to build correctly.