### PR TITLE
Bug fix for #968

### DIFF
--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -775,7 +775,7 @@ bool PatternMatchEngine::tree_compare(const PatternTermPtr& ptm,
 	try
 	{
 		Handle gnd(var_grounding.at(hp));
-		if (gnd == hg) return true;
+		return (gnd == hg);
 	}
 	catch (...) { }
 

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -99,8 +99,7 @@ bool PatternMatchEngine::variable_compare(const Handle& hp,
 	try
 	{
 		Handle gnd(var_grounding.at(hp));
-		if (gnd)
-			return (gnd == hg);
+		return (gnd == hg);
 	}
 	catch (...) { }
 
@@ -239,7 +238,7 @@ bool PatternMatchEngine::ordered_compare(const PatternTermPtr& ptm,
 				if (ip+1 < osp_size)
 				{
 					have_post = true;
-					post_glob = (osp[ip+1]);
+					post_glob = osp[ip+1];
 				}
 
 				// Match at least one.
@@ -769,6 +768,16 @@ bool PatternMatchEngine::tree_compare(const PatternTermPtr& ptm,
                                       Caller caller)
 {
 	const Handle& hp = ptm->getHandle();
+
+	// Do we already have a grounding for this? If we do, and the
+	// proposed grounding is the same as before, then there is
+	// nothing more to do.
+	try
+	{
+		Handle gnd(var_grounding.at(hp));
+		if (gnd == hg) return true;
+	}
+	catch (...) { }
 
 	// If the pattern link is executable, then we should execute, and
 	// use the result of that execution. (This isn't implemented yet,


### PR DESCRIPTION
This used to work before, but only due to a bug in the old code.
The new code records all groundings, so make use of that.