### PR TITLE
Thread safe fixed integer index

### DIFF
--- a/opencog/atomspace/AttentionBank.h
+++ b/opencog/atomspace/AttentionBank.h
@@ -115,8 +115,7 @@ class AttentionBank
     AttentionValue::sti_t STIAtomWage;
     AttentionValue::lti_t LTIAtomWage;
 
-    /** The importance index, and it's lock. */
-    mutable std::mutex _lock_index;
+    /** The importance index */
     ImportanceIndex _importanceIndex;
 
     async_caller<AttentionBank,Handle> _index_insert_queue;
@@ -306,7 +305,6 @@ public:
     UnorderedHandleSet getHandlesByAV(AttentionValue::sti_t lowerBound,
                   AttentionValue::sti_t upperBound = AttentionValue::MAXSTI) const
     {
-        std::lock_guard<std::mutex> lck(_lock_index);
         return _importanceIndex.getHandleSet(lowerBound, upperBound);
     }
 
@@ -319,7 +317,6 @@ public:
      */
     void updateImportanceIndex(AtomPtr a, int bin)
     {
-        std::lock_guard<std::mutex> lck(_lock_index);
         _importanceIndex.updateImportance(a.operator->(), bin);
     }
 
@@ -335,13 +332,11 @@ public:
 
     void put_atom_into_index(const Handle& h)
     {
-        std::lock_guard<std::mutex> lck(_lock_index);
         _importanceIndex.insertAtom(h.operator->());
     }
 
     void remove_atom_from_index(const AtomPtr& atom)
     {
-        std::lock_guard<std::mutex> lck(_lock_index);
         _importanceIndex.removeAtom(atom.operator->());
     }
 

--- a/opencog/atomspace/CMakeLists.txt
+++ b/opencog/atomspace/CMakeLists.txt
@@ -10,6 +10,7 @@ ADD_LIBRARY (atomspace
 	AttentionBank.cc
 	BackingStore.cc
 	FixedIntegerIndex.cc
+    ThreadSafeFixedIntegerIndex.cc
 	HandleSeqIndex.cc
 	# HandleSetIndex.cc
 	ImportanceIndex.cc
@@ -25,7 +26,7 @@ ADD_DEPENDENCIES(atomspace opencog_atom_types)
 
 TARGET_LINK_LIBRARIES(atomspace
 	atombase
-	truthvalue  
+	truthvalue
 	lambda
 	${COGUTIL_LIBRARY}
 	${Boost_THREAD_LIBRARY}
@@ -41,6 +42,7 @@ INSTALL (FILES
 	AttentionBank.h
 	BackingStore.h
 	FixedIntegerIndex.h
+	ThreadSafeFixedIntegerIndex.h
 	HandleSeqIndex.h
 	ImportanceIndex.h
 	LinkIndex.h

--- a/opencog/atomspace/ImportanceIndex.cc
+++ b/opencog/atomspace/ImportanceIndex.cc
@@ -46,9 +46,9 @@ using namespace opencog;
 #define GROUP_NUM 12
 #define IMPORTANCE_INDEX_SIZE (GROUP_NUM*GROUP_SIZE)+GROUP_NUM //104
 
-ImportanceIndex::ImportanceIndex(void)
+ImportanceIndex::ImportanceIndex()
+    : _index(IMPORTANCE_INDEX_SIZE)
 {
-	resize(IMPORTANCE_INDEX_SIZE);
 }
 
 unsigned int ImportanceIndex::importanceBin(short importance)
@@ -76,108 +76,105 @@ unsigned int ImportanceIndex::importanceBin(short importance)
 
 void ImportanceIndex::updateImportance(Atom* atom, int bin)
 {
-	int newbin = importanceBin(atom->getAttentionValue()->getSTI());
-	if (bin == newbin) return;
+    int newbin = importanceBin(atom->getAttentionValue()->getSTI());
+    if (bin == newbin) return;
 
-	remove(bin, atom);
-	insert(newbin, atom);
+    _index.remove(bin, atom);
+    _index.insert(newbin, atom);
 }
 
 void ImportanceIndex::insertAtom(Atom* atom)
 {
-	int sti = atom->getAttentionValue()->getSTI();
-	int bin = importanceBin(sti);
-	insert(bin, atom);
+    int sti = atom->getAttentionValue()->getSTI();
+    int bin = importanceBin(sti);
+    _index.insert(bin, atom);
 }
 
 void ImportanceIndex::removeAtom(Atom* atom)
 {
-	int sti = atom->getAttentionValue()->getSTI();
-	int bin = importanceBin(sti);
-	remove(bin, atom);
+    int sti = atom->getAttentionValue()->getSTI();
+    int bin = importanceBin(sti);
+    _index.remove(bin, atom);
 }
 
 UnorderedHandleSet ImportanceIndex::getHandleSet(
         AttentionValue::sti_t lowerBound,
         AttentionValue::sti_t upperBound) const
 {
-	AtomSet set;
+    AtomSet set;
 
-	// The indexes for the lower bound and upper bound lists is returned.
-	int lowerBin = importanceBin(lowerBound);
-	int upperBin = importanceBin(upperBound);
+    // The indexes for the lower bound and upper bound lists is returned.
+    int lowerBin = importanceBin(lowerBound);
+    int upperBin = importanceBin(upperBound);
 
-	// Build a list of atoms whose importance is equal to the lower bound.
-	// For the lower bound and upper bound index, the list is filtered,
-	// because there may be atoms that have the same importanceIndex
-	// and whose importance is lower than lowerBound or bigger than
-	// upperBound.
-	const AtomSet &sl = idx[lowerBin];
-	std::copy_if(sl.begin(), sl.end(), inserter(set),
-		[&](Atom* atom)->bool {
-			AttentionValue::sti_t sti =
-				atom->getAttentionValue()->getSTI();
-			return (lowerBound <= sti and sti <= upperBound);
-		});
+    // Build a list of atoms whose importance is equal to the lower bound.
+    // For the lower bound and upper bound index, the list is filtered,
+    // because there may be atoms that have the same importanceIndex
+    // and whose importance is lower than lowerBound or bigger than
+    // upperBound.
+    std::function<bool(Atom *)> pred =
+        [&](Atom* atom)->bool {
+            AttentionValue::sti_t sti =
+                atom->getAttentionValue()->getSTI();
+            return (lowerBound <= sti and sti <= upperBound);
+        };
 
-	// If both lower and upper bounds are in the same bin,
-	// Then we are done.
-	if (lowerBin == upperBin) {
-		UnorderedHandleSet ret;
-		std::transform(set.begin(), set.end(), inserter(ret),
-		               [](Atom* atom)->Handle { return atom->getHandle(); });
-		return ret;
-	}
+    _index.getContentIf(lowerBin,inserter(set),pred);
 
-	// For every index within lowerBound and upperBound,
-	// add to the list.
-	while (++lowerBin < upperBin) {
-		const AtomSet &ss = idx[lowerBin];
-		set.insert(ss.begin(), ss.end());
-	}
+    // If both lower and upper bounds are in the same bin,
+    // Then we are done.
+    if (lowerBin == upperBin) {
+        UnorderedHandleSet ret;
+        std::transform(set.begin(), set.end(), inserter(ret),
+                       [](Atom* atom)->Handle { return atom->getHandle(); });
+        return ret;
+    }
 
-	// The two lists are concatenated.
-	const AtomSet &uset = idx[upperBin];
-	std::copy_if(uset.begin(), uset.end(), inserter(set),
-		[&](Atom* atom)->bool {
-			AttentionValue::sti_t sti = atom->getAttentionValue()->getSTI();
-			return (lowerBound <= sti and sti <= upperBound);
-		});
+    // For every index within lowerBound and upperBound,
+    // add to the list.
+    while (++lowerBin < upperBin) {
+        _index.getContent(lowerBin,inserter(set));
+    }
 
-	UnorderedHandleSet ret;
-	std::transform(set.begin(), set.end(), inserter(ret),
-	               [](Atom* atom)->Handle { return atom->getHandle(); });
-	return ret;
+    // The two lists are concatenated.
+    _index.getContentIf(upperBin,inserter(set),pred);
+
+    UnorderedHandleSet ret;
+    std::transform(set.begin(), set.end(), inserter(ret),
+                   [](Atom* atom)->Handle { return atom->getHandle(); });
+    return ret;
 }
 
 UnorderedHandleSet ImportanceIndex::getMaxBinContents()
 {
+    AtomSet set;
     UnorderedHandleSet ret;
-    for (AtomSet s : boost::adaptors::reverse(idx))
+    for (int i = IMPORTANCE_INDEX_SIZE ; i >= 0 ; i--)
     {
-        if (s.size() > 0)
+        if (_index.size(i) > 0)
         {
-	        std::transform(s.begin(), s.end(), inserter(ret),
-	               [](Atom* atom)->Handle { return atom->getHandle(); });
-	        return ret;
+            _index.getContent(i,inserter(set));
+            std::transform(set.begin(), set.end(), inserter(ret),
+                   [](Atom* atom)->Handle { return atom->getHandle(); });
+            return ret;
         }
     }
-
     return ret;
 }
 
 UnorderedHandleSet ImportanceIndex::getMinBinContents()
 {
+    AtomSet set;
     UnorderedHandleSet ret;
-    for (AtomSet s : idx)
+    for (int i = IMPORTANCE_INDEX_SIZE ; i >= 0 ; i--)
     {
-        if (s.size() > 0)
+        if (_index.size(i) > 0)
         {
-	        std::transform(s.begin(), s.end(), inserter(ret),
-	               [](Atom* atom)->Handle { return atom->getHandle(); });
-	        return ret;
+            _index.getContent(i,inserter(set));
+            std::transform(set.begin(), set.end(), inserter(ret),
+                   [](Atom* atom)->Handle { return atom->getHandle(); });
+            return ret;
         }
     }
-
     return ret;
 }

--- a/opencog/atomspace/ImportanceIndex.h
+++ b/opencog/atomspace/ImportanceIndex.h
@@ -24,7 +24,7 @@
 #define _OPENCOG_IMPORTANCEINDEX_H
 
 #include <opencog/truthvalue/AttentionValue.h>
-#include <opencog/atomspace/FixedIntegerIndex.h>
+#include <opencog/atomspace/ThreadSafeFixedIntegerIndex.h>
 
 namespace opencog
 {
@@ -33,12 +33,15 @@ namespace opencog
  */
 
 /**
- * Implements an index with additional routines needed for managing 
+ * Implements an index with additional routines needed for managing
  * short-term importance.  This index is not thread-safe, by itself.
  * Users of this class must gauarantee single-threaded access!
  */
-class ImportanceIndex: public FixedIntegerIndex
+class ImportanceIndex
 {
+private:
+    ThreadSafeFixedIntegerIndex _index;
+
 public:
     ImportanceIndex(void);
     void insertAtom(Atom*);
@@ -52,7 +55,7 @@ public:
      * @param The old importance bin where the atom originally was.
      */
     void updateImportance(Atom*, int);
-    
+
     UnorderedHandleSet getHandleSet(AttentionValue::sti_t,
                                     AttentionValue::sti_t) const;
 

--- a/opencog/atomspace/ThreadSafeFixedIntegerIndex.cc
+++ b/opencog/atomspace/ThreadSafeFixedIntegerIndex.cc
@@ -23,11 +23,6 @@
 
 using namespace opencog;
 
-ThreadSafeFixedIntegerIndex::ThreadSafeFixedIntegerIndex(size_t size)
-{
-    resize(size);
-}
-
 size_t ThreadSafeFixedIntegerIndex::size() const
 {
     size_t cnt = 0;

--- a/opencog/atomspace/ThreadSafeFixedIntegerIndex.cc
+++ b/opencog/atomspace/ThreadSafeFixedIntegerIndex.cc
@@ -1,0 +1,39 @@
+/*
+ * opencog/atomspace/ThreadSafeFixedIntegerIndex.cc
+ *
+ * Copyright (C) 2016 Roman Treutlein <roman.treutlein@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/atomspace/ThreadSafeFixedIntegerIndex.h>
+
+using namespace opencog;
+
+ThreadSafeFixedIntegerIndex::ThreadSafeFixedIntegerIndex(size_t size)
+{
+    resize(size);
+}
+
+size_t ThreadSafeFixedIntegerIndex::size() const
+{
+    size_t cnt = 0;
+	for (unsigned int i = 0; i < idx.size(); i++)
+		cnt += size(i);
+	return cnt;
+}
+
+// ================================================================

--- a/opencog/atomspace/ThreadSafeFixedIntegerIndex.h
+++ b/opencog/atomspace/ThreadSafeFixedIntegerIndex.h
@@ -25,6 +25,7 @@
 #include <vector>
 #include <mutex>
 #include <atomic>
+#include <memory>
 
 #include <opencog/atoms/base/Atom.h>
 #include <opencog/atoms/base/Handle.h>
@@ -54,17 +55,22 @@ class ThreadSafeFixedIntegerIndex : public FixedIntegerIndex
 	private:
 		using FixedIntegerIndex::idx;
         mutable std::vector<std::unique_ptr<std::mutex>> _locks;
-        //mutable std::mutex lock;
+        //mutable std::vector<std::mutex> _locks;
 
         void resize(size_t sz)
         {
             FixedIntegerIndex::resize(sz);
-
+            //std::vector<std::mutex> new_locks(sz);
+            _locks.resize(sz);
+            for (auto iter = _locks.begin(); iter != _locks.end(); ++iter)
+                (*iter) = std::unique_ptr<std::mutex>(new std::mutex());
         }
 
-
 	public:
-        ThreadSafeFixedIntegerIndex(size_t);
+        ThreadSafeFixedIntegerIndex(size_t size)
+        {
+            resize(size);
+        }
 		~ThreadSafeFixedIntegerIndex () {}
 
         void insert(size_t i, Atom* a)

--- a/opencog/atomspace/ThreadSafeFixedIntegerIndex.h
+++ b/opencog/atomspace/ThreadSafeFixedIntegerIndex.h
@@ -1,0 +1,113 @@
+/*
+ * opencog/atomspace/ThreadSafeFixedIntegerIndex.h
+ *
+ * Copyright (C) 2016 Roman Treutlein <roman.treutlein@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef _OPENCOG_THREADSAFEFIXEDINTEGERINDEX_H
+#define _OPENCOG_THREADSAFEFIXEDINTEGERINDEX_H
+
+#include <vector>
+#include <mutex>
+#include <atomic>
+
+#include <opencog/atoms/base/Atom.h>
+#include <opencog/atoms/base/Handle.h>
+
+#include <opencog/atomspace/FixedIntegerIndex.h>
+
+namespace opencog
+{
+/** \addtogroup grp_atomspace
+ *  @{
+ */
+
+typedef std::unordered_set<Atom*> UnorderedAtomSet;
+
+// This is possibly very costly and only used to get deterministic
+// behavior
+typedef std::set<Atom*, content_based_atom_ptr_less> ContentBasedOrderedAtomSet;
+
+typedef UnorderedAtomSet AtomSet;
+
+/**
+ * Implements a vector of atom sets; each set can be found via an
+ * integer index.
+ */
+class ThreadSafeFixedIntegerIndex : public FixedIntegerIndex
+{
+	private:
+		using FixedIntegerIndex::idx;
+        mutable std::vector<std::unique_ptr<std::mutex>> _locks;
+        //mutable std::mutex lock;
+
+        void resize(size_t sz)
+        {
+            FixedIntegerIndex::resize(sz);
+
+        }
+
+
+	public:
+        ThreadSafeFixedIntegerIndex(size_t);
+		~ThreadSafeFixedIntegerIndex () {}
+
+        void insert(size_t i, Atom* a)
+        {
+            std::lock_guard<std::mutex> lck(*_locks[i]);
+            FixedIntegerIndex::insert(i,a);
+        }
+
+        void remove(size_t i, Atom* a)
+        {
+            std::lock_guard<std::mutex> lck(*_locks[i]);
+            FixedIntegerIndex::remove(i,a);
+        }
+
+        size_t size(size_t i) const
+        {
+            std::lock_guard<std::mutex> lck(*_locks[i]);
+            return FixedIntegerIndex::size(i);
+        }
+
+        size_t size() const;
+
+
+        template <typename OutputIterator> OutputIterator
+        getContent(size_t i,OutputIterator out) const
+        {
+            std::lock_guard<std::mutex> lck(*_locks[i]);
+			const AtomSet &s(idx.at(i));
+            return std::copy(s.begin(), s.end(), out);
+        }
+
+        template <typename OutputIterator> OutputIterator
+        getContentIf(size_t i
+                    ,OutputIterator out
+                    ,std::function<bool(Atom *)> pred) const
+        {
+            std::lock_guard<std::mutex> lck(*_locks[i]);
+			const AtomSet &s(idx.at(i));
+            return std::copy_if(s.begin(), s.end(), out,pred);
+        }
+};
+
+/** @}*/
+} //namespace opencog
+
+#endif // _OPENCOG_FIXEDINTEGERINDEX_H


### PR DESCRIPTION
@linas could you take a look at this. I was thinking about the Importance Index and underlying Fixed Integer Index when I realized that you don't actually need to lock the whole index if somebody wants to use it. It should be enough to lock the individual bins. So this change should reduce the lock contention for the Importance Index. But I am unsure if this is actually an improvement as i do not have any performance data.

