### PR TITLE
Integrate the generic value API into the atom

### DIFF
--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -195,6 +195,17 @@ void Atom::merge(TruthValuePtr tvn, const MergeCtrl& mc)
 }
 
 // ==============================================================
+// Setting values associated with this atom.
+void Atom::setValue(const Handle& key, ProtoAtomPtr& value)
+{
+}
+
+ProtoAtomPtr Atom::getValue(const Handle& key)
+{
+    return nullptr;
+}
+
+// ==============================================================
 // Flag stuff
 bool Atom::isMarkedForRemoval() const
 {

--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -183,11 +183,14 @@ void Atom::merge(TruthValuePtr tvn, const MergeCtrl& mc)
 // Setting values associated with this atom.
 void Atom::setValue(const Handle& key, ProtoAtomPtr& value)
 {
+    if (nullptr == _atom_space) return;
+    _atom_space->_value_table.addValuation(key, getHandle(), value);
 }
 
 ProtoAtomPtr Atom::getValue(const Handle& key)
 {
-    return nullptr;
+    if (nullptr == _atom_space) return nullptr;
+    return _atom_space->_value_table.getValue(key, getHandle());
 }
 
 // ==============================================================

--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -59,7 +59,7 @@ namespace opencog {
 
 Atom::~Atom()
 {
-    _atomTable = NULL;
+    _atom_space = NULL;
     if (0 < getIncomingSetSize()) {
         // This can't ever possibly happen. If it does, then there is
         // some very sick bug with the reference counting that the
@@ -70,15 +70,6 @@ Atom::~Atom()
              classserver().getTypeName(_type).c_str(), get_hash());
     }
     drop_incoming_set();
-}
-
-// ==============================================================
-
-// Return the atomspace in which this atom is inserted.
-AtomSpace* Atom::getAtomSpace() const
-{
-    if (_atomTable) return _atomTable->getAtomSpace();
-    return nullptr;
 }
 
 // ==============================================================
@@ -102,8 +93,8 @@ void Atom::setTruthValue(TruthValuePtr newTV)
     _truthValue = newTV;
     lck.unlock();
 
-    if (_atomTable != NULL) {
-        TVCHSigl& tvch = _atomTable->TVChangedSignal();
+    if (_atom_space != nullptr) {
+        TVCHSigl& tvch = _atom_space->_atom_table.TVChangedSignal();
         tvch(getHandle(), oldTV, newTV);
     }
 }
@@ -143,16 +134,10 @@ TruthValuePtr Atom::getTruthValue() const
     if (_flags & FETCHED_RECENTLY)
         return local;
 
-    if (nullptr == _atomTable)
+    if (nullptr == _atom_space)
         return local;
 
-    // XXX The only time that as is null is in BasicSaveUTest
-    // In all other cases, it will never be null.
-    AtomSpace* as = _atomTable->getAtomSpace();
-    if (nullptr == as)
-        return local;
-
-    BackingStore* bs = as->_backing_store;
+    BackingStore* bs = _atom_space->_backing_store;
     if (nullptr == bs)
         return local;
 
@@ -239,17 +224,23 @@ void Atom::setUnchecked(void)
 
 // ==============================================================
 
-void Atom::setAtomTable(AtomTable *tb)
+void Atom::setAtomSpace(AtomSpace *tb)
 {
-    if (tb == _atomTable) return;
+    if (tb == _atom_space) return;
 
-    // Either the existing _atomTable is null, and tb is not, i.e. this
-    // atom is being inserted into tb, or _atomTable is not null, while
-    // tb is null, i.e. atom is being removed from _atomTable.  It is
+    // Either the existing _atomSpace is null, and tb is not, i.e. this
+    // atom is being inserted into tb, or _atomSpace is not null, while
+    // tb is null, i.e. atom is being removed from _atomSpace.  It is
     // illegal to just switch membership: one or the other of these two
     // pointers must be null.
-    OC_ASSERT (NULL == _atomTable or tb == NULL, "Atom table is not null!");
-    _atomTable = tb;
+    OC_ASSERT (nullptr == _atom_space or tb == nullptr,
+               "Atom table is not null!");
+    _atom_space = tb;
+}
+
+AtomTable* Atom::getAtomTable() const
+{
+    return &(_atom_space->_atom_table);
 }
 
 // ==============================================================
@@ -376,7 +367,7 @@ IncomingSet Atom::getIncomingSetByType(Type type, bool subclass)
 std::string Atom::idToString() const
 {
     return std::string("[") + std::to_string(get_hash()) + "][" +
-        std::to_string(_atomTable? _atomTable->get_uuid() : -1) + "]";
+        std::to_string(_atom_space? _atom_space->_atom_table.get_uuid() : -1) + "]";
 }
 
 std::string oc_to_string(const IncomingSet& iset)

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -47,8 +47,8 @@ namespace opencog
  *  @{
  */
 
-class AtomTable;
 class AtomSpace;
+class AtomTable;
 
 //! arity of Links, represented as short integer (16 bits)
 typedef unsigned short Arity;
@@ -82,11 +82,11 @@ class Atom
     friend class ProtocolBufferSerializer; // Needs to de/ser-ialize an Atom
 
 private:
-    //! Sets the AtomTable in which this Atom is inserted.
-    void setAtomTable(AtomTable *);
+    //! Sets the AtomSpace in which this Atom is inserted.
+    void setAtomSpace(AtomSpace *);
 
     //! Returns the AtomTable in which this Atom is inserted.
-    AtomTable *getAtomTable() const { return _atomTable; }
+    AtomTable *getAtomTable() const;
 
 protected:
     // Byte of bitflags (each bit is a flag).
@@ -97,7 +97,7 @@ protected:
     /// for indexing and comparison operations.
     mutable ContentHash _content_hash;
 
-    AtomTable *_atomTable;
+    AtomSpace *_atom_space;
 
     mutable TruthValuePtr _truthValue;
 
@@ -121,7 +121,7 @@ protected:
       : ProtoAtom(t),
         _flags(0),
         _content_hash(Handle::INVALID_HASH),
-        _atomTable(NULL),
+        _atom_space(nullptr),
         _truthValue(tv)
     {}
 
@@ -178,8 +178,8 @@ public:
     virtual ~Atom();
     virtual bool isAtom() const { return true; }
 
-    //! Returns the AtomTable in which this Atom is inserted.
-    AtomSpace* getAtomSpace() const;
+    //! Returns the AtomSpace in which this Atom is inserted.
+    AtomSpace* getAtomSpace() const { return _atom_space; }
 
     /// Merkle-tree hash of the atom contents. Generically useful
     /// for indexing and comparison operations.

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -233,6 +233,13 @@ public:
         return getHandle();
     }
 
+    /**
+     * Set and gets values for this atom.
+     */
+    void setValue(const Handle& key, ProtoAtomPtr& value);
+    ProtoAtomPtr getValue(const Handle& key);
+
+
     //! Get the size of the incoming set.
     size_t getIncomingSetSize() const;
 

--- a/opencog/atoms/reduct/ArithmeticLink.cc
+++ b/opencog/atoms/reduct/ArithmeticLink.cc
@@ -127,9 +127,9 @@ Handle ArithmeticLink::reorder(void)
 	for (const Handle& h : numbers) result.push_back(h);
 
 	Handle h(FoldLink::factory(getType(), result));
-	if (NULL == _atomTable) return h;
+	if (NULL == _atom_space) return h;
 
-	return _atomTable->getAtomSpace()->add_atom(h);
+	return _atom_space->add_atom(h);
 }
 
 // ===========================================================

--- a/opencog/atoms/reduct/FoldLink.cc
+++ b/opencog/atoms/reduct/FoldLink.cc
@@ -74,9 +74,8 @@ void FoldLink::init(void) {}
 // the atomspace with intermediate results. This needs to
 // be fixed somehow. Right now, I don't know how.
 #define DO_RETURN(result) { \
-	if (not _atomTable) return (result); \
-	AtomSpace* as = _atomTable->getAtomSpace(); \
-	return as->add_atom(result); \
+	if (not _atom_space) return (result); \
+	return _atom_space->add_atom(result); \
 }
 
 /// reduce() -- reduce the expression by summing constants, etc.
@@ -125,8 +124,8 @@ Handle FoldLink::reduce(void)
 {
 	// The atom table is typically not set when the ctor runs.
 	// So fix it up now.
-	if (_atomTable)
-		knil = _atomTable->getAtomSpace()->add_atom(knil);
+	if (_atom_space)
+		knil = _atom_space->add_atom(knil);
 
 	HandleSeq reduct;
 	bool did_reduce = false;
@@ -214,8 +213,8 @@ Handle FoldLink::reduce(void)
 			// when reduce is called; else the knil
 			// compares up above fail.
 			Handle foo(createLink(getType(), rere));
-			if (_atomTable)
-				foo = _atomTable->getAtomSpace()->add_atom(foo);
+			if (_atom_space)
+				foo = _atom_space->add_atom(foo);
 
 			FoldLinkPtr flp = factory(foo);
 			DO_RETURN(Handle(flp->reduce()));

--- a/opencog/atoms/reduct/PlusLink.cc
+++ b/opencog/atoms/reduct/PlusLink.cc
@@ -150,8 +150,8 @@ Handle PlusLink::kons(const Handle& fi, const Handle& fj)
 			// We need to insert into the atomspace, else reduce() horks
 			// up the knil compares during reduction.
 			Handle foo(createLink(PLUS_LINK, rest));
-			if (_atomTable)
-				foo = _atomTable->getAtomSpace()->add_atom(foo);
+			if (_atom_space)
+				foo = _atom_space->add_atom(foo);
 
 			PlusLinkPtr ap = PlusLinkCast(foo);
 			Handle a_plus(ap->reduce());

--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -25,18 +25,14 @@
 #ifndef _OPENCOG_ATOMSPACE_H
 #define _OPENCOG_ATOMSPACE_H
 
-#include <algorithm>
 #include <list>
-#include <set>
-#include <vector>
 
 #include <opencog/util/exceptions.h>
 #include <opencog/truthvalue/TruthValue.h>
 
-#include <opencog/atoms/base/ClassServer.h>
-
 #include <opencog/atomspace/AtomTable.h>
 #include <opencog/atomspace/BackingStore.h>
+#include <opencog/atomspace/ValuationTable.h>
 
 namespace opencog
 {
@@ -73,6 +69,7 @@ class AtomSpace
     AtomSpace(const AtomSpace&);
 
     AtomTable _atom_table;
+    ValuationTable _value_table;
     /**
      * Used to fetch atoms from disk.
      */

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -95,7 +95,7 @@ AtomTable::~AtomTable()
     // find a reference to this atomtable.
     for (auto& pr : _atom_store) {
         Handle& atom_to_delete = pr.second;
-        atom_to_delete->_atomTable = NULL;
+        atom_to_delete->_atom_space = nullptr;
 
         // Aiee ... We added this link to every incoming set;
         // thus, it is our responsibility to remove it as well.
@@ -159,7 +159,7 @@ void AtomTable::clear_all_atoms()
     // Clear the atoms in the set.
     for (auto& pr : _atom_store) {
         Handle& atom_to_clear = pr.second;
-        atom_to_clear->_atomTable = NULL;
+        atom_to_clear->_atom_space = nullptr;
 
         // If this is a link we need to remove this atom from the incoming
         // sets for any atoms in this atom's outgoing set. See note in
@@ -552,7 +552,7 @@ Handle AtomTable::add(AtomPtr atom, bool async)
                 try {
                     Handle alias = slp->get_alias();
                     Handle old_state = StateLink::get_link(alias);
-                    atom->setAtomTable(this);
+                    atom->setAtomSpace(_as);
                     alias->swap_atom(LinkCast(old_state), slp);
                     extract(old_state, true);
                 } catch (const InvalidParamException& ex) {}
@@ -568,7 +568,7 @@ Handle AtomTable::add(AtomPtr atom, bool async)
     }
 
     atom->keep_incoming_set();
-    atom->setAtomTable(this);
+    atom->setAtomSpace(_as);
 
     _size++;
     if (atom->isNode()) _num_nodes++;
@@ -847,7 +847,7 @@ AtomPtrSet AtomTable::extract(Handle& handle, bool recursive)
     // We should really do this unlocked, but I'm too lazy to fix, and
     // am hoping no one will notice. This will probably need to be fixed
     // someday.
-    atom->setAtomTable(NULL);
+    atom->setAtomSpace(nullptr);
 
     result.insert(atom);
     return result;


### PR DESCRIPTION
This provides a C++ API making it clear that generic values can be associated with atoms.