### PR TITLE
Cut the cord between the atomspace and the attentionbank.

### DIFF
--- a/examples/c++-api/AtomSpaceEventSubscribeExample.cc
+++ b/examples/c++-api/AtomSpaceEventSubscribeExample.cc
@@ -3,6 +3,7 @@
 #include <boost/signals2.hpp>
 
 #include <opencog/atomspace/AtomSpace.h>
+#include <opencog/attentionbank/AttentionBank.h>
 #include <opencog/truthvalue/AttentionValue.h>
 #include <opencog/truthvalue/SimpleTruthValue.h>
 #include <opencog/truthvalue/TruthValue.h>
@@ -40,15 +41,17 @@ int main(int argc, char ** args)
     //Register Atomspace Event call back handlers.
     AtomAddedSignalConn = as.addAtomSignal(
             boost::bind(&AtomAddedCBHandler, _1));
-    AVChangedSignalConn = as.AVChangedSignal(
+    AVChangedSignalConn = attentionbank(&as).getAVChangedSignal().connect(
             boost::bind(&AVChangedCBHandler, _1, _2, _3));
     TVChangedSignalConn = as.TVChangedSignal(
             boost::bind(&TVChangedCBHandler, _1, _2, _3));
     AtomsRemovedSignalConn = as.removeAtomSignal(
             boost::bind(&AtomRemovedCBHandler, _1));
-    AtomAddedToAttentionalFocusSignalConn = as.AddAFSignal(
+    AtomAddedToAttentionalFocusSignalConn =
+        attentionbank(&as).AddAFSignal().connect(
             boost::bind(&AtomAddedToAFCBHandler, _1, _2, _3));
-    AtomRemovedFromAttentionalFocusSignalConn = as.RemoveAFSignal(
+    AtomRemovedFromAttentionalFocusSignalConn =
+        attentionbank(&as).RemoveAFSignal().connect(
             boost::bind(&AtomRemovedFromAFCBHandler, _1, _2, _3));
 
     // create atoms

--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -196,11 +196,11 @@ void Atom::setAttentionValue(AttentionValuePtr av)
     // If the atom importance has changed its bin,
     // update the importance index.
     if (oldBin != newBin) {
-        attentionbank().updateImportanceIndex(getHandle(), oldBin);
+        attentionbank(_atomTable->getAtomSpace()).updateImportanceIndex(getHandle(), oldBin);
     }
 
     // Notify any interested parties that the AV changed.
-    AVCHSigl& avch = attentionbank().getAVChangedSignal();
+    AVCHSigl& avch = attentionbank(_atomTable->getAtomSpace()).getAVChangedSignal();
     avch(getHandle(), local, av);
 }
 

--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -40,8 +40,6 @@
 
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/atomspace/AtomTable.h>
-#include <opencog/attentionbank/AttentionBank.h>
-#include <opencog/attentionbank/ImportanceIndex.h>
 
 //! Atom flag
 // #define WRITE_MUTEX             1  //BIT0
@@ -58,8 +56,6 @@
 #undef Type
 
 namespace opencog {
-
-#define _avmtx _mtx
 
 Atom::~Atom()
 {
@@ -150,68 +146,6 @@ void Atom::merge(TruthValuePtr tvn, const MergeCtrl& mc)
 
     TruthValuePtr mergedTV(currentTV->merge(tvn, mc));
     setTruthValue(mergedTV);
-}
-
-// ==============================================================
-
-AttentionValuePtr Atom::getAttentionValue() const
-{
-    // OK. The atomic thread-safety of shared-pointers is subtle. See
-    // http://www.boost.org/doc/libs/1_53_0/libs/smart_ptr/shared_ptr.htm#ThreadSafety
-    // and http://cppwisdom.quora.com/shared_ptr-is-almost-thread-safe
-    // What it boils down to here is that we must *always* make a copy
-    // of _attentionValue before we use it, since it can go out of scope
-    // because it can get set in another thread.  Viz, using it to
-    // dereference can return a raw pointer to an object that has been
-    // deconstructed. Furthermore, we must make a copy while holding
-    // the lock! Got that?
-
-    std::lock_guard<std::mutex> lck(_mtx);
-    AttentionValuePtr local(_attentionValue);
-    return local;
-}
-
-// XXX TODO This is insane. All this needs to be moved to the attention bank.
-void Atom::setAttentionValue(AttentionValuePtr av)
-{
-    // Must obtain a local copy of the AV, since there may be
-    // parallel writers in other threads.
-    AttentionValuePtr local(getAttentionValue());
-    if (av == local) return;
-    if (*av == *local) return;
-
-    // Need to lock, shared_ptr is NOT atomic!
-    std::unique_lock<std::mutex> lck (_avmtx);
-    local = _attentionValue; // Get it again, to avoid races.
-    _attentionValue = av;
-    lck.unlock();
-
-    // If the atom free-floating, we are done.
-    if (NULL == _atomTable) return;
-
-    // Get old and new bins.
-    int oldBin = ImportanceIndex::importanceBin(local->getSTI());
-    int newBin = ImportanceIndex::importanceBin(av->getSTI());
-
-    // If the atom importance has changed its bin,
-    // update the importance index.
-    if (oldBin != newBin) {
-        attentionbank(_atomTable->getAtomSpace()).updateImportanceIndex(getHandle(), oldBin);
-    }
-
-    // Notify any interested parties that the AV changed.
-    AVCHSigl& avch = attentionbank(_atomTable->getAtomSpace()).getAVChangedSignal();
-    avch(getHandle(), local, av);
-}
-
-void Atom::chgVLTI(int unit)
-{
-    AttentionValuePtr old_av = getAttentionValue();
-    AttentionValuePtr new_av = createAV(
-        old_av->getSTI(),
-        old_av->getLTI(),
-        old_av->getVLTI() + unit);
-    setAttentionValue(new_av);
 }
 
 // ==============================================================

--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -40,6 +40,8 @@
 
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/atomspace/AtomTable.h>
+#include <opencog/attentionbank/AttentionBank.h>
+#include <opencog/attentionbank/ImportanceIndex.h>
 
 //! Atom flag
 // #define WRITE_MUTEX             1  //BIT0
@@ -194,11 +196,11 @@ void Atom::setAttentionValue(AttentionValuePtr av)
     // If the atom importance has changed its bin,
     // update the importance index.
     if (oldBin != newBin) {
-        _atomTable->getAtomSpace()->updateImportanceIndex(getHandle(), oldBin);
+        attentionbank().updateImportanceIndex(getHandle(), oldBin);
     }
 
     // Notify any interested parties that the AV changed.
-    AVCHSigl& avch = _atomTable->getAtomSpace()->getAVChangedSignal();
+    AVCHSigl& avch = attentionbank().getAVChangedSignal();
     avch(getHandle(), local, av);
 }
 

--- a/opencog/atomspace/AtomSpace.cc
+++ b/opencog/atomspace/AtomSpace.cc
@@ -61,7 +61,6 @@ using namespace opencog;
  */
 AtomSpace::AtomSpace(AtomSpace* parent, bool transient) :
     _atom_table(parent? &parent->_atom_table : NULL, this, transient),
-    _bank(this, transient),
     _backing_store(NULL),
     _transient(transient)
 {
@@ -69,14 +68,10 @@ AtomSpace::AtomSpace(AtomSpace* parent, bool transient) :
 
 AtomSpace::~AtomSpace()
 {
-    // Be sure to disconnect the attention bank signals before the
-    // atom table destructor runs. XXX FIXME yes this is an ugly hack.
-    _bank.shutdown();
 }
 
 AtomSpace::AtomSpace(const AtomSpace&) :
     _atom_table(NULL),
-    _bank(this, true),
     _backing_store(NULL)
 {
      throw opencog::RuntimeException(TRACE_INFO,

--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -551,33 +551,8 @@ public:
      * If you need this function, just cut and paste the code below into
      * whatever you are doing!
      */
-    template <typename OutputIterator> OutputIterator
-    get_handles_by_name(OutputIterator result,
-                        const std::string& name,
-                        Type type = NODE,
-                        bool subclass = true)
-    {
-        if (name.c_str()[0] == 0)
-            return get_handles_by_type(result, type, subclass);
-
-        if (false == subclass) {
-            Handle h(get_handle(type, name));
-            if (h) *(result++) = h;
-            return result;
-        }
-
-        classserver().foreachRecursive(
-            [&](Type t)->void {
-                Handle h(get_handle(t, name));
-                if (h) *(result++) = h; }, type);
-
-        return result;
-    }
-
-    /** DEPRECATED! Do NOT USE IN NEW CODE!
-     * If you need this, just copy the code below into your app! */
-    bool is_node(Handle h) const { return NodeCast(h) != NULL; }
-    bool is_link(Handle h) const { return LinkCast(h) != NULL; }
+    bool is_node(Handle h) const { return h != nullptr and h->isNode(); }
+    bool is_link(Handle h) const { return h != nullptr and h->isLink(); }
 
     /** DEPRECATED! Do NOT USE IN NEW CODE!
      * If you need this, just copy the code below into your app! */
@@ -586,7 +561,7 @@ public:
         return h->toString();
     }
 
-    /** DEPRECATED! Do NOT USE IN NEW CODE!
+    /** DEPRECATED! Do NOT USE IN NEW CODE! (in use by pattern miner)
      * If you need this, just copy the code below into your app! */
     const std::string& get_name(Handle h) const {
         static std::string noname;
@@ -595,25 +570,13 @@ public:
         return noname;
     }
 
-    /** DEPRECATED! Do NOT USE IN NEW CODE!
-     * If you need this, just copy the code below into your app! */
-    void set_STI(Handle h, AttentionValue::sti_t stiValue) const {
-        h->setSTI(stiValue);
-    }
-
-    /** DEPRECATED! Do NOT USE IN NEW CODE!
-     * If you need this, just copy the code below into your app! */
-    AttentionValue::sti_t get_STI(Handle h) const {
-        return h->getAttentionValue()->getSTI();
-    }
-
-    /** DEPRECATED! Do NOT USE IN NEW CODE!
+    /** DEPRECATED! Do NOT USE IN NEW CODE! (in use by pattern miner)
      * If you need this, just copy the code below into your app! */
     Type get_type(Handle h) const {
         return h->getType();
     }
 
-    /** DEPRECATED! Do NOT USE IN NEW CODE!
+    /** DEPRECATED! Do NOT USE IN NEW CODE! (in use by pattern miner)
      * If you need this, just copy the code below into your app! */
     TruthValuePtr get_TV(Handle h) const
     {

--- a/opencog/atomspace/CMakeLists.txt
+++ b/opencog/atomspace/CMakeLists.txt
@@ -25,6 +25,7 @@ ADD_DEPENDENCIES(atomspace opencog_atom_types)
 
 TARGET_LINK_LIBRARIES(atomspace
 	-Wl,--no-as-needed
+	attentionbank
 	atomcore
 	lambda
 	clearbox

--- a/opencog/atomspace/CMakeLists.txt
+++ b/opencog/atomspace/CMakeLists.txt
@@ -25,7 +25,6 @@ ADD_DEPENDENCIES(atomspace opencog_atom_types)
 
 TARGET_LINK_LIBRARIES(atomspace
 	-Wl,--no-as-needed
-	attentionbank
 	atomcore
 	lambda
 	clearbox

--- a/opencog/attentionbank/AtomAttention.cc
+++ b/opencog/attentionbank/AtomAttention.cc
@@ -1,0 +1,101 @@
+/*
+ * opencog/atoms/base/Atom.cc
+ *
+ * Copyright (C) 2002-2007 Novamente LLC
+ * All Rights Reserved
+ *
+ * Written by Thiago Maia <thiago@vettatech.com>
+ *            Andre Senna <senna@vettalabs.com>
+ *            Welter Silva <welter@vettalabs.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/atoms/base/Atom.h>
+#include <opencog/atomspace/AtomSpace.h>
+#include <opencog/atomspace/AtomTable.h>
+#include <opencog/attentionbank/AttentionBank.h>
+#include <opencog/attentionbank/ImportanceIndex.h>
+
+namespace opencog {
+
+#define _avmtx _mtx
+
+// ==============================================================
+
+AttentionValuePtr Atom::getAttentionValue() const
+{
+    // OK. The atomic thread-safety of shared-pointers is subtle. See
+    // http://www.boost.org/doc/libs/1_53_0/libs/smart_ptr/shared_ptr.htm#ThreadSafety
+    // and http://cppwisdom.quora.com/shared_ptr-is-almost-thread-safe
+    // What it boils down to here is that we must *always* make a copy
+    // of _attentionValue before we use it, since it can go out of scope
+    // because it can get set in another thread.  Viz, using it to
+    // dereference can return a raw pointer to an object that has been
+    // deconstructed. Furthermore, we must make a copy while holding
+    // the lock! Got that?
+
+    std::lock_guard<std::mutex> lck(_mtx);
+    AttentionValuePtr local(_attentionValue);
+    return local;
+}
+
+// XXX TODO This is insane. All this needs to be moved to the attention bank.
+void Atom::setAttentionValue(AttentionValuePtr av)
+{
+    // Must obtain a local copy of the AV, since there may be
+    // parallel writers in other threads.
+    AttentionValuePtr local(getAttentionValue());
+    if (av == local) return;
+    if (*av == *local) return;
+
+    // Need to lock, shared_ptr is NOT atomic!
+    std::unique_lock<std::mutex> lck (_avmtx);
+    local = _attentionValue; // Get it again, to avoid races.
+    _attentionValue = av;
+    lck.unlock();
+
+    // If the atom free-floating, we are done.
+    if (NULL == _atomTable) return;
+
+    // Get old and new bins.
+    int oldBin = ImportanceIndex::importanceBin(local->getSTI());
+    int newBin = ImportanceIndex::importanceBin(av->getSTI());
+
+    // If the atom importance has changed its bin,
+    // update the importance index.
+    if (oldBin != newBin) {
+        attentionbank(_atomTable->getAtomSpace()).updateImportanceIndex(getHandle(), oldBin);
+    }
+
+    // Notify any interested parties that the AV changed.
+    AVCHSigl& avch = attentionbank(_atomTable->getAtomSpace()).getAVChangedSignal();
+    avch(getHandle(), local, av);
+}
+
+void Atom::chgVLTI(int unit)
+{
+    AttentionValuePtr old_av = getAttentionValue();
+    AttentionValuePtr new_av = createAV(
+        old_av->getSTI(),
+        old_av->getLTI(),
+        old_av->getVLTI() + unit);
+    setAttentionValue(new_av);
+}
+
+// ==============================================================
+
+} // ~namespace opencog

--- a/opencog/attentionbank/AttentionBank.cc
+++ b/opencog/attentionbank/AttentionBank.cc
@@ -31,7 +31,7 @@
 
 using namespace opencog;
 
-AttentionBank::AttentionBank(void)
+AttentionBank::AttentionBank(void) :
     _index_insert_queue(this, &AttentionBank::put_atom_into_index, 4),
     _index_remove_queue(this, &AttentionBank::remove_atom_from_index, 4)
 {

--- a/opencog/attentionbank/AttentionBank.cc
+++ b/opencog/attentionbank/AttentionBank.cc
@@ -247,3 +247,10 @@ double AttentionBank::getNormalisedZeroToOneSTI(AttentionValuePtr av,
     if (clip) return std::max(0.0, std::min(val, 1.0));
     return val;
 }
+
+/** Unique singleton instance (for now) */
+AttentionBank& attentionbank()
+{
+    static std::unique_ptr<AttentionBank> instance(new AttentionBank());
+    return *instance;
+}

--- a/opencog/attentionbank/AttentionBank.cc
+++ b/opencog/attentionbank/AttentionBank.cc
@@ -248,7 +248,7 @@ double AttentionBank::getNormalisedZeroToOneSTI(AttentionValuePtr av,
 }
 
 /** Unique singleton instance (for now) */
-AttentionBank& attentionbank(AtomSpace* asp)
+AttentionBank& opencog::attentionbank(AtomSpace* asp)
 {
     static std::map<AtomSpace*, AttentionBank*> banksy;
 

--- a/opencog/attentionbank/AttentionBank.cc
+++ b/opencog/attentionbank/AttentionBank.cc
@@ -251,6 +251,9 @@ double AttentionBank::getNormalisedZeroToOneSTI(AttentionValuePtr av,
 AttentionBank& opencog::attentionbank(AtomSpace* asp)
 {
     static std::map<AtomSpace*, AttentionBank*> banksy;
+    static std::mutex art;
+
+    std::unique_lock<std::mutex> graffiti(art);
 
     auto pr = banksy.find(asp);
     if (pr != banksy.end()) return *(pr->second);

--- a/opencog/attentionbank/AttentionBank.cc
+++ b/opencog/attentionbank/AttentionBank.cc
@@ -253,7 +253,8 @@ double AttentionBank::getNormalisedZeroToOneSTI(AttentionValuePtr av,
 // One of the issues is that access via this function can be CPU-wasteful.
 AttentionBank& opencog::attentionbank(AtomSpace* asp)
 {
-    static AttentionBank* instance = nullptr;
+    static AttentionBank* _instance = nullptr;
+    static AtomSpace* _as = nullptr;
 
     // Protect setting and getting against thread races.
     // This is probably not needed.
@@ -261,7 +262,14 @@ AttentionBank& opencog::attentionbank(AtomSpace* asp)
     static std::mutex art;
     std::unique_lock<std::mutex> graffiti(art);
 
-    if (asp and nullptr == instance) instance = new AttentionBank(asp);
-    if (nullptr == asp and instance) { delete instance; instance = nullptr; }
-    return *instance;
+    if (_as != asp and _instance) {
+        delete _instance;
+        _instance = nullptr;
+        _as = nullptr;
+    }
+    if (asp and nullptr == _instance) {
+        _instance = new AttentionBank(asp);
+        _as = asp;
+    }
+    return *_instance;
 }

--- a/opencog/attentionbank/AttentionBank.cc
+++ b/opencog/attentionbank/AttentionBank.cc
@@ -56,18 +56,18 @@ AttentionBank::AttentionBank(void) :
 
     if (async) {
      _addAtomConnection =
-        asp->addAtomSignal(
+        addAtomSignal(
             boost::bind(&AttentionBank::add_atom_to_indexInsertQueue, this, _1));
     _removeAtomConnection =
-        asp->removeAtomSignal(
+        removeAtomSignal(
             boost::bind(&AttentionBank::add_atom_to_indexRemoveQueue, this, _1));
     }
     else {
      _addAtomConnection =
-        asp->addAtomSignal(
+        addAtomSignal(
             boost::bind(&AttentionBank::put_atom_into_index, this, _1));
     _removeAtomConnection =
-        asp->removeAtomSignal(
+        removeAtomSignal(
             boost::bind(&AttentionBank::remove_atom_from_index, this, _1));
 
     }

--- a/opencog/attentionbank/AttentionBank.h
+++ b/opencog/attentionbank/AttentionBank.h
@@ -307,7 +307,7 @@ public:
                       AttentionValue::sti_t lowerBound,
                       AttentionValue::sti_t upperBound = AttentionValue::MAXSTI) const
     {
-        UnorderedHandleSet hs = _bank.getHandlesByAV(lowerBound, upperBound);
+        UnorderedHandleSet hs = getHandlesByAV(lowerBound, upperBound);
         return std::copy(hs.begin(), hs.end(), result);
     }
 
@@ -320,7 +320,7 @@ public:
     template <typename OutputIterator> OutputIterator
     get_handle_set_in_attentional_focus(OutputIterator result) const
     {
-        return get_handles_by_AV(result, get_attentional_focus_boundary(),
+        return get_handles_by_AV(result, getAttentionalFocusBoundary(),
                                  AttentionValue::AttentionValue::MAXSTI);
     }
 

--- a/opencog/attentionbank/AttentionBank.h
+++ b/opencog/attentionbank/AttentionBank.h
@@ -54,6 +54,7 @@ typedef boost::signals2::signal<void (const Handle&,
                                       const AttentionValuePtr&,
                                       const AttentionValuePtr&)> AFCHSigl;
 
+class AtomSpace;
 class AttentionBank
 {
     friend class ecan::StochasticDiffusionAmountCalculator; //need to access _importanceIndex
@@ -118,7 +119,7 @@ class AttentionBank
 
     void shutdown(void);
 public:
-    AttentionBank(void);
+    AttentionBank(AtomSpace*);
     ~AttentionBank();
 
     /**
@@ -359,7 +360,7 @@ public:
 };
 
 /* Singleton instance (for now) */
-AttentionBank& attentionbank();
+AttentionBank& attentionbank(AtomSpace*);
 
 /** @}*/
 } //namespace opencog

--- a/opencog/attentionbank/AttentionBank.h
+++ b/opencog/attentionbank/AttentionBank.h
@@ -54,20 +54,9 @@ typedef boost::signals2::signal<void (const Handle&,
                                       const AttentionValuePtr&,
                                       const AttentionValuePtr&)> AFCHSigl;
 
-class AtomSpace;
-
 class AttentionBank
 {
     friend class ecan::StochasticDiffusionAmountCalculator; //need to access _importanceIndex
-
-    AtomSpace* _as;
-    /**
-     * If true, then this AttentionBank is not being used.
-     * Yes, this is totally bogus, but is needed, due to design
-     * flaws related to attention allocation.
-     */
-    bool _zombie;
-    
 
     /** The connection by which we are notified of AV changes */
     boost::signals2::connection _AVChangedConnection;
@@ -127,11 +116,10 @@ class AttentionBank
     /** Signal emitted when the AV changes. */
     AVCHSigl _AVChangedSignal;
 
-public:
-    /** The table notifies us about AV changes */
-    AttentionBank(AtomSpace*, bool);
-    ~AttentionBank();
     void shutdown(void);
+public:
+    AttentionBank(void);
+    ~AttentionBank();
 
     /**
      * Provide ability for others to find out about atoms that cross in or
@@ -153,34 +141,34 @@ public:
     void stimulate(Handle&, double stimulus);
 
     /**
-     * Get the total amount of STI in the AtomSpace, sum of
+     * Get the total amount of STI in the AttentionBank, sum of
      * STI across all atoms.
      *
-     * @return total STI in AtomSpace
+     * @return total STI in the AttentionBank
      */
     long getTotalSTI() const {
         return startingFundsSTI - fundsSTI;
     }
 
     /**
-     * Get the total amount of LTI in the AtomSpace, sum of
+     * Get the total amount of LTI in the AttentionBank, sum of
      * all LTI across atoms.
      *
-     * @return total LTI in AtomSpace
+     * @return total LTI in the AttentionBank
      */
     long getTotalLTI() const {
         return startingFundsLTI - fundsLTI;
     }
 
     /**
-     * Get the STI funds available in the AtomSpace pool.
+     * Get the STI funds available in the AttentionBank pool.
      *
      * @return STI funds available
      */
     long getSTIFunds() const { return fundsSTI; }
 
     /**
-     * Get the LTI funds available in the AtomSpace pool.
+     * Get the LTI funds available in the AttentionBank pool.
      *
      * @return LTI funds available
      */
@@ -220,7 +208,7 @@ public:
     }
 
     /**
-     * Get the maximum STI observed in the AtomSpace.
+     * Get the maximum STI observed in the AttentionBank.
      *
      * @param average If true, return an exponentially decaying
      *        average of maximum STI, otherwise return the actual
@@ -230,7 +218,7 @@ public:
     AttentionValue::sti_t getMaxSTI(bool average=true) const;
 
     /**
-     * Get the minimum STI observed in the AtomSpace.
+     * Get the minimum STI observed in the AttentionBank.
      *
      * @param average If true, return an exponentially decaying
      *        average of minimum STI, otherwise return the actual
@@ -244,7 +232,7 @@ public:
     AttentionValue::sti_t calculateLTIWage(void);
 
     /**
-     * Update the minimum STI observed in the connected AtomSpace.
+     * Update the minimum STI observed in the AttentionBank.
      * Min/max are not updated on setSTI because average is calculate
      * by lobe cycle, although this could potentially also be handled
      * by the cogServer.
@@ -255,7 +243,7 @@ public:
     void updateMinSTI(AttentionValue::sti_t m);
 
     /**
-     * Update the maximum STI observed in the connected AtomSpace.
+     * Update the maximum STI observed in the AttentionBank.
      * Min/max are not updated on setSTI because average is calculate
      * by lobe cycle, although this could potentially also be handled
      * by the cogServer.

--- a/opencog/attentionbank/AttentionBank.h
+++ b/opencog/attentionbank/AttentionBank.h
@@ -358,6 +358,9 @@ public:
 
 };
 
+/* Singleton instance (for now) */
+AttentionBank& attentionbank();
+
 /** @}*/
 } //namespace opencog
 

--- a/opencog/attentionbank/AttentionBank.h
+++ b/opencog/attentionbank/AttentionBank.h
@@ -223,7 +223,8 @@ public:
      * Get the maximum STI observed in the AtomSpace.
      *
      * @param average If true, return an exponentially decaying
-     * average of maximum STI, otherwise return the actual maximum.
+     *        average of maximum STI, otherwise return the actual
+     *        maximum.
      * @return Maximum STI
      */
     AttentionValue::sti_t getMaxSTI(bool average=true) const;
@@ -232,7 +233,8 @@ public:
      * Get the minimum STI observed in the AtomSpace.
      *
      * @param average If true, return an exponentially decaying
-     * average of minimum STI, otherwise return the actual maximum.
+     *        average of minimum STI, otherwise return the actual
+     *        minimum.
      * @return Minimum STI
      */
     AttentionValue::sti_t getMinSTI(bool average=true) const;
@@ -309,6 +311,29 @@ public:
                   AttentionValue::sti_t upperBound = AttentionValue::MAXSTI) const
     {
         return _importanceIndex.getHandleSet(lowerBound, upperBound);
+    }
+
+    /** Same as above, different API */
+    template <typename OutputIterator> OutputIterator
+    get_handles_by_AV(OutputIterator result,
+                      AttentionValue::sti_t lowerBound,
+                      AttentionValue::sti_t upperBound = AttentionValue::MAXSTI) const
+    {
+        UnorderedHandleSet hs = _bank.getHandlesByAV(lowerBound, upperBound);
+        return std::copy(hs.begin(), hs.end(), result);
+    }
+
+    /**
+     * Gets the set of all handles in the Attentional Focus
+     *
+     * @return The set of all atoms in the Attentional Focus
+     * @note: This method utilizes the ImportanceIndex
+     */
+    template <typename OutputIterator> OutputIterator
+    get_handle_set_in_attentional_focus(OutputIterator result) const
+    {
+        return get_handles_by_AV(result, get_attentional_focus_boundary(),
+                                 AttentionValue::AttentionValue::MAXSTI);
     }
 
     /**

--- a/opencog/attentionbank/CMakeLists.txt
+++ b/opencog/attentionbank/CMakeLists.txt
@@ -1,6 +1,7 @@
 
 
 ADD_LIBRARY (attentionbank
+	AtomAttention.cc
 	AttentionBank.cc
 	ImportanceIndex.cc
 	StochasticImportanceDiffusion.cc

--- a/opencog/attentionbank/StochasticImportanceDiffusion.cc
+++ b/opencog/attentionbank/StochasticImportanceDiffusion.cc
@@ -24,8 +24,9 @@
  */
 
 #include <algorithm>
+#include <math.h>
 
-#include <opencog/atomspace/AtomSpace.h>
+#include <opencog/attentionbank/AttentionBank.h>
 #include "StochasticImportanceDiffusion.h"
 
 using namespace opencog;
@@ -33,13 +34,13 @@ using namespace opencog::ecan;
 
 unsigned int StochasticDiffusionAmountCalculator::bin_index(const Handle& h)
 {
-    return _as->_bank._importanceIndex.
+    return attentionbank()._importanceIndex.
                      importanceBin(h->getAttentionValue()->getSTI());
 }
 
 size_t StochasticDiffusionAmountCalculator::bin_size(unsigned int index)
 {
-   return _as->_bank._importanceIndex.size(index);
+   return attentionbank()._importanceIndex.size(index);
 }
 
 void StochasticDiffusionAmountCalculator::update_bin(const Handle& h)
@@ -64,8 +65,7 @@ void StochasticDiffusionAmountCalculator::update_bin(const Handle& h)
     bin.size = bin_size(index);
 }
 
-StochasticDiffusionAmountCalculator::StochasticDiffusionAmountCalculator
-                                     (const AtomSpace * as) : _as(as)
+StochasticDiffusionAmountCalculator::StochasticDiffusionAmountCalculator(void)
 {
 }
 

--- a/opencog/attentionbank/StochasticImportanceDiffusion.cc
+++ b/opencog/attentionbank/StochasticImportanceDiffusion.cc
@@ -34,13 +34,13 @@ using namespace opencog::ecan;
 
 unsigned int StochasticDiffusionAmountCalculator::bin_index(const Handle& h)
 {
-    return attentionbank()._importanceIndex.
+    return attentionbank(_as)._importanceIndex.
                      importanceBin(h->getAttentionValue()->getSTI());
 }
 
 size_t StochasticDiffusionAmountCalculator::bin_size(unsigned int index)
 {
-   return attentionbank()._importanceIndex.size(index);
+   return attentionbank(_as)._importanceIndex.size(index);
 }
 
 void StochasticDiffusionAmountCalculator::update_bin(const Handle& h)
@@ -65,7 +65,8 @@ void StochasticDiffusionAmountCalculator::update_bin(const Handle& h)
     bin.size = bin_size(index);
 }
 
-StochasticDiffusionAmountCalculator::StochasticDiffusionAmountCalculator(void)
+StochasticDiffusionAmountCalculator::StochasticDiffusionAmountCalculator
+                                     (AtomSpace * as) : _as(as)
 {
 }
 

--- a/opencog/attentionbank/StochasticImportanceDiffusion.h
+++ b/opencog/attentionbank/StochasticImportanceDiffusion.h
@@ -33,7 +33,6 @@ using namespace std::chrono;
 namespace opencog
 {
     class Handle;
-    class AtomSpace;
     namespace ecan
     {
         struct DiffusionRecordBin {
@@ -61,7 +60,6 @@ namespace opencog
          */
         class StochasticDiffusionAmountCalculator
         {
-            const AtomSpace * _as;
             std::vector<DiffusionRecordBin> _bins; 
 
             unsigned int bin_index(const Handle& h);
@@ -69,7 +67,7 @@ namespace opencog
             void update_bin(const Handle& h);
 
             public:
-            StochasticDiffusionAmountCalculator(const AtomSpace * as);
+            StochasticDiffusionAmountCalculator(void);
             ~StochasticDiffusionAmountCalculator();
 
             std::vector<DiffusionRecordBin> merge_bins(const std::vector<DiffusionRecordBin>& past,

--- a/opencog/attentionbank/StochasticImportanceDiffusion.h
+++ b/opencog/attentionbank/StochasticImportanceDiffusion.h
@@ -33,6 +33,7 @@ using namespace std::chrono;
 namespace opencog
 {
     class Handle;
+    class AtomSpace;
     namespace ecan
     {
         struct DiffusionRecordBin {
@@ -60,6 +61,7 @@ namespace opencog
          */
         class StochasticDiffusionAmountCalculator
         {
+            AtomSpace * _as;
             std::vector<DiffusionRecordBin> _bins; 
 
             unsigned int bin_index(const Handle& h);
@@ -67,7 +69,7 @@ namespace opencog
             void update_bin(const Handle& h);
 
             public:
-            StochasticDiffusionAmountCalculator(void);
+            StochasticDiffusionAmountCalculator(AtomSpace * as);
             ~StochasticDiffusionAmountCalculator();
 
             std::vector<DiffusionRecordBin> merge_bins(const std::vector<DiffusionRecordBin>& past,

--- a/opencog/benchmark/CMakeLists.txt
+++ b/opencog/benchmark/CMakeLists.txt
@@ -24,6 +24,7 @@ ENDIF(HAVE_CYTHON)
 
 TARGET_LINK_LIBRARIES (atomspace_bm m
 	atomutils
+	attentionbank
 	atomspace
 	execution
 	clearbox
@@ -39,6 +40,7 @@ IF (HAVE_GUILE)
 
 	TARGET_LINK_LIBRARIES (profile_bindlink m
 		atomutils
+		attentionbank
 		atomspace
 		execution
 		query

--- a/opencog/cython/opencog/CMakeLists.txt
+++ b/opencog/cython/opencog/CMakeLists.txt
@@ -79,6 +79,7 @@ ADD_LIBRARY(atomspace_cython
 ADD_DEPENDENCIES(atomspace_cython opencog_atom_types)
 
 TARGET_LINK_LIBRARIES(atomspace_cython
+	attentionbank
 	atomspace
 	atomutils
 	clearbox

--- a/opencog/cython/opencog/atomspace.pxd
+++ b/opencog/cython/opencog/atomspace.pxd
@@ -211,7 +211,7 @@ cdef extern from "opencog/attentionbank/AttentionBank.h" namespace "opencog":
         # get from AttentionalFocus
         output_iterator get_handle_set_in_attentional_focus(output_iterator)
 
-    cdef cAttentionBank attentionbank()
+    cdef cAttentionBank attentionbank(cAtomSpace*)
 
 
 cdef extern from "opencog/atomutils/AtomUtils.h" namespace "opencog":

--- a/opencog/cython/opencog/atomspace.pxd
+++ b/opencog/cython/opencog/atomspace.pxd
@@ -192,13 +192,6 @@ cdef extern from "opencog/atomspace/AtomSpace.h" namespace "opencog":
         # get by type
         output_iterator get_handles_by_type(output_iterator, Type t, bint subclass)
 
-        # get by STI range
-        output_iterator get_handles_by_AV(output_iterator, short lowerBound, short upperBound)
-        output_iterator get_handles_by_AV(output_iterator, short lowerBound)
-
-        # get from AttentionalFocus
-        output_iterator get_handle_set_in_attentional_focus(output_iterator)
-
         void clear()
         bint remove_atom(cHandle h, bint recursive)
 
@@ -207,6 +200,18 @@ cdef AtomSpace_factory(cAtomSpace *to_wrap)
 cdef class AtomSpace:
     cdef cAtomSpace *atomspace
     cdef bint owns_atomspace
+
+cdef extern from "opencog/attentionbank/AttentionBank.h" namespace "opencog":
+    cdef cppclass cAttentionBank "opencog::AttentionBank":
+
+        # get by STI range
+        output_iterator get_handles_by_AV(output_iterator, short lowerBound, short upperBound)
+        output_iterator get_handles_by_AV(output_iterator, short lowerBound)
+
+        # get from AttentionalFocus
+        output_iterator get_handle_set_in_attentional_focus(output_iterator)
+
+    cdef cAttentionBank attentionbank()
 
 
 cdef extern from "opencog/atomutils/AtomUtils.h" namespace "opencog":

--- a/opencog/cython/opencog/atomspace_details.pyx
+++ b/opencog/cython/opencog/atomspace_details.pyx
@@ -218,10 +218,10 @@ cdef class AtomSpace:
             return None
         cdef vector[cHandle] handle_vector
         if upper_bound is not None:
-            self.atomspace.get_handles_by_AV(back_inserter(handle_vector),
+            attentionbank().get_handles_by_AV(back_inserter(handle_vector),
                     lower_bound, upper_bound)
         else:
-            self.atomspace.get_handles_by_AV(back_inserter(handle_vector),
+            attentionbank().get_handles_by_AV(back_inserter(handle_vector),
                     lower_bound)
         return convert_handle_seq_to_python_list(handle_vector, self)
 
@@ -230,10 +230,10 @@ cdef class AtomSpace:
             return None
         cdef vector[cHandle] handle_vector
         if upper_bound is not None:
-            self.atomspace.get_handles_by_AV(back_inserter(handle_vector),
+            attentionbank().get_handles_by_AV(back_inserter(handle_vector),
                     lower_bound, upper_bound)
         else:
-            self.atomspace.get_handles_by_AV(back_inserter(handle_vector),
+            attentionbank().get_handles_by_AV(back_inserter(handle_vector),
                     lower_bound)
 
         # This code is the same for all the x iterators but there is no
@@ -251,16 +251,14 @@ cdef class AtomSpace:
         if self.atomspace == NULL:
             return None
         cdef vector[cHandle] handle_vector
-        self.atomspace.get_handle_set_in_attentional_focus(
-                back_inserter(handle_vector))
+        attentionbank().get_handle_set_in_attentional_focus(back_inserter(handle_vector))
         return convert_handle_seq_to_python_list(handle_vector, self)
 
     def xget_atoms_in_attentional_focus(self):
         if self.atomspace == NULL:
             return None
         cdef vector[cHandle] handle_vector
-        self.atomspace.get_handle_set_in_attentional_focus(
-                back_inserter(handle_vector))
+        attentionbank().get_handle_set_in_attentional_focus(back_inserter(handle_vector))
 
         # This code is the same for all the x iterators but there is no
         # way in Cython to yield out of a cdef function and no way to pass a

--- a/opencog/cython/opencog/atomspace_details.pyx
+++ b/opencog/cython/opencog/atomspace_details.pyx
@@ -45,14 +45,17 @@ cdef class AtomSpace:
         if (addr == 0) :
             self.atomspace = new cAtomSpace()
             self.owns_atomspace = True
+            attentionbank(self.atomspace)
         else :
             self.atomspace = <cAtomSpace*> PyLong_AsVoidPtr(addr)
             self.owns_atomspace = False
+            attentionbank(self.atomspace)
 
     def __dealloc__(self):
         if self.owns_atomspace:
             if self.atomspace:
                 del self.atomspace
+                attentionbank(<cAtomSpace*> PyLong_AsVoidPtr(0))
 
     def __richcmp__(as_1, as_2, int op):
         if not isinstance(as_1, AtomSpace) or not isinstance(as_2, AtomSpace):

--- a/opencog/cython/opencog/atomspace_details.pyx
+++ b/opencog/cython/opencog/atomspace_details.pyx
@@ -218,10 +218,10 @@ cdef class AtomSpace:
             return None
         cdef vector[cHandle] handle_vector
         if upper_bound is not None:
-            attentionbank().get_handles_by_AV(back_inserter(handle_vector),
+            attentionbank(self.atomspace).get_handles_by_AV(back_inserter(handle_vector),
                     lower_bound, upper_bound)
         else:
-            attentionbank().get_handles_by_AV(back_inserter(handle_vector),
+            attentionbank(self.atomspace).get_handles_by_AV(back_inserter(handle_vector),
                     lower_bound)
         return convert_handle_seq_to_python_list(handle_vector, self)
 
@@ -230,10 +230,10 @@ cdef class AtomSpace:
             return None
         cdef vector[cHandle] handle_vector
         if upper_bound is not None:
-            attentionbank().get_handles_by_AV(back_inserter(handle_vector),
+            attentionbank(self.atomspace).get_handles_by_AV(back_inserter(handle_vector),
                     lower_bound, upper_bound)
         else:
-            attentionbank().get_handles_by_AV(back_inserter(handle_vector),
+            attentionbank(self.atomspace).get_handles_by_AV(back_inserter(handle_vector),
                     lower_bound)
 
         # This code is the same for all the x iterators but there is no
@@ -251,14 +251,14 @@ cdef class AtomSpace:
         if self.atomspace == NULL:
             return None
         cdef vector[cHandle] handle_vector
-        attentionbank().get_handle_set_in_attentional_focus(back_inserter(handle_vector))
+        attentionbank(self.atomspace).get_handle_set_in_attentional_focus(back_inserter(handle_vector))
         return convert_handle_seq_to_python_list(handle_vector, self)
 
     def xget_atoms_in_attentional_focus(self):
         if self.atomspace == NULL:
             return None
         cdef vector[cHandle] handle_vector
-        attentionbank().get_handle_set_in_attentional_focus(back_inserter(handle_vector))
+        attentionbank(self.atomspace).get_handle_set_in_attentional_focus(back_inserter(handle_vector))
 
         # This code is the same for all the x iterators but there is no
         # way in Cython to yield out of a cdef function and no way to pass a

--- a/opencog/guile/CMakeLists.txt
+++ b/opencog/guile/CMakeLists.txt
@@ -22,6 +22,7 @@ ADD_LIBRARY (logger
 )
 
 TARGET_LINK_LIBRARIES(smob
+	attentionbank
 	atomspace
 	${GUILE_LIBRARIES}
 	${COGUTIL_LIBRARY}

--- a/opencog/guile/SchemeSmobAF.cc
+++ b/opencog/guile/SchemeSmobAF.cc
@@ -26,17 +26,16 @@
 #include <libguile.h>
 
 #include <opencog/guile/SchemeSmob.h>
+#include <opencog/attentionbank/AttentionBank.h>
 
 using namespace opencog;
 
 /**
  * Return AttentionalFocus Boundary
  */
-
 SCM SchemeSmob::ss_af_boundary (void)
 {
-	AtomSpace* atomspace = ss_get_env_as("cog-af-boundary");
-	return scm_from_short(atomspace->get_attentional_focus_boundary());
+	return scm_from_short(attentionbank().getAttentionalFocusBoundary());
 }
 
 /**
@@ -44,13 +43,12 @@ SCM SchemeSmob::ss_af_boundary (void)
  */
 SCM SchemeSmob::ss_set_af_boundary (SCM sboundary)
 {
-	AtomSpace* atomspace = ss_get_env_as("cog-set-af-boundary!");
 	if (scm_is_false(scm_integer_p(sboundary)))
 		scm_wrong_type_arg_msg("cog-set-af-boundary", 1, sboundary,
 			"integer opencog AttentionalFocus Boundary");
 
 	short bdy = scm_to_short(sboundary);
-	return scm_from_short(atomspace->set_attentional_focus_boundary(bdy));
+	return scm_from_short(attentionbank().setAttentionalFocusBoundary(bdy));
 }
 
 /**
@@ -58,10 +56,8 @@ SCM SchemeSmob::ss_set_af_boundary (SCM sboundary)
  */
 SCM SchemeSmob::ss_af (void)
 {
-    AtomSpace* atomspace = ss_get_env_as("cog-af");
-
     HandleSeq attentionalFocus;
-    atomspace->get_handle_set_in_attentional_focus(back_inserter(attentionalFocus));
+    attentionbank().get_handle_set_in_attentional_focus(back_inserter(attentionalFocus));
     size_t isz = attentionalFocus.size();
 	if (0 == isz) return SCM_EOL;
 

--- a/opencog/guile/SchemeSmobAF.cc
+++ b/opencog/guile/SchemeSmobAF.cc
@@ -35,7 +35,8 @@ using namespace opencog;
  */
 SCM SchemeSmob::ss_af_boundary (void)
 {
-	return scm_from_short(attentionbank().getAttentionalFocusBoundary());
+	AtomSpace* atomspace = ss_get_env_as("cog-af-boundary");
+	return scm_from_short(attentionbank(atomspace).getAttentionalFocusBoundary());
 }
 
 /**
@@ -43,12 +44,13 @@ SCM SchemeSmob::ss_af_boundary (void)
  */
 SCM SchemeSmob::ss_set_af_boundary (SCM sboundary)
 {
+	AtomSpace* atomspace = ss_get_env_as("cog-set-af-boundary!");
 	if (scm_is_false(scm_integer_p(sboundary)))
 		scm_wrong_type_arg_msg("cog-set-af-boundary", 1, sboundary,
 			"integer opencog AttentionalFocus Boundary");
 
 	short bdy = scm_to_short(sboundary);
-	return scm_from_short(attentionbank().setAttentionalFocusBoundary(bdy));
+	return scm_from_short(attentionbank(atomspace).setAttentionalFocusBoundary(bdy));
 }
 
 /**
@@ -56,17 +58,18 @@ SCM SchemeSmob::ss_set_af_boundary (SCM sboundary)
  */
 SCM SchemeSmob::ss_af (void)
 {
-    HandleSeq attentionalFocus;
-    attentionbank().get_handle_set_in_attentional_focus(back_inserter(attentionalFocus));
-    size_t isz = attentionalFocus.size();
+	AtomSpace* atomspace = ss_get_env_as("cog-af");
+	HandleSeq attentionalFocus;
+	attentionbank(atomspace).get_handle_set_in_attentional_focus(back_inserter(attentionalFocus));
+	size_t isz = attentionalFocus.size();
 	if (0 == isz) return SCM_EOL;
 
-    SCM head = SCM_EOL;
-    for (size_t i = 0; i < isz; i++) {
-        Handle hi = attentionalFocus[i];
-        SCM smob = handle_to_scm(hi);
-        head = scm_cons(smob, head);
-    }
+	SCM head = SCM_EOL;
+	for (size_t i = 0; i < isz; i++) {
+		Handle hi = attentionalFocus[i];
+		SCM smob = handle_to_scm(hi);
+		head = scm_cons(smob, head);
+	}
 
 	return head;
 }

--- a/opencog/guile/SchemeSmobAV.cc
+++ b/opencog/guile/SchemeSmobAV.cc
@@ -9,6 +9,7 @@
 #include <cstddef>
 #include <libguile.h>
 
+#include <opencog/attentionbank/AttentionBank.h>
 #include <opencog/truthvalue/AttentionValue.h>
 #include <opencog/guile/SchemeSmob.h>
 
@@ -100,8 +101,7 @@ SCM SchemeSmob::ss_stimulate (SCM satom, SCM sstimulus)
 {
 	Handle h(scm_to_handle(satom));
 	double stimulus = scm_to_double(sstimulus);
-	AtomSpace* atomspace = ss_get_env_as("cog-stimulate");
-	atomspace->stimulate(h,stimulus);
+	attentionbank().stimulate(h, stimulus);
 	return satom;
 }
 

--- a/opencog/guile/SchemeSmobAV.cc
+++ b/opencog/guile/SchemeSmobAV.cc
@@ -101,7 +101,8 @@ SCM SchemeSmob::ss_stimulate (SCM satom, SCM sstimulus)
 {
 	Handle h(scm_to_handle(satom));
 	double stimulus = scm_to_double(sstimulus);
-	attentionbank().stimulate(h, stimulus);
+	AtomSpace* atomspace = ss_get_env_as("cog-stimulate");
+	attentionbank(atomspace).stimulate(h, stimulus);
 	return satom;
 }
 

--- a/opencog/query/AttentionalFocusCB.cc
+++ b/opencog/query/AttentionalFocusCB.cc
@@ -20,6 +20,8 @@
  * Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+
+#include <opencog/attentionbank/AttentionBank.h>
 #include "AttentionalFocusCB.h"
 
 using namespace opencog;
@@ -34,13 +36,13 @@ AttentionalFocusCB::AttentionalFocusCB(AtomSpace* as) :
 bool AttentionalFocusCB::node_match(const Handle& node1, const Handle& node2)
 {
 	return node1 == node2 and
-		node2->getSTI() > _as->get_attentional_focus_boundary();
+		node2->getSTI() > attentionbank(_as).getAttentionalFocusBoundary();
 }
 
 bool AttentionalFocusCB::link_match(const PatternTermPtr& ptm, const Handle& lsoln)
 {
 	return DefaultPatternMatchCB::link_match(ptm, lsoln)
-		and lsoln->getSTI() > _as->get_attentional_focus_boundary();
+		and lsoln->getSTI() > attentionbank(_as).getAttentionalFocusBoundary();
 }
 
 static bool compare_sti(const LinkPtr& lptr1, const LinkPtr& lptr2)
@@ -58,7 +60,7 @@ IncomingSet AttentionalFocusCB::get_incoming_set(const Handle& h)
 	// parts of the hypergraph.
 	IncomingSet filtered_set;
 	for (const auto& l : incoming_set)
-		if (l->getSTI() > _as->get_attentional_focus_boundary())
+		if (l->getSTI() > attentionbank(_as).getAttentionalFocusBoundary())
 			filtered_set.push_back(l);
 
 	// If nothing is in AF

--- a/tests/atomspace/AtomSpaceAsyncUTest.cxxtest
+++ b/tests/atomspace/AtomSpaceAsyncUTest.cxxtest
@@ -32,6 +32,7 @@
 #include <boost/bind.hpp>
 
 #include <opencog/atomspace/AtomSpace.h>
+#include <opencog/attentionbank/AttentionBank.h>
 #include <opencog/atoms/base/Node.h>
 #include <opencog/truthvalue/SimpleTruthValue.h>
 #include <opencog/util/Logger.h>
@@ -495,16 +496,16 @@ public:
     void testAFSignals()
     {
         boost::signals2::connection addAFConnection =
-            atomSpace->AddAFSignal(
+            attentionbank(atomSpace).AddAFSignal().connect(
                     boost::bind(&AtomSpaceAsyncUTest::addAFSignal,
                                 this, _1, _2, _3));
         boost::signals2::connection removeAFConnection =
-            atomSpace->RemoveAFSignal(
+            attentionbank(atomSpace).RemoveAFSignal().connect(
                     boost::bind(&AtomSpaceAsyncUTest::removeAFSignal,
                                 this, _1, _2, _3));
 
         __testAFSignalsCounter = 0;
-        atomSpace->set_attentional_focus_boundary(100);
+        attentionbank(atomSpace).setAttentionalFocusBoundary(100);
 
         // Add a node to the AttentionalFocus
         Handle h = atomSpace->add_node(CONCEPT_NODE,

--- a/tests/atomspace/AtomSpaceAsyncUTest.cxxtest
+++ b/tests/atomspace/AtomSpaceAsyncUTest.cxxtest
@@ -87,11 +87,13 @@ public:
     void setUp()
     {
         atomSpace = new AtomSpace();
+        attentionbank(atomSpace);
         rng = new opencog::MT19937RandGen((unsigned long) time(NULL));
     }
 
     void tearDown()
     {
+        attentionbank(nullptr);
         delete atomSpace;
         delete rng;
     }

--- a/tests/atomspace/AtomSpaceImplUTest.cxxtest
+++ b/tests/atomspace/AtomSpaceImplUTest.cxxtest
@@ -29,6 +29,7 @@
 
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/atoms/base/Node.h>
+#include <opencog/attentionbank/AttentionBank.h>
 #include <opencog/truthvalue/SimpleTruthValue.h>
 #include <opencog/util/misc.h>
 #include <opencog/util/oc_assert.h>
@@ -737,13 +738,13 @@ public:
     void testGetNormalisedSTI() {
         Handle h = atomSpace->add_node(CONCEPT_NODE,"blah");
         bool clip = false, average = false;
-        TS_ASSERT_EQUALS(atomSpace->get_normalised_zero_to_one_STI(h, average, clip), 0.0f);
+        TS_ASSERT_EQUALS(attentionbank(atomSpace).getNormalisedZeroToOneSTI(h->getAttentionValue(), average, clip), 0.0f);
         average = true;
         setSTI(h,10);
-        atomSpace->update_max_STI(10);
-        TS_ASSERT(atomSpace->get_normalised_zero_to_one_STI(h, average, clip) > 1.0f);
+        attentionbank(atomSpace).updateMaxSTI(10);
+        TS_ASSERT(attentionbank(atomSpace).getNormalisedZeroToOneSTI(h->getAttentionValue(), average, clip) > 1.0f);
         clip = true;
-        TS_ASSERT_DELTA(atomSpace->get_normalised_zero_to_one_STI(h, average, clip), 1.0f, 0.001f);
+        TS_ASSERT_DELTA(attentionbank(atomSpace).getNormalisedZeroToOneSTI(h->getAttentionValue(), average, clip), 1.0f, 0.001f);
     }
 
 };

--- a/tests/atomspace/AtomSpaceUTest.cxxtest
+++ b/tests/atomspace/AtomSpaceUTest.cxxtest
@@ -29,10 +29,9 @@
 #include <math.h>
 #include <string.h>
 
-#define DEPRECATED_ATOMSPACE_CALLS 1
-
 #include <opencog/atoms/base/types.h>
 #include <opencog/atomspace/AtomSpace.h>
+#include <opencog/attentionbank/AttentionBank.h>
 #include <opencog/atoms/base/Handle.h>
 #include <opencog/atoms/base/Node.h>
 #include <opencog/truthvalue/SimpleTruthValue.h>
@@ -234,7 +233,7 @@ struct LTIAboveThreshold : public HandlePredicate
 template<typename InputIterator>
 HandleSeq filter_InAttentionalFocus(AtomSpace* as, InputIterator begin, InputIterator end)
 {
-    STIAboveThreshold sti_above(as->get_attentional_focus_boundary());
+    STIAboveThreshold sti_above(attentionbank(as).getAttentionalFocusBoundary());
     return filter(begin, end, sti_above);
 }
 
@@ -320,7 +319,28 @@ getSortedHandleSet(AtomSpace* as,
     return std::copy(hs.begin(), hs.end(), result);
 }
 
+template <typename OutputIterator> OutputIterator
+get_handles_by_name(AtomSpace* as,
+                    OutputIterator result,
+                    const std::string& name,
+                    Type type = NODE,
+                    bool subclass = true)
+{
+    if (name.c_str()[0] == 0)
+        return as->get_handles_by_type(result, type, subclass);
 
+    if (false == subclass) {
+        Handle h(as->get_handle(type, name));
+        if (h) *(result++) = h;
+        return result;
+    }
+    classserver().foreachRecursive(
+        [&](Type t)->void {
+            Handle h(as->get_handle(t, name));
+            if (h) *(result++) = h; }, type);
+
+    return result;
+}
 
 class AtomSpaceUTest :  public CxxTest::TestSuite
 {
@@ -499,7 +519,7 @@ public:
         for (int vhIdx = 0; vhIdx < NUM_VHS; vhIdx++) {
             for (int i = 0; i < NUM_NODES; i++) {
                 HandleSeq nodes;
-                atomSpace->get_handles_by_name(back_inserter(nodes), nodeNames[i], NODE, true);
+                get_handles_by_name(atomSpace, back_inserter(nodes), nodeNames[i], NODE, true);
                 TS_ASSERT_EQUALS(nodes.size(), 1);
                 for (int j = 0; j < NUM_NODES; j++) {
                     if (i == j) {
@@ -514,34 +534,33 @@ public:
 
             // Note: SUBSET_LINK is a subType of INHERITANCE_LINK
             HandleSeq links;
-            atomSpace->get_handles_by_name(back_inserter(links), "", LINK, true);
+            get_handles_by_name(atomSpace, back_inserter(links), "", LINK, true);
             logger().debug("1) links.size() = %d Expected = %d\n", (int) links.size(), 8);
             TS_ASSERT(links.size() == 8);
             links.clear();
-            atomSpace->get_handles_by_name(back_inserter(links), "", LINK, false);
+            get_handles_by_name(atomSpace, back_inserter(links), "", LINK, false);
             //logger().debug("2) links.size() = %d\n", links.size());
             TS_ASSERT(links.size() == 0);
             HandleSeq allInhLinks;
-            atomSpace->get_handles_by_name(back_inserter(allInhLinks), "", INHERITANCE_LINK, true);
+            get_handles_by_name(atomSpace, back_inserter(allInhLinks), "", INHERITANCE_LINK, true);
             //logger().info("4) allInhLinks.size() = %d (vhIdx: %d)\n", allInhLinks.size(), vhIdx);
             //for (unsigned int x = 0; x < allInhLinks.size(); ++x) {
             //    logger().info("allInhLinks[x]: %s\n", allInhLinks[x]->toString().c_str());
             //}
             TS_ASSERT(allInhLinks.size() == 8);
             HandleSeq justInhLinks;
-            atomSpace->get_handles_by_name(back_inserter(justInhLinks), "", INHERITANCE_LINK, false);
+            get_handles_by_name(atomSpace, back_inserter(justInhLinks), "", INHERITANCE_LINK, false);
             //logger().info("5) justInhLinks.size() = %d (vhIdx: %d)\n", justInhLinks.size(), vhIdx);
             TS_ASSERT(justInhLinks.size() == 4);
             HandleSeq partOfLinks;
-            atomSpace->get_handles_by_name(back_inserter(partOfLinks), "", SUBSET_LINK, true);
+            get_handles_by_name(atomSpace, back_inserter(partOfLinks), "", SUBSET_LINK, true);
             //logger().debug("5) partOfLinks.size() = %d\n", partOfLinks.size());
             TS_ASSERT(partOfLinks.size() == 4);
             partOfLinks.clear();
-            atomSpace->get_handles_by_name(back_inserter(partOfLinks), "", SUBSET_LINK, false);
+            get_handles_by_name(atomSpace, back_inserter(partOfLinks), "", SUBSET_LINK, false);
             //logger().debug("6) partOfLinks.size() = %d\n", partOfLinks.size());
             TS_ASSERT(partOfLinks.size() == 4);
         }
-
     }
 
     /**

--- a/tests/atomspace/AtomSpaceUTest.cxxtest
+++ b/tests/atomspace/AtomSpaceUTest.cxxtest
@@ -356,9 +356,11 @@ public:
 
     void setUp() {
         atomSpace = new AtomSpace();
+        attentionbank(atomSpace);
     }
 
     void tearDown() {
+        attentionbank(nullptr);
         delete atomSpace;
     }
 

--- a/tests/atomspace/CMakeLists.txt
+++ b/tests/atomspace/CMakeLists.txt
@@ -4,6 +4,7 @@ LINK_LIBRARIES(
 	atomutils
 	atomspaceutils
 	atomspace
+	attentionbank
 	clearbox
 )
 

--- a/tests/query/AttentionalFocusCBUTest.cxxtest
+++ b/tests/query/AttentionalFocusCBUTest.cxxtest
@@ -22,6 +22,7 @@
  */
 #include <opencog/guile/SchemeEval.h>
 #include <opencog/atomspace/AtomSpace.h>
+#include <opencog/attentionbank/AttentionBank.h>
 #include <opencog/query/BindLinkAPI.h>
 #include <opencog/util/Logger.h>
 
@@ -69,7 +70,7 @@ void AttentionalFocusCBUTest::setUp(void)
 void AttentionalFocusCBUTest::test_af_bindlink(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
-	as->set_attentional_focus_boundary(20); //for test purpose
+	attentionbank(as).setAttentionalFocusBoundary(20); //for test purpose
 	eval->eval("(load-from-path \"tests/query/af-filtering-test.scm\")");
 
 	Handle findMan = eval->eval_h("find-man");
@@ -77,5 +78,5 @@ void AttentionalFocusCBUTest::test_af_bindlink(void)
 	// first match
 	Handle answersSingle = af_bindlink(as, findMan);
 	TS_ASSERT_EQUALS(1, getarity(answersSingle));
-	TS_ASSERT_EQUALS(20, as->get_attentional_focus_boundary());
+	TS_ASSERT_EQUALS(20, attentionbank(as).getAttentionalFocusBoundary());
 }

--- a/tests/rule-engine/ForwardChainerUTest.cxxtest
+++ b/tests/rule-engine/ForwardChainerUTest.cxxtest
@@ -7,6 +7,7 @@
 #include <boost/range/algorithm/find.hpp>
 
 #include <opencog/atomspace/AtomSpace.h>
+#include <opencog/attentionbank/AttentionBank.h>
 #include <opencog/guile/SchemeEval.h>
 
 #include <opencog/rule-engine/forwardchainer/ForwardChainer.h>
@@ -37,7 +38,7 @@ public:
 		logger().set_print_to_stdout_flag(true);
 
 		// Disable the AF mechanism during testing!
-		_as.set_attentional_focus_boundary(AttentionValue::MINSTI);
+		attentionbank(&_as).setAttentionalFocusBoundary(AttentionValue::MINSTI);
 
 		string source_dir = string(PROJECT_SOURCE_DIR),
 			test_dir = source_dir + "/tests",

--- a/tests/truthvalue/AttentionValueUTest.cxxtest
+++ b/tests/truthvalue/AttentionValueUTest.cxxtest
@@ -23,6 +23,7 @@
  */
 
 #include <opencog/atomspace/AtomSpace.h>
+#include <opencog/attentionbank/AttentionBank.h>
 #include <opencog/truthvalue/AttentionValue.h>
 #include <opencog/atoms/base/Node.h>
 #include <opencog/truthvalue/SimpleTruthValue.h>
@@ -184,8 +185,9 @@ public:
 
     void testVLTI() {
         AtomSpace* atomSpace = new AtomSpace();
+        attentionbank(atomSpace);
         HandleSeq atoms = createSimpleGraph(atomSpace, "vlti");
-        
+
         TS_ASSERT(getVLTI(atoms[0])==AttentionValue::DISPOSABLE);
         incVLTI(atoms[0]);//VLTI=1
         TS_ASSERT(getVLTI(atoms[0])!=AttentionValue::DISPOSABLE);
@@ -207,14 +209,16 @@ public:
 
     void testComparisons() {
         logger().debug("BEGIN TEST:");
-        
+
         AtomSpace* atomSpace = new AtomSpace();
+        attentionbank(atomSpace);
+
         HandleSeq atoms = createSimpleGraph(atomSpace, "comparisons");
-        
+
         logger().debug("STISort");
 
         STISort sSort;
-        
+
         // an atom which has higher sti is strictly before one with lower sti
         TS_ASSERT_EQUALS(sSort(atoms[1], atoms[0]), true);
         // an atom which has lower sti is not strictly before one with higher sti
@@ -222,11 +226,11 @@ public:
         // two atoms with the same sti are not strictly before each other
         TS_ASSERT_EQUALS(sSort(atoms[2], atoms[1]), false);
         TS_ASSERT_EQUALS(sSort(atoms[1], atoms[2]), false);
-        
+
         logger().debug("LTIAndTVAscendingSort");
 
         LTIAndTVAscendingSort latvSort;
-        
+
         // an atom which has higher LTI*TV is not strictly before one with lower LTI*TV
         TS_ASSERT_EQUALS(latvSort(atoms[1], atoms[0]), false);
         // an atom which has lower LTI*TV is strictly before one with higher LTI*TV
@@ -236,26 +240,32 @@ public:
         TS_ASSERT_EQUALS(latvSort(atoms[1], atoms[2]), false);
 
         logger().debug("LTIThenTVAscendingSort");
-        
+
         LTIThenTVAscendingSort lttvSort;
 
-        // an atom which has higher LTI is not strictly before one with lower LTI
+        // An atom which has higher LTI is not strictly before one
+        // with lower LTI.
         TS_ASSERT_EQUALS(lttvSort(atoms[1], atoms[0]), false);
         // an atom which has lower LTI is strictly before one with higher LTI
         TS_ASSERT_EQUALS(lttvSort(atoms[0], atoms[1]), true);
-        // two atoms with the same LTI and the same TV are not strictly before each other
+        // Two atoms with the same LTI and the same TV are not
+        // strictly before each other.
         TS_ASSERT_EQUALS(lttvSort(atoms[2], atoms[1]), false);
         TS_ASSERT_EQUALS(lttvSort(atoms[1], atoms[2]), false);
-        // two atoms with the same LTI: the one with lower TV is strictly before the one with higher TV
+        // Two atoms with the same LTI: the one with lower TV is
+        // strictly before the one with higher TV.
         TS_ASSERT_EQUALS(lttvSort(atoms[2], atoms[3]), true);
-        // two atoms with the same LTI: the one with higher TV is not strictly before the one with lower TV
+        // Two atoms with the same LTI: the one with higher TV is not
+        // strictly before the one with lower TV.
         TS_ASSERT_EQUALS(lttvSort(atoms[3], atoms[2]), false);
-        
+
         logger().debug("END TEST:");
     }
 
-    // copied from AtomSpaceUTest.cxxtest, but modified for the test testComparisons 
-    HandleSeq createSimpleGraph(AtomSpace* atomSpace, const char* baseName) {
+    // Copied from AtomSpaceUTest.cxxtest, but modified for the test
+    // testComparisons
+    HandleSeq createSimpleGraph(AtomSpace* atomSpace, const char* baseName)
+    {
         char buf[256];
         HandleSeq testAtoms;
         int baseNameLength;
@@ -331,7 +341,8 @@ public:
     }
 
     //static std::string toStr();
-    void testtoString() {
+    void testtoString()
+    {
         char buffer[100];
         //logger().debug("AttentionValue::testtoString()");
         for (int i = 0; i < NUM_AVS; i++) {

--- a/tests/truthvalue/CMakeLists.txt
+++ b/tests/truthvalue/CMakeLists.txt
@@ -1,8 +1,9 @@
 
 LINK_LIBRARIES(
+	attentionbank
+	atomspace
 	atombase
 	atomutils
-	atomspace
 )
 
 ADD_CXXTEST(SimpleTruthValueUTest)


### PR DESCRIPTION
This is a large step towards fulfilling bug https://github.com/opencog/opencog/issues/2333 and continues work started in #1050.

The attentionbank now lives separately from the atomspace.  Attentionvalues remain tangled into atoms. 

This requires a corresponding pull req for the main opencog repo. -- https://github.com/opencog/opencog/pull/2558
