### PR TITLE
Guile initialization cleanup

### DIFF
--- a/opencog/guile/SchemeEval.cc
+++ b/opencog/guile/SchemeEval.cc
@@ -31,10 +31,6 @@
 #include "SchemePrimitive.h"
 #include "SchemeSmob.h"
 
-#ifdef DBG_CRASH
-#include <sys/syscall.h>
-#endif
-
 using namespace opencog;
 
 static std::mutex init_mtx;
@@ -70,19 +66,9 @@ void SchemeEval::init(void)
 
 	_rc = SCM_EOL;
 	_rc = scm_gc_protect_object(_rc);
-#ifdef DBG_CRASH
-	_rc_cnt = 1;
-	_rc_id = 1;
-	_untid = 0;
-#endif
 
 	_gc_ctr = 0;
 }
-#ifdef DBG_CRASH
-static pid_t gettid() {
-	return syscall(SYS_gettid);
-}
-#endif
 
 /// When the user is using the guile shell from within the cogserver,
 /// We need to capture the output port. It is used by the cogserver

--- a/opencog/guile/SchemeEval.h
+++ b/opencog/guile/SchemeEval.h
@@ -78,13 +78,6 @@ class SchemeEval : public GenericEval
 		const std::string *_pexpr;
 		std::string _answer;
 		SCM _rc;
-#define DBG_CRASH 1
-#ifdef DBG_CRASH
-		int _rc_cnt; // debugging only, remove when done.
-		std::string previn;
-		int _rc_id;
-		pid_t _untid;
-#endif // DBG_CRASH
 		bool _eval_done;
 		bool _poll_done;
 		std::mutex _poll_mtx;

--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -50,7 +50,7 @@ void SchemeSmob::init()
 	// with mutexes, but atomic test-n-set is easier and faster.
 	if (is_inited.test_and_set())
 	{
-		while (not done_with_init) { usleep(5000); }
+		while (not done_with_init) { usleep(1000); }
 		return;
 	}
 
@@ -62,8 +62,7 @@ void SchemeSmob::init()
 	atomspace_fluid = scm_permanent_object(atomspace_fluid);
 	_radix_ten = scm_from_int8(10);
 
-	// Tell the compiler to set the flag dead-last, after above has
-	// executed.
+	// Tell compiler to set flag dead-last, after above has executed.
 	asm volatile("": : :"memory");
 	done_with_init = true;
 }

--- a/tests/scm/MultiThreadUTest.cxxtest
+++ b/tests/scm/MultiThreadUTest.cxxtest
@@ -19,6 +19,7 @@
  * Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+#include <sys/syscall.h>
 
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/guile/SchemeEval.h>
@@ -49,16 +50,21 @@ class MultiThreadUTest :  public CxxTest::TestSuite
 		void setUp(void);
 		void tearDown(void);
 
+		void test_init_race(void);
+		void threadedInit(int thread_id);
 		void test_three_evals_one_thread(void);
 		void test_multi_threads(void);
 		void threadedAdd(int thread_id, int N);
 };
 
-/*
- * This function sets up .. whatever.
- */
 #define an as->add_node
 #define al as->add_link
+#define CHKEV(ev) \
+	TSM_ASSERT("Caught scm error during eval", \
+		(false == ev->eval_error()));
+
+// static pid_t gettid() { return syscall(SYS_gettid); }
+
 void MultiThreadUTest::setUp(void)
 {
 }
@@ -68,12 +74,54 @@ void MultiThreadUTest::tearDown(void)
 }
 
 /*
+ * Test multiple threads, all performing intialization at the same
+ * time.  Initialization should happen once, and there should be no
+ * corruption.
+ */
+static volatile bool hold = true;
+static std::atomic_int start_cnt(0);
+
+void MultiThreadUTest::test_init_race(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+	as = new AtomSpace();
+	std::vector<std::thread> thread_pool;
+
+	int n_threads = 120;
+	start_cnt = 0;
+	hold = true;
+	for (int i=0; i < n_threads; i++) {
+		thread_pool.push_back(
+			std::thread(&MultiThreadUTest::threadedInit, this, i));
+	}
+	while (start_cnt != n_threads) {}  // spin
+	printf("Done creating %d threads\n", n_threads);
+	hold = false;
+
+	for (std::thread& t : thread_pool) t.join();
+
+	printf("Done joining %d threads\n", n_threads);
+	delete as;
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+void MultiThreadUTest::threadedInit(int thread_id)
+{
+	start_cnt ++;
+	while (hold) {} // spin
+
+	SchemeEval* ev = new SchemeEval(as);
+
+	Handle h1 = ev->eval_h("(cog-new-node 'ConceptNode \"stuff\")");
+	CHKEV(ev);
+	TSM_ASSERT("Failed to create atom", Handle::UNDEFINED != h1);
+
+	delete ev;
+}
+
+/*
  * Test three evaluators writing to a single atomspace, in the same thread.
  */
-
-#define CHKEV(ev) \
-	TSM_ASSERT("Caught scm error during eval", \
-		(false == ev->eval_error()));
 void MultiThreadUTest::test_three_evals_one_thread(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);


### PR DESCRIPTION
-- Remove debug prints from pull req #1036 
-- Remove old guile-1.8 bug work-arounds
-- Protect threaded-init properly
-- Expand unit test to test simultaneous init.

This might just possibly resolve the random-crash/stack-corruption issue that was being seen in the lab