### PR TITLE
Change inhertance of TruthValues

### DIFF
--- a/opencog/atoms/base/FloatValue.h
+++ b/opencog/atoms/base/FloatValue.h
@@ -56,7 +56,7 @@ public:
 	void setValue(double v) { _value = std::vector<double>({v}); }
 
 	/** Returns a string representation of the value.  */
-	virtual std::string toString(const std::string& indent) const;
+	virtual std::string toString(const std::string& indent = "") const;
 
 	/** Returns true if two atoms are equal.  */
 	virtual bool operator==(const ProtoAtom&) const;

--- a/opencog/atoms/base/FloatValue.h
+++ b/opencog/atoms/base/FloatValue.h
@@ -43,6 +43,8 @@ class FloatValue
 protected:
 	std::vector<double> _value;
 
+	FloatValue(Type t) : ProtoAtom(t) {}
+
 public:
 	FloatValue(double v) : ProtoAtom(FLOAT_VALUE) { _value.push_back(v); }
 	FloatValue(std::vector<double> v) : ProtoAtom(FLOAT_VALUE), _value(v) {}

--- a/opencog/atoms/base/ProtoAtom.h
+++ b/opencog/atoms/base/ProtoAtom.h
@@ -70,8 +70,8 @@ public:
 	/**
 	 * Returns a string representation of the proto-atom.
 	 */
-	virtual std::string toString(const std::string& indent = "") const = 0;
-	virtual std::string toShortString(const std::string& indent = "") const
+	virtual std::string toString(const std::string& indent) const = 0;
+	virtual std::string toShortString(const std::string& indent) const
 		{ return toString(indent); }
 
 	// Work around gdb's inability to build a string on the fly,

--- a/opencog/atoms/base/ProtoAtom.h
+++ b/opencog/atoms/base/ProtoAtom.h
@@ -70,8 +70,8 @@ public:
 	/**
 	 * Returns a string representation of the proto-atom.
 	 */
-	virtual std::string toString(const std::string& indent) const = 0;
-	virtual std::string toShortString(const std::string& indent) const
+	virtual std::string toString(const std::string& indent = "") const = 0;
+	virtual std::string toShortString(const std::string& indent = "") const
 		{ return toString(indent); }
 
 	// Work around gdb's inability to build a string on the fly,

--- a/opencog/atoms/base/atom_types.script
+++ b/opencog/atoms/base/atom_types.script
@@ -21,7 +21,7 @@ LINK_VALUE <- VALUE     // vector of values ("link" holding values)
 VALUATION <- VALUE
 
 // All of the different flavors of truth values
-TRUTH_VALUE <- VALUE
+TRUTH_VALUE <- FLOAT_VALUE
 SIMPLE_TRUTH_VALUE <- TRUTH_VALUE
 COUNT_TRUTH_VALUE <- TRUTH_VALUE
 INDEFINITE_TRUTH_VALUE <- TRUTH_VALUE

--- a/opencog/atomspace/ValuationTable.cc
+++ b/opencog/atomspace/ValuationTable.cc
@@ -81,6 +81,14 @@ ProtoAtomPtr ValuationTable::getValue(const Handle& key, const Handle& atom)
 	return getValuation(key, atom)->value();
 }
 
+/// Obtain all of the keys in use for a given atom.
+//
+// XXX FIXME this implementation is ... poor. Its probably just enough
+// to store all keys in use, instead of all keys for a given atom.
+// i.e. this uses too much RAM, and we could get away wtih just
+// searching the _vindex, instead, which would be slower but more memory
+// efficient.  The point is that the only user of this function is going
+// to be the peristence framework, and so we should optimize for that.
 std::set<Handle> ValuationTable::getKeys(const Handle& atom)
 {
 	auto ikeys = _keyset.find(atom);

--- a/opencog/atomspace/ValuationTable.cc
+++ b/opencog/atomspace/ValuationTable.cc
@@ -34,12 +34,32 @@ ValuationTable::~ValuationTable()
 {
 }
 
+/// Associate a value with a particular (key,atom) pair
+/// The atom, key and value are wrapped up in a single valuation.
 void ValuationTable::addValuation(ValuationPtr& vp)
 {
+	const Handle& key = vp->key();
+	const Handle& atom = vp->atom();
+
+	// Make a record of all the keys being used for this atom.
+	auto ikeys = _keyset.find(atom);
+	if (ikeys == _keyset.end())
+	{
+		std::set<Handle> keys;
+		keys.insert(key);
+		_keyset.insert(make_pair(atom, keys));
+	}
+	else
+	{
+		ikeys->second.insert(key);
+	}
+
+	// Record the actual valuation
 	_vindex.insert(std::make_pair(
-		std::make_pair(vp->key(), vp->atom()), vp));
+		std::make_pair(key, atom), vp));
 }
 
+/// Associate a value with a particular (key,atom) pair
 void ValuationTable::addValuation(const Handle& key,
                                   const Handle& atom,
                                   ProtoAtomPtr& val)
@@ -59,4 +79,13 @@ ValuationPtr ValuationTable::getValuation(const Handle& key, const Handle& atom)
 ProtoAtomPtr ValuationTable::getValue(const Handle& key, const Handle& atom)
 {
 	return getValuation(key, atom)->value();
+}
+
+std::set<Handle> ValuationTable::getKeys(const Handle& atom)
+{
+	auto ikeys = _keyset.find(atom);
+	if (ikeys == _keyset.end())
+		return std::set<Handle>();
+
+	return ikeys->second;
 }

--- a/opencog/atomspace/ValuationTable.h
+++ b/opencog/atomspace/ValuationTable.h
@@ -24,6 +24,7 @@
 #define _OPENCOG_VALUTATION_TABLE_H
 
 #include <map>
+#include <set>
 
 #include <opencog/atoms/base/Handle.h>
 #include <opencog/atoms/base/Valuation.h>
@@ -45,6 +46,7 @@ private:
 	mutable std::mutex _mtx;
 
 	std::map<std::pair<Handle, Handle>, ValuationPtr> _vindex;
+	std::map<Handle, std::set<Handle>> _keyset;
 
 	/**
 	 * Override and declare copy constructor and equals operator as
@@ -62,6 +64,8 @@ public:
    void addValuation(const Handle&, const Handle&, ProtoAtomPtr&);
 	ValuationPtr getValuation(const Handle&, const Handle&);
 	ProtoAtomPtr getValue(const Handle&, const Handle&);
+
+	std::set<Handle> getKeys(const Handle&);
 };
 
 /** @}*/

--- a/opencog/persist/sql/README.md
+++ b/opencog/persist/sql/README.md
@@ -334,7 +334,6 @@ try doing this, replacing 'alex' with your username.
    $ psql template1
    template1=# CREATE ROLE alex WITH SUPERUSER;
    template1=# ALTER ROLE alex WITH LOGIN;
-
 ```
 
 Verify that worked out by typing \dg to see:

--- a/opencog/persist/sql/README.md
+++ b/opencog/persist/sql/README.md
@@ -413,14 +413,24 @@ TCP-IP sockets to `localhost`:
    $  psql mycogdata -U opencog_user
 ```
 
-For most users, this will fail. To fix this, you need to edit the file
+For most users, this will fail with the message
+```
+psql: FATAL:  Peer authentication failed for user "opencog_user"
+```
+To fix this, you need to edit the file
 ```
    /etc/postgresql/9.3/main/pg_hba.conf
 ```
-as `root` or as user `postgres`, and add the following line. It will
-allow password logins to all local users:
+as unix user `postgres`, and add the following line. It will allow
+password logins for all local users. (A local user is a user on the
+same machine, connecting to the database by means of unix-domain
+sockets, instead of tcp/ip sockets.)
 ```
    local   all      all           md5
+```
+Be sure to reload or restart the postgres server after the above change:
+```
+   service postgresql reload
 ```
 
 Table initialization

--- a/opencog/persist/zmq/atomspace/ProtocolBufferSerializer.cc
+++ b/opencog/persist/zmq/atomspace/ProtocolBufferSerializer.cc
@@ -52,7 +52,10 @@ void ProtocolBufferSerializer::deserializeAtom(
 {
     //deserializeAttentionValueHolder(atomMessage.attentionvalueholder(), atom);
 
-    atom._atomTable = NULL;
+    // XXX FIXME This is truly a bad and illegal design -- screwing
+    // around with the Atom internals is just plain the wrong thing to
+    // do.  Please use the Atom ctors correctly!
+    atom._atom_space = NULL;
     if (atomMessage.incoming_size() == 0)
     {
         atom._incoming_set = NULL;

--- a/opencog/truthvalue/CountTruthValue.cc
+++ b/opencog/truthvalue/CountTruthValue.cc
@@ -22,10 +22,7 @@
  * along with this program; if not, write to:
  * Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
- *
  */
-
-#include "CountTruthValue.h"
 
 #include <math.h>
 
@@ -33,6 +30,7 @@
 #include <opencog/util/exceptions.h>
 
 #include <opencog/atoms/base/atom_types.h>
+#include "CountTruthValue.h"
 
 using namespace opencog;
 
@@ -102,8 +100,8 @@ bool CountTruthValue::operator==(const ProtoAtom& rhs) const
 }
 
 // Note: this is NOT the merge formula used by PLN.  This is
-// because the CountTruthValue usally stores an integer  _value[COUNT],
-// and a log-probability or entropy, instead of a _value[CONFIDENCE].
+// because the CountTruthValue usally stores an integer count,
+// and a log-probability or entropy, instead of a confidence.
 TruthValuePtr CountTruthValue::merge(TruthValuePtr other,
                                      const MergeCtrl& mc) const
 {

--- a/opencog/truthvalue/CountTruthValue.cc
+++ b/opencog/truthvalue/CountTruthValue.cc
@@ -1,5 +1,5 @@
 /*
- * opencog/atomspace/CountTruthValue.cc
+ * opencog/truthvalue/CountTruthValue.cc
  *
  * Copyright (C) 2002-2007 Novamente LLC
  * All Rights Reserved

--- a/opencog/truthvalue/CountTruthValue.h
+++ b/opencog/truthvalue/CountTruthValue.h
@@ -42,10 +42,11 @@ typedef std::shared_ptr<const CountTruthValue> CountTruthValuePtr;
 class CountTruthValue : public TruthValue
 {
 protected:
-
-    strength_t mean;
-    confidence_t confidence;
-    count_t count;
+    enum {
+        MEAN, /// Mean of the strength of the TV over all observations.
+        CONFIDENCE, /// Estimate of confidence of the observation.
+        COUNT /// Raw count
+    };
 
 public:
 
@@ -55,7 +56,7 @@ public:
 
     virtual bool operator==(const ProtoAtom& rhs) const;
 
-    std::string toString(const std::string&) const;
+    virtual std::string toString(const std::string& = "") const;
 
     strength_t getMean() const;
     count_t getCount() const;

--- a/opencog/truthvalue/EvidenceCountTruthValue.cc
+++ b/opencog/truthvalue/EvidenceCountTruthValue.cc
@@ -41,6 +41,7 @@ EvidenceCountTruthValue::EvidenceCountTruthValue(count_t pos_count,
                                                  count_t total_count)
 	: TruthValue(EVIDENCE_COUNT_TRUTH_VALUE)
 {
+	_value.resize(2);
 	_value[POS_COUNT] = pos_count;
 	_value[TOTAL_COUNT] = total_count;
 }
@@ -48,6 +49,7 @@ EvidenceCountTruthValue::EvidenceCountTruthValue(count_t pos_count,
 EvidenceCountTruthValue::EvidenceCountTruthValue(const TruthValue& source)
 	: TruthValue(EVIDENCE_COUNT_TRUTH_VALUE)
 {
+	_value.resize(2);
 	_value[POS_COUNT] = source.getMean() * source.getCount();
 	_value[TOTAL_COUNT] = source.getCount();
 }
@@ -55,6 +57,7 @@ EvidenceCountTruthValue::EvidenceCountTruthValue(const TruthValue& source)
 EvidenceCountTruthValue::EvidenceCountTruthValue(EvidenceCountTruthValue const& source)
 	: TruthValue(EVIDENCE_COUNT_TRUTH_VALUE)
 {
+	_value.resize(2);
 	_value[POS_COUNT] = source.getPositiveCount();
 	_value[TOTAL_COUNT] = source.getCount();
 }

--- a/opencog/truthvalue/EvidenceCountTruthValue.cc
+++ b/opencog/truthvalue/EvidenceCountTruthValue.cc
@@ -1,5 +1,5 @@
 /*
- * opencog/atomspace/EvidenceCountTruthValue.cc
+ * opencog/truthvalue/EvidenceCountTruthValue.cc
  *
  * Copyright (C) 2016 OpenCog Foundation
  * All Rights Reserved
@@ -41,51 +41,51 @@ EvidenceCountTruthValue::EvidenceCountTruthValue(count_t pos_count,
                                                  count_t total_count)
 	: TruthValue(EVIDENCE_COUNT_TRUTH_VALUE)
 {
-	_pos_count = pos_count;
-	_total_count = total_count;
+	_value[POS_COUNT] = pos_count;
+	_value[TOTAL_COUNT] = total_count;
 }
 
 EvidenceCountTruthValue::EvidenceCountTruthValue(const TruthValue& source)
 	: TruthValue(EVIDENCE_COUNT_TRUTH_VALUE)
 {
-	_pos_count = source.getMean() * source.getCount();
-	_total_count = source.getCount();
+	_value[POS_COUNT] = source.getMean() * source.getCount();
+	_value[TOTAL_COUNT] = source.getCount();
 }
 
 EvidenceCountTruthValue::EvidenceCountTruthValue(EvidenceCountTruthValue const& source)
 	: TruthValue(EVIDENCE_COUNT_TRUTH_VALUE)
 {
-	_pos_count = source._pos_count;
-	_total_count = source._total_count;
+	_value[POS_COUNT] = source.getPositiveCount();
+	_value[TOTAL_COUNT] = source.getCount();
 }
 
 strength_t EvidenceCountTruthValue::getMean() const
 {
 	if (is_count_valid())
-		return _pos_count / _total_count;
+		return getPositiveCount() / getCount();
 	return NAN;
 }
 
 count_t EvidenceCountTruthValue::getPositiveCount() const
 {
-	return _pos_count;
+	return _value[POS_COUNT];
 }
 
 count_t EvidenceCountTruthValue::getCount() const
 {
-	return _total_count;
+	return _value[TOTAL_COUNT];
 }
 
 confidence_t EvidenceCountTruthValue::getConfidence() const
 {
 	if (is_count_valid())
-		return _total_count / (DEFAULT_K + _total_count);
+		return _value[TOTAL_COUNT] / (DEFAULT_K + _value[TOTAL_COUNT]);
 	return NAN;
 }
 
 bool EvidenceCountTruthValue::is_count_valid() const
 {
-	return _pos_count <= _total_count;
+	return _value[POS_COUNT] <= _value[TOTAL_COUNT];
 }
 
 // This is the merge formula appropriate for PLN.
@@ -130,8 +130,8 @@ std::string EvidenceCountTruthValue::toString(const std::string& indent) const
 {
 	char buf[1024];
 	sprintf(buf, "(ectv %f %f)",
-	        static_cast<float>(_pos_count),
-	        static_cast<float>(_total_count));
+	        static_cast<float>(_value[POS_COUNT]),
+	        static_cast<float>(_value[TOTAL_COUNT]));
 	return buf;
 }
 
@@ -147,8 +147,8 @@ bool EvidenceCountTruthValue::operator==(const ProtoAtom& rhs) const
 	};
 #undef FLOAT_ACCEPTABLE_ERROR
 
-	return close_enough(_pos_count, ectv->_pos_count)
+	return close_enough(getPositiveCount(), ectv->getPositiveCount())
 		and is_count_valid() == ectv->is_count_valid()
 		and (!is_count_valid() or
-		     close_enough(_total_count, ectv->_total_count));
+		     close_enough(getCount(), ectv->getCount()));
 }

--- a/opencog/truthvalue/EvidenceCountTruthValue.h
+++ b/opencog/truthvalue/EvidenceCountTruthValue.h
@@ -40,13 +40,12 @@ typedef std::shared_ptr<EvidenceCountTruthValue> EvidenceCountTruthValuePtr;
 class EvidenceCountTruthValue : public TruthValue
 {
 protected:
+   enum {
+		POS_COUNT, /// Positive evidence count, i.e. number of
+		           /// observations corroborating with the atom's truth.
 
-	/// Positive evidence count, i.e. number of observations
-	/// corroborating with the atom's truth.
-	count_t _pos_count;
-
-	/// Total number of observations.
-	count_t _total_count;
+		TOTAL_COUNT /// Total number of observations.
+   };
 
 public:
 	EvidenceCountTruthValue(count_t pos_count, count_t total_count = -1);

--- a/opencog/truthvalue/FuzzyTruthValue.cc
+++ b/opencog/truthvalue/FuzzyTruthValue.cc
@@ -1,5 +1,5 @@
 /*
- * opencog/atomspace/FuzzyTruthValue.cc
+ * opencog/truthvalue/FuzzyTruthValue.cc
  *
  * Copyright (C) 2002-2007 Novamente LLC
  * All Rights Reserved
@@ -32,44 +32,44 @@
 
 #include "FuzzyTruthValue.h"
 
-//#define DPRINTF printf
-#define DPRINTF(...)
-
 using namespace opencog;
 
 FuzzyTruthValue::FuzzyTruthValue(strength_t m, count_t c)
 	: TruthValue(FUZZY_TRUTH_VALUE)
 {
-    mean = m;
-    count = c;
+    _value.resize(2);
+    _value[MEAN] = m;
+    _value[COUNT] = c;
 }
 
 FuzzyTruthValue::FuzzyTruthValue(const TruthValue& source)
 	: TruthValue(FUZZY_TRUTH_VALUE)
 {
-    mean = source.getMean();
-    count = source.getCount();
+    _value.resize(2);
+    _value[MEAN] = source.getMean();
+    _value[COUNT] = source.getCount();
 }
 FuzzyTruthValue::FuzzyTruthValue(FuzzyTruthValue const& source)
 	: TruthValue(FUZZY_TRUTH_VALUE)
 {
-    mean = source.mean;
-    count = source.count;
+    _value.resize(2);
+    _value[MEAN] = source.getMean();
+    _value[COUNT] = source.getCount();
 }
 
 strength_t FuzzyTruthValue::getMean() const
 {
-    return mean;
+    return _value[MEAN];
 }
 
 count_t FuzzyTruthValue::getCount() const
 {
-    return count;
+    return _value[COUNT];
 }
 
 confidence_t FuzzyTruthValue::getConfidence() const
 {
-    return countToConfidence(count);
+    return countToConfidence(getCount());
 }
 
 // This is the merge formula appropriate for PLN.
@@ -103,7 +103,7 @@ bool FuzzyTruthValue::operator==(const ProtoAtom& rhs) const
     if (NULL == stv) return false;
 
 #define FLOAT_ACCEPTABLE_MEAN_ERROR 0.000001
-    if (FLOAT_ACCEPTABLE_MEAN_ERROR < fabs(mean - stv->mean)) return false;
+    if (FLOAT_ACCEPTABLE_MEAN_ERROR < fabs(getMean() - stv->getMean())) return false;
 
 // Converting from confidence to count and back again using single-precision
 // float is a real accuracy killer.  In particular, 2/802 = 0.002494 but
@@ -112,7 +112,7 @@ bool FuzzyTruthValue::operator==(const ProtoAtom& rhs) const
 // thereabouts.
 #define FLOAT_ACCEPTABLE_COUNT_ERROR 0.0002
 
-    if (FLOAT_ACCEPTABLE_COUNT_ERROR < fabs(1.0 - (stv->count/count))) return false;
+    if (FLOAT_ACCEPTABLE_COUNT_ERROR < fabs(1.0 - (stv->getCount()/getCount()))) return false;
     return true;
 }
 

--- a/opencog/truthvalue/FuzzyTruthValue.h
+++ b/opencog/truthvalue/FuzzyTruthValue.h
@@ -38,16 +38,15 @@ namespace opencog
 class FuzzyTruthValue;
 typedef std::shared_ptr<FuzzyTruthValue> FuzzyTruthValuePtr;
 
-//! a TruthValue that stores a mean and the number of observations (strength and confidence)
+//! A TruthValue that stores a mean and the number of observations
+//! (strength and confidence)
 class FuzzyTruthValue : public TruthValue
 {
 protected:
-
-    /// Mean of the strength of the TV over all observations
-    strength_t mean;
-
-    /// Total number of observations used to estimate the mean 
-    count_t count;
+    enum {
+        MEAN, /// Mean of the strength of the TV over all observations
+        COUNT /// Total number of observations used to estimate the mean
+    };
 
     void init(strength_t mean, count_t count);
 

--- a/opencog/truthvalue/GenericTruthValue.cc
+++ b/opencog/truthvalue/GenericTruthValue.cc
@@ -34,88 +34,90 @@ GenericTruthValue::GenericTruthValue(count_t pe, count_t te,
                                      confidence_t c, entropy_t e)
 	: TruthValue(GENERIC_TRUTH_VALUE)
 {
-    positiveEvidence = pe;
-    totalEvidence = te;
-    frequency = f;
-    fuzzyStrength = fs;
-    confidence = c;
-    entropy = e;
+    _value.resize(6);
+    _value[POSITIVE_EVIDENCE] = pe;
+    _value[TOTAL_EVIDENCE] = te;
+    _value[FREQUENCY] = f;
+    _value[FUZZY_STRENGTH] = fs;
+    _value[CONFIDENCE] = c;
+    _value[ENTROPY] = e;
 }
 
 GenericTruthValue::GenericTruthValue(GenericTruthValue const& gtv)
 	: TruthValue(GENERIC_TRUTH_VALUE)
 {
-    positiveEvidence = gtv.positiveEvidence;
-    totalEvidence = gtv.totalEvidence;
-    frequency = gtv.frequency;
-    fuzzyStrength = gtv.fuzzyStrength;
-    confidence = gtv.confidence;
-    entropy = gtv.entropy;
+    _value.resize(6);
+    _value[POSITIVE_EVIDENCE] = gtv.getPositiveEvidence();
+    _value[TOTAL_EVIDENCE] = gtv.getTotalEvidence();
+    _value[FREQUENCY] = gtv.getFrequency();
+    _value[FUZZY_STRENGTH] = gtv.getFuzzyStrength();
+    _value[CONFIDENCE] = gtv.getConfidence();
+    _value[ENTROPY] = gtv.getEntropy();
 }
 
 count_t GenericTruthValue::getCount() const
 {
-    return frequency;
+    return _value[FREQUENCY];
 }
 
 confidence_t GenericTruthValue::getConfidence() const
 {
-    return confidence;
+    return _value[CONFIDENCE];
 }
 
 strength_t GenericTruthValue::getMean() const
 {
-    return totalEvidence;
+    return _value[TOTAL_EVIDENCE];
 }
 
 count_t GenericTruthValue::getPositiveEvidence() const
 {
-    return positiveEvidence;
+    return _value[POSITIVE_EVIDENCE];
 }
 
 count_t GenericTruthValue::getLogPositiveEvidence() const
 {
-    return log(positiveEvidence);
+    return log(_value[POSITIVE_EVIDENCE]);
 }
 
 count_t GenericTruthValue::getTotalEvidence() const
 {
-    return totalEvidence;
+    return _value[TOTAL_EVIDENCE];
 }
 
 count_t GenericTruthValue::getLogTotalEvidence() const
 {
-    return log(totalEvidence);
+    return log(_value[TOTAL_EVIDENCE]);
 }
 
 strength_t GenericTruthValue::getFrequency() const
 {
-    return frequency;
+    return _value[FREQUENCY];
 }
 
 strength_t GenericTruthValue::getLogFrequency() const
 {
-    return log(frequency);
+    return log(_value[FREQUENCY]);
 }
 
 strength_t GenericTruthValue::getFuzzyStrength() const
 {
-    return fuzzyStrength;
+    return _value[FUZZY_STRENGTH];
 }
 
 strength_t GenericTruthValue::getLogFuzzyStrength() const
 {
-    return log(fuzzyStrength);
+    return log(_value[FUZZY_STRENGTH]);
 }
 
 confidence_t GenericTruthValue::getLogConfidence() const
 {
-    return log(confidence);
+    return log(_value[CONFIDENCE]);
 }
 
 entropy_t GenericTruthValue::getEntropy() const
 {
-    return entropy;
+    return _value[ENTROPY];
 }
 
 TruthValuePtr GenericTruthValue::merge(TruthValuePtr tv, const MergeCtrl& mc) const
@@ -123,16 +125,16 @@ TruthValuePtr GenericTruthValue::merge(TruthValuePtr tv, const MergeCtrl& mc) co
     GenericTruthValuePtr gtv = std::dynamic_pointer_cast<const GenericTruthValue>(tv);
     if (NULL == gtv) return tv;
     auto other_te = gtv->getTotalEvidence();
-    auto new_pe = positiveEvidence + gtv->getPositiveEvidence();
-    auto new_te = totalEvidence + other_te
-                  - std::min(totalEvidence, other_te) * CVAL;
-    auto new_f = (frequency * totalEvidence + gtv->getFrequency() * other_te)
-                 / (totalEvidence + other_te);
-    auto new_fs = std::max(fuzzyStrength, gtv->getFuzzyStrength());
+    auto new_pe = getPositiveEvidence() + gtv->getPositiveEvidence();
+    auto new_te = getTotalEvidence() + other_te
+                  - std::min(getTotalEvidence(), other_te) * CVAL;
+    auto new_f = (getFrequency() * getTotalEvidence() + gtv->getFrequency() * other_te)
+                 / (getTotalEvidence() + other_te);
+    auto new_fs = std::max(getFuzzyStrength(), gtv->getFuzzyStrength());
     auto new_c = new_te / (new_te + KKK);
 
     // XXX
-    auto new_e = std::max(entropy, gtv->getEntropy());
+    auto new_e = std::max(getEntropy(), gtv->getEntropy());
 
     return std::make_shared<GenericTruthValue>(new_pe, new_te, new_f, new_fs,
                                                new_c, new_e);
@@ -145,19 +147,19 @@ bool GenericTruthValue::operator==(const ProtoAtom& rhs) const
     if (NULL == gtv) return false;
 
 #define FLOAT_ACCEPTABLE_ERROR 0.000001
-    if (FLOAT_ACCEPTABLE_ERROR < fabs(frequency - gtv->frequency))
+    if (FLOAT_ACCEPTABLE_ERROR < fabs(getFrequency() - gtv->getFrequency()))
         return false;
-    if (FLOAT_ACCEPTABLE_ERROR < fabs(fuzzyStrength - gtv->fuzzyStrength))
+    if (FLOAT_ACCEPTABLE_ERROR < fabs(getFuzzyStrength() - gtv->getFuzzyStrength()))
         return false;
-    if (FLOAT_ACCEPTABLE_ERROR < fabs(confidence - gtv->confidence))
+    if (FLOAT_ACCEPTABLE_ERROR < fabs(getConfidence() - gtv->getConfidence()))
         return false;
 
 #define DOUBLE_ACCEPTABLE_ERROR 1.0e-14
-    if (DOUBLE_ACCEPTABLE_ERROR < fabs(1.0 - (gtv->positiveEvidence/positiveEvidence)))
+    if (DOUBLE_ACCEPTABLE_ERROR < fabs(1.0 - (gtv->getPositiveEvidence()/getPositiveEvidence())))
         return false;
-    if (DOUBLE_ACCEPTABLE_ERROR < fabs(1.0 - (gtv->totalEvidence/totalEvidence)))
+    if (DOUBLE_ACCEPTABLE_ERROR < fabs(1.0 - (gtv->getTotalEvidence()/getTotalEvidence())))
         return false;
-    if (DOUBLE_ACCEPTABLE_ERROR < fabs(1.0 - (gtv->entropy/entropy)))
+    if (DOUBLE_ACCEPTABLE_ERROR < fabs(1.0 - (gtv->getEntropy()/getEntropy())))
         return false;
 
     return true;

--- a/opencog/truthvalue/GenericTruthValue.h
+++ b/opencog/truthvalue/GenericTruthValue.h
@@ -25,7 +25,6 @@
 #define _OPENCOG_GENERIC_TRUTH_VALUE_H
 
 #include <string>
-#include <memory>
 
 #include <opencog/util/exceptions.h>
 #include <opencog/truthvalue/TruthValue.h>
@@ -90,21 +89,14 @@ class GenericTruthValue : public TruthValue
         std::string toString(const std::string&) const;
 
     protected:
-        count_t positiveEvidence;
-
-        // PLN count
-        count_t totalEvidence;
-
-        // Probabilistic strength
-        strength_t frequency;
-
-        // Fuzzy set membership strength
-        strength_t fuzzyStrength;
-
-        confidence_t confidence;
-
-        entropy_t entropy;
-
+        enum {
+            POSITIVE_EVIDENCE,
+            TOTAL_EVIDENCE, // PLN count
+            FREQUENCY, // Probabilistic strength
+            FUZZY_STRENGTH, // Fuzzy set membership strength
+            CONFIDENCE,
+            ENTROPY
+        };
 };
 } // namespace opencog
 

--- a/opencog/truthvalue/IndefiniteTruthValue.cc
+++ b/opencog/truthvalue/IndefiniteTruthValue.cc
@@ -75,6 +75,7 @@ static strength_t DensityIntegral(strength_t lower, strength_t upper,
 
 void IndefiniteTruthValue::init(strength_t l, strength_t u, confidence_t c)
 {
+    _value.resize(4);
     _value[L] = l;
     _value[U] = u;
     _value[CONFIDENCE_LEVEL] = c;

--- a/opencog/truthvalue/IndefiniteTruthValue.h
+++ b/opencog/truthvalue/IndefiniteTruthValue.h
@@ -49,10 +49,12 @@ static inline IndefiniteTruthValuePtr IndefiniteTVCast(TruthValuePtr tv)
 class IndefiniteTruthValue : public TruthValue
 {
 private:
-
-    strength_t U;
-    strength_t L;
-    confidence_t confidenceLevel; //!< referred as "b" in the paper
+    enum {
+        MEAN,
+        U,
+        L,
+        CONFIDENCE_LEVEL //!< referred as "b" in the paper
+    };
     bool symmetric;
 
     //! used in inference rule procedure in order to compute L1 and U1
@@ -69,7 +71,6 @@ private:
      * is correct
 	 */
 	///@{
-    strength_t mean;
     count_t count;
     confidence_t confidence;
 	///@}
@@ -92,17 +93,17 @@ public:
     //! it is a strict equality comparison, without error interval tolerance
     virtual bool operator==(const ProtoAtom&) const;
 
-    strength_t getMean() const { return mean; }
-    strength_t getU() const { return U; }
-    strength_t getL() const { return L; }
-    confidence_t getConfidenceLevel() const { return confidenceLevel; }
+    strength_t getMean() const { return _value[MEAN]; }
+    strength_t getU() const { return _value[U]; }
+    strength_t getL() const { return _value[L]; }
+    confidence_t getConfidenceLevel() const { return _value[CONFIDENCE_LEVEL]; }
     strength_t getDiff() const { return diff; }
     const std::vector<strength_t*>& getFirstOrderDistribution() const;
 
     count_t getCount() const { return count; }
     confidence_t getConfidence() const { return confidence; }
-    strength_t getU_() const { return U + diff; }
-    strength_t getL_() const { return L - diff; }
+    strength_t getU_() const { return _value[U] + diff; }
+    strength_t getL_() const { return _value[L] - diff; }
     bool isSymmetric() const { return symmetric; }
 
     TruthValuePtr merge(TruthValuePtr,

--- a/opencog/truthvalue/IndefiniteTruthValue.h
+++ b/opencog/truthvalue/IndefiniteTruthValue.h
@@ -26,7 +26,6 @@
 #ifndef _OPENCOG_INDEFINITE_TRUTH_VALUE_H
 #define _OPENCOG_INDEFINITE_TRUTH_VALUE_H
 
-#include <memory>
 #include <vector>
 
 #include <opencog/truthvalue/TruthValue.h>

--- a/opencog/truthvalue/ProbabilisticTruthValue.cc
+++ b/opencog/truthvalue/ProbabilisticTruthValue.cc
@@ -22,55 +22,57 @@
  * along with this program; if not, write to:
  * Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
- *
  */
-
-#include "ProbabilisticTruthValue.h"
 
 #include <math.h>
 
 #include <opencog/util/platform.h>
 #include <opencog/util/exceptions.h>
 
+#include <opencog/atoms/base/atom_types.h>
+#include "ProbabilisticTruthValue.h"
+
 using namespace opencog;
 
 ProbabilisticTruthValue::ProbabilisticTruthValue(strength_t m, confidence_t n, count_t c)
 	: TruthValue(PROBABILISTIC_TRUTH_VALUE)
 {
-    mean = m;
-    confidence = n;
-    count = c;
+    _value.resize(3);
+    _value[MEAN] = m;
+    _value[CONFIDENCE] = n;
+    _value[COUNT] = c;
 }
 
 ProbabilisticTruthValue::ProbabilisticTruthValue(const TruthValue& source)
 	: TruthValue(PROBABILISTIC_TRUTH_VALUE)
 {
-    mean = source.getMean();
-    confidence = source.getConfidence();
-    count = source.getCount();
+    _value.resize(3);
+    _value[MEAN] = source.getMean();
+    _value[CONFIDENCE] = source.getConfidence();
+    _value[COUNT] = source.getCount();
 }
-
 ProbabilisticTruthValue::ProbabilisticTruthValue(ProbabilisticTruthValue const& source)
 	: TruthValue(PROBABILISTIC_TRUTH_VALUE)
 {
-    mean = source.mean;
-    confidence = source.confidence;
-    count = source.count;
+    _value.resize(3);
+    _value[MEAN] = source.getMean();
+    _value[CONFIDENCE] = source.getConfidence();
+    _value[COUNT] = source.getCount();
 }
 
 strength_t ProbabilisticTruthValue::getMean() const
 {
-    return mean;
+    return _value[MEAN];
 }
 
 count_t ProbabilisticTruthValue::getCount() const
 {
-    return count;
+    return  _value[COUNT];
 }
 
 confidence_t ProbabilisticTruthValue::getConfidence() const
 {
-    return confidence;
+    return _value[CONFIDENCE];
 }
 
 std::string ProbabilisticTruthValue::toString(const std::string& indent) const
@@ -89,10 +91,10 @@ bool ProbabilisticTruthValue::operator==(const ProtoAtom& rhs) const
     if (NULL == ctv) return false;
 
 #define FLOAT_ACCEPTABLE_ERROR 0.000001
-    if (FLOAT_ACCEPTABLE_ERROR < fabs(mean - ctv->mean)) return false;
-    if (FLOAT_ACCEPTABLE_ERROR < fabs(confidence - ctv->confidence)) return false;
+    if (FLOAT_ACCEPTABLE_ERROR < fabs(getMean() - ctv->getMean())) return false;
+    if (FLOAT_ACCEPTABLE_ERROR < fabs(getConfidence() - ctv->getConfidence())) return false;
 #define DOUBLE_ACCEPTABLE_ERROR 1.0e-14
-    if (DOUBLE_ACCEPTABLE_ERROR < fabs(1.0 - (ctv->count/count))) return false;
+    if (DOUBLE_ACCEPTABLE_ERROR < fabs(1.0 - (ctv->getCount()/getCount()))) return false;
 
     return true;
 }
@@ -101,7 +103,7 @@ bool ProbabilisticTruthValue::operator==(const ProtoAtom& rhs) const
 // because the ProbabilisticTruthValue usally stores an integer count,
 // and a log-probability or entropy, instead of a confidence.
 TruthValuePtr ProbabilisticTruthValue::merge(TruthValuePtr other,
-                                             const MergeCtrl& mc) const
+                                     const MergeCtrl& mc) const
 {
     ProbabilisticTruthValuePtr oc =
         std::dynamic_pointer_cast<const ProbabilisticTruthValue>(other);
@@ -111,24 +113,24 @@ TruthValuePtr ProbabilisticTruthValue::merge(TruthValuePtr other,
     // value with a count of 1?  In which case, we should add a merge
     // routine to SimpleTruthValue to do likewise... Anyway, for now,
     // just ignore this possible complication to the semantics.
-    if (NULL == oc)
-         return std::dynamic_pointer_cast<const TruthValue>(shared_from_this());
-    
-    // If both this and other are counts, then accumulate to get the
-    // total count, and average together the strengths, using the 
-    // count as the relative weight.
-    count_t cnt = count + oc->count;
-    strength_t meeny = (this->mean * this->count +
-                   oc->mean * oc->count) / cnt;
+    if (NULL == oc) return
+        std::dynamic_pointer_cast<const TruthValue>(shared_from_this());
 
-    // XXX This is not the correct way to handle confidence ... 
+    // If both this and other are counts, then accumulate to get the
+    // total count, and average together the strengths, using the
+    // count as the relative weight.
+    count_t cnt =  getCount() + oc->getCount();
+    strength_t meeny = (getMean() * getCount() +
+                   oc->getMean() * oc->getCount()) / cnt;
+
+    // XXX This is not the correct way to handle confidence ...
     // The confidence will typically hold the log probability,
     // where the probability is the normalized count.  Thus
     // the right thing to do is probably to add the probabilities!?
     // However, this is not correct when the confidence is actually
-    // holding the mutual information ... which is additive ... 
+    // holding the mutual information ... which is additive ...
     // Argh .. what to do?
     //    confidence = oc->confidence;
-    
-    return createTV(meeny, this->confidence, cnt);
+
+    return createTV(meeny, getConfidence(), cnt);
 }

--- a/opencog/truthvalue/ProbabilisticTruthValue.cc
+++ b/opencog/truthvalue/ProbabilisticTruthValue.cc
@@ -1,5 +1,5 @@
 /*
- * opencog/atomspace/ProbabilisticTruthValue.cc
+ * opencog/truthvalue/ProbabilisticTruthValue.cc
  *
  * Copyright (C) 2002-2007 Novamente LLC
  * All Rights Reserved

--- a/opencog/truthvalue/ProbabilisticTruthValue.h
+++ b/opencog/truthvalue/ProbabilisticTruthValue.h
@@ -42,10 +42,11 @@ typedef std::shared_ptr<const ProbabilisticTruthValue> ProbabilisticTruthValuePt
 class ProbabilisticTruthValue : public TruthValue
 {
 protected:
-
-    strength_t mean;
-    confidence_t confidence;
-    count_t count;
+    enum {
+        MEAN, /// Mean of the strength of the TV over all observations.
+        CONFIDENCE, /// Estimate of confidence of the observation.
+        COUNT /// Raw count
+    };
 
 public:
 

--- a/opencog/truthvalue/SimpleTruthValue.cc
+++ b/opencog/truthvalue/SimpleTruthValue.cc
@@ -40,46 +40,48 @@ using namespace opencog;
 SimpleTruthValue::SimpleTruthValue(strength_t m, confidence_t c)
 	: TruthValue(SIMPLE_TRUTH_VALUE)
 {
-    _mean = m;
-    _confidence = c;
+    _value.resize(2);
+    _value[MEAN] = m;
+    _value[CONFIDENCE] = c;
 }
 
 SimpleTruthValue::SimpleTruthValue(const TruthValue& source)
 	: TruthValue(SIMPLE_TRUTH_VALUE)
 {
-    _mean = source.getMean();
-    _confidence = source.getConfidence();
+    _value.resize(2);
+    _value[MEAN] = source.getMean();
+    _value[CONFIDENCE] = source.getConfidence();
 }
 
 SimpleTruthValue::SimpleTruthValue(SimpleTruthValue const& source)
 	: TruthValue(SIMPLE_TRUTH_VALUE)
 {
-    _mean = source._mean;
-    _confidence = source._confidence;
+    _value[MEAN] = source._value[MEAN];
+    _value[CONFIDENCE] = source._value[CONFIDENCE];
 }
 
 strength_t SimpleTruthValue::getMean() const
 {
-    return _mean;
+    return _value[MEAN];
 }
 
 count_t SimpleTruthValue::getCount() const
 {
     // Formula from PLN book.
-    confidence_t cf = std::min(_confidence, 0.9999998f);
+    confidence_t cf = std::min(_value[CONFIDENCE], 0.9999998);
     return static_cast<count_t>(DEFAULT_K * cf / (1.0f - cf));
 }
 
 confidence_t SimpleTruthValue::getConfidence() const
 {
-    return _confidence;
+    return _value[CONFIDENCE];
 }
 
 // This is the merge formula appropriate for PLN.
 TruthValuePtr SimpleTruthValue::merge(TruthValuePtr other,
                                       const MergeCtrl& mc) const
 {
-    switch(mc.tv_formula)
+    switch (mc.tv_formula)
     {
         case MergeCtrl::TVFormula::HIGHER_CONFIDENCE:
             return higher_confidence_merge(other);
@@ -126,8 +128,8 @@ bool SimpleTruthValue::operator==(const ProtoAtom& rhs) const
     if (NULL == stv) return false;
 
 #define FLOAT_ACCEPTABLE_ERROR 0.000001
-    if (FLOAT_ACCEPTABLE_ERROR < fabs(_mean - stv->_mean)) return false;
+    if (FLOAT_ACCEPTABLE_ERROR < fabs(_value[MEAN] - stv->_value[MEAN])) return false;
 
-    if (FLOAT_ACCEPTABLE_ERROR < fabs(_confidence - stv->_confidence)) return false;
+    if (FLOAT_ACCEPTABLE_ERROR < fabs(_value[CONFIDENCE] - stv->_value[CONFIDENCE])) return false;
     return true;
 }

--- a/opencog/truthvalue/SimpleTruthValue.cc
+++ b/opencog/truthvalue/SimpleTruthValue.cc
@@ -56,6 +56,7 @@ SimpleTruthValue::SimpleTruthValue(const TruthValue& source)
 SimpleTruthValue::SimpleTruthValue(SimpleTruthValue const& source)
 	: TruthValue(SIMPLE_TRUTH_VALUE)
 {
+    _value.resize(2);
     _value[MEAN] = source._value[MEAN];
     _value[CONFIDENCE] = source._value[CONFIDENCE];
 }

--- a/opencog/truthvalue/SimpleTruthValue.cc
+++ b/opencog/truthvalue/SimpleTruthValue.cc
@@ -1,5 +1,5 @@
 /*
- * opencog/atomspace/SimpleTruthValue.cc
+ * opencog/truthvalue/SimpleTruthValue.cc
  *
  * Copyright (C) 2002-2007 Novamente LLC
  * All Rights Reserved

--- a/opencog/truthvalue/SimpleTruthValue.h
+++ b/opencog/truthvalue/SimpleTruthValue.h
@@ -42,12 +42,10 @@ typedef std::shared_ptr<SimpleTruthValue> SimpleTruthValuePtr;
 class SimpleTruthValue : public TruthValue
 {
 protected:
-
-    /// Mean of the strength of the TV over all observations.
-    strength_t _mean;
-
-    /// Estimate of confidence of the observation.
-    confidence_t _confidence;
+    enum {
+        MEAN, /// Mean of the strength of the TV over all observations.
+        CONFIDENCE /// Estimate of confidence of the observation.
+    };
 
 public:
     SimpleTruthValue(strength_t, confidence_t);

--- a/opencog/truthvalue/TruthValue.h
+++ b/opencog/truthvalue/TruthValue.h
@@ -112,7 +112,7 @@ public:
     TruthValue(Type t) : FloatValue(t) {}
     virtual ~TruthValue() {}
 
-    std::string toShortString(const std::string&) const;
+    virtual std::string toShortString(const std::string& = "") const;
 
     // Special TVs
 

--- a/opencog/truthvalue/TruthValue.h
+++ b/opencog/truthvalue/TruthValue.h
@@ -31,7 +31,7 @@
 #include <vector>
 
 #include <opencog/util/exceptions.h>
-#include <opencog/atoms/base/ProtoAtom.h>
+#include <opencog/atoms/base/FloatValue.h>
 
 /** \addtogroup grp_atomspace
  *  @{
@@ -90,7 +90,7 @@ class TruthValue;
 typedef std::shared_ptr<const TruthValue> TruthValuePtr;
 
 class TruthValue
-    : public ProtoAtom
+    : public FloatValue
 {
     friend class Atom;
 
@@ -109,7 +109,7 @@ public:
         DEFAULT_K = k;
     }
 
-    TruthValue(Type t) : ProtoAtom(t) {}
+    TruthValue(Type t) : FloatValue(t) {}
     virtual ~TruthValue() {}
 
     std::string toShortString(const std::string&) const;

--- a/opencog/truthvalue/TruthValue.h
+++ b/opencog/truthvalue/TruthValue.h
@@ -112,7 +112,7 @@ public:
     TruthValue(Type t) : FloatValue(t) {}
     virtual ~TruthValue() {}
 
-    virtual std::string toShortString(const std::string& = "") const;
+    virtual std::string toShortString(const std::string&) const;
 
     // Special TVs
 

--- a/tests/atomspace/ValuationTableUTest.cxxtest
+++ b/tests/atomspace/ValuationTableUTest.cxxtest
@@ -67,10 +67,32 @@ public:
 
 		ProtoAtomPtr fvalue(createFloatValue(2.222));
 
+		// Place a valuation in the table.
 		vtable->addValuation(key, blah, fvalue);
 
+		// Get it back, and make sure that its equal to what we put in.
 		ProtoAtomPtr fetch = vtable->getValue(key, blah);
 
 		TS_ASSERT_EQUALS(fvalue, fetch);
+	}
+
+	void testKeyset()
+	{
+		Handle ka = space->add_node(CONCEPT_NODE, "The F Key");
+		Handle kb = space->add_node(CONCEPT_NODE, "The G Key");
+		Handle kc = space->add_node(CONCEPT_NODE, "The H Key");
+		Handle blah = space->add_node(CONCEPT_NODE, "Hi Mom!");
+
+		ProtoAtomPtr fvalue(createFloatValue(2.222));
+		vtable->addValuation(ka, blah, fvalue);
+		vtable->addValuation(kb, blah, fvalue);
+		vtable->addValuation(kc, blah, fvalue);
+
+		std::set<Handle> keys = vtable->getKeys(blah);
+
+		TS_ASSERT_EQUALS(3, keys.size());
+		TS_ASSERT(keys.end() != keys.find(ka));
+		TS_ASSERT(keys.end() != keys.find(kb));
+		TS_ASSERT(keys.end() != keys.find(kc));
 	}
 };

--- a/tests/persist/sql/README.md
+++ b/tests/persist/sql/README.md
@@ -72,12 +72,12 @@ To run these tests, perform the following steps:
 ```
     opencog_test=> \d
                   List of relations
-     Schema |   Name    | Type  |     Owner
-    --------+-----------+-------+----------------
-     public | atoms     | table | opencog_tester
-     public | edges     | table | opencog_tester
-     public | global    | table | opencog_tester
-     public | typecodes | table | opencog_tester
+     Schema |    Name    | Type  |     Owner
+    --------+------------+-------+----------------
+     public | atoms      | table | opencog_tester
+     public | spaces     | table | opencog_tester
+     public | typecodes  | table | opencog_tester
+     public | valuations | table | opencog_tester
     (4 rows)
 ```
     If the above doesn't work, go back, and try again.
@@ -132,17 +132,35 @@ To run these tests, perform the following steps:
 3) Run the four test cases:
 
 ```
-   $ ./tests/persist/sql/BasicSaveUTest
-   $ ./tests/persist/sql/PersistUTest
-   $ ./tests/persist/sql/MultiPersistUTest
-   $ ./tests/persist/sql/FetchUTest
+   $ ./tests/persist/sql/multi-driver/BasicSaveUTest
+   $ ./tests/persist/sql/multi-driver/PersistUTest
+   $ ./tests/persist/sql/multi-driver/MultiPersistUTest
+   $ ./tests/persist/sql/multi-driver/FetchUTest
 ```
-   It should print OK! at the end, if all tests passed.
+   It should print `OK!` at the end, if all tests passed.
 
-3a) If the above doesn't work, note that the `lib/atomspace-test.conf`
+3a) If the above gives the message
+```
+    Error: Test failed: Cannot connect to database: FATAL:  Peer authentication failed for user "opencog_tester"
+```
+    then edit
+```
+    /etc/postgresql/9.3/main/pg_hba.conf
+```
+    and add the line
+```
+    local   all      all           md5
+```
+    Be sure to reload or restart the postgres server after the above change:
+```
+   service postgresql reload
+```
+
+
+3b) If the above doesn't work, note that the `lib/atomspace-test.conf`
     being used is the one in the BUILD directory not the SOURCE directory!
 
-3b) If the above still doesn't work, make sure that postgres is actually
+3c) If the above still doesn't work, make sure that postgres is actually
     listening on port 5432, and not some other port.  If it is using a
     different port, and testing ODBC, then change `~/.odbc.ini` to that.
     The postgres config can be found in


### PR DESCRIPTION
Truth values now derive from FloatValue, with is a vector of double-precision floats.

This change simplifies the save/restore of truth-values: they all get handled as vectors.

Also, some initial work for sql persistance of any kind of values.  This is all a part of the ongoing work to fulfill #513 