### PR TITLE
Improved database login API

### DIFF
--- a/opencog/persist/sql/README.md
+++ b/opencog/persist/sql/README.md
@@ -378,14 +378,12 @@ that a distinct user be created, called `opencog_tester`, although you
 can bypass this, too, by altering the opencog test configuration file.
 
 The database user is NOT the same thing as a unix user: the login is for
-the database (only), not the OS.  The current authentication method that
-OpenCog uses is password-based, and the passwords must be supplied in
-clear-text; thus, you will want to pick a password that is DIFFERENT
-than your unix-password! This is because you will often be using the
-database password as clear-text, allowing almost anyone to see it.
-Experienced Postgres coder-admins are invited to set up more flexible,
-more sophisticated authentication schemes. Some tinkering with the
-OpenCog driver code will be required for this.
+the database (only), not the OS. In general, you will want to pick a
+password that is DIFFERENT than your unix-password. This is because some
+of the database login methods require a clear-text password to be
+supplied. The full set of postgres login styles are supported, as long
+as you use the postgres URI format.  The ODBC logins require cleartext
+passwords to be used.
 
 In the following, a database user named `opencog_user` is created, and
 given the password `cheese`.  You can pick a different username and

--- a/opencog/persist/sql/README.md
+++ b/opencog/persist/sql/README.md
@@ -385,6 +385,10 @@ supplied. The full set of postgres login styles are supported, as long
 as you use the postgres URI format.  The ODBC logins require cleartext
 passwords to be used.
 
+See the [postgres
+documentation]((https://www.postgresql.org/docs/9.6/static/libpq-connect.html)
+for details on the allowed URI format.
+
 In the following, a database user named `opencog_user` is created, and
 given the password `cheese`.  You can pick a different username and
 password.  If you are using ODBC (not recommended), then these two must

--- a/opencog/persist/sql/README.md
+++ b/opencog/persist/sql/README.md
@@ -637,9 +637,21 @@ scheme@(guile-user)> (use-modules (opencog persist) (opencog persist-sql))
 ```
 Open a database with `sql-open`:
 ```
-scheme@(guile-user)> (sql-open "opencog_test" "opencog_tester" "cheese")
+scheme@(guile-user)> (sql-open "postgres:///opencog_test?user=opencog_tester")
 Reserving UUID up to 3
 ```
+There are other, alternate forms for the URI. See the [postgres
+documentation](https://www.postgresql.org/docs/9.6/static/libpq-connect.html)
+for details.
+```
+> (sql-open "odbc://opencog_tester:cheese/opencog_test")
+> (sql-open "postgres://opencog_tester@localhost/opencog_test")
+> (sql-open "postgres://opencog_tester:cheese@localhost/opencog_test")
+> (sql-open "postgres:///opencog_test?user=opencog_tester")
+> (sql-open "postgres:///opencog_test?user=opencog_tester&host=localhost")
+> (sql-open "postgres:///opencog_test?user=opencog_tester&password=cheese")
+```
+
 Save an atom with `store-atom`:
 ```
 scheme@(guile-user)> (define x (ConceptNode "asdfasdf" (stv 0.123 0.789)))

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.h
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.h
@@ -62,7 +62,7 @@ class SQLAtomStorage : public AtomStorage
 		class Response;
 		class Outgoing;
 
-		void init(const char *, const char *, const char *, const char *);
+		void init(const char *);
 
 		// ---------------------------------------------
 		// Handle multiple atomspaces like typecodes: we have to
@@ -173,14 +173,7 @@ class SQLAtomStorage : public AtomStorage
 		async_caller<SQLAtomStorage, Handle> _write_queue;
 
 	public:
-		SQLAtomStorage(const std::string& driver,
-		               const std::string& dbname,
-		               const std::string& username,
-		               const std::string& authentication);
-		SQLAtomStorage(const char * driver,
-		               const char * dbname,
-		               const char * username,
-		               const char * authentication);
+		SQLAtomStorage(std::string uri);
 		SQLAtomStorage(const SQLAtomStorage&) = delete; // disable copying
 		SQLAtomStorage& operator=(const SQLAtomStorage&) = delete; // disable assignment
 		virtual ~SQLAtomStorage();

--- a/opencog/persist/sql/multi-driver/SQLPersistSCM.h
+++ b/opencog/persist/sql/multi-driver/SQLPersistSCM.h
@@ -47,7 +47,6 @@ private:
     static void init_in_module(void*);
     void init(void);
 
-    std::string _driver;
     SQLBackingStore *_backing;
     SQLAtomStorage *_store;
     AtomSpace *_as;
@@ -56,8 +55,7 @@ public:
     SQLPersistSCM(AtomSpace*);
     ~SQLPersistSCM();
 
-    void pick_driver(const std::string&);
-    void do_open(const std::string&, const std::string&, const std::string&);
+    void do_open(const std::string&);
     void do_close(void);
     void do_load(void);
     void do_store(void);

--- a/opencog/persist/sql/multi-driver/ll-pg-cxx.h
+++ b/opencog/persist/sql/multi-driver/ll-pg-cxx.h
@@ -45,9 +45,7 @@ class LLPGConnection : public LLConnection
 		LLPGRecordSet* get_record_set(void);
 
 	public:
-		LLPGConnection(const char * dbname,
-		               const char * username,
-		               const char * authentication);
+		LLPGConnection(const char * uri);
 		~LLPGConnection();
 
 		LLRecordSet *exec(const char *);

--- a/opencog/persist/sql/multi-driver/llapi.cc
+++ b/opencog/persist/sql/multi-driver/llapi.cc
@@ -50,20 +50,9 @@
 
 /* =========================================================== */
 
-LLConnection::LLConnection(const char * _dbname,
-                           const char * _username,
-                           const char * _authentication)
+LLConnection::LLConnection(void)
 {
     is_connected = false;
-
-    if (NULL == _dbname)
-    {
-        PERR("No DB specified");
-        return;
-    }
-
-    dbname = _dbname;
-    username = _username;
 }
 
 /* =========================================================== */

--- a/opencog/persist/sql/multi-driver/llapi.h
+++ b/opencog/persist/sql/multi-driver/llapi.h
@@ -41,15 +41,11 @@ class LLConnection
 {
     friend class LLRecordSet;
     protected:
-        std::string dbname;
-        std::string username;
         bool is_connected;
         std::stack<LLRecordSet *> free_pool;
 
     public:
-        LLConnection(const char * dbname,
-                     const char * username,
-                     const char * authentication);
+        LLConnection(void);
         virtual ~LLConnection();
 
         bool connected(void) const;

--- a/opencog/persist/sql/multi-driver/notes
+++ b/opencog/persist/sql/multi-driver/notes
@@ -499,3 +499,15 @@ Both:
         Start  41: FetchUTest
  41/109 Test  #41: FetchUTest .......................   Passed    1.58 sec
 
+Both, with the new URI scheme  (wtf is this different!??!!??)
+
+
+        Start  38: BasicSaveUTest
+ 38/109 Test  #38: BasicSaveUTest ...................   Passed    9.65 sec
+        Start  39: PersistUTest
+ 39/109 Test  #39: PersistUTest .....................   Passed    4.02 sec
+        Start  40: MultiPersistUTest
+ 40/109 Test  #40: MultiPersistUTest ................   Passed   11.37 sec
+        Start  41: FetchUTest
+ 41/109 Test  #41: FetchUTest .......................   Passed    2.08 sec
+

--- a/opencog/persist/sql/multi-driver/odbcxx.h
+++ b/opencog/persist/sql/multi-driver/odbcxx.h
@@ -51,9 +51,7 @@ class ODBCConnection : public LLConnection
         ODBCRecordSet *get_record_set(void);
 
     public:
-        ODBCConnection(const char * dbname,
-                       const char * username,
-                       const char * authentication);
+        ODBCConnection(const char * uri);
         ~ODBCConnection();
 
         LLRecordSet *exec(const char *);

--- a/opencog/persist/sql/multi-driver/sniff.cc
+++ b/opencog/persist/sql/multi-driver/sniff.cc
@@ -160,8 +160,12 @@ int main ()
 
 #if 1
     SQLAtomStorage *store = new SQLAtomStorage(
+             // "odbc://opencog_tester:cheese/opencog_test");
              // "postgres://opencog_tester:cheese@localhost/opencog_test");
-             "odbc://opencog_tester:cheese/opencog_test");
+             // "postgres://opencog_tester@localhost/opencog_test");
+             // "postgres:///opencog_test?user=opencog_tester");
+             // "postgres:///opencog_test?user=opencog_tester&host=localhost");
+             "postgres:///opencog_test?user=opencog_tester&password=cheese");
 
     AtomTable *table = new AtomTable();
     store->load(*table);

--- a/opencog/persist/sql/multi-driver/sniff.cc
+++ b/opencog/persist/sql/multi-driver/sniff.cc
@@ -159,8 +159,9 @@ int main ()
 #endif
 
 #if 1
-    // SQLAtomStorage *store = new SQLAtomStorage("opencog", "linas", NULL);
-    SQLAtomStorage *store = new SQLAtomStorage("postgres", "opencog_test", "opencog_tester", "cheese");
+    SQLAtomStorage *store = new SQLAtomStorage(
+             // "postgres://opencog_tester:cheese@localhost/opencog_test");
+             "odbc://opencog_tester:cheese/opencog_test");
 
     AtomTable *table = new AtomTable();
     store->load(*table);

--- a/tests/persist/sql/multi-driver/BasicSaveUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/BasicSaveUTest.cxxtest
@@ -47,7 +47,7 @@ class BasicSaveUTest :  public CxxTest::TestSuite
 {
     private:
         AtomSpace *as;
-        const char * driver;
+        std::string uri;
         const char * dbname;
         const char * username;
         const char * passwd;
@@ -121,6 +121,8 @@ class BasicSaveUTest :  public CxxTest::TestSuite
             exit(1);
         }
 
+        void mkuri(std::string);
+
         SQLAtomStorage *astore;
         void single_atom_save_restore(std::string id);
         void add_to_table(int, AtomTable *, std::string id);
@@ -152,24 +154,36 @@ void BasicSaveUTest::tearDown(void)
     delete as;
 }
 
+void BasicSaveUTest::mkuri(std::string driver)
+{
+    uri = driver;
+    uri += "://";
+    uri += username;
+    uri += ":";
+    uri += passwd;
+    if (driver == "postgres") uri += "@localhost";
+    uri += "/";
+    uri += dbname;
+}
+
 void BasicSaveUTest::test_odbc_single_atom(void)
 {
 #if HAVE_ODBC_STORAGE
-	driver = "odbc";   
+	mkuri("odbc");
 	do_test_single_atom();
 #endif
 }
 void BasicSaveUTest::test_odbc_fresh_atom(void)
 {
 #if HAVE_ODBC_STORAGE
-	driver = "odbc";   
+	mkuri("odbc");
 	do_test_fresh_atom();
 #endif
 }
 void BasicSaveUTest::test_odbc_table(void)
 {
 #if HAVE_ODBC_STORAGE
-	driver = "odbc";   
+	mkuri("odbc");
 	do_test_table();
 #endif
 }
@@ -177,21 +191,21 @@ void BasicSaveUTest::test_odbc_table(void)
 void BasicSaveUTest::test_pq_single_atom(void)
 {
 #if HAVE_PGSQL_STORAGE
-	driver = "postgres";
+	mkuri("postgres");
 	do_test_single_atom();
 #endif // HAVE_PGSQL_STORAGE
 }
 void BasicSaveUTest::test_pq_fresh_atom(void)
 {
 #if HAVE_PGSQL_STORAGE
-	driver = "postgres";
+	mkuri("postgres");
 	do_test_fresh_atom();
 #endif // HAVE_PGSQL_STORAGE
 }
 void BasicSaveUTest::test_pq_table(void)
 {
 #if HAVE_PGSQL_STORAGE
-	driver = "postgres";
+	mkuri("postgres");
 	do_test_table();
 #endif // HAVE_PGSQL_STORAGE
 }
@@ -253,7 +267,7 @@ static void atomCompare(AtomPtr a, AtomPtr b, const char* where)
  */
 void BasicSaveUTest::single_atom_save_restore(std::string id)
 {
-    SQLAtomStorage *store = new SQLAtomStorage(driver, dbname, username, passwd);
+    SQLAtomStorage *store = new SQLAtomStorage(uri);
     if (!store->connected())
     {
         logger().debug("single_atom_save_restore: cannot connect to db");
@@ -377,15 +391,14 @@ void BasicSaveUTest::do_test_single_atom(void)
 {
     logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    astore = new SQLAtomStorage(driver, dbname, username, passwd);
+    astore = new SQLAtomStorage(uri);
     if (!astore->connected())
     {
         logger().info("setUp: cannot connect to database");
         friendlyFailMessage(true);
         exit(1);
     }
-    logger().info("Using \"%s\", connect to \"%s\" as \"%s\" passwd \"%s\"", 
-        driver, dbname, username, passwd);
+    logger().info("Connecting to \"%s\"", uri.c_str());
 
     // Trash the contents of the database.
     astore->kill_data();
@@ -405,8 +418,7 @@ void BasicSaveUTest::do_test_fresh_atom(void)
 {
     logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    SQLAtomStorage *store = new SQLAtomStorage(driver,
-                                       dbname, username, passwd);
+    SQLAtomStorage *store = new SQLAtomStorage(uri);
     if (!store->connected())
     {
         logger().debug("single_atom_save_restore: cannot connect to db");
@@ -452,8 +464,7 @@ void BasicSaveUTest::do_test_table()
 {
     logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    SQLAtomStorage *store = new SQLAtomStorage(driver,
-                                          dbname, username, passwd);
+    SQLAtomStorage *store = new SQLAtomStorage(uri);
     if (!store->connected())
     {
         logger().debug("test_table: cannot connect to db");
@@ -474,7 +485,7 @@ void BasicSaveUTest::do_test_table()
     delete table1;
 
     // Reopen connection, and load the atom table.
-    store = new SQLAtomStorage(driver, dbname, username, passwd);
+    store = new SQLAtomStorage(uri);
     TSM_ASSERT("Not connected to database", store->connected());
 
     AtomTable *table2 = new AtomTable();

--- a/tests/persist/sql/multi-driver/FetchUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/FetchUTest.cxxtest
@@ -44,7 +44,7 @@ using namespace opencog;
 class FetchUTest :  public CxxTest::TestSuite
 {
 	private:
-		const char * driver;
+		std::string uri;
 		const char * dbname;
 		const char * username;
 		const char * passwd;
@@ -66,6 +66,7 @@ class FetchUTest :  public CxxTest::TestSuite
 		void setUp(void);
 		void tearDown(void);
 		void kill_data(void);
+		void mkuri(std::string);
 
 		void friendlyFailMessage()
 		{
@@ -86,7 +87,7 @@ class FetchUTest :  public CxxTest::TestSuite
 		void test_stuff(void);
 };
 
-FetchUTest:: FetchUTest(void)
+FetchUTest::FetchUTest(void)
 {
 	try
 	{
@@ -99,34 +100,38 @@ FetchUTest:: FetchUTest(void)
 	logger().set_level(Logger::DEBUG);
 	logger().set_print_to_stdout_flag(true);
 
-	// use postgres preferentially, unless its missing.
-#ifdef HAVE_ODBC_STORAGE
-	driver = "odbc";
-#endif
-#ifdef HAVE_PGSQL_STORAGE
-	driver = "postgres";
-#endif
-
 	try {
 		// Get the database logins & etc from the config file.
       dbname = config().get("TEST_DB_NAME", "opencog_test").c_str();
       username = config().get("TEST_DB_USERNAME", "opencog_tester").c_str();
       passwd = config().get("TEST_DB_PASSWD", "cheese").c_str();
 
-		sql_open = "(sql-driver \"";
-		sql_open += driver;
-		sql_open += "\")\n(sql-open \"";
-		sql_open += dbname;
-		sql_open += "\" \"";
-		sql_open += username;
-		sql_open += "\" \"";
-		sql_open += passwd;
-		sql_open += "\")\n";
+		// use postgres preferentially, unless its missing.
+#ifdef HAVE_ODBC_STORAGE
+		mkuri("odbc");
+#endif
+#ifdef HAVE_PGSQL_STORAGE
+		mkuri("postgres");
+#endif
+
+		sql_open = "(sql-open \"" + uri + "\")\n";
 	}
 	catch (InvalidParamException &e)
 	{
 		friendlyFailMessage();
 	}
+}
+
+void FetchUTest::mkuri(std::string driver)
+{
+	uri = driver;
+	uri += "://";
+	uri += username;
+	uri += ":";
+	uri += passwd;
+	if (driver == "postgres") uri += "@localhost";
+	uri += "/";
+	uri += dbname;
 }
 
 /*
@@ -157,7 +162,7 @@ void FetchUTest::tearDown(void)
 
 void FetchUTest::kill_data(void)
 {
-	SQLAtomStorage* astore = new SQLAtomStorage(driver, dbname, username, passwd);
+	SQLAtomStorage* astore = new SQLAtomStorage(uri);
 	if (!astore->connected())
 	{
 		logger().info("setUp: SQLAtomStorage cannot connect to database");

--- a/tests/persist/sql/multi-driver/MultiPersistUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/MultiPersistUTest.cxxtest
@@ -51,7 +51,7 @@ class MultiPersistUTest :  public CxxTest::TestSuite
     private:
         AtomSpace *_as;
         SQLPersistSCM *_pm;
-        const char * driver;
+        std::string uri;
         const char * dbname;
         const char * username;
         const char * passwd;
@@ -90,6 +90,7 @@ class MultiPersistUTest :  public CxxTest::TestSuite
         void setUp(void);
         void tearDown(void);
         void kill_data(void);
+        void mkuri(std::string);
 
         void friendlyFailMessage()
         {
@@ -147,14 +148,6 @@ MultiPersistUTest:: MultiPersistUTest(void)
     hl2 = new Handle[NATOMS];
     hl3 = new Handle[NATOMS];
 
-    // use postgres preferentially, unless its missing.
-#ifdef HAVE_ODBC_STORAGE
-    driver = "odbc";
-#endif
-#ifdef HAVE_PGSQL_STORAGE
-    driver = "postgres";
-#endif
-
     try
     {
         // Get the database logins & etc from the config file.
@@ -166,6 +159,15 @@ MultiPersistUTest:: MultiPersistUTest(void)
     {
         friendlyFailMessage();
     }
+
+    // use postgres preferentially, unless its missing.
+#ifdef HAVE_ODBC_STORAGE
+    mkuri("odbc");
+#endif
+#ifdef HAVE_PGSQL_STORAGE
+    mkuri("postgres");
+#endif
+
 }
 
 /*
@@ -177,8 +179,7 @@ void MultiPersistUTest::setUp(void)
     _pm = new SQLPersistSCM(_as);
 
     try {
-        _pm->pick_driver(driver);
-        _pm->do_open(dbname, username, passwd);
+        _pm->do_open(uri);
     }
     catch (RuntimeException &e)
     {
@@ -201,11 +202,23 @@ void MultiPersistUTest::tearDown(void)
     kill_data();
 }
 
+void MultiPersistUTest::mkuri(std::string driver)
+{
+    uri = driver;
+    uri += "://";
+    uri += username;
+    uri += ":";
+    uri += passwd;
+    if (driver == "postgres") uri += "@localhost";
+    uri += "/";
+    uri += dbname;
+}
+
 // ============================================================
 
 void MultiPersistUTest::kill_data(void)
 {
-    SQLAtomStorage* astore = new SQLAtomStorage(driver, dbname, username, passwd);
+    SQLAtomStorage* astore = new SQLAtomStorage(uri);
     if (!astore->connected())
     {
         logger().info("setUp: SQLAtomStorage cannot connect to database");

--- a/tests/persist/sql/multi-driver/PersistUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/PersistUTest.cxxtest
@@ -47,7 +47,7 @@ class PersistUTest :  public CxxTest::TestSuite
 {
     private:
         AtomSpace *_as;
-        const char * driver;
+        std::string uri;
         const char * dbname;
         const char * username;
         const char * passwd;
@@ -79,6 +79,7 @@ class PersistUTest :  public CxxTest::TestSuite
 
         void setUp(void);
         void tearDown(void);
+        void mkuri(std::string);
         void kill_data(void);
 
         void friendlyFailMessage()
@@ -147,17 +148,29 @@ void PersistUTest::tearDown(void)
     kill_data();
 }
 
+void PersistUTest::mkuri(std::string driver)
+{
+    uri = driver;
+    uri += "://";
+    uri += username;
+    uri += ":";
+    uri += passwd;
+    if (driver == "postgres") uri += "@localhost";
+    uri += "/";
+    uri += dbname;
+}
+
 // ============================================================
 
 void PersistUTest::kill_data(void)
 {
 #if HAVE_ODBC_STORAGE
-    if (nullptr==driver) driver = "odbc";
+    if ("" == uri) mkuri("odbc");
 #endif
 #if HAVE_PGSQL_STORAGE
-    if (nullptr==driver) driver = "postgres";
+    if ("" == uri) mkuri("postgres");
 #endif
-    SQLAtomStorage* astore = new SQLAtomStorage(driver, dbname, username, passwd);
+    SQLAtomStorage* astore = new SQLAtomStorage(uri);
     if (!astore->connected())
     {
         logger().info("setUp: SQLAtomStorage cannot connect to database");
@@ -369,7 +382,7 @@ void PersistUTest::check_empty(int idx, AtomSpace *space)
 void PersistUTest::test_odbc_atomspace(void)
 {
 #ifdef HAVE_ODBC_STORAGE
-    driver = "odbc";
+    mkuri("odbc");
     do_test_atomspace();
 #endif
 }
@@ -377,7 +390,7 @@ void PersistUTest::test_odbc_atomspace(void)
 void PersistUTest::test_pq_atomspace(void)
 {
 #ifdef HAVE_PGSQL_STORAGE
-    driver = "postgres";
+    mkuri("postgres");
     do_test_atomspace();
 #endif
 }
@@ -390,8 +403,7 @@ void PersistUTest::do_test_atomspace(void)
     TSM_ASSERT("Persist Module not loaded", _pm);
 
     try {
-        _pm->pick_driver(driver);
-        _pm->do_open(dbname, username, passwd);
+        _pm->do_open(uri);
     }
     catch (RuntimeException &e)
     {


### PR DESCRIPTION
Use standard URI's for database logins.  These allow local, remote hosts to be specified, non-standard posrt numbers, unix-domain or tcpip sockets to be used, and three different types of authentication and encryption (kerberos, gssapi, ssl, etc)

These are documented here:
https://www.postgresql.org/docs/9.6/static/libpq-connect.html