### PR TITLE
Support BC fitness + misc improvements

### DIFF
--- a/opencog/rule-engine/CMakeLists.txt
+++ b/opencog/rule-engine/CMakeLists.txt
@@ -5,6 +5,7 @@ ADD_LIBRARY(ruleengine
 	backwardchainer/BackwardChainer
 	backwardchainer/BackwardChainerPMCB
 	backwardchainer/BIT
+	backwardchainer/Fitness
 	backwardchainer/UnifyPMCB
 	backwardchainer/BCLogger
 	forwardchainer/FCStat

--- a/opencog/rule-engine/UREConfigReader.cc
+++ b/opencog/rule-engine/UREConfigReader.cc
@@ -33,52 +33,78 @@ using namespace opencog;
 const std::string UREConfigReader::top_rbs_name = "URE";
 const std::string UREConfigReader::attention_alloc_name = "URE:attention-allocation";
 const std::string UREConfigReader::max_iter_name = "URE:maximum-iterations";
+const std::string UREConfigReader::bc_complexity_penalty_name = "URE:BC:complexity-penalty";
 
 UREConfigReader::UREConfigReader(AtomSpace& as, const Handle& rbs) : _as(as)
 {
+	//////////////////////////
+	// Common parameters    //
+	//////////////////////////
+
 	if (Handle::UNDEFINED == rbs)
 		throw RuntimeException(TRACE_INFO,
 			"UREConfigReader - invalid rulebase specified!");
 
 	// Retrieve the rules (MemberLinks) and instantiate them
 	for (const Handle& rule_name : fetch_rule_names(rbs))
-		_rbparams.rules.emplace(rule_name, rbs);
+		_common_params.rules.emplace(rule_name, rbs);
 
 	// Fetch maximum number of iterations
-	_rbparams.max_iter = fetch_num_param(max_iter_name, rbs);
+	_common_params.max_iter = fetch_num_param(max_iter_name, rbs);
 
 	// Fetch attention allocation parameter
-	_rbparams.attention_alloc = fetch_bool_param(attention_alloc_name, rbs);
+	_common_params.attention_alloc = fetch_bool_param(attention_alloc_name, rbs);
+
+	//////////////////////
+	// FC parameters    //
+	//////////////////////
+
+	//////////////////////
+	// BC parameters    //
+	//////////////////////
+
+	// Fetch BC complexity penalty parameter
+	_bc_params.complexity_penalty = fetch_num_param(bc_complexity_penalty_name, rbs);
 }
 
 const RuleSet& UREConfigReader::get_rules() const
 {
-	return _rbparams.rules;
+	return _common_params.rules;
 }
 
 RuleSet& UREConfigReader::get_rules()
 {
-	return _rbparams.rules;
+	return _common_params.rules;
 }
 
 bool UREConfigReader::get_attention_allocation() const
 {
-	return _rbparams.attention_alloc;
+	return _common_params.attention_alloc;
 }
 
 int UREConfigReader::get_maximum_iterations() const
 {
-	return _rbparams.max_iter;
+	return _common_params.max_iter;
+}
+
+double UREConfigReader::get_complexity_penalty() const
+{
+	return _bc_params.complexity_penalty;
 }
 
 void UREConfigReader::set_attention_allocation(bool aa)
 {
-	_rbparams.attention_alloc = aa;
+	_common_params.attention_alloc = aa;
 }
 
 void UREConfigReader::set_maximum_iterations(int mi)
 {
-	_rbparams.max_iter = mi;
+	_common_params.max_iter = mi;
+}
+
+void UREConfigReader::set_complexity_penalty(double cp)
+{
+	_bc_params.complexity_penalty = cp;
 }
 
 HandleSeq UREConfigReader::fetch_rule_names(const Handle& rbs)

--- a/opencog/rule-engine/UREConfigReader.h
+++ b/opencog/rule-engine/UREConfigReader.h
@@ -44,21 +44,39 @@ namespace opencog {
 class UREConfigReader
 {
 public:
-	// Ctor
+	/////////////
+	// Ctor    //
+	/////////////
 
 	// rbs is a Handle pointing to a rule-based system is as
 	UREConfigReader(AtomSpace& as, const Handle& rbs);
 
-	// Access methods, return parameters given a rule-based system
+	///////////////
+	// Accessors //
+	///////////////
+
+	// Common
 	const RuleSet& get_rules() const;
 	RuleSet& get_rules();
 	bool get_attention_allocation() const;
 	int get_maximum_iterations() const;
+	// BC
+	double get_complexity_penalty() const;
 
-	// Modifiers. WARNING: Those changes are not reflected in the
-	// AtomSpace, only in the UREConfigReader object.
+	///////////////////////////////////////////////////////////////////
+	// Modifiers. WARNING: Those changes are not reflected in the    //
+	// AtomSpace, only in the UREConfigReader object.                //
+	///////////////////////////////////////////////////////////////////
+
+	// Common
 	void set_attention_allocation(bool);
 	void set_maximum_iterations(int);
+	// BC
+	void set_complexity_penalty(double);
+
+	//////////////////
+	// Constants    //
+	//////////////////
 
 	// Name of the top rule base from which all rule-based systems
 	// inherit. It should corresponds to a ConceptNode in the
@@ -72,6 +90,10 @@ public:
 	// Name of the SchemaNode outputing the maximum iterations
 	// parameter
 	static const std::string max_iter_name;
+
+	// Name of the complexity penalty parameter for the Backward
+	// Chainer
+	static const std::string bc_complexity_penalty_name;
 private:
 
 	// Fetch from the AtomSpace all rules of a given rube-based
@@ -84,12 +106,27 @@ private:
 
 	AtomSpace& _as;
 
-	struct RuleBaseParameters {
+	// Parameter common to the forward and backward chainer.
+	struct CommonParameters {
 		RuleSet rules;
 		bool attention_alloc;
 		int max_iter;
 	};
-	RuleBaseParameters _rbparams;
+	CommonParameters _common_params;
+
+	// Parameter specific to the forward chainer.
+	struct FCParameters {};
+	FCParameters _fc_params;
+
+	// Parameter specific to the backward chainer.
+	struct BCParameters {
+		// This parameter biases select_expansion_andbit towards
+		// simpler FCS. Range from 0 to +inf. 0 means there is no
+		// complexity penalty, the greater value the greater the
+		// complexity penalty.
+		double complexity_penalty;
+	};
+	BCParameters _bc_params;
 
 	// Given <schema>, an <input> and optionally an output <type> (or
 	// subtype), return the <output>s in

--- a/opencog/rule-engine/backwardchainer/BIT.cc
+++ b/opencog/rule-engine/backwardchainer/BIT.cc
@@ -87,8 +87,7 @@ BITNode& AndBIT::select_leaf()
 {
 	// TODO: optimize, do not remake the distribution each time
 	LeafDistribution dist = get_distribution();
-	size_t index = dist(randGen());
-	return std::next(leaf2bitnode.begin(), index)->second;
+	return rand_element(leaf2bitnode, dist).second;
 }
 
 bool AndBIT::operator==(const AndBIT& andbit) const

--- a/opencog/rule-engine/backwardchainer/BIT.cc
+++ b/opencog/rule-engine/backwardchainer/BIT.cc
@@ -1,9 +1,8 @@
 /*
  * BIT.cc
  *
- * Author: William Ma <https://github.com/williampma>
- *
- * Copyright (C) 2015 OpenCog Foundation
+ * Copyright (C) 2016-2017 OpenCog Foundation
+ * Author: Nil Geisweiller
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License v3 as
@@ -37,7 +36,7 @@ namespace opencog {
 // BITNode //
 /////////////
 
-BITNode::BITNode(const Handle& bd, const BITFitness& fi)
+BITNode::BITNode(const Handle& bd, const BITNodeFitness& fi)
 	: body(bd), fitness(fi) {}
 
 std::string	BITNode::to_string() const
@@ -55,7 +54,7 @@ std::string	BITNode::to_string() const
 AndBIT::AndBIT() {}
 
 AndBIT::AndBIT(AtomSpace& as, const Handle& target, const Handle& vardecl,
-               const BITFitness& fitness)
+               const BITNodeFitness& fitness)
 {
 	// Create initial FCS
 	HandleSeq bl{target, target};
@@ -136,16 +135,16 @@ void AndBIT::set_leaf2bitnode()
 {
 	// For each leaf of fcs, associate a corresponding BITNode
 	for (const Handle& leaf : get_leaves())
-		insert_bitnode(leaf, BITFitness());
+		insert_bitnode(leaf, BITNodeFitness());
 }
 
-void AndBIT::insert_bitnode(Handle leaf, const BITFitness& fitness)
+void AndBIT::insert_bitnode(Handle leaf, const BITNodeFitness& fitness)
 {
 	if (leaf.is_undefined())
 		return;
 
 	if (leaf2bitnode.find(leaf) == leaf2bitnode.end())
-		leaf2bitnode[leaf] = BITNode(leaf, fitness);
+		leaf2bitnode.emplace(leaf, BITNode(leaf, fitness));
 }
 
 OrderedHandleSet AndBIT::get_leaves() const
@@ -305,7 +304,7 @@ bool AndBIT::is_locally_quoted_eq(const Handle& lhs, const Handle& rhs) const
 BIT::BIT(AtomSpace& as,
          const Handle& target,
          const Handle& vardecl,
-         const BITFitness& fitness)
+         const BITNodeFitness& fitness)
 	: bit_as(&as),
 	  _init_target(target), _init_vardecl(vardecl), _init_fitness(fitness)
 {}

--- a/opencog/rule-engine/backwardchainer/BIT.h
+++ b/opencog/rule-engine/backwardchainer/BIT.h
@@ -26,18 +26,10 @@
 #include <boost/operators.hpp>
 #include <opencog/rule-engine/Rule.h>
 #include <opencog/atoms/base/Handle.h>
+#include "Fitness.h"
 
 namespace opencog
 {
-
-/**
- * Contains the fitness type of a certain BIT node. For instance
- * whether the target is a variable query such that the variables
- * maximize the target TV in a certain way, etc.
- */
-class BITFitness
-{
-};
 
 /**
  * A BIT (Back Inference Tree) node, and how it relates to its
@@ -52,13 +44,13 @@ class BITNode
 {
 public:
 	BITNode(const Handle& body=Handle::UNDEFINED,
-	        const BITFitness& fitness=BITFitness());
+	        const BITNodeFitness& fitness=BITNodeFitness());
 
 	// BITNode handle (TODO: maybe this is not necessary)
 	Handle body;
 
 	// BITNode fitness
-	BITFitness fitness;
+	BITNodeFitness fitness;
 
 	// Or-children at the rule level, as multiple rules, or rule
 	// variations (partially unified, etc) can yield the same target.
@@ -87,7 +79,7 @@ public:
 	 */
 	AndBIT();
 	AndBIT(AtomSpace& as, const Handle& target, const Handle& vardecl,
-	       const BITFitness& fitness=BITFitness());
+	       const BITNodeFitness& fitness=BITNodeFitness());
 
 	/**
 	 * @brief Expand the and-BIT given a target leaf and rule.
@@ -141,7 +133,7 @@ private:
 	 * @brief Build the bitnode associated to leaf and insert it in
 	 * leaf2bitnode.
 	 */
-	void insert_bitnode(Handle leaf, const BITFitness& fitness);
+	void insert_bitnode(Handle leaf, const BITNodeFitness& fitness);
 
 	/**
 	 * Return all the leaves (or blanket because these new target
@@ -211,7 +203,7 @@ public:
 	 * Ctor
 	 */
 	BIT(AtomSpace& as, const Handle& target, const Handle& vardecl,
-	    const BITFitness& fitness=BITFitness());
+	    const BITNodeFitness& fitness=BITNodeFitness());
 
 	/**
 	 * @brief return true iff the BIT is empty (i.e. has no and-BITs).
@@ -254,7 +246,7 @@ private:
 
 	Handle _init_target;
 	Handle _init_vardecl;
-	BITFitness _init_fitness;
+	BITNodeFitness _init_fitness;
 
 	// // Mapping from handles to their corresponding BITNode
 	// // bodies. Also where the BITNode are actually instantiated.

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.cc
@@ -52,11 +52,12 @@ BackwardChainer::BackwardChainer(AtomSpace& as, const Handle& rbs,
                                                           // support
                                                           // focus_set
                                  const BITNodeFitness& fitness)
-	: _fcs_maximum_size(2000), _fcs_complexity_penalty(0.001),
+	: _fcs_maximum_size(2000),
 	  _as(as), _configReader(as, rbs),
 	  _bit(as, target, vardecl, fitness),
 	  _iteration(0), _last_expansion_andbit(nullptr),
-	  _rules(_configReader.get_rules()) {}
+	  _rules(_configReader.get_rules()) {
+}
 
 UREConfigReader& BackwardChainer::get_config()
 {
@@ -254,5 +255,5 @@ RuleSet BackwardChainer::get_valid_rules(const BITNode& target,
 
 double BackwardChainer::complexity_factor(const AndBIT& andbit) const
 {
-	return exp(- _fcs_complexity_penalty * andbit.fcs->size());
+	return exp(- _configReader.get_complexity_penalty() * andbit.fcs->size());
 }

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.cc
@@ -185,7 +185,7 @@ void BackwardChainer::reduce_bit()
 		return andbit.fcs->size() < max_size; };
 	auto it = boost::lower_bound(_bit.andbits, _max_fcs_size, less_complex_than);
 	size_t previous_size = _bit.andbits.size();
-	_bit.andbits.erase(it, _bit.andbits.end());
+	_bit.erase(it, _bit.andbits.end());
 	if (size_t removed_andbits = previous_size - _bit.andbits.size()) {
 		LAZY_BC_LOG_DEBUG << "Removed " << removed_andbits
 		                  << " overly complex and-BITs from the BIT";

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.cc
@@ -49,7 +49,7 @@ BackwardChainer::BackwardChainer(AtomSpace& as, const Handle& rbs,
                                  const Handle& focus_set, // TODO:
                                                           // support
                                                           // focus_set
-                                 const BITFitness& fitness)
+                                 const BITNodeFitness& fitness)
 	: _max_fcs_size(950), _as(as), _configReader(as, rbs),
 	  _bit(as, target, vardecl, fitness),
 	  _iteration(0), _last_expansion_andbit(nullptr),

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.h
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.h
@@ -168,17 +168,12 @@ private:
 
 	// Return the complexity factor of an andbit. The formula is
 	//
-	// exp(-_fcs_complexity_penalty * andbit.fcs->size())
+	// exp(-complexity_penalty * andbit.fcs->size())
 	double complexity_factor(const AndBIT& andbit) const;
 
 	// FCS above this size are considered too big and automatically
 	// removed.
 	const size_t _fcs_maximum_size;
-
-	// This parameter biases select_expansion_andbit towards simpler
-	// FCS. Range from 0 to +inf. 0 means there is no complexity
-	// penalty, the greater value the greater the complexity penalty.
-	double _fcs_complexity_penalty;
 
 	AtomSpace& _as;
 	UREConfigReader _configReader;

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.h
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.h
@@ -158,18 +158,24 @@ private:
 	//
 	// The Selection is random amongst the valid rules and weighted
 	// according to their weights.
-	Rule select_rule(const BITNode& target,
-	                 const Handle& vardecl=Handle::UNDEFINED);
+	//
+	// The target is not const because if the rules are exhausted it
+	// will set its exhausted flag to false.
+	Rule select_rule(BITNode& target, const Handle& vardecl=Handle::UNDEFINED);
 	Rule select_rule(const RuleSet& rules);
 
-	// Return all valid rules, in the sense that these rules may
-	// possibly be used to infer the target.
+	// Return all valid rules, in the sense that they may possibly be
+	// used to infer the target.
 	RuleSet get_valid_rules(const BITNode& target, const Handle& vardecl);
 
 	// Return the complexity factor of an andbit. The formula is
 	//
 	// exp(-complexity_penalty * andbit.fcs->size())
 	double complexity_factor(const AndBIT& andbit) const;
+
+	// Return an very crude estimate of the probability that expanding
+	// this and-BIT may lead to a successful inference.
+	double operator()(const AndBIT& andbit) const;
 
 	// FCS above this size are considered too big and automatically
 	// removed.

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.h
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.h
@@ -155,8 +155,12 @@ private:
 	// object because a new rule is created, its variables are
 	// uniquely renamed, possibly some partial substitutions are
 	// applied.
+	//
+	// The Selection is random amongst the valid rules and weighted
+	// according to their weights.
 	Rule select_rule(const BITNode& target,
 	                 const Handle& vardecl=Handle::UNDEFINED);
+	Rule select_rule(const RuleSet& rules);
 
 	// Return all valid rules, in the sense that these rules may
 	// possibly be used to infer the target.

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.h
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.h
@@ -166,8 +166,19 @@ private:
 	// possibly be used to infer the target.
 	RuleSet get_valid_rules(const BITNode& target, const Handle& vardecl);
 
-	// Hack alert!!! FCS above this size are considered too big
-	const size_t _max_fcs_size;
+	// Return the complexity factor of an andbit. The formula is
+	//
+	// exp(-_fcs_complexity_penalty * andbit.fcs->size())
+	double complexity_factor(const AndBIT& andbit) const;
+
+	// FCS above this size are considered too big and automatically
+	// removed.
+	const size_t _fcs_maximum_size;
+
+	// This parameter biases select_expansion_andbit towards simpler
+	// FCS. Range from 0 to +inf. 0 means there is no complexity
+	// penalty, the greater value the greater the complexity penalty.
+	double _fcs_complexity_penalty;
 
 	AtomSpace& _as;
 	UREConfigReader _configReader;

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.h
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.h
@@ -96,7 +96,7 @@ public:
 	                const Handle& target,
 	                const Handle& vardecl=Handle::UNDEFINED,
 	                const Handle& focus_set=Handle::UNDEFINED,
-	                const BITFitness& fitness=BITFitness());
+	                const BITNodeFitness& fitness=BITNodeFitness());
 
 	/**
 	 * URE configuration accessors

--- a/opencog/rule-engine/backwardchainer/CMakeLists.txt
+++ b/opencog/rule-engine/backwardchainer/CMakeLists.txt
@@ -2,5 +2,6 @@ INSTALL (FILES
 	BackwardChainer.h
 	BackwardChainerPMCB.h
 	BIT.h
+    Fitness.h
 	DESTINATION "include/opencog/rule-engine/backwardchainer"
 )

--- a/opencog/rule-engine/backwardchainer/Fitness.cc
+++ b/opencog/rule-engine/backwardchainer/Fitness.cc
@@ -1,0 +1,47 @@
+/*
+ * Fitness.cc
+ *
+ * Copyright (C) 2016-2017 OpenCog Foundation
+ * Author: Nil Geisweiller
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "Fitness.h"
+#include "BIT.h"
+#include "BCLogger.h"
+
+using namespace opencog;
+
+BITNodeFitness::BITNodeFitness(FitnessType ft) : type(ft)
+{
+	switch(type) {
+	case (MaximizeConfidence):
+		function = [](const BITNode& bitnode) {
+			return bitnode.body->getTruthValue()->getConfidence();
+		};
+		upper = 1;
+		lower = 0;
+		break;
+	default:
+		bc_logger().error() << "Not implemented";
+	}
+}
+
+double BITNodeFitness::operator()(const BITNode& bitnode) const
+{
+	return function(bitnode);
+};

--- a/opencog/rule-engine/backwardchainer/Fitness.h
+++ b/opencog/rule-engine/backwardchainer/Fitness.h
@@ -1,0 +1,59 @@
+/*
+ * Fitness.h
+ *
+ * Copyright (C) 2016-2017 OpenCog Foundation
+ * Author: Nil Geisweiller
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef _OPENCOG_URE_FITNESS_H
+#define _OPENCOG_URE_FITNESS_H
+
+#include <functional>
+
+namespace opencog
+{
+
+class BITNode;
+
+/**
+ * Contains the BIT-node fitness type.
+ */
+class BITNodeFitness
+{
+public:
+	enum FitnessType {
+		MaximizeConfidence
+	};
+
+	BITNodeFitness(FitnessType ft=MaximizeConfidence);
+
+	// Fitness type
+	const FitnessType type;
+
+	// Fitness attributes
+	std::function<double(const BITNode&)> function;
+	double upper;       // Co-domain upper bound
+	double lower;       // Co-domain lower bound
+
+	// Evaluate the fitness of a given BIT-node.
+	double operator()(const BITNode& bitnode) const;
+};
+
+} // ~namespace opencog
+
+#endif // _OPENCOG_URE_FITNESS_H

--- a/tests/rule-engine/BackwardChainerUTest.cxxtest
+++ b/tests/rule-engine/BackwardChainerUTest.cxxtest
@@ -410,7 +410,7 @@ void BackwardChainerUTest::test_impossible_criminal()
 	// Should NOT be possible to find the solution without deduction
 	// rule, as it won't be able to tell that missile@123 is a weapon.
 	BackwardChainer bc(_as, top_rbs, target, vardecl);
-	bc.get_config().set_maximum_iterations(100);
+	bc.get_config().set_maximum_iterations(400);
 	bc.do_chain();
 
 	Handle results = bc.get_results(),
@@ -449,7 +449,7 @@ void BackwardChainerUTest::test_criminal()
 	Handle soln = _eval.eval_h("(ConceptNode \"West\")");
 
 	BackwardChainer bc(_as, top_rbs, target, vardecl);
-	bc.get_config().set_maximum_iterations(5000);
+	bc.get_config().set_maximum_iterations(400);
 	bc.do_chain();
 
 	Handle results = bc.get_results(),

--- a/tests/rule-engine/BackwardChainerUTest.cxxtest
+++ b/tests/rule-engine/BackwardChainerUTest.cxxtest
@@ -167,7 +167,7 @@ void BackwardChainerUTest::test_deduction()
 	Handle X = an(VARIABLE_NODE, "$X"),
 		D = an(CONCEPT_NODE, "D"),
 		target = al(INHERITANCE_LINK, X, D);
-		
+
 	BackwardChainer bc(_as, top_rbs, target);
 	bc.get_config().set_maximum_iterations(10);
 	bc.do_chain();
@@ -180,7 +180,7 @@ void BackwardChainerUTest::test_deduction()
 		BD = al(INHERITANCE_LINK, B, D),
 		AD = al(INHERITANCE_LINK, A, D),
 		expected = al(SET_LINK, CD, BD, AD);
-		
+
 	logger().debug() << "results = " << results;
 	logger().debug() << "expected = " << expected;
 
@@ -206,7 +206,7 @@ void BackwardChainerUTest::test_deduction_tv_query()
 	                             "   (Concept \"D\"))");
 
 	BackwardChainer bc(_as, top_rbs, target);
-	bc.get_config().set_maximum_iterations(20);
+	bc.get_config().set_maximum_iterations(10);
 	bc.do_chain();
 
 	TS_ASSERT_DELTA(target->getTruthValue()->getMean(), 1, 1e-10);
@@ -230,7 +230,7 @@ void BackwardChainerUTest::test_modus_ponens_tv_query()
 	Handle target = an(PREDICATE_NODE, "T");
 
 	BackwardChainer bc(_as, top_rbs, target);
-	bc.get_config().set_maximum_iterations(100);
+	bc.get_config().set_maximum_iterations(40);
 	bc.do_chain();
 
 	TS_ASSERT_DELTA(target->getTruthValue()->getMean(), 1, 1e-10);
@@ -302,7 +302,7 @@ void BackwardChainerUTest::test_conditional_instantiation_1()
 		                target_var, an(TYPE_NODE, "ConceptNode")));
 
 	BackwardChainer bc(_as, top_rbs, target, vardecl);
-	bc.get_config().set_maximum_iterations(50);
+	bc.get_config().set_maximum_iterations(20);
 	bc.do_chain();
 
 	Handle results = bc.get_results(),
@@ -342,7 +342,7 @@ void BackwardChainerUTest::test_conditional_instantiation_2()
 		vardecl = al(TYPED_VARIABLE_LINK, what, concept);
 
 	BackwardChainer bc(_as, top_rbs, target, vardecl);
-	bc.get_config().set_maximum_iterations(40);
+	bc.get_config().set_maximum_iterations(20);
 	bc.do_chain();
 
 	Handle results = bc.get_results(),
@@ -375,7 +375,7 @@ void BackwardChainerUTest::test_conditional_instantiation_tv_query()
 	                 "   (ConceptNode \"green\"))");
 
 	BackwardChainer bc(_as, top_rbs, target);
-	bc.get_config().set_maximum_iterations(40);
+	bc.get_config().set_maximum_iterations(20);
 	bc.do_chain();
 
 	TS_ASSERT_DELTA(target->getTruthValue()->getMean(), 1, .1);

--- a/tests/rule-engine/BackwardChainerUTest.cxxtest
+++ b/tests/rule-engine/BackwardChainerUTest.cxxtest
@@ -410,7 +410,7 @@ void BackwardChainerUTest::test_impossible_criminal()
 	// Should NOT be possible to find the solution without deduction
 	// rule, as it won't be able to tell that missile@123 is a weapon.
 	BackwardChainer bc(_as, top_rbs, target, vardecl);
-	bc.get_config().set_maximum_iterations(200);
+	// See bc-criminal-config.scm to change the number of iterations
 	bc.do_chain();
 
 	Handle results = bc.get_results(),
@@ -449,7 +449,7 @@ void BackwardChainerUTest::test_criminal()
 	Handle soln = _eval.eval_h("(ConceptNode \"West\")");
 
 	BackwardChainer bc(_as, top_rbs, target, vardecl);
-	bc.get_config().set_maximum_iterations(200);
+	// See bc-criminal-config.scm to change the number of iterations
 	bc.do_chain();
 
 	Handle results = bc.get_results(),

--- a/tests/rule-engine/BackwardChainerUTest.cxxtest
+++ b/tests/rule-engine/BackwardChainerUTest.cxxtest
@@ -410,7 +410,7 @@ void BackwardChainerUTest::test_impossible_criminal()
 	// Should NOT be possible to find the solution without deduction
 	// rule, as it won't be able to tell that missile@123 is a weapon.
 	BackwardChainer bc(_as, top_rbs, target, vardecl);
-	bc.get_config().set_maximum_iterations(400);
+	bc.get_config().set_maximum_iterations(200);
 	bc.do_chain();
 
 	Handle results = bc.get_results(),
@@ -449,7 +449,7 @@ void BackwardChainerUTest::test_criminal()
 	Handle soln = _eval.eval_h("(ConceptNode \"West\")");
 
 	BackwardChainer bc(_as, top_rbs, target, vardecl);
-	bc.get_config().set_maximum_iterations(400);
+	bc.get_config().set_maximum_iterations(200);
 	bc.do_chain();
 
 	Handle results = bc.get_results(),

--- a/tests/rule-engine/bc-criminal-config.scm
+++ b/tests/rule-engine/bc-criminal-config.scm
@@ -45,7 +45,7 @@
 (ExecutionLink
    (SchemaNode "URE:maximum-iterations")
    (ConceptNode "URE")
-   (NumberNode "20")
+   (NumberNode "200")
 )
 
 ;; Attention allocation (set the TV strength to 0 to disable it, 1 to
@@ -53,4 +53,11 @@
 (EvaluationLink (stv 0 1)
    (PredicateNode "URE:attention-allocation")
    (ConceptNode "URE")
+)
+
+;; termination criteria parameters
+(ExecutionLink
+   (SchemaNode "URE:BC:complexity-penalty")
+   (ConceptNode "URE")
+   (NumberNode "0.001")
 )


### PR DESCRIPTION
Implement fitness function + other goodies like keeping track of exhausted and-BIT and BIT-node expansion + proper Occam's razor.

The speed up is massive (x2 to x100 on the unit tests) and the complexity penalty parameter allows greater BIT expansion control (breath first vs depth first).