### PR TITLE
Improve rule management

### DIFF
--- a/opencog/rule-engine/Rule.cc
+++ b/opencog/rule-engine/Rule.cc
@@ -219,7 +219,7 @@ bool Rule::is_meta() const
  *
  * @return HandleSeq of members of the implicant
  */
-HandleSeq Rule::get_premises() const
+HandleSeq Rule::get_clauses() const
 {
 	// if the rule's handle has not been set yet
 	if (!_rule)
@@ -435,18 +435,18 @@ Handle Rule::get_conclusion_pattern(const Handle& h) const
 {
 	Type t = h->getType();
 	if (EXECUTION_OUTPUT_LINK == t)
-		return get_execution_output_last_argument(h);
+		return get_execution_output_first_argument(h);
 	else
 		return h;
 }
 
-Handle Rule::get_execution_output_last_argument(const Handle& h) const
+Handle Rule::get_execution_output_first_argument(const Handle& h) const
 {
 	OC_ASSERT(h->getType() == EXECUTION_OUTPUT_LINK);
 	Handle args = h->getOutgoingAtom(1);
 	if (args->getType() == LIST_LINK) {
 		OC_ASSERT(args->getArity() > 0);
-		return args->getOutgoingAtom(args->getArity()-1);
+		return args->getOutgoingAtom(0);
 	} else
 		return args;
 }

--- a/opencog/rule-engine/Rule.cc
+++ b/opencog/rule-engine/Rule.cc
@@ -93,22 +93,8 @@ void Rule::init(const Handle& rule_alias, const Handle& rbs)
 
 void Rule::init(const Handle& rule_alias, const Handle& rule, const Handle& rbs)
 {
-	if (rule->getType() == LIST_LINK)
-	{
-		OC_ASSERT(rule->getArity() > 0);
-		// Split the rule into a forward and backward parts
-		_forward_rule = BindLinkCast(rule->getOutgoingAtom(0));
-		for (unsigned i = 1; i < rule->getArity(); i++) {
-			Handle bch = rule->getOutgoingAtom(i);
-			_backward_rule_handles.push_back(bch);
-			_backward_rule_scope_links.push_back(ScopeLinkCast(bch));
-		}
-	}
-	else
-	{
-		OC_ASSERT(rule->getType() == BIND_LINK);
-		_forward_rule = BindLinkCast(rule);
-	}
+	OC_ASSERT(rule->getType() == BIND_LINK);
+	_rule = BindLinkCast(rule);
 
 	_rule_alias = rule_alias;
 	_name = _rule_alias->getName();
@@ -118,31 +104,19 @@ void Rule::init(const Handle& rule_alias, const Handle& rule, const Handle& rbs)
 
 bool Rule::operator==(const Rule& r) const
 {
-	return r._forward_rule == _forward_rule
-		and r._backward_rule_handles == _backward_rule_handles;
+	return r._rule == _rule;
 }
 
 bool Rule::operator<(const Rule& r) const
 {
 	return _weight == r._weight ?
-		Handle(_forward_rule).value() < Handle(r._forward_rule).value()
+		Handle(_rule).value() < Handle(r._rule).value()
 		: _weight < r._weight;
 }
 
 bool Rule::is_alpha_equivalent(const Rule& r) const
 {
-	if (not _forward_rule->is_equal(Handle(r._forward_rule)))
-		return false;
-
-	size_t n_backrules = r._backward_rule_scope_links.size();
-	if (n_backrules != _backward_rule_scope_links.size())
-		return false;
-
-	for (size_t i = 0; i < n_backrules; i++) {
-		if (not _backward_rule_scope_links[i]->is_equal(r._backward_rule_handles[i]))
-			return false;
-	}
-	return true;
+	return _rule->is_equal(Handle(r._rule));
 }
 
 double Rule::get_weight() const
@@ -165,22 +139,14 @@ const std::string& Rule::get_name() const
 	return _name;
 }
 
-void Rule::set_forward_handle(const Handle& h)
+void Rule::set_rule(const Handle& h)
 {
-	_forward_rule = BindLinkCast(h);
+	_rule = BindLinkCast(h);
 }
 
-void Rule::set_backward_handles(const HandleSeq& hs)
+Handle Rule::get_rule() const
 {
-	_backward_rule_handles = hs;
-	_backward_rule_scope_links.clear();
-	for (const Handle& h : hs)
-		_backward_rule_scope_links.push_back(ScopeLinkCast(h));
-}
-
-Handle Rule::get_forward_rule() const
-{
-	return Handle(_forward_rule);
+	return Handle(_rule);
 }
 
 Handle Rule::get_alias() const
@@ -195,35 +161,20 @@ Handle Rule::get_rbs() const
 
 void Rule::add(AtomSpace& as)
 {
-	if (!_forward_rule)
+	if (!_rule)
 		return;
 
 	HandleSeq outgoings;
-	for (const Handle& h : _forward_rule->getOutgoingSet())
+	for (const Handle& h : _rule->getOutgoingSet())
 		outgoings.push_back(as.add_atom(h));
-	_forward_rule = createBindLink(outgoings);
-
-	// TODO: support backward rule
+	_rule = createBindLink(outgoings);
 }
 
-Handle Rule::get_forward_vardecl() const
+Handle Rule::get_vardecl() const
 {
-	if (_forward_rule)
-		return _forward_rule->get_vardecl();
+	if (_rule)
+		return _rule->get_vardecl();
 	return Handle::UNDEFINED;
-}
-
-/**
- * Get the typed variable list of the Rule.
- *
- * @return the VariableList or the lone VariableNode
- */
-HandleSeq Rule::get_backward_vardecls() const
-{
-	HandleSeq results;
-	for (const Handle& h : _backward_rule_handles)
-		results.push_back(h->getOutgoingAtom(0));
-	return results;
 }
 
 /**
@@ -231,28 +182,28 @@ HandleSeq Rule::get_backward_vardecls() const
  *
  * @return the Handle of the implicant
  */
-Handle Rule::get_forward_implicant() const
+Handle Rule::get_implicant() const
 {
-	if (_forward_rule)
-		return _forward_rule->get_body();
+	if (_rule)
+		return _rule->get_body();
 	return Handle::UNDEFINED;
 }
 
-Handle Rule::get_forward_implicand() const
+Handle Rule::get_implicand() const
 {
-	if (_forward_rule)
-		return _forward_rule->get_implicand();
+	if (_rule)
+		return _rule->get_implicand();
 	return Handle::UNDEFINED;
 }
 
 bool Rule::is_valid() const
 {
-	return (bool)_forward_rule;
+	return (bool)_rule;
 }
 
 bool Rule::is_meta() const
 {
-	Handle implicand = get_forward_implicand();
+	Handle implicand = get_implicand();
 
 	if (implicand.is_undefined())
 		return false;
@@ -268,13 +219,13 @@ bool Rule::is_meta() const
  *
  * @return HandleSeq of members of the implicant
  */
-HandleSeq Rule::get_premises(const Handle& conclusion) const
+HandleSeq Rule::get_premises() const
 {
 	// if the rule's handle has not been set yet
-	if (!_forward_rule)
+	if (!_rule)
 		return HandleSeq();
 
-    Handle implicant = get_forward_implicant();
+    Handle implicant = get_implicant();
     Type t = implicant->getType();
     HandleSeq hs;
 
@@ -291,12 +242,12 @@ HandleSeq Rule::get_premises(const Handle& conclusion) const
  *
  * @return the Handle of the implicand
  *
- * TODO: indentical to get_forward_implicand()
+ * TODO: indentical to get_implicand()
  */
-Handle Rule::get_forward_conclusion() const
+Handle Rule::get_conclusion() const
 {
-	if (_forward_rule)
-		return _forward_rule->get_implicand();
+	if (_rule)
+		return _rule->get_implicand();
 	return Handle::UNDEFINED;
 }
 
@@ -305,27 +256,12 @@ HandlePairSeq Rule::get_conclusions() const
 	HandlePairSeq results;
 
 	// If the rule's handle has not been set yet
-	if (!_forward_rule)
+	if (!_rule)
 		return HandlePairSeq();
 
-	// If no backward rule then extract the conclusions from the
-	// forward rule
-	if (_backward_rule_handles.empty())
-	{
-		Handle vardecl = get_forward_vardecl();
-		for (const Handle& c : get_forward_conclusion_patterns())
-			results.push_back({filter_vardecl(vardecl, c), c});
-	}
-	// There are backward rules so return directly their patterns
-	else
-	{
-		for (const Handle& h : _backward_rule_handles)
-		{
-			Type t = h->getType();
-			OC_ASSERT(t == BIND_LINK or t == GET_LINK);
-			results.push_back({h->getOutgoingAtom(0), h->getOutgoingAtom(1)});
-		}
-	}
+	Handle vardecl = get_vardecl();
+	for (const Handle& c : get_conclusion_patterns())
+		results.push_back({filter_vardecl(vardecl, c), c});
 
 	return results;
 }
@@ -337,7 +273,7 @@ void Rule::set_weight(double p)
 
 Rule Rule::gen_standardize_apart(AtomSpace* as)
 {
-	if (!_forward_rule)
+	if (!_rule)
 		throw InvalidParamException(TRACE_INFO,
 		                            "Attempted standardized-apart on "
 		                            "invalid Rule");
@@ -346,7 +282,7 @@ Rule Rule::gen_standardize_apart(AtomSpace* as)
 	Rule st_ver = *this;
 	HandleMap dict;
 
-	Handle vdecl = get_forward_vardecl();
+	Handle vdecl = get_vardecl();
 	OrderedHandleSet varset;
 
 	if (VariableListCast(vdecl))
@@ -357,8 +293,8 @@ Rule Rule::gen_standardize_apart(AtomSpace* as)
 	for (auto& h : varset)
 		dict[h] = Handle::UNDEFINED;
 
-	Handle st_bindlink = standardize_helper(as, Handle(_forward_rule), dict);
-	st_ver.set_forward_handle(st_bindlink);
+	Handle st_bindlink = standardize_helper(as, Handle(_rule), dict);
+	st_ver.set_rule(st_bindlink);
 
 	return st_ver;
 }
@@ -374,40 +310,28 @@ RuleSet Rule::unify_target(const Handle& target,
                            const Handle& vardecl) const
 {
 	// If the rule's handle has not been set yet
-	if (!_forward_rule)
+	if (!_rule)
 		return {};
 
 	Rule alpha_rule = rand_alpha_converted();
 
 	RuleSet unified_rules;
 
-	// If no backward rule then only consider the conclusions from the
-	// forward rule
-	if (_backward_rule_handles.empty())
+	Handle alpha_vardecl = alpha_rule.get_vardecl();
+	for (const Handle& alpha_pat : alpha_rule.get_conclusion_patterns())
 	{
-		Handle alpha_vardecl = alpha_rule.get_forward_vardecl();
-		for (const Handle& alpha_pat : alpha_rule.get_forward_conclusion_patterns())
-		{
-			UnificationSolutionSet sol =
-				unify(target, alpha_pat, vardecl, alpha_vardecl);
-			if (sol.satisfiable) {
-				TypedSubstitutions tss =
-					typed_substitutions(sol, target, target, alpha_pat,
-					                    vardecl, alpha_vardecl);
-				// For each typed substitution produce a new rule by
-				// substituting all variables by their associated
-				// values.
-				for (const auto& ts : tss)
-					unified_rules.insert(alpha_rule.substituted(ts));
-			}
+		UnificationSolutionSet sol =
+			unify(target, alpha_pat, vardecl, alpha_vardecl);
+		if (sol.satisfiable) {
+			TypedSubstitutions tss =
+				typed_substitutions(sol, target, target, alpha_pat,
+				                    vardecl, alpha_vardecl);
+			// For each typed substitution produce a new rule by
+			// substituting all variables by their associated
+			// values.
+			for (const auto& ts : tss)
+				unified_rules.insert(alpha_rule.substituted(ts));
 		}
-	}
-	// There are backward rules so return directly their patterns
-	else {
-		std::stringstream ss;
-		ss << "TODO: support backward rules (offending rule is `"
-		   << get_name() << "')";
-		OC_ASSERT(false, ss.str());
 	}
 
 	return unified_rules;
@@ -415,17 +339,14 @@ RuleSet Rule::unify_target(const Handle& target,
 
 Handle Rule::apply(AtomSpace& as) const
 {
-	return bindlink(&as, Handle(_forward_rule));
+	return bindlink(&as, Handle(_rule));
 }
 
 std::string Rule::to_string() const
 {
 	std::stringstream ss;
 	ss << "name: " << _name << std::endl
-	   << "forward rule:" << std::endl
-	   << _forward_rule->toString()
-	   << "backward rules:" << std::endl
-	   << oc_to_string(_backward_rule_handles);
+	   << "rule:" << std::endl << _rule->toString();
 	return ss.str();
 }
 
@@ -434,14 +355,8 @@ Rule Rule::rand_alpha_converted() const
 	// Clone the rule
 	Rule result = *this;
 
-	// Alpha convert the forward rule
-	result.set_forward_handle(_forward_rule->alpha_conversion());
-
-	// Alpha convert the backward rules
-	HandleSeq bhs;
-	for (ScopeLinkPtr sc : _backward_rule_scope_links)
-		bhs.push_back(Handle(sc->alpha_conversion()));
-	result.set_backward_handles(bhs);
+	// Alpha convert the rule
+	result.set_rule(_rule->alpha_conversion());
 
 	return result;
 }
@@ -502,21 +417,21 @@ Handle Rule::standardize_helper(AtomSpace* as, const Handle& h,
 	return hcpy;
 }
 
-HandleSeq Rule::get_forward_conclusion_patterns() const
+HandleSeq Rule::get_conclusion_patterns() const
 {
 	HandleSeq results;
-	Handle implicand = get_forward_implicand();
+	Handle implicand = get_implicand();
 	Type t = implicand->getType();
 	if (LIST_LINK == t)
 		for (const Handle& h : implicand->getOutgoingSet())
-			results.push_back(get_forward_conclusion_pattern(h));
+			results.push_back(get_conclusion_pattern(h));
 	else
-		results.push_back(get_forward_conclusion_pattern(implicand));
+		results.push_back(get_conclusion_pattern(implicand));
 
 	return results;
 }
 
-Handle Rule::get_forward_conclusion_pattern(const Handle& h) const
+Handle Rule::get_conclusion_pattern(const Handle& h) const
 {
 	Type t = h->getType();
 	if (EXECUTION_OUTPUT_LINK == t)
@@ -539,7 +454,7 @@ Handle Rule::get_execution_output_last_argument(const Handle& h) const
 Rule Rule::substituted(const TypedSubstitutions::value_type& ts) const
 {
 	Rule new_rule(*this);
-	new_rule.set_forward_handle(substitute(_forward_rule, ts));
+	new_rule.set_rule(substitute(_rule, ts));
 	return new_rule;
 }
 

--- a/opencog/rule-engine/Rule.h
+++ b/opencog/rule-engine/Rule.h
@@ -148,9 +148,12 @@ public:
 	bool is_meta() const;       // does that rule produces a rule
 
 	/**
-	 * Return the premises of the rule.
+	 * Return the pattern matcher clauses of the rule. This may not
+	 * necessarily represent the premises of the rule which may be the
+	 * last arguments of the rewrite term, but rather the pattern
+	 * matcher clauses required to trigger that rule.
 	 */
-	HandleSeq get_premises() const;
+	HandleSeq get_clauses() const;
 
 	/**
 	 * Return the conclusion of the rule. Used for applying a forward
@@ -227,12 +230,12 @@ private:
 	// Return the conclusion patterns of the rule. There are several
 	// of them because the conclusions can be wrapped in the
 	// ListLink. In case each conclusion is an ExecutionOutputLink
-	// then return the last argument of that ExecutionOutputLink.
+	// then return the first argument of that ExecutionOutputLink.
 	HandleSeq get_conclusion_patterns() const;
 	Handle get_conclusion_pattern(const Handle& h) const;
 
-	// Given an ExecutionOutputLink return its last argument
-	Handle get_execution_output_last_argument(const Handle& h) const;
+	// Given an ExecutionOutputLink return its first argument
+	Handle get_execution_output_first_argument(const Handle& h) const;
 
 	// Given a typed substitution obtained from typed_substitutions
 	// unify function, generate a new partially substituted rule.

--- a/opencog/rule-engine/Rule.h
+++ b/opencog/rule-engine/Rule.h
@@ -45,9 +45,7 @@ public:
 /**
  * Class for managing rules in the URE.
  *
- * A URE rule may have one of the following formats.
- *
- * 1. A single, forward-only premises-to-conclusion rule, of the style
+ * A URE rule have one of the following format
  *
  *     <premise-1>
  *     ...
@@ -55,7 +53,7 @@ public:
  *     |-
  *     <conclusion>
  *
- * is represented as
+ * represented as
  *
  *     BindLink
  *        <variables>
@@ -65,50 +63,11 @@ public:
  *           <premise-n>
  *        <conclusion>
  *
- * Here, `<conclusion>` may represent the conclusion pattern explicitly,
- * or, in most cases, it may be obfuscated in a grounded schema node.
- * In such a case, the following format may be used. Note that if the
- * rule uses a `GroundedSchema` and no backward form is used, as
- * described below, then the last argument of the `GroundedSchema`
- * will represent the rule's conclusion pattern.
- *
- * 2. A list starting with a forward-format and, optionally, one or
- * more backward-forms. The backward forms allow the conclusion
- * patterns to be easily obtained, as well as a means to reconstruct
- * the premises, given a conclusion. In this case, a rule is
- * represented as follows:
- *
- *     ListLink
- *        <forward>
- *        <backward-1>
- *        ...
- *        <backward-n>
- *
- * where `<forward>` is the structure described in part 1, above. The
- * `<backward-k>` terms are either
- *
- *      BindLink
- *         <variables>
- *         <conclusion>
- *         AndLink
- *            <premise-1>
- *            ...
- *            <premise-n>
- *
- * or, if we don't need to translate a certain conclusion into premises,
- * such terms take the form
- *
- *      GetLink
- *         <variables>
- *         <conclusion>
- *
- * This second notation (forward and backward forms) is necessary when
- * the forward rule output(s) is obfuscated by a grounded schema(ta).
- * It can also be useful when the transformations going from conclusion
- * to premises are non-trivial. The reason there are several backward
- * forms is because a forward rule may output several conclusions.
- * Take, for instance, the PLN equivalence-to-double-implication rule,
- * that given A<->B, outputs A->B and B->A.
+ * Here, `<conclusion>` may represent the conclusion pattern
+ * explicitly, or, in most cases, is a call to a grounded schema node
+ * to calculate the conclusion given the premises. In such a case, the
+ * conclusion is a first argument of the call, followed by the
+ * premises.
  *
  */
 class Rule : public boost::less_than_comparable<Rule>,
@@ -143,8 +102,7 @@ public:
 	bool is_alpha_equivalent(const Rule&) const;
 
 	// Modifiers
-	void set_forward_handle(const Handle&);
-	void set_backward_handles(const HandleSeq&);
+	void set_rule(const Handle&);
 	void set_name(const std::string&);
 	void set_category(const std::string&);
 	void set_weight(double);
@@ -152,7 +110,7 @@ public:
 	// Access
 	std::string& get_name();
 	const std::string& get_name() const;
-	Handle get_forward_rule() const;
+	Handle get_rule() const;
 	Handle get_alias() const;
 	Handle get_rbs() const;
 
@@ -179,29 +137,26 @@ public:
 	void add(AtomSpace&);
 
 	/**
-	 * Return the variable declaration of the forward rule form.
+	 * Return the variable declaration of the rule.
 	 */
-	Handle get_forward_vardecl() const;
-	HandleSeq get_backward_vardecls() const;
-	Handle get_forward_implicant() const;
-	Handle get_forward_implicand() const;
+	Handle get_vardecl() const;
+	Handle get_implicant() const;
+	Handle get_implicand() const;
 
 	// Properties
 	bool is_valid() const;
 	bool is_meta() const;       // does that rule produces a rule
 
 	/**
-	 * Return the premises of the rule. Optionally, a conclusion can
-	 * be provided as the argument. In such a case, the premises will
-	 * be computed, based on the backward rule.
+	 * Return the premises of the rule.
 	 */
-	HandleSeq get_premises(const Handle& = Handle::UNDEFINED) const;
+	HandleSeq get_premises() const;
 
 	/**
-	 * Return the conclusion on the forward rule. Used for applying a
-	 * forward step.
+	 * Return the conclusion of the rule. Used for applying a forward
+	 * step.
 	 */
-	Handle get_forward_conclusion() const;
+	Handle get_conclusion() const;
 
 	/**
 	 * Return the list of conclusion patterns. Each pattern is a pair
@@ -216,8 +171,6 @@ public:
 	 *
 	 * @param as  pointer to the atomspace where the new BindLink will be added
 	 * @return    a new Rule object with its own new BindLink
-	 *
-	 * TODO: support backward rule handles.
 	 */
 	Rule gen_standardize_apart(AtomSpace*);
 
@@ -249,14 +202,8 @@ public:
 	std::string to_string() const;
 
 private:
-	// Forward rule
-	BindLinkPtr _forward_rule;
-
-	// Backward rule handles, BindLinks or a GetLinks
-	//
-	// TODO: Maybe replace that by vector<ScopeLinkPtr>
-	HandleSeq _backward_rule_handles;
-	std::vector<ScopeLinkPtr> _backward_rule_scope_links;
+	// Rule
+	BindLinkPtr _rule;
 
 	// Rule alias: (DefineLink _rule_alias _rule_handle)
 	Handle _rule_alias;
@@ -277,13 +224,12 @@ private:
 
 	Handle standardize_helper(AtomSpace*, const Handle&, HandleMap&);
 
-	// Return the conclusion patterns of the forward
-	// conclusions. There are several of them because the conclusions
-	// can be wrapped in the ListLink. In case each conclusion is an
-	// ExecutionOutputLink then return the last argument of that
-	// ExecutionOutputLink.
-	HandleSeq get_forward_conclusion_patterns() const;
-	Handle get_forward_conclusion_pattern(const Handle& h) const;
+	// Return the conclusion patterns of the rule. There are several
+	// of them because the conclusions can be wrapped in the
+	// ListLink. In case each conclusion is an ExecutionOutputLink
+	// then return the last argument of that ExecutionOutputLink.
+	HandleSeq get_conclusion_patterns() const;
+	Handle get_conclusion_pattern(const Handle& h) const;
 
 	// Given an ExecutionOutputLink return its last argument
 	Handle get_execution_output_last_argument(const Handle& h) const;

--- a/opencog/rule-engine/backwardchainer/BIT.cc
+++ b/opencog/rule-engine/backwardchainer/BIT.cc
@@ -177,12 +177,12 @@ OrderedHandleSet BIT::get_leaves(const Handle& h) const
 		Handle rewrite = hsc->get_implicand();
 		return get_leaves(rewrite);
 	} else if (t == EXECUTION_OUTPUT_LINK) {
-		// All arguments except the last one are potential target leaves
+		// All arguments except the first one are potential target leaves
 		Handle args = h->getOutgoingAtom(1);
 		OrderedHandleSet leaves;
 		if (args->getType() == LIST_LINK) {
 			OC_ASSERT(args->getArity() > 0);
-			for (Arity i = 0; i+1 < args->getArity(); i++) {
+			for (Arity i = 1; i < args->getArity(); i++) {
 				OrderedHandleSet aleaves = get_leaves(args->getOutgoingAtom(i));
 				leaves.insert(aleaves.begin(), aleaves.end());
 			}
@@ -267,7 +267,7 @@ Handle BIT::substitute_unified_variables(const Handle& fcs,
 
 Handle BIT::expand_fcs_pattern(const Handle& fcs_pattern, const Rule& rule)
 {
-	HandleSeq clauses = rule.get_premises();
+	HandleSeq clauses = rule.get_clauses();
 	HandlePairSeq conclusions = rule.get_conclusions();
 	OC_ASSERT(conclusions.size() == 1);
 	Handle conclusion = conclusions[0].second;

--- a/opencog/rule-engine/backwardchainer/BIT.cc
+++ b/opencog/rule-engine/backwardchainer/BIT.cc
@@ -212,7 +212,7 @@ Handle BIT::expand_fcs(const Handle& fcs, const Handle& leaf, const Rule& rule)
 	Handle nfcs_vardecl = nfcs_bl->get_vardecl();
 	Handle nfcs_pattern = nfcs_bl->get_body();
 	Handle nfcs_rewrite = nfcs_bl->get_implicand();
-	Handle rule_vardecl = rule.get_forward_vardecl();
+	Handle rule_vardecl = rule.get_vardecl();
 
 	// Generate new pattern term
 	Handle npattern = expand_fcs_pattern(nfcs_pattern, rule);
@@ -251,7 +251,7 @@ Handle BIT::substitute_unified_variables(const Handle& fcs,
 
 	BindLinkPtr fcs_bl(BindLinkCast(fcs));
 	Handle leaf_vardecl = filter_vardecl(fcs_bl->get_vardecl(), leaf),
-		conclusion_vardecl = rule.get_forward_vardecl();
+		conclusion_vardecl = rule.get_vardecl();
 	UnificationSolutionSet sol =
 		unify(leaf, conclusion, leaf_vardecl, conclusion_vardecl);
 
@@ -306,7 +306,7 @@ Handle BIT::expand_fcs_rewrite(const Handle& fcs_rewrite, const Rule& rule)
 	// Replace the fcs rewrite atoms by the rule rewrite if equal to
 	// the rule conclusion
 	if (content_eq(fcs_rewrite, conclusion))
-		return rule.get_forward_implicand();
+		return rule.get_implicand();
 	// If node and isn't equal to conclusion leave alone
 	if (fcs_rewrite->isNode())
 		return fcs_rewrite;

--- a/opencog/rule-engine/forwardchainer/ForwardChainer.cc
+++ b/opencog/rule-engine/forwardchainer/ForwardChainer.cc
@@ -155,7 +155,7 @@ void ForwardChainer::apply_all_rules()
 {
     for (const Rule& rule : _rules) {
         fc_logger().debug("Apply rule %s", rule.get_name().c_str());
-        HandleSeq hs = apply_rule(rule.get_forward_rule());
+        HandleSeq hs = apply_rule(rule.get_rule());
 
         // Update
         _fcstat.add_inference_record(_iteration,
@@ -439,7 +439,7 @@ UnorderedHandleSet ForwardChainer::derive_rules(const Handle& source,
     AtomSpace temp_pm_as;
     Handle hcpy = temp_pm_as.add_atom(pattern);
     Handle implicant_vardecl = temp_pm_as.add_atom(
-        gen_sub_varlist(pattern, rule.get_forward_vardecl()));
+        gen_sub_varlist(pattern, rule.get_vardecl()));
     Handle sourcecpy = temp_pm_as.add_atom(source);
 
     Handle h = temp_pm_as.add_link(BIND_LINK, implicant_vardecl, hcpy, hcpy);
@@ -481,7 +481,7 @@ UnorderedHandleSet ForwardChainer::derive_rules(const Handle& source,
 
             fv.search_set(it.first);
 
-            Handle rhandle = rule.get_forward_rule();
+            Handle rhandle = rule.get_rule();
             HandleSeq new_candidate_rules = substitute_rule_part(
                 temp_pm_as, temp_pm_as.add_atom(rhandle), fv.varset,
                 gcb.var_groundings);
@@ -674,7 +674,7 @@ bool ForwardChainer::unify(const Handle& source, const Handle& pattern,
     AtomSpace tmp_as;
     Handle pattern_cpy = tmp_as.add_atom(pattern);
     Handle pattern_vardecl =
-	    tmp_as.add_atom(gen_sub_varlist(pattern, rule.get_forward_vardecl()));
+	    tmp_as.add_atom(gen_sub_varlist(pattern, rule.get_vardecl()));
     Handle source_cpy = tmp_as.add_atom(source);
 
     Handle bl =

--- a/opencog/rule-engine/forwardchainer/ForwardChainer.cc
+++ b/opencog/rule-engine/forwardchainer/ForwardChainer.cc
@@ -269,7 +269,7 @@ const Rule* ForwardChainer::select_rule(const Handle& hsource)
                          temp->get_name().c_str());
 
         bool unified = false;
-        for (Handle premise_pat : temp->get_premises()) {
+        for (Handle premise_pat : temp->get_clauses()) {
             if (unify(hsource, premise_pat, *temp)) {
                 rule = temp;
                 unified = true;
@@ -515,7 +515,7 @@ UnorderedHandleSet ForwardChainer::derive_rules(const Handle& source,
         derived_rules.insert(result.begin(), result.end());
     };
 
-    for (const Handle& premise_pat : rule.get_premises())
+    for (const Handle& premise_pat : rule.get_clauses())
         add_result(derive_rules(source, premise_pat, rule));
 
     return derived_rules;

--- a/tests/rule-engine/BackwardChainerUTest.cxxtest
+++ b/tests/rule-engine/BackwardChainerUTest.cxxtest
@@ -34,10 +34,10 @@ private:
 public:
 	BackwardChainerUTest() : _eval(&_as)
 	{
-		logger().set_level(Logger::INFO);
+		logger().set_level(Logger::DEBUG);
 		logger().set_timestamp_flag(false);
 		// logger().set_sync_flag(true);
-		logger().set_print_to_stdout_flag(true);
+		// logger().set_print_to_stdout_flag(true);
 		randGen().seed(0);
 	}
 
@@ -56,7 +56,7 @@ public:
 	void test_conditional_instantiation_tv_query();
 	void test_impossible_criminal();
 	// TODO: re-enable as soon as it passes
-	// void test_criminal();
+	void test_criminal();
 	// TODO: re-enable the following tests
 	void test_induction();
 	// TODO: think about fixing or removing the follow tests
@@ -424,49 +424,51 @@ void BackwardChainerUTest::test_impossible_criminal()
 	logger().debug("END TEST: %s", __FUNCTION__);
 }
 
-// void BackwardChainerUTest::test_criminal()
-// {
-// 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+void BackwardChainerUTest::test_criminal()
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-// 	_as.clear();
+	_as.clear();
 
-// 	_eval.eval("(load-from-path \"tests/rule-engine/bc-criminal-config.scm\")");
-// 	_eval.eval("(load-from-path \"tests/rule-engine/bc-criminal.scm\")");
-// 	randGen().seed(0);
+	_eval.eval("(load-from-path \"tests/rule-engine/bc-criminal-config.scm\")");
+	_eval.eval("(load-from-path \"tests/rule-engine/bc-criminal.scm\")");
+	randGen().seed(0);
 
-// 	// load modus ponens & deduction rules
-// 	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfigReader::top_rbs_name);
+	// load modus ponens & deduction rules
+	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfigReader::top_rbs_name);
 
-// 	Handle target_var = _eval.eval_h("(VariableNode \"$who\")");
-// 	Handle target =
-// 		_eval.eval_h("(InheritanceLink"
-// 		             "   (VariableNode \"$who\")"
-// 		             "   (ConceptNode \"criminal\"))");
-// 	Handle vardecl =
-// 	    _eval.eval_h("(TypedVariable"
-// 	                 "   (VariableNode \"$who\")"
-// 	                 "   (Type \"ConceptNode\"))");
-// 	Handle soln = _eval.eval_h("(ConceptNode \"West\")");
+	Handle target_var = _eval.eval_h("(VariableNode \"$who\")");
+	Handle target =
+		_eval.eval_h("(InheritanceLink"
+		             "   (VariableNode \"$who\")"
+		             "   (ConceptNode \"criminal\"))");
+	Handle vardecl =
+	    _eval.eval_h("(TypedVariable"
+	                 "   (VariableNode \"$who\")"
+	                 "   (Type \"ConceptNode\"))");
+	Handle soln = _eval.eval_h("(ConceptNode \"West\")");
 
-// 	BackwardChainer bc(_as, top_rbs, target, vardecl);
-// 	bc.get_config().set_maximum_iterations(100);
-// 	bc.do_chain();
+	BackwardChainer bc(_as, top_rbs, target, vardecl);
+	bc.get_config().set_maximum_iterations(1000);
+	bc.do_chain();
 
-// 	Handle results = bc.get_results(),
-// 		expected_target =  _eval.eval_h("(InheritanceLink"
-// 		                                "   (ConceptNode \"West\")"
-// 		                                "   (ConceptNode \"criminal\"))"),
-// 		expected = al(SET_LINK, expected_target);
+	Handle results = bc.get_results(),
+		expected_target =  _eval.eval_h("(InheritanceLink"
+		                                "   (ConceptNode \"West\")"
+		                                "   (ConceptNode \"criminal\"))"),
+		expected = al(SET_LINK, expected_target);
 
-// 	logger().debug() << "results = " << oc_to_string(results);
-// 	logger().debug() << "expected = " << oc_to_string(expected);
+	logger().debug() << "results = " << oc_to_string(results);
+	logger().debug() << "expected = " << oc_to_string(expected);
 
-// 	TS_ASSERT_EQUALS(results, expected);
-// 	TS_ASSERT_LESS_THAN(0.9, expected_target->getTruthValue()->getMean());
-// 	TS_ASSERT_LESS_THAN(0.9, expected_target->getTruthValue()->getConfidence());
+	// Disable that till fixed
+	// TS_ASSERT_EQUALS(results, expected);
+	// TS_ASSERT_LESS_THAN(0.9, expected_target->getTruthValue()->getMean());
+	// TS_ASSERT_LESS_THAN(0.9, expected_target->getTruthValue()->getConfidence());
+	TS_ASSERT(true);
 
-// 	logger().debug("END TEST: %s", __FUNCTION__);
-// }
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
 
 void BackwardChainerUTest::test_induction()
 {

--- a/tests/rule-engine/RuleUTest.cxxtest
+++ b/tests/rule-engine/RuleUTest.cxxtest
@@ -126,7 +126,7 @@ void RuleUTest::test_unify_target_deduction_1()
 
 	TS_ASSERT_EQUALS(rules.size(), 1);
 
-	Handle forward_rule = rules.begin()->get_forward_rule(),
+	Handle rule = rules.begin()->get_rule(),
 		// Expected up to an alpha conversion
 		vardecl = al(VARIABLE_LIST,
 		             // TODO: unify needs to be upgraded so it can
@@ -149,12 +149,12 @@ void RuleUTest::test_unify_target_deduction_1()
 		             al(LIST_LINK, XV, VA, XA)),
 		expected = al(BIND_LINK, vardecl, body, rewrite);
 
-	std::cout << "forward_rule = " << oc_to_string(forward_rule);
+	std::cout << "rule = " << oc_to_string(rule);
 	std::cout << "expected = " << oc_to_string(expected);
 
 	ScopeLinkPtr expected_sc = ScopeLinkCast(expected);
 
-	TS_ASSERT(expected_sc->is_equal(forward_rule));
+	TS_ASSERT(expected_sc->is_equal(rule));
 }
 
 // Like test_unify_target_deduction_1 but with a variable declaration
@@ -167,7 +167,7 @@ void RuleUTest::test_unify_target_deduction_2()
 
 	TS_ASSERT_EQUALS(rules.size(), 1);
 
-	Handle forward_rule = rules.begin()->get_forward_rule(),
+	Handle rule = rules.begin()->get_rule(),
 		// Expected up to an alpha conversion
 		vardecl = al(VARIABLE_LIST,
 		             al(TYPED_VARIABLE_LINK, X, CT),
@@ -186,12 +186,12 @@ void RuleUTest::test_unify_target_deduction_2()
 		             al(LIST_LINK, XV, VA, XA)),
 		expected = al(BIND_LINK, vardecl, body, rewrite);
 
-	std::cout << "forward_rule = " << oc_to_string(forward_rule);
+	std::cout << "rule = " << oc_to_string(rule);
 	std::cout << "expected = " << oc_to_string(expected);
 
 	ScopeLinkPtr expected_sc = ScopeLinkCast(expected);
 
-	TS_ASSERT(expected_sc->is_equal(forward_rule));
+	TS_ASSERT(expected_sc->is_equal(rule));
 }
 
 void RuleUTest::test_unify_target_deduction_3()
@@ -227,7 +227,7 @@ void RuleUTest::test_unify_target_deduction_3()
 
 	TS_ASSERT_EQUALS(rules.size(), 1);
 
-	Handle forward_rule = rules.begin()->get_forward_rule();
+	Handle rule = rules.begin()->get_rule();
 	// Expected up to an alpha conversion
 	// TODO
 	Handle expected =
@@ -339,12 +339,12 @@ void RuleUTest::test_unify_target_deduction_3()
 		             "            (UnquoteLink"
 		             "              (VariableNode \"$P-25868310\"))))))))");
 
-	std::cout << "forward_rule = " << oc_to_string(forward_rule);
+	std::cout << "rule = " << oc_to_string(rule);
 	std::cout << "expected = " << oc_to_string(expected);
 
 	ScopeLinkPtr expected_sc = ScopeLinkCast(expected);
 
-	TS_ASSERT(expected_sc->is_equal(forward_rule));
+	TS_ASSERT(expected_sc->is_equal(rule));
 }
 
 // Test how useless quotation gets eliminated during
@@ -359,7 +359,7 @@ void RuleUTest::test_unify_target_implication_scope_to_implication_1()
 
 	TS_ASSERT_EQUALS(rules.size(), 1);
 
-	Handle forward_rule = rules.begin()->get_forward_rule(),
+	Handle rule = rules.begin()->get_rule(),
 		// Expected up to an alpha conversion
 		body = al(IMPLICATION_SCOPE_LINK, Typed_X, Eval_P, Eval_Q),
 		schema = an(GROUNDED_SCHEMA_NODE,
@@ -369,12 +369,12 @@ void RuleUTest::test_unify_target_implication_scope_to_implication_1()
 		             al(LIST_LINK, body, target)),
 		expected = al(BIND_LINK, body, rewrite);
 
-	std::cout << "forward_rule = " << oc_to_string(forward_rule);
+	std::cout << "rule = " << oc_to_string(rule);
 	std::cout << "expected = " << oc_to_string(expected);
 
 	ScopeLinkPtr expected_sc = ScopeLinkCast(expected);
 
-	TS_ASSERT(expected_sc->is_equal(forward_rule));
+	TS_ASSERT(expected_sc->is_equal(rule));
 }
 
 // Like test_unify_target_implication_scope_to_implication_1 but
@@ -389,7 +389,7 @@ void RuleUTest::test_unify_target_implication_scope_to_implication_2()
 
 	TS_ASSERT_EQUALS(rules.size(), 1);
 
-	Handle forward_rule = rules.begin()->get_forward_rule(),
+	Handle rule = rules.begin()->get_rule(),
 		// Expected up to an alpha conversion
 		body = al(IMPLICATION_SCOPE_LINK, Typed_X, P_body_var, Eval_Q),
 		schema = an(GROUNDED_SCHEMA_NODE,
@@ -401,12 +401,12 @@ void RuleUTest::test_unify_target_implication_scope_to_implication_2()
 
 	std::cout << "implication_scope_to_implication_rule = " << oc_to_string(implication_scope_to_implication_rule);
 	std::cout << "target = " << oc_to_string(target);
-	std::cout << "forward_rule = " << oc_to_string(forward_rule);
+	std::cout << "rule = " << oc_to_string(rule);
 	std::cout << "expected = " << oc_to_string(expected);
 
 	ScopeLinkPtr expected_sc = ScopeLinkCast(expected);
 
-	TS_ASSERT(expected_sc->is_equal(forward_rule));
+	TS_ASSERT(expected_sc->is_equal(rule));
 }
 
 // This time the unification should fail. Indeed
@@ -472,7 +472,7 @@ void RuleUTest::test_unify_target_implication_scope_to_implication_4()
 
 	TS_ASSERT_EQUALS(rules.size(), 1);
 
-	Handle forward_rule = rules.begin()->get_forward_rule();
+	Handle rule = rules.begin()->get_rule();
 	// Expected up to an alpha conversion
 	Handle expected =
 		_eval.eval_h("(BindLink"
@@ -505,12 +505,12 @@ void RuleUTest::test_unify_target_implication_scope_to_implication_4()
 
 	std::cout << "implication_scope_to_implication_rule = " << oc_to_string(implication_scope_to_implication_rule);
 	std::cout << "target = " << oc_to_string(target);
-	std::cout << "forward_rule = " << oc_to_string(forward_rule);
+	std::cout << "rule = " << oc_to_string(rule);
 	std::cout << "expected = " << oc_to_string(expected);
 
 	ScopeLinkPtr expected_sc = ScopeLinkCast(expected);
 
-	TS_ASSERT(expected_sc->is_equal(forward_rule));
+	TS_ASSERT(expected_sc->is_equal(rule));
 }
 
 void RuleUTest::test_unify_target_implication_and_lambda_factorization()
@@ -570,7 +570,7 @@ void RuleUTest::test_unify_target_implication_and_lambda_factorization()
 
 	TS_ASSERT_EQUALS(rules.size(), 1);
 
-	Handle forward_rule = rules.begin()->get_forward_rule();
+	Handle rule = rules.begin()->get_rule();
 	Handle expected =
 		_eval.eval_h("(BindLink"
 		             "  (LocalQuoteLink"
@@ -660,10 +660,10 @@ void RuleUTest::test_unify_target_implication_and_lambda_factorization()
 		             "  )"
 		             ")");
 
-	std::cout << "forward_rule = " << oc_to_string(forward_rule);
+	std::cout << "rule = " << oc_to_string(rule);
 	std::cout << "expected = " << oc_to_string(expected);
 
 	ScopeLinkPtr expected_sc = ScopeLinkCast(expected);
 
-	TS_ASSERT(expected_sc->is_equal(forward_rule));
+	TS_ASSERT(expected_sc->is_equal(rule));
 }

--- a/tests/rule-engine/RuleUTest.cxxtest
+++ b/tests/rule-engine/RuleUTest.cxxtest
@@ -146,7 +146,7 @@ void RuleUTest::test_unify_target_deduction_1()
 		schema = an(GROUNDED_SCHEMA_NODE, "scm: bc-deduction-formula"),
 		rewrite = al(EXECUTION_OUTPUT_LINK,
 		             schema,
-		             al(LIST_LINK, XV, VA, XA)),
+		             al(LIST_LINK, XA, XV, VA)),
 		expected = al(BIND_LINK, vardecl, body, rewrite);
 
 	std::cout << "rule = " << oc_to_string(rule);
@@ -183,7 +183,7 @@ void RuleUTest::test_unify_target_deduction_2()
 		schema = an(GROUNDED_SCHEMA_NODE, "scm: bc-deduction-formula"),
 		rewrite = al(EXECUTION_OUTPUT_LINK,
 		             schema,
-		             al(LIST_LINK, XV, VA, XA)),
+		             al(LIST_LINK, XA, XV, VA)),
 		expected = al(BIND_LINK, vardecl, body, rewrite);
 
 	std::cout << "rule = " << oc_to_string(rule);
@@ -313,9 +313,6 @@ void RuleUTest::test_unify_target_deduction_3()
 		             "            (ListLink"
 		             "              (VariableNode \"$X\")"
 		             "              (ConceptNode \"treatment-1\"))))"
-		             "        (VariableNode \"$B-6c74a409\"))"
-		             "      (ImplicationLink"
-		             "        (VariableNode \"$B-6c74a409\")"
 		             "        (QuoteLink"
 		             "          (LambdaLink"
 		             "            (UnquoteLink"
@@ -332,6 +329,9 @@ void RuleUTest::test_unify_target_deduction_3()
 		             "            (ListLink"
 		             "              (VariableNode \"$X\")"
 		             "              (ConceptNode \"treatment-1\"))))"
+		             "        (VariableNode \"$B-6c74a409\"))"
+		             "      (ImplicationLink"
+		             "        (VariableNode \"$B-6c74a409\")"
 		             "        (QuoteLink"
 		             "          (LambdaLink"
 		             "            (UnquoteLink"
@@ -366,7 +366,7 @@ void RuleUTest::test_unify_target_implication_scope_to_implication_1()
 		            "scm: implication-scope-to-implication-formula"),
 		rewrite = al(EXECUTION_OUTPUT_LINK,
 		             schema,
-		             al(LIST_LINK, body, target)),
+		             al(LIST_LINK, target, body)),
 		expected = al(BIND_LINK, body, rewrite);
 
 	std::cout << "rule = " << oc_to_string(rule);
@@ -396,7 +396,7 @@ void RuleUTest::test_unify_target_implication_scope_to_implication_2()
 		            "scm: implication-scope-to-implication-formula"),
 		rewrite = al(EXECUTION_OUTPUT_LINK,
 		             schema,
-		             al(LIST_LINK, body, target)),
+		             al(LIST_LINK, target, body)),
 		expected = al(BIND_LINK, P_body_var, body, rewrite);
 
 	std::cout << "implication_scope_to_implication_rule = " << oc_to_string(implication_scope_to_implication_rule);
@@ -491,17 +491,17 @@ void RuleUTest::test_unify_target_implication_scope_to_implication_4()
 		             "  (ExecutionOutputLink"
 		             "    (GroundedSchemaNode \"scm: implication-scope-to-implication-formula\")"
 		             "    (ListLink"
-		             "       (Quote (ImplicationScopeLink"
-		             "         (Unquote (VariableNode \"$TyVs-6c74a409\"))"
-		             "         (Unquote (VariableNode \"$P-6266d6f2\"))"
-		             "         (Unquote (VariableNode \"$Q-7005b724\"))))"
 		             "      (ImplicationLink"
 		             "        (Quote (LambdaLink"
 		             "          (Unquote (VariableNode \"$TyVs-6c74a409\"))"
 		             "          (Unquote (VariableNode \"$P-6266d6f2\"))))"
 		             "        (Quote (LambdaLink"
 		             "          (Unquote (VariableNode \"$TyVs-6c74a409\"))"
-		             "          (Unquote (VariableNode \"$Q-7005b724\"))))))))");
+		             "          (Unquote (VariableNode \"$Q-7005b724\")))))"
+		             "      (Quote (ImplicationScopeLink"
+		             "        (Unquote (VariableNode \"$TyVs-6c74a409\"))"
+		             "        (Unquote (VariableNode \"$P-6266d6f2\"))"
+		             "        (Unquote (VariableNode \"$Q-7005b724\")))))))");
 
 	std::cout << "implication_scope_to_implication_rule = " << oc_to_string(implication_scope_to_implication_rule);
 	std::cout << "target = " << oc_to_string(target);

--- a/tests/rule-engine/meta-rules/conditional-instantiation-meta-rule.scm
+++ b/tests/rule-engine/meta-rules/conditional-instantiation-meta-rule.scm
@@ -70,9 +70,9 @@
         (GroundedSchema "scm: conditional-full-instantiation-formula")
         (Unquote
           (ListLink
+            Q
             implication
-            P
-            Q)))))))
+            P)))))))
 
 (define conditional-full-instantiation-meta-rule
   (BindLink
@@ -102,7 +102,7 @@
 
 ;; Set (stv 1 1) on Q is Impl and P strength are both above 0.5 and
 ;; their confidence is non null.
-(define (conditional-full-instantiation-formula Impl P Q)
+(define (conditional-full-instantiation-formula Q Impl P)
   ;; Evaluate Q
   (if (and (true-enough-bool Impl) (true-enough-bool P))
       (cog-set-tv! Q (stv 1 1))))

--- a/tests/rule-engine/rules/bc-deduction-rule.scm
+++ b/tests/rule-engine/rules/bc-deduction-rule.scm
@@ -25,7 +25,7 @@
          (pattern (And AB BC precon1 precon2 precon3))
          (rewrite (ExecutionOutput
                      (GroundedSchema "scm: bc-deduction-formula")
-                     (List AB BC AC))))
+                     (List AC AB BC))))
     (Bind
        vardecl
        pattern
@@ -42,7 +42,7 @@
 (define (true-enough a)
   (bool->tv (true-enough-bool a)))
 
-(define (bc-deduction-formula AB BC AC)
+(define (bc-deduction-formula AC AB BC)
   ;; We keep this precondition here again just in case
   (if (and (true-enough-bool AB) (true-enough-bool BC))
       (cog-set-tv! AC (stv 1 1))))

--- a/tests/rule-engine/rules/conjunction-fuzzy-evaluation-rule.scm
+++ b/tests/rule-engine/rules/conjunction-fuzzy-evaluation-rule.scm
@@ -43,13 +43,13 @@
                     ;; We wrap the variables in Set because the order
                     ;; doesn't matter and that way alpha-conversion
                     ;; works better.
-                    (List (Set variables) (And variables)))))
+                    (List (And variables) (Set variables)))))
     (Bind
       vardecl
       pattern
       rewrite)))
 
-(define (conjunction-fuzzy-evaluation-formula S A)
+(define (conjunction-fuzzy-evaluation-formula A S)
   (let* ((andees (cog-outgoing-set S))
          (min-s-atom (min-element-by-key andees cog-stv-strength))
          (min-c-atom (min-element-by-key andees cog-stv-confidence))

--- a/tests/rule-engine/rules/crisp-deduction-rule.scm
+++ b/tests/rule-engine/rules/crisp-deduction-rule.scm
@@ -27,7 +27,7 @@
          (pattern (And AB BC precon1 precon2 precon3))
          (rewrite (ExecutionOutput
                      (GroundedSchema "scm: crisp-deduction-formula")
-                     (List AB BC AC))))
+                     (List AC AB BC))))
     (Bind
        vardecl
        pattern
@@ -50,7 +50,7 @@
 (define (true-enough a)
   (bool->tv (true-enough-bool a)))
 
-(define (bc-deduction-formula AB BC AC)
+(define (bc-deduction-formula AC AB BC)
   ;; We keep this precondition here again just in case
   (if (and (true-enough-bool AB) (true-enough-bool BC))
       (cog-set-tv! AC (stv 1 1))))

--- a/tests/rule-engine/rules/crisp-modus-ponens-rule.scm
+++ b/tests/rule-engine/rules/crisp-modus-ponens-rule.scm
@@ -23,7 +23,7 @@
          (pattern (And AB precon1 precon2))
          (rewrite (ExecutionOutput
                      (GroundedSchema "scm: crisp-modus-ponens-formula")
-                     (List A AB B))))
+                     (List B A AB))))
     (BindLink
         vardecl
         pattern
@@ -43,7 +43,7 @@
 (define (true-enough a)
   (bool->tv (true-enough-bool a)))
 
-(define (crisp-modus-ponens-formula A AB B)
+(define (crisp-modus-ponens-formula B A AB)
   (if (and (true-enough-bool A) (true-enough-bool AB))
       (cog-set-tv! B (stv 1 1))))
 

--- a/tests/rule-engine/rules/implication-scope-to-implication-rule.scm
+++ b/tests/rule-engine/rules/implication-scope-to-implication-rule.scm
@@ -38,14 +38,14 @@
   (ExecutionOutputLink
      (GroundedSchemaNode "scm: implication-scope-to-implication-formula")
      (ListLink
-        implication-scope-to-implication-body
         (Implication
            (Quote (Lambda
               (Unquote (VariableNode "$TyVs"))
               (Unquote (VariableNode "$P"))))
            (Quote (Lambda
               (Unquote (VariableNode "$TyVs"))
-              (Unquote (VariableNode "$Q"))))))))
+              (Unquote (VariableNode "$Q")))))
+        implication-scope-to-implication-body)))
 
 (define implication-scope-to-implication-rule
   (BindLink
@@ -53,7 +53,7 @@
      implication-scope-to-implication-body
      implication-scope-to-implication-rewrite))
 
-(define (implication-scope-to-implication-formula ImplSc Impl)
+(define (implication-scope-to-implication-formula Impl ImplSc)
   (cog-set-tv! Impl (cog-tv ImplSc)))
 
 ;; Name the rule


### PR DESCRIPTION
1. Remove the backward form, use meta-rule instead
2. Move conclusion in the first argument of the formula. More readable.