### PR TITLE
More bc fixes

### DIFF
--- a/opencog/atomutils/TypeUtils.cc
+++ b/opencog/atomutils/TypeUtils.cc
@@ -260,7 +260,9 @@ Handle filter_vardecl(const Handle& vardecl, const HandleSeq& hs)
 	// Base cases
 
 	if (vardecl.is_undefined())
-		return Handle::UNDEFINED;  // XXX TODO .. return?? or throw?
+		// Return Handle::UNDEFINED to indicate that this variable
+		// declaration is useless.
+		return Handle::UNDEFINED;
 
 	Type t = vardecl->getType();
 	if (VARIABLE_NODE == t)
@@ -273,7 +275,9 @@ Handle filter_vardecl(const Handle& vardecl, const HandleSeq& hs)
 
 	else if (TYPED_VARIABLE_LINK == t)
 	{
-		if (filter_vardecl(vardecl->getOutgoingAtom(0), hs).is_defined())
+		Handle var = vardecl->getOutgoingAtom(0);
+		Type t = var->getType();
+		if (t == VARIABLE_NODE and filter_vardecl(var, hs).is_defined())
 			return vardecl;
 	}
 
@@ -292,7 +296,9 @@ Handle filter_vardecl(const Handle& vardecl, const HandleSeq& hs)
 		return Handle(createVariableList(subvardecls));
 	}
 
-	// XXX TODO .. undefined?? or throw?
+	// If we're here we have failed to recognize vardecl as a useful
+	// and well formed variable declaration, so Handle::UNDEFINED is
+	// returned.
 	return Handle::UNDEFINED;
 }
 

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -116,7 +116,7 @@ bool PatternMatchEngine::variable_compare(const Handle& hp,
 	// VariableNode had better be an actual node!
 	// If it's not then we are very very confused ...
 	OC_ASSERT (hp->isNode(),
-	           "ERROR: expected variable to be a node, got this: %s\n",
+	           "Expected variable to be a node, got this: %s\n",
 	           hp->toShortString().c_str());
 
 	// Else, we have a candidate grounding for this variable.

--- a/opencog/rule-engine/Rule.cc
+++ b/opencog/rule-engine/Rule.cc
@@ -576,12 +576,7 @@ void Rule::consume_bad_quotations()
 		rewrite = _forward_rule->get_implicand();
 
 	// Consume the pattern's quotations
-	if (pattern->getType() == LOCAL_QUOTE_LINK
-	    and is_pm_connector(pattern->getOutgoingAtom(0))) {
-		Handle connector = consume_bad_quotations(pattern->getOutgoingAtom(0));
-		pattern = createLink(LOCAL_QUOTE_LINK, connector);
-	} else
-		pattern = consume_bad_quotations(pattern);
+	pattern = consume_bad_quotations(pattern);
 
 	// Consume the rewrite's quotations
 	rewrite = consume_bad_quotations(rewrite);
@@ -618,13 +613,9 @@ Handle Rule::consume_bad_quotations(Handle h, Quotation quotation, bool escape)
 				quotation.update(t);
 				return consume_bad_quotations(h->getOutgoingAtom(0), quotation);
 			}
-		} else {
-			logger().error() << "No other quotation types should be found here. "
-			                 << "To understand why, see this function comment. "
-			                 << "The culprit is:" << std::endl << oc_to_string(h)
-			                 << "from rule: " << oc_to_string(*this);
-			OC_ASSERT(false);
 		}
+		// Ignore LocalQuotes as they supposedly used only to quote
+		// pattern matcher connectors.
 	}
 
 	quotation.update(t);

--- a/opencog/rule-engine/Rule.cc
+++ b/opencog/rule-engine/Rule.cc
@@ -545,34 +545,24 @@ Rule Rule::substituted(const TypedSubstitutions::value_type& ts) const
 	Rule new_rule(*this);
 	new_rule.set_forward_handle(h);
 
-	// Limited hack: if none of the values are variables then consume
-	// all quotations. The right fix would be to associate each
-	// variable to its scope during unification (and start from the
-	// scope links of the rule and the FCS containing the target),
-	// Then we know when a variable substituted by another variable
-	// may actually act as a value according to a sub scope link.
-	auto is_not_var = [](const Handle& v)
-		{ return v->getType() != VARIABLE_NODE; };
-	bool no_variable = all_of(values.begin(), values.end(), is_not_var);
-	if (no_variable) {
-		// Remove rule BindLink variable declaration
-		if (h->getArity() == 3) {
-			h = Handle(createBindLink(h->getOutgoingAtom(1), h->getOutgoingAtom(2)));
-			new_rule.set_forward_handle(h);
-		}
-		// Consume consumable quotations
+	// If the quotation are useless or even harmful, then consume them
+	if (is_bad_quotation(BindLinkCast(new_rule.get_forward_rule())))
 		new_rule.consume_quotations();
-	}
 
 	return new_rule;
 }
 
-bool Rule::is_pm_connector(const Handle& h)
+bool Rule::is_bad_quotation(BindLinkPtr bl) const
+{
+	return bl->get_vardecl().is_undefined();
+}
+
+bool Rule::is_pm_connector(const Handle& h) const
 {
 	return is_pm_connector(h->getType());
 }
 
-bool Rule::is_pm_connector(Type t)
+bool Rule::is_pm_connector(Type t) const
 {
 	return t == AND_LINK or t == OR_LINK or t == NOT_LINK;
 }

--- a/opencog/rule-engine/Rule.h
+++ b/opencog/rule-engine/Rule.h
@@ -292,23 +292,31 @@ private:
 	// unify function, generate a new partially substituted rule.
 	Rule substituted(const TypedSubstitutions::value_type& ts) const;
 
-	// In some circumstances the quotes of a rule are useless. This is
-	// true for instance when the role of the quotation is to only
-	// prevent that some variable be associated to a scope link
-	// instead of the rule scope. During substitution these variables
-	// (associated to the rule scope) may be replaced by variables
-	// associated to local scopes. If that is the case then the
-	// quotations preventing them from being associated to their local
-	// scopes should be removed.
+	// If the quotations are useless or harmful, which might be the
+	// case if they deprive a ScopeLink from hiding supposedly hidden
+	// variables, then consume them.
 	//
-	// Also, local quotes in front of root level And, Or or Not links
-	// on the pattern body are not consumed because they are typically
-	// used to avoid interpreting them as pattern matcher connectors.
+	// Specifically this code makes 2 assumptions
+	//
+	// 1. LocalQuotes in front root level And, Or or Not links on the
+	//    pattern body are not consumed because they are supposedly
+	//    used to avoid interpreting them as pattern matcher
+	//    connectors.
+	//
+	// 2. Quote/Unquote are used to wrap scope links so that their
+	//    variable declaration can pattern match grounded or partially
+	//    grounded scope links.
+	//
+	// No other of quotation is assumed besides the 2 above.
 	bool is_bad_quotation(BindLinkPtr bl) const;
 	bool is_pm_connector(const Handle& h) const;
 	bool is_pm_connector(Type t) const;
+	bool has_bl_variable_in_local_scope(const Handle& h) const;
 	void consume_bad_quotations();
-	Handle consume_bad_quotations(Handle h, Quotation quotation=Quotation());
+	Handle consume_bad_quotations(Handle h, Quotation quotation=Quotation(),
+	                              bool escape=false /* ignore the next
+	                                                 * quotation
+	                                                 * consumption */);
 };
 
 // For Gdb debugging, see

--- a/opencog/rule-engine/Rule.h
+++ b/opencog/rule-engine/Rule.h
@@ -307,8 +307,8 @@ private:
 	bool is_bad_quotation(BindLinkPtr bl) const;
 	bool is_pm_connector(const Handle& h) const;
 	bool is_pm_connector(Type t) const;
-	void consume_quotations();
-	static Handle consume_quotations(Handle h, Quotation quotation=Quotation());
+	void consume_bad_quotations();
+	Handle consume_bad_quotations(Handle h, Quotation quotation=Quotation());
 };
 
 // For Gdb debugging, see

--- a/opencog/rule-engine/Rule.h
+++ b/opencog/rule-engine/Rule.h
@@ -304,8 +304,9 @@ private:
 	// Also, local quotes in front of root level And, Or or Not links
 	// on the pattern body are not consumed because they are typically
 	// used to avoid interpreting them as pattern matcher connectors.
-	bool is_pm_connector(const Handle& t);
-	bool is_pm_connector(Type t);
+	bool is_bad_quotation(BindLinkPtr bl) const;
+	bool is_pm_connector(const Handle& h) const;
+	bool is_pm_connector(Type t) const;
 	void consume_quotations();
 	static Handle consume_quotations(Handle h, Quotation quotation=Quotation());
 };

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.cc
@@ -148,9 +148,9 @@ void BackwardChainer::fulfill_bit()
 	}
 
 	// Select an and-BIT for fulfillment
-	Handle fcs = select_fulfilment_fcs();
+	Handle fcs = select_fulfillment_fcs();
 	if (fcs == Handle::UNDEFINED) {
-		bc_logger().debug() << "Cannot fulfill an empty FCS. Abort BIT fulfilment";
+		bc_logger().debug() << "Cannot fulfill an empty FCS. Abort BIT fulfillment";
 		return;
 	}
 	LAZY_BC_LOG_DEBUG << "Selected FCS for fulfillment:" << std::endl
@@ -171,7 +171,7 @@ Handle BackwardChainer::select_expansion_fcs() const
 	return _bit.select_fcs();
 }
 
-Handle BackwardChainer::select_fulfilment_fcs() const
+Handle BackwardChainer::select_fulfillment_fcs() const
 {
 	// Select the lastly expanded and-BIT
 	if (_last_expansion_fcs.is_defined())

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.h
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.h
@@ -147,7 +147,7 @@ private:
 	Handle select_expansion_fcs() const;
 
 	// Select an FCS (i.e. and-BIT) for fulfilment
-	Handle select_fulfilment_fcs() const;
+	Handle select_fulfillment_fcs() const;
 
 	// Select a valid rule given a target. The selected is a new
 	// object because a new rule is created, its variables are

--- a/tests/rule-engine/RuleUTest.cxxtest
+++ b/tests/rule-engine/RuleUTest.cxxtest
@@ -39,7 +39,7 @@ private:
 	AtomSpace _as;
 	SchemeEval _eval;
 	Handle deduction_rule_h, X, A, V, CT, Typed_X,
-		P, Q, Eval_P, Eval_Q,
+		P_body_var, P, Q, Eval_P, Eval_Q,
 		implication_scope_to_implication_rule_h;
 
 public:
@@ -51,7 +51,9 @@ public:
 	void tearDown();
 
 	void test_unify_target_deduction();
-	void test_unify_target_implication_scope_to_implication();
+	void test_unify_target_implication_scope_to_implication_1();
+	void test_unify_target_implication_scope_to_implication_2();
+	// TODO provide a third unit tests when some quotation should be not consumed
 };
 
 void RuleUTest::setUp()
@@ -87,6 +89,7 @@ void RuleUTest::setUp()
 	CT = an(TYPE_NODE, "ConceptNode");
 	Typed_X = al(TYPED_VARIABLE_LINK, X, CT);
 	P = an(PREDICATE_NODE, "P");
+	P_body_var = an(VARIABLE_NODE, "$P");
 	Q = an(PREDICATE_NODE, "Q");
 	Eval_P = al(EVALUATION_LINK, P, X);
 	Eval_Q = al(EVALUATION_LINK, Q, X);
@@ -133,7 +136,9 @@ void RuleUTest::test_unify_target_deduction()
 	TS_ASSERT(expected_sc->is_equal(forward_rule));
 }
 
-void RuleUTest::test_unify_target_implication_scope_to_implication()
+// Test how useless quotation gets eliminated during
+// Rule::unify_target.
+void RuleUTest::test_unify_target_implication_scope_to_implication_1()
 {
 	Rule implication_scope_to_implication_rule(implication_scope_to_implication_rule_h);
 	Handle target = al(IMPLICATION_LINK,
@@ -153,6 +158,38 @@ void RuleUTest::test_unify_target_implication_scope_to_implication()
 		             al(LIST_LINK, body, target)),
 		expected = al(BIND_LINK, body, rewrite);
 
+	std::cout << "forward_rule = " << oc_to_string(forward_rule);
+	std::cout << "expected = " << oc_to_string(expected);
+
+	ScopeLinkPtr expected_sc = ScopeLinkCast(expected);
+
+	TS_ASSERT(expected_sc->is_equal(forward_rule));
+}
+
+// Like test_unify_target_implication_scope_to_implication_1 but
+// Eval_P is replaced by Variable "$P".
+void RuleUTest::test_unify_target_implication_scope_to_implication_2()
+{
+	Rule implication_scope_to_implication_rule(implication_scope_to_implication_rule_h);
+	Handle target = al(IMPLICATION_LINK,
+	                   al(LAMBDA_LINK, Typed_X, P_body_var),
+	                   al(LAMBDA_LINK, Typed_X, Eval_Q));
+	RuleSet rules = implication_scope_to_implication_rule.unify_target(target);
+
+	TS_ASSERT_EQUALS(rules.size(), 1);
+
+	Handle forward_rule = rules.begin()->get_forward_rule(),
+		// Expected up to an alpha conversion
+		body = al(IMPLICATION_SCOPE_LINK, Typed_X, P_body_var, Eval_Q),
+		schema = an(GROUNDED_SCHEMA_NODE,
+		            "scm: implication-scope-to-implication-formula"),
+		rewrite = al(EXECUTION_OUTPUT_LINK,
+		             schema,
+		             al(LIST_LINK, body, target)),
+		expected = al(BIND_LINK, P_body_var, body, rewrite);
+
+	std::cout << "implication_scope_to_implication_rule = " << oc_to_string(implication_scope_to_implication_rule);
+	std::cout << "target = " << oc_to_string(target);
 	std::cout << "forward_rule = " << oc_to_string(forward_rule);
 	std::cout << "expected = " << oc_to_string(expected);
 

--- a/tests/rule-engine/RuleUTest.cxxtest
+++ b/tests/rule-engine/RuleUTest.cxxtest
@@ -107,7 +107,7 @@ void RuleUTest::test_unify_target_deduction()
 	TS_ASSERT_EQUALS(rules.size(), 1);
 
 	Handle forward_rule = rules.begin()->get_forward_rule(),
-		// expected up to an alpha conversion
+		// Expected up to an alpha conversion
 		vardecl = al(VARIABLE_LIST,
 		             al(TYPED_VARIABLE_LINK, X, CT),
 		             al(TYPED_VARIABLE_LINK, V, CT)),
@@ -144,7 +144,7 @@ void RuleUTest::test_unify_target_implication_scope_to_implication()
 	TS_ASSERT_EQUALS(rules.size(), 1);
 
 	Handle forward_rule = rules.begin()->get_forward_rule(),
-		// expected up to an alpha conversion
+		// Expected up to an alpha conversion
 		body = al(IMPLICATION_SCOPE_LINK, Typed_X, Eval_P, Eval_Q),
 		schema = an(GROUNDED_SCHEMA_NODE,
 		            "scm: implication-scope-to-implication-formula"),

--- a/tests/rule-engine/meta-rules/conditional-instantiation-meta-rule.scm
+++ b/tests/rule-engine/meta-rules/conditional-instantiation-meta-rule.scm
@@ -38,11 +38,10 @@
      (Variable "$Q")))
 
 (define conditional-full-instantiation-meta-body
-  (let* ((implication (LocalQuote
-                        (ImplicationScope
-                          (Variable "$TyVs")
-                          (Variable "$P")
-                          (Variable "$Q"))))
+  (let* ((implication (Quote (ImplicationScope
+                         (Unquote (Variable "$TyVs"))
+                         (Unquote (Variable "$P"))
+                         (Unquote (Variable "$Q")))))
          (precondition (Evaluation
                          (GroundedPredicate "scm: true-enough")
                          implication)))
@@ -58,11 +57,10 @@
   (let* ((TyVs (Variable "$TyVs"))
          (P (Variable "$P"))
          (Q (Variable "$Q"))
-         (implication (LocalQuote
-                        (ImplicationScope
-                          TyVs
-                          P
-                          Q))))
+         (implication (Quote (ImplicationScope
+                         (Unquote TyVs)
+                         (Unquote P)
+                         (Unquote Q)))))
     (Quote (Bind
       (Unquote TyVs)
       (And
@@ -76,34 +74,6 @@
             P
             Q)))))))
 
-;; Bind
-;;   VariableList
-;;     TypedVariable
-;;       Variable "$TyVs"
-;;       TypeChoice
-;;         Type "TypedVariableLink"
-;;         Type "VariableLink"
-;;     Variable "$P"
-;;     Variable "$Q"
-;;   LocalQuote
-;;     ImplicationScope
-;;       Variable "$TyVs"
-;;       Variable "$P"
-;;       Variable "$Q"
-;;   LocalQuote
-;;     Bind
-;;       Variable "$TyVs"
-;;       Variable "$P"
-;;       ExecutionOutput
-;;         GroundedSchema "scm: conditional-full-instantiation-formula"
-;;         List
-;;           LocalQuote
-;;             ImplicationScope
-;;               Variable "$TyVs"
-;;               Variable "$P"
-;;               Variable "$Q"
-;;           Variable "$P"
-;;           Variable "$Q"
 (define conditional-full-instantiation-meta-rule
   (BindLink
      conditional-full-instantiation-meta-variables

--- a/tests/rule-engine/rules/implication-scope-to-implication-rule.scm
+++ b/tests/rule-engine/rules/implication-scope-to-implication-rule.scm
@@ -40,14 +40,12 @@
      (ListLink
         implication-scope-to-implication-body
         (Implication
-           (LocalQuote
-           (Lambda
-              (VariableNode "$TyVs")
-              (VariableNode "$P")))
-           (LocalQuote
-           (Lambda
-              (VariableNode "$TyVs")
-              (VariableNode "$Q")))))))
+           (Quote (Lambda
+              (Unquote (VariableNode "$TyVs"))
+              (Unquote (VariableNode "$P"))))
+           (Quote (Lambda
+              (Unquote (VariableNode "$TyVs"))
+              (Unquote (VariableNode "$Q"))))))))
 
 (define implication-scope-to-implication-rule
   (BindLink

--- a/tests/rule-engine/rules/pln-implication-and-lambda-factorization-rule.scm
+++ b/tests/rule-engine/rules/pln-implication-and-lambda-factorization-rule.scm
@@ -62,17 +62,15 @@
      (VariableNode "$A2")))
 
 (define implication-and-lambda-factorization-body
-  (QuoteLink                        ; Necessary so the AndLink doesn't
-                                    ; count as a connective
+  (LocalQuoteLink                        ; Necessary so the AndLink doesn't
+                                         ; count as a connective
      (AndLink
-        (UnquoteLink
-           (LambdaLink
-              (VariableNode "$TyVs-one")
-              (VariableNode "$A1")))
-        (UnquoteLink
-           (LambdaLink
-              (VariableNode "$TyVs-two")
-              (VariableNode "$A2"))))))
+        (QuoteLink (LambdaLink
+           (Unquote (VariableNode "$TyVs-one"))
+           (Unquote (VariableNode "$A1"))))
+        (QuoteLink (LambdaLink
+           (Unquote (VariableNode "$TyVs-two"))
+           (Unquote (VariableNode "$A2")))))))
 
 (define implication-and-lambda-factorization-rewrite
   (ExecutionOutputLink


### PR DESCRIPTION
Also, as a workaround to #1022 `LocalQuoteLink` are banded with `ScopeLink`, they are almost exclusively only used to escape pattern matcher And, Or, Not connector which is still very handy.