### PR TITLE
Fix and speed up BC

### DIFF
--- a/opencog/rule-engine/backwardchainer/BackwardChainer.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.cc
@@ -137,14 +137,15 @@ void BackwardChainer::expand_bit(const AndBITFCMap::value_type& andbit)
 void BackwardChainer::expand_bit(const AndBITFCMap::value_type& andbit,
                                  BITNode& bitleaf, const Rule& rule)
 {
-	// Make sure that the rule is not a or-child of leaf.
+	// Make sure that the rule is not already an or-child of bitleaf.
 	if (is_in(rule, bitleaf)) {
-		bc_logger().debug() << "An equivalent rule has already expanded that BIT-node, abort expansion";
+		bc_logger().debug() << "An equivalent rule has already expanded "
+		                    << "that BIT-node, abort expansion";
 		return;
 	}
 
 	// Expand the leaf
-	// 1. Insert the rule to it
+	// 1. Insert the rule into it
 	// 2. Instantiate the premises as BITNodes
 	HandleSeq premises(rule.get_premises());
 	bitleaf.rules.insert(rule);
@@ -156,6 +157,13 @@ void BackwardChainer::expand_bit(const AndBITFCMap::value_type& andbit,
 
 	// Define new and-BIT and associate new forward chaining strategy
 	// to it
+	new_andbit(andbit, bitleaf, premises, fcs);
+}
+
+void BackwardChainer::new_andbit(const AndBITFCMap::value_type& andbit,
+                                 BITNode& bitleaf, const HandleSeq& premises,
+                                 const Handle& fcs)
+{
 	AndBITFCMap::key_type new_leaves(andbit.first);
 	new_leaves.erase(bitleaf.body);
 	new_leaves.insert(premises.begin(), premises.end());

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.h
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.h
@@ -148,29 +148,32 @@ private:
 	                BITNode& leaf, const HandleSeq& premises,
 	                const Handle& fcs);
 
-	// Given an atomese forward chaining strategy, a leaf of it to
-	// expand, and a rule, return a new forward chaining strategy
-	// where the leaf has been substituted by the rule premises and
-	// rule application.
+	// Given an FCS, a leaf of it to expand, and a rule, return a new
+	// FCS where the leaf has been substituted by the rule premises
+	// and rule application.
 	//
 	// TODO: give examples.
 	Handle expand_fcs(const Handle& fcs, const Handle& leaf, const Rule& rule);
 
-	// Given the pattern term of an atomese forward chaining strategy,
-	// the leaf from which to expand and premises, replace the leaf by
-	// the premises.
-	//
-	// TODO: give examples.
-	Handle expand_fcs_pattern(const Handle& fcs_pattern,
-	                          const Handle& leaf, const HandleSeq& premises);
+	// Given a FCS, a leaf of it and a rule. Unify the rule conclusion
+	// with the leaf and replace any variables in the FCS by its
+	// corresponding term in the rule.
+	Handle substitute_unified_variables(const Handle& fcs, const Handle& leaf,
+	                                    const Rule& rule);
 
-	// Given the rewrite term of an atomese forward chaining strategy,
-	// the leaf from which to expand and a rule rewrite term, replace
-	// the leaf by the rule rewrite term.
+	// Given the pattern term of an FCS where all variables have been
+	// substituted by the corresponding terms in the rule conclusion,
+	// expand the rule conclusion by its premises.
 	//
 	// TODO: give examples.
-	Handle expand_fcs_rewrite(const Handle& fcs_rewrite,
-	                          const Handle& leaf, const Handle& rule_rewrite);
+	Handle expand_fcs_pattern(const Handle& fcs_pattern, const Rule& rule);
+
+	// Given the rewrite term of an FCS where all variables have been
+	// substituted by the corresponding terms in the rule conclusion,
+	// replace the rule conclusion by the rule rewrite term.
+	//
+	// TODO: give examples.
+	Handle expand_fcs_rewrite(const Handle& fcs_rewrite, const Rule& rule);
 
 	// Fulfill the BIT. That is run some or all its and-BITs
 	void fulfill_bit();
@@ -231,6 +234,9 @@ private:
 
 	int _iteration;
 	AtomSpace _focus_space;
+
+	// TODO: we might want to wrap the BIT data and methods in a BIT
+	// class and move it to BIT.h
 
 	// Mapping from handles to their corresponding BITNode
 	// bodies. Also where the BITNode are actually instantiated.

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.h
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.h
@@ -140,13 +140,9 @@ private:
 	void expand_bit(const AndBITFCMap::value_type& andbit,
 	                BITNode& leaf, const Rule& rule);
 
-	// Given an and-BIT, a BIT-leaf of it, unified rule premises and a
-	// FCS (Forward Chaining Strategy), make a new and-BIT, where the
-	// BIT-leaf has been replaced by the premises, and associate the
-	// FCS to it.
-	void new_andbit(const AndBITFCMap::value_type& andbit,
-	                BITNode& leaf, const HandleSeq& premises,
-	                const Handle& fcs);
+	// Given a new FCS (Forward Chaining Strategy), create a new
+	// associated and-BIT and insert it into the BIT
+	void expand_bit(const Handle& fcs);
 
 	// Given an FCS, a leaf of it to expand, and a rule, return a new
 	// FCS where the leaf has been substituted by the rule premises
@@ -191,9 +187,6 @@ private:
 	// Select a leaf of an and-BIT for subsequent expansion
 	BITNode& select_bitleaf(const AndBITFCMap::value_type& andbit);
 
-	// Select the target to expand
-	BITNode* select_target();
-
 	// Select a valid rule given a target. The selected is a new
 	// object because a new rule is created, its variables are
 	// uniquely renamed, possibly some partial substitutions are
@@ -204,8 +197,8 @@ private:
 	// possibly be used to infer the target.
 	RuleSet get_valid_rules(const BITNode& target);
 
-	// Insert body and vardecl in _bit_as, build the bitnode
-	// associated to body and insert it in _handle2bitnode.
+	// Add body and vardecl into _bit_as, build the bitnode associated
+	// to body and insert it in _handle2bitnode.
 	void insert_h2b(Handle body, Handle vardecl, const BITFitness& fitness);
 
 	// Initialize the _andbits container with
@@ -222,6 +215,9 @@ private:
 	// to an alpha conversion.
 	bool is_in(const Rule& rule, const BITNode& bitnode);
 
+	// Return all the leaves of an and-BIT FCS
+	OrderedHandleSet get_fcs_leaves(const Handle& fcs);
+
 	AtomSpace& _as;
 	UREConfigReader _configReader;
 
@@ -237,6 +233,8 @@ private:
 
 	// TODO: we might want to wrap the BIT data and methods in a BIT
 	// class and move it to BIT.h
+
+	// TODO: we might want to build a FCS class as well
 
 	// Mapping from handles to their corresponding BITNode
 	// bodies. Also where the BITNode are actually instantiated.

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.h
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.h
@@ -140,6 +140,14 @@ private:
 	void expand_bit(const AndBITFCMap::value_type& andbit,
 	                BITNode& leaf, const Rule& rule);
 
+	// Given an and-BIT, a BIT-leaf of it, unified rule premises and a
+	// FCS (Forward Chaining Strategy), make a new and-BIT, where the
+	// BIT-leaf has been replaced by the premises, and associate the
+	// FCS to it.
+	void new_andbit(const AndBITFCMap::value_type& andbit,
+	                BITNode& leaf, const HandleSeq& premises,
+	                const Handle& fcs);
+
 	// Given an atomese forward chaining strategy, a leaf of it to
 	// expand, and a rule, return a new forward chaining strategy
 	// where the leaf has been substituted by the rule premises and

--- a/tests/rule-engine/BackwardChainerUTest.cxxtest
+++ b/tests/rule-engine/BackwardChainerUTest.cxxtest
@@ -414,7 +414,7 @@ void BackwardChainerUTest::test_criminal()
 	Handle soln = _eval.eval_h("(ConceptNode \"West\")");
 
 	BackwardChainer bc(_as, top_rbs, target, vardecl);
-	bc.get_config().set_maximum_iterations(500);
+	bc.get_config().set_maximum_iterations(100);
 	bc.do_chain();
 
 	Handle results = bc.get_results(),


### PR DESCRIPTION
There was a bug when the rule conclusion would be more specific than the target, then this specification should be propagated to the whole and-BIT.

This speeds up the BIT search as well, x5 in the criminal inference, as it prunes many useless and/or wrong and-BITs.