### PR TITLE
Disable ImplicationLink

### DIFF
--- a/opencog/atoms/core/CMakeLists.txt
+++ b/opencog/atoms/core/CMakeLists.txt
@@ -8,7 +8,7 @@ ADD_LIBRARY (atomcore
 	DeleteLink.cc
 	FreeLink.cc
 	FunctionLink.cc
-	ImplicationLink.cc
+	# ImplicationLink.cc
 	LambdaLink.cc
 	PutLink.cc
 	RandomChoice.cc

--- a/opencog/atoms/core/PutLink.cc
+++ b/opencog/atoms/core/PutLink.cc
@@ -239,7 +239,7 @@ void PutLink::static_typecheck_values(void)
  * Type checking is performed during substitution; if the values fail to
  * have the desired types, no substitution is performed.  In this case,
  * an undefined handle is returned. For set substitutions, this acts as
- * a filter, removeing (filtering out) the mismatched types.
+ * a filter, removing (filtering out) the mismatched types.
  *
  * Again, only a substitution is performed, there is no execution or
  * evaluation.  Note also that the resulting tree is NOT placed into
@@ -263,7 +263,8 @@ Handle PutLink::do_reduce(void) const
 			      bods->toString().c_str());
 	}
 
-	if (LAMBDA_LINK == btype)
+	// if (LAMBDA_LINK == btype)
+	if (classserver().isA(btype, LAMBDA_LINK))
 	{
 		LambdaLinkPtr lam(LambdaLinkCast(bods));
 		if (NULL == lam)

--- a/opencog/atoms/core/ScopeLink.cc
+++ b/opencog/atoms/core/ScopeLink.cc
@@ -29,7 +29,7 @@
 #include <opencog/atoms/core/FreeLink.h>
 #include <opencog/atoms/core/LambdaLink.h>
 #include <opencog/atoms/core/PutLink.h>
-#include <opencog/atoms/core/ImplicationLink.h>
+// #include <opencog/atoms/core/ImplicationLink.h>
 #include <opencog/atoms/pattern/PatternLink.h>
 #include <opencog/atomutils/TypeUtils.h>
 
@@ -279,8 +279,10 @@ ScopeLinkPtr ScopeLink::factory(Type t, const HandleSeq& seq)
 	if (LAMBDA_LINK == t)
 		return createLambdaLink(seq);
 
+/*
 	if (classserver().isA(t, IMPLICATION_LINK))
 		return createImplicationLink(t, seq);
+*/
 
 	if (classserver().isA(t, PATTERN_LINK))
 		return PatternLink::factory(t, seq);

--- a/tests/atoms/PutLinkUTest.cxxtest
+++ b/tests/atoms/PutLinkUTest.cxxtest
@@ -218,11 +218,11 @@ void PutLinkUTest::test_lambda_partial_substitution()
  *       )
  *       (AndLink
  *          (InheritanceLink
- *             (VariableNode "$X-bar")
+ *             (VariableNode "$X")
  *             (ConceptNode "human")
  *          )
  *          (InheritanceLink
- *             (VariableNode "$Y-bar")
+ *             (VariableNode "$Y")
  *             (ConceptNode "human")
  *          )
  *          (EvaluationLink
@@ -298,11 +298,11 @@ void PutLinkUTest::test_eval_inheritance()
  *       )
  *       (AndLink
  *          (ImplicationLink
- *             (VariableNode "$X")
+ *             (VariableNode "$X-bar")
  *             (PredicateNode "is-human")
  *          )
  *          (ImplicationLink
- *             (VariableNode "$Y")
+ *             (VariableNode "$Y-bar")
  *             (PredicateNode "is-human")
  *          )
  *          (EvaluationLink

--- a/tests/atoms/PutLinkUTest.cxxtest
+++ b/tests/atoms/PutLinkUTest.cxxtest
@@ -218,11 +218,11 @@ void PutLinkUTest::test_lambda_partial_substitution()
  *       )
  *       (AndLink
  *          (InheritanceLink
- *             (VariableNode "$X")
+ *             (VariableNode "$X-bar")
  *             (ConceptNode "human")
  *          )
  *          (InheritanceLink
- *             (VariableNode "$Y")
+ *             (VariableNode "$Y-bar")
  *             (ConceptNode "human")
  *          )
  *          (EvaluationLink


### PR DESCRIPTION
It seems that ImplicationLink is not actually used anywhere -- at least, not in a way that is detectable by the unit tests.  So, stub it out, for now. 