### PR TITLE
Improve BC

### DIFF
--- a/opencog/rule-engine/backwardchainer/BIT.cc
+++ b/opencog/rule-engine/backwardchainer/BIT.cc
@@ -127,10 +127,13 @@ bool AndBIT::operator==(const AndBIT& andbit) const
 
 bool AndBIT::operator<(const AndBIT& andbit) const
 {
+	// Sort by size first to so that shorter and-BITs come
+	// first. Makes it easier to prune by complexity. Then by content.
 	size_t fcs_size = fcs->size();
 	size_t other_size = andbit.fcs->size();
 	return (fcs_size < other_size)
-		or (fcs_size == other_size and fcs < andbit.fcs);
+		or (fcs_size == other_size
+		    and content_based_handle_less()(fcs, andbit.fcs));
 }
 
 std::string AndBIT::to_string() const
@@ -409,9 +412,11 @@ AndBIT* BIT::insert(const AndBIT& andbit)
 		// Check that it is not alpha-equivalent either
 		for (const AndBIT& ab : andbits) {
 			if (ScopeLinkCast(andbit.fcs)->is_equal(ab.fcs)) {
-				LAZY_BC_LOG_DEBUG << "The following and-BIT is alpha-equivalent "
-				                  << "to another one already in the BIT:"
-				                  << std::endl << andbit.to_string();
+				LAZY_BC_LOG_DEBUG << "The following and-BIT:"
+				                  << std::endl << andbit.to_string()
+				                  << "is alpha-equivalent to another one "
+				                  << "already in the BIT:"
+				                  << std::endl << ab.to_string();
 				return nullptr;
 			}
 		}

--- a/opencog/rule-engine/backwardchainer/BIT.cc
+++ b/opencog/rule-engine/backwardchainer/BIT.cc
@@ -29,7 +29,6 @@
 
 #include <opencog/util/random.h>
 
-#include <opencog/atomutils/Neighbors.h>
 #include <opencog/atomutils/FindUtils.h>
 
 #include "BIT.h"

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.cc
@@ -206,8 +206,19 @@ AndBIT* BackwardChainer::select_expansion_andbit()
 	for (const AndBIT& andbit : _bit.andbits)
 		weights.push_back(operator()(andbit));
 
-	std::discrete_distribution<size_t> dist(weights.begin(), weights.end());
+	// Debug log
+	if (bc_logger().is_debug_enabled()) {
+		OC_ASSERT(weights.size() == _bit.andbits.size());
+		std::stringstream ss;
+		ss << "Weighted and-BITs:";
+		for (size_t i = 0; i < weights.size(); i++)
+			ss << std::endl << weights[i] << " "
+			   << _bit.andbits[i].fcs->idToString();
+		bc_logger().debug() << ss.str();
+	}
 
+	// Sample andbits according to this distribution
+	std::discrete_distribution<size_t> dist(weights.begin(), weights.end());
 	return &rand_element(_bit.andbits, dist);
 }
 

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.cc
@@ -183,8 +183,15 @@ void BackwardChainer::fulfill_bit()
 
 void BackwardChainer::fulfill_fcs(const Handle& fcs)
 {
-	Handle hresult = bindlink(&_as, fcs);
-	const HandleSeq& results = hresult->getOutgoingSet();
+	// Temporary atomspace to not pollute _as with intermediary
+	// results
+	AtomSpace tmp_as(&_as);
+
+	// Run the FCS and add the results in _as
+	Handle hresult = bindlink(&tmp_as, fcs);
+	HandleSeq results;
+	for (const Handle& result : hresult->getOutgoingSet())
+		results.push_back(_as.add_atom(result));
 	LAZY_BC_LOG_DEBUG << "Results:" << std::endl << results;
 	_results.insert(results.begin(), results.end());
 }


### PR DESCRIPTION
* Dump intermediary results in a temporary atomspace to not pollute the main atomspace
* Log weighted and-BITs