### PR TITLE
Improve unify target

### DIFF
--- a/opencog/atoms/base/Quotation.h
+++ b/opencog/atoms/base/Quotation.h
@@ -86,7 +86,7 @@ public:
 
 // For gdb, see
 // http://wiki.opencog.org/w/Development_standards#Print_OpenCog_Objects
-std::string oc_to_string();
+std::string oc_to_string(const Quotation& quotation);
 	
 /** @}*/
 } // namespace opencog

--- a/opencog/atoms/core/ScopeLink.cc
+++ b/opencog/atoms/core/ScopeLink.cc
@@ -335,7 +335,7 @@ ContentHash ScopeLink::term_hash(const Handle& h,
 	// different order. Thus, the hash must be computed in a purely
 	// commutative fashion: using only addition, so as never create
 	// any entropy, until the end.
-	bool is_ordered = (false == classserver().isA(t, UNORDERED_LINK));
+	bool is_ordered = not classserver().isA(t, UNORDERED_LINK);
 	ContentHash mixer = (ContentHash) is_ordered;
 	ContentHash hsh = ((1UL<<8) - 59) * t;
 	for (const Handle& ho: h->getOutgoingSet())

--- a/opencog/atomutils/Unify.h
+++ b/opencog/atomutils/Unify.h
@@ -52,8 +52,8 @@ struct UnificationSolutionSet :
 		public boost::equality_comparable<UnificationSolutionSet>
 {
 	// Default ctor
-	UnificationSolutionSet(bool s = true,
-	                       const UnificationPartitions& p = UnificationPartitions());
+	UnificationSolutionSet(bool s=true,
+	                       const UnificationPartitions& p=UnificationPartitions());
 
 	// Whether the unification satisfiable. Not that satisfiable is
 	// different than empty. An empty solution set may still be
@@ -163,8 +163,8 @@ TypedSubstitutions typed_substitutions(const UnificationSolutionSet& sol,
  * TODO: take care of Un/Quote and Scope links.
  */
 UnificationSolutionSet unify(const Handle& lhs, const Handle& rhs,
-                             const Handle& lhs_vardecl = Handle::UNDEFINED,
-                             const Handle& rhs_vardecl = Handle::UNDEFINED,
+                             const Handle& lhs_vardecl=Handle::UNDEFINED,
+                             const Handle& rhs_vardecl=Handle::UNDEFINED,
                              Quotation lhs_quotation=Quotation(),
                              Quotation rhs_quotation=Quotation());
 UnificationSolutionSet unordered_unify(const HandleSeq& lhs,
@@ -262,8 +262,8 @@ bool is_satisfiable(const UnificationBlock& block);
  *       instead of Handle, so we don't rebuild it every time.
  */
 Handle type_intersection(const Handle& lhs, const Handle& rhs,
-                         const Handle& lhs_vardecl = Handle::UNDEFINED,
-                         const Handle& rhs_vardecl = Handle::UNDEFINED);
+                         const Handle& lhs_vardecl=Handle::UNDEFINED,
+                         const Handle& rhs_vardecl=Handle::UNDEFINED);
 
 /**
  * Return a simplification of a type union, by eliminating all types

--- a/opencog/rule-engine/Rule.h
+++ b/opencog/rule-engine/Rule.h
@@ -229,14 +229,16 @@ public:
 	 * TODO: we probably want to support a vector of sources for rules
 	 * with multiple premises.
 	 */
-	RuleSet unify_source(const Handle& source, const Handle& vardecl) const;
+	RuleSet unify_source(const Handle& source,
+	                     const Handle& vardecl=Handle::UNDEFINED) const;
 
 	/**
 	 * Used by the backward chainer. Given a target, generate all rule
 	 * variations that may infer this target. The variables in the
 	 * rules are renamed to almost certainly avoid name collision.
 	 */
-	RuleSet unify_target(const Handle& target, const Handle& vardecl) const;
+	RuleSet unify_target(const Handle& target,
+	                     const Handle& vardecl=Handle::UNDEFINED) const;
 
 	/**
 	 * Apply rule (in a forward way) over atomspace as.

--- a/opencog/rule-engine/Rule.h
+++ b/opencog/rule-engine/Rule.h
@@ -30,6 +30,7 @@
 #include <opencog/atoms/core/ScopeLink.h>
 #include <opencog/atoms/core/VariableList.h>
 #include <opencog/atoms/pattern/BindLink.h>
+#include <opencog/atomutils/Unify.h>
 
 namespace opencog {
 
@@ -287,9 +288,20 @@ private:
 	// Given an ExecutionOutputLink return its last argument
 	Handle get_execution_output_last_argument(const Handle& h) const;
 
-	// Copy of this rule and split of its conclusions so each
-	// resulting have only one conclusion
-	RuleSet split_conclusions() const;
+	// Given a typed substitution obtained from typed_substitutions
+	// unify function, generate a new partially substituted rule.
+	Rule substituted(const TypedSubstitutions::value_type& ts) const;
+
+	// In some circumstances the quotes of a rule are useless. This is
+	// true for instance when the role of the quotation is to only
+	// prevent that some variable be associated to a scope link
+	// instead of the rule scope. During substitution these variables
+	// (associated to the rule scope) may be replaced by variables
+	// associated to local scopes. If that is the case then the
+	// quotations preventing them from being associated to their local
+	// scopes should be removed.
+	void consume_quotations();
+	static Handle consume_quotations(Handle h, Quotation quotation=Quotation());
 };
 
 // For Gdb debugging, see

--- a/tests/atomutils/UnifyUTest.cxxtest
+++ b/tests/atomutils/UnifyUTest.cxxtest
@@ -82,6 +82,8 @@ public:
 	void test_unify_unordered_6();
 	void test_unify_unordered_7();
 	void test_unify_unordered_8();
+
+	// TODO: add test about same variable X in different scopes
 };
 
 void UnifyUTest::setUp(void)

--- a/tests/rule-engine/RuleUTest.cxxtest
+++ b/tests/rule-engine/RuleUTest.cxxtest
@@ -38,7 +38,9 @@ class RuleUTest: public CxxTest::TestSuite
 private:
 	AtomSpace _as;
 	SchemeEval _eval;
-	Handle deduction_rule_h, X, A, V, CT;
+	Handle deduction_rule_h, X, A, V, CT, Typed_X,
+		P, Q, Eval_P, Eval_Q,
+		implication_scope_to_implication_rule_h;
 
 public:
 	RuleUTest() : _eval(&_as)
@@ -48,7 +50,8 @@ public:
 	void setUp();
 	void tearDown();
 
-	void test_unify_target();
+	void test_unify_target_deduction();
+	void test_unify_target_implication_scope_to_implication();
 };
 
 void RuleUTest::setUp()
@@ -67,14 +70,26 @@ void RuleUTest::setUp()
 
 	string eval_result =
 		_eval.eval("(load-from-path \"tests/rule-engine/bc-config.scm\")");
+	eval_result =
+		_eval.eval("(load-from-path \"tests/rule-engine/rules/implication-scope-to-implication-rule.scm\")");
 
-	deduction_rule_h = _eval.eval_h("(MemberLink (stv 1 1)"
-	                                "   bc-deduction-rule-name"
-	                                "   (ConceptNode \"URE\"))");
+	deduction_rule_h =
+		_eval.eval_h("(MemberLink (stv 1 1)"
+		             "   bc-deduction-rule-name"
+		             "   (ConceptNode \"URE\"))");
+	implication_scope_to_implication_rule_h =
+		_eval.eval_h("(MemberLink (stv 1 1)"
+		             "   implication-scope-to-implication-rule-name"
+		             "   (ConceptNode \"URE\"))");
 	X = an(VARIABLE_NODE, "$X");
 	A = an(CONCEPT_NODE, "$A");
 	V = an(VARIABLE_NODE, "$V");
 	CT = an(TYPE_NODE, "ConceptNode");
+	Typed_X = al(TYPED_VARIABLE_LINK, X, CT);
+	P = an(PREDICATE_NODE, "P");
+	Q = an(PREDICATE_NODE, "Q");
+	Eval_P = al(EVALUATION_LINK, P, X);
+	Eval_Q = al(EVALUATION_LINK, Q, X);
 }
 
 void RuleUTest::tearDown()
@@ -82,7 +97,7 @@ void RuleUTest::tearDown()
 	_as.clear();
 }
 
-void RuleUTest::test_unify_target()
+void RuleUTest::test_unify_target_deduction()
 {
 	Rule deduction_rule(deduction_rule_h);
 	Handle target = al(INHERITANCE_LINK, X, A),
@@ -109,6 +124,34 @@ void RuleUTest::test_unify_target()
 		             schema,
 		             al(LIST_LINK, XV, VA, XA)),
 		expected = al(BIND_LINK, vardecl, body, rewrite);
+
+	std::cout << "forward_rule = " << oc_to_string(forward_rule);
+	std::cout << "expected = " << oc_to_string(expected);
+
+	ScopeLinkPtr expected_sc = ScopeLinkCast(expected);
+
+	TS_ASSERT(expected_sc->is_equal(forward_rule));
+}
+
+void RuleUTest::test_unify_target_implication_scope_to_implication()
+{
+	Rule implication_scope_to_implication_rule(implication_scope_to_implication_rule_h);
+	Handle target = al(IMPLICATION_LINK,
+	                   al(LAMBDA_LINK, Typed_X, Eval_P),
+	                   al(LAMBDA_LINK, Typed_X, Eval_Q));
+	RuleSet rules = implication_scope_to_implication_rule.unify_target(target);
+
+	TS_ASSERT_EQUALS(rules.size(), 1);
+
+	Handle forward_rule = rules.begin()->get_forward_rule(),
+		// expected up to an alpha conversion
+		body = al(IMPLICATION_SCOPE_LINK, Typed_X, Eval_P, Eval_Q),
+		schema = an(GROUNDED_SCHEMA_NODE,
+		            "scm: implication-scope-to-implication-formula"),
+		rewrite = al(EXECUTION_OUTPUT_LINK,
+		             schema,
+		             al(LIST_LINK, body, target)),
+		expected = al(BIND_LINK, body, rewrite);
 
 	std::cout << "forward_rule = " << oc_to_string(forward_rule);
 	std::cout << "expected = " << oc_to_string(expected);

--- a/tests/rule-engine/rules/implication-scope-to-implication-rule.scm
+++ b/tests/rule-engine/rules/implication-scope-to-implication-rule.scm
@@ -1,0 +1,65 @@
+;; =======================================================================
+;; Implication Scope to Implication Rule
+;;
+;; ImplicationScopeLink
+;;    V
+;;    P
+;;    Q
+;; |-
+;; ImplicationLink
+;;    LambdaLink
+;;       V
+;;       P
+;;    LambdaLink
+;;       V
+;;       Q
+;;
+;; where V is a variable declaration, P and Q are the implicant and
+;; implicand bodies.
+;; -----------------------------------------------------------------------
+
+(define implication-scope-to-implication-variables
+  (VariableList
+     (TypedVariableLink
+        (VariableNode "$TyVs")
+        (TypeChoice
+           (TypeNode "TypedVariableLink")
+           (TypeNode "VariableList")))
+     (VariableNode "$P")
+     (VariableNode "$Q")))
+
+(define implication-scope-to-implication-body
+  (Quote (ImplicationScopeLink
+     (Unquote (VariableNode "$TyVs"))
+     (Unquote (VariableNode "$P"))
+     (Unquote (VariableNode "$Q")))))
+
+(define implication-scope-to-implication-rewrite
+  (ExecutionOutputLink
+     (GroundedSchemaNode "scm: implication-scope-to-implication-formula")
+     (ListLink
+        implication-scope-to-implication-body
+        (Implication
+           (LocalQuote
+           (Lambda
+              (VariableNode "$TyVs")
+              (VariableNode "$P")))
+           (LocalQuote
+           (Lambda
+              (VariableNode "$TyVs")
+              (VariableNode "$Q")))))))
+
+(define implication-scope-to-implication-rule
+  (BindLink
+     implication-scope-to-implication-variables
+     implication-scope-to-implication-body
+     implication-scope-to-implication-rewrite))
+
+(define (implication-scope-to-implication-formula ImplSc Impl)
+  (cog-set-tv! Impl (cog-tv ImplSc)))
+
+;; Name the rule
+(define implication-scope-to-implication-rule-name
+  (DefinedSchemaNode "implication-scope-to-implication-rule"))
+(DefineLink implication-scope-to-implication-rule-name
+  implication-scope-to-implication-rule)


### PR DESCRIPTION
Add partial support for consuming quotation when no longer necessary and possibly harmful when a variable with a scope at the rule level is substituted by a variable with scope within the rule or the target.

To do well the unification function should associate each variable it encounters to its scope, pass this to the Rule::substitute which should then be able to sort out whether a variable belongs to a local scope of the rule scope. For now it only works when the substituted variable is a type declaration, and it doesn't work when it's a untyped variable (which should be less useful though in principle possible).