### PR TITLE
Remove redundant unification

### DIFF
--- a/opencog/rule-engine/Rule.cc
+++ b/opencog/rule-engine/Rule.cc
@@ -301,23 +301,25 @@ Rule Rule::gen_standardize_apart(AtomSpace* as)
 	return st_ver;
 }
 
-RuleSet Rule::unify_source(const Handle& source,
-                           const Handle& vardecl) const
+RuleTypedSubstitutionMap Rule::unify_source(const Handle& source,
+                                            const Handle& vardecl) const
 {
 	// TODO
 	return {};
 }
 
-RuleSet Rule::unify_target(const Handle& target, const Handle& vardecl) const
+RuleTypedSubstitutionMap Rule::unify_target(const Handle& target,
+                                            const Handle& vardecl) const
 {
 	// If the rule's handle has not been set yet
 	if (!_rule)
 		return {};
 
+	// To guaranty that the rule variable does not share any variable
+	// of the target.
 	Rule alpha_rule = rand_alpha_converted();
 
-	RuleSet unified_rules;
-
+	RuleTypedSubstitutionMap unified_rules;
 	Handle alpha_vardecl = alpha_rule.get_vardecl();
 	for (const Handle& alpha_pat : alpha_rule.get_conclusion_patterns())
 	{
@@ -330,7 +332,7 @@ RuleSet Rule::unify_target(const Handle& target, const Handle& vardecl) const
 			// substituting all variables by their associated
 			// values.
 			for (const auto& ts : tss)
-				unified_rules.insert(alpha_rule.substituted(ts));
+				unified_rules.insert({alpha_rule.substituted(ts), ts});
 		}
 	}
 
@@ -469,6 +471,26 @@ std::string oc_to_string(const RuleSet& rules)
 	ss << "size = " << rules.size() << std::endl;
 	size_t i = 0;
 	for (const Rule& rule : rules)
+		ss << "rule[" << i++ << "]:" << std::endl
+		   << oc_to_string(rule) << std::endl;
+	return ss.str();
+}
+
+std::string oc_to_string(const RuleTypedSubstitutionPair& rule_ts)
+{
+	std::stringstream ss;
+	ss << "rule:" << std::endl << oc_to_string(rule_ts.first) << std::endl;
+	ss << "typed substitutions:" << std::endl
+	   << oc_to_string(rule_ts.second) << std::endl;
+	return ss.str();
+}
+
+std::string oc_to_string(const RuleTypedSubstitutionMap& rules)
+{
+	std::stringstream ss;
+	ss << "size = " << rules.size() << std::endl;
+	size_t i = 0;
+	for (const RuleTypedSubstitutionPair& rule : rules)
 		ss << "rule[" << i++ << "]:" << std::endl
 		   << oc_to_string(rule) << std::endl;
 	return ss.str();

--- a/opencog/rule-engine/Rule.h
+++ b/opencog/rule-engine/Rule.h
@@ -42,6 +42,9 @@ public:
 	void expand_meta_rules(AtomSpace& as);
 };
 
+typedef std::map<Rule, Unify::TypedSubstitution> RuleTypedSubstitutionMap;
+typedef RuleTypedSubstitutionMap::value_type RuleTypedSubstitutionPair;
+
 /**
  * Class for managing rules in the URE.
  *
@@ -184,17 +187,34 @@ public:
 	 *
 	 * TODO: we probably want to support a vector of sources for rules
 	 * with multiple premises.
+	 *
+	 * TODO: we probably want to return only typed substitutions.
+	 * However due to the unifier not supporting well same variables
+	 * one different sides, we need to perform alpha conversion to
+	 * avoid troubles, thus having to return the rules along side the
+	 * typed substitutions.
 	 */
-	RuleSet unify_source(const Handle& source,
-	                     const Handle& vardecl=Handle::UNDEFINED) const;
+	RuleTypedSubstitutionMap unify_source(const Handle& source,
+	                                      const Handle& vardecl=Handle::UNDEFINED) const;
 
 	/**
 	 * Used by the backward chainer. Given a target, generate all rule
 	 * variations that may infer this target. The variables in the
 	 * rules are renamed to almost certainly avoid name collision.
+	 *
+	 * TODO: we probably want to return only typed substitutions.
+	 * However due to the unifier not supporting well same variables
+	 * one different sides, we need to perform alpha conversion to
+	 * avoid troubles, thus having to return the rules along side the
+	 * typed substitutions.
 	 */
-	RuleSet unify_target(const Handle& target,
-	                     const Handle& vardecl=Handle::UNDEFINED) const;
+	 RuleTypedSubstitutionMap unify_target(const Handle& target,
+	                                       const Handle& vardecl=Handle::UNDEFINED) const;
+
+	/**
+	 * Remove the typed substitutions from the rule typed substitution map.
+	 */
+	static RuleSet strip_typed_substitution(const RuleTypedSubstitutionMap& rules);
 
 	/**
 	 * Apply rule (in a forward way) over atomspace as.
@@ -245,6 +265,8 @@ private:
 // http://wiki.opencog.org/w/Development_standards#Print_OpenCog_Objects
 std::string oc_to_string(const Rule& rule);
 std::string oc_to_string(const RuleSet& rules);
+std::string oc_to_string(const RuleTypedSubstitutionPair& rule_ts_pair);
+std::string oc_to_string(const RuleTypedSubstitutionMap& rule_ts_map);
 
 } // ~namespace opencog
 

--- a/opencog/rule-engine/backwardchainer/BIT.h
+++ b/opencog/rule-engine/backwardchainer/BIT.h
@@ -55,7 +55,7 @@ public:
 
 	// Or-children at the rule level, as multiple rules, or rule
 	// variations (partially unified, etc) can yield the same target.
-	RuleSet rules;
+	RuleTypedSubstitutionMap rules;
 
 	// The complexity of the BITNode. For now -log(probability).
 	double complexity;
@@ -118,7 +118,7 @@ public:
 	 *
 	 * @todo support fitness function.
 	 */
-	AndBIT expand(const Handle& leaf, const Rule& rule) const;
+	AndBIT expand(const Handle& leaf, const RuleTypedSubstitutionPair& rule) const;
 
 	/**
 	 * @brief Randomly select a leaf of the FCS. Leaves with lower
@@ -167,7 +167,8 @@ private:
 	 *
 	 * TODO: give examples.
 	 */
-	Handle expand_fcs(const Handle& leaf, const Rule& rule) const;
+	Handle expand_fcs(const Handle& leaf,
+	                  const RuleTypedSubstitutionPair& rule) const;
 
 	/**
 	 * @brief Given that FCS is defined generate the mapping from FCS
@@ -192,12 +193,12 @@ private:
 	OrderedHandleSet get_leaves(const Handle& h) const;
 
 	/**
-	 * Given a FCS, a leaf of it and a rule. Unify the rule conclusion
-	 * with the leaf and replace any variables in the FCS by its
-	 * corresponding term in the rule.
+	 * Given a FCS, a leaf of it and a rule and its associated typed
+	 * substitution. Substitution the FCS according to the typed
+	 * substitution.
 	 */
 	Handle substitute_unified_variables(const Handle& leaf,
-	                                    const Rule& rule) const;
+	                                    const Unify::TypedSubstitution& ts) const;
 
 	/**
 	 * Given the pattern term of an FCS where all variables have been
@@ -206,8 +207,7 @@ private:
 	 *
 	 * TODO: give examples.
 	 */
-	Handle expand_fcs_pattern(const Handle& fcs_pattern,
-	                          const Rule& rule) const;
+	Handle expand_fcs_pattern(const Handle& fcs_pattern, const Rule& rule) const;
 
 	/**
 	 * Given the rewrite term of an FCS where all variables have been
@@ -273,7 +273,8 @@ public:
 	 * keeps a record of that expansion and is this modified during
 	 * that step.
 	 */
-	AndBIT* expand(AndBIT& andbit, BITNode& bitleaf, const Rule& rule);
+	AndBIT* expand(AndBIT& andbit, BITNode& bitleaf,
+	               const RuleTypedSubstitutionPair& rule);
 
 	/**
 	 * Insert a new andbit in the BIT and return its pointer, nullptr
@@ -297,7 +298,8 @@ public:
 	 * Return true if the rule is already an or-children of bitnode up
 	 * to an alpha conversion.
 	 */
-	bool is_in(const Rule& rule, const BITNode& bitnode) const;
+	bool is_in(const RuleTypedSubstitutionPair& rule,
+	           const BITNode& bitnode) const;
 
 private:
 	Handle _init_target;

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.cc
@@ -142,10 +142,11 @@ void BackwardChainer::expand_bit(AndBIT& andbit)
 		return;
 	}
 
-	// Build the leaf vardecl from fcs
-	Handle vardecl = andbit.fcs.is_defined() ?
-		filter_vardecl(BindLinkCast(andbit.fcs)->get_vardecl(), bitleaf->body)
-		: Handle::UNDEFINED;
+	// Get the leaf vardecl from fcs. We don't want to filter it
+	// because otherwise the typed substitution obtained may miss some
+	// variables in the FCS declaration that needs to be substituted
+	// during expension.
+	Handle vardecl = BindLinkCast(andbit.fcs)->get_vardecl();
 
 	// Select a valid rule
 	RuleTypedSubstitutionPair rule_ts = select_rule(*bitleaf, vardecl);

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.cc
@@ -148,7 +148,9 @@ void BackwardChainer::expand_bit(AndBIT& andbit)
 		: Handle::UNDEFINED;
 
 	// Select a valid rule
-	Rule rule = select_rule(*bitleaf, vardecl);
+	RuleTypedSubstitutionPair rule_ts = select_rule(*bitleaf, vardecl);
+	Rule rule(rule_ts.first);
+	Unify::TypedSubstitution ts(rule_ts.second);
 	// Add the rule in the _bit.bit_as to make comparing atoms easier
 	// as well as logging more consistent.
 	rule.add(_bit.bit_as);
@@ -159,7 +161,7 @@ void BackwardChainer::expand_bit(AndBIT& andbit)
 	LAZY_BC_LOG_DEBUG << "Selected rule for BIT expansion:" << std::endl
 	                  << rule.to_string();
 
-	_last_expansion_andbit = _bit.expand(andbit, *bitleaf, rule);
+	_last_expansion_andbit = _bit.expand(andbit, *bitleaf, {rule, ts});
 }
 
 void BackwardChainer::fulfill_bit()
@@ -243,57 +245,60 @@ void BackwardChainer::reduce_bit()
 	// }
 }
 
-Rule BackwardChainer::select_rule(BITNode& target, const Handle& vardecl)
+RuleTypedSubstitutionPair BackwardChainer::select_rule(BITNode& target,
+                                                       const Handle& vardecl)
 {
 	// The rule is randomly selected amongst the valid ones, with
 	// probability of selection being proportional to its weight.
-	const RuleSet valid_rules = get_valid_rules(target, vardecl);
+	const RuleTypedSubstitutionMap valid_rules = get_valid_rules(target, vardecl);
 	if (valid_rules.empty()) {
 		target.exhausted = true;
-		return Rule();
+		return {Rule(), Unify::TypedSubstitution()};;
 	}
 
 	// Log all valid rules and their weights
 	if (bc_logger().is_debug_enabled()) {
 		std::stringstream ss;
 		ss << "The following weighted rules are valid:";
-		for (const Rule& r : valid_rules)
-			ss << std::endl << r.get_weight() << " " << r.get_name();
+		for (const auto& r : valid_rules)
+			ss << std::endl << r.first.get_weight() << " " << r.first.get_name();
 		LAZY_BC_LOG_DEBUG << ss.str();
 	}
 
 	return select_rule(valid_rules);
 }
 
-Rule BackwardChainer::select_rule(const RuleSet& rules)
+RuleTypedSubstitutionPair BackwardChainer::select_rule(const RuleTypedSubstitutionMap& rules)
 {
 	// Build weight vector to do weighted random selection
 	std::vector<double> weights;
-	for (const Rule& rule : rules)
-		weights.push_back(rule.get_weight());
+	for (const auto& rule : rules)
+		weights.push_back(rule.first.get_weight());
 
 	// No rule exhaustion, sample one according to the distribution
 	std::discrete_distribution<size_t> dist(weights.begin(), weights.end());
 	return rand_element(rules, dist);
 }
 
-RuleSet BackwardChainer::get_valid_rules(const BITNode& target,
-                                         const Handle& vardecl)
+RuleTypedSubstitutionMap BackwardChainer::get_valid_rules(const BITNode& target,
+                                                          const Handle& vardecl)
 {
 	// Generate all valid rules
-	RuleSet valid_rules;
+	RuleTypedSubstitutionMap valid_rules;
 	for (const Rule& rule : _rules) {
 		// For now ignore meta rules as they are forwardly applied in
 		// expand_bit()
 		if (rule.is_meta())
 			continue;
 
-		RuleSet unified_rules = rule.unify_target(target.body, vardecl);
+		RuleTypedSubstitutionMap unified_rules
+			= rule.unify_target(target.body, vardecl);
 
 		// Insert only rules with positive probability of success
-		RuleSet pos_rules;
-		for (const Rule& rule : unified_rules) {
-			double p = (_bit.is_in(rule, target) ? 0.0 : 1.0) * rule.get_weight();
+		RuleTypedSubstitutionMap pos_rules;
+		for (const auto& rule : unified_rules) {
+			double p = (_bit.is_in(rule, target) ? 0.0 : 1.0)
+				* rule.first.get_weight();
 			if (p > 0) pos_rules.insert(rule);
 		}
 

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.h
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.h
@@ -161,12 +161,14 @@ private:
 	//
 	// The target is not const because if the rules are exhausted it
 	// will set its exhausted flag to false.
-	Rule select_rule(BITNode& target, const Handle& vardecl=Handle::UNDEFINED);
-	Rule select_rule(const RuleSet& rules);
+	RuleTypedSubstitutionPair select_rule(BITNode& target,
+	                                      const Handle& vardecl=Handle::UNDEFINED);
+	RuleTypedSubstitutionPair select_rule(const RuleTypedSubstitutionMap& rules);
 
 	// Return all valid rules, in the sense that they may possibly be
 	// used to infer the target.
-	RuleSet get_valid_rules(const BITNode& target, const Handle& vardecl);
+	RuleTypedSubstitutionMap get_valid_rules(const BITNode& target,
+	                                         const Handle& vardecl);
 
 	// Return the complexity factor of an andbit. The formula is
 	//

--- a/tests/rule-engine/BITUTest.cxxtest
+++ b/tests/rule-engine/BITUTest.cxxtest
@@ -743,8 +743,9 @@ void BITUTest::test_expand_1()
 	                           "      (ConceptNode \"compound-A\"))))");
 
 	Rule lambda_closed_construction_rule(lambda_closed_construction_rule_h);
-	RuleSet rules = lambda_closed_construction_rule.unify_target(leaf);
-	Rule rule = *rules.begin();
+	RuleTypedSubstitutionMap rules =
+		lambda_closed_construction_rule.unify_target(leaf);
+	RuleTypedSubstitutionPair rule = *rules.begin();
 
 	AndBIT result = andbit.expand(leaf, rule);
 	AndBIT expected(
@@ -1296,9 +1297,9 @@ void BITUTest::test_expand_2()
 		             ")");
 
 	Rule implication_and_lambda_factorization_rule(implication_and_lambda_factorization_rule_h);
-	RuleSet rules =
+	RuleTypedSubstitutionMap rules =
         implication_and_lambda_factorization_rule.unify_target(leaf, vardecl);
-	Rule rule = *rules.begin();
+	RuleTypedSubstitutionPair rule = *rules.begin();
 
 	AndBIT result = andbit.expand(leaf, rule);
 	AndBIT expected(

--- a/tests/rule-engine/BackwardChainerUTest.cxxtest
+++ b/tests/rule-engine/BackwardChainerUTest.cxxtest
@@ -109,9 +109,9 @@ void BackwardChainerUTest::test_select_rule_1()
 	                               "   (Concept \"B\"))");
 	BITNode target(target_h);
 
-	Rule selected_rule = _bc->select_rule(target);
+	RuleTypedSubstitutionPair selected_rule = _bc->select_rule(target);
 
-	TS_ASSERT_EQUALS(selected_rule.get_name(), "bc-deduction-rule");
+	TS_ASSERT_EQUALS(selected_rule.first.get_name(), "bc-deduction-rule");
 }
 
 // Test select rule with a target with variables
@@ -126,9 +126,9 @@ void BackwardChainerUTest::test_select_rule_2()
 	                               "   (Variable \"$X\"))");
 	BITNode target(target_h);
 
-	Rule selected_rule = _bc->select_rule(target);
+	RuleTypedSubstitutionPair selected_rule = _bc->select_rule(target);
 
-	TS_ASSERT_EQUALS(selected_rule.get_name(), "bc-deduction-rule");
+	TS_ASSERT_EQUALS(selected_rule.first.get_name(), "bc-deduction-rule");
 }
 
 // Test select rule with a target with variables with the same name as
@@ -145,9 +145,9 @@ void BackwardChainerUTest::test_select_rule_3()
 		                         "   (Type \"InheritanceLink\"))");
 	BITNode target(target_h);
 
-	Rule selected_rule = _bc->select_rule(target, vardecl_h);
+	RuleTypedSubstitutionPair selected_rule = _bc->select_rule(target, vardecl_h);
 
-	TS_ASSERT_EQUALS(selected_rule.get_name(), "bc-deduction-rule");
+	TS_ASSERT_EQUALS(selected_rule.first.get_name(), "bc-deduction-rule");
 }
 
 void BackwardChainerUTest::test_deduction()

--- a/tests/rule-engine/RuleUTest.cxxtest
+++ b/tests/rule-engine/RuleUTest.cxxtest
@@ -129,11 +129,11 @@ void RuleUTest::test_unify_target_deduction_1()
 {
 	Rule deduction_rule(deduction_rule_h);
 	Handle target = al(INHERITANCE_LINK, X, A);
-	RuleSet rules = deduction_rule.unify_target(target);
+	RuleTypedSubstitutionMap rules = deduction_rule.unify_target(target);
 
 	TS_ASSERT_EQUALS(rules.size(), 1);
 
-	Handle rule = rules.begin()->get_rule(),
+	Handle rule = rules.begin()->first.get_rule(),
 		// Expected up to an alpha conversion
 		vardecl = al(VARIABLE_LIST,
 		             // TODO: unify needs to be upgraded so it can
@@ -170,11 +170,12 @@ void RuleUTest::test_unify_target_deduction_2()
 	Rule deduction_rule(deduction_rule_h);
 	Handle target = al(INHERITANCE_LINK, X, A),
 		target_vardecl = al(TYPED_VARIABLE_LINK, X, CT);
-	RuleSet rules = deduction_rule.unify_target(target, target_vardecl);
+	RuleTypedSubstitutionMap rules =
+		deduction_rule.unify_target(target, target_vardecl);
 
 	TS_ASSERT_EQUALS(rules.size(), 1);
 
-	Handle rule = rules.begin()->get_rule(),
+	Handle rule = rules.begin()->first.get_rule(),
 		// Expected up to an alpha conversion
 		vardecl = al(VARIABLE_LIST,
 		             al(TYPED_VARIABLE_LINK, X, CT),
@@ -230,11 +231,12 @@ void RuleUTest::test_unify_target_deduction_3()
 		             "      (TypeNode \"VariableList\")))"
 		             "  (VariableNode \"$P-25868310\"))");
 
-	RuleSet rules = deduction_implication_rule.unify_target(target, vardecl);
+	RuleTypedSubstitutionMap rules =
+		deduction_implication_rule.unify_target(target, vardecl);
 
 	TS_ASSERT_EQUALS(rules.size(), 1);
 
-	Handle rule = rules.begin()->get_rule();
+	Handle rule = rules.begin()->first.get_rule();
 	// Expected up to an alpha conversion
 	// TODO
 	Handle expected =
@@ -362,11 +364,12 @@ void RuleUTest::test_unify_target_implication_scope_to_implication_1()
 	Handle target = al(IMPLICATION_LINK,
 	                   al(LAMBDA_LINK, Typed_X, Eval_P),
 	                   al(LAMBDA_LINK, Typed_X, Eval_Q));
-	RuleSet rules = implication_scope_to_implication_rule.unify_target(target);
+	RuleTypedSubstitutionMap rules =
+		implication_scope_to_implication_rule.unify_target(target);
 
 	TS_ASSERT_EQUALS(rules.size(), 1);
 
-	Handle rule = rules.begin()->get_rule(),
+	Handle rule = rules.begin()->first.get_rule(),
 		// Expected up to an alpha conversion
 		body = al(IMPLICATION_SCOPE_LINK, Typed_X, Eval_P, Eval_Q),
 		schema = an(GROUNDED_SCHEMA_NODE,
@@ -392,11 +395,12 @@ void RuleUTest::test_unify_target_implication_scope_to_implication_2()
 	Handle target = al(IMPLICATION_LINK,
 	                   al(LAMBDA_LINK, Typed_X, P_body_var),
 	                   al(LAMBDA_LINK, Typed_X, Eval_Q));
-	RuleSet rules = implication_scope_to_implication_rule.unify_target(target);
+	RuleTypedSubstitutionMap rules =
+		implication_scope_to_implication_rule.unify_target(target);
 
 	TS_ASSERT_EQUALS(rules.size(), 1);
 
-	Handle rule = rules.begin()->get_rule(),
+	Handle rule = rules.begin()->first.get_rule(),
 		// Expected up to an alpha conversion
 		body = al(IMPLICATION_SCOPE_LINK, Typed_X, P_body_var, Eval_Q),
 		schema = an(GROUNDED_SCHEMA_NODE,
@@ -443,7 +447,7 @@ void RuleUTest::test_unify_target_implication_scope_to_implication_3()
 		             ")");
 	Handle vardecl =
 		_eval.eval_h("(VariableNode \"$P-1dd6c910\")");
-	RuleSet rules =
+	RuleTypedSubstitutionMap rules =
 		implication_scope_to_implication_rule.unify_target(target, vardecl);
 
 	// It should fail
@@ -474,12 +478,12 @@ void RuleUTest::test_unify_target_implication_scope_to_implication_4()
 		             "  )"
 		             ")");
 
-	RuleSet rules =
+	RuleTypedSubstitutionMap rules =
 		implication_scope_to_implication_rule.unify_target(target, vardecl);
 
 	TS_ASSERT_EQUALS(rules.size(), 1);
 
-	Handle rule = rules.begin()->get_rule();
+	Handle rule = rules.begin()->first.get_rule();
 	// Expected up to an alpha conversion
 	Handle expected =
 		_eval.eval_h("(BindLink"
@@ -510,7 +514,8 @@ void RuleUTest::test_unify_target_implication_scope_to_implication_4()
 		             "        (Unquote (VariableNode \"$P-6266d6f2\"))"
 		             "        (Unquote (VariableNode \"$Q-7005b724\")))))))");
 
-	std::cout << "implication_scope_to_implication_rule = " << oc_to_string(implication_scope_to_implication_rule);
+	std::cout << "implication_scope_to_implication_rule = "
+	          << oc_to_string(implication_scope_to_implication_rule);
 	std::cout << "target = " << oc_to_string(target);
 	std::cout << "rule = " << oc_to_string(rule);
 	std::cout << "expected = " << oc_to_string(expected);
@@ -572,14 +577,14 @@ void RuleUTest::test_unify_target_implication_and_lambda_factorization()
 		             "    (TypeNode \"PredicateNode\")"
 		             "  )"
 		             ")");
-	RuleSet rules =
+	RuleTypedSubstitutionMap rules =
 		implication_and_lambda_factorization_rule.unify_target(target, vardecl);
 
 	std::cout << "rules = " << oc_to_string(rules) << std::endl;
 
 	TS_ASSERT_EQUALS(rules.size(), 1);
 
-	Handle rule = rules.begin()->get_rule();
+	Handle rule = rules.begin()->first.get_rule();
 	Handle expected =
 		_eval.eval_h("(BindLink"
 		             "  (LocalQuoteLink"
@@ -690,12 +695,12 @@ void RuleUTest::test_unify_target_lambda_closed_construction()
 		             "    (ListLink"
 		             "      (ConceptNode \"treatment-1\")"
 		             "      (ConceptNode \"compound-A\"))))");
-	RuleSet rules =
+	RuleTypedSubstitutionMap rules =
 		lambda_closed_construction_rule.unify_target(target);
 
 	TS_ASSERT_EQUALS(rules.size(), 1);
 
-	Handle rule = rules.begin()->get_rule();
+	Handle rule = rules.begin()->first.get_rule();
 	Handle expected =
 		_eval.eval_h("(BindLink"
 		             "  (VariableList)"


### PR DESCRIPTION
Instead of re-unify the selected rule conclusion with the to be expended fcs, pass the typed substitution obtained during target unification.