### PR TITLE
Use RAII principles to make sure that we never leak DB connections

### DIFF
--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.h
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.h
@@ -54,12 +54,10 @@ class SQLAtomStorage : public AtomStorage
 {
 	private:
 		// Pool of shared connections
-		LLConnection* get_conn();
-		void put_conn(LLConnection*);
 		concurrent_stack<LLConnection*> conn_pool;
 		int _initial_conn_pool_size;
 
-		// Utility for handling responses on stack.
+		// Utility for handling responses (on stack).
 		class Response;
 		class Outgoing;
 
@@ -68,7 +66,6 @@ class SQLAtomStorage : public AtomStorage
 		// ---------------------------------------------
 		// Handle multiple atomspaces like typecodes: we have to
 		// convert from sql UUID to the atual UUID.
-		std::mutex table_cache_mutex;
 		std::set<UUID> table_id_cache;
 		void store_atomtable_id(const AtomTable&);
 

--- a/opencog/persist/sql/multi-driver/llapi.cc
+++ b/opencog/persist/sql/multi-driver/llapi.cc
@@ -67,14 +67,8 @@ LLConnection::~LLConnection()
     }
 }
 
-bool LLConnection::connected (void) const
-{
-    return is_connected;
-}
-
 /* =========================================================== */
 /* pseudo-private routine */
-
 
 LLRecordSet::LLRecordSet(LLConnection *_conn)
 {

--- a/opencog/persist/sql/multi-driver/llapi.h
+++ b/opencog/persist/sql/multi-driver/llapi.h
@@ -48,7 +48,8 @@ class LLConnection
         LLConnection(void);
         virtual ~LLConnection();
 
-        bool connected(void) const;
+        // No future version of this must ever throw!
+        bool connected(void) const { return is_connected; }
 
         virtual LLRecordSet *exec(const char *) = 0;
 };

--- a/opencog/persist/sql/multi-driver/odbcxx.cc
+++ b/opencog/persist/sql/multi-driver/odbcxx.cc
@@ -290,6 +290,11 @@ ODBCConnection::exec(const char * buff)
      * atom.  We could try to convert &#63; back into a question-mark,
      * when we read the atom name, but then, in that case, how can we
      * know that the atom name didn't originally have &#63; in it?
+     *
+     * Basically, its a really crappy situation, and the only real
+     * solution is to simply not use the old/broken drivers, or not
+     * use ODBC at all. Since this is not always possible, we have
+     * to, uhh, pretend we can make lemonade out of the lemons.
      */
     if (need_qmark_escape and strchr(buff, '?'))
     {

--- a/opencog/persist/sql/multi-driver/odbcxx.cc
+++ b/opencog/persist/sql/multi-driver/odbcxx.cc
@@ -91,7 +91,7 @@ ODBCConnection::ODBCConnection(const char * uri)
     SQLRETURN rc;
 
     is_connected = false;
-    need_qmark_escape = false;
+    need_qmark_escape = true; // worst-case assumption
 
     sql_hdbc = NULL;
     sql_henv = NULL;

--- a/opencog/persist/sql/multi-driver/odbcxx.cc
+++ b/opencog/persist/sql/multi-driver/odbcxx.cc
@@ -17,6 +17,9 @@
  *    Wow! Aside from the bad English, this is a stunningly bad idea!
  * 4) It's slowww. Terrible performance. The native bindings are 3x
  *    faster!
+ * 5) It's verbose. Notice how the native postgres driver can
+ *    accomplish the same thing in less than half the number of lines
+ *    of code!
  *
  * Blame it on SQLBindCol(), which is a terrible idea.  @#$%^ Microsoft.
  *

--- a/opencog/persist/sql/multi-driver/odbcxx.cc
+++ b/opencog/persist/sql/multi-driver/odbcxx.cc
@@ -265,11 +265,11 @@ ODBCConnection::exec(const char * buff)
     {
         int cnt = 0;
         const char* p = buff;
-        while ((p = strchr(buff, '?'))) { ++p; cnt++; }
+        while ((p = strchr(p, '?'))) { ++p; cnt++; }
         char *escape = (char *) malloc(strlen(buff) + 4*cnt + 1);
         char *d = escape;
         const char *b = buff;
-        while ((p = strchr(buff, '?'))) {
+        while ((p = strchr(b, '?'))) {
             size_t len = p-b;
             memcpy(d, b, len);
             d += len;

--- a/opencog/persist/sql/multi-driver/odbcxx.cc
+++ b/opencog/persist/sql/multi-driver/odbcxx.cc
@@ -81,7 +81,7 @@
                                                                 \
     SQLGetDiagRec(HTYPE, HAN, 1, (SQLCHAR *) sql_stat,          \
                   &err, (SQLCHAR*) msg, sizeof(msg), &msglen);  \
-    opencog::logger().warn("(%ld) %s\n", (long int) err, msg);  \
+    opencog::logger().warn("ODBC Driver: (%ld) %s\n", (long int) err, msg);  \
 }
 
 /* =========================================================== */
@@ -197,6 +197,13 @@ ODBCConnection::ODBCConnection(const char * uri)
         // except "03.51".
         need_qmark_escape = true;
         if (0 == strcmp(buf, "03.51")) need_qmark_escape = false;
+
+        if (need_qmark_escape)
+            opencog::logger().warn(
+               "ODBC Driver: Version %s needs question-mark escaping\n"
+               "\tThis WILL garble atom names with question-marks in them!\n"
+               "\tIt will replace question-marks by &#63;\n",
+               buf);
     }
 }
 
@@ -256,7 +263,7 @@ void ODBCConnection::extract_error(const char *msg)
         ret = SQLGetDiagRec(SQL_HANDLE_ENV, sql_henv, ++i,
                state, &native, text, sizeof(text), &len);
         if (SQL_SUCCEEDED(ret))
-            opencog::logger().warn("\t%s : %d : %d : %s\n",
+            opencog::logger().warn("ODBC Driver: %s : %d : %d : %s\n",
                                     state, i, native, text);
     } while (ret == SQL_SUCCESS);
 }
@@ -316,7 +323,7 @@ ODBCConnection::exec(const char * buff)
     {
         PRINT_SQLERR (SQL_HANDLE_STMT, rs->sql_hstmt);
         rs->release();
-        opencog::logger().warn("\tQuery was: %s\n", buff);
+        opencog::logger().warn("ODCB Driver: Query was: %s\n", buff);
         extract_error("exec");
         PERR ("Can't perform query rc=%d ", rc);
         return NULL;

--- a/opencog/persist/sql/multi-driver/odbcxx.cc
+++ b/opencog/persist/sql/multi-driver/odbcxx.cc
@@ -280,9 +280,16 @@ ODBCConnection::exec(const char * buff)
     /* ODBC treats the appearence of the question-mark character ? as
      * something special -- for binding columns, even if you are NOT
      * actualy binding columns. If it shows up in the query, it will
-     * result in error message
+     * result in the error message
      * (34) The # of binded parameters < the # of parameter markers;
-     * Therefore we scan for and html-escape al question marks.
+     * Therefore we scan for and html-escape all question marks.
+     *
+     * XXX FIXME This changes the name of the atom in the database,
+     * itself.  This is fine, if we only ever store or update the
+     * truth value on the atom, but breaks it if we try to read the
+     * atom.  We could try to convert &#63; back into a question-mark,
+     * when we read the atom name, but then, in that case, how can we
+     * know that the atom name didn't originally have &#63; in it?
      */
     if (need_qmark_escape and strchr(buff, '?'))
     {

--- a/opencog/persist/sql/multi-driver/odbcxx.cc
+++ b/opencog/persist/sql/multi-driver/odbcxx.cc
@@ -3,9 +3,18 @@
  * ODBC driver -- developed/tested with unixodbc http://www.unixodbc.org
  *
  * ODBC is basically brain-damaged, and so is this driver.
- * The problem is that ODBC forces you to guess how many columns there
- * are in your reply, and etc. which we don't know a-priori.  Also
- * makes VARCHAR difficult (impossible ??) to support correctly!
+ *
+ * ODBC has several problems:
+ * 1) It forces you to guess how many columns there are in your reply,
+ *    which we don't know a-priori.
+ * 2) VARCHAR is difficult (impossible ??) to support correctly!
+ * 3) The use of the question mark as a special character, even when
+ *    you have nothing bound, nothing at all, giving this message:
+ *    (34) The # of binded parameters < the # of parameter markers;
+ *    Wow! Aside from the bad English, this is a stunningly bad idea!
+ * 4) It's slowww. Terrible performance. The native bindings are 3x
+ *    faster!
+ *
  * Blame it on SQLBindCol(), which is a terrible idea.  @#$%^ Microsoft.
  *
  * Threading:

--- a/opencog/persist/sql/multi-driver/odbcxx.h
+++ b/opencog/persist/sql/multi-driver/odbcxx.h
@@ -45,6 +45,7 @@ class ODBCConnection : public LLConnection
 {
     friend class ODBCRecordSet;
     private:
+        bool need_qmark_escape;
         SQLHENV sql_henv;
         SQLHDBC sql_hdbc;
 

--- a/tests/persist/sql/multi-driver/BasicSaveUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/BasicSaveUTest.cxxtest
@@ -321,7 +321,10 @@ void BasicSaveUTest::add_to_table(int idx, AtomTable *table, std::string id)
     n2[idx] = NodeCast(table->add(n2[idx], false));
     a2[idx] = n2[idx];
 
-    n3[idx] = createNode(SCHEMA_NODE, id + "third wheel");
+    // ODBC fails when there is a question mark in the text.
+    // Sad but painfully true.
+    std::string qmark = "? ";
+    n3[idx] = createNode(SCHEMA_NODE, qmark + id + "third ? wheel");
     TruthValuePtr stv3(SimpleTruthValue::createTV(0.33, 1.0/(300.0+idx)));
     n3[idx]->setTruthValue(stv3);
     n3[idx] = NodeCast(table->add(n3[idx], false));


### PR DESCRIPTION
Older ODBC drivers have the "design feature" that question marks are always interpreted as bound parameters, no matter what. Thus, ay question mark in the data resulted in an exception being thrown, which resulted in database descriptors being leaked, which resulted in a cogserver hang, if atom names have question-marks in them.

This patch-set uses RAII to avoid the leak,  no matter what, and to work-around, at least partly, this fine Microsoft design decision.