### PR TITLE
Have Implicator::grounding catch all exceptions.

### DIFF
--- a/opencog/query/Implicator.cc
+++ b/opencog/query/Implicator.cc
@@ -58,7 +58,7 @@ bool Implicator::grounding(const HandleMap &var_soln,
 	try {
 		Handle h = inst.instantiate(implicand, var_soln);
 		insert_result(h);
-	} catch(const InvalidParamException& e) {}
+	} catch(...) {}
 
 	// If we found as many as we want, then stop looking for more.
 	return (_result_set.size() >= max_results);

--- a/tests/query/NoExceptionUTest.cxxtest
+++ b/tests/query/NoExceptionUTest.cxxtest
@@ -99,8 +99,7 @@ void NoExceptionUTest::test_exception()
 	TSM_ASSERT("Failed to load test data", Handle::UNDEFINED != bl);
 
 	// We expect NOT to catch an error.
-	// TODO: not clear we want that so disabled for now.
-	// TS_ASSERT_THROWS_NOTHING(bindlink(as, bl));
+	TS_ASSERT_THROWS_NOTHING(bindlink(as, bl));
 	
 	logger().debug("END TEST: %s", __FUNCTION__);
 }


### PR DESCRIPTION
I know it's pretty extreme but it turns out there are more exceptions
that need to be accounted for like for instance when a scheme function
doesn't get the right number of arguments (due to ill formed ListLink
that hand the arguments to a rewrite part of a rule).