### PR TITLE
Redesign bit representation

### DIFF
--- a/opencog/rule-engine/backwardchainer/BIT.cc
+++ b/opencog/rule-engine/backwardchainer/BIT.cc
@@ -21,7 +21,9 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <boost/range/algorithm/lower_bound.hpp>
 #include <boost/range/algorithm/remove_if.hpp>
+#include <boost/range/algorithm/binary_search.hpp>
 
 #include <opencog/util/random.h>
 
@@ -31,8 +33,12 @@
 
 namespace opencog {
 
-BITNode::BITNode(const Handle& bd, const BITFitness& fit)
-	: body(bd), fitness(fit) {}
+/////////////
+// BITNode //
+/////////////
+
+BITNode::BITNode(const Handle& bd, const BITFitness& fi)
+	: body(bd), fitness(fi) {}
 
 std::string	BITNode::to_string() const
 {
@@ -42,134 +48,112 @@ std::string	BITNode::to_string() const
 	return ss.str();
 }
 
-BIT::BIT(AtomSpace& as,
-         const Handle& target,
-         const Handle& vardecl,
-         const BITFitness& fitness)
-	: bit_as(&as),
-	  _init_target(target), _init_vardecl(vardecl), _init_fitness(fitness)
-{}
+////////////
+// AndBIT //
+////////////
 
-bool BIT::empty() const
+AndBIT::AndBIT() {}
+
+AndBIT::AndBIT(AtomSpace& as, const Handle& target, const Handle& vardecl,
+               const BITFitness& fitness)
 {
-	return _handle2bitnode.empty();
-}
-
-Handle BIT::init()
-{
-	// Initialize the BIT with an FCS basedon the initial target
-	init_fcss();
-
-	LAZY_BC_LOG_DEBUG << "Initialize BIT with:" << std::endl
-	                  << _handle2bitnode[_init_target].to_string();
-
-	return *_fcss.begin();
-}
-
-Handle BIT::expand(const Handle& fcs, BITNode& bitleaf, const Rule& rule)
-{
-	// Make sure that the rule is not already an or-child of bitleaf.
-	if (is_in(rule, bitleaf)) {
-		bc_logger().debug() << "An equivalent rule has already expanded "
-		                    << "that BIT-node, abort expansion";
-		return Handle::UNDEFINED;
-	}
-
-	// Insert the rule as or-branch of this bitleaf
-	bitleaf.rules.insert(rule);
-
-	// Expand the FCS
- 	Handle new_fcs = expand_fcs(fcs, bitleaf.body, rule);
-
-	// Insert the new FCS into the BIT
-	insert_fcs(new_fcs);
-
-	return new_fcs;
-}
-
-OrderedHandleSet& BIT::get_fcss()
-{
-	return _fcss;
-}
-
-const OrderedHandleSet& BIT::get_fcss() const
-{
-	return _fcss;
-}
-
-Handle BIT::select_fcs() const
-{
-	return rand_element(_fcss);
-}
-
-BITNode& BIT::select_bitleaf(const Handle& fcs)
-{
-	// For now selection is uniformly random
-	return _handle2bitnode[rand_element(get_leaves(fcs))];
-}
-
-void BIT::insert_bitnode(Handle body, const BITFitness& fitness)
-{
-	if (body.is_undefined())
-		return;
-
-	if (_handle2bitnode.find(body) == _handle2bitnode.end())
-		_handle2bitnode[body] = BITNode(body, fitness);
-}
-
-void BIT::init_fcss()
-{
-	if (_init_target.is_undefined())
-		return;
-
 	// Create initial FCS
-	HandleSeq bl{_init_target, _init_target};
-	if (_init_vardecl.is_defined())
-		bl.insert(bl.begin(), _init_vardecl);
-	Handle fcs = bit_as.add_link(BIND_LINK, bl);
+	HandleSeq bl{target, target};
+	if (vardecl.is_defined())
+		bl.insert(bl.begin(), vardecl);
+	fcs = as.add_link(BIND_LINK, bl);
 
-	// Insert it into the BIT
-	insert_fcs(fcs);
+	insert_bitnode(target, fitness);
 }
 
-void BIT::insert_fcs(const Handle& fcs)
+AndBIT AndBIT::expand(const Handle& leaf, const Rule& rule) const
 {
-	auto it = _fcss.find(fcs);
-	if (it == _fcss.end()) {
-		// Check that it is not alpha-equivalent either
-		for (const Handle& efcs : _fcss) {
-			if (ScopeLinkCast(fcs)->is_equal(efcs)) {
-				LAZY_BC_LOG_DEBUG << "The following FCS is alpha-equivalent "
-				                  << "to another one already in the BIT:"
-				                  << std::endl << oc_to_string(fcs);
-				return;
-			}
-		}
-
-		_fcss.insert(fcs);
-
-		// For each leave associate a corresponding BITNode
-		Handle fcs_vardecl = BindLinkCast(fcs)->get_vardecl();
-		for (const Handle& leaf : get_leaves(fcs)) {
-			Handle leaf_vardecl = filter_vardecl(fcs_vardecl, leaf);
-			insert_bitnode(leaf, BITFitness());
-		}
-	}
-	else {
-		LAZY_BC_LOG_DEBUG << "The following FCS is already in the BIT:"
-		                  << std::endl << oc_to_string(fcs);
-	}
+	AndBIT andbit;
+	andbit.fcs = expand_fcs(leaf, rule);
+	andbit.set_leaf2bitnode();
+	return andbit;
 }
 
-bool BIT::is_in(const Rule& rule, const BITNode& bitnode)
+BITNode& AndBIT::select_leaf()
 {
-	for (const Rule& bnr : bitnode.rules)
-		if (rule.is_alpha_equivalent(bnr))
-			return true;
-	return false;
+	return rand_element(leaf2bitnode).second;
 }
 
-OrderedHandleSet BIT::get_leaves(const Handle& h) const
+bool AndBIT::operator==(const AndBIT& andbit) const
+{
+	return fcs == andbit.fcs;
+}
+
+bool AndBIT::operator<(const AndBIT& andbit) const
+{
+	size_t fcs_size = fcs->size();
+	size_t other_size = andbit.fcs->size();
+	return (fcs_size < other_size)
+		or (fcs_size == other_size and fcs < andbit.fcs);
+}
+
+std::string AndBIT::to_string() const
+{
+	return oc_to_string(fcs);
+}
+
+Handle AndBIT::expand_fcs(const Handle& leaf, const Rule& rule) const
+{
+	// Unify the rule conclusion with the leaf, and substitute any
+	// variables in it by the associated term.
+	Handle nfcs = substitute_unified_variables(leaf, rule);
+
+	BindLinkPtr nfcs_bl(BindLinkCast(nfcs));
+	Handle nfcs_vardecl = nfcs_bl->get_vardecl();
+	Handle nfcs_pattern = nfcs_bl->get_body();
+	Handle nfcs_rewrite = nfcs_bl->get_implicand();
+	Handle rule_vardecl = rule.get_vardecl();
+
+	// Generate new pattern term
+	Handle npattern = expand_fcs_pattern(nfcs_pattern, rule);
+
+	// Generate new rewrite term
+	Handle nrewrite = expand_fcs_rewrite(nfcs_rewrite, rule);
+
+	// Generate new vardecl
+	Handle nvardecl = filter_vardecl(merge_vardecl(nfcs_vardecl, rule_vardecl),
+	                                 {npattern, nrewrite});
+
+	// Generate new atomese forward chaining strategy
+	HandleSeq noutgoings({npattern, nrewrite});
+	if (nvardecl.is_defined())
+		noutgoings.insert(noutgoings.begin(), nvardecl);
+	nfcs = fcs->getAtomSpace()->add_link(BIND_LINK, noutgoings);
+
+	LAZY_BC_LOG_DEBUG << "Expanded forward chainer strategy:" << std::endl
+	                  << "from:" << std::endl << fcs
+	                  << "to:" << std::endl << nfcs;
+
+	return nfcs;
+}
+
+void AndBIT::set_leaf2bitnode()
+{
+	// For each leaf of fcs, associate a corresponding BITNode
+	for (const Handle& leaf : get_leaves())
+		insert_bitnode(leaf, BITFitness());
+}
+
+void AndBIT::insert_bitnode(Handle leaf, const BITFitness& fitness)
+{
+	if (leaf.is_undefined())
+		return;
+
+	if (leaf2bitnode.find(leaf) == leaf2bitnode.end())
+		leaf2bitnode[leaf] = BITNode(leaf, fitness);
+}
+
+OrderedHandleSet AndBIT::get_leaves() const
+{
+	return get_leaves(fcs);
+}
+
+OrderedHandleSet AndBIT::get_leaves(const Handle& h) const
 {
 	Type t = h->getType();
 	if (t == BIND_LINK) {
@@ -202,44 +186,8 @@ OrderedHandleSet BIT::get_leaves(const Handle& h) const
 		return OrderedHandleSet{h};
 }
 
-Handle BIT::expand_fcs(const Handle& fcs, const Handle& leaf, const Rule& rule)
-{
-	// Unify the rule conclusion with the leaf, and substitute any
-	// variables in it by the associated term.
-	Handle nfcs = substitute_unified_variables(fcs, leaf, rule);
-
-	BindLinkPtr nfcs_bl(BindLinkCast(nfcs));
-	Handle nfcs_vardecl = nfcs_bl->get_vardecl();
-	Handle nfcs_pattern = nfcs_bl->get_body();
-	Handle nfcs_rewrite = nfcs_bl->get_implicand();
-	Handle rule_vardecl = rule.get_vardecl();
-
-	// Generate new pattern term
-	Handle npattern = expand_fcs_pattern(nfcs_pattern, rule);
-
-	// Generate new rewrite term
-	Handle nrewrite = expand_fcs_rewrite(nfcs_rewrite, rule);
-
-	// Generate new vardecl
-	Handle nvardecl = filter_vardecl(merge_vardecl(nfcs_vardecl, rule_vardecl),
-	                                 {npattern, nrewrite});
-
-	// Generate new atomese forward chaining strategy
-	HandleSeq noutgoings({npattern, nrewrite});
-	if (nvardecl.is_defined())
-		noutgoings.insert(noutgoings.begin(), nvardecl);
-	nfcs = bit_as.add_link(BIND_LINK, noutgoings);
-
-	LAZY_BC_LOG_DEBUG << "Expanded forward chainer strategy:" << std::endl
-	                  << "from:" << std::endl << fcs
-	                  << "to:" << std::endl << nfcs;
-
-	return nfcs;
-}
-
-Handle BIT::substitute_unified_variables(const Handle& fcs,
-                                         const Handle& leaf,
-                                         const Rule& rule)
+Handle AndBIT::substitute_unified_variables(const Handle& leaf,
+                                            const Rule& rule) const
 {
 	HandlePairSeq conclusions = rule.get_conclusions();
 	OC_ASSERT(conclusions.size() == 1);
@@ -265,7 +213,8 @@ Handle BIT::substitute_unified_variables(const Handle& fcs,
 	return Handle(substitute(fcs_bl, ts));
 }
 
-Handle BIT::expand_fcs_pattern(const Handle& fcs_pattern, const Rule& rule)
+Handle AndBIT::expand_fcs_pattern(const Handle& fcs_pattern,
+                                  const Rule& rule) const
 {
 	HandleSeq clauses = rule.get_clauses();
 	HandlePairSeq conclusions = rule.get_conclusions();
@@ -274,8 +223,9 @@ Handle BIT::expand_fcs_pattern(const Handle& fcs_pattern, const Rule& rule)
 
 	// Simple case where the fcs contains the conclusion itself
 	if (content_eq(fcs_pattern, conclusion))
-		return bit_as.add_link(AND_LINK, HandleSeq(clauses.begin(),
-		                                           clauses.end()));
+		return fcs->getAtomSpace()->add_link(AND_LINK,
+		                                     HandleSeq(clauses.begin(),
+		                                               clauses.end()));
 
 	// The fcs contains a conjunction of clauses. Remove any clause
 	// that is equal to the rule conclusion, or precondition that uses
@@ -292,10 +242,11 @@ Handle BIT::expand_fcs_pattern(const Handle& fcs_pattern, const Rule& rule)
 	// Add the patterns and preconditions associated to the rule
 	fcs_clauses.insert(fcs_clauses.end(), clauses.begin(), clauses.end());
 
-	return bit_as.add_link(AND_LINK, fcs_clauses);
+	return fcs->getAtomSpace()->add_link(AND_LINK, fcs_clauses);
 }
 
-Handle BIT::expand_fcs_rewrite(const Handle& fcs_rewrite, const Rule& rule)
+Handle AndBIT::expand_fcs_rewrite(const Handle& fcs_rewrite,
+                                  const Rule& rule) const
 {
 	HandlePairSeq conclusions = rule.get_conclusions();
 	OC_ASSERT(conclusions.size() == 1);
@@ -317,10 +268,10 @@ Handle BIT::expand_fcs_rewrite(const Handle& fcs_rewrite, const Rule& rule)
 	HandleSeq outgoings;
 	for (const Handle& h : fcs_rewrite->getOutgoingSet())
 		outgoings.push_back(expand_fcs_rewrite(h, rule));
-	return bit_as.add_link(t, outgoings);
+	return fcs->getAtomSpace()->add_link(t, outgoings);
 }
 
-bool BIT::is_argument_of(const Handle& eval, const Handle& atom)
+bool AndBIT::is_argument_of(const Handle& eval, const Handle& atom) const
 {
 	if (eval->getType() == EVALUATION_LINK) {
 		Handle args = eval->getOutgoingAtom(1);
@@ -334,7 +285,7 @@ bool BIT::is_argument_of(const Handle& eval, const Handle& atom)
 	return false;
 }
 
-bool BIT::is_locally_quoted_eq(const Handle& lhs, const Handle& rhs)
+bool AndBIT::is_locally_quoted_eq(const Handle& lhs, const Handle& rhs) const
 {
 	if (content_eq(lhs, rhs))
 		return true;
@@ -347,23 +298,96 @@ bool BIT::is_locally_quoted_eq(const Handle& lhs, const Handle& rhs)
 	return false;
 }
 
+/////////
+// BIT //
+/////////
+
+BIT::BIT(AtomSpace& as,
+         const Handle& target,
+         const Handle& vardecl,
+         const BITFitness& fitness)
+	: bit_as(&as),
+	  _init_target(target), _init_vardecl(vardecl), _init_fitness(fitness)
+{}
+
+bool BIT::empty() const
+{
+	return andbits.empty();
+}
+
+AndBIT* BIT::init()
+{
+	andbits.emplace_back(bit_as, _init_target, _init_vardecl, _init_fitness);
+
+	LAZY_BC_LOG_DEBUG << "Initialize BIT with:" << std::endl
+	                  << andbits.begin()->to_string();
+
+	return &*andbits.begin();
+}
+
+AndBIT* BIT::expand(AndBIT& andbit, BITNode& bitleaf, const Rule& rule)
+{
+	// Make sure that the rule is not already an or-child of bitleaf.
+	if (is_in(rule, bitleaf)) {
+		bc_logger().debug() << "An equivalent rule has already expanded "
+		                    << "that BIT-node, abort expansion";
+		return nullptr;
+	}
+
+	// Insert the rule as or-branch of this bitleaf
+	bitleaf.rules.insert(rule);
+
+	// Expand the and-BIT and insert it in the BIT
+	return insert_andbit(andbit.expand(bitleaf.body, rule));
+}
+
+AndBIT* BIT::insert_andbit(const AndBIT& andbit)
+{
+	// Check that it isn't already in the BIT
+	if (boost::binary_search(andbits, andbit)) {
+		LAZY_BC_LOG_DEBUG << "The following and-BIT is already in the BIT:"
+		                  << std::endl << andbit.to_string();
+		return nullptr;
+	} else {
+		// Check that it is not alpha-equivalent either
+		for (const AndBIT& ab : andbits) {
+			if (ScopeLinkCast(andbit.fcs)->is_equal(ab.fcs)) {
+				LAZY_BC_LOG_DEBUG << "The following and-BIT is alpha-equivalent "
+				                  << "to another one already in the BIT:"
+				                  << std::endl << andbit.to_string();
+				return nullptr;
+			}
+		}
+	}
+
+	// Insert while keeping the order
+	auto it = andbits.insert(boost::lower_bound(andbits, andbit), andbit);
+
+	// Return andbit pointer
+	return &*it;
+}
+
+bool BIT::is_in(const Rule& rule, const BITNode& bitnode)
+{
+	for (const Rule& bnr : bitnode.rules)
+		if (rule.is_alpha_equivalent(bnr))
+			return true;
+	return false;
+}
+
 std::string oc_to_string(const BITNode& bitnode)
 {
 	return bitnode.to_string();
 }
 
-std::string oc_to_string(const HandleBITNodeMap& hbn)
+std::string oc_to_string(const AndBIT& andbit)
 {
-	std::stringstream ss;
-	ss << "size = " << hbn.size() << std::endl;
-	size_t i = 0;
-	for (const auto& el : hbn) {
-		ss << "Handle[" << i << "]:" << std::endl
-		   << oc_to_string(el.first)
-		   << "BITNode[" << i << "]:" << std::endl
-		   << oc_to_string(el.second);
-	}
-	return ss.str();
+	return andbit.to_string();
 }
+
+// std::string oc_to_string(const BIT& bit)
+// {
+// 	return bit.to_string();
+// }
 
 } // ~namespace opencog

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.h
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.h
@@ -130,8 +130,9 @@ private:
 	// Expand the BIT
 	void expand_bit();
 
-	// Expand a selected FCS (i.e. and-BIT)
-	void expand_bit(const Handle& fcs);
+	// Expand a selected and-BIT. It is not passed by const because it
+	// will keep a record of the expansion if successful.
+	void expand_bit(AndBIT& andbit);
 
 	// Fulfill the BIT. That is run some or all its and-BITs
 	void fulfill_bit();
@@ -143,11 +144,12 @@ private:
 	// Reduce the BIT. Remove some and-BITs.
 	void reduce_bit();
 
-	// Select an FCS (i.e. and-BIT) for expansion
-	Handle select_expansion_fcs() const;
+	// Select an and-BIT for expansion
+	AndBIT* select_expansion_andbit();
 
-	// Select an FCS (i.e. and-BIT) for fulfilment
-	Handle select_fulfillment_fcs() const;
+	// Select an and-BIT for fulfilment. Return nullptr if none have
+	// been selected.
+	const AndBIT* select_fulfillment_andbit() const;
 
 	// Select a valid rule given a target. The selected is a new
 	// object because a new rule is created, its variables are
@@ -161,7 +163,7 @@ private:
 	RuleSet get_valid_rules(const BITNode& target, const Handle& vardecl);
 
 	// Hack alert!!! FCS above this size are considered too big
-	const size_t _max_fcs_size = 1200;
+	const size_t _max_fcs_size;
 
 	AtomSpace& _as;
 	UREConfigReader _configReader;
@@ -171,9 +173,9 @@ private:
 
 	int _iteration;
 
-	// Keep track of the and-BIT (FCS) of the last
-	// expansion. UNDEFINED if the last expansion has failed.
-	Handle _last_expansion_fcs;
+	// Keep track of the and-BIT of the last expansion. Null if the
+	// last expansion has failed.
+	const AndBIT* _last_expansion_andbit;
 
 	RuleSet _rules;
 

--- a/tests/rule-engine/BackwardChainerUTest.cxxtest
+++ b/tests/rule-engine/BackwardChainerUTest.cxxtest
@@ -34,7 +34,7 @@ private:
 public:
 	BackwardChainerUTest() : _eval(&_as)
 	{
-		logger().set_level(Logger::DEBUG);
+		logger().set_level(Logger::INFO);
 		logger().set_timestamp_flag(false);
 		// logger().set_sync_flag(true);
 		// logger().set_print_to_stdout_flag(true);
@@ -342,7 +342,7 @@ void BackwardChainerUTest::test_conditional_instantiation_2()
 		vardecl = al(TYPED_VARIABLE_LINK, what, concept);
 
 	BackwardChainer bc(_as, top_rbs, target, vardecl);
-	bc.get_config().set_maximum_iterations(20);
+	bc.get_config().set_maximum_iterations(40);
 	bc.do_chain();
 
 	Handle results = bc.get_results(),
@@ -375,7 +375,7 @@ void BackwardChainerUTest::test_conditional_instantiation_tv_query()
 	                 "   (ConceptNode \"green\"))");
 
 	BackwardChainer bc(_as, top_rbs, target);
-	bc.get_config().set_maximum_iterations(20);
+	bc.get_config().set_maximum_iterations(40);
 	bc.do_chain();
 
 	TS_ASSERT_DELTA(target->getTruthValue()->getMean(), 1, .1);
@@ -449,7 +449,7 @@ void BackwardChainerUTest::test_criminal()
 	Handle soln = _eval.eval_h("(ConceptNode \"West\")");
 
 	BackwardChainer bc(_as, top_rbs, target, vardecl);
-	bc.get_config().set_maximum_iterations(1000);
+	bc.get_config().set_maximum_iterations(5000);
 	bc.do_chain();
 
 	Handle results = bc.get_results(),
@@ -462,10 +462,10 @@ void BackwardChainerUTest::test_criminal()
 	logger().debug() << "expected = " << oc_to_string(expected);
 
 	// Disable that till fixed
-	// TS_ASSERT_EQUALS(results, expected);
-	// TS_ASSERT_LESS_THAN(0.9, expected_target->getTruthValue()->getMean());
-	// TS_ASSERT_LESS_THAN(0.9, expected_target->getTruthValue()->getConfidence());
-	TS_ASSERT(true);
+	TS_ASSERT_EQUALS(results, expected);
+	TS_ASSERT_LESS_THAN(0.9, expected_target->getTruthValue()->getMean());
+	TS_ASSERT_LESS_THAN(0.9, expected_target->getTruthValue()->getConfidence());
+	// TS_ASSERT(true);
 
 	logger().debug("END TEST: %s", __FUNCTION__);
 }


### PR DESCRIPTION
There was a design flaw, same targets were treated indentically while they shouldn't. Indeed they should be distinguished by the and-BIT to which they belong, otherwise the record on which rule are applied on which and-BIT target is wrong.