### PR TITLE
Remove the troublesome "value()" function from the python bindings

### DIFF
--- a/opencog/cython/opencog/Cast.cc
+++ b/opencog/cython/opencog/Cast.cc
@@ -8,4 +8,3 @@ using namespace opencog;
 Handle atom_from_the_void(long p) { return *((Handle*) p); }
 long void_from_candle(const Handle& hp) { return (long) (&hp); }
 long void_from_cptr(Handle* hp) { return (long) (hp); }
-long avoid_from_cptr(Handle* hp) { return (long) (hp->operator->()); }

--- a/opencog/cython/opencog/Cast.h
+++ b/opencog/cython/opencog/Cast.h
@@ -6,4 +6,3 @@ using namespace opencog;
 Handle atom_from_the_void(long p);
 long   void_from_candle(const Handle& hp);
 long   void_from_cptr(Handle* hp);
-long   avoid_from_cptr(Handle* hp);

--- a/opencog/cython/opencog/atom.pyx
+++ b/opencog/cython/opencog/atom.pyx
@@ -9,9 +9,6 @@ cdef class Atom(object):
     def __dealloc__(self):
         del self.handle
 
-    def value(self):
-        return avoid_from_cptr(self.handle)
-
     def __init__(self, PANDLE lptr, AtomSpace a):
         # self.handle = h is set in __cinit__ above
 

--- a/opencog/cython/opencog/atomspace.pxd
+++ b/opencog/cython/opencog/atomspace.pxd
@@ -9,7 +9,6 @@ cdef extern from "Python.h":
     # Needed to return truth value pointers to C++ callers.
     cdef object PyLong_FromVoidPtr(void *p)
 
-ctypedef public long PATOM
 ctypedef public long PANDLE
 
 cdef extern from "opencog/cython/opencog/Cast.h":
@@ -19,7 +18,6 @@ cdef extern from "opencog/cython/opencog/Cast.h":
     # Tacky hack to convert C objects into Python objects.
     cdef PANDLE   void_from_candle(const cHandle& h)
     cdef PANDLE   void_from_cptr(cHandle* hp)
-    cdef PATOM   avoid_from_cptr(cHandle* hp)
 
 
 # Basic wrapping for std::string conversion.

--- a/tests/cython/atomspace/test_atomspace.py
+++ b/tests/cython/atomspace/test_atomspace.py
@@ -392,22 +392,22 @@ class AtomTest(TestCase):
         space_uuid = 0
 
         # test string representation
-        a1_expected = "(Node \"test1\") ; [{0}][{1}]\n".format(str(a1.value()), space_uuid)
+        a1_expected = "(Node \"test1\") ; [{0}]\n".format(space_uuid)
         a1_expected_long = \
-            "(Node \"test1\" (stv 0.500000 0.800000)) ; [{0}][{1}]\n"\
-            .format(str(a1.value()), space_uuid)
+            "(Node \"test1\" (stv 0.500000 0.800000)) ; [{0}]\n"\
+            .format(space_uuid)
 
-        a2_expected = "(Node \"test2\") ; [{0}][{1}]\n".format(str(a2.value()), space_uuid)
+        a2_expected = "(Node \"test2\") ; [{0}]\n".format(space_uuid)
         a2_expected_long = \
-            "(Node \"test2\" (av 10 1 1) (stv 0.100000 0.300000)) ; [{0}][{1}]\n"\
-            .format(str(a2.value()), space_uuid)
+            "(Node \"test2\" (av 10 1 1) (stv 0.100000 0.300000)) ; [{0}]\n"\
+            .format(space_uuid)
 
         l_expected = \
-            "(Link\n  {0}  {1}) ; [{2}][{3}]\n"\
-            .format(a1_expected, a2_expected, str(l.value()), space_uuid)
+            "(Link\n  {0}  {1}) ; [{2}]\n"\
+            .format(a1_expected, a2_expected, space_uuid)
         l_expected_long = \
-            "(Link\n  {0}  {1}) ; [{2}][{3}]\n"\
-            .format(a1_expected_long, a2_expected_long, str(l.value()), space_uuid)
+            "(Link\n  {0}  {1}) ; [{2}]\n"\
+            .format(a1_expected_long, a2_expected_long, space_uuid)
 
         # This just won't work as designed.
         #self.assertEqual(str(a1), a1_expected)

--- a/tests/cython/bindlink/bindlink.py
+++ b/tests/cython/bindlink/bindlink.py
@@ -56,7 +56,7 @@ starting_size = atomspace.size()
 
 # Run bindlink.
 result = stub_bindlink(atomspace, bindlink_atom)
-assert_true(result is not None and result.value() > 0)
+assert_true(result is not None)
 
 # Check the ending atomspace size, it should be the same.
 ending_size = atomspace.size()
@@ -67,7 +67,7 @@ starting_size = atomspace.size()
 
 # Run bindlink.
 result = bindlink(atomspace, bindlink_atom)
-assert_true(result is not None and result.value() > 0)
+assert_true(result is not None)
 
 # Check the ending atomspace size, it should have added one SetLink.
 ending_size = atomspace.size()

--- a/tests/cython/bindlink/test_bindlink.py
+++ b/tests/cython/bindlink/test_bindlink.py
@@ -87,7 +87,7 @@ class BindlinkTest(TestCase):
 
         # Run bindlink.
         atom = stub_bindlink(self.atomspace, self.bindlink_atom)
-        self.assertTrue(atom is not None and atom.value() > 0)
+        self.assertTrue(atom is not None)
 
         # Check the ending atomspace size, it should be the same.
         ending_size = self.atomspace.size()
@@ -96,7 +96,7 @@ class BindlinkTest(TestCase):
     def _check_result_setlink(self, atom, expected_arity):
 
         # Check if the atom is a SetLink
-        self.assertTrue(atom is not None and atom.value() > 0)
+        self.assertTrue(atom is not None)
         self.assertEquals(atom.type, types.SetLink)
 
         # Check the ending atomspace size, it should have added one SetLink.


### PR DESCRIPTION
There's no legitimate use for this function. It just causes trouble. Remove it.