### PR TITLE
Ongoing work to implement ProtoAtoms in SQL

### DIFF
--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -193,6 +193,12 @@ ProtoAtomPtr Atom::getValue(const Handle& key)
     return _atom_space->_value_table.getValue(key, getHandle());
 }
 
+std::set<Handle> Atom::getKeys()
+{
+    if (nullptr == _atom_space) return std::set<Handle>();
+    return _atom_space->_value_table.getKeys(getHandle());
+}
+
 // ==============================================================
 // Flag stuff
 bool Atom::isMarkedForRemoval() const

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -239,6 +239,8 @@ public:
     void setValue(const Handle& key, ProtoAtomPtr& value);
     ProtoAtomPtr getValue(const Handle& key);
 
+    /// Get the set of all keys in use for this Atom.
+    std::set<Handle> getKeys();
 
     //! Get the size of the incoming set.
     size_t getIncomingSetSize() const;

--- a/opencog/atomspace/ValuationTable.cc
+++ b/opencog/atomspace/ValuationTable.cc
@@ -55,8 +55,7 @@ void ValuationTable::addValuation(ValuationPtr& vp)
 	}
 
 	// Record the actual valuation
-	_vindex.insert(std::make_pair(
-		std::make_pair(key, atom), vp));
+	_vindex[std::make_pair(key, atom)] = vp;
 }
 
 /// Associate a value with a particular (key,atom) pair

--- a/opencog/atomspace/ValuationTable.h
+++ b/opencog/atomspace/ValuationTable.h
@@ -37,6 +37,11 @@ namespace opencog
 
 /**
  * This class provides a mechanism to store valuations for atoms.
+ * XXX FIXME:  An alternative sould be to store values directly
+ * with each atom. That would make access to values faster, but
+ * some number of bytes in each atom, to hold the needed map.
+ * Not clear which is preferale, at this point.  RAM is cheap,
+ * CPU cycles are harder to get. Hmmmm.
  */
 class ValuationTable
 {

--- a/opencog/persist/sql/README.md
+++ b/opencog/persist/sql/README.md
@@ -1063,6 +1063,7 @@ TODO
    `postgres-dead`, and design something from scratch.
 
  * Store ProtoAtoms. Work is underway, see issue #513 for progress.
+   Right now, its not thread-safe.... vuid issuance is not thread-safe.
 
  * Current implementation leaks in the Values table, when the values
    are changed. This is a bug, needs fixing.

--- a/opencog/persist/sql/README.md
+++ b/opencog/persist/sql/README.md
@@ -1063,10 +1063,7 @@ TODO
    `postgres-dead`, and design something from scratch.
 
  * Store ProtoAtoms. Work is underway, see issue #513 for progress.
-   Right now, its not thread-safe.... see FIXME in valuationExists
-
- * Current implementation leaks in the Values table, when the values
-   are changed. This is a bug, needs fixing.
+   Right now, its not thread-safe....
 
  * Consider an alternate implementation, using JSONB to do an EAV-like
    storage: For details, see

--- a/opencog/persist/sql/README.md
+++ b/opencog/persist/sql/README.md
@@ -1057,10 +1057,15 @@ TODO
 ====
  * See also to-do list way up top.
 
- * Finish and document the non-ODBC PGSQL interfaces. Explain why this
-   is better.
+ * Implement the large-outgoing-set extension. A version of this can be
+   found in the `postgres-dead` directory, but the code there is badly
+   broken. Its probably simplest to just ignore the code in
+   `postgres-dead`, and design something from scratch.
 
- * Store ProtoAtoms
+ * Store ProtoAtoms. Work is underway, see issue #513 for progress.
+
+ * Current implementation leaks in the Values table, when the values
+   are changed. This is a bug, needs fixing.
 
  * Consider an alternate implementation, using JSONB to do an EAV-like
    storage: For details, see

--- a/opencog/persist/sql/README.md
+++ b/opencog/persist/sql/README.md
@@ -1063,7 +1063,7 @@ TODO
    `postgres-dead`, and design something from scratch.
 
  * Store ProtoAtoms. Work is underway, see issue #513 for progress.
-   Right now, its not thread-safe.... vuid issuance is not thread-safe.
+   Right now, its not thread-safe.... see FIXME in valuationExists
 
  * Current implementation leaks in the Values table, when the values
    are changed. This is a bug, needs fixing.

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
@@ -266,7 +266,7 @@ class SQLAtomStorage::Response
 			return false;
 		}
 
-		// deal twith the type-to-id map
+		// deal with the type-to-id map
 		bool type_cb(void)
 		{
 			rs->foreach_column(&Response::type_column_cb, this);
@@ -291,7 +291,7 @@ class SQLAtomStorage::Response
 		// Values ---------------------------------------------------
 		// If a value exists, then return its type.
 		Type vtype;
-		bool valtype_cb(const char *colname, const char * colvalue)
+		bool valtype_column_cb(const char *colname, const char * colvalue)
 		{
 			// printf ("%s = %s\n", colname, colvalue);
 			if (strcmp(colname, "type"))
@@ -301,6 +301,13 @@ class SQLAtomStorage::Response
 			vtype = atoi(colvalue);
 			return false;
 		}
+
+		bool valtype_cb(void)
+		{
+			rs->foreach_column(&Response::valtype_column_cb, this);
+			return false;
+		}
+
 #ifdef OUT_OF_LINE_TVS
 		// Callbacks for SimpleTruthValues
 		int tvid;
@@ -581,7 +588,6 @@ Type SQLAtomStorage::valueExists(const ValuationPtr& valn)
 	rp.vtype = 0;
 	rp.exec(buff);
 	rp.rs->foreach_row(&Response::valtype_cb, &rp);
-xxxxxxx
 
 	return rp.vtype;
 }

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
@@ -580,7 +580,12 @@ void SQLAtomStorage::store_atomtable_id(const AtomTable& at)
 
 /* ================================================================ */
 
-Type SQLAtomStorage::valueExists(const ValuationPtr& valn)
+/// Return the type of the valuation, if it exists in the
+/// Valuation table; else return zero.  This is used only
+/// for determining whether to perform an insert or an update.
+/// XXX FIXME: in order to be thread-safe, this should grab
+/// and return a lock, the same way that maybe_create_id does it.
+Type SQLAtomStorage::valuationExists(const ValuationPtr& valn)
 {
 	char buff[BUFSZ];
 	snprintf(buff, BUFSZ,
@@ -613,7 +618,7 @@ void SQLAtomStorage::storeValuation(const ValuationPtr& valn)
 	char aidbuff[BUFSZ];
 	snprintf(aidbuff, BUFSZ, "%lu", _tlbuf.getUUID(valn->atom()));
 
-	bool update = valueExists(valn);
+	bool update = valuationExists(valn);
 	if (update)
 	{
 		cols = "UPDATE Valuations SET ";
@@ -713,6 +718,11 @@ SQLAtomStorage::VUID SQLAtomStorage::storeValue(const ProtoAtomPtr& pap)
 	rp.exec(qry.c_str());
 
 	return vuid;
+}
+
+ProtoAtomPtr SQLAtomStorage::getValue(VUID vuid)
+{
+	return nullptr;
 }
 
 #ifdef OUT_OF_LINE_TVS

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
@@ -1599,6 +1599,15 @@ void SQLAtomStorage::create_tables(void)
 	            "UNIQUE (type, name),"
 	            "UNIQUE (type, outgoing));");
 
+	rp.exec("CREATE TABLE Valuations ("
+	            "key BIGINT REFERENCES Atoms(uuid),"
+	            "atom BIGINT REFERENCES Atoms(uuid),"
+	            "type  SMALLINT,"
+	            "floatvalue DOUBLE PRECISION[],"
+	            "stringvalue TEXT[],"
+	            "linkvalue BIGINT[],"
+	            "UNIQUE (key, atom));");
+
 	rp.exec("CREATE TABLE TypeCodes ("
 	            "type SMALLINT UNIQUE,"
 	            "typename TEXT UNIQUE);");
@@ -1617,6 +1626,7 @@ void SQLAtomStorage::kill_data(void)
 
 	// See the file "atom.sql" for detailed documentation as to the
 	// structure of the SQL tables.
+	rp.exec("DELETE from Valuations;");
 	rp.exec("DELETE from Atoms;");
 
 	// Delete the atomspaces as well!

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
@@ -620,7 +620,7 @@ void SQLAtomStorage::storeValuation(const ValuationPtr& valn)
 		vals = "";
 		coda = " WHERE key = ";
 		coda += kidbuff;
-		coda = " AND atom = ";
+		coda += " AND atom = ";
 		coda += aidbuff;
 		coda += ";";
 	}
@@ -858,7 +858,8 @@ void SQLAtomStorage::flushStoreQueue()
  *
  * By default, the actual store is done asynchronously (in a different
  * thread); this routine merely queues up the atom. If the synchronous
- * flag is set, then the store is done in this thread.
+ * flag is set, then the store is performed in this thread, and it is
+ * completed (sent to the Postgres server) before this method returns.
  */
 void SQLAtomStorage::storeAtom(const Handle& h, bool synchronous)
 {

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
@@ -629,7 +629,15 @@ void SQLAtomStorage::storeValuation(const ValuationPtr& valn)
 		STMT("atom", aidbuff);
 	}
 
-	STMTI("type", valn->getType());
+	Type vtype = valn->getType();
+	STMTI("type", vtype);
+
+	if (classserver().isA(vtype, FLOAT_VALUE))
+	{
+		FloatValuePtr fvp = FloatValueCast(valn->value());
+		std::string fstr = float_to_string(fvp);
+		STMT("floatvalue", fstr);
+	}
 
 	std::string qry = cols + vals + coda;
 	Response rp(conn_pool);
@@ -708,6 +716,20 @@ std::string SQLAtomStorage::oset_to_string(const HandleSeq& out)
 		if (not_first) str += ", ";
 		not_first = true;
 		str += std::to_string(get_uuid(h));
+	}
+	str += "}\'";
+	return str;
+}
+
+std::string SQLAtomStorage::float_to_string(const FloatValuePtr& fvle)
+{
+	bool not_first = false;
+	std::string str = "\'{";
+	for (double v : fvle->value())
+	{
+		if (not_first) str += ", ";
+		not_first = true;
+		str += std::to_string(v);
 	}
 	str += "}\'";
 	return str;

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
@@ -592,7 +592,6 @@ Type SQLAtomStorage::valueExists(const ValuationPtr& valn)
 	return rp.vtype;
 }
 
-#ifdef OUT_OF_LINE_TVS
 /**
  * Store a valuation
  */
@@ -603,36 +602,41 @@ void SQLAtomStorage::storeValuation(const ValuationPtr& valn)
 	std::string vals;
 	std::string coda;
 
-	// Use the TLB Handle as the UUID.
-	char tvidbuff[BUFSZ];
-	snprintf(tvidbuff, BUFSZ, "%u", tvid);
+	// Get UUID from the TLB.
+	char kidbuff[BUFSZ];
+	snprintf(kidbuff, BUFSZ, "%lu", _tlbuf.getUUID(valn->key()));
 
-	bool update = tvExists(tvid);
+	char aidbuff[BUFSZ];
+	snprintf(aidbuff, BUFSZ, "%lu", _tlbuf.getUUID(valn->atom()));
+
+	bool update = valueExists(valn);
 	if (update)
 	{
-		cols = "UPDATE SimpleTVs SET ";
+		cols = "UPDATE Valuations SET ";
 		vals = "";
-		coda = " WHERE tvid = ";
-		coda += tvidbuff;
+		coda = " WHERE key = ";
+		coda += kidbuff;
+		coda = " AND atom = ";
+		coda += aidbuff;
 		coda += ";";
 	}
 	else
 	{
-		cols = "INSERT INTO SimpleTVs (";
+		cols = "INSERT INTO Valuations (";
 		vals = ") VALUES (";
 		coda = ");";
-		STMT("tvid", tvidbuff);
+		STMT("key", kidbuff);
+		STMT("atom", aidbuff);
 	}
 
-	STMTF("mean", tv.getMean());
-	STMTF("count", tv.getCount());
+	STMTI("type", valn->getType());
 
 	std::string qry = cols + vals + coda;
 	Response rp(conn_pool);
 	rp.exec(qry.c_str());
-	return tvid;
 }
 
+#ifdef OUT_OF_LINE_TVS
 TruthValue* SQLAtomStorage::getTV(int tvid)
 {
 	char buff[BUFSZ];

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
@@ -731,7 +731,29 @@ ProtoAtomPtr SQLAtomStorage::getValue(VUID vuid)
 {
 	char buff[BUFSZ];
 	snprintf(buff, BUFSZ, "SELECT * FROM Values WHERE vuid = %lu;", vuid);
+	return doGetValue(buff);
+}
 
+/// Return a value, given by the key-atom pair.
+/// If the value type is a link, then the full recursive
+/// fetch is performed.
+ProtoAtomPtr SQLAtomStorage::getValuation(const Handle& key,
+                                          const Handle& atom)
+{
+	char buff[BUFSZ];
+	snprintf(buff, BUFSZ,
+		"SELECT * FROM Valuations WHERE key = %lu AND atom = %lu;",
+		_tlbuf.getUUID(key),
+		_tlbuf.getUUID(atom));
+
+	return doGetValue(buff);
+}
+
+/// Return a value, given by indicated query buffer.
+/// If the value type is a link, then the full recursive
+/// fetch is performed.
+ProtoAtomPtr SQLAtomStorage::doGetValue(const char * buff)
+{
 	Response rp(conn_pool);
 	rp.exec(buff);
 	rp.rs->foreach_row(&Response::get_value_cb, &rp);

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
@@ -323,7 +323,7 @@ class SQLAtomStorage::Response
 		}
 		bool create_value_column_cb(const char *colname, const char * colvalue)
 		{
-			printf ("value -- %s = %s\n", colname, colvalue);
+			// printf ("value -- %s = %s\n", colname, colvalue);
 			if (!strcmp(colname, "floatvalue"))
 			{
 				fltval = colvalue;
@@ -724,8 +724,6 @@ SQLAtomStorage::VUID SQLAtomStorage::storeValue(const ProtoAtomPtr& pap)
 	Response rp(conn_pool);
 	rp.exec(qry.c_str());
 
-ProtoAtomPtr foo = getValue(vuid);
-if (foo) std::cout << foo << std::endl;
 	return vuid;
 }
 
@@ -737,8 +735,6 @@ ProtoAtomPtr SQLAtomStorage::getValue(VUID vuid)
 	char buff[BUFSZ];
 	snprintf(buff, BUFSZ, "SELECT * FROM Values WHERE vuid = %lu;", vuid);
 
-printf("duuude enter getval\n");
-fflush(stdout);
 	Response rp(conn_pool);
 	rp.exec(buff);
 	rp.rs->foreach_row(&Response::create_value_cb, &rp);
@@ -797,16 +793,14 @@ fflush(stdout);
 		std::vector<ProtoAtomPtr> lnkarr;
 		const char *p = rp.lnkval;
 		if (p and *p == '{') p++;
-printf("duuude start a linkval\n");
 		while (p)
 		{
 			if (*p == '}' or *p == '\0') break;
 			VUID vu = atoi(p);
-printf("duuude reusrse to vuid %lu\n", vu);
 			ProtoAtomPtr pap = getValue(vu);
 			lnkarr.emplace_back(pap);
 			p = strchr(p, ',');
-			p++;
+			if (p) p++;
 		}
 		return createLinkValue(lnkarr);
 	}

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
@@ -311,32 +311,32 @@ class SQLAtomStorage::Response
 			return false;
 		}
 
-#ifdef OUT_OF_LINE_TVS
-		// Callbacks for SimpleTruthValues
-		int tvid;
-		bool create_tv_cb(void)
+		// Callbacks for Values
+		VUID vuid;
+		bool create_value_cb(void)
 		{
-			// printf ("---- New SimpleTV found ----\n");
-			rs->foreach_column(&Response::create_tv_column_cb, this);
+			rs->foreach_column(&Response::create_value_column_cb, this);
 			return false;
 		}
-		bool create_tv_column_cb(const char *colname, const char * colvalue)
+		bool create_value_column_cb(const char *colname, const char * colvalue)
 		{
 			printf ("%s = %s\n", colname, colvalue);
-			if (!strcmp(colname, "mean"))
+			if (!strcmp(colname, "floatvalue"))
 			{
-				mean = atof(colvalue);
+				// mean = atof(colvalue);
 			}
-			else if (!strcmp(colname, "count"))
+			else if (!strcmp(colname, "stringvalue"))
 			{
-				count = atof(colvalue);
+				// count = atof(colvalue);
+			}
+			else if (!strcmp(colname, "linkvalue"))
+			{
+				// count = atof(colvalue);
 			}
 			return false;
 		}
 
-#endif /* OUT_OF_LINE_TVS */
-
-		// get generic positive integer values
+		// Get generic positive integer values
 		unsigned long intval;
 		bool intval_cb(void)
 		{
@@ -722,23 +722,22 @@ SQLAtomStorage::VUID SQLAtomStorage::storeValue(const ProtoAtomPtr& pap)
 
 ProtoAtomPtr SQLAtomStorage::getValue(VUID vuid)
 {
+	char buff[BUFSZ];
+	snprintf(buff, BUFSZ, "SELECT * FROM Values WHERE vuid = %lu;", vuid);
+
+	Response rp(conn_pool);
+	rp.exec(buff);
+	rp.rs->foreach_row(&Response::create_value_cb, &rp);
+
 	return nullptr;
 }
 
 #ifdef OUT_OF_LINE_TVS
 TruthValue* SQLAtomStorage::getTV(int tvid)
 {
-	char buff[BUFSZ];
-	snprintf(buff, BUFSZ, "SELECT * FROM SimpleTVs WHERE tvid = %u;", tvid);
-
-	Response rp(conn_pool);
-	rp.exec(buff);
-	rp.rs->foreach_row(&Response::create_tv_cb, &rp);
-
 	SimpleTruthValue *stv = new SimpleTruthValue(rp.mean, rp.confidence);
 	return stv;
 }
-
 #endif /* OUT_OF_LINE_TVS */
 
 /* ================================================================== */

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
@@ -433,7 +433,7 @@ void SQLAtomStorage::init(const char * uri)
 	if (!connected()) return;
 
 	reserve();
-	_next_valid = 1;
+	_next_valid = getMaxObservedVUID() + 1;
 
 #define STORAGE_DEBUG 1
 #ifdef STORAGE_DEBUG
@@ -1782,6 +1782,15 @@ UUID SQLAtomStorage::getMaxObservedUUID(void)
 	Response rp(conn_pool);
 	rp.intval = 0;
 	rp.exec("SELECT uuid FROM Atoms ORDER BY uuid DESC LIMIT 1;");
+	rp.rs->foreach_row(&Response::intval_cb, &rp);
+	return rp.intval;
+}
+
+SQLAtomStorage::VUID SQLAtomStorage::getMaxObservedVUID(void)
+{
+	Response rp(conn_pool);
+	rp.intval = 0;
+	rp.exec("SELECT vuid FROM Values ORDER BY vuid DESC LIMIT 1;");
 	rp.rs->foreach_row(&Response::intval_cb, &rp);
 	return rp.intval;
 }

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
@@ -1573,6 +1573,7 @@ SQLAtomStorage::PseudoPtr SQLAtomStorage::doGetNode(Type t, const char * str)
 TruthValuePtr SQLAtomStorage::getNode(Type t, const char * str)
 {
 	PseudoPtr p = doGetNode(t, str);
+	if (!p) return nullptr;
 	Handle h = _tlbuf.getAtom(p->uuid);
 	get_atom_values(h);
 	return p->tv;

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
@@ -42,6 +42,9 @@
 #include <opencog/atoms/base/ClassServer.h>
 #include <opencog/atoms/base/Link.h>
 #include <opencog/atoms/base/Node.h>
+#include <opencog/atoms/base/FloatValue.h>
+#include <opencog/atoms/base/LinkValue.h>
+#include <opencog/atoms/base/StringValue.h>
 #include <opencog/atoms/base/Valuation.h>
 #include <opencog/truthvalue/CountTruthValue.h>
 #include <opencog/truthvalue/IndefiniteTruthValue.h>
@@ -638,6 +641,13 @@ void SQLAtomStorage::storeValuation(const ValuationPtr& valn)
 		std::string fstr = float_to_string(fvp);
 		STMT("floatvalue", fstr);
 	}
+	else
+	if (classserver().isA(vtype, STRING_VALUE))
+	{
+		StringValuePtr fvp = StringValueCast(valn->value());
+		std::string sstr = string_to_string(fvp);
+		STMT("stringvalue", sstr);
+	}
 
 	std::string qry = cols + vals + coda;
 	Response rp(conn_pool);
@@ -730,6 +740,20 @@ std::string SQLAtomStorage::float_to_string(const FloatValuePtr& fvle)
 		if (not_first) str += ", ";
 		not_first = true;
 		str += std::to_string(v);
+	}
+	str += "}\'";
+	return str;
+}
+
+std::string SQLAtomStorage::string_to_string(const StringValuePtr& svle)
+{
+	bool not_first = false;
+	std::string str = "\'{";
+	for (const std::string& v : svle->value())
+	{
+		if (not_first) str += ", ";
+		not_first = true;
+		str += v;
 	}
 	str += "}\'";
 	return str;

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
@@ -641,6 +641,8 @@ void SQLAtomStorage::storeValuation(const ValuationPtr& valn)
 		FloatValuePtr fvp = FloatValueCast(valn->value());
 		std::string fstr = float_to_string(fvp);
 		STMT("floatvalue", fstr);
+		STMT("stringvalue", "'{}'");
+		STMT("linkvalue", "'{}'");
 	}
 	else
 	if (classserver().isA(vtype, STRING_VALUE))
@@ -648,6 +650,8 @@ void SQLAtomStorage::storeValuation(const ValuationPtr& valn)
 		StringValuePtr fvp = StringValueCast(valn->value());
 		std::string sstr = string_to_string(fvp);
 		STMT("stringvalue", sstr);
+		STMT("floatvalue", "'{}'");
+		STMT("linkvalue", "'{}'");
 	}
 	else
 	if (classserver().isA(vtype, LINK_VALUE))
@@ -655,6 +659,8 @@ void SQLAtomStorage::storeValuation(const ValuationPtr& valn)
 		LinkValuePtr fvp = LinkValueCast(valn->value());
 		std::string lstr = link_to_string(fvp);
 		STMT("linkvalue", lstr);
+		STMT("floatvalue", "'{}'");
+		STMT("stringvalue", "'{}'");
 	}
 
 	std::string qry = cols + vals + coda;
@@ -673,7 +679,7 @@ SQLAtomStorage::VUID SQLAtomStorage::storeValue(const ProtoAtomPtr& pap)
 	std::string vals;
 	std::string coda;
 
-	cols = "INSERT INTO Valuations (";
+	cols = "INSERT INTO Values (";
 	vals = ") VALUES (";
 	coda = ");";
 	STMT("vuid", std::to_string(vuid));

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.h
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.h
@@ -138,10 +138,10 @@ class SQLAtomStorage : public AtomStorage
 		Type valuationExists(const ValuationPtr&);
 public:
 		void storeValuation(const ValuationPtr&);
-private:
 		VUID storeValue(const ProtoAtomPtr&);
 		ProtoAtomPtr getValue(VUID);
 
+private:
 		std::string float_to_string(const FloatValuePtr&);
 		std::string string_to_string(const StringValuePtr&);
 		std::string link_to_string(const LinkValuePtr&);

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.h
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.h
@@ -134,7 +134,8 @@ class SQLAtomStorage : public AtomStorage
 		typedef unsigned long VUID;
 
 		Type valueExists(const ValuationPtr&);
-		VUID storeValuation(const ValuationPtr&);
+		void storeValuation(const ValuationPtr&);
+		VUID storeValue(const ProtoAtomPtr&);
 		std::string float_to_string(const FloatValuePtr&);
 		std::string string_to_string(const StringValuePtr&);
 		std::string link_to_string(const LinkValuePtr&);

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.h
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.h
@@ -54,6 +54,8 @@ namespace opencog
  *  @{
  */
 
+/// This class can only be used safely as a singleton; however, this
+/// singleton can be used by multiple threads.
 class SQLAtomStorage : public AtomStorage
 {
 	private:
@@ -133,17 +135,20 @@ class SQLAtomStorage : public AtomStorage
 		// Values
 		typedef unsigned long VUID;
 
-		Type valueExists(const ValuationPtr&);
+		Type valuationExists(const ValuationPtr&);
 public:
 		void storeValuation(const ValuationPtr&);
 private:
 		VUID storeValue(const ProtoAtomPtr&);
+		ProtoAtomPtr getValue(VUID);
+
 		std::string float_to_string(const FloatValuePtr&);
 		std::string string_to_string(const StringValuePtr&);
 		std::string link_to_string(const LinkValuePtr&);
 
 		VUID getMaxObservedVUID(void);
 		std::atomic<VUID> _next_valid;
+
 
 		// --------------------------
 		// Performance statistics

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.h
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.h
@@ -160,13 +160,6 @@ class SQLAtomStorage : public AtomStorage
 		void set_typemap(int, const char *);
 		std::mutex _typemap_mutex;
 
-#ifdef OUT_OF_LINE_TVS
-		bool tvExists(int);
-		int storeTruthValue(AtomPtr, Handle);
-		int  TVID(const TruthValue &);
-		TruthValue * getTV(int);
-#endif /* OUT_OF_LINE_TVS */
-
 		// Provider of asynchronous store of atoms.
 		async_caller<SQLAtomStorage, Handle> _write_queue;
 

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.h
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.h
@@ -69,7 +69,7 @@ class SQLAtomStorage : public AtomStorage
 
 		// ---------------------------------------------
 		// Handle multiple atomspaces like typecodes: we have to
-		// convert from sql UUID to the atual UUID.
+		// convert from sql UUID to the actual UUID.
 		std::set<UUID> table_id_cache;
 		void store_atomtable_id(const AtomTable&);
 
@@ -143,7 +143,7 @@ private:
 		std::string link_to_string(const LinkValuePtr&);
 
 		VUID getMaxObservedVUID(void);
-		VUID _next_valid;
+		std::atomic<VUID> _next_valid;
 
 		// --------------------------
 		// Performance statistics

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.h
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.h
@@ -135,7 +135,7 @@ class SQLAtomStorage : public AtomStorage
 		// Values
 		typedef unsigned long VUID;
 
-		Type valuationExists(const ValuationPtr&);
+		void deleteValuation(const ValuationPtr&);
 public:
 		void storeValuation(const ValuationPtr&);
 		VUID storeValue(const ProtoAtomPtr&);

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.h
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.h
@@ -153,7 +153,6 @@ private:
 		VUID getMaxObservedVUID(void);
 		std::atomic<VUID> _next_valid;
 
-
 		// --------------------------
 		// Performance statistics
 		std::atomic<size_t> _num_get_nodes;

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.h
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.h
@@ -126,10 +126,13 @@ class SQLAtomStorage : public AtomStorage
 		bool idExists(const char *);
 		TLB _tlbuf;
 
+		// --------------------------
 		// Values
 		Type valueExists(const ValuationPtr&);
 		void storeValuation(const ValuationPtr&);
+		std::string float_to_string(const FloatValuePtr&);
 
+		// --------------------------
 		// Performance statistics
 		std::atomic<size_t> _num_get_nodes;
 		std::atomic<size_t> _num_got_nodes;

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.h
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.h
@@ -128,6 +128,7 @@ class SQLAtomStorage : public AtomStorage
 
 		// Values
 		Type valueExists(const ValuationPtr&);
+		void storeValuation(const ValuationPtr&);
 
 		// Performance statistics
 		std::atomic<size_t> _num_get_nodes;

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.h
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.h
@@ -133,19 +133,22 @@ class SQLAtomStorage : public AtomStorage
 
 		// --------------------------
 		// Values
+
+		void store_atom_values(const Handle &);
+
 		typedef unsigned long VUID;
 
 		ProtoAtomPtr doGetValue(const char *);
-public:
+
 		void storeValuation(const ValuationPtr&);
+		void storeValuation(const Handle&, const Handle&, const ProtoAtomPtr&);
 		ProtoAtomPtr getValuation(const Handle&, const Handle&);
-		void deleteValuation(const ValuationPtr&);
+		void deleteValuation(const Handle&, const Handle&);
 
 		VUID storeValue(const ProtoAtomPtr&);
 		ProtoAtomPtr getValue(VUID);
 		void deleteValue(VUID);
 
-private:
 		std::string float_to_string(const FloatValuePtr&);
 		std::string string_to_string(const StringValuePtr&);
 		std::string link_to_string(const LinkValuePtr&);

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.h
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.h
@@ -42,7 +42,6 @@
 #include <opencog/atoms/base/StringValue.h>
 #include <opencog/atoms/base/Valuation.h>
 
-
 #include <opencog/atomspace/AtomTable.h>
 #include <opencog/atomspaceutils/TLB.h>
 #include <opencog/persist/sql/AtomStorage.h>
@@ -132,10 +131,15 @@ class SQLAtomStorage : public AtomStorage
 
 		// --------------------------
 		// Values
+		typedef unsigned long VUID;
+
 		Type valueExists(const ValuationPtr&);
-		void storeValuation(const ValuationPtr&);
+		VUID storeValuation(const ValuationPtr&);
 		std::string float_to_string(const FloatValuePtr&);
 		std::string string_to_string(const StringValuePtr&);
+		std::string link_to_string(const LinkValuePtr&);
+
+		VUID _next_valid;
 
 		// --------------------------
 		// Performance statistics

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.h
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.h
@@ -134,12 +134,15 @@ class SQLAtomStorage : public AtomStorage
 		typedef unsigned long VUID;
 
 		Type valueExists(const ValuationPtr&);
+public:
 		void storeValuation(const ValuationPtr&);
+private:
 		VUID storeValue(const ProtoAtomPtr&);
 		std::string float_to_string(const FloatValuePtr&);
 		std::string string_to_string(const StringValuePtr&);
 		std::string link_to_string(const LinkValuePtr&);
 
+		VUID getMaxObservedVUID(void);
 		VUID _next_valid;
 
 		// --------------------------

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.h
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.h
@@ -135,9 +135,12 @@ class SQLAtomStorage : public AtomStorage
 		// Values
 		typedef unsigned long VUID;
 
-		void deleteValuation(const ValuationPtr&);
+		ProtoAtomPtr doGetValue(const char *);
 public:
 		void storeValuation(const ValuationPtr&);
+		ProtoAtomPtr getValuation(const Handle&, const Handle&);
+		void deleteValuation(const ValuationPtr&);
+
 		VUID storeValue(const ProtoAtomPtr&);
 		ProtoAtomPtr getValue(VUID);
 		void deleteValue(VUID);

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.h
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.h
@@ -140,6 +140,7 @@ public:
 		void storeValuation(const ValuationPtr&);
 		VUID storeValue(const ProtoAtomPtr&);
 		ProtoAtomPtr getValue(VUID);
+		void deleteValue(VUID);
 
 private:
 		std::string float_to_string(const FloatValuePtr&);

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.h
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.h
@@ -37,6 +37,7 @@
 #include <opencog/atoms/base/Link.h>
 #include <opencog/atoms/base/Node.h>
 #include <opencog/atoms/base/types.h>
+#include <opencog/atoms/base/Valuation.h>
 
 #include <opencog/atomspace/AtomTable.h>
 #include <opencog/atomspaceutils/TLB.h>
@@ -124,6 +125,9 @@ class SQLAtomStorage : public AtomStorage
 		int getMaxObservedHeight(void);
 		bool idExists(const char *);
 		TLB _tlbuf;
+
+		// Values
+		Type valueExists(const ValuationPtr&);
 
 		// Performance statistics
 		std::atomic<size_t> _num_get_nodes;

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.h
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.h
@@ -92,6 +92,9 @@ class SQLAtomStorage : public AtomStorage
 		PseudoPtr getAtom(const char *, int);
 		PseudoPtr petAtom(UUID);
 
+		PseudoPtr doGetNode(Type, const char *);
+		TruthValuePtr doGetLink(const Handle&);
+
 		int get_height(const Handle&);
 		int max_height;
 
@@ -135,6 +138,7 @@ class SQLAtomStorage : public AtomStorage
 		// Values
 
 		void store_atom_values(const Handle &);
+		void get_atom_values(const Handle &);
 
 		typedef unsigned long VUID;
 

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.h
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.h
@@ -37,7 +37,11 @@
 #include <opencog/atoms/base/Link.h>
 #include <opencog/atoms/base/Node.h>
 #include <opencog/atoms/base/types.h>
+#include <opencog/atoms/base/FloatValue.h>
+#include <opencog/atoms/base/LinkValue.h>
+#include <opencog/atoms/base/StringValue.h>
 #include <opencog/atoms/base/Valuation.h>
+
 
 #include <opencog/atomspace/AtomTable.h>
 #include <opencog/atomspaceutils/TLB.h>
@@ -131,6 +135,7 @@ class SQLAtomStorage : public AtomStorage
 		Type valueExists(const ValuationPtr&);
 		void storeValuation(const ValuationPtr&);
 		std::string float_to_string(const FloatValuePtr&);
+		std::string string_to_string(const StringValuePtr&);
 
 		// --------------------------
 		// Performance statistics

--- a/opencog/persist/sql/multi-driver/atom.sql
+++ b/opencog/persist/sql/multi-driver/atom.sql
@@ -113,6 +113,9 @@ CREATE TABLE Valuations (
     UNIQUE (key, atom)
 );
 
+-- Index for the fast lookup of all valuations for a given atom.
+CREATE INDEX ON Valuations (atom);
+
 -- A recursive overflow table, if recursive values did not directly
 -- fit into the Valuation table.
 CREATE TABLE Values (

--- a/opencog/persist/sql/multi-driver/atom.sql
+++ b/opencog/persist/sql/multi-driver/atom.sql
@@ -87,7 +87,7 @@ CREATE TABLE Atoms (
 -- CREATE INDEX outidx ON Edges(dst_uuid);
 
 -- -----------------------------------------------------------
--- An SQL table representation for opencog Values
+-- An SQL table representation for opencog Valuations
 --
 CREATE TABLE Valuations (
     -- The key for this value
@@ -99,15 +99,38 @@ CREATE TABLE Valuations (
     type  SMALLINT,
 
     -- An array of values associated with the (key,atom) pair
-    -- Only float, or string or link should be non-empty, the other
-    -- two should be empty. We could have three different tables,
-    -- one each for each of these, but then the UNIQUE constraint is
-    -- harder to force.
+    -- Only one of the three of float, or string or link should be
+    -- non-empty; the other two should be empty. We could have three
+    -- different tables, one each for each of these, but then the
+    -- UNIQUE constraint is harder to force.
+    -- The linkevalue should be an array of vuid's from the Values
+    -- table. The "ELEMENT REFERENCES" would do the trick, but it's
+    -- not yet implemented in postgres.
     floatvalue DOUBLE PRECISION[],
     stringvalue TEXT[],
-    linkvalue BIGINT[],
+    linkvalue BIGINT[], -- ELEMENT REFERENCES Values(vuid),
 
     UNIQUE (key, atom)
+);
+
+-- A recursive overflow table, if recursive values did not directly
+-- fit into the Valuation table.
+CREATE TABLE Values (
+    -- The unique ID for this value
+    vuid BIGINT PRIMARY KEY,
+
+    -- Value type, e.g. FloatValue, StringValue, etc.
+    type  SMALLINT,
+
+    -- An array of values associated with the vuid.
+    -- Only one of the three of float, or string or link should be
+    -- non-empty; the other two should be empty.
+    -- The linkevalue should be an array of vuid's for other rows
+    -- in this table. The "ELEMENT REFERENCES" would do the trick,
+    -- but it's not yet implemented in postgres.
+    floatvalue DOUBLE PRECISION[],
+    stringvalue TEXT[],
+    linkvalue BIGINT[] -- ELEMENT REFERENCES Values(vuid)
 );
 
 -- -----------------------------------------------------------

--- a/opencog/persist/sql/multi-driver/ll-pg-cxx.cc
+++ b/opencog/persist/sql/multi-driver/ll-pg-cxx.cc
@@ -106,7 +106,9 @@ LLPGConnection::exec(const char * buff)
 	    rest != PGRES_EMPTY_QUERY and
 	    rest != PGRES_TUPLES_OK)
 	{
-		opencog::logger().warn("%s", PQresultErrorMessage(rs->_result));
+		opencog::logger().warn("PQresult message: %s",
+		               PQresultErrorMessage(rs->_result));
+		opencog::logger().warn("PQ query was: %s", buff);
 		rs->release();
 		PERR("Failed to execute!");
 	}

--- a/opencog/persist/sql/multi-driver/notes
+++ b/opencog/persist/sql/multi-driver/notes
@@ -572,3 +572,4 @@ _backing->set_store(_store);
     _backing->registerWith(_as);
 
 
+getNode

--- a/opencog/persist/sql/multi-driver/notes
+++ b/opencog/persist/sql/multi-driver/notes
@@ -549,3 +549,5 @@ _num_open_sockets -- static  uint
 
 
 store->_tlbuf..getUUID(h)
+
+oset_to_string

--- a/opencog/persist/sql/multi-driver/notes
+++ b/opencog/persist/sql/multi-driver/notes
@@ -559,3 +559,11 @@ do_store_single_atom wtf uuid not checked!
 maybe_create_id but assumes the UUID is already correct!
 
 getNode
+
+Atom::getValue(key)
+
+ValuationTable::
+std::set<Handle> getKeys(const Handle&);
+    ValuationTable _value_table;
+
+

--- a/opencog/persist/sql/multi-driver/notes
+++ b/opencog/persist/sql/multi-driver/notes
@@ -551,3 +551,11 @@ _num_open_sockets -- static  uint
 store->_tlbuf..getUUID(h)
 
 oset_to_string
+
+maybe_create_id
+
+do_store_single_atom wtf uuid not checked!
+
+maybe_create_id but assumes the UUID is already correct!
+
+getNode

--- a/opencog/persist/sql/multi-driver/notes
+++ b/opencog/persist/sql/multi-driver/notes
@@ -566,4 +566,9 @@ ValuationTable::
 std::set<Handle> getKeys(const Handle&);
     ValuationTable _value_table;
 
+    _backing = new SQLBackingStore();
+
+_backing->set_store(_store);
+    _backing->registerWith(_as);
+
 

--- a/opencog/persist/sql/multi-driver/notes
+++ b/opencog/persist/sql/multi-driver/notes
@@ -547,3 +547,5 @@ console has a _use_count -- volative per-inst updated byg get put in the req
 _max_open_sockets -- static uint
 _num_open_sockets -- static  uint
 
+
+store->_tlbuf..getUUID(h)

--- a/opencog/persist/sql/multi-driver/sniff.cc
+++ b/opencog/persist/sql/multi-driver/sniff.cc
@@ -1,6 +1,6 @@
 /*
  * FUNCTION:
- * Sniff test. Low-brow test, to see if basic atom storage is working.
+ * Scratch and Sniff test. A test & debug scaffold.
  *
  * HISTORY:
  * Copyright (c) 2008 Linas Vepstas <linas@linas.org>
@@ -12,6 +12,11 @@
 #include <opencog/atoms/base/Link.h>
 #include <opencog/atoms/base/Node.h>
 #include <opencog/truthvalue/SimpleTruthValue.h>
+
+#include <opencog/atoms/base/FloatValue.h>
+#include <opencog/atoms/base/LinkValue.h>
+#include <opencog/atoms/base/StringValue.h>
+#include <opencog/atoms/base/Valuation.h>
 
 #include <opencog/atomspaceutils/TLB.h>
 #include <opencog/persist/sql/multi-driver/SQLAtomStorage.h>
@@ -158,7 +163,7 @@ int main ()
     single_atom_test("eee ");
 #endif
 
-#if 1
+#if 0
     SQLAtomStorage *store = new SQLAtomStorage(
              // "odbc://opencog_tester:cheese/opencog_test");
              // "postgres://opencog_tester:cheese@localhost/opencog_test");
@@ -173,6 +178,21 @@ int main ()
     printf("Printing table:\n");
     // table->print();
 
+    delete store;
+#endif
+
+#if 1
+    SQLAtomStorage *store = new SQLAtomStorage(
+             "postgres:///opencog_test?user=opencog_tester&password=cheese");
+
+    Handle key(createNode(CONCEPT_NODE, "keynode"));
+    Handle atom(createNode(CONCEPT_NODE, "atom"));
+    store->storeAtom(key);
+    store->storeAtom(atom);
+
+    ProtoAtomPtr pv = createFloatValue(std::vector<double>({1.0, 2.0, 3.0}));
+    ValuationPtr valn = createValuation(key, atom, pv);
+    store->storeValuation(valn);
     delete store;
 #endif
 

--- a/opencog/persist/sql/multi-driver/sniff.cc
+++ b/opencog/persist/sql/multi-driver/sniff.cc
@@ -197,7 +197,7 @@ int main ()
     ValuationPtr valf = createValuation(key, atom, pvf);
     store->storeValuation(valf);
 
-    ProtoAtomPtr pvs = createStringValue(std::vector<std::string>({"a", "b", "c"}));
+    ProtoAtomPtr pvs = createStringValue(std::vector<std::string>({"aaa", "bb bb bb", "ccc ccc ccc"}));
     ValuationPtr vals = createValuation(key, atom, pvs);
     store->storeValuation(vals);
 

--- a/opencog/persist/sql/multi-driver/sniff.cc
+++ b/opencog/persist/sql/multi-driver/sniff.cc
@@ -185,14 +185,21 @@ int main ()
     SQLAtomStorage *store = new SQLAtomStorage(
              "postgres:///opencog_test?user=opencog_tester&password=cheese");
 
+    store->getNode(CONCEPT_NODE, "keynode");
+    store->getNode(CONCEPT_NODE, "atom");
+
     Handle key(createNode(CONCEPT_NODE, "keynode"));
     Handle atom(createNode(CONCEPT_NODE, "atom"));
-    store->storeAtom(key);
-    store->storeAtom(atom);
+    store->storeAtom(key, true);
+    store->storeAtom(atom, true);
 
-    ProtoAtomPtr pv = createFloatValue(std::vector<double>({1.0, 2.0, 3.0}));
-    ValuationPtr valn = createValuation(key, atom, pv);
-    store->storeValuation(valn);
+    ProtoAtomPtr pvf = createFloatValue(std::vector<double>({1.1, 2.2, 3.3}));
+    ValuationPtr valf = createValuation(key, atom, pvf);
+    store->storeValuation(valf);
+
+    ProtoAtomPtr pvs = createStringValue(std::vector<std::string>({"a", "b", "c"}));
+    ValuationPtr vals = createValuation(key, atom, pvs);
+    store->storeValuation(vals);
     delete store;
 #endif
 

--- a/opencog/persist/sql/multi-driver/sniff.cc
+++ b/opencog/persist/sql/multi-driver/sniff.cc
@@ -181,7 +181,7 @@ int main ()
     delete store;
 #endif
 
-#if 1
+#if 0
     SQLAtomStorage *store = new SQLAtomStorage(
              "postgres:///opencog_test?user=opencog_tester&password=cheese");
 

--- a/opencog/persist/sql/multi-driver/sniff.cc
+++ b/opencog/persist/sql/multi-driver/sniff.cc
@@ -193,13 +193,22 @@ int main ()
     store->storeAtom(key, true);
     store->storeAtom(atom, true);
 
-    ProtoAtomPtr pvf = createFloatValue(std::vector<double>({1.1, 2.2, 3.3}));
+    ProtoAtomPtr pvf = createFloatValue(std::vector<double>({1.14, 2.24, 3.34}));
     ValuationPtr valf = createValuation(key, atom, pvf);
     store->storeValuation(valf);
 
     ProtoAtomPtr pvs = createStringValue(std::vector<std::string>({"a", "b", "c"}));
     ValuationPtr vals = createValuation(key, atom, pvs);
     store->storeValuation(vals);
+
+    ProtoAtomPtr pvl = createLinkValue(std::vector<ProtoAtomPtr>({pvf, pvs}));
+    ValuationPtr vall = createValuation(key, atom, pvl);
+    store->storeValuation(vall);
+
+    ProtoAtomPtr pvl2 = createLinkValue(std::vector<ProtoAtomPtr>({pvl, pvl, pvl, pvf, pvs}));
+    ValuationPtr vall2 = createValuation(key, atom, pvl2);
+    store->storeValuation(vall2);
+
     delete store;
 #endif
 

--- a/tests/persist/sql/multi-driver/BasicSaveUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/BasicSaveUTest.cxxtest
@@ -1,5 +1,5 @@
 /*
- * tests/persist/sql/odbc/BasicSaveUTest.cxxtest
+ * tests/persist/sql/multi-driver/BasicSaveUTest.cxxtest
  *
  * Most basic, simplest sniff test, saves and restores a few atoms.
  *

--- a/tests/persist/sql/multi-driver/CMakeLists.txt
+++ b/tests/persist/sql/multi-driver/CMakeLists.txt
@@ -63,6 +63,7 @@ IF (DB_IS_CONFIGURED)
     MESSAGE(STATUS "Postgres database is configured for unit tests." )
 
     ADD_CXXTEST(BasicSaveUTest)
+    ADD_CXXTEST(ValueSaveUTest)
     IF (HAVE_GUILE)
         ADD_CXXTEST(PersistUTest)
         ADD_CXXTEST(MultiPersistUTest)

--- a/tests/persist/sql/multi-driver/FetchUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/FetchUTest.cxxtest
@@ -1,5 +1,5 @@
 /*
- * tests/persist/sql/odbc/FetchUTest.cxxtest
+ * tests/persist/sql/multi-driver/FetchUTest.cxxtest
  *
  * Test atom fetch semantics.  Assumes PersistUTest is passing.
  *

--- a/tests/persist/sql/multi-driver/MultiPersistUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/MultiPersistUTest.cxxtest
@@ -1,5 +1,5 @@
 /*
- * tests/persist/sql/odbc/MultiPersistUTest.cxxtest
+ * tests/persist/sql/multi-driver/MultiPersistUTest.cxxtest
  *
  * Test multi-threaded persistance.  Assumes PersistUTest is passing.
  *

--- a/tests/persist/sql/multi-driver/PersistUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/PersistUTest.cxxtest
@@ -1,5 +1,5 @@
 /*
- * tests/persist/sql/odbc/PersistUTest.cxxtest
+ * tests/persist/sql/multi-driver/PersistUTest.cxxtest
  *
  * Test AtomSpace persistance.  Assumes BasicSaveUTest is passing.
  *

--- a/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
@@ -1,0 +1,222 @@
+/*
+ * tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
+ *
+ * Basic test of generic value save and restore.
+ *
+ * If this test is failing for you, then be sure to read the README in
+ * this directory, and also ../../opencong/persist/README, and then
+ * create and configure the SQL database as described there. Next,
+ * edit ../../lib/test-opencog.conf to add the database credentials
+ * (the username and passwd).
+ *
+ * Copyright (C) 2008, 2009, 2017 Linas Vepstas <linasvepstas@gmail.com>
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#include <cstdio>
+
+#include <opencog/atoms/base/Atom.h>
+#include <opencog/atoms/base/Link.h>
+#include <opencog/atoms/base/Node.h>
+#include <opencog/atoms/base/atom_types.h>
+#include <opencog/atomspace/AtomSpace.h>
+
+#include <opencog/atoms/base/FloatValue.h>
+#include <opencog/atoms/base/LinkValue.h>
+#include <opencog/atoms/base/StringValue.h>
+#include <opencog/atoms/base/Valuation.h>
+
+#include <opencog/persist/sql/multi-driver/SQLAtomStorage.h>
+
+#include <opencog/util/Logger.h>
+#include <opencog/util/Config.h>
+
+#include "mkuri.h"
+
+using namespace opencog;
+
+class ValueSaveUTest :  public CxxTest::TestSuite
+{
+    private:
+        AtomSpace *as;
+        std::string uri;
+        const char * dbname;
+        const char * username;
+        const char * passwd;
+
+    public:
+
+        ValueSaveUTest(void)
+        {
+            try
+            {
+                config().load("atomspace-test.conf");
+            }
+            catch (RuntimeException &e)
+            {
+                std::cerr << e.get_message() << std::endl;
+            }
+
+            logger().set_level(Logger::DEBUG);
+            logger().set_print_to_stdout_flag(true);
+
+            try {
+                // Get the database logins & etc from the config file.
+                dbname = config().get("TEST_DB_NAME", "opencog_test").c_str();
+                username = config().get("TEST_DB_USERNAME", "opencog_tester").c_str();
+                passwd = config().get("TEST_DB_PASSWD", "cheese").c_str();
+            }
+            catch (InvalidParamException &e)
+            {
+                friendlyFailMessage(false);
+            }
+        }
+
+        ~ValueSaveUTest()
+        {
+            // erase the log file if no assertions failed
+            if (!CxxTest::TestTracker::tracker().suiteFailed())
+                std::remove(logger().get_filename().c_str());
+        }
+
+        void setUp(void);
+        void tearDown(void);
+
+        void friendlyFailMessage(bool ts)
+        {
+            const char * fail = "The ValueSaveUTest failed.\n"
+                "This is probably because you do not have SQL installed\n"
+                "or configured the way that OpenCog expects.\n\n"
+                "SQL persistance is optional for OpenCog, so if you don't\n"
+                "want it or need it, just ignore this test failure.\n"
+                "Otherwise, please be sure to read opencong/persist/sql/README,\n"
+                "and create/configure the SQL database as described there.\n"
+                "Next, edit lib/atomspace-test.conf appropriately, so as\n"
+                "to indicate the location of your database. If this is\n"
+                "done correctly, then this test will pass.\n";
+
+            if (ts)
+                TS_FAIL(fail);
+            else
+                fprintf(stderr, "%s", fail);
+            exit(1);
+        }
+
+        SQLAtomStorage *astore;
+
+        void do_test_single_atom();
+        void single_atom_save_restore(std::string);
+
+        void test_odbc_single_atom();
+        void test_pq_single_atom();
+};
+
+/*
+ * This is called once before each test, for each test (!!)
+ */
+void ValueSaveUTest::setUp(void)
+{
+    as = new AtomSpace();
+}
+
+void ValueSaveUTest::tearDown(void)
+{
+    delete as;
+}
+
+void ValueSaveUTest::test_odbc_single_atom(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+#if HAVE_ODBC_STORAGE
+	uri = mkuri("odbc", dbname, username, passwd);
+	do_test_single_atom();
+#endif
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+void ValueSaveUTest::test_pq_single_atom(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+#if HAVE_PGSQL_STORAGE
+	uri = mkuri("postgres", dbname, username, passwd);
+	do_test_single_atom();
+#endif // HAVE_PGSQL_STORAGE
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+// ============================================================
+/**
+ * A simple test case that tests the save and restore of
+ * a couple of nodes and a link. Does not test atomtable/atomspace at all.
+ */
+void ValueSaveUTest::single_atom_save_restore(std::string id)
+{
+	SQLAtomStorage *store = new SQLAtomStorage(uri);
+	if (!store->connected())
+	{
+		logger().debug("single_atom_save_restore: cannot connect to db");
+		return;
+	}
+
+	Handle key(createNode(CONCEPT_NODE, id + " some keynode"));
+	Handle atom(createNode(CONCEPT_NODE, id + " some node"));
+
+	// Store the key and the atom, so as to avoid any UUID
+	// confusions.
+	store->storeAtom(key, true);
+	store->storeAtom(atom, true);
+
+	// --------------------
+	// Now set some values
+	ProtoAtomPtr pvf = createFloatValue(
+		std::vector<double>({1.14, 2.24, 3.34}));
+
+	atom->setValue(key, pvf);
+	store->storeAtom(atom, true);
+
+	// --------------------
+	ProtoAtomPtr pvs = createStringValue(
+		std::vector<std::string>({"aaa", "bb bb bb", "ccc ccc ccc"}));
+
+	atom->setValue(key, pvs);
+	store->storeAtom(atom, true);
+
+	// --------------------
+	ProtoAtomPtr pvl = createLinkValue(
+		std::vector<ProtoAtomPtr>({pvf, pvs}));
+
+	atom->setValue(key, pvl);
+	store->storeAtom(atom, true);
+
+	// --------------------
+	ProtoAtomPtr pvl2 = createLinkValue(
+		std::vector<ProtoAtomPtr>({pvl, pvl, pvf, pvs}));
+
+	atom->setValue(key, pvl2);
+	store->storeAtom(atom, true);
+
+	// --------------------
+	// store->kill_data();
+	delete store;
+}
+
+void ValueSaveUTest::do_test_single_atom()
+{
+	single_atom_save_restore("aaa");
+}
+
+/* ============================= END OF FILE ================= */

--- a/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
@@ -40,6 +40,7 @@
 #include <opencog/atoms/base/StringValue.h>
 #include <opencog/atoms/base/Valuation.h>
 
+#include <opencog/persist/sql/SQLBackingStore.h>
 #include <opencog/persist/sql/multi-driver/SQLAtomStorage.h>
 
 #include <opencog/util/Logger.h>
@@ -116,12 +117,10 @@ class ValueSaveUTest :  public CxxTest::TestSuite
             exit(1);
         }
 
-        SQLAtomStorage *astore;
-
         void do_test_single_atom();
         void single_atom_save_restore(std::string);
 
-        void test_odbc_single_atom();
+        void xtest_odbc_single_atom();
         void test_pq_single_atom();
 };
 
@@ -138,7 +137,7 @@ void ValueSaveUTest::tearDown(void)
     delete as;
 }
 
-void ValueSaveUTest::test_odbc_single_atom(void)
+void ValueSaveUTest::xtest_odbc_single_atom(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 #if HAVE_ODBC_STORAGE
@@ -172,13 +171,18 @@ void ValueSaveUTest::single_atom_save_restore(std::string id)
 		return;
 	}
 
-	Handle key(createNode(CONCEPT_NODE, id + " some keynode"));
-	Handle atom(createNode(CONCEPT_NODE, id + " some node"));
+	SQLBackingStore* backing = new SQLBackingStore();
+	backing->set_store(store);
+	backing->registerWith(as);
+
+	Handle key = as->add_node(CONCEPT_NODE, id + " some keynode");
+	Handle atom = as->add_node(CONCEPT_NODE, id + " some node");
 
 	// Store the key and the atom, so as to avoid any UUID
 	// confusions.
-	store->storeAtom(key, true);
-	store->storeAtom(atom, true);
+	as->store_atom(key);
+	as->store_atom(atom);
+	as->barrier();
 
 	// --------------------
 	// Now set some values
@@ -186,30 +190,31 @@ void ValueSaveUTest::single_atom_save_restore(std::string id)
 		std::vector<double>({1.14, 2.24, 3.34}));
 
 	atom->setValue(key, pvf);
-	store->storeAtom(atom, true);
+	as->store_atom(atom);
 
 	// --------------------
 	ProtoAtomPtr pvs = createStringValue(
 		std::vector<std::string>({"aaa", "bb bb bb", "ccc ccc ccc"}));
 
 	atom->setValue(key, pvs);
-	store->storeAtom(atom, true);
+	as->store_atom(atom);
 
 	// --------------------
 	ProtoAtomPtr pvl = createLinkValue(
 		std::vector<ProtoAtomPtr>({pvf, pvs}));
 
 	atom->setValue(key, pvl);
-	store->storeAtom(atom, true);
+	as->store_atom(atom);
 
 	// --------------------
 	ProtoAtomPtr pvl2 = createLinkValue(
 		std::vector<ProtoAtomPtr>({pvl, pvl, pvf, pvs}));
 
 	atom->setValue(key, pvl2);
-	store->storeAtom(atom, true);
+	as->store_atom(atom);
 
 	// --------------------
+	delete backing;
 	// store->kill_data();
 	delete store;
 }

--- a/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
@@ -191,6 +191,7 @@ void ValueSaveUTest::single_atom_save_restore(std::string id)
 
 	atom->setValue(key, pvf);
 	as->store_atom(atom);
+	as->barrier();
 
 	// --------------------
 	ProtoAtomPtr pvs = createStringValue(
@@ -198,6 +199,7 @@ void ValueSaveUTest::single_atom_save_restore(std::string id)
 
 	atom->setValue(key, pvs);
 	as->store_atom(atom);
+	as->barrier();
 
 	// --------------------
 	ProtoAtomPtr pvl = createLinkValue(
@@ -205,6 +207,7 @@ void ValueSaveUTest::single_atom_save_restore(std::string id)
 
 	atom->setValue(key, pvl);
 	as->store_atom(atom);
+	as->barrier();
 
 	// --------------------
 	ProtoAtomPtr pvl2 = createLinkValue(
@@ -212,6 +215,7 @@ void ValueSaveUTest::single_atom_save_restore(std::string id)
 
 	atom->setValue(key, pvl2);
 	as->store_atom(atom);
+	as->barrier();
 
 	// --------------------
 	delete backing;

--- a/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
@@ -171,6 +171,9 @@ void ValueSaveUTest::single_atom_save_restore(std::string id)
 		return;
 	}
 
+	// Clear out left-over junk, just in case.
+	store->kill_data();
+
 	SQLBackingStore* backing = new SQLBackingStore();
 	backing->set_store(store);
 	backing->registerWith(as);
@@ -219,7 +222,7 @@ void ValueSaveUTest::single_atom_save_restore(std::string id)
 
 	// --------------------
 	delete backing;
-	// store->kill_data();
+	store->kill_data();
 	delete store;
 }
 


### PR DESCRIPTION
This is a partial implementation for storing protoatoms (generic values) in the SQL backend. It passes the unit tests, and the database layout is still backwards-compatible with the old layout. The next pull req in this series will break this compatbility and will use the new system to store truth values.