### PR TITLE
Attempt to fix problem exiting/re-entering a shell

### DIFF
--- a/opencog/guile/SchemeEval.cc
+++ b/opencog/guile/SchemeEval.cc
@@ -66,7 +66,7 @@ void SchemeEval::init(void)
 	_captured_stack = scm_gc_protect_object(_captured_stack);
 
 	_pexpr = NULL;
-	_eval_done = false;
+	_eval_done = true;
 	_poll_done = false;
 
 	_rc = SCM_EOL;

--- a/opencog/guile/SchemeEval.cc
+++ b/opencog/guile/SchemeEval.cc
@@ -67,7 +67,7 @@ void SchemeEval::init(void)
 
 	_pexpr = NULL;
 	_eval_done = true;
-	_poll_done = false;
+	_poll_done = true;
 
 	_rc = SCM_EOL;
 	_rc = scm_gc_protect_object(_rc);


### PR DESCRIPTION
As described in https://github.com/opencog/opencog/issues/2595

From what I can tell, it hangs because it's waiting for `evalthr` to finish at the dtor of `GenericShell`, and that thread is stuck at the loop in `SchemeEval::do_poll_result`, as it's waiting for the evaluation to finish while there is actually nothing to be evaluated?

I'm not sure if it's the right fix, but it seem to work, and as long as `SchemeEval::begin_eval` is called before doing any evaluation, it should be harmless