### PR TITLE
Add Atom::size(). Returns the number of atoms in a hypergraph

### DIFF
--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -205,6 +205,10 @@ public:
         throw RuntimeException(TRACE_INFO, "Not a link!");
     }
 
+    // Return the size of an atom. 1 if a node, 1 + sizes of its
+    // outgoings if a link.
+    virtual size_t size() const = 0;
+
     virtual const HandleSeq& getOutgoingSet() const {
         throw RuntimeException(TRACE_INFO, "Not a link!");
     }

--- a/opencog/atoms/base/Link.h
+++ b/opencog/atoms/base/Link.h
@@ -151,6 +151,13 @@ public:
         return _outgoing.size();
     }
 
+    virtual size_t size() const {
+        size_t size = 1;
+        for (const Handle&h : _outgoing)
+            size += h->size();
+        return size;
+    }
+
     /**
      * Returns a const reference to the array containing this
      * atom's outgoing set.

--- a/opencog/atoms/base/Node.h
+++ b/opencog/atoms/base/Node.h
@@ -89,6 +89,8 @@ public:
      */
     virtual const std::string& getName() const { return _name; }
 
+    virtual size_t size() const { return 1; }
+
     /**
      * Returns a string representation of the node.
      *


### PR DESCRIPTION
More specifically

1 if the atom is a node
1 + sizes of the outgoings if the atom is a link

Related to issue #1029 