### PR TITLE
4x improvement in pattern matcher performance with this one weird little trick....

### DIFF
--- a/opencog/benchmark/README.md
+++ b/opencog/benchmark/README.md
@@ -147,6 +147,7 @@ Install:
 apt-get install linux-tools
 ```
 
+oprofile
 
 
 ### Using valgrind ###

--- a/opencog/benchmark/README.md
+++ b/opencog/benchmark/README.md
@@ -37,7 +37,7 @@ Ingnore this: 32619
 Benchmarking AtomSpace's addLink method 10000 times .....
 0.226272 seconds elapsed (110486.44 per second)
 Sum clock() time for all requests: 184614 (0.184614 seconds, 135418 requests per second)
-Per operation stats, in CPU clock ticks: 
+Per operation stats, in CPU clock ticks:
   N: 5
   mean: 36922
   min: 34017
@@ -137,19 +137,41 @@ optional arguments:
 
 ## Profiling ##
 
-The benchmark directory now includes a sample profiling for the bindlink 
-function in `profile_bindlink.cc` This file can be used as a template 
-for profiling other atomspace functions.
+The benchmark directory now includes a sample profiling for the
+bindlink function in `profile_bindlink.cc` This file can be used as a
+template for profiling other atomspace functions.
 
-To use the `gprof` profiler, you will need to build a profile build of AtomSpace. 
+### Using perf_events ###
+Install:
+```
+apt-get install linux-tools
+```
 
-The following commands will create a new profile directory and build the atomspace
-with the compiler options so that gprof will output the appropriate profiling
-function hooks. It will also make the libraries static and not shared which is
-required for gprof to profile functions in the libraries.
 
-From the top level atomspace directory, i.e. the one that already contains the
-build directory, execute:
+
+### Using valgrind ###
+Build as normal, then use
+
+```
+valgrind --tool=callgrind ./opencog/benchmark/profile_bindlink
+```
+after this completes:
+```
+kcachegrind callgrind.out.<pid>
+```
+
+### Using gprof ###
+To use the `gprof` profiler, you will need to build a profile build
+of AtomSpace.
+
+The following commands will create a new profile directory and build
+the atomspace with the compiler options so that gprof will output the
+appropriate profiling function hooks. It will also make the libraries
+static and not shared which is required for gprof to profile functions
+in the libraries.
+
+From the top level atomspace directory, i.e. the one that already
+contains the build directory, execute:
 
 ```
 mkdir profile
@@ -158,8 +180,8 @@ cmake -D CMAKE_BUILD_TYPE=Profile ..
 make
 ```
 
-This will build atomspace using the profile options. After the build finishes
-there will be a program `profile_bindlink` in the directory:
+This will build atomspace using the profile options. After the build
+finishes there will be a program `profile_bindlink` in the directory:
 
 ```
 opencog/benchmark/
@@ -171,8 +193,8 @@ within the profile build directory. Running:
 ./profile_bindlink
 ```
 
-from that directory will run the executable and after few seconds it will
-exit and generate a file:
+from that directory will run the executable and after few seconds it
+will exit and generate a file:
 
 ```
 gmon.out
@@ -184,7 +206,7 @@ Now execute the following command:
 gprof profile_bindlink gmon.out > analysis.txt
 ```
 
-This will take the binary profiling information in gmon.out and format it so 
-that you can read it in a file called `analysis.txt`. Open `analysis.txt` in a 
-text viewer and you will see the results of the profiling.
-
+This will take the binary profiling information in gmon.out and format
+it so that you can read it in a file called `analysis.txt`. Open
+`analysis.txt` in a text viewer and you will see the results of the
+profiling.

--- a/opencog/benchmark/diary.txt
+++ b/opencog/benchmark/diary.txt
@@ -1305,3 +1305,35 @@ Remarks:
    to cache-alignment effects?
  * Hashing does seem to improve atomtable performance, though not
    as much as might be guessed.
+
+======================================================================
+
+3 Nov 2016
+----------
+
+HandleMap access time.
+----------------------
+Wow.  I was using try...catch semantics under the assumption that
+this is fast, but it turns out that stack unwinding is very expensive.
+Thus, catch should only be used for those cases tha trigger
+infrequently.
+
+PatternMatchEngine.cc line 777: var_grounding.at(hp)
+time ./opencog/benchmark/profile_bindlink
+
+0m12.820s
+0m12.732s
+0m13.178s
+0m12.872s
+0m13.351s
+
+PatternMatchEngine.cc line 777: var_grounding.find(hp);
+time ./opencog/benchmark/profile_bindlink
+
+0m7.209s
+0m7.240s
+0m7.400s
+0m7.168s
+0m7.287s
+
+That one change almost doubles the performance!!

--- a/opencog/benchmark/diary.txt
+++ b/opencog/benchmark/diary.txt
@@ -1356,3 +1356,13 @@ PatternMatchEngine.cc line 100
 0m3.712s
 
 Awesome!
+
+Now remove all the pattern matcher print statements...
+
+0m3.444s
+0m3.353s
+0m3.391s
+0m3.388s
+0m3.479s
+
+Less of a hit, but still significant.

--- a/opencog/benchmark/diary.txt
+++ b/opencog/benchmark/diary.txt
@@ -1337,3 +1337,22 @@ time ./opencog/benchmark/profile_bindlink
 0m7.287s
 
 That one change almost doubles the performance!!
+
+try again: replace try by find at
+PatternMatchEngine.cc line 1558
+
+0m5.506s
+0m5.638s
+0m5.584s
+0m5.666s
+0m5.717s
+
+PatternMatchEngine.cc line 100
+
+0m3.595s
+0m3.689s
+0m3.498s
+0m3.660s
+0m3.712s
+
+Awesome!

--- a/opencog/benchmark/profile_bindlink.cc
+++ b/opencog/benchmark/profile_bindlink.cc
@@ -74,7 +74,6 @@ Handle get_animals(Handle& animals_query)
 
 int main(void)
 {
-
     // Create the atomspace and scheme evaluator.
     atomspace = new AtomSpace();
     scheme = new SchemeEval(atomspace);

--- a/opencog/query/DefaultPatternMatchCB.cc
+++ b/opencog/query/DefaultPatternMatchCB.cc
@@ -32,6 +32,12 @@
 
 using namespace opencog;
 
+#ifdef DEBUG
+#define DO_LOG(STUFF) STUFF
+#else
+#define DO_LOG(STUFF)
+#endif
+
 /* ======================================================== */
 // Cache for temp (transient) atomsapaces.  The evaluation of
 // expressions during pattern matching requires having a temporary
@@ -526,8 +532,8 @@ bool DefaultPatternMatchCB::clause_match(const Handle& ptrn,
 	    (grnd->getOutgoingAtom(0)->getType() == GROUNDED_PREDICATE_NODE or
 	    grnd->getOutgoingAtom(0)->getType() == DEFINED_PREDICATE_NODE))
 	{
-		LAZY_LOG_FINE << "Evaluate the grounding clause=" << std::endl
-		              << grnd->toShortString() << std::endl;
+		DO_LOG({LAZY_LOG_FINE << "Evaluate the grounding clause=" << std::endl
+		              << grnd->toShortString() << std::endl;})
 
 		// We make two awkard asumptions here: the ground term itself
 		// does not contain any variables, and so does not need any
@@ -539,8 +545,8 @@ bool DefaultPatternMatchCB::clause_match(const Handle& ptrn,
 		_temp_aspace->clear();
 		TruthValuePtr tvp(EvaluationLink::do_eval_scratch(_as, grnd, _temp_aspace));
 
-		LAZY_LOG_FINE << "Clause_match evaluation yeilded tv"
-		              << std::endl << tvp->toString() << std::endl;
+		DO_LOG({LAZY_LOG_FINE << "Clause_match evaluation yeilded tv"
+		              << std::endl << tvp->toString() << std::endl;})
 
 		// XXX FIXME: we are making a crisp-logic go/no-go decision
 		// based on the TV strength. Perhaps something more subtle might be
@@ -592,10 +598,10 @@ bool DefaultPatternMatchCB::eval_term(const Handle& virt,
 
 	Handle gvirt(_instor->instantiate(virt, gnds));
 
-	LAZY_LOG_FINE << "Enter eval_term CB with virt=" << std::endl
-	              << virt->toShortString() << std::endl;
-	LAZY_LOG_FINE << "Grounded by gvirt=" << std::endl
-	              << gvirt->toShortString() << std::endl;
+	DO_LOG({LAZY_LOG_FINE << "Enter eval_term CB with virt=" << std::endl
+	              << virt->toShortString() << std::endl;})
+	DO_LOG({LAZY_LOG_FINE << "Grounded by gvirt=" << std::endl
+	              << gvirt->toShortString() << std::endl;})
 
 	// At this time, we expect all virutal links to be in one of two
 	// forms: either EvaluationLink's or GreaterThanLink's.  The
@@ -666,8 +672,8 @@ bool DefaultPatternMatchCB::eval_term(const Handle& virt,
 	            "Expecting a TruthValue for an evaluatable link: %s\n",
 	            gvirt->toShortString().c_str());
 
-	LAZY_LOG_FINE << "Eval_term evaluation yeilded tv="
-	              << tvp->toString() << std::endl;
+	DO_LOG({LAZY_LOG_FINE << "Eval_term evaluation yeilded tv="
+	              << tvp->toString() << std::endl;})
 
 	// XXX FIXME: we are making a crsip-logic go/no-go decision
 	// based on the TV strength. Perhaps something more subtle might be
@@ -688,8 +694,8 @@ bool DefaultPatternMatchCB::eval_term(const Handle& virt,
 bool DefaultPatternMatchCB::eval_sentence(const Handle& top,
                                           const HandleMap& gnds)
 {
-	LAZY_LOG_FINE << "Enter eval_sentence CB with top=" << std::endl
-	              << top->toShortString() << std::endl;
+	DO_LOG({LAZY_LOG_FINE << "Enter eval_sentence CB with top=" << std::endl
+	              << top->toShortString() << std::endl;})
 
 	if (top->getType() == VARIABLE_NODE)
 	{
@@ -804,8 +810,8 @@ bool DefaultPatternMatchCB::eval_sentence(const Handle& top,
 	if (gnds.end() != g)
 	{
 		TruthValuePtr tvp(g->second->getTruthValue());
-		LAZY_LOG_FINE << "Non-logical atom has tv="
-		              << tvp->toString() << std::endl;
+		DO_LOG({LAZY_LOG_FINE << "Non-logical atom has tv="
+		              << tvp->toString() << std::endl;})
 		// XXX FIXME: we are making a crisp-logic go/no-go decision
 		// based on the TV strength. Perhaps something more subtle might be
 		// wanted, here.

--- a/opencog/query/DefaultPatternMatchCB.cc
+++ b/opencog/query/DefaultPatternMatchCB.cc
@@ -742,14 +742,7 @@ bool DefaultPatternMatchCB::eval_sentence(const Handle& top,
 		// clause is present" is implemented by ChoiceLink.
 		for (const Handle& h : oset)
 		{
-			try
-			{
-				Handle g = gnds.at(h);
-			}
-			catch (...)
-			{
-				return false;
-			}
+			if (gnds.end() == gnds.find(h)) return false;
 		}
 		return true;
 	}
@@ -764,15 +757,9 @@ bool DefaultPatternMatchCB::eval_sentence(const Handle& top,
 		// AbsentLink is same as NotLink PresentLink.
 		for (const Handle& h : oset)
 		{
-			try
-			{
-				Handle g = gnds.at(h);
-			}
-			catch (...)
-			{
-				// If no grounding, that,s good, try the next one.
-				continue;
-			}
+			// If no grounding, that's good, try the next one.
+			if (gnds.end() == gnds.find(h)) continue;
+
 			// If we are here, a grounding was found; that's bad.
 			return false;
 		}
@@ -794,14 +781,7 @@ bool DefaultPatternMatchCB::eval_sentence(const Handle& top,
 		// anything about that here? Seems like we can't do anything...
 		for (const Handle& h : oset)
 		{
-			try
-			{
-				Handle g = gnds.at(h);
-			}
-			catch (...)
-			{
-				continue;
-			}
+			if (gnds.end() == gnds.find(h)) continue;
 			return true;
 		}
 		return false;
@@ -820,10 +800,10 @@ bool DefaultPatternMatchCB::eval_sentence(const Handle& top,
 	// There are several minor issues: 1) we need to check the TV
 	// of the grounded atom, not the TV of the pattern, and 2) if
 	// the atom is executable, we need to execute it.
-	try
+	auto g = gnds.find(top);
+	if (gnds.end() != g)
 	{
-		Handle g = gnds.at(top);
-		TruthValuePtr tvp(g->getTruthValue());
+		TruthValuePtr tvp(g->second->getTruthValue());
 		LAZY_LOG_FINE << "Non-logical atom has tv="
 		              << tvp->toString() << std::endl;
 		// XXX FIXME: we are making a crisp-logic go/no-go decision
@@ -832,7 +812,6 @@ bool DefaultPatternMatchCB::eval_sentence(const Handle& top,
 		bool relation_holds = tvp->getMean() > 0.5;
 		return relation_holds;
 	}
-	catch (...) {}
 
 	// If it's not grounded, then perhaps its executable.
 	return eval_term(top, gnds);

--- a/opencog/query/PatternMatch.cc
+++ b/opencog/query/PatternMatch.cc
@@ -152,6 +152,7 @@ bool PatternMatch::recursive_virtual(PatternMatchCallback& cb,
 	// what they've got to say about it.
 	if (0 == comp_var_gnds.size())
 	{
+#ifdef DEBUG
 		if (logger().is_fine_enabled())
 		{
 			logger().fine("Explore one possible combinatoric grounding "
@@ -159,6 +160,7 @@ bool PatternMatch::recursive_virtual(PatternMatchCallback& cb,
 			              var_gnds.size(), term_gnds.size());
 			PatternMatchEngine::log_solution(var_gnds, term_gnds);
 		}
+#endif
 
 		// Note, FYI, that if there are no virtual clauses at all,
 		// then this loop falls straight-through, and the grounding
@@ -196,7 +198,9 @@ bool PatternMatch::recursive_virtual(PatternMatchCallback& cb,
 		// pattern! See what the callback thinks of it.
 		return cb.grounding(var_gnds, term_gnds);
 	}
+#ifdef DEBUG
 	LAZY_LOG_FINE << "Component recursion: num comp=" << comp_var_gnds.size();
+#endif
 
 	// Recurse over all components. If component k has N_k groundings,
 	// and there are m components, then we have to explore all
@@ -343,13 +347,17 @@ bool PatternLink::satisfy(PatternMatchCallback& pmcb) const
 	{
 		PatternMatchEngine pme(pmcb);
 
+#ifdef DEBUG
 		debug_log();
+#endif
 
 		pme.set_pattern(_varlist, _pat);
 		pmcb.set_pattern(_varlist, _pat);
 		bool found = pmcb.initiate_search(&pme);
 
+#ifdef DEBUG
 		logger().fine("================= Done with Search =================");
+#endif
 		found = pmcb.search_finished(found);
 
 		return found;
@@ -367,6 +375,7 @@ bool PatternLink::satisfy(PatternMatchCallback& pmcb) const
 	// grounding combination through the virtual link, for the final
 	// accept/reject determination.
 
+#ifdef DEBUG
 	if (logger().is_fine_enabled())
 	{
 		logger().fine("VIRTUAL PATTERN: ====== "
@@ -380,14 +389,17 @@ bool PatternLink::satisfy(PatternMatchCallback& pmcb) const
 			iii++;
 		}
 	}
+#endif
 
 	std::vector<HandleMapSeq> comp_term_gnds;
 	std::vector<HandleMapSeq> comp_var_gnds;
 
 	for (size_t i=0; i<_num_comps; i++)
 	{
+#ifdef DEBUG
 		LAZY_LOG_FINE << "BEGIN COMPONENT GROUNDING " << i+1
 		              << " of " << _num_comps << ": ===========\n";
+#endif
 
 		PatternLinkPtr clp(PatternLinkCast(_component_patterns.at(i)));
 		Pattern pat = clp->get_pattern();
@@ -413,8 +425,10 @@ bool PatternLink::satisfy(PatternMatchCallback& pmcb) const
 			// to try to solve the other components, their product
 			// will have no solution.
 			if (gcb._term_groundings.empty()) {
+#ifdef DEBUG
 				logger().fine("No solution for this component. "
 				              "Abort search as no product solution may exist.");
+#endif
 				return false;
 			}
 
@@ -424,9 +438,11 @@ bool PatternLink::satisfy(PatternMatchCallback& pmcb) const
 	}
 
 	// And now, try grounding each of the virtual clauses.
+#ifdef DEBUG
 	LAZY_LOG_FINE << "BEGIN component recursion: ====================== "
 	              << "num comp=" << comp_var_gnds.size()
 	              << " num virts=" << _virtual.size();
+#endif
 	HandleMap empty_vg;
 	HandleMap empty_pg;
 	HandleSeq optionals; // currently ignored

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -884,19 +884,19 @@ bool PatternMatchEngine::explore_term_branches(const Handle& term,
 {
 	// The given term may appear in the clause in more than one place.
 	// Each distinct locatation should be explored separately.
-	try
+	auto pl = _pat->connected_terms_map.find({term, clause_root});
+	if (_pat->connected_terms_map.end() == pl)
 	{
-		for (const PatternTermPtr &ptm :
-			_pat->connected_terms_map.at({term, clause_root}))
-		{
-			if (explore_link_branches(ptm, hg, clause_root))
-				return true;
-		}
-	}
-	catch (const std::out_of_range&)
-	{
+		// XXX ???? Isn't this a hard-error ???
 		LAZY_LOG_FINE << "Pattern term not found for " << term->toShortString()
 		              << ", clause=" << clause_root->toShortString();
+		return false;
+	}
+
+	for (const PatternTermPtr &ptm : pl->second)
+	{
+		if (explore_link_branches(ptm, hg, clause_root))
+			return true;
 	}
 	return false;
 }

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -386,23 +386,19 @@ size_t PatternMatchEngine::curr_choice(const PatternTermPtr& ptm,
                                        const Handle& hg,
                                        bool& fresh)
 {
-	size_t istart;
-	try { istart = _choice_state.at(GndChoice(ptm, hg)); }
-	catch(...) { istart = 0; fresh = true; }
-	return istart;
+	auto cs = _choice_state.find(GndChoice(ptm, hg));
+	if (_choice_state.end() == cs)
+	{
+		fresh = true;
+		return 0;
+	}
+	return cs->second;
 }
 
 bool PatternMatchEngine::have_choice(const PatternTermPtr& ptm,
                                      const Handle& hg)
 {
-#if USE_AT
-	bool have = true;
-	try { _choice_state.at(GndChoice(ptm, hg)); }
-	catch(...) { have = false;}
-	return have;
-#else
 	return 0 < _choice_state.count(GndChoice(ptm, hg));
-#endif
 }
 
 /* ======================================================== */
@@ -686,17 +682,17 @@ PatternMatchEngine::curr_perm(const PatternTermPtr& ptm,
                               const Handle& hg,
                               bool& fresh)
 {
-	Permutation perm;
-	try { perm = _perm_state.at(Unorder(ptm, hg)); }
-	catch(...)
+	auto ps = _perm_state.find(Unorder(ptm, hg));
+	if (_perm_state.end() == ps)
 	{
 		LAZY_LOG_FINE << "tree_comp fresh start unordered link term="
 		              << ptm->toString();
-		perm = ptm->getOutgoingSet();
+		Permutation perm = ptm->getOutgoingSet();
 		sort(perm.begin(), perm.end());
 		fresh = true;
+		return perm;
 	}
-	return perm;
+	return ps->second;
 }
 
 /// Return true if there are more permutations to explore.
@@ -704,8 +700,8 @@ PatternMatchEngine::curr_perm(const PatternTermPtr& ptm,
 bool PatternMatchEngine::have_perm(const PatternTermPtr& ptm,
                                    const Handle& hg)
 {
-	try { _perm_state.at(Unorder(ptm, hg)); }
-	catch(...) { return false; }
+	if (_perm_state.end() == _perm_state.find(Unorder(ptm, hg)))
+		return false;
 	return true;
 }
 

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -772,12 +772,8 @@ bool PatternMatchEngine::tree_compare(const PatternTermPtr& ptm,
 	// Do we already have a grounding for this? If we do, and the
 	// proposed grounding is the same as before, then there is
 	// nothing more to do.
-	try
-	{
-		Handle gnd(var_grounding.at(hp));
-		return (gnd == hg);
-	}
-	catch (...) { }
+	auto gnd = var_grounding.find(hp);
+	if (gnd != var_grounding.end()) return (gnd->second == hg);
 
 	// If the pattern link is executable, then we should execute, and
 	// use the result of that execution. (This isn't implemented yet,


### PR DESCRIPTION
You won't believe how simple it is to improve pattern matcher performance!

Did you know that exception stack unwinding is very expensive?  Most people don't, and this includes people like Linas!  Using exceptions to handle default code paths can be a huge drag on performance, and converting the `std::` container class `.at()` method, which throws when a value is not found, to the `find()` method, which simply returns the iterator `end()`, results in much much faster code!  About 4x faster, for the pattern matcher!