### PR TITLE
Change importance values type from short to double

### DIFF
--- a/opencog/truthvalue/AttentionValue.cc
+++ b/opencog/truthvalue/AttentionValue.cc
@@ -33,7 +33,7 @@ const AttentionValue::vlti_t AttentionValue::DEFAULTATOMVLTI = 0;
 std::string AttentionValue::toString() const
 {
     char buffer[256];
-    sprintf(buffer, "[%d, %d, %s]", (int)m_STI, (int)m_LTI,
+    sprintf(buffer, "[%f, %f, %s]", m_STI, m_LTI,
             m_VLTI ? "SAVABLE" : "DISPOSABLE");
     return buffer;
 }

--- a/opencog/truthvalue/AttentionValue.h
+++ b/opencog/truthvalue/AttentionValue.h
@@ -49,9 +49,9 @@ class AttentionValue
     : public std::enable_shared_from_this<AttentionValue>
 {
 public:
-    typedef short sti_t;   //!< short-term importance type
-    typedef short lti_t;   //!< long-term importance type
-    typedef short vlti_t;  //!< very long-term importance type
+    typedef double sti_t;   //!< short-term importance type
+    typedef double lti_t;   //!< long-term importance type
+    typedef double vlti_t;  //!< very long-term importance type
 
     static const int DISPOSABLE = 0; //!< Status flag for vlti
 
@@ -60,10 +60,10 @@ public:
     static const lti_t DEFAULTATOMLTI;   //!< long-term importance default
     static const vlti_t DEFAULTATOMVLTI; //!< very long-term default
 
-    static const sti_t MAXSTI = SHRT_MAX;
-    static const lti_t MAXLTI = SHRT_MAX;
-    static const sti_t MINSTI = SHRT_MIN;
-    static const lti_t MINLTI = SHRT_MIN;
+    static constexpr sti_t MAXSTI = SHRT_MAX;
+    static constexpr lti_t MAXLTI = SHRT_MAX;
+    static constexpr sti_t MINSTI = SHRT_MIN;
+    static constexpr lti_t MINLTI = SHRT_MIN;
 
     //! to be used as default attention value
     static AttentionValuePtr DEFAULT_AV() {

--- a/tests/truthvalue/AttentionValueUTest.cxxtest
+++ b/tests/truthvalue/AttentionValueUTest.cxxtest
@@ -353,7 +353,7 @@ public:
         for (int i = 0; i < NUM_AVS; i++) {
             //logger().debug("AV[%d] = %s", i, avs[i]->toString().c_str());
             std::string str = avs[i]->toString();
-            sprintf(buffer, "[%d, %d, %s]", avs[i]->getSTI(), avs[i]->getLTI(), avs[i]->getVLTI() ? "SAVABLE" : "DISPOSABLE");
+            sprintf(buffer, "[%f, %f, %s]", avs[i]->getSTI(), avs[i]->getLTI(), avs[i]->getVLTI() ? "SAVABLE" : "DISPOSABLE");
             TS_ASSERT(!strcmp(str.c_str(), buffer));
         }
     }


### PR DESCRIPTION
This will allow us to do floating point importance calculations without losing precision as mentioned  [here] (https://github.com/opencog/opencog/issues/676). Opencog repo seems to be building fine when compiled with these changes. So, I am tempted to make a PR.