### PR TITLE
decrease the path lenth of code held under a lock.

### DIFF
--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -496,13 +496,6 @@ Handle AtomTable::add(AtomPtr atom, bool async)
     if (in_environ(atom))
         return atom->getHandle();
 
-    // Is the equivalent of this atom already in the table?  If so,
-    // then return the existing atom.  Note that this 'existing'
-    // atom might be in a parent atomspace. We will double-check
-    // later, while holding a lock.
-    Handle hexist(getHandle(atom));
-    if (hexist) return hexist;
-
     // Factory implements C++ atom types.
     AtomPtr orig(atom);
     Type atom_type = atom->getType();
@@ -536,8 +529,8 @@ Handle AtomTable::add(AtomPtr atom, bool async)
     else if (atom == orig)
         atom = clone_factory(atom_type, atom);
 
-    // Lock before re-checking to see if this kind of atom is already
-    // in the atomspace.  Lock, to prevent two different threads from
+    // Lock before checking to see if this kind of atom is already in
+    // the atomspace.  Lock, to prevent two different threads from
     // trying to add exactly the same atom.
     std::unique_lock<std::recursive_mutex> lck(_mtx);
     Handle hcheck(getHandle(orig));

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -496,15 +496,6 @@ Handle AtomTable::add(AtomPtr atom, bool async)
     if (in_environ(atom))
         return atom->getHandle();
 
-    // Lock before checking to see if this kind of atom can already
-    // be found in the atomspace.  We need to lock here, to avoid two
-    // different threads from trying to add exactly the same atom.
-    std::unique_lock<std::recursive_mutex> lck(_mtx);
-
-    // Check again, under the lock this time.
-    if (in_environ(atom))
-        return atom->getHandle();
-
     // Factory implements C++ atom types.
     AtomPtr orig(atom);
     Type atom_type = atom->getType();
@@ -512,6 +503,11 @@ Handle AtomTable::add(AtomPtr atom, bool async)
 
     // Certain DeleteLinks can never be added!
     if (nullptr == atom) return Handle();
+
+    // Lock before checking to see if this kind of atom can already
+    // be found in the atomspace.  We need to lock here, to avoid two
+    // different threads from trying to add exactly the same atom.
+    std::unique_lock<std::recursive_mutex> lck(_mtx);
 
     // Is the equivalent of this atom already in the table?  If so,
     // then return the existing atom.  Note that this 'existing'

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -515,10 +515,6 @@ Handle AtomTable::add(AtomPtr atom, bool async)
     Handle hexist(getHandle(atom));
     if (hexist) return hexist;
 
-    // Sometimes one inserts an atom that was previously deleted.
-    // In this case, the removal flag might still be set. Clear it.
-    atom->unsetRemovalFlag();
-
     // If this atom is in some other atomspace or not in any atomspace,
     // then we need to clone it. We cannot insert it into this atomtable
     // as-is.  (We already know that its not in this atomspace, or its

--- a/tests/atomspace/AtomSpaceAsyncUTest.cxxtest
+++ b/tests/atomspace/AtomSpaceAsyncUTest.cxxtest
@@ -707,9 +707,8 @@ public:
         __totalPurged = 0;
         __altTotalPurged = 0;
 
-        boost::signals2::connection del =
-            atomSpace->removeAtomSignal(boost::bind(&AtomSpaceAsyncUTest::countAtomPurged, this, _1));
-            atomSpace->removeAtomSignal(boost::bind(&AtomSpaceAsyncUTest::simpleCountPurged, this, _1));
+        atomSpace->removeAtomSignal(boost::bind(&AtomSpaceAsyncUTest::countAtomPurged, this, _1));
+        atomSpace->removeAtomSignal(boost::bind(&AtomSpaceAsyncUTest::simpleCountPurged, this, _1));
 
         spinwait = true;
         std::vector<std::thread> thread_pool;


### PR DESCRIPTION
This improves performance by maybe 5% or so.