### PR TITLE
Fix ScopeUTest

### DIFF
--- a/tests/query/ScopeUTest.cxxtest
+++ b/tests/query/ScopeUTest.cxxtest
@@ -238,7 +238,7 @@ void ScopeUTest::test_hide(void)
 	Handle forall = eval->eval_h("forall");
 	Handle varx = forall->getOutgoingAtom(0);
 
-	Handle forpat = getx->getOutgoingAtom(0);
+	Handle forpat = getx->getOutgoingAtom(0)->getOutgoingAtom(0);
 	Handle patvar = forpat->getOutgoingAtom(0);
 
 	// This unit test doesn't test anything critical if the pattern

--- a/tests/query/scope-hide.scm
+++ b/tests/query/scope-hide.scm
@@ -15,10 +15,10 @@
 ;; This has the same variable name as the above -- and so,
 ;; during pattern matching, this should not be considered to be
 ;; a self-grounding -- $X should bind to $X just fine.
-(define getx (Get (ForAllLink (Variable "$X") (Variable "$B"))))
+(define getx (Get (LocalQuote (ForAllLink (Variable "$X") (Variable "$B")))))
 
 ;; Alpha conversion means that getv should be exactly the same atom
 ;; as getx.  Note that chronological order matters: this MUST be
 ;; defined after the above, for this unit test to actually test
 ;; something valid.
-(define getv (Get (ForAllLink (Variable "$V") (Variable "$B"))))
+(define getv (Get (LocalQuote (ForAllLink (Variable "$V") (Variable "$B")))))


### PR DESCRIPTION
If no quotation is used the variables in the `ForAll` pattern should be hidden and not match the `ForAll` ground. So use a `LocalQuote` to correct `ScopeUTest::test_hide`.