### PR TITLE
Constify TruthValues again.

### DIFF
--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -187,13 +187,13 @@ void Atom::setValue(const Handle& key, ProtoAtomPtr& value)
     _atom_space->_value_table.addValuation(key, getHandle(), value);
 }
 
-ProtoAtomPtr Atom::getValue(const Handle& key)
+ProtoAtomPtr Atom::getValue(const Handle& key) const
 {
     if (nullptr == _atom_space) return nullptr;
     return _atom_space->_value_table.getValue(key, getHandle());
 }
 
-std::set<Handle> Atom::getKeys()
+std::set<Handle> Atom::getKeys() const
 {
     if (nullptr == _atom_space) return std::set<Handle>();
     return _atom_space->_value_table.getKeys(getHandle());
@@ -209,7 +209,7 @@ void Atom::copyValues(const Handle& other)
     }
 }
 
-std::string Atom::valuesToString()
+std::string Atom::valuesToString() const
 {
     std::string rv;
 
@@ -357,7 +357,7 @@ size_t Atom::getIncomingSetSize() const
 // is not thread-safe during reading while simultaneous insertion and
 // deletion.  Besides, the incoming set is weak; we have to make it
 // strong in order to hand it out.
-IncomingSet Atom::getIncomingSet(AtomSpace* as)
+IncomingSet Atom::getIncomingSet(AtomSpace* as) const
 {
     static IncomingSet empty_set;
     if (NULL == _incoming_set) return empty_set;
@@ -387,7 +387,7 @@ IncomingSet Atom::getIncomingSet(AtomSpace* as)
     return iset;
 }
 
-IncomingSet Atom::getIncomingSetByType(Type type, bool subclass)
+IncomingSet Atom::getIncomingSetByType(Type type, bool subclass) const
 {
     HandleSeq inhs;
     getIncomingSetByType(std::back_inserter(inhs), type, subclass);

--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -157,7 +157,7 @@ TruthValuePtr Atom::getTruthValue() const
 #endif
 }
 
-void Atom::merge(TruthValuePtr tvn, const MergeCtrl& mc)
+void Atom::merge(const TruthValuePtr& tvn, const MergeCtrl& mc)
 {
     if (nullptr == tvn or tvn->isDefaultTV()) return;
 

--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -181,7 +181,7 @@ void Atom::merge(const TruthValuePtr& tvn, const MergeCtrl& mc)
 
 // ==============================================================
 // Setting values associated with this atom.
-void Atom::setValue(const Handle& key, ProtoAtomPtr& value)
+void Atom::setValue(const Handle& key, const ProtoAtomPtr& value)
 {
     if (nullptr == _atom_space) return;
     _atom_space->_value_table.addValuation(key, getHandle(), value);

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -210,8 +210,9 @@ public:
     }
 
     /** Returns the handle of the atom. */
-    inline Handle getHandle() {
-        return Handle(std::dynamic_pointer_cast<Atom>(shared_from_this()));
+    inline Handle getHandle() const {
+        return Handle(std::dynamic_pointer_cast<Atom>(
+             const_cast<Atom*>(this)->shared_from_this()));
     }
 
     /** Returns the TruthValue object of the atom. */

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -237,16 +237,16 @@ public:
     /// Associate `value` to `key` for this atom.
     void setValue(const Handle& key, ProtoAtomPtr& value);
     /// Get value at `key` for this atom.
-    ProtoAtomPtr getValue(const Handle& key);
+    ProtoAtomPtr getValue(const Handle& key) const;
 
     /// Get the set of all keys in use for this Atom.
-    std::set<Handle> getKeys();
+    std::set<Handle> getKeys() const;
 
     /// Copy all the values from the other atom to this one.
     void copyValues(const Handle&);
 
     /// Print all of the key-value pairs.
-    virtual std::string valuesToString();
+    virtual std::string valuesToString() const;
 
     //! Get the size of the incoming set.
     size_t getIncomingSetSize() const;
@@ -260,7 +260,7 @@ public:
     //! That is, this call returns the incoming set as it was att the
     //! time of the call; any deletions that occur afterwards (possibly
     //! in other threads) will not be reflected in the returned set.
-    IncomingSet getIncomingSet(AtomSpace* = NULL);
+    IncomingSet getIncomingSet(AtomSpace* = NULL) const;
 
     //! Place incoming set into STL container of Handles.
     //! Example usage:
@@ -270,7 +270,7 @@ public:
     //! that were actually part of the incoming set at the time of
     //! the call to this function.
     template <typename OutputIterator> OutputIterator
-    getIncomingSet(OutputIterator result)
+    getIncomingSet(OutputIterator result) const
     {
         if (NULL == _incoming_set) return result;
         std::lock_guard<std::mutex> lck(_mtx);
@@ -312,7 +312,7 @@ public:
      */
     template <typename OutputIterator> OutputIterator
     getIncomingSetByType(OutputIterator result,
-                         Type type, bool subclass = false)
+                         Type type, bool subclass = false) const
     {
         if (NULL == _incoming_set) return result;
         std::lock_guard<std::mutex> lck(_mtx);
@@ -334,7 +334,7 @@ public:
     }
 
     /** Functional version of getIncomingSetByType.  */
-    IncomingSet getIncomingSetByType(Type type, bool subclass = false);
+    IncomingSet getIncomingSetByType(Type type, bool subclass = false) const;
 
     /** Returns a string representation of the node. */
     virtual std::string toString(const std::string& indent) const = 0;

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -222,14 +222,14 @@ public:
     void setTruthValue(TruthValuePtr);
 
     /** merge truth value into this */
-    void merge(TruthValuePtr, const MergeCtrl& mc=MergeCtrl());
+    void merge(const TruthValuePtr&, const MergeCtrl& mc=MergeCtrl());
 
     /**
      * Merge truth value, return Handle for this.
      * This allows oneliners such as:
      *   Handle h = atomSpace->addNode(FOO_NODE, "foo")->tvmerge(tv);
      */
-    inline Handle tvmerge(TruthValuePtr tv) {
+    inline Handle tvmerge(const TruthValuePtr& tv) {
         merge(tv);
         return getHandle();
     }

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -235,7 +235,7 @@ public:
     }
 
     /// Associate `value` to `key` for this atom.
-    void setValue(const Handle& key, ProtoAtomPtr& value);
+    void setValue(const Handle& key, const ProtoAtomPtr& value);
     /// Get value at `key` for this atom.
     ProtoAtomPtr getValue(const Handle& key) const;
 

--- a/opencog/atoms/base/FloatValue.h
+++ b/opencog/atoms/base/FloatValue.h
@@ -45,17 +45,16 @@ protected:
 
 	FloatValue(Type t) : ProtoAtom(t) {}
 public: // XXX should be protected...
-	FloatValue(Type t, std::vector<double> v) : ProtoAtom(t), _value(v) {}
+	FloatValue(Type t, const std::vector<double>& v) : ProtoAtom(t), _value(v) {}
 
 public:
 	FloatValue(double v) : ProtoAtom(FLOAT_VALUE) { _value.push_back(v); }
-	FloatValue(std::vector<double> v) : ProtoAtom(FLOAT_VALUE), _value(v) {}
+	FloatValue(const std::vector<double>& v)
+		: ProtoAtom(FLOAT_VALUE), _value(v) {}
 
 	virtual ~FloatValue() {}
 
-	std::vector<double>& value() { return _value; }
-	void setValue(const std::vector<double>& v) { _value = v; }
-	void setValue(double v) { _value = std::vector<double>({v}); }
+	const std::vector<double>& value() const { return _value; }
 
 	/** Returns a string representation of the value.  */
 	virtual std::string toString(const std::string& indent = "") const;
@@ -64,9 +63,9 @@ public:
 	virtual bool operator==(const ProtoAtom&) const;
 };
 
-typedef std::shared_ptr<FloatValue> FloatValuePtr;
+typedef std::shared_ptr<const FloatValue> FloatValuePtr;
 static inline FloatValuePtr FloatValueCast(const ProtoAtomPtr& a)
-	{ return std::dynamic_pointer_cast<FloatValue>(a); }
+	{ return std::dynamic_pointer_cast<const FloatValue>(a); }
 
 // XXX temporary hack ...
 #define createFloatValue std::make_shared<FloatValue>

--- a/opencog/atoms/base/LinkValue.h
+++ b/opencog/atoms/base/LinkValue.h
@@ -45,12 +45,12 @@ protected:
 	std::vector<ProtoAtomPtr> _value;
 
 public:
-	LinkValue(std::vector<ProtoAtomPtr> v) : ProtoAtom(LINK_VALUE), _value(v) {}
+	LinkValue(const std::vector<ProtoAtomPtr>& v)
+		: ProtoAtom(LINK_VALUE), _value(v) {}
 
 	virtual ~LinkValue() {}
 
-	std::vector<ProtoAtomPtr>& value() { return _value; }
-	void setValue(const std::vector<ProtoAtomPtr>& v) { _value = v; }
+	const std::vector<ProtoAtomPtr>& value() const { return _value; }
 
 	/** Returns a string representation of the value.  */
 	virtual std::string toString(const std::string& indent) const;

--- a/opencog/atoms/base/StringValue.h
+++ b/opencog/atoms/base/StringValue.h
@@ -45,16 +45,14 @@ protected:
 	std::vector<std::string> _value;
 
 public:
-	StringValue(std::string v) : ProtoAtom(STRING_VALUE) { _value.push_back(v); }
-	StringValue(std::vector<std::string> v) : ProtoAtom(STRING_VALUE), _value(v) {}
+	StringValue(const std::string& v)
+		: ProtoAtom(STRING_VALUE) { _value.push_back(v); }
+	StringValue(const std::vector<std::string>& v)
+		: ProtoAtom(STRING_VALUE), _value(v) {}
 
 	virtual ~StringValue() {}
 
-	std::vector<std::string>& value() { return _value; }
-	void setValue(const std::vector<std::string>& v) { _value = v; }
-	void setValue(const std::string& v) {
-		_value = std::vector<std::string>({v}); }
-
+	const std::vector<std::string>& value() const { return _value; }
 
 	/** Returns a string representation of the value.  */
 	virtual std::string toString(const std::string& indent) const;
@@ -63,9 +61,9 @@ public:
 	virtual bool operator==(const ProtoAtom&) const;
 };
 
-typedef std::shared_ptr<StringValue> StringValuePtr;
+typedef std::shared_ptr<const StringValue> StringValuePtr;
 static inline StringValuePtr StringValueCast(const ProtoAtomPtr& a)
-	{ return std::dynamic_pointer_cast<StringValue>(a); }
+	{ return std::dynamic_pointer_cast<const StringValue>(a); }
 
 // XXX temporary hack ...
 #define createStringValue std::make_shared<StringValue>

--- a/opencog/atomspace/ValuationTable.cc
+++ b/opencog/atomspace/ValuationTable.cc
@@ -37,7 +37,7 @@ ValuationTable::~ValuationTable()
 
 /// Associate a value with a particular (key,atom) pair
 /// The atom, key and value are wrapped up in a single valuation.
-void ValuationTable::addValuation(ValuationPtr& vp)
+void ValuationTable::addValuation(const ValuationPtr& vp)
 {
 	const Handle& key = vp->key();
 	const Handle& atom = vp->atom();
@@ -62,7 +62,7 @@ void ValuationTable::addValuation(ValuationPtr& vp)
 /// Associate a value with a particular (key,atom) pair
 void ValuationTable::addValuation(const Handle& key,
                                   const Handle& atom,
-                                  ProtoAtomPtr& val)
+                                  const ProtoAtomPtr& val)
 {
 	ValuationPtr vp(createValuation(key, atom, val));
 	addValuation(vp);

--- a/opencog/atomspace/ValuationTable.h
+++ b/opencog/atomspace/ValuationTable.h
@@ -65,8 +65,8 @@ public:
 	ValuationTable();
 	~ValuationTable();
 
-   void addValuation(ValuationPtr&);
-   void addValuation(const Handle&, const Handle&, ProtoAtomPtr&);
+   void addValuation(const ValuationPtr&);
+   void addValuation(const Handle&, const Handle&, const ProtoAtomPtr&);
 	ValuationPtr getValuation(const Handle&, const Handle&);
 	ProtoAtomPtr getValue(const Handle&, const Handle&);
 

--- a/opencog/cython/opencog/atomspace.pxd
+++ b/opencog/cython/opencog/atomspace.pxd
@@ -41,7 +41,7 @@ ctypedef float confidence_t
 ctypedef float strength_t
 
 cdef extern from "opencog/truthvalue/TruthValue.h" namespace "opencog":
-    cdef cppclass tv_ptr "std::shared_ptr<opencog::TruthValue>":
+    cdef cppclass tv_ptr "std::shared_ptr<const opencog::TruthValue>":
         tv_ptr()
         tv_ptr(tv_ptr copy)
         tv_ptr(cTruthValue* fun)

--- a/opencog/guile/SchemePrimitive.h
+++ b/opencog/guile/SchemePrimitive.h
@@ -537,9 +537,9 @@ class SchemePrimitive : public PrimitiveEnviron
 				}
 				case P_H:
 				{
-					Handle h = SchemeSmob::verify_handle(scm_car(args), scheme_name);
+					Handle h(SchemeSmob::verify_handle(scm_car(args), scheme_name));
 					TruthValuePtr tv((that->*method.p_h)(h));
-					rc = SchemeSmob::protom_to_scm(tv);
+					rc = SchemeSmob::tv_to_scm(tv);
 					break;
 				}
 				case S_AS:

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -70,6 +70,7 @@ private:
 
 	static SCM handle_to_scm(const Handle&);
 	static SCM protom_to_scm(const ProtoAtomPtr&);
+	static SCM tv_to_scm(const TruthValuePtr&);
 	static Handle scm_to_handle(SCM);
 	static ProtoAtomPtr scm_to_protom(SCM);
 	static TruthValuePtr scm_to_tv(SCM);

--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -104,7 +104,7 @@ SCM SchemeSmob::ss_arity (SCM satom)
 SCM SchemeSmob::ss_tv (SCM satom)
 {
 	Handle h = verify_handle(satom, "cog-tv");
-	return protom_to_scm(h->getTruthValue());
+	return tv_to_scm(h->getTruthValue());
 }
 
 SCM SchemeSmob::ss_set_tv (SCM satom, SCM stv)

--- a/opencog/guile/SchemeSmobTV.cc
+++ b/opencog/guile/SchemeSmobTV.cc
@@ -187,7 +187,7 @@ std::string SchemeSmob::tv_to_string(const TruthValuePtr& tv)
 
 	if (EVIDENCE_COUNT_TRUTH_VALUE == tvt)
 	{
-		const EvidenceCountTruthValuePtr etv = std::dynamic_pointer_cast<EvidenceCountTruthValue>(tv);
+		const EvidenceCountTruthValuePtr etv = std::dynamic_pointer_cast<const EvidenceCountTruthValue>(tv);
 		snprintf(buff, BUFLEN, "(etv %.8g ", etv->getPositiveCount());
 		ret += buff;
 		snprintf(buff, BUFLEN, "%.8g)", etv->getCount());
@@ -198,6 +198,23 @@ std::string SchemeSmob::tv_to_string(const TruthValuePtr& tv)
 }
 
 /* ============================================================== */
+
+SCM SchemeSmob::tv_to_scm (const TruthValuePtr& tv)
+{
+	// This should have worked!?
+	// ProtoAtomPtr pa(std::const_pointer_cast<ProtoAtom>(tv));
+
+	// This, too, should have worked!?
+	// ProtoAtomPtr pa(std::shared_ptr<ProtoAtom>(tv,
+	//	const_cast<ProtoAtom*>(tv.get())));
+
+	// This works...
+	ProtoAtomPtr pa(std::shared_ptr<ProtoAtom>(tv,
+		(ProtoAtom*) tv.get()));
+
+	return protom_to_scm(pa);
+}
+
 /**
  * Create a new simple truth value, with indicated mean and confidence.
  */
@@ -206,8 +223,8 @@ SCM SchemeSmob::ss_new_stv (SCM smean, SCM sconfidence)
 	double mean = scm_to_double(smean);
 	double confidence = scm_to_double(sconfidence);
 
-	ProtoAtomPtr tv = SimpleTruthValue::createTV(mean, confidence);
-	return protom_to_scm(tv);
+	TruthValuePtr tv = SimpleTruthValue::createTV(mean, confidence);
+	return tv_to_scm(tv);
 }
 
 SCM SchemeSmob::ss_new_ctv (SCM smean, SCM sconfidence, SCM scount)
@@ -216,8 +233,8 @@ SCM SchemeSmob::ss_new_ctv (SCM smean, SCM sconfidence, SCM scount)
 	double confidence = scm_to_double(sconfidence);
 	double count = scm_to_double(scount);
 
-	ProtoAtomPtr tv = CountTruthValue::createTV(mean, confidence, count);
-	return protom_to_scm(tv);
+	TruthValuePtr tv = CountTruthValue::createTV(mean, confidence, count);
+	return tv_to_scm(tv);
 }
 
 SCM SchemeSmob::ss_new_itv (SCM slower, SCM supper, SCM sconfidence)
@@ -226,8 +243,8 @@ SCM SchemeSmob::ss_new_itv (SCM slower, SCM supper, SCM sconfidence)
 	double upper = scm_to_double(supper);
 	double confidence = scm_to_double(sconfidence);
 
-	ProtoAtomPtr tv = IndefiniteTruthValue::createTV(lower, upper, confidence);
-	return protom_to_scm(tv);
+	TruthValuePtr tv = IndefiniteTruthValue::createTV(lower, upper, confidence);
+	return tv_to_scm(tv);
 }
 
 SCM SchemeSmob::ss_new_ptv (SCM smean, SCM sconfidence, SCM scount)
@@ -236,8 +253,8 @@ SCM SchemeSmob::ss_new_ptv (SCM smean, SCM sconfidence, SCM scount)
 	double confidence = scm_to_double(sconfidence);
 	double count = scm_to_double(scount);
 
-	ProtoAtomPtr tv = ProbabilisticTruthValue::createTV(mean, confidence, count);
-	return protom_to_scm(tv);
+	TruthValuePtr tv = ProbabilisticTruthValue::createTV(mean, confidence, count);
+	return tv_to_scm(tv);
 }
 
 SCM SchemeSmob::ss_new_ftv (SCM smean, SCM sconfidence)
@@ -246,8 +263,8 @@ SCM SchemeSmob::ss_new_ftv (SCM smean, SCM sconfidence)
 	double confidence = scm_to_double(sconfidence);
 
 	float cnt = FuzzyTruthValue::confidenceToCount(confidence);
-	ProtoAtomPtr tv = FuzzyTruthValue::createTV(mean, cnt);
-	return protom_to_scm(tv);
+	TruthValuePtr tv = FuzzyTruthValue::createTV(mean, cnt);
+	return tv_to_scm(tv);
 }
 
 SCM SchemeSmob::ss_new_etv (SCM sposcount, SCM stotalcount)
@@ -255,8 +272,8 @@ SCM SchemeSmob::ss_new_etv (SCM sposcount, SCM stotalcount)
 	double pos_count = scm_to_double(sposcount);
 	double total_count = scm_to_double(stotalcount);
 
-	ProtoAtomPtr tv = EvidenceCountTruthValue::createTV(pos_count, total_count);
-	return protom_to_scm(tv);
+	TruthValuePtr tv = EvidenceCountTruthValue::createTV(pos_count, total_count);
+	return tv_to_scm(tv);
 }
 
 /* ============================================================== */
@@ -435,7 +452,7 @@ SCM SchemeSmob::ss_tv_get_value (SCM s)
 
 	if	(EVIDENCE_COUNT_TRUTH_VALUE == tvt)
 	{
-		EvidenceCountTruthValuePtr etv = std::dynamic_pointer_cast<EvidenceCountTruthValue>(tv);
+		EvidenceCountTruthValuePtr etv = std::dynamic_pointer_cast<const EvidenceCountTruthValue>(tv);
 		SCM poscount = scm_from_double(etv->getPositiveCount());
 		SCM mean = scm_from_double(etv->getMean());
 		SCM conf = scm_from_double(etv->getConfidence());

--- a/opencog/guile/SchemeSmobTV.cc
+++ b/opencog/guile/SchemeSmobTV.cc
@@ -201,18 +201,7 @@ std::string SchemeSmob::tv_to_string(const TruthValuePtr& tv)
 
 SCM SchemeSmob::tv_to_scm (const TruthValuePtr& tv)
 {
-	// This should have worked!?
-	// ProtoAtomPtr pa(std::const_pointer_cast<ProtoAtom>(tv));
-
-	// This, too, should have worked!?
-	// ProtoAtomPtr pa(std::shared_ptr<ProtoAtom>(tv,
-	//	const_cast<ProtoAtom*>(tv.get())));
-
-	// This works...
-	ProtoAtomPtr pa(std::shared_ptr<ProtoAtom>(tv,
-		(ProtoAtom*) tv.get()));
-
-	return protom_to_scm(pa);
+	return protom_to_scm(ProtoAtomCast(tv));
 }
 
 /**

--- a/opencog/haskell/AtomSpace_CWrapper.cpp
+++ b/opencog/haskell/AtomSpace_CWrapper.cpp
@@ -188,7 +188,7 @@ int AtomSpace_setTruthValue( AtomSpace* this_ptr
                                            ,parameters[3]);
         // iptr->setMean(parameters[0]);
         // iptr->setDiff(parameters[4]);
-        h->setTruthValue(std::static_pointer_cast<TruthValue>(iptr));
+        h->setTruthValue(std::static_pointer_cast<const TruthValue>(iptr));
     }
     else
     if (type == FUZZY_TRUTH_VALUE) {

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
@@ -827,7 +827,7 @@ ProtoAtomPtr SQLAtomStorage::doUnpackValue(Response& rp)
 		if (rp.vtype == FLOAT_VALUE)
 			return createFloatValue(fltarr);
 		else
-			return TruthValue::factory(rp.vtype, fltarr);
+			return ProtoAtomCast(TruthValue::factory(rp.vtype, fltarr));
 	}
 
 	// We expect rp.lnkval to be a comma-separated list of
@@ -893,7 +893,7 @@ void SQLAtomStorage::store_atom_values(const Handle& atom)
 		storeValuation(key, atom, pap);
 	}
 
-	// Special-case for TruthValues.
+	// Special-case for TruthValues. Can we get rid of this someday?
 	TruthValuePtr tv(atom->getTruthValue());
 
 	// XXX This is wasteful of performance; do we really
@@ -904,7 +904,7 @@ void SQLAtomStorage::store_atom_values(const Handle& atom)
 		return;
 	}
 
-	storeValuation(tvpred, atom, tv);
+	storeValuation(tvpred, atom, ProtoAtomCast(tv));
 }
 
 /// Get ALL of the values associated with an atom.

--- a/opencog/truthvalue/CountTruthValue.cc
+++ b/opencog/truthvalue/CountTruthValue.cc
@@ -117,19 +117,18 @@ bool CountTruthValue::operator==(const ProtoAtom& rhs) const
 // Note: this is NOT the merge formula used by PLN.  This is
 // because the CountTruthValue usally stores an integer count,
 // and a log-probability or entropy, instead of a confidence.
-TruthValuePtr CountTruthValue::merge(TruthValuePtr other,
+TruthValuePtr CountTruthValue::merge(const TruthValuePtr& other,
                                      const MergeCtrl& mc)
 {
-    CountTruthValuePtr oc =
-        std::dynamic_pointer_cast<CountTruthValue>(other);
+    CountTruthValuePtr oc(CountTruthValueCast(other));
 
     // If other is a simple truth value, *and* its not the default TV,
     // then perhaps we should merge it in, as if it were a count truth
     // value with a count of 1?  In which case, we should add a merge
     // routine to SimpleTruthValue to do likewise... Anyway, for now,
     // just ignore this possible complication to the semantics.
-    if (NULL == oc) return
-        std::dynamic_pointer_cast<TruthValue>(shared_from_this());
+    if (NULL == oc)
+        return TruthValueCast(shared_from_this());
 
     // If both this and other are counts, then accumulate to get the
     // total count, and average together the strengths, using the

--- a/opencog/truthvalue/CountTruthValue.cc
+++ b/opencog/truthvalue/CountTruthValue.cc
@@ -118,7 +118,7 @@ bool CountTruthValue::operator==(const ProtoAtom& rhs) const
 // because the CountTruthValue usally stores an integer count,
 // and a log-probability or entropy, instead of a confidence.
 TruthValuePtr CountTruthValue::merge(const TruthValuePtr& other,
-                                     const MergeCtrl& mc)
+                                     const MergeCtrl& mc) const
 {
     CountTruthValuePtr oc(CountTruthValueCast(other));
 
@@ -128,7 +128,7 @@ TruthValuePtr CountTruthValue::merge(const TruthValuePtr& other,
     // routine to SimpleTruthValue to do likewise... Anyway, for now,
     // just ignore this possible complication to the semantics.
     if (NULL == oc)
-        return TruthValueCast(shared_from_this());
+        return std::dynamic_pointer_cast<const TruthValue>(shared_from_this());
 
     // If both this and other are counts, then accumulate to get the
     // total count, and average together the strengths, using the

--- a/opencog/truthvalue/CountTruthValue.h
+++ b/opencog/truthvalue/CountTruthValue.h
@@ -36,7 +36,7 @@ namespace opencog
  */
 
 class CountTruthValue;
-typedef std::shared_ptr<CountTruthValue> CountTruthValuePtr;
+typedef std::shared_ptr<const CountTruthValue> CountTruthValuePtr;
 
 //! a TruthValue that stores a mean, a confidence and the number of observations
 class CountTruthValue : public TruthValue
@@ -63,18 +63,18 @@ public:
     count_t getCount() const;
     confidence_t getConfidence() const;
 
-    virtual TruthValuePtr merge(TruthValuePtr,
+    virtual TruthValuePtr merge(const TruthValuePtr&,
                                 const MergeCtrl& mc=MergeCtrl());
 
     static TruthValuePtr createTV(strength_t s, confidence_t f, count_t c)
     {
-        return std::static_pointer_cast<TruthValue>(
-            std::make_shared<CountTruthValue>(s, f, c));
+        return std::static_pointer_cast<const TruthValue>(
+            std::make_shared<const CountTruthValue>(s, f, c));
     }
     static TruthValuePtr createTV(const ProtoAtomPtr& pap)
     {
-        return std::static_pointer_cast<TruthValue>(
-            std::make_shared<CountTruthValue>(pap));
+        return std::static_pointer_cast<const TruthValue>(
+            std::make_shared<const CountTruthValue>(pap));
     }
 
     TruthValuePtr clone() const
@@ -86,6 +86,10 @@ public:
         return new CountTruthValue(*this);
     }
 };
+
+static inline CountTruthValuePtr CountTruthValueCast(const TruthValuePtr& tv)
+    { return std::dynamic_pointer_cast<const CountTruthValue>(tv); }
+
 
 /** @}*/
 } // namespace opencog

--- a/opencog/truthvalue/CountTruthValue.h
+++ b/opencog/truthvalue/CountTruthValue.h
@@ -64,7 +64,7 @@ public:
     confidence_t getConfidence() const;
 
     virtual TruthValuePtr merge(const TruthValuePtr&,
-                                const MergeCtrl& mc=MergeCtrl());
+                                const MergeCtrl& mc=MergeCtrl()) const;
 
     static TruthValuePtr createTV(strength_t s, confidence_t f, count_t c)
     {

--- a/opencog/truthvalue/EvidenceCountTruthValue.cc
+++ b/opencog/truthvalue/EvidenceCountTruthValue.cc
@@ -108,7 +108,7 @@ bool EvidenceCountTruthValue::is_count_valid() const
 
 // This is the merge formula appropriate for PLN.
 TruthValuePtr EvidenceCountTruthValue::merge(const TruthValuePtr& other,
-                                             const MergeCtrl& mc)
+                                             const MergeCtrl& mc) const
 {
 	// TODO
 	switch (mc.tv_formula)

--- a/opencog/truthvalue/EvidenceCountTruthValue.cc
+++ b/opencog/truthvalue/EvidenceCountTruthValue.cc
@@ -107,7 +107,7 @@ bool EvidenceCountTruthValue::is_count_valid() const
 }
 
 // This is the merge formula appropriate for PLN.
-TruthValuePtr EvidenceCountTruthValue::merge(TruthValuePtr other,
+TruthValuePtr EvidenceCountTruthValue::merge(const TruthValuePtr& other,
                                              const MergeCtrl& mc)
 {
 	// TODO

--- a/opencog/truthvalue/EvidenceCountTruthValue.h
+++ b/opencog/truthvalue/EvidenceCountTruthValue.h
@@ -34,7 +34,7 @@ namespace opencog
  */
 
 class EvidenceCountTruthValue;
-typedef std::shared_ptr<EvidenceCountTruthValue> EvidenceCountTruthValuePtr;
+typedef std::shared_ptr<const EvidenceCountTruthValue> EvidenceCountTruthValuePtr;
 
 //! a TruthValue that stores a strength and confidence.
 class EvidenceCountTruthValue : public TruthValue
@@ -77,23 +77,23 @@ public:
 	 * the resulting TV is either tv1 or tv2, the result being the one
 	 * with the highest confidence.
 	 */
-	TruthValuePtr merge(TruthValuePtr,
+	TruthValuePtr merge(const TruthValuePtr&,
 	                    const MergeCtrl& mc=MergeCtrl());
 
 	static EvidenceCountTruthValuePtr createECTV(count_t pos_count,
 	                                             count_t total_count = -1.0)
 	{
-		return std::make_shared<EvidenceCountTruthValue>(pos_count, total_count);
+		return std::make_shared<const EvidenceCountTruthValue>(pos_count, total_count);
 	}
 	static TruthValuePtr createTV(count_t pos_count, count_t total_count = -1.0)
 	{
-		return std::static_pointer_cast<TruthValue>(createECTV(pos_count,
+		return std::static_pointer_cast<const TruthValue>(createECTV(pos_count,
 		                                                       total_count));
 	}
 	static TruthValuePtr createTV(const ProtoAtomPtr& pap)
 	{
-		return std::static_pointer_cast<TruthValue>(
-			std::make_shared<EvidenceCountTruthValue>(pap));
+		return std::static_pointer_cast<const TruthValue>(
+			std::make_shared<const EvidenceCountTruthValue>(pap));
 	}
 
 	TruthValuePtr clone() const

--- a/opencog/truthvalue/EvidenceCountTruthValue.h
+++ b/opencog/truthvalue/EvidenceCountTruthValue.h
@@ -78,7 +78,7 @@ public:
 	 * with the highest confidence.
 	 */
 	TruthValuePtr merge(const TruthValuePtr&,
-	                    const MergeCtrl& mc=MergeCtrl());
+	                    const MergeCtrl& mc=MergeCtrl()) const;
 
 	static EvidenceCountTruthValuePtr createECTV(count_t pos_count,
 	                                             count_t total_count = -1.0)

--- a/opencog/truthvalue/FuzzyTruthValue.cc
+++ b/opencog/truthvalue/FuzzyTruthValue.cc
@@ -90,7 +90,7 @@ confidence_t FuzzyTruthValue::getConfidence() const
 
 // This is the merge formula appropriate for PLN.
 TruthValuePtr FuzzyTruthValue::merge(const TruthValuePtr& other,
-                                     const MergeCtrl& mc)
+                                     const MergeCtrl& mc) const
 {
     if (other->getType() != SIMPLE_TRUTH_VALUE) {
         throw RuntimeException(TRACE_INFO,
@@ -101,7 +101,7 @@ TruthValuePtr FuzzyTruthValue::merge(const TruthValuePtr& other,
     if (other->getConfidence() > getConfidence())
         return other;
 
-    return std::dynamic_pointer_cast<TruthValue>(shared_from_this());
+    return std::static_pointer_cast<const TruthValue>(shared_from_this());
 }
 
 std::string FuzzyTruthValue::toString(const std::string& indent) const

--- a/opencog/truthvalue/FuzzyTruthValue.cc
+++ b/opencog/truthvalue/FuzzyTruthValue.cc
@@ -89,7 +89,7 @@ confidence_t FuzzyTruthValue::getConfidence() const
 }
 
 // This is the merge formula appropriate for PLN.
-TruthValuePtr FuzzyTruthValue::merge(TruthValuePtr other,
+TruthValuePtr FuzzyTruthValue::merge(const TruthValuePtr& other,
                                      const MergeCtrl& mc)
 {
     if (other->getType() != SIMPLE_TRUTH_VALUE) {

--- a/opencog/truthvalue/FuzzyTruthValue.h
+++ b/opencog/truthvalue/FuzzyTruthValue.h
@@ -36,7 +36,7 @@ namespace opencog
  */
 
 class FuzzyTruthValue;
-typedef std::shared_ptr<FuzzyTruthValue> FuzzyTruthValuePtr;
+typedef std::shared_ptr<const FuzzyTruthValue> FuzzyTruthValuePtr;
 
 //! A TruthValue that stores a mean and the number of observations
 //! (strength and confidence)
@@ -85,7 +85,7 @@ public:
      * the resulting TV is either tv1 or tv2, the result being the one
      * with the highest confidence.
      */
-    TruthValuePtr merge(TruthValuePtr,
+    TruthValuePtr merge(const TruthValuePtr&,
                         const MergeCtrl& mc=MergeCtrl());
 
     static FuzzyTruthValuePtr createSTV(strength_t mean, count_t count)
@@ -94,12 +94,12 @@ public:
     }
     static TruthValuePtr createTV(strength_t mean, count_t count)
     {
-        return std::static_pointer_cast<TruthValue>(createSTV(mean, count));
+        return std::static_pointer_cast<const TruthValue>(createSTV(mean, count));
     }
     static TruthValuePtr createTV(const ProtoAtomPtr& pap)
     {
-        return std::static_pointer_cast<TruthValue>(
-            std::make_shared<FuzzyTruthValue>(pap));
+        return std::static_pointer_cast<const TruthValue>(
+            std::make_shared<const FuzzyTruthValue>(pap));
     }
 
     TruthValuePtr clone() const

--- a/opencog/truthvalue/FuzzyTruthValue.h
+++ b/opencog/truthvalue/FuzzyTruthValue.h
@@ -86,7 +86,7 @@ public:
      * with the highest confidence.
      */
     TruthValuePtr merge(const TruthValuePtr&,
-                        const MergeCtrl& mc=MergeCtrl());
+                        const MergeCtrl& mc=MergeCtrl()) const;
 
     static FuzzyTruthValuePtr createSTV(strength_t mean, count_t count)
     {

--- a/opencog/truthvalue/GenericTruthValue.cc
+++ b/opencog/truthvalue/GenericTruthValue.cc
@@ -137,7 +137,8 @@ entropy_t GenericTruthValue::getEntropy() const
     return _value[ENTROPY];
 }
 
-TruthValuePtr GenericTruthValue::merge(const TruthValuePtr& tv, const MergeCtrl& mc)
+TruthValuePtr GenericTruthValue::merge(const TruthValuePtr& tv,
+                                       const MergeCtrl& mc) const
 {
     GenericTruthValuePtr gtv = std::dynamic_pointer_cast<const GenericTruthValue>(tv);
     if (NULL == gtv) return tv;

--- a/opencog/truthvalue/GenericTruthValue.cc
+++ b/opencog/truthvalue/GenericTruthValue.cc
@@ -137,7 +137,7 @@ entropy_t GenericTruthValue::getEntropy() const
     return _value[ENTROPY];
 }
 
-TruthValuePtr GenericTruthValue::merge(TruthValuePtr tv, const MergeCtrl& mc)
+TruthValuePtr GenericTruthValue::merge(const TruthValuePtr& tv, const MergeCtrl& mc)
 {
     GenericTruthValuePtr gtv = std::dynamic_pointer_cast<const GenericTruthValue>(tv);
     if (NULL == gtv) return tv;

--- a/opencog/truthvalue/GenericTruthValue.h
+++ b/opencog/truthvalue/GenericTruthValue.h
@@ -71,17 +71,17 @@ class GenericTruthValue : public TruthValue
 
         entropy_t getEntropy() const;
 
-        TruthValuePtr merge(TruthValuePtr, const MergeCtrl& = MergeCtrl());
+        TruthValuePtr merge(const TruthValuePtr&, const MergeCtrl& = MergeCtrl());
 
         static TruthValuePtr createTV(const ProtoAtomPtr& pap)
         {
-            return std::static_pointer_cast<TruthValue>(
-                std::make_shared<GenericTruthValue>(pap));
+            return std::static_pointer_cast<const TruthValue>(
+                std::make_shared<const GenericTruthValue>(pap));
         }
 
         TruthValuePtr clone() const
         {
-            return std::make_shared<GenericTruthValue>(*this);
+            return std::make_shared<const GenericTruthValue>(*this);
         }
 
         TruthValue* rawclone() const

--- a/opencog/truthvalue/GenericTruthValue.h
+++ b/opencog/truthvalue/GenericTruthValue.h
@@ -71,7 +71,8 @@ class GenericTruthValue : public TruthValue
 
         entropy_t getEntropy() const;
 
-        TruthValuePtr merge(const TruthValuePtr&, const MergeCtrl& = MergeCtrl());
+        TruthValuePtr merge(const TruthValuePtr&,
+                            const MergeCtrl& = MergeCtrl()) const;
 
         static TruthValuePtr createTV(const ProtoAtomPtr& pap)
         {

--- a/opencog/truthvalue/IndefiniteTruthValue.cc
+++ b/opencog/truthvalue/IndefiniteTruthValue.cc
@@ -204,7 +204,7 @@ const std::vector<strength_t*>& IndefiniteTruthValue::getFirstOrderDistribution(
 }
 
 // Merge formula, as specified by PLN.
-TruthValuePtr IndefiniteTruthValue::merge(TruthValuePtr other,
+TruthValuePtr IndefiniteTruthValue::merge(const TruthValuePtr& other,
                                           const MergeCtrl& mc)
 {
     return higher_confidence_merge(other);

--- a/opencog/truthvalue/IndefiniteTruthValue.cc
+++ b/opencog/truthvalue/IndefiniteTruthValue.cc
@@ -205,7 +205,7 @@ const std::vector<strength_t*>& IndefiniteTruthValue::getFirstOrderDistribution(
 
 // Merge formula, as specified by PLN.
 TruthValuePtr IndefiniteTruthValue::merge(const TruthValuePtr& other,
-                                          const MergeCtrl& mc)
+                                          const MergeCtrl& mc) const
 {
     return higher_confidence_merge(other);
 }

--- a/opencog/truthvalue/IndefiniteTruthValue.h
+++ b/opencog/truthvalue/IndefiniteTruthValue.h
@@ -37,10 +37,10 @@ namespace opencog
  */
 
 class IndefiniteTruthValue;
-typedef std::shared_ptr<IndefiniteTruthValue> IndefiniteTruthValuePtr;
+typedef std::shared_ptr<const IndefiniteTruthValue> IndefiniteTruthValuePtr;
 
 static inline IndefiniteTruthValuePtr IndefiniteTVCast(TruthValuePtr tv)
-    { return std::dynamic_pointer_cast<IndefiniteTruthValue>(tv); }
+    { return std::dynamic_pointer_cast<const IndefiniteTruthValue>(tv); }
 
 /**
  * Indefinite probabilities are in the form ([L,U],b,N). In practical work,
@@ -112,7 +112,7 @@ public:
     strength_t getL_() const { return _value[L] - diff; }
     bool isSymmetric() const { return symmetric; }
 
-    TruthValuePtr merge(TruthValuePtr,
+    TruthValuePtr merge(const TruthValuePtr&,
                         const MergeCtrl& mc=MergeCtrl());
 
     std::string toString(const std::string&) const;
@@ -128,24 +128,24 @@ public:
 
     static TruthValuePtr createTV(TruthValuePtr tv)
     {
-        return std::static_pointer_cast<TruthValue>(createITV(tv));
+        return std::static_pointer_cast<const TruthValue>(createITV(tv));
     }
 
     static IndefiniteTruthValuePtr createITV(strength_t l, strength_t u,
                          confidence_t c = DEFAULT_CONFIDENCE_LEVEL)
     {
-        return std::make_shared<IndefiniteTruthValue>(l, u, c);
+        return std::make_shared<const IndefiniteTruthValue>(l, u, c);
     }
 
     static TruthValuePtr createTV(strength_t l, strength_t u,
                          confidence_t c = DEFAULT_CONFIDENCE_LEVEL)
     {
-        return std::static_pointer_cast<TruthValue>(createITV(l, u, c));
+        return std::static_pointer_cast<const TruthValue>(createITV(l, u, c));
     }
     static TruthValuePtr createTV(const ProtoAtomPtr& pap)
     {
-        return std::static_pointer_cast<TruthValue>(
-            std::make_shared<IndefiniteTruthValue>(pap));
+        return std::static_pointer_cast<const TruthValue>(
+            std::make_shared<const IndefiniteTruthValue>(pap));
     }
 
     TruthValuePtr clone() const

--- a/opencog/truthvalue/IndefiniteTruthValue.h
+++ b/opencog/truthvalue/IndefiniteTruthValue.h
@@ -113,7 +113,7 @@ public:
     bool isSymmetric() const { return symmetric; }
 
     TruthValuePtr merge(const TruthValuePtr&,
-                        const MergeCtrl& mc=MergeCtrl());
+                        const MergeCtrl& mc=MergeCtrl()) const;
 
     std::string toString(const std::string&) const;
 

--- a/opencog/truthvalue/ProbabilisticTruthValue.cc
+++ b/opencog/truthvalue/ProbabilisticTruthValue.cc
@@ -118,7 +118,7 @@ bool ProbabilisticTruthValue::operator==(const ProtoAtom& rhs) const
 // because the ProbabilisticTruthValue usally stores an integer count,
 // and a log-probability or entropy, instead of a confidence.
 TruthValuePtr ProbabilisticTruthValue::merge(const TruthValuePtr& other,
-                                     const MergeCtrl& mc)
+                                     const MergeCtrl& mc) const
 {
     ProbabilisticTruthValuePtr oc =
         std::dynamic_pointer_cast<const ProbabilisticTruthValue>(other);
@@ -129,7 +129,7 @@ TruthValuePtr ProbabilisticTruthValue::merge(const TruthValuePtr& other,
     // routine to SimpleTruthValue to do likewise... Anyway, for now,
     // just ignore this possible complication to the semantics.
     if (nullptr == oc)
-        return TruthValueCast(shared_from_this());
+        return std::static_pointer_cast<const TruthValue>(shared_from_this());
 
     // If both this and other are counts, then accumulate to get the
     // total count, and average together the strengths, using the

--- a/opencog/truthvalue/ProbabilisticTruthValue.cc
+++ b/opencog/truthvalue/ProbabilisticTruthValue.cc
@@ -117,19 +117,19 @@ bool ProbabilisticTruthValue::operator==(const ProtoAtom& rhs) const
 // Note: this is NOT the merge formula used by PLN.  This is
 // because the ProbabilisticTruthValue usally stores an integer count,
 // and a log-probability or entropy, instead of a confidence.
-TruthValuePtr ProbabilisticTruthValue::merge(TruthValuePtr other,
+TruthValuePtr ProbabilisticTruthValue::merge(const TruthValuePtr& other,
                                      const MergeCtrl& mc)
 {
     ProbabilisticTruthValuePtr oc =
-        std::dynamic_pointer_cast<ProbabilisticTruthValue>(other);
+        std::dynamic_pointer_cast<const ProbabilisticTruthValue>(other);
 
     // If other is a simple truth value, *and* its not the default TV,
     // then perhaps we should merge it in, as if it were a count truth
     // value with a count of 1?  In which case, we should add a merge
     // routine to SimpleTruthValue to do likewise... Anyway, for now,
     // just ignore this possible complication to the semantics.
-    if (nullptr == oc) return
-        std::dynamic_pointer_cast<TruthValue>(shared_from_this());
+    if (nullptr == oc)
+        return TruthValueCast(shared_from_this());
 
     // If both this and other are counts, then accumulate to get the
     // total count, and average together the strengths, using the

--- a/opencog/truthvalue/ProbabilisticTruthValue.h
+++ b/opencog/truthvalue/ProbabilisticTruthValue.h
@@ -64,7 +64,7 @@ public:
     confidence_t getConfidence() const;
 
     virtual TruthValuePtr merge(const TruthValuePtr&,
-                                const MergeCtrl& mc=MergeCtrl());
+                                const MergeCtrl& mc=MergeCtrl()) const;
 
     static TruthValuePtr createTV(strength_t s, confidence_t f, count_t c)
     {

--- a/opencog/truthvalue/ProbabilisticTruthValue.h
+++ b/opencog/truthvalue/ProbabilisticTruthValue.h
@@ -36,7 +36,7 @@ namespace opencog
  */
 
 class ProbabilisticTruthValue;
-typedef std::shared_ptr<ProbabilisticTruthValue> ProbabilisticTruthValuePtr;
+typedef std::shared_ptr<const ProbabilisticTruthValue> ProbabilisticTruthValuePtr;
 
 //! a TruthValue that stores a mean, a confidence and the number of observations
 class ProbabilisticTruthValue : public TruthValue
@@ -63,23 +63,23 @@ public:
     count_t getCount() const;
     confidence_t getConfidence() const;
 
-    virtual TruthValuePtr merge(TruthValuePtr,
+    virtual TruthValuePtr merge(const TruthValuePtr&,
                                 const MergeCtrl& mc=MergeCtrl());
 
     static TruthValuePtr createTV(strength_t s, confidence_t f, count_t c)
     {
-        return std::static_pointer_cast<TruthValue>(
-            std::make_shared<ProbabilisticTruthValue>(s, f, c));
+        return std::static_pointer_cast<const TruthValue>(
+            std::make_shared<const ProbabilisticTruthValue>(s, f, c));
     }
     static TruthValuePtr createTV(const ProtoAtomPtr& pap)
     {
-        return std::static_pointer_cast<TruthValue>(
-            std::make_shared<ProbabilisticTruthValue>(pap));
+        return std::static_pointer_cast<const TruthValue>(
+            std::make_shared<const ProbabilisticTruthValue>(pap));
     }
 
     TruthValuePtr clone() const
     {
-        return std::make_shared<ProbabilisticTruthValue>(*this);
+        return std::make_shared<const ProbabilisticTruthValue>(*this);
     }
     TruthValue* rawclone() const
     {

--- a/opencog/truthvalue/SimpleTruthValue.cc
+++ b/opencog/truthvalue/SimpleTruthValue.cc
@@ -94,7 +94,7 @@ confidence_t SimpleTruthValue::getConfidence() const
 }
 
 // This is the merge formula appropriate for PLN.
-TruthValuePtr SimpleTruthValue::merge(TruthValuePtr other,
+TruthValuePtr SimpleTruthValue::merge(const TruthValuePtr& other,
                                       const MergeCtrl& mc)
 {
     switch (mc.tv_formula)
@@ -120,7 +120,7 @@ TruthValuePtr SimpleTruthValue::merge(TruthValuePtr other,
             auto mean_new = (getMean() * count + other->getMean() * count2)
                 / (count + count2);
             confidence_t confidence_new = static_cast<confidence_t>(count_new / (count_new + DEFAULT_K));
-            return std::make_shared<SimpleTruthValue>(mean_new, confidence_new);
+            return createTV(mean_new, confidence_new);
         }
         default:
             throw RuntimeException(TRACE_INFO,

--- a/opencog/truthvalue/SimpleTruthValue.cc
+++ b/opencog/truthvalue/SimpleTruthValue.cc
@@ -95,7 +95,7 @@ confidence_t SimpleTruthValue::getConfidence() const
 
 // This is the merge formula appropriate for PLN.
 TruthValuePtr SimpleTruthValue::merge(const TruthValuePtr& other,
-                                      const MergeCtrl& mc)
+                                      const MergeCtrl& mc) const
 {
     switch (mc.tv_formula)
     {
@@ -113,13 +113,13 @@ TruthValuePtr SimpleTruthValue::merge(const TruthValuePtr& other,
                                    typeid(*other).name());
 
             confidence_t cf = std::min(getConfidence(), 0.9999998);
-            auto count = static_cast<count_t>(DEFAULT_K * cf / (1.0 - cf));
+            auto count = DEFAULT_K * cf / (1.0 - cf);
             auto count2 = other->getCount();
 #define CVAL  0.2f
             auto count_new = count + count2 - std::min(count, count2) * CVAL;
             auto mean_new = (getMean() * count + other->getMean() * count2)
                 / (count + count2);
-            confidence_t confidence_new = static_cast<confidence_t>(count_new / (count_new + DEFAULT_K));
+            confidence_t confidence_new = (count_new / (count_new + DEFAULT_K));
             return createTV(mean_new, confidence_new);
         }
         default:

--- a/opencog/truthvalue/SimpleTruthValue.h
+++ b/opencog/truthvalue/SimpleTruthValue.h
@@ -36,7 +36,7 @@ namespace opencog
  */
 
 class SimpleTruthValue;
-typedef std::shared_ptr<SimpleTruthValue> SimpleTruthValuePtr;
+typedef std::shared_ptr<const SimpleTruthValue> SimpleTruthValuePtr;
 
 //! a TruthValue that stores a strength and confidence.
 class SimpleTruthValue : public TruthValue
@@ -70,26 +70,26 @@ public:
      * the resulting TV is either tv1 or tv2, the result being the one
      * with the highest confidence.
      */
-    TruthValuePtr merge(TruthValuePtr,
+    TruthValuePtr merge(const TruthValuePtr&,
                         const MergeCtrl& mc=MergeCtrl());
 
     static SimpleTruthValuePtr createSTV(strength_t mean, confidence_t conf)
     {
-        return std::make_shared<SimpleTruthValue>(mean, conf);
+        return std::make_shared<const SimpleTruthValue>(mean, conf);
     }
     static TruthValuePtr createTV(strength_t mean, confidence_t conf)
     {
-        return std::static_pointer_cast<TruthValue>(createSTV(mean, conf));
+        return std::static_pointer_cast<const TruthValue>(createSTV(mean, conf));
     }
     static TruthValuePtr createTV(const ProtoAtomPtr& pap)
     {
-        return std::static_pointer_cast<TruthValue>(
-            std::make_shared<SimpleTruthValue>(pap));
+        return std::static_pointer_cast<const TruthValue>(
+            std::make_shared<const SimpleTruthValue>(pap));
     }
 
     TruthValuePtr clone() const
     {
-        return std::make_shared<SimpleTruthValue>(*this);
+        return std::make_shared<const SimpleTruthValue>(*this);
     }
     TruthValue* rawclone() const
     {

--- a/opencog/truthvalue/SimpleTruthValue.h
+++ b/opencog/truthvalue/SimpleTruthValue.h
@@ -71,7 +71,7 @@ public:
      * with the highest confidence.
      */
     TruthValuePtr merge(const TruthValuePtr&,
-                        const MergeCtrl& mc=MergeCtrl());
+                        const MergeCtrl& mc=MergeCtrl()) const;
 
     static SimpleTruthValuePtr createSTV(strength_t mean, confidence_t conf)
     {

--- a/opencog/truthvalue/TruthValue.cc
+++ b/opencog/truthvalue/TruthValue.cc
@@ -132,15 +132,15 @@ bool TruthValue::isDefinedTV() const
     return false;
 }
 
-TruthValuePtr TruthValue::higher_confidence_merge(TruthValuePtr other)
+TruthValuePtr TruthValue::higher_confidence_merge(const TruthValuePtr& other)
 {
     if (other->getConfidence() > getConfidence()) {
         return other;
     }
-    return std::dynamic_pointer_cast<TruthValue>(shared_from_this());
+    return TruthValueCast(shared_from_this());
 }
 
-TruthValuePtr TruthValue::factory(Type t, std::vector<double> v)
+TruthValuePtr TruthValue::factory(Type t, const std::vector<double>& v)
 {
 	ProtoAtomPtr pap = createFloatValue(t,v);
 	return factory(pap);

--- a/opencog/truthvalue/TruthValue.cc
+++ b/opencog/truthvalue/TruthValue.cc
@@ -132,12 +132,13 @@ bool TruthValue::isDefinedTV() const
     return false;
 }
 
-TruthValuePtr TruthValue::higher_confidence_merge(const TruthValuePtr& other)
+TruthValuePtr
+TruthValue::higher_confidence_merge(const TruthValuePtr& other) const
 {
     if (other->getConfidence() > getConfidence()) {
         return other;
     }
-    return TruthValueCast(shared_from_this());
+    return std::dynamic_pointer_cast<const TruthValue>(shared_from_this());
 }
 
 TruthValuePtr TruthValue::factory(Type t, const std::vector<double>& v)

--- a/opencog/truthvalue/TruthValue.h
+++ b/opencog/truthvalue/TruthValue.h
@@ -166,6 +166,18 @@ public:
 static inline TruthValuePtr TruthValueCast(const ProtoAtomPtr& pa)
     { return std::dynamic_pointer_cast<const TruthValue>(pa); }
 
+static inline ProtoAtomPtr ProtoAtomCast(const TruthValuePtr& tv)
+{
+    // This should have worked!?
+    // return std::const_pointer_cast<ProtoAtom>(tv);
+
+    // This, too, should have worked!?
+    // return std::shared_ptr<ProtoAtom>(tv, const_cast<ProtoAtom*>(tv.get()));
+
+    // This works...
+    return std::shared_ptr<ProtoAtom>(tv, (ProtoAtom*) tv.get());
+}
+
 } // namespace opencog
 
 /** @}*/

--- a/opencog/truthvalue/TruthValue.h
+++ b/opencog/truthvalue/TruthValue.h
@@ -101,7 +101,7 @@ protected:
     TruthValue(Type t) : FloatValue(t) {}
 
     // Merge helper method
-    TruthValuePtr higher_confidence_merge(const TruthValuePtr&);
+    TruthValuePtr higher_confidence_merge(const TruthValuePtr&) const;
 
 public:
     virtual ~TruthValue() {}
@@ -153,7 +153,7 @@ public:
      *        https://github.com/opencog/opencog/issues/1295
      */
     virtual TruthValuePtr merge(const TruthValuePtr&,
-                                const MergeCtrl& = MergeCtrl()) = 0;
+                                const MergeCtrl& = MergeCtrl()) const = 0;
 
     /**
      * Check if this TV is equal to the default TV.

--- a/opencog/truthvalue/TruthValue.h
+++ b/opencog/truthvalue/TruthValue.h
@@ -81,7 +81,7 @@ struct MergeCtrl
 };
 
 class TruthValue;
-typedef std::shared_ptr<TruthValue> TruthValuePtr;
+typedef std::shared_ptr<const TruthValue> TruthValuePtr;
 
 class TruthValue
     : public FloatValue
@@ -101,12 +101,12 @@ protected:
     TruthValue(Type t) : FloatValue(t) {}
 
     // Merge helper method
-    TruthValuePtr higher_confidence_merge(TruthValuePtr);
+    TruthValuePtr higher_confidence_merge(const TruthValuePtr&);
 
 public:
     virtual ~TruthValue() {}
 
-    static TruthValuePtr factory(Type, std::vector<double>);
+    static TruthValuePtr factory(Type, const std::vector<double>&);
     static TruthValuePtr factory(const ProtoAtomPtr&);
 
     virtual std::string toShortString(const std::string&) const;
@@ -152,7 +152,7 @@ public:
      * @param ms the merge style as described in
      *        https://github.com/opencog/opencog/issues/1295
      */
-    virtual TruthValuePtr merge(TruthValuePtr,
+    virtual TruthValuePtr merge(const TruthValuePtr&,
                                 const MergeCtrl& = MergeCtrl()) = 0;
 
     /**
@@ -164,7 +164,7 @@ public:
 };
 
 static inline TruthValuePtr TruthValueCast(const ProtoAtomPtr& pa)
-    { return std::dynamic_pointer_cast<TruthValue>(pa); }
+    { return std::dynamic_pointer_cast<const TruthValue>(pa); }
 
 } // namespace opencog
 

--- a/tests/scm/BasicSCMUTest.cxxtest
+++ b/tests/scm/BasicSCMUTest.cxxtest
@@ -253,7 +253,7 @@ void BasicSCMUTest::check_truth_value(const TruthValuePtr& tv)
 		   << " " << tv->getCount();
 	else if (tvt == INDEFINITE_TRUTH_VALUE) {
 		const IndefiniteTruthValuePtr& itv =
-			dynamic_pointer_cast<IndefiniteTruthValue>(tv);
+			dynamic_pointer_cast<const IndefiniteTruthValue>(tv);
 		ss << "cog-new-itv " << itv->getL() << " " << itv->getU()
 		   << " " << itv->getConfidence();
 	}
@@ -325,7 +325,7 @@ void BasicSCMUTest::test_values(void)
 	TSM_ASSERT("Failed to set float", not eval->eval_error());
 
 	ProtoAtomPtr fv = h->getValue(k);
-	std::vector<double>& vv(FloatValueCast(fv)->value());
+	const std::vector<double>& vv(FloatValueCast(fv)->value());
 
 	TS_ASSERT_LESS_THAN_EQUALS(fabs(vv[0] - 0.1), 1.0e-6);
 	TS_ASSERT_LESS_THAN_EQUALS(fabs(vv[1] - 0.2), 1.0e-6);


### PR DESCRIPTION
Truth values used to be const pointers.  I removed this a few days ago, as it interfered with code development. This diff restores this.

This constification makes truth values immutable: you cannot change a given truth value, although you can the association of truth values to atoms.  The same principle now applies to "values" as well.