### PR TITLE
Remove multi-iterator version of BIT::erase

### DIFF
--- a/opencog/rule-engine/backwardchainer/BIT.cc
+++ b/opencog/rule-engine/backwardchainer/BIT.cc
@@ -638,16 +638,6 @@ BIT::AndBITs::iterator BIT::erase(AndBITs::const_iterator pos)
 	return andbits.erase(pos);
 }
 
-BIT::AndBITs::iterator BIT::erase(AndBITs::const_iterator from,
-                                  AndBITs::const_iterator to)
-{
-	while (from != to) {
-		bit_as.remove_atom(from->fcs);
-		++from;
-	}
-	return andbits.erase(from, to);
-}
-
 void BIT::reset_exhausted_flags()
 {
 	for (AndBIT& andbit : andbits)

--- a/opencog/rule-engine/backwardchainer/BIT.h
+++ b/opencog/rule-engine/backwardchainer/BIT.h
@@ -399,12 +399,10 @@ public:
 	AndBIT* insert(const AndBIT& andbit);
 
 	/**
-	 * Erase the given and-BIT(s) from the BIT and remove its (their)
-	 * FCS from bit_as.
+	 * Erase the given and-BIT from the BIT and remove its FCS from
+	 * bit_as.
 	 */
 	AndBITs::iterator erase(AndBITs::const_iterator pos);
-	AndBITs::iterator erase(AndBITs::const_iterator from,
-	                        AndBITs::const_iterator to);
 
 	/**
 	 * Reset to false all and-BITs exhausted flags.


### PR DESCRIPTION
so that it compiles under older versions of gcc, see #1129