### PR TITLE
Complete local quote

### DIFF
--- a/opencog/atoms/base/CMakeLists.txt
+++ b/opencog/atoms/base/CMakeLists.txt
@@ -20,6 +20,7 @@ ADD_LIBRARY (atombase
 	LinkValue.cc
 	Node.cc
 	StringValue.cc
+	Quotation.cc
 )
 
 # Without this, parallel make will race and crap up the generated files.
@@ -47,6 +48,7 @@ INSTALL (FILES
 	ProtoAtom.h
 	StringValue.h
 	types.h
+	Quotation.h
 	DESTINATION "include/opencog/atoms/base"
 )
 

--- a/opencog/atoms/base/Quotation.cc
+++ b/opencog/atoms/base/Quotation.cc
@@ -1,0 +1,66 @@
+/*
+ * opencog/atoms/base/Quotation.h
+ *
+ * Copyright (C) 2016 OpenCog Foundation
+ * All Rights Reserved
+ *
+ * Written by Nil Geisweiller
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "Quotation.h"
+
+using namespace opencog;
+
+Quotation::Quotation(int ql, bool lq)
+	: _quotation_level(ql), _local_quote(lq) {}
+
+int Quotation::quotation_level() const
+{
+	return _quotation_level;
+}
+
+bool Quotation::is_locally_quoted() const
+{
+	return _local_quote;
+}
+
+bool Quotation::is_quoted() const
+{
+	return _quotation_level != 0 or is_locally_quoted();
+}
+
+void Quotation::update(Type t)
+{
+	bool is_unquoted = not is_quoted();
+	bool is_locally_unquoted = not is_locally_quoted();
+	
+	// Locally quoted iff it is an unquoted LocalQuote
+	_local_quote = is_unquoted and LOCAL_QUOTE_LINK == t;
+
+	// Increment or decrement quotation level if locally unquoted
+	if (is_locally_unquoted) {
+		if (QUOTE_LINK == t) _quotation_level++;
+	    else if (UNQUOTE_LINK == t) _quotation_level--;
+    }
+}
+
+bool Quotation::consumable_quotation(Type t)
+{
+	return (not is_quoted() and (LOCAL_QUOTE_LINK == t or QUOTE_LINK == t))
+		or (quotation_level() == 1 and UNQUOTE_LINK == t);
+}

--- a/opencog/atoms/base/Quotation.cc
+++ b/opencog/atoms/base/Quotation.cc
@@ -50,6 +50,12 @@ bool Quotation::is_unquoted() const
 	return not is_quoted();
 }
 
+bool Quotation::consumable(Type t) const
+{
+	return (not is_quoted() and (LOCAL_QUOTE_LINK == t or QUOTE_LINK == t))
+		or (level() == 1 and UNQUOTE_LINK == t);
+}
+
 void Quotation::update(Type t)
 {
 	bool is_unquoted = not is_quoted();
@@ -63,12 +69,6 @@ void Quotation::update(Type t)
 		if (QUOTE_LINK == t) _quotation_level++;
 	    else if (UNQUOTE_LINK == t) _quotation_level--;
     }
-}
-
-bool Quotation::consume(Type t)
-{
-	return (not is_quoted() and (LOCAL_QUOTE_LINK == t or QUOTE_LINK == t))
-		or (level() == 1 and UNQUOTE_LINK == t);
 }
 
 std::string Quotation::to_string() const

--- a/opencog/atoms/base/Quotation.cc
+++ b/opencog/atoms/base/Quotation.cc
@@ -50,6 +50,11 @@ bool Quotation::is_unquoted() const
 	return not is_quoted();
 }
 
+bool Quotation::is_quotation_type(Type t)
+{
+	return QUOTE_LINK == t or UNQUOTE_LINK == t or LOCAL_QUOTE_LINK == t;
+}
+
 bool Quotation::consumable(Type t) const
 {
 	return (not is_quoted() and (LOCAL_QUOTE_LINK == t or QUOTE_LINK == t))

--- a/opencog/atoms/base/Quotation.cc
+++ b/opencog/atoms/base/Quotation.cc
@@ -23,13 +23,14 @@
  */
 
 #include "Quotation.h"
+#include <sstream>
 
-using namespace opencog;
+namespace opencog {
 
 Quotation::Quotation(int ql, bool lq)
 	: _quotation_level(ql), _local_quote(lq) {}
 
-int Quotation::quotation_level() const
+int Quotation::level() const
 {
 	return _quotation_level;
 }
@@ -42,6 +43,11 @@ bool Quotation::is_locally_quoted() const
 bool Quotation::is_quoted() const
 {
 	return _quotation_level != 0 or is_locally_quoted();
+}
+
+bool Quotation::is_unquoted() const
+{
+	return not is_quoted();
 }
 
 void Quotation::update(Type t)
@@ -59,8 +65,23 @@ void Quotation::update(Type t)
     }
 }
 
-bool Quotation::consumable_quotation(Type t)
+bool Quotation::consume(Type t)
 {
 	return (not is_quoted() and (LOCAL_QUOTE_LINK == t or QUOTE_LINK == t))
-		or (quotation_level() == 1 and UNQUOTE_LINK == t);
+		or (level() == 1 and UNQUOTE_LINK == t);
 }
+
+std::string Quotation::to_string() const
+{
+	std::stringstream ss;
+	ss << "quotation level = " << _quotation_level << std::endl
+	   << "local quote = " << _local_quote << std::endl;
+	return ss.str();
+}
+
+std::string oc_to_string(const Quotation& quotation)
+{
+	return quotation.to_string();
+}
+	
+} // namespace opencog

--- a/opencog/atoms/base/Quotation.h
+++ b/opencog/atoms/base/Quotation.h
@@ -52,31 +52,28 @@ public:
 	bool is_unquoted() const;
 
 	/**
+	 * Check whether the current atom would be consumed as quotation
+	 * operator or not. More specifically:
+	 *
+	 * 1. An unquoted QuoteLink would be consumed, turning the
+	 * quotation state from unquoted to quoted.
+	 *
+	 * 2. An UnquoteLink with quotation level of 1 would be consumed,
+	 * turning the quotation state from quoted to unquoted.
+	 *
+	 * 3. An unquoted LocalQuoteLink would be consumed, turning
+	 * temporarily the quotation state from unquoted to quoted.
+	 *
+	 * Remark: you must call this function before calling update,
+	 * otherwise the result will not be correct on the current atom.
+	 */
+	bool consumable(Type t) const;
+
+	/**
 	 * Increment, decrement or change local quote given the type of
 	 * the current atom before handing the quotation to the outgoing.
 	 */
 	void update(Type t);
-
-	/**
-	 * Check whether the current atom would be consumed as quotation
-	 * operator or not. More specifically:
-	 *
-	 * 1. An unquoted QuoteLink would be consumed, passing the
-	 * quotation state from unquoted to quoted.
-	 *
-	 * 2. An UnquoteLink with quotation level of 1 would be consumed,
-	 * passing the quotation state from quoted to unquoted.
-	 *
-	 * 3. An unquoted LocalQuoteLink would be consumed, passing
-	 * temporarily the quotation state from unquoted to quoted.
-	 *
-	 * Remark: you must call this function before calling update,
-	 * otherwise the result will not be correct.
-	 *
-	 * TODO: perhaps set _local_quote to false
-	 * TODO: perhaps merge update and consume into a single function
-	 */
-	bool consume(Type t);
 
 	std::string to_string() const;
 };

--- a/opencog/atoms/base/Quotation.h
+++ b/opencog/atoms/base/Quotation.h
@@ -26,6 +26,7 @@
 #define _OPENCOG_QUOTATION_H
 
 #include <opencog/atoms/base/atom_types.h>
+#include <string>
 
 namespace opencog
 {
@@ -45,9 +46,10 @@ class Quotation
 public:
 	Quotation(int ql=0, bool lq=false);
 
-	int quotation_level() const;
+	int level() const;
 	bool is_locally_quoted() const;
 	bool is_quoted() const;
+	bool is_unquoted() const;
 
 	/**
 	 * Increment, decrement or change local quote given the type of
@@ -67,10 +69,22 @@ public:
 	 *
 	 * 3. An unquoted LocalQuoteLink would be consumed, passing
 	 * temporarily the quotation state from unquoted to quoted.
-	*/
-	bool consumable_quotation(Type t);
+	 *
+	 * Remark: you must call this function before calling update,
+	 * otherwise the result will not be correct.
+	 *
+	 * TODO: perhaps set _local_quote to false
+	 * TODO: perhaps merge update and consume into a single function
+	 */
+	bool consume(Type t);
+
+	std::string to_string() const;
 };
 
+// For gdb, see
+// http://wiki.opencog.org/w/Development_standards#Print_OpenCog_Objects
+std::string oc_to_string();
+	
 /** @}*/
 } // namespace opencog
 

--- a/opencog/atoms/base/Quotation.h
+++ b/opencog/atoms/base/Quotation.h
@@ -52,6 +52,12 @@ public:
 	bool is_unquoted() const;
 
 	/**
+	 * Return true iff the type is QUOTE_LINK, UNQUOTE_LINK or
+	 * LOCAL_QUOTE_LINK.
+	 */
+	static bool is_quotation_type(Type t);
+
+	/**
 	 * Check whether the current atom would be consumed as quotation
 	 * operator or not. More specifically:
 	 *

--- a/opencog/atoms/base/Quotation.h
+++ b/opencog/atoms/base/Quotation.h
@@ -1,0 +1,77 @@
+/*
+ * opencog/atoms/base/Quotation.h
+ *
+ * Copyright (C) 2016 OpenCog Foundation
+ * All Rights Reserved
+ *
+ * Written by Nil Geisweiller
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef _OPENCOG_QUOTATION_H
+#define _OPENCOG_QUOTATION_H
+
+#include <opencog/atoms/base/atom_types.h>
+
+namespace opencog
+{
+
+/** \addtogroup grp_atomspace
+ *  @{
+ */
+
+/**
+ * Quotation data and methods. See http://wiki.opencog.org/w/QuoteLink.
+ */
+class Quotation
+{
+	int _quotation_level;
+	bool _local_quote;
+
+public:
+	Quotation(int ql=0, bool lq=false);
+
+	int quotation_level() const;
+	bool is_locally_quoted() const;
+	bool is_quoted() const;
+
+	/**
+	 * Increment, decrement or change local quote given the type of
+	 * the current atom before handing the quotation to the outgoing.
+	 */
+	void update(Type t);
+
+	/**
+	 * Check whether the current atom would be consumed as quotation
+	 * operator or not. More specifically:
+	 *
+	 * 1. An unquoted QuoteLink would be consumed, passing the
+	 * quotation state from unquoted to quoted.
+	 *
+	 * 2. An UnquoteLink with quotation level of 1 would be consumed,
+	 * passing the quotation state from quoted to unquoted.
+	 *
+	 * 3. An unquoted LocalQuoteLink would be consumed, passing
+	 * temporarily the quotation state from unquoted to quoted.
+	*/
+	bool consumable_quotation(Type t);
+};
+
+/** @}*/
+} // namespace opencog
+
+#endif // _OPENCOG_QUOTATION_H

--- a/opencog/atoms/base/atom_types.script
+++ b/opencog/atoms/base/atom_types.script
@@ -150,7 +150,7 @@ QUOTE_LINK <- ORDERED_LINK
 UNQUOTE_LINK <- ORDERED_LINK
 
 // Like QuoteLink but only affects the direct child, not its
-// descendent. It has the same effect as wrapping the child with a
+// descendants. It has the same effect as wrapping the child with a
 // QuoteLink and each atom of the its outgoing set with an UnquoteLink.
 LOCAL_QUOTE_LINK <- ORDERED_LINK
 

--- a/opencog/atoms/core/ScopeLink.h
+++ b/opencog/atoms/core/ScopeLink.h
@@ -24,6 +24,7 @@
 #define _OPENCOG_SCOPE_LINK_H
 
 #include <opencog/atoms/core/VariableList.h>
+#include <opencog/atoms/base/Quotation.h>
 
 namespace opencog
 {
@@ -73,7 +74,8 @@ protected:
 	void init_scoped_variables(const Handle& hvar);
 
 	bool skip_init(Type);
-	ContentHash term_hash(const Handle&, UnorderedHandleSet&, int) const;
+	ContentHash term_hash(const Handle&, UnorderedHandleSet&,
+	                      Quotation quotation = Quotation()) const;
 	virtual ContentHash compute_hash() const;
 
 public:

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -161,9 +161,11 @@ Handle FreeVariables::substitute_scoped(const Handle& term,
                                         const IndexMap& index_map,
                                         Quotation quotation) const
 {
+	bool unquoted = quotation.is_unquoted();
+
 	// If we are not in a quote context, and `term` is a variable,
 	// then just return the corresponding value.
-	if (quotation.is_unquoted())
+	if (unquoted)
 	{
 		IndexMap::const_iterator idx = index_map.find(term);
 		if (idx != index_map.end())
@@ -176,9 +178,10 @@ Handle FreeVariables::substitute_scoped(const Handle& term,
 
 	Type ty = term->getType();
 
+	// Update for subsequent recursive calls of substitute_scoped
 	quotation.update(ty);
 
-	if (quotation.is_unquoted() and classserver().isA(ty, SCOPE_LINK))
+	if (unquoted and classserver().isA(ty, SCOPE_LINK))
 	{
 		// Perform alpha-conversion duck-n-cover.  We don't actually need
 		// to alpha-convert anything, if we happen to encounter a bound

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -178,7 +178,7 @@ Handle FreeVariables::substitute_scoped(const Handle& term,
 
 	quotation.update(ty);
 
-	if (0 == quotation.is_unquoted() and classserver().isA(ty, SCOPE_LINK))
+	if (quotation.is_unquoted() and classserver().isA(ty, SCOPE_LINK))
 	{
 		// Perform alpha-conversion duck-n-cover.  We don't actually need
 		// to alpha-convert anything, if we happen to encounter a bound

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -159,11 +159,11 @@ Handle FreeVariables::substitute_scoped(const Handle& term,
                                         const HandleSeq& args,
                                         bool silent,
                                         const IndexMap& index_map,
-                                        int quotation_level) const
+                                        Quotation quotation) const
 {
 	// If we are not in a quote context, and `term` is a variable,
 	// then just return the corresponding value.
-	if (0 == quotation_level)
+	if (quotation.is_unquoted())
 	{
 		IndexMap::const_iterator idx = index_map.find(term);
 		if (idx != index_map.end())
@@ -174,24 +174,11 @@ Handle FreeVariables::substitute_scoped(const Handle& term,
 	// and just return that.
 	if (not term->isLink()) return term;
 
-	// Quotation management
 	Type ty = term->getType();
-	if (QUOTE_LINK == ty)
-	{
-		quotation_level++;
-	}
-	else
-	if (UNQUOTE_LINK == ty)
-	{
-		quotation_level--;
-		if (quotation_level < 0)
-		{
-			if (silent) throw NestingException();
-			throw SyntaxException(TRACE_INFO, "Unbalanced quotes!");
-		}
-	}
-	else
-	if (0 == quotation_level and classserver().isA(ty, SCOPE_LINK))
+
+	quotation.update(ty);
+
+	if (0 == quotation.is_unquoted() and classserver().isA(ty, SCOPE_LINK))
 	{
 		// Perform alpha-conversion duck-n-cover.  We don't actually need
 		// to alpha-convert anything, if we happen to encounter a bound
@@ -239,7 +226,8 @@ Handle FreeVariables::substitute_scoped(const Handle& term,
 			HandleSeq oset;
 			for (const Handle& h : term->getOutgoingSet())
 			{
-				oset.emplace_back(substitute_scoped(h, args, silent, hidden_map, quotation_level));
+				oset.emplace_back(substitute_scoped(h, args, silent,
+				                                    hidden_map, quotation));
 			}
 			return Handle(createLink(term->getType(), oset));
 		}
@@ -254,7 +242,7 @@ Handle FreeVariables::substitute_scoped(const Handle& term,
 		// that wraps them up.  See MapLinkUTest for examples.
 		if (GLOB_NODE == h->getType())
 		{
-			Handle glst(substitute_scoped(h, args, silent, index_map, quotation_level));
+			Handle glst(substitute_scoped(h, args, silent, index_map, quotation));
 			if (glst->isNode())
 				return glst;
 			for (const Handle& gl : glst->getOutgoingSet())
@@ -262,7 +250,7 @@ Handle FreeVariables::substitute_scoped(const Handle& term,
 		}
 		else
 			oset.emplace_back(
-				substitute_scoped(h, args, silent, index_map, quotation_level));
+				substitute_scoped(h, args, silent, index_map, quotation));
 	}
 	return Handle(createLink(term->getType(), oset));
 }

--- a/opencog/atoms/core/Variables.h
+++ b/opencog/atoms/core/Variables.h
@@ -27,6 +27,7 @@
 #include <set>
 
 #include <opencog/atoms/base/Handle.h>
+#include <opencog/atoms/base/Quotation.h>
 
 namespace opencog
 {
@@ -101,7 +102,8 @@ struct FreeVariables
 	Handle substitute_nocheck(const Handle&, const HandleSeq&, bool silent=false) const;
 protected:
 	Handle substitute_scoped(const Handle&, const HandleSeq&, bool,
-	                         const IndexMap&, int) const;
+	                         const IndexMap&,
+	                         Quotation quotation=Quotation()) const;
 };
 
 typedef std::map<Handle, const std::set<Type> > VariableTypeMap;

--- a/opencog/atoms/execution/Instantiator.cc
+++ b/opencog/atoms/execution/Instantiator.cc
@@ -104,7 +104,7 @@ Handle Instantiator::walk_tree(const Handle& expr)
 
 	// Discard the following QuoteLink, UnquoteLink or LocalQuoteLink
 	// as it is serving its quoting or unquoting function.
-	if (_avoid_discarding_quotes_level == 0 and _quotation.consume(t))
+	if (_avoid_discarding_quotes_level == 0 and _quotation.consumable(t))
 	{
 		if (1 != expr->getArity())
 			throw InvalidParamException(TRACE_INFO,

--- a/opencog/atoms/execution/Instantiator.cc
+++ b/opencog/atoms/execution/Instantiator.cc
@@ -302,7 +302,7 @@ Handle Instantiator::walk_tree(const Handle& expr)
 			// XXX I don't get it ... something is broken here, because
 			// the ExecutionOutputLink below *also* performs eager
 			// execution of its arguments. So the step below should not
-			// be neeeded -- yet, it is ... Funny thing is, it only
+			// be needed -- yet, it is ... Funny thing is, it only
 			// breaks the BackwardChainerUTest ... why?
 			_avoid_discarding_quotes_level++;
 			args = walk_tree(args);

--- a/opencog/atoms/execution/Instantiator.h
+++ b/opencog/atoms/execution/Instantiator.h
@@ -26,6 +26,8 @@
 
 #include <opencog/atomspace/AtomSpace.h>
 
+#include <opencog/atoms/base/Quotation.h>
+
 /**
  * class Instantiator -- create grounded expressions from ungrounded ones.
  * Given an ungrounded expression (i.e. an expression containing variables)
@@ -53,7 +55,7 @@ private:
 	 * (e.g. GetLink, BindLink), since these handle QuoteLinks within
 	 * their own scope. We must avoid damaging quotes for these atoms.
 	 */
-	int _quotation_level = 0;
+	Quotation _quotation;
 	int _avoid_discarding_quotes_level = 0;
 
 	/**

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -756,25 +756,20 @@ bool PatternLink::add_dummies()
 /// evaluatable.
 void PatternLink::trace_connectives(const std::set<Type>& connectives,
                                     const HandleSeq& oset,
-                                    int quotation_level)
+                                    Quotation quotation)
 {
 	for (const Handle& term: oset)
 	{
 		Type t = term->getType();
 
-		// Deal with quote
-		if (t == QUOTE_LINK)
-			quotation_level++;
-		else if (t == UNQUOTE_LINK)
-			quotation_level--;
+		quotation.update(t);
 
-		if (quotation_level > 0
-		    or connectives.find(t) == connectives.end()) continue;
+		if (quotation.is_quoted() or connectives.find(t) == connectives.end())
+			continue;
 		_pat.evaluatable_holders.insert(term);
 		add_to_map(_pat.in_evaluatable, term, term);
 		if (term->isLink())
-			trace_connectives(connectives, term->getOutgoingSet(),
-			                  quotation_level);
+			trace_connectives(connectives, term->getOutgoingSet(), quotation);
 	}
 }
 

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -867,43 +867,17 @@ void PatternLink::make_term_tree_recursive(const Handle& root,
                                            Handle h,
                                            PatternTermPtr& parent)
 {
-	Type t = h->getType();
-
-	// If the pattern link is a quote, then we compare the quoted
-	// contents. This is done recursively, of course.  The QuoteLink
-	// must have only one child; anything else beyond that is ignored
-	// (as its not clear what else could possibly be done).
-	//
-	// Ignore quoting and unquoting nodes in the PatternTerm
-	if ((not parent->isQuoted() and (QUOTE_LINK == t or LOCAL_QUOTE_LINK == t))
-	    or (parent->getQuotationLevel() == 1
-	        and not parent->isLocalQuoted() and UNQUOTE_LINK == t)) {
-		if (1 != h->getArity())
-			throw InvalidParamException(TRACE_INFO,
-			                            "QuoteLink/UnquoteLink has "
-			                            "unexpected arity!");
-		h = h->getOutgoingAtom(0);
-	}
-
 	PatternTermPtr ptm(std::make_shared<PatternTerm>(parent, h));
 	parent->addOutgoingTerm(ptm);
 	_pat.connected_terms_map[{h, root}].emplace_back(ptm);
-
-	// Update the PatternTerm quotation level
-	if (not parent->isQuoted() and LOCAL_QUOTE_LINK == t)
-		ptm->setLocalQuote(true);
-	else if (QUOTE_LINK == t)
-		ptm->addQuote();
-	else if (UNQUOTE_LINK == t)
-		ptm->remQuote();
 
 	// If the current node is a bound variable store this information for
 	// later checks. The flag telling whether the term subtree contains
 	// any bound variable is set by addBoundVariable() method for all terms
 	// on the path up to the root (unless it has been set already).
-	t = h->getType();
+	Type t = h->getType();
 	if ((VARIABLE_NODE == t or GLOB_NODE == t)
-	    and not ptm->isQuoted()
+	    and not ptm->getQuotation().is_quoted()
 	    and _varlist.varset.end() != _varlist.varset.find(h))
 	{
 		ptm->addBoundVariable();

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -868,6 +868,7 @@ void PatternLink::make_term_tree_recursive(const Handle& root,
                                            PatternTermPtr& parent)
 {
 	PatternTermPtr ptm(std::make_shared<PatternTerm>(parent, h));
+	h = ptm->getHandle();
 	parent->addOutgoingTerm(ptm);
 	_pat.connected_terms_map[{h, root}].emplace_back(ptm);
 

--- a/opencog/atoms/pattern/PatternLink.h
+++ b/opencog/atoms/pattern/PatternLink.h
@@ -25,6 +25,7 @@
 
 #include <unordered_map>
 
+#include <opencog/atoms/base/Quotation.h>
 #include <opencog/atoms/pattern/Pattern.h>
 #include <opencog/atoms/core/ScopeLink.h>
 #include <opencog/atoms/core/VariableList.h>
@@ -118,7 +119,7 @@ protected:
 
 	void trace_connectives(const std::set<Type>&,
 	                       const HandleSeq& clauses,
-	                       int quotation_level = 0);
+	                       Quotation quotation=Quotation());
 
 	void make_connectivity_map(const HandleSeq&);
 	void make_map_recursive(const Handle&, const Handle&);

--- a/opencog/atoms/pattern/PatternTerm.cc
+++ b/opencog/atoms/pattern/PatternTerm.cc
@@ -41,7 +41,7 @@ PatternTerm::PatternTerm(const PatternTermPtr& parent, const Handle& h)
 
 	// Discard the following QuoteLink, UnquoteLink or LocalQuoteLink
 	// as it is serving its quoting or unquoting function.
-	if (_quotation.consume(t)) {
+	if (_quotation.consumable(t)) {
 		if (1 != h->getArity())
 			throw InvalidParamException(TRACE_INFO,
 			                            "QuoteLink/UnquoteLink/LocalQuoteLink has "

--- a/opencog/atoms/pattern/PatternTerm.cc
+++ b/opencog/atoms/pattern/PatternTerm.cc
@@ -33,14 +33,15 @@ PatternTerm::PatternTerm()
 
 PatternTerm::PatternTerm(const PatternTermPtr& parent, const Handle& h)
 	: _handle(h), _parent(parent),
-	  _quotation(parent->_quotation.quotation_level(),
+	  _quotation(parent->_quotation.level(),
 	             false /* necessarily false since it is local */),
 	  _has_any_bound_var(false)
 {
 	Type t = h->getType();
 
-	// Possibly consume the quotation
-	if (_quotation.consumable_quotation(t)) {
+	// Discard the following QuoteLink, UnquoteLink or LocalQuoteLink
+	// as it is serving its quoting or unquoting function.
+	if (_quotation.consume(t)) {
 		if (1 != h->getArity())
 			throw InvalidParamException(TRACE_INFO,
 			                            "QuoteLink/UnquoteLink/LocalQuoteLink has "

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -278,24 +278,14 @@ Handle AtomTable::getHandle(Type t, const HandleSeq& seq) const
     return getLinkHandle(a);
 }
 
-Handle AtomTable::getLinkHandle(AtomPtr& a, int quotelevel, bool localquote) const
+Handle AtomTable::getLinkHandle(AtomPtr& a, Quotation quotation) const
 {
     Type t = a->getType();
     const HandleSeq &seq = a->getOutgoingSet();
-    bool unquoted = is_unquoted(quotelevel, localquote);
+    bool unquoted = not quotation.is_quoted();
 
-    // We need to keep track of the quote nesting, as this affects
-    // how embedded ScopeLinks are treated, below.  That is, unquoted
-    // ScopeLinks really do have to be atomspace-unique, but if they
-    // are quoted, then the checks are not to be performed.
-    if (not localquote) {
-        if (QUOTE_LINK == t) quotelevel++;
-        else if (UNQUOTE_LINK == t) quotelevel--;
-    }
-
-    // Unless the current link is an unquoted LocalQuote, then the
-    // outgoing is not quoted.
-    bool next_localquote = unquoted and LOCAL_QUOTE_LINK == t;
+    // Update quotation for the outgoing given the atom type
+    quotation.update(t);
 
     // Make sure all the atoms in the outgoing set are in a valid
     // format. One of the troublemakers here is the NumberNode,
@@ -304,7 +294,7 @@ Handle AtomTable::getLinkHandle(AtomPtr& a, int quotelevel, bool localquote) con
     HandleSeq resolved_seq;
     for (const Handle& ho : seq) {
         AtomPtr ao(ho);
-        Handle rh(getHandle(ao, quotelevel, next_localquote));
+        Handle rh(getHandle(ao, quotation));
         if (rh == nullptr) return Handle::UNDEFINED;
         resolved_seq.emplace_back(rh);
     }
@@ -347,25 +337,15 @@ Handle AtomTable::getLinkHandle(AtomPtr& a, int quotelevel, bool localquote) con
     }
 
     if (_environ) {
-        return _environ->getHandle(a, quotelevel, next_localquote);
+        return _environ->getHandle(a, quotation);
     }
     return Handle::UNDEFINED;
-}
-
-bool AtomTable::is_quoted(int quotelevel, bool localquote) const
-{
-    return quotelevel != 0 or localquote;
-}
-
-bool AtomTable::is_unquoted(int quotelevel, bool localquote) const
-{
-    return not is_quoted(quotelevel, localquote);
 }
 
 /// Find an equivalent atom that is exactly the same as the arg. If
 /// such an atom is in the table, it is returned, else the return
 /// is the bad handle.
-Handle AtomTable::getHandle(AtomPtr& a, int quotelevel, bool localquote) const
+Handle AtomTable::getHandle(AtomPtr& a, Quotation quotation) const
 {
     if (nullptr == a) return Handle::UNDEFINED;
 
@@ -375,7 +355,7 @@ Handle AtomTable::getHandle(AtomPtr& a, int quotelevel, bool localquote) const
     if (a->isNode())
         return getNodeHandle(a);
     else if (a->isLink())
-        return getLinkHandle(a, quotelevel, localquote);
+        return getLinkHandle(a, quotation);
 
     return Handle::UNDEFINED;
 }

--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -204,12 +204,22 @@ public:
     Handle getHandle(Type, const std::string&) const;
     Handle getNodeHandle(AtomPtr&) const;
     Handle getHandle(Type, const HandleSeq&) const;
-    Handle getLinkHandle(AtomPtr&, int=0) const;
-    Handle getHandle(AtomPtr&, int=0) const;
-    Handle getHandle(const Handle& h, int quotelevel=0) const {
+    Handle getLinkHandle(AtomPtr&, int=0, bool=false) const;
+    Handle getHandle(AtomPtr&, int=0, bool=false) const;
+    Handle getHandle(const Handle& h, int quotelevel=0, bool localquote=false) const {
         AtomPtr a(h); return getHandle(a, quotelevel);
     }
     Handle getHandle(UUID) const;
+
+    /**
+     * Static helper to support Quote, UnQuote and LocalQuote links.
+     *
+     * @param quotelevel  quotation level
+     * @param localquote  whether the atom is locally quoted
+     * @return            true iff quotelevel is not null or localquote is true.
+     */
+    bool is_quoted(int quotelevel, bool localquote) const;
+    bool is_unquoted(int quotelevel, bool localquote) const;
 
     /**
      * Returns the set of atoms of a given type (subclasses optionally).

--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -36,7 +36,7 @@
 
 #include <opencog/truthvalue/TruthValue.h>
 
-#include <opencog/atoms/base/atom_types.h>
+#include <opencog/atoms/base/Quotation.h>
 #include <opencog/atoms/base/ClassServer.h>
 #include <opencog/atoms/base/Link.h>
 #include <opencog/atoms/base/Node.h>
@@ -204,22 +204,12 @@ public:
     Handle getHandle(Type, const std::string&) const;
     Handle getNodeHandle(AtomPtr&) const;
     Handle getHandle(Type, const HandleSeq&) const;
-    Handle getLinkHandle(AtomPtr&, int=0, bool=false) const;
-    Handle getHandle(AtomPtr&, int=0, bool=false) const;
-    Handle getHandle(const Handle& h, int quotelevel=0, bool localquote=false) const {
-        AtomPtr a(h); return getHandle(a, quotelevel);
+    Handle getLinkHandle(AtomPtr&, Quotation quotation = Quotation()) const;
+    Handle getHandle(AtomPtr&, Quotation quotation = Quotation()) const;
+    Handle getHandle(const Handle& h) const {
+        AtomPtr a(h); return getHandle(a);
     }
     Handle getHandle(UUID) const;
-
-    /**
-     * Static helper to support Quote, UnQuote and LocalQuote links.
-     *
-     * @param quotelevel  quotation level
-     * @param localquote  whether the atom is locally quoted
-     * @return            true iff quotelevel is not null or localquote is true.
-     */
-    bool is_quoted(int quotelevel, bool localquote) const;
-    bool is_unquoted(int quotelevel, bool localquote) const;
 
     /**
      * Returns the set of atoms of a given type (subclasses optionally).

--- a/opencog/atomutils/FindUtils.cc
+++ b/opencog/atomutils/FindUtils.cc
@@ -269,18 +269,19 @@ bool is_unquoted_in_any_tree(const HandleSeq& trees,
 	return false;
 }
 
-bool contains_atomtype(const Handle& clause, Type atom_type)
+bool contains_atomtype(const Handle& clause, Type atom_type, Quotation quotation)
 {
 	Type clause_type = clause->getType();
-	if (classserver().isA(clause_type, atom_type)) return true;
-	if (QUOTE_LINK == clause_type) return false;
-	// if (classserver().isA(clause_type, SCOPE_LINK)) return false;
+	if (quotation.is_unquoted() and classserver().isA(clause_type, atom_type))
+		return true;
+
+	quotation.update(clause_type);
 
 	if (not clause->isLink()) return false;
 
 	for (const Handle& subclause: clause->getOutgoingSet())
 	{
-		if (contains_atomtype(subclause, atom_type)) return true;
+		if (contains_atomtype(subclause, atom_type, quotation)) return true;
 	}
 	return false;
 }

--- a/opencog/atomutils/FindUtils.h
+++ b/opencog/atomutils/FindUtils.h
@@ -81,9 +81,10 @@ namespace opencog {
 /// the intersection between the set of given atoms, and the set of all
 /// atoms that occur in the clauses.
 ///
-/// Note that anything occuring below a QUOTE_LINK is not explored.
-/// Thus, a quote acts like a cut, halting recursion until it gets
-/// unquoted later on with an UNQUOTE_LINK.
+/// Note that anything quoted (by the use of
+/// QUOTE_LINK/LOCAL_QUOTE_LINK/UNQUOTE_LINK) is not explored.  Thus,
+/// a quote acts like a cut, halting recursion until it gets unquoted
+/// later on with an UNQUOTE_LINK.
 ///
 class FindAtoms
 {
@@ -277,7 +278,8 @@ bool is_unquoted_in_any_tree(const HandleSeq& trees,
  * Returns true if the clause contains an atom of type atom_type.
  * ... but only if it is not quoted.  Quoted terms are constants (literals).
  */
-bool contains_atomtype(const Handle& clause, Type atom_type);
+bool contains_atomtype(const Handle& clause, Type atom_type,
+                       Quotation quotation=Quotation());
 
 /**
  * Returns true if any of the clauses contain an atom of type atom_type.

--- a/opencog/atomutils/FindUtils.h
+++ b/opencog/atomutils/FindUtils.h
@@ -37,6 +37,7 @@
 #include <opencog/atoms/base/Handle.h>
 #include <opencog/atoms/base/Link.h>
 #include <opencog/atoms/base/types.h>
+#include <opencog/atoms/base/Quotation.h>
 #include <opencog/atoms/core/ScopeLink.h>
 
 namespace opencog {
@@ -112,7 +113,7 @@ private:
 		IMM    // Contains immediately below.
 	} Loco;
 
-	Loco find_rec(const Handle& h, int quotation_level = 0);
+	Loco find_rec(const Handle& h, Quotation quotation=Quotation());
 
 private:
 	std::set<Type> _target_types;
@@ -151,8 +152,7 @@ bool is_unquoted_in_tree(const Handle& tree, const Handle& atom);
  *
  * @param atom             handle of the atom to check
  *
- * @param quotation_level  quotation level from the root to the handle
- *                         the of tree
+ * @param quotation        quotation state
  *
  * @return                 minimum quotation level. If atom doesn't appear
  *                         in the tree then it returns the maximum integer.
@@ -163,7 +163,7 @@ bool is_unquoted_in_tree(const Handle& tree, const Handle& atom);
  */
 int min_quotation_level(const Handle& tree,
                         const Handle& atom,
-                        int level_from_root = 0);
+                        Quotation quotation=Quotation());
 
 /**
  * Return the maximum quotation level of a given atom. The maximum
@@ -187,7 +187,7 @@ int min_quotation_level(const Handle& tree,
  */
 int max_quotation_level(const Handle& tree,
                         const Handle& atom,
-                        int level_from_root = 0);
+                        Quotation quotation=Quotation());
 
 /**
  * Return true if the atom (variable) occurs unscoped somewhere in the
@@ -301,7 +301,8 @@ bool contains_atomtype(const HandleSeq& clauses, Type atom_type);
  * returns {VariableNode "$X"}, because although $X is scoped by the
  * lambda it is also unscoped in the And.
  */
-OrderedHandleSet get_free_variables(const Handle& h, int quotation_level = 0);
+OrderedHandleSet get_free_variables(const Handle& h,
+                                    Quotation quotation=Quotation());
 
 /**
  * Return true if h has no free variable (unscoped or unquoted) in it,

--- a/opencog/query/DefaultPatternMatchCB.cc
+++ b/opencog/query/DefaultPatternMatchCB.cc
@@ -28,6 +28,8 @@
 #include <opencog/atoms/execution/Instantiator.h>
 #include <opencog/atomutils/FindUtils.h>
 
+#include <opencog/util/algorithm.h>
+
 #include "DefaultPatternMatchCB.h"
 
 using namespace opencog;
@@ -453,26 +455,15 @@ bool DefaultPatternMatchCB::is_self_ground(const Handle& ptrn,
 	{
 		// Step 1: Look to see if the scope link binds any of the
 		// variables that the pattern also binds.
-		OrderedHandleSet hidden;
 		const Variables& slv = ScopeLinkCast(grnd)->get_variables();
-		for (const Handle& hide: slv.varset)
-		{
-			if (varset.end() != varset.find(hide))
-				hidden.insert(hide);
-		}
+		OrderedHandleSet hidden = opencog::set_intersection(slv.varset, varset);
 
 		// Step 2: If there are hidden variables, then remove them
-		// before recursing dowwards.
+		// before recursing donwards.
 		if (0 < hidden.size())
 		{
-			// Make a copy
-			OrderedHandleSet vcopy = varset;
-
-			// Remove the hidden vars from the copy
-			for (const Handle& hide: hidden)
-			{
-				vcopy.erase(hide);
-			}
+			// Make a copy with visible variables only
+			OrderedHandleSet vcopy = opencog::set_difference(varset, hidden);
 
 			// Recurse using only the visible variables.
 			for (size_t i=0; i<pari; i++)

--- a/opencog/query/DefaultPatternMatchCB.cc
+++ b/opencog/query/DefaultPatternMatchCB.cc
@@ -394,7 +394,7 @@ bool DefaultPatternMatchCB::is_self_ground(const Handle& ptrn,
 	Type ptype = ptrn->getType();
 
 	// Unwrap quotations, so that they can be compared properly.
-	if (ptype == QUOTE_LINK or ptype == UNQUOTE_LINK)
+	if (Quotation::is_quotation_type(ptype))
 	{
 		// Wow, if we are here, and patern==grnd, this must be
 		// a self-grounding, as I don't believe there is any other

--- a/opencog/query/DefaultPatternMatchCB.cc
+++ b/opencog/query/DefaultPatternMatchCB.cc
@@ -379,7 +379,7 @@ void DefaultPatternMatchCB::post_link_mismatch(const Handle& lpat,
 }
 
 /// is_self_ground() -- Reject clauses that are grounded by themselves.
-/// This code is neeed in order to handle multiple complex, confusing
+/// This code is needed in order to handle multiple complex, confusing
 /// situations. The most serious of these is variables that are hidden
 /// due to alpha-renaming -- they mostly look like ordinary variables
 /// to the lower layers of the pattern matcher, but here, from the

--- a/opencog/query/DefaultPatternMatchCB.cc
+++ b/opencog/query/DefaultPatternMatchCB.cc
@@ -389,7 +389,7 @@ bool DefaultPatternMatchCB::is_self_ground(const Handle& ptrn,
                                            const Handle& grnd,
                                            const HandleMap& term_gnds,
                                            const OrderedHandleSet& varset,
-                                           int quote_level)
+                                           Quotation quotation)
 {
 	Type ptype = ptrn->getType();
 
@@ -397,20 +397,18 @@ bool DefaultPatternMatchCB::is_self_ground(const Handle& ptrn,
 	if (ptype == QUOTE_LINK or ptype == UNQUOTE_LINK)
 	{
 		// Wow, if we are here, and patern==grnd, this must be
-		// a self-grounding, as I don't beleive there is any other
+		// a self-grounding, as I don't believe there is any other
 		// valid way to get to here.
-		if (ptype == QUOTE_LINK and 0 == quote_level and ptrn == grnd) return true;
-		if (ptype == UNQUOTE_LINK and 1 == quote_level and ptrn == grnd) return true;
+		if (quotation.consume(ptype) and ptrn == grnd) return true;
 
-		if (ptype == QUOTE_LINK) quote_level++;
-		else quote_level--;
+		quotation.update(ptype);
 
 		const Handle& qpat = ptrn->getOutgoingAtom(0);
-		return is_self_ground(qpat, grnd, term_gnds, varset, quote_level);
+		return is_self_ground(qpat, grnd, term_gnds, varset, quotation);
 	}
 
 	// Only unquoted variables...
-	if (0 == quote_level and
+	if (quotation.is_unquoted() and
 	    ((ptype == VARIABLE_NODE ) or (ptype == GLOB_NODE)))
 	{
 		return (varset.end() != varset.find(grnd));
@@ -427,7 +425,7 @@ bool DefaultPatternMatchCB::is_self_ground(const Handle& ptrn,
 			const auto pr = term_gnds.find(ch);
 			if (pr != term_gnds.end() or CHOICE_LINK == ch->getType())
 			{
-				if (is_self_ground(ch, grnd, term_gnds, varset, quote_level))
+				if (is_self_ground(ch, grnd, term_gnds, varset, quotation))
 					return true;
 			}
 		}
@@ -479,7 +477,7 @@ bool DefaultPatternMatchCB::is_self_ground(const Handle& ptrn,
 			// Recurse using only the visible variables.
 			for (size_t i=0; i<pari; i++)
 			{
-				if (is_self_ground(pset[i], gset[i], term_gnds, vcopy, quote_level))
+				if (is_self_ground(pset[i], gset[i], term_gnds, vcopy, quotation))
 					return true;
 			}
 			return false;
@@ -491,7 +489,7 @@ bool DefaultPatternMatchCB::is_self_ground(const Handle& ptrn,
 
 	for (size_t i=0; i<pari; i++)
 	{
-		if (is_self_ground(pset[i], gset[i], term_gnds, varset, quote_level))
+		if (is_self_ground(pset[i], gset[i], term_gnds, varset, quotation))
 			return true;
 	}
 

--- a/opencog/query/DefaultPatternMatchCB.cc
+++ b/opencog/query/DefaultPatternMatchCB.cc
@@ -403,9 +403,9 @@ bool DefaultPatternMatchCB::is_self_ground(const Handle& ptrn,
 		// valid way to get to here.
 		if (quotation.consumable(ptype) and ptrn == grnd) return true;
 
-		quotation.update(ptype);
-
 		const Handle& qpat = ptrn->getOutgoingAtom(0);
+
+		quotation.update(ptype);
 		return is_self_ground(qpat, grnd, term_gnds, varset, quotation);
 	}
 
@@ -415,6 +415,9 @@ bool DefaultPatternMatchCB::is_self_ground(const Handle& ptrn,
 	{
 		return (varset.end() != varset.find(grnd));
 	}
+
+	// To pass an updated quotation to the recursive calls
+	quotation.update(ptype);
 
 	// Handle choice-links.
 	if (CHOICE_LINK == ptype)

--- a/opencog/query/DefaultPatternMatchCB.cc
+++ b/opencog/query/DefaultPatternMatchCB.cc
@@ -399,7 +399,7 @@ bool DefaultPatternMatchCB::is_self_ground(const Handle& ptrn,
 		// Wow, if we are here, and patern==grnd, this must be
 		// a self-grounding, as I don't believe there is any other
 		// valid way to get to here.
-		if (quotation.consume(ptype) and ptrn == grnd) return true;
+		if (quotation.consumable(ptype) and ptrn == grnd) return true;
 
 		quotation.update(ptype);
 

--- a/opencog/query/DefaultPatternMatchCB.h
+++ b/opencog/query/DefaultPatternMatchCB.h
@@ -26,6 +26,7 @@
 #define _OPENCOG_DEFAULT_PATTERN_MATCH_H
 
 #include <opencog/atoms/base/types.h>
+#include <opencog/atoms/base/Quotation.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/atoms/execution/Instantiator.h>
 #include <opencog/query/PatternMatchCallback.h>
@@ -104,7 +105,8 @@ class DefaultPatternMatchCB : public virtual PatternMatchCallback
 		Handle _pattern_body;
 
 		bool is_self_ground(const Handle&, const Handle&,
-		                    const HandleMap&, const OrderedHandleSet&, int=0);
+		                    const HandleMap&, const OrderedHandleSet&,
+		                    Quotation quotation=Quotation());
 
 		// Variables that should be ignored, because they are bound
 		// (scoped) in the current context (i.e. appear in a ScopeLink

--- a/opencog/query/InitiateSearchCB.cc
+++ b/opencog/query/InitiateSearchCB.cc
@@ -551,7 +551,7 @@ void InitiateSearchCB::find_rarest(const Handle& clause,
 
 	if (not clause->isLink()) return;
 
-	if (not quotation.consume(t))
+	if (not quotation.consumable(t))
 	{
 		size_t num = (size_t) _as->get_num_atoms_of_type(t);
 		if (num < count)

--- a/opencog/query/InitiateSearchCB.cc
+++ b/opencog/query/InitiateSearchCB.cc
@@ -542,18 +542,16 @@ bool InitiateSearchCB::initiate_search(PatternMatchEngine *pme)
 void InitiateSearchCB::find_rarest(const Handle& clause,
                                    Handle& rarest,
                                    size_t& count,
-                                   int quotation_level)
+                                   Quotation quotation)
 {
 	Type t = clause->getType();
 
 	// Base case
-	if ((quotation_level < 1) and (CHOICE_LINK == t)) return;
+	if (quotation.is_unquoted() and (CHOICE_LINK == t)) return;
 
 	if (not clause->isLink()) return;
 
-	if ((QUOTE_LINK == t and quotation_level > 0)
-	    or (UNQUOTE_LINK == t and quotation_level > 1)
-	    or (QUOTE_LINK != t and UNQUOTE_LINK != t))
+	if (not quotation.consume(t))
 	{
 		size_t num = (size_t) _as->get_num_atoms_of_type(t);
 		if (num < count)
@@ -564,12 +562,11 @@ void InitiateSearchCB::find_rarest(const Handle& clause,
 	}
 
 	// Recursive case
-	if (QUOTE_LINK == t) quotation_level++;
-	else if (UNQUOTE_LINK == t) quotation_level--;
+	quotation.update(t);
 
 	const HandleSeq& oset = clause->getOutgoingSet();
 	for (const Handle& h : oset)
-		find_rarest(h, rarest, count, quotation_level);
+		find_rarest(h, rarest, count, quotation);
 }
 
 /* ======================================================== */

--- a/opencog/query/InitiateSearchCB.cc
+++ b/opencog/query/InitiateSearchCB.cc
@@ -206,7 +206,7 @@ InitiateSearchCB::find_starter_recursive(const Handle& h, size_t& depth,
 		Handle sbr(h);
 
 		// Blow past the QuoteLinks, since they just screw up the search start.
-		if (QUOTE_LINK == hunt->getType())
+		if (Quotation::is_quotation_type(hunt->getType()))
 			hunt = hunt->getOutgoingAtom(0);
 
 		Handle s(find_starter_recursive(hunt, brdepth, sbr, brwid));

--- a/opencog/query/InitiateSearchCB.h
+++ b/opencog/query/InitiateSearchCB.h
@@ -26,6 +26,7 @@
 #define _OPENCOG_INITIATE_SEARCH_H
 
 #include <opencog/atoms/base/types.h>
+#include <opencog/atoms/base/Quotation.h>
 #include <opencog/atoms/pattern/PatternLink.h>
 #include <opencog/query/PatternMatchCallback.h>
 #include <opencog/query/PatternMatchEngine.h>
@@ -84,7 +85,7 @@ protected:
 	                             const OrderedHandleSet&,
 	                             Handle&, size_t&);
 	virtual void find_rarest(const Handle&, Handle&, size_t&,
-	                         int quotation_level = 0);
+	                         Quotation quotation=Quotation());
 
 	bool _search_fail;
 	virtual bool neighbor_search(PatternMatchEngine *);

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -898,7 +898,7 @@ bool PatternMatchEngine::explore_term_branches(const Handle& term,
                                                const Handle& clause_root)
 {
 	// The given term may appear in the clause in more than one place.
-	// Each distinct locatation should be explored separately.
+	// Each distinct location should be explored separately.
 	auto pl = _pat->connected_terms_map.find({term, clause_root});
 	if (_pat->connected_terms_map.end() == pl)
 	{

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -685,7 +685,7 @@ bool PatternMatchEngine::clause_compare(const PatternTermPtr& ptm,
                                         const Handle& clause)
 {
 	return ptm->getHandle() == clause
-		or (clause->getType() == QUOTE_LINK
+		or (Quotation::is_quotation_type(clause->getType())
 		    and ptm->getHandle() == clause->getOutgoingAtom(0));
 }
 

--- a/tests/query/LocalQuoteUTest.cxxtest
+++ b/tests/query/LocalQuoteUTest.cxxtest
@@ -70,11 +70,6 @@ void LocalQuoteUTest::setUp(void)
 	             body_var);
 	forall_pattern = al(FORALL_LINK, vardecl_var, body_var);
 	forall_get = al(GET_LINK, vardecl, al(LOCAL_QUOTE_LINK, forall_pattern));
-	// Version using Quote/Unquote, useful for debugging
-	// forall_pattern = al(FORALL_LINK,
-	//                     al(UNQUOTE_LINK, vardecl_var),
-	//                     al(UNQUOTE_LINK, body_var));
-	// forall_get = al(GET_LINK, vardecl, al(QUOTE_LINK, forall_pattern));
 	A = an(CONCEPT_NODE, "A");
 	CT = an(TYPE_NODE, "ConceptNode");
 	P_A = al(EVALUATION_LINK, P, A);

--- a/tests/query/LocalQuoteUTest.cxxtest
+++ b/tests/query/LocalQuoteUTest.cxxtest
@@ -22,23 +22,24 @@
  */
 
 #include <opencog/atomspace/AtomSpace.h>
-#include <opencog/guile/SchemeEval.h>
+#include <opencog/atoms/execution/Instantiator.h>
 #include <opencog/query/BindLinkAPI.h>
 #include <opencog/util/Logger.h>
 #include <cxxtest/TestSuite.h>
 
 using namespace opencog;
 
-#define al as.add_link
-#define an as.add_node
+#define al _as.add_link
+#define an _as.add_node
 
 class LocalQuoteUTest: public CxxTest::TestSuite
 {
 private:
-    AtomSpace as;
+    AtomSpace _as;
 
-	Handle X, P, forall,
-		VT, vardecl_var, body_var, vardecl, forall_pattern, forall_get;
+	Handle X, P, P_X, forall,
+		VT, vardecl_var, body_var, vardecl, forall_pattern, forall_get,
+		A, P_A, CT;
 
 public:
     LocalQuoteUTest(void)
@@ -51,14 +52,16 @@ public:
     void setUp(void);
     void tearDown(void);
 
-    void test_local_quote(void);
+    void test_forall_query(void);
+	void test_implication_rewrite();
 };
 
 void LocalQuoteUTest::setUp(void)
 {
 	X = an(VARIABLE_NODE, "$X");
 	P = an(PREDICATE_NODE, "P");
-	forall = al(FORALL_LINK, X, al(EVALUATION_LINK, P, X));
+	P_X = al(EVALUATION_LINK, P, X);
+	forall = al(FORALL_LINK, X, P_X);
 	VT = an(TYPE_NODE, "VariableNode");
 	vardecl_var = an(VARIABLE_NODE, "$vardecl");
 	body_var = an(VARIABLE_NODE, "$body");
@@ -67,6 +70,9 @@ void LocalQuoteUTest::setUp(void)
 	             body_var);
 	forall_pattern = al(FORALL_LINK, vardecl_var, body_var);
 	forall_get = al(GET_LINK, vardecl, al(LOCAL_QUOTE_LINK, forall_pattern));
+	A = an(CONCEPT_NODE, "A");
+	CT = an(TYPE_NODE, "ConceptNode");
+	P_A = al(EVALUATION_LINK, P, A);
 }
 
 void LocalQuoteUTest::tearDown(void)
@@ -74,23 +80,45 @@ void LocalQuoteUTest::tearDown(void)
 }
 
 /*
- * LocalQuoteLink unit test.
+ * LocalQuoteLink unit test on a ForAll pattern query.
  */
-void LocalQuoteUTest::test_local_quote(void)
+void LocalQuoteUTest::test_forall_query(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    Handle result = satisfying_set(&as, forall_get),
+    Handle result = satisfying_set(&_as, forall_get),
 	    expected = al(SET_LINK, forall);
 
     logger().debug() << "result = " << result;
 	logger().debug() << "expected = " << expected;
 
-	// Disable till fixed
-	// TS_ASSERT_EQUALS(result, expected);
-	TS_ASSERT(true);
+	TS_ASSERT_EQUALS(result, expected);
 
 	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+/**
+ * Same as test_eval_implication_1 but using LocalQuoteLink this time.
+ */
+void LocalQuoteUTest::test_implication_rewrite()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle
+		body = al(LOCAL_QUOTE_LINK, al(IMPLICATION_SCOPE_LINK, P_X, P_X)),
+		vardecl = al(TYPED_VARIABLE_LINK, X, CT),
+		put = al(PUT_LINK, al(LAMBDA_LINK, vardecl, body), A);
+
+	Instantiator inst(&_as);
+	Handle putted = inst.execute(put);
+	Handle expected = al(IMPLICATION_SCOPE_LINK, P_A, P_A);
+
+	printf("Executing %s\n", put->toString().c_str());
+	printf("Expecting %s\n", expected->toString().c_str());
+	printf("Got %s\n", putted->toString().c_str());
+	TS_ASSERT_EQUALS(putted, expected);
+
+	logger().info("END TEST: %s", __FUNCTION__);
 }
 
 #undef al

--- a/tests/query/LocalQuoteUTest.cxxtest
+++ b/tests/query/LocalQuoteUTest.cxxtest
@@ -70,6 +70,11 @@ void LocalQuoteUTest::setUp(void)
 	             body_var);
 	forall_pattern = al(FORALL_LINK, vardecl_var, body_var);
 	forall_get = al(GET_LINK, vardecl, al(LOCAL_QUOTE_LINK, forall_pattern));
+	// Version using Quote/Unquote, useful for debugging
+	// forall_pattern = al(FORALL_LINK,
+	//                     al(UNQUOTE_LINK, vardecl_var),
+	//                     al(UNQUOTE_LINK, body_var));
+	// forall_get = al(GET_LINK, vardecl, al(QUOTE_LINK, forall_pattern));
 	A = an(CONCEPT_NODE, "A");
 	CT = an(TYPE_NODE, "ConceptNode");
 	P_A = al(EVALUATION_LINK, P, A);
@@ -86,10 +91,10 @@ void LocalQuoteUTest::test_forall_query(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    Handle result = satisfying_set(&_as, forall_get),
-	    expected = al(SET_LINK, forall);
+	Handle result = satisfying_set(&_as, forall_get),
+	    expected = al(SET_LINK, al(LIST_LINK, X, P_X));
 
-    logger().debug() << "result = " << result;
+	logger().debug() << "result = " << result;
 	logger().debug() << "expected = " << expected;
 
 	TS_ASSERT_EQUALS(result, expected);


### PR DESCRIPTION
For issue #980 

It introduces a `Quotation` class to keep track of the quotation state and simplify a lot of the existing code with it while supporting `LocalQuoteLink` as well.

Note that it might slow down a bit the atomspace and the pattern matcher, although I didn't measure a substantial slowdown when running the utest before and after.

@linas I'm confident, but I think it's wiser if you review it.