### PR TITLE
Bugfix for #1070 - odbc columns not cleared.

### DIFF
--- a/opencog/persist/sql/odbc/odbcxx.cc
+++ b/opencog/persist/sql/odbc/odbcxx.cc
@@ -491,6 +491,8 @@ ODBCRecordSet::fetch_row(void)
 {
     if (!this) return 0;
 
+    for (int i=0; i<ncols; i++) values[i][0] = 0;
+
     SQLRETURN rc = SQLFetch(sql_hstmt);
 
     /* no more data */


### PR DESCRIPTION
I suspect that this bug is due to a change in the ODBC implementation:
old column values are no longer being cleared, and thus, they contain
left-over garbage. So, explicitly truncate the garbage.  This fixes
a crash described in opencog/atomspace #1070