### PR TITLE
Disable variables in clauses check in PatternLink

### DIFF
--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -75,7 +75,7 @@ void PatternLink::common_init(void)
 	_num_comps = _components.size();
 
 	// Make sure every variable is in some component.
-	check_satisfiability(_varlist.varset, _component_vars);
+	// check_satisfiability(_varlist.varset, _component_vars);
 
 	// If there is only one connected component, then this can be
 	// handled during search by a single PatternLink. The multi-clause
@@ -456,6 +456,9 @@ void PatternLink::validate_clauses(OrderedHandleSet& vars,
 			              __FUNCTION__);
 		}
 	}
+
+	// Ignore the subsequent checks
+	return;
 
 	// Make sure that each declared variable appears in some clause.
 	// We won't (can't) ground variables that don't show up in a


### PR DESCRIPTION
In order to have `LocalQuoteLink` work on `PatternLink` (i.e. `BindLink`) I need to disable checks that clauses need to contains variables.

For instance this allows to define the following BindLink https://github.com/opencog/atomspace/blob/master/tests/query/LocalQuoteUTest.cxxtest#L144 used as rewrite term of meta-rule https://github.com/opencog/atomspace/blob/master/tests/query/LocalQuoteUTest.cxxtest#L139.

@linas What do you think about these checks, are they really necessary? Can we somehow make them optional so that in this context they allow such a `BindLink` to exist?
