### PR TITLE
Move atom factory to the classserver

### DIFF
--- a/opencog/atoms/NumberNode.h
+++ b/opencog/atoms/NumberNode.h
@@ -66,22 +66,19 @@ protected:
 	double value;
 
 public:
-	NumberNode(const std::string& s,
-	           TruthValuePtr tv = TruthValue::DEFAULT_TV())
+	NumberNode(const std::string& s)
 		// Convert to number and back to string to avoid miscompares.
-		: Node(NUMBER_NODE, double_to_string(std::stod(s)), tv),
+		: Node(NUMBER_NODE, double_to_string(std::stod(s))),
 		  value(std::stod(s))
 	{}
 
-	NumberNode(double vvv,
-	           TruthValuePtr tv = TruthValue::DEFAULT_TV())
-		: Node(NUMBER_NODE, double_to_string(vvv), tv),
+	NumberNode(double vvv)
+		: Node(NUMBER_NODE, double_to_string(vvv)),
 		  value(vvv)
 	{}
 
 	NumberNode(Node &n)
-		: Node(n.getType(), double_to_string(std::stod(n.getName())),
-		       n.getTruthValue()),
+		: Node(n.getType(), double_to_string(std::stod(n.getName()))),
 		  value(std::stod(n.getName()))
 	{
 		OC_ASSERT(classserver().isA(_type, NUMBER_NODE),

--- a/opencog/atoms/TypeNode.h
+++ b/opencog/atoms/TypeNode.h
@@ -42,10 +42,9 @@ protected:
 	Type value;
 
 public:
-	TypeNode(const std::string& s,
-	           TruthValuePtr tv = TruthValue::DEFAULT_TV())
+	TypeNode(const std::string& s)
 		// Convert to number and back to string to avoid miscompares.
-		: Node(TYPE_NODE, s, tv),
+		: Node(TYPE_NODE, s),
 		  value(classserver().getType(s))
 	{
 		if (NOTYPE == value)
@@ -53,8 +52,8 @@ public:
 				"Not a valid typename: '%s'", s.c_str());
 	}
 
-	TypeNode(Type t, TruthValuePtr tv = TruthValue::DEFAULT_TV())
-		: Node(TYPE_NODE, classserver().getTypeName(t), tv),
+	TypeNode(Type t)
+		: Node(TYPE_NODE, classserver().getTypeName(t)),
 		  value(t)
 	{}
 

--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -207,6 +207,9 @@ void Atom::copyValues(const Handle& other)
         ProtoAtomPtr p = other->getValue(k);
         setValue(k, p);
     }
+
+    // Special case for truth values
+    setTruthValue(other->getTruthValue());
 }
 
 std::string Atom::valuesToString() const

--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -80,6 +80,9 @@ void Atom::setTruthValue(TruthValuePtr newTV)
 {
     if (nullptr == newTV) return;
 
+    // If both old and new are e.g. DEFAULT_TV, then do nothing.
+    if (_truthValue.get() == newTV.get()) return;
+
     // We need to guarantee that the signal goes out with the
     // correct truth value.  That is, another setter could be changing
     // this, even as we are.  So make a copy, first.

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -117,12 +117,12 @@ protected:
      * atom references. It must be an empty vector if the atom is a node.
      * @param The truthValue of the atom.
      */
-    Atom(Type t, TruthValuePtr tv = TruthValue::DEFAULT_TV())
+    Atom(Type t)
       : ProtoAtom(t),
         _flags(0),
         _content_hash(Handle::INVALID_HASH),
         _atom_space(nullptr),
-        _truthValue(tv)
+        _truthValue(TruthValue::DEFAULT_TV())
     {}
 
     struct InSet

--- a/opencog/atoms/base/ClassServer.cc
+++ b/opencog/atoms/base/ClassServer.cc
@@ -99,6 +99,8 @@ Type ClassServer::addType(const Type parent, const std::string& name)
 
 void ClassServer::setParentRecursively(Type parent, Type type, Type& maxd)
 {
+    if (recursiveMap[parent][type]) return;
+
     bool incr = false;
     recursiveMap[parent][type] = true;
     for (Type i = 0; i < nTypes; ++i) {

--- a/opencog/atoms/base/ClassServer.cc
+++ b/opencog/atoms/base/ClassServer.cc
@@ -115,14 +115,14 @@ void ClassServer::addFactory(Type t, AtomFactory* fact)
     _atomFactory[t] = fact;
 }
 
-Handle ClassServer::factory(const ProtoAtomPtr& pap)
+Handle ClassServer::factory(const Handle& h)
 {
-	auto fpr = _atomFactory.find(pap->getType());
+	auto fpr = _atomFactory.find(h->getType());
 	if (_atomFactory.end() == fpr)
-		return HandleCast(pap);
+		return Handle(h);
 
 	AtomFactory* fact = fpr->second;
-	return (*fact)(pap);
+	return (*fact)(h);
 }
 
 Type ClassServer::getNumberOfClasses()

--- a/opencog/atoms/base/ClassServer.cc
+++ b/opencog/atoms/base/ClassServer.cc
@@ -30,7 +30,6 @@
 #include "ClassServer.h"
 
 #include <exception>
-#include <boost/bind.hpp>
 
 #include <opencog/atoms/base/types.h>
 #include <opencog/atoms/base/atom_types.h>
@@ -72,11 +71,8 @@ Type ClassServer::addType(const Type parent, const std::string& name)
     inheritanceMap.resize(nTypes);
     recursiveMap.resize(nTypes);
 
-    std::for_each(inheritanceMap.begin(), inheritanceMap.end(),
-          boost::bind(&std::vector<bool>::resize, _1, nTypes, false));
-
-    std::for_each(recursiveMap.begin(), recursiveMap.end(),
-          boost::bind(&std::vector<bool>::resize, _1, nTypes, false));
+    for (auto& bv: inheritanceMap) bv.resize(nTypes, false);
+    for (auto& bv: recursiveMap) bv.resize(nTypes, false);
 
     inheritanceMap[type][type]   = true;
     inheritanceMap[parent][type] = true;

--- a/opencog/atoms/base/ClassServer.cc
+++ b/opencog/atoms/base/ClassServer.cc
@@ -178,7 +178,7 @@ Handle ClassServer::factory(const Handle& h)
 	if (fact)
 		return (*fact)(h);
 
-	return Handle(h);
+	return h;
 }
 
 Type ClassServer::getNumberOfClasses()

--- a/opencog/atoms/base/ClassServer.cc
+++ b/opencog/atoms/base/ClassServer.cc
@@ -136,7 +136,7 @@ ClassServer::AtomFactory* ClassServer::searchToDepth(Type t, int depth)
 	if (depth < 0) return nullptr;
 
 	std::vector<Type> parents;
-	getParents(t, parents.begin());
+	getParents(t, back_inserter(parents));
 	for (auto p: parents)
 	{
 		AtomFactory* fact = searchToDepth(p, depth);
@@ -145,6 +145,7 @@ ClassServer::AtomFactory* ClassServer::searchToDepth(Type t, int depth)
 
 	return nullptr;
 }
+
 ClassServer::AtomFactory* ClassServer::getFactory(Type t)
 {
 	// If there is a factory, then return it.

--- a/opencog/atoms/base/ClassServer.h
+++ b/opencog/atoms/base/ClassServer.h
@@ -253,7 +253,7 @@ public:
 
 ClassServer& classserver();
 
-#define DECLARE_LINK_FACTORY(CNAME,CTYPE)                         \
+#define DEFINE_LINK_FACTORY(CNAME,CTYPE)                          \
                                                                   \
 Handle CNAME::factory(const Handle& base)                         \
 {                                                                 \
@@ -266,8 +266,6 @@ static __attribute__ ((constructor)) void init(void)              \
 {                                                                 \
    classserver().addFactory(CTYPE, &CNAME::factory);              \
 }
-
-/* ===================== END OF FILE ===================== */
 
 /** @}*/
 } // namespace opencog

--- a/opencog/atoms/base/ClassServer.h
+++ b/opencog/atoms/base/ClassServer.h
@@ -258,7 +258,9 @@ ClassServer& classserver();
 Handle CNAME::factory(const Handle& base)                         \
 {                                                                 \
    if (CNAME##Cast(base)) return base;                            \
-   return Handle(create##CNAME(base->getOutgoingSet()));          \
+   Handle h(create##CNAME(base->getOutgoingSet()));               \
+   h->copyValues(base);                                           \
+   return h;                                                      \
 }                                                                 \
                                                                   \
 /* This runs when the shared lib is loaded. */                    \

--- a/opencog/atoms/base/ClassServer.h
+++ b/opencog/atoms/base/ClassServer.h
@@ -70,6 +70,7 @@ private:
     mutable std::mutex type_mutex;
 
     Type nTypes;
+    Type _maxDepth;
 
     std::vector< std::vector<bool> > inheritanceMap;
     std::vector< std::vector<bool> > recursiveMap;
@@ -78,7 +79,7 @@ private:
     std::unordered_map<Type, AtomFactory*> _atomFactory;
     TypeSignal _addTypeSignal;
 
-    void setParentRecursively(Type parent, Type type);
+    void setParentRecursively(Type parent, Type type, Type& maxd);
 
     AtomFactory* searchToDepth(Type, int);
 

--- a/opencog/atoms/base/ClassServer.h
+++ b/opencog/atoms/base/ClassServer.h
@@ -80,6 +80,8 @@ private:
 
     void setParentRecursively(Type parent, Type type);
 
+    AtomFactory* searchToDepth(Type, int);
+
 public:
     /** Gets the singleton instance (following meyer's design pattern) */
     friend ClassServer& classserver();
@@ -94,7 +96,7 @@ public:
      * Declare a factory for an atom type.
      */
     void addFactory(Type, AtomFactory*);
-    AtomFactory* getFactory(Type, int = 0);
+    AtomFactory* getFactory(Type);
 
     /**
      * Convert the indicated Atom into a C++ instance of the

--- a/opencog/atoms/base/ClassServer.h
+++ b/opencog/atoms/base/ClassServer.h
@@ -258,7 +258,7 @@ ClassServer& classserver();
 Handle CNAME::factory(const Handle& base)                         \
 {                                                                 \
    if (CNAME##Cast(base)) return base;                            \
-   Handle h(create##CNAME(base->getOutgoingSet()));               \
+   Handle h(create##CNAME(base->getOutgoingSet(), base->getType())); \
    return h;                                                      \
 }                                                                 \
                                                                   \

--- a/opencog/atoms/base/ClassServer.h
+++ b/opencog/atoms/base/ClassServer.h
@@ -42,9 +42,6 @@ namespace opencog
 
 typedef boost::signals2::signal<void (Type)> TypeSignal;
 
-class ProtoAtom;
-typedef std::shared_ptr<ProtoAtom> ProtoAtomPtr;
-
 /**
  * This class keeps track of the complete protoatom (value and atom)
  * class hierarchy. It also provides factories for those atom types
@@ -54,8 +51,9 @@ class ClassServer
 {
 public:
     // Currently, we provide factories only for atoms, not for
-    // values.
-    typedef Handle (AtomFactory)(const ProtoAtomPtr&);
+    // values. TruthValues could use a factory, but, for now,
+    // we don't have a pressing reason to add that.
+    typedef Handle (AtomFactory)(const Handle&);
 private:
 
     /** Private default constructor for this class to make it a singleton. */
@@ -98,10 +96,10 @@ public:
     void addFactory(Type, AtomFactory*);
 
     /**
-     * Convert the indicated ProtoAtom into a C++ instance of the
+     * Convert the indicated Atom into a C++ instance of the
      * same type.
      */
-    Handle factory(const ProtoAtomPtr&);
+    Handle factory(const Handle&);
 
     /** Provides ability to get type-added signals.
      * @warning methods connected to this signal must not call ClassServer::addType or

--- a/opencog/atoms/base/ClassServer.h
+++ b/opencog/atoms/base/ClassServer.h
@@ -94,6 +94,7 @@ public:
      * Declare a factory for an atom type.
      */
     void addFactory(Type, AtomFactory*);
+    AtomFactory* getFactory(Type, int = 0);
 
     /**
      * Convert the indicated Atom into a C++ instance of the
@@ -108,15 +109,15 @@ public:
     TypeSignal& addTypeSignal();
 
     /**
-     * Stores the children types on the OutputIterator 'result'. Returns the
-     * number of children types.
+     * Stores the children types on the OutputIterator 'result'.
+     * Returns the number of children types.
      */
     template<typename OutputIterator>
     unsigned long getChildren(Type type, OutputIterator result)
     {
         unsigned long n_children = 0;
         for (Type i = 0; i < nTypes; ++i) {
-            if (inheritanceMap[type][i] && (type != i)) {
+            if (inheritanceMap[type][i] and (type != i)) {
                 *(result++) = i;
                 n_children++;
             }
@@ -124,12 +125,29 @@ public:
         return n_children;
     }
 
+    /**
+     * Stores the parent types on the OutputIterator 'result'.
+     * Returns the number of parent types.
+     */
+    template<typename OutputIterator>
+    unsigned long getParents(Type type, OutputIterator result)
+    {
+        unsigned long n_parents = 0;
+        for (Type i = 0; i < nTypes; ++i) {
+            if (inheritanceMap[i][type] and (type != i)) {
+                *(result++) = i;
+                n_parents++;
+            }
+        }
+        return n_parents;
+    }
+
     template <typename OutputIterator>
     unsigned long getChildrenRecursive(Type type, OutputIterator result)
     {
         unsigned long n_children = 0;
         for (Type i = 0; i < nTypes; ++i) {
-            if (recursiveMap[type][i] && (type != i)) {
+            if (recursiveMap[type][i] and (type != i)) {
                 *(result++) = i;
                 n_children++;
             }

--- a/opencog/atoms/base/ClassServer.h
+++ b/opencog/atoms/base/ClassServer.h
@@ -2,6 +2,7 @@
  * opencog/atoms/base/ClassServer.h
  *
  * Copyright (C) 2011 by The OpenCog Foundation
+ * Copyright (C) 2017 by Linas Vepstas
  * All Rights Reserved
  *
  * This program is free software; you can redistribute it and/or modify

--- a/opencog/atoms/base/ClassServer.h
+++ b/opencog/atoms/base/ClassServer.h
@@ -253,6 +253,22 @@ public:
 
 ClassServer& classserver();
 
+#define DECLARE_LINK_FACTORY(CNAME,CTYPE)                         \
+                                                                  \
+Handle CNAME::factory(const Handle& base)                         \
+{                                                                 \
+   if (CNAME##Cast(base)) return base;                            \
+   return Handle(create##CNAME(base->getOutgoingSet()));          \
+}                                                                 \
+                                                                  \
+/* This runs when the shared lib is loaded. */                    \
+static __attribute__ ((constructor)) void init(void)              \
+{                                                                 \
+   classserver().addFactory(CTYPE, &CNAME::factory);              \
+}
+
+/* ===================== END OF FILE ===================== */
+
 /** @}*/
 } // namespace opencog
 

--- a/opencog/atoms/base/ClassServer.h
+++ b/opencog/atoms/base/ClassServer.h
@@ -259,7 +259,6 @@ Handle CNAME::factory(const Handle& base)                         \
 {                                                                 \
    if (CNAME##Cast(base)) return base;                            \
    Handle h(create##CNAME(base->getOutgoingSet()));               \
-   h->copyValues(base);                                           \
    return h;                                                      \
 }                                                                 \
                                                                   \

--- a/opencog/atoms/base/Link.h
+++ b/opencog/atoms/base/Link.h
@@ -71,16 +71,14 @@ public:
      *        referenced by this link.
      * @param Link truthvalue.
      */
-    Link(Type t, const HandleSeq& oset,
-         TruthValuePtr tv = TruthValue::DEFAULT_TV())
-        : Atom(t, tv)
+    Link(Type t, const HandleSeq& oset)
+        : Atom(t)
     {
         init(oset);
     }
 
-    Link(Type t, const Handle& h,
-         TruthValuePtr tv = TruthValue::DEFAULT_TV())
-        : Atom(t, tv)
+    Link(Type t, const Handle& h)
+        : Atom(t)
     {
         // reserve+assign is 2x faster than push_back()/emplace_back()
         HandleSeq oset(1);
@@ -88,9 +86,8 @@ public:
         init(oset);
     }
 
-    Link(Type t, const Handle& ha, const Handle &hb,
-         TruthValuePtr tv = TruthValue::DEFAULT_TV())
-        : Atom(t, tv)
+    Link(Type t, const Handle& ha, const Handle &hb)
+        : Atom(t)
     {
         // reserve+assign is 2x faster than push_back()/emplace_back()
         HandleSeq oset(2);
@@ -99,9 +96,8 @@ public:
         init(oset);
     }
 
-    Link(Type t, const Handle& ha, const Handle &hb, const Handle &hc,
-         TruthValuePtr tv = TruthValue::DEFAULT_TV())
-        : Atom(t, tv)
+    Link(Type t, const Handle& ha, const Handle &hb, const Handle &hc)
+        : Atom(t)
     {
         // reserve+assign is 2x faster than push_back()/emplace_back()
         HandleSeq oset(3);
@@ -111,9 +107,8 @@ public:
         init(oset);
     }
     Link(Type t, const Handle& ha, const Handle &hb,
-	      const Handle &hc, const Handle &hd,
-         TruthValuePtr tv = TruthValue::DEFAULT_TV())
-        : Atom(t, tv)
+	      const Handle &hc, const Handle &hd)
+        : Atom(t)
     {
         // reserve+assign is 2x faster than push_back()/emplace_back()
         HandleSeq oset(4);
@@ -125,11 +120,11 @@ public:
     }
 
     /**
-     * Copy constructor, does NOT copy atom table membership!
-     * Cannot be const, because the get() functions can't be,
-     * because thread-safe locking required in the gets. */
+     * Copy constructor, does NOT copy atomspace membership,
+     * or any of the values or truth values.
+     */
     Link(Link &l)
-        : Atom(l.getType(), l.getTruthValue())
+        : Atom(l.getType())
     {
         init(l.getOutgoingSet());
     }

--- a/opencog/atoms/base/Link.h
+++ b/opencog/atoms/base/Link.h
@@ -68,7 +68,7 @@ public:
      *        referenced by this link.
      * @param Link truthvalue.
      */
-    Link(Type t, const HandleSeq& oset)
+    Link(const HandleSeq& oset, Type t=LINK)
         : Atom(t)
     {
         init(oset);

--- a/opencog/atoms/base/Link.h
+++ b/opencog/atoms/base/Link.h
@@ -52,16 +52,13 @@ private:
     void init(const HandleSeq&);
     void resort(void);
 
-    Link(const Link &l) : Atom(0)
-    { OC_ASSERT(false, "Link: bad use of copy ctor"); }
-
 protected:
-
     //! Array holding actual outgoing set of the link.
     //! Should not change during atom lifespan.
     HandleSeq _outgoing;
 
     virtual ContentHash compute_hash() const;
+
 public:
     /**
      * Constructor for this class.
@@ -123,7 +120,7 @@ public:
      * Copy constructor, does NOT copy atomspace membership,
      * or any of the values or truth values.
      */
-    Link(Link &l)
+    Link(const Link &l)
         : Atom(l.getType())
     {
         init(l.getOutgoingSet());

--- a/opencog/atoms/base/LinkValue.cc
+++ b/opencog/atoms/base/LinkValue.cc
@@ -31,9 +31,11 @@ bool LinkValue::operator==(const ProtoAtom& other) const
 	const LinkValue* lov = (const LinkValue*) &other;
 
 	if (_value.size() != lov->_value.size()) return false;
+
+	// Content-compare, NOT pointer-compare!
 	size_t len = _value.size();
 	for (size_t i=0; i<len; i++)
-		if (_value[i] != lov->_value[i]) return false;
+		if (*(_value[i]) != *(lov->_value[i])) return false;
 	return true;
 }
 

--- a/opencog/atoms/base/Node.h
+++ b/opencog/atoms/base/Node.h
@@ -46,9 +46,6 @@ protected:
     std::string _name;
     void init(const std::string&);
 
-    Node(const Node &l) : Atom(0)
-    { OC_ASSERT(false, "Node: bad use of copy ctor"); }
-
     virtual ContentHash compute_hash() const;
 
 public:
@@ -69,7 +66,7 @@ public:
      * Copy constructor, does not copy atomspace membership,
      * or any of the values/truthvalues.
      */
-    Node(Node &n)
+    Node(const Node &n)
         : Atom(n.getType())
     {
         init(n._name);

--- a/opencog/atoms/base/Node.h
+++ b/opencog/atoms/base/Node.h
@@ -58,22 +58,19 @@ public:
      * @param Node type
      * @param Node name A reference to a std::string with the name of
      *                  the node.  Use empty string for unamed node.
-     * @param Node truthvalue A reference to a TruthValue object.
      */
-    Node(Type t, const std::string& s,
-         TruthValuePtr tv = TruthValue::DEFAULT_TV())
-        : Atom(t,tv)
+    Node(Type t, const std::string& s)
+        : Atom(t)
     {
         init(s);
     }
 
     /**
-     * Copy constructor, does not copy atom table membership!
-     * Cannot be const, because the get() functions can't be,
-     * because thread-safe locking required in the gets.
+     * Copy constructor, does not copy atomspace membership,
+     * or any of the values/truthvalues.
      */
     Node(Node &n)
-        : Atom(n.getType(), n.getTruthValue())
+        : Atom(n.getType())
     {
         init(n._name);
     }

--- a/opencog/atoms/core/ArityLink.cc
+++ b/opencog/atoms/core/ArityLink.cc
@@ -70,17 +70,6 @@ Handle ArityLink::execute(AtomSpace * as) const
 	return as->add_atom(createNumberNode(ary));
 }
 
-Handle ArityLink::factory(const Handle& base)
-{
-	if (ArityLinkCast(base)) return base;
-	return Handle(createArityLink(base->getOutgoingSet()));
-}
-
-// This runs when the shared lib is loaded.  The factory
-// must get registered early, b efore anyone can do anything else.
-static __attribute__ ((constructor)) void init(void)
-{
-   classserver().addFactory(ARITY_LINK, &ArityLink::factory);
-}
+DEFINE_LINK_FACTORY(ArityLink, ARITY_LINK)
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/core/ArityLink.cc
+++ b/opencog/atoms/core/ArityLink.cc
@@ -70,4 +70,17 @@ Handle ArityLink::execute(AtomSpace * as) const
 	return as->add_atom(createNumberNode(ary));
 }
 
+Handle ArityLink::factory(const Handle& base)
+{
+	if (ArityLinkCast(base)) return base;
+	return Handle(createArityLink(base->getOutgoingSet()));
+}
+
+// This runs when the shared lib is loaded.  The factory
+// must get registered early, b efore anyone can do anything else.
+static __attribute__ ((constructor)) void init(void)
+{
+   classserver().addFactory(ARITY_LINK, &ArityLink::factory);
+}
+
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/core/ArityLink.cc
+++ b/opencog/atoms/core/ArityLink.cc
@@ -28,8 +28,8 @@
 
 using namespace opencog;
 
-ArityLink::ArityLink(const HandleSeq& oset, TruthValuePtr tv)
-	: FunctionLink(ARITY_LINK, oset, tv)
+ArityLink::ArityLink(const HandleSeq& oset)
+	: FunctionLink(ARITY_LINK, oset)
 {
 }
 

--- a/opencog/atoms/core/ArityLink.cc
+++ b/opencog/atoms/core/ArityLink.cc
@@ -28,12 +28,18 @@
 
 using namespace opencog;
 
-ArityLink::ArityLink(const HandleSeq& oset)
-	: FunctionLink(ARITY_LINK, oset)
+ArityLink::ArityLink(const HandleSeq& oset, Type t)
+	: FunctionLink(oset, t)
 {
+	if (not classserver().isA(t, ARITY_LINK))
+	{
+		const std::string& tname = classserver().getTypeName(t);
+		throw InvalidParamException(TRACE_INFO,
+			"Expecting an ArityLink, got %s", tname.c_str());
+	}
 }
 
-ArityLink::ArityLink(Link &l)
+ArityLink::ArityLink(const Link &l)
 	: FunctionLink(l)
 {
 	// Type must be as expected

--- a/opencog/atoms/core/ArityLink.h
+++ b/opencog/atoms/core/ArityLink.h
@@ -54,6 +54,8 @@ public:
 
 	// Return a pointer to the atom being specified.
 	virtual Handle execute(AtomSpace* = NULL) const;
+
+	static Handle factory(const Handle&);
 };
 
 typedef std::shared_ptr<ArityLink> ArityLinkPtr;

--- a/opencog/atoms/core/ArityLink.h
+++ b/opencog/atoms/core/ArityLink.h
@@ -47,9 +47,7 @@ namespace opencog
 class ArityLink : public FunctionLink
 {
 public:
-	ArityLink(const HandleSeq&,
-	           TruthValuePtr tv = TruthValue::DEFAULT_TV());
-
+	ArityLink(const HandleSeq&);
 	ArityLink(Link &l);
 
 	// Return a pointer to the atom being specified.

--- a/opencog/atoms/core/ArityLink.h
+++ b/opencog/atoms/core/ArityLink.h
@@ -47,8 +47,8 @@ namespace opencog
 class ArityLink : public FunctionLink
 {
 public:
-	ArityLink(const HandleSeq&);
-	ArityLink(Link &l);
+	ArityLink(const HandleSeq&, Type = ARITY_LINK);
+	ArityLink(const Link &l);
 
 	// Return a pointer to the atom being specified.
 	virtual Handle execute(AtomSpace* = NULL) const;

--- a/opencog/atoms/core/DefineLink.cc
+++ b/opencog/atoms/core/DefineLink.cc
@@ -78,17 +78,6 @@ Handle DefineLink::get_definition(const Handle& alias)
 	return uniq->getOutgoingAtom(1);
 }
 
-Handle DefineLink::factory(const Handle& base)
-{
-	if (DefineLinkCast(base)) return base;
-	return Handle(createDefineLink(base->getOutgoingSet()));
-}
-
-// This runs when the shared lib is loaded.  The factory
-// must get registered early, b efore anyone can do anything else.
-static __attribute__ ((constructor)) void init(void)
-{
-   classserver().addFactory(DEFINE_LINK, &DefineLink::factory);
-}
+DEFINE_LINK_FACTORY(DefineLink, DEFINE_LINK)
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/core/DefineLink.cc
+++ b/opencog/atoms/core/DefineLink.cc
@@ -38,7 +38,7 @@ void DefineLink::init()
 	UniqueLink::init(false);
 
 	// Type-check. The execution and FunctionLink's only expand
-	// definitions anchored with these type; other definitions won't
+	// definitions anchored with these types; other definitions won't
 	// work during execution.
 	Type dtype = _outgoing[0]->getType();
 	if (DEFINED_SCHEMA_NODE != dtype and
@@ -49,15 +49,14 @@ void DefineLink::init()
 				classserver().getTypeName(dtype).c_str());
 }
 
-DefineLink::DefineLink(const HandleSeq& oset, TruthValuePtr tv)
-	: UniqueLink(DEFINE_LINK, oset, tv)
+DefineLink::DefineLink(const HandleSeq& oset)
+	: UniqueLink(DEFINE_LINK, oset)
 {
 	init();
 }
 
-DefineLink::DefineLink(const Handle& name, const Handle& defn,
-                       TruthValuePtr tv)
-	: UniqueLink(DEFINE_LINK, HandleSeq({name, defn}), tv)
+DefineLink::DefineLink(const Handle& name, const Handle& defn)
+	: UniqueLink(DEFINE_LINK, HandleSeq({name, defn}))
 {
 	init();
 }
@@ -77,6 +76,19 @@ Handle DefineLink::get_definition(const Handle& alias)
 {
 	Handle uniq(get_unique(alias, DEFINE_LINK, false));
 	return uniq->getOutgoingAtom(1);
+}
+
+Handle DefineLink::factory(const Handle& base)
+{
+	if (DefineLinkCast(base)) return base;
+	return Handle(createDefineLink(base->getOutgoingSet()));
+}
+
+// This runs when the shared lib is loaded.  The factory
+// must get registered early, b efore anyone can do anything else.
+static __attribute__ ((constructor)) void init(void)
+{
+   classserver().addFactory(DEFINE_LINK, &DefineLink::factory);
 }
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/core/DefineLink.cc
+++ b/opencog/atoms/core/DefineLink.cc
@@ -29,6 +29,11 @@ using namespace opencog;
 
 void DefineLink::init()
 {
+	if (not classserver().isA(getType(), DEFINE_LINK))
+		throw SyntaxException(TRACE_INFO,
+			"Expecting a DefineLink, got %s",
+				classserver().getTypeName(getType()).c_str());
+
 	// Must have name and body
 	if (2 != _outgoing.size())
 		throw SyntaxException(TRACE_INFO,
@@ -49,19 +54,19 @@ void DefineLink::init()
 				classserver().getTypeName(dtype).c_str());
 }
 
-DefineLink::DefineLink(const HandleSeq& oset)
-	: UniqueLink(DEFINE_LINK, oset)
+DefineLink::DefineLink(const HandleSeq& oset, Type t)
+	: UniqueLink(oset, t)
 {
 	init();
 }
 
 DefineLink::DefineLink(const Handle& name, const Handle& defn)
-	: UniqueLink(DEFINE_LINK, HandleSeq({name, defn}))
+	: UniqueLink(HandleSeq({name, defn}), DEFINE_LINK)
 {
 	init();
 }
 
-DefineLink::DefineLink(Link &l)
+DefineLink::DefineLink(const Link &l)
 	: UniqueLink(l)
 {
 	init();

--- a/opencog/atoms/core/DefineLink.h
+++ b/opencog/atoms/core/DefineLink.h
@@ -62,11 +62,11 @@ class DefineLink : public UniqueLink
 protected:
 	void init();
 public:
-	DefineLink(const HandleSeq&);
+	DefineLink(const HandleSeq&, Type=DEFINE_LINK);
 
 	DefineLink(const Handle& alias, const Handle& body);
 
-	DefineLink(Link &l);
+	DefineLink(const Link &l);
 	Handle get_alias(void) const { return _outgoing[0]; }
 	Handle get_definition(void) const { return _outgoing[1]; }
 

--- a/opencog/atoms/core/DefineLink.h
+++ b/opencog/atoms/core/DefineLink.h
@@ -62,11 +62,9 @@ class DefineLink : public UniqueLink
 protected:
 	void init();
 public:
-	DefineLink(const HandleSeq&,
-	           TruthValuePtr tv = TruthValue::DEFAULT_TV());
+	DefineLink(const HandleSeq&);
 
-	DefineLink(const Handle& alias, const Handle& body,
-	           TruthValuePtr tv = TruthValue::DEFAULT_TV());
+	DefineLink(const Handle& alias, const Handle& body);
 
 	DefineLink(Link &l);
 	Handle get_alias(void) const { return _outgoing[0]; }
@@ -82,6 +80,8 @@ public:
 	 * return <body>
 	 */
 	static Handle get_definition(const Handle& alias);
+
+	static Handle factory(const Handle&);
 };
 
 typedef std::shared_ptr<DefineLink> DefineLinkPtr;

--- a/opencog/atoms/core/DeleteLink.cc
+++ b/opencog/atoms/core/DeleteLink.cc
@@ -62,8 +62,8 @@ Handle DeleteLink::execute(AtomSpace * as) const
 }
 #endif
 
-DeleteLink::DeleteLink(const HandleSeq& oset, TruthValuePtr tv)
-	: FreeLink(DELETE_LINK, oset, tv)
+DeleteLink::DeleteLink(const HandleSeq& oset)
+	: FreeLink(DELETE_LINK, oset)
 {
 	init();
 }

--- a/opencog/atoms/core/DeleteLink.cc
+++ b/opencog/atoms/core/DeleteLink.cc
@@ -63,12 +63,12 @@ Handle DeleteLink::execute(AtomSpace * as) const
 #endif
 
 DeleteLink::DeleteLink(const HandleSeq& oset)
-	: FreeLink(DELETE_LINK, oset)
+	: FreeLink(oset, DELETE_LINK)
 {
 	init();
 }
 
-DeleteLink::DeleteLink(Link &l)
+DeleteLink::DeleteLink(const Link &l)
 	: FreeLink(l)
 {
 	// Type must be as expected

--- a/opencog/atoms/core/DeleteLink.h
+++ b/opencog/atoms/core/DeleteLink.h
@@ -47,7 +47,7 @@ protected:
 public:
 	DeleteLink(const HandleSeq&);
 
-	DeleteLink(Link &l);
+	DeleteLink(const Link&);
 };
 
 typedef std::shared_ptr<DeleteLink> DeleteLinkPtr;

--- a/opencog/atoms/core/DeleteLink.h
+++ b/opencog/atoms/core/DeleteLink.h
@@ -45,8 +45,7 @@ class DeleteLink : public FreeLink
 protected:
 	void init(void);
 public:
-	DeleteLink(const HandleSeq&,
-	           TruthValuePtr tv = TruthValue::DEFAULT_TV());
+	DeleteLink(const HandleSeq&);
 
 	DeleteLink(Link &l);
 };

--- a/opencog/atoms/core/FreeLink.cc
+++ b/opencog/atoms/core/FreeLink.cc
@@ -26,20 +26,14 @@
 
 using namespace opencog;
 
-FreeLink::FreeLink(const HandleSeq& oset)
-    : Link(FREE_LINK, oset)
-{
-	init();
-}
-
 FreeLink::FreeLink(const Handle& a)
     : Link(FREE_LINK, a)
 {
 	init();
 }
 
-FreeLink::FreeLink(Type t, const HandleSeq& oset)
-    : Link(t, oset)
+FreeLink::FreeLink(const HandleSeq& oset, Type t)
+    : Link(oset, t)
 {
 	if (not classserver().isA(t, FREE_LINK))
 		throw InvalidParamException(TRACE_INFO, "Expecting a FreeLink");
@@ -71,7 +65,7 @@ FreeLink::FreeLink(Type t, const Handle& a, const Handle& b)
 	init();
 }
 
-FreeLink::FreeLink(Link& l)
+FreeLink::FreeLink(const Link& l)
     : Link(l)
 {
 	Type tscope = l.getType();
@@ -90,20 +84,6 @@ void FreeLink::init(void)
 	_vars.find_variables(_outgoing);
 }
 
-/* ================================================================= */
-
-Handle FreeLink::factory(const Handle& h)
-{
-	if (FreeLinkCast(h)) return h;
-
-	return HandleCast(createFreeLink(h->getType(), h->getOutgoingSet()));
-}
-
-// This runs when the shared lib is loaded.  The factory
-// must get registered early, b efore anyone can do anything else.
-static __attribute__ ((constructor)) void init(void)
-{
-   classserver().addFactory(FREE_LINK, &FreeLink::factory);
-}
+DEFINE_LINK_FACTORY(FreeLink, FREE_LINK);
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/core/FreeLink.cc
+++ b/opencog/atoms/core/FreeLink.cc
@@ -23,7 +23,6 @@
 #include <opencog/atoms/base/atom_types.h>
 #include <opencog/atoms/base/ClassServer.h>
 #include "FreeLink.h"
-#include "DefineLink.h"
 #include "FunctionLink.h"
 #include "StateLink.h"
 #include "TypedAtomLink.h"
@@ -118,9 +117,6 @@ FreeLinkPtr FreeLink::factory(const Handle& h)
 // Basic type factory.
 FreeLinkPtr FreeLink::factory(Type t, const HandleSeq& seq)
 {
-	if (DEFINE_LINK == t)
-		return createDefineLink(seq);
-
 	if (classserver().isA(t, FUNCTION_LINK))
 		return FunctionLink::factory(t, seq);
 

--- a/opencog/atoms/core/FreeLink.cc
+++ b/opencog/atoms/core/FreeLink.cc
@@ -23,29 +23,23 @@
 #include <opencog/atoms/base/atom_types.h>
 #include <opencog/atoms/base/ClassServer.h>
 #include "FreeLink.h"
-#include "StateLink.h"
-#include "TypedAtomLink.h"
-#include "UniqueLink.h"
 
 using namespace opencog;
 
-FreeLink::FreeLink(const HandleSeq& oset,
-                   TruthValuePtr tv)
-    : Link(FREE_LINK, oset, tv)
+FreeLink::FreeLink(const HandleSeq& oset)
+    : Link(FREE_LINK, oset)
 {
 	init();
 }
 
-FreeLink::FreeLink(const Handle& a,
-                   TruthValuePtr tv)
-    : Link(FREE_LINK, a, tv)
+FreeLink::FreeLink(const Handle& a)
+    : Link(FREE_LINK, a)
 {
 	init();
 }
 
-FreeLink::FreeLink(Type t, const HandleSeq& oset,
-                   TruthValuePtr tv)
-    : Link(t, oset, tv)
+FreeLink::FreeLink(Type t, const HandleSeq& oset)
+    : Link(t, oset)
 {
 	if (not classserver().isA(t, FREE_LINK))
 		throw InvalidParamException(TRACE_INFO, "Expecting a FreeLink");
@@ -55,9 +49,8 @@ FreeLink::FreeLink(Type t, const HandleSeq& oset,
 	init();
 }
 
-FreeLink::FreeLink(Type t, const Handle& a,
-                   TruthValuePtr tv)
-    : Link(t, a, tv)
+FreeLink::FreeLink(Type t, const Handle& a)
+    : Link(t, a)
 {
 	if (not classserver().isA(t, FREE_LINK))
 		throw InvalidParamException(TRACE_INFO, "Expecting a FreeLink");
@@ -67,9 +60,8 @@ FreeLink::FreeLink(Type t, const Handle& a,
 	init();
 }
 
-FreeLink::FreeLink(Type t, const Handle& a, const Handle& b,
-                   TruthValuePtr tv)
-    : Link(t, a, b, tv)
+FreeLink::FreeLink(Type t, const Handle& a, const Handle& b)
+    : Link(t, a, b)
 {
 	if (not classserver().isA(t, FREE_LINK))
 		throw InvalidParamException(TRACE_INFO, "Expecting a FreeLink");
@@ -100,35 +92,18 @@ void FreeLink::init(void)
 
 /* ================================================================= */
 
-FreeLinkPtr FreeLink::factory(const Handle& h)
+Handle FreeLink::factory(const Handle& h)
 {
-	// If h is of the right form already, its just a matter of calling
-	// it.  Otherwise, we have to create
-	FreeLinkPtr flp(FreeLinkCast(h));
-	if (flp) return flp;
+	if (FreeLinkCast(h)) return h;
 
-	if (nullptr == h)
-		throw RuntimeException(TRACE_INFO, "Not executable!");
-
-	return factory(h->getType(), h->getOutgoingSet());
+	return HandleCast(createFreeLink(h->getType(), h->getOutgoingSet()));
 }
 
-// Basic type factory.
-FreeLinkPtr FreeLink::factory(Type t, const HandleSeq& seq)
+// This runs when the shared lib is loaded.  The factory
+// must get registered early, b efore anyone can do anything else.
+static __attribute__ ((constructor)) void init(void)
 {
-	if (STATE_LINK == t)
-		return createStateLink(seq);
-
-	if (TYPED_ATOM_LINK == t)
-		return createTypedAtomLink(seq);
-
-	if (UNIQUE_LINK == t)
-		return createUniqueLink(seq);
-
-	if (classserver().isA(t, FREE_LINK))
-		return createFreeLink(t, seq);
-
-	throw SyntaxException(TRACE_INFO,
-		"FreeLink is not a factory for %s",
-		classserver().getTypeName(t).c_str());
+   classserver().addFactory(FREE_LINK, &FreeLink::factory);
 }
+
+/* ===================== END OF FILE ===================== */

--- a/opencog/atoms/core/FreeLink.cc
+++ b/opencog/atoms/core/FreeLink.cc
@@ -23,7 +23,6 @@
 #include <opencog/atoms/base/atom_types.h>
 #include <opencog/atoms/base/ClassServer.h>
 #include "FreeLink.h"
-#include "FunctionLink.h"
 #include "StateLink.h"
 #include "TypedAtomLink.h"
 #include "UniqueLink.h"
@@ -117,9 +116,6 @@ FreeLinkPtr FreeLink::factory(const Handle& h)
 // Basic type factory.
 FreeLinkPtr FreeLink::factory(Type t, const HandleSeq& seq)
 {
-	if (classserver().isA(t, FUNCTION_LINK))
-		return FunctionLink::factory(t, seq);
-
 	if (STATE_LINK == t)
 		return createStateLink(seq);
 

--- a/opencog/atoms/core/FreeLink.h
+++ b/opencog/atoms/core/FreeLink.h
@@ -48,21 +48,16 @@ protected:
 	void init(void);
 
 public:
-	FreeLink(Type, const HandleSeq& oset,
-	         TruthValuePtr tv = TruthValue::DEFAULT_TV());
+	// XXX Need to make this public, so that the factory can call it!
+	FreeLink(Type, const HandleSeq& oset);
 
 protected:
-	// XXX Need to make this public, so that the factory can call it!
-	FreeLink(Type, const Handle& a,
-	         TruthValuePtr tv = TruthValue::DEFAULT_TV());
+	FreeLink(Type, const Handle& a);
+	FreeLink(Type, const Handle& a, const Handle& b);
 
-	FreeLink(Type, const Handle& a, const Handle& b,
-	         TruthValuePtr tv = TruthValue::DEFAULT_TV());
 public:
-	FreeLink(const HandleSeq& oset,
-	         TruthValuePtr tv = TruthValue::DEFAULT_TV());
-	FreeLink(const Handle& a,
-	         TruthValuePtr tv = TruthValue::DEFAULT_TV());
+	FreeLink(const HandleSeq& oset);
+	FreeLink(const Handle& a);
 
 	FreeLink(Link& l);
 	virtual ~FreeLink() {}
@@ -70,8 +65,7 @@ public:
 	const FreeVariables& get_vars() const
 	{ return  _vars; }
 
-	static FreeLinkPtr factory(const Handle&);
-	static FreeLinkPtr factory(Type, const HandleSeq&);
+	static Handle factory(const Handle&);
 };
 
 static inline FreeLinkPtr FreeLinkCast(const Handle& h)

--- a/opencog/atoms/core/FreeLink.h
+++ b/opencog/atoms/core/FreeLink.h
@@ -47,19 +47,14 @@ protected:
 
 	void init(void);
 
-public:
-	// XXX Need to make this public, so that the factory can call it!
-	FreeLink(Type, const HandleSeq& oset);
-
 protected:
 	FreeLink(Type, const Handle& a);
 	FreeLink(Type, const Handle& a, const Handle& b);
 
 public:
-	FreeLink(const HandleSeq& oset);
+	FreeLink(const HandleSeq& oset, Type=FREE_LINK);
 	FreeLink(const Handle& a);
-
-	FreeLink(Link& l);
+	FreeLink(const Link& l);
 	virtual ~FreeLink() {}
 
 	const FreeVariables& get_vars() const

--- a/opencog/atoms/core/FunctionLink.cc
+++ b/opencog/atoms/core/FunctionLink.cc
@@ -31,27 +31,24 @@ void FunctionLink::init(void)
 	FreeLink::init();
 }
 
-FunctionLink::FunctionLink(Type t, const HandleSeq& oset,
-                   TruthValuePtr tv)
-    : FreeLink(t, oset, tv)
+FunctionLink::FunctionLink(Type t, const HandleSeq& oset)
+    : FreeLink(t, oset)
 {
 	if (not classserver().isA(t, FUNCTION_LINK))
 		throw InvalidParamException(TRACE_INFO, "Expecting a FunctionLink");
 	init();
 }
 
-FunctionLink::FunctionLink(Type t, const Handle& a,
-                   TruthValuePtr tv)
-    : FreeLink(t, a, tv)
+FunctionLink::FunctionLink(Type t, const Handle& a)
+    : FreeLink(t, a)
 {
 	if (not classserver().isA(t, FUNCTION_LINK))
 		throw InvalidParamException(TRACE_INFO, "Expecting a FunctionLink");
 	init();
 }
 
-FunctionLink::FunctionLink(Type t, const Handle& a, const Handle& b,
-                   TruthValuePtr tv)
-    : FreeLink(t, {a, b}, tv)
+FunctionLink::FunctionLink(Type t, const Handle& a, const Handle& b)
+    : FreeLink(t, {a, b})
 {
 	if (not classserver().isA(t, FUNCTION_LINK))
 		throw InvalidParamException(TRACE_INFO, "Expecting a FunctionLink");

--- a/opencog/atoms/core/FunctionLink.cc
+++ b/opencog/atoms/core/FunctionLink.cc
@@ -31,8 +31,8 @@ void FunctionLink::init(void)
 	FreeLink::init();
 }
 
-FunctionLink::FunctionLink(Type t, const HandleSeq& oset)
-    : FreeLink(t, oset)
+FunctionLink::FunctionLink(const HandleSeq& oset, Type t)
+    : FreeLink(oset, t)
 {
 	if (not classserver().isA(t, FUNCTION_LINK))
 		throw InvalidParamException(TRACE_INFO, "Expecting a FunctionLink");
@@ -48,14 +48,14 @@ FunctionLink::FunctionLink(Type t, const Handle& a)
 }
 
 FunctionLink::FunctionLink(Type t, const Handle& a, const Handle& b)
-    : FreeLink(t, {a, b})
+    : FreeLink({a, b}, t)
 {
 	if (not classserver().isA(t, FUNCTION_LINK))
 		throw InvalidParamException(TRACE_INFO, "Expecting a FunctionLink");
 	init();
 }
 
-FunctionLink::FunctionLink(Link& l)
+FunctionLink::FunctionLink(const Link& l)
     : FreeLink(l)
 {
 	Type tscope = l.getType();
@@ -90,18 +90,6 @@ FunctionLinkPtr FunctionLink::castfactory(const Handle& h)
 	return FunctionLinkCast((*fact)(h));
 }
 
-Handle FunctionLink::factory(const Handle& h)
-{
-	if (FunctionLinkCast(h)) return h;
-
-	return HandleCast(createFunctionLink(h->getType(), h->getOutgoingSet()));
-}
-
-// This runs when the shared lib is loaded.  The factory
-// must get registered early, b efore anyone can do anything else.
-static __attribute__ ((constructor)) void init(void)
-{
-   classserver().addFactory(FUNCTION_LINK, &FunctionLink::factory);
-}
+DEFINE_LINK_FACTORY(FunctionLink, FUNCTION_LINK);
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/core/FunctionLink.h
+++ b/opencog/atoms/core/FunctionLink.h
@@ -62,9 +62,9 @@ protected:
 
 public:
 	// XXX Need to make this public, so that the factory can call it!
-	FunctionLink(Type, const HandleSeq& oset);
+	FunctionLink(const HandleSeq& oset, Type = FUNCTION_LINK);
 
-	FunctionLink(Link& l);
+	FunctionLink(const Link& l);
 	virtual ~FunctionLink() {}
 
 	virtual Handle execute(AtomSpace* = NULL) const;

--- a/opencog/atoms/core/FunctionLink.h
+++ b/opencog/atoms/core/FunctionLink.h
@@ -76,7 +76,6 @@ public:
 
 	static Handle factory(const Handle&);
 	static FunctionLinkPtr castfactory(const Handle&);
-	static FunctionLinkPtr factory(Type, const HandleSeq&);
 };
 
 static inline FunctionLinkPtr FunctionLinkCast(const Handle& h)

--- a/opencog/atoms/core/FunctionLink.h
+++ b/opencog/atoms/core/FunctionLink.h
@@ -74,7 +74,8 @@ public:
 	virtual Handle execute(AtomSpace* = NULL) const;
 	static Handle do_execute(AtomSpace*, const Handle&);
 
-	static FunctionLinkPtr factory(const Handle&);
+	static Handle factory(const Handle&);
+	static FunctionLinkPtr castfactory(const Handle&);
 	static FunctionLinkPtr factory(Type, const HandleSeq&);
 };
 

--- a/opencog/atoms/core/FunctionLink.h
+++ b/opencog/atoms/core/FunctionLink.h
@@ -57,16 +57,12 @@ class FunctionLink : public FreeLink
 {
 protected:
 	void init(void);
-	FunctionLink(Type, const Handle& a,
-	             TruthValuePtr tv = TruthValue::DEFAULT_TV());
-
-	FunctionLink(Type, const Handle& a, const Handle& b,
-	             TruthValuePtr tv = TruthValue::DEFAULT_TV());
+	FunctionLink(Type, const Handle& a);
+	FunctionLink(Type, const Handle& a, const Handle& b);
 
 public:
 	// XXX Need to make this public, so that the factory can call it!
-	FunctionLink(Type, const HandleSeq& oset,
-	             TruthValuePtr tv = TruthValue::DEFAULT_TV());
+	FunctionLink(Type, const HandleSeq& oset);
 
 	FunctionLink(Link& l);
 	virtual ~FunctionLink() {}

--- a/opencog/atoms/core/ImplicationScopeLink.cc
+++ b/opencog/atoms/core/ImplicationScopeLink.cc
@@ -31,18 +31,12 @@ void ImplicationScopeLink::init(void)
 }
 
 ImplicationScopeLink::ImplicationScopeLink(const HandleSeq& hseq)
-	: ScopeLink(IMPLICATION_SCOPE_LINK, hseq)
+	: ScopeLink(hseq, IMPLICATION_SCOPE_LINK)
 {
 	init();
 }
 
-ImplicationScopeLink::ImplicationScopeLink(Type t, const HandleSeq& hseq)
-	: ScopeLink(t, hseq)
-{
-	init();
-}
-
-ImplicationScopeLink::ImplicationScopeLink(Link &l)
+ImplicationScopeLink::ImplicationScopeLink(const Link &l)
 	: ScopeLink(l)
 {
 	Type t = l.getType();

--- a/opencog/atoms/core/ImplicationScopeLink.cc
+++ b/opencog/atoms/core/ImplicationScopeLink.cc
@@ -30,16 +30,14 @@ void ImplicationScopeLink::init(void)
 	extract_variables(_outgoing);
 }
 
-ImplicationScopeLink::ImplicationScopeLink(const HandleSeq& hseq,
-                                           TruthValuePtr tv)
-	: ScopeLink(IMPLICATION_SCOPE_LINK, hseq, tv)
+ImplicationScopeLink::ImplicationScopeLink(const HandleSeq& hseq)
+	: ScopeLink(IMPLICATION_SCOPE_LINK, hseq)
 {
 	init();
 }
 
-ImplicationScopeLink::ImplicationScopeLink(Type t, const HandleSeq& hseq,
-                                           TruthValuePtr tv)
-	: ScopeLink(t, hseq, tv)
+ImplicationScopeLink::ImplicationScopeLink(Type t, const HandleSeq& hseq)
+	: ScopeLink(t, hseq)
 {
 	init();
 }

--- a/opencog/atoms/core/ImplicationScopeLink.h
+++ b/opencog/atoms/core/ImplicationScopeLink.h
@@ -48,20 +48,15 @@ namespace opencog
 ///       <Q-body>
 class ImplicationScopeLink : public ScopeLink
 {
-public:
-	// XXX Need to make this public, so that the factory can call it!
-	ImplicationScopeLink(Type, const HandleSeq&,
-	                     TruthValuePtr tv = TruthValue::DEFAULT_TV());
-
 protected:
+	ImplicationScopeLink(Type, const HandleSeq&);
+
 	void init(void);
 	void extract_variables(const HandleSeq& oset);
 	// Useless for now, but...
 	Handle _implicand;
 public:
-	ImplicationScopeLink(const HandleSeq&,
-	                     TruthValuePtr tv = TruthValue::DEFAULT_TV());
-
+	ImplicationScopeLink(const HandleSeq&);
 	ImplicationScopeLink(Link &l);
 };
 

--- a/opencog/atoms/core/ImplicationScopeLink.h
+++ b/opencog/atoms/core/ImplicationScopeLink.h
@@ -49,15 +49,13 @@ namespace opencog
 class ImplicationScopeLink : public ScopeLink
 {
 protected:
-	ImplicationScopeLink(Type, const HandleSeq&);
-
 	void init(void);
 	void extract_variables(const HandleSeq& oset);
 	// Useless for now, but...
 	Handle _implicand;
 public:
 	ImplicationScopeLink(const HandleSeq&);
-	ImplicationScopeLink(Link &l);
+	ImplicationScopeLink(const Link &l);
 };
 
 typedef std::shared_ptr<ImplicationScopeLink> ImplicationScopeLinkPtr;

--- a/opencog/atoms/core/LambdaLink.cc
+++ b/opencog/atoms/core/LambdaLink.cc
@@ -27,27 +27,28 @@
 
 using namespace opencog;
 
-LambdaLink::LambdaLink(const HandleSeq& oset)
-	: ScopeLink(LAMBDA_LINK, oset)
-{
-}
-
 LambdaLink::LambdaLink(const Handle& vars, const Handle& body)
-	: ScopeLink(LAMBDA_LINK, HandleSeq({vars, body}))
+	: ScopeLink(HandleSeq({vars, body}), LAMBDA_LINK)
 {
 }
 
 LambdaLink::LambdaLink(Type t, const Handle& body)
-	: ScopeLink(t, HandleSeq({body}))
+	: ScopeLink(HandleSeq({body}), t)
 {
 }
 
-LambdaLink::LambdaLink(Type t, const HandleSeq& oset)
-	: ScopeLink(t, oset)
+LambdaLink::LambdaLink(const HandleSeq& oset, Type t)
+	: ScopeLink(oset, t)
 {
+	if (not classserver().isA(t, LAMBDA_LINK))
+	{
+		const std::string& tname = classserver().getTypeName(t);
+		throw SyntaxException(TRACE_INFO,
+			"Expecting a LambdaLink, got %s", tname.c_str());
+	}
 }
 
-LambdaLink::LambdaLink(Link &l)
+LambdaLink::LambdaLink(const Link &l)
 	: ScopeLink(l)
 {
 	// Type must be as expected

--- a/opencog/atoms/core/LambdaLink.cc
+++ b/opencog/atoms/core/LambdaLink.cc
@@ -27,27 +27,23 @@
 
 using namespace opencog;
 
-LambdaLink::LambdaLink(const HandleSeq& oset,
-                       TruthValuePtr tv)
-	: ScopeLink(LAMBDA_LINK, oset, tv)
+LambdaLink::LambdaLink(const HandleSeq& oset)
+	: ScopeLink(LAMBDA_LINK, oset)
 {
 }
 
-LambdaLink::LambdaLink(const Handle& vars, const Handle& body,
-                       TruthValuePtr tv)
-	: ScopeLink(LAMBDA_LINK, HandleSeq({vars, body}), tv)
+LambdaLink::LambdaLink(const Handle& vars, const Handle& body)
+	: ScopeLink(LAMBDA_LINK, HandleSeq({vars, body}))
 {
 }
 
-LambdaLink::LambdaLink(Type t, const Handle& body,
-                       TruthValuePtr tv)
-	: ScopeLink(t, HandleSeq({body}), tv)
+LambdaLink::LambdaLink(Type t, const Handle& body)
+	: ScopeLink(t, HandleSeq({body}))
 {
 }
 
-LambdaLink::LambdaLink(Type t, const HandleSeq& oset,
-                       TruthValuePtr tv)
-	: ScopeLink(t, oset, tv)
+LambdaLink::LambdaLink(Type t, const HandleSeq& oset)
+	: ScopeLink(t, oset)
 {
 }
 
@@ -63,5 +59,7 @@ LambdaLink::LambdaLink(Link &l)
 			"Expecting a LambdaLink, got %s", tname.c_str());
 	}
 }
+
+DEFINE_LINK_FACTORY(LambdaLink, LAMBDA_LINK)
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/core/LambdaLink.h
+++ b/opencog/atoms/core/LambdaLink.h
@@ -38,20 +38,12 @@ namespace opencog
 class LambdaLink : public ScopeLink
 {
 protected:
-
-	LambdaLink(Type, const Handle&,
-	           TruthValuePtr tv = TruthValue::DEFAULT_TV());
-
-	LambdaLink(Type, const HandleSeq&,
-	           TruthValuePtr tv = TruthValue::DEFAULT_TV());
+	LambdaLink(Type, const Handle&);
+	LambdaLink(Type, const HandleSeq&);
 
 public:
-	LambdaLink(const HandleSeq&,
-	           TruthValuePtr tv = TruthValue::DEFAULT_TV());
-
-	LambdaLink(const Handle& varcdecls, const Handle& body,
-	           TruthValuePtr tv = TruthValue::DEFAULT_TV());
-
+	LambdaLink(const HandleSeq&);
+	LambdaLink(const Handle& varcdecls, const Handle& body);
 	LambdaLink(Link &l);
 
 	// Take the list of values `vals`, and substitute them in for the
@@ -61,6 +53,8 @@ public:
 	{
 		return get_variables().substitute(_body, vals);
 	}
+
+	static Handle factory(const Handle&);
 };
 
 typedef std::shared_ptr<LambdaLink> LambdaLinkPtr;

--- a/opencog/atoms/core/LambdaLink.h
+++ b/opencog/atoms/core/LambdaLink.h
@@ -39,12 +39,11 @@ class LambdaLink : public ScopeLink
 {
 protected:
 	LambdaLink(Type, const Handle&);
-	LambdaLink(Type, const HandleSeq&);
 
 public:
-	LambdaLink(const HandleSeq&);
+	LambdaLink(const HandleSeq&, Type=LAMBDA_LINK);
 	LambdaLink(const Handle& varcdecls, const Handle& body);
-	LambdaLink(Link &l);
+	LambdaLink(const Link &l);
 
 	// Take the list of values `vals`, and substitute them in for the
 	// variables in the body of this lambda. The values must satisfy all

--- a/opencog/atoms/core/PutLink.cc
+++ b/opencog/atoms/core/PutLink.cc
@@ -29,14 +29,14 @@
 
 using namespace opencog;
 
-PutLink::PutLink(const HandleSeq& oset, TruthValuePtr tv)
-    : ScopeLink(PUT_LINK, oset, tv)
+PutLink::PutLink(const HandleSeq& oset)
+    : ScopeLink(PUT_LINK, oset)
 {
 	init();
 }
 
-PutLink::PutLink(const Handle& a, TruthValuePtr tv)
-    : ScopeLink(PUT_LINK, a, tv)
+PutLink::PutLink(const Handle& a)
+    : ScopeLink(PUT_LINK, a)
 {
 	init();
 }
@@ -333,5 +333,7 @@ Handle PutLink::reduce(void)
 {
 	return do_reduce();
 }
+
+DEFINE_LINK_FACTORY(PutLink, PUT_LINK)
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/core/PutLink.cc
+++ b/opencog/atoms/core/PutLink.cc
@@ -29,8 +29,8 @@
 
 using namespace opencog;
 
-PutLink::PutLink(const HandleSeq& oset)
-    : ScopeLink(PUT_LINK, oset)
+PutLink::PutLink(const HandleSeq& oset, Type t)
+    : ScopeLink(oset, t)
 {
 	init();
 }
@@ -41,12 +41,9 @@ PutLink::PutLink(const Handle& a)
 	init();
 }
 
-PutLink::PutLink(Link& l)
+PutLink::PutLink(const Link& l)
     : ScopeLink(l)
 {
-	Type tscope = l.getType();
-	if (not classserver().isA(tscope, PUT_LINK))
-		throw InvalidParamException(TRACE_INFO, "Expecting a PutLink");
 	init();
 }
 
@@ -87,6 +84,9 @@ PutLink::PutLink(Link& l)
 ///
 void PutLink::init(void)
 {
+	if (not classserver().isA(getType(), PUT_LINK))
+		throw InvalidParamException(TRACE_INFO, "Expecting a PutLink");
+
 	size_t sz = _outgoing.size();
 	if (2 != sz and 3 != sz)
 		throw InvalidParamException(TRACE_INFO,
@@ -298,7 +298,7 @@ Handle PutLink::do_reduce(void) const
 			}
 			catch (const TypeCheckException& ex) {}
 		}
-		return Handle(createLink(SET_LINK, bset));
+		return Handle(createLink(bset, SET_LINK));
 	}
 	if (LIST_LINK == vtype)
 	{
@@ -326,7 +326,7 @@ Handle PutLink::do_reduce(void) const
 		}
 		catch (const TypeCheckException& ex) {}
 	}
-	return Handle(createLink(SET_LINK, bset));
+	return Handle(createLink(bset, SET_LINK));
 }
 
 Handle PutLink::reduce(void)

--- a/opencog/atoms/core/PutLink.h
+++ b/opencog/atoms/core/PutLink.h
@@ -59,17 +59,16 @@ protected:
 	Handle do_reduce(void) const;
 
 public:
-	PutLink(const HandleSeq& oset,
-	         TruthValuePtr tv = TruthValue::DEFAULT_TV());
-	PutLink(const Handle& a,
-	         TruthValuePtr tv = TruthValue::DEFAULT_TV());
-
+	PutLink(const HandleSeq& oset);
+	PutLink(const Handle& a);
 	PutLink(Link& l);
 	virtual ~PutLink() {}
 
 	// PutLink values may be e second or the third outset elt.
 	Handle get_values() { return _values; }
 	virtual Handle reduce(void);
+
+	static Handle factory(const Handle&);
 };
 
 typedef std::shared_ptr<PutLink> PutLinkPtr;

--- a/opencog/atoms/core/PutLink.h
+++ b/opencog/atoms/core/PutLink.h
@@ -59,9 +59,9 @@ protected:
 	Handle do_reduce(void) const;
 
 public:
-	PutLink(const HandleSeq& oset);
+	PutLink(const HandleSeq& oset, Type=PUT_LINK);
 	PutLink(const Handle& a);
-	PutLink(Link& l);
+	PutLink(const Link& l);
 	virtual ~PutLink() {}
 
 	// PutLink values may be e second or the third outset elt.

--- a/opencog/atoms/core/RandomChoice.cc
+++ b/opencog/atoms/core/RandomChoice.cc
@@ -206,4 +206,17 @@ uniform:
 	return _outgoing.at(randy.randint(ary));
 }
 
+Handle RandomChoiceLink::factory(const Handle& base)
+{
+	if (RandomChoiceLinkCast(base)) return base;
+	return Handle(createRandomChoiceLink(base->getOutgoingSet()));
+}
+
+// This runs when the shared lib is loaded.  The factory
+// must get registered early, b efore anyone can do anything else.
+static __attribute__ ((constructor)) void init(void)
+{
+   classserver().addFactory(RANDOM_CHOICE_LINK, &RandomChoiceLink::factory);
+}
+
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/core/RandomChoice.cc
+++ b/opencog/atoms/core/RandomChoice.cc
@@ -32,12 +32,18 @@ using namespace opencog;
 
 static MT19937RandGen randy(43);
 
-RandomChoiceLink::RandomChoiceLink(const HandleSeq& oset)
-	: FunctionLink(RANDOM_CHOICE_LINK, oset)
+RandomChoiceLink::RandomChoiceLink(const HandleSeq& oset, Type t)
+	: FunctionLink(oset, t)
 {
+	if (not classserver().isA(t, RANDOM_CHOICE_LINK))
+	{
+		const std::string& tname = classserver().getTypeName(t);
+		throw InvalidParamException(TRACE_INFO,
+			"Expecting an RandomChoiceLink, got %s", tname.c_str());
+	}
 }
 
-RandomChoiceLink::RandomChoiceLink(Link &l)
+RandomChoiceLink::RandomChoiceLink(const Link &l)
 	: FunctionLink(l)
 {
 	// Type must be as expected

--- a/opencog/atoms/core/RandomChoice.cc
+++ b/opencog/atoms/core/RandomChoice.cc
@@ -32,9 +32,8 @@ using namespace opencog;
 
 static MT19937RandGen randy(43);
 
-RandomChoiceLink::RandomChoiceLink(const HandleSeq& oset,
-                       TruthValuePtr tv)
-	: FunctionLink(RANDOM_CHOICE_LINK, oset, tv)
+RandomChoiceLink::RandomChoiceLink(const HandleSeq& oset)
+	: FunctionLink(RANDOM_CHOICE_LINK, oset)
 {
 }
 

--- a/opencog/atoms/core/RandomChoice.cc
+++ b/opencog/atoms/core/RandomChoice.cc
@@ -206,17 +206,6 @@ uniform:
 	return _outgoing.at(randy.randint(ary));
 }
 
-Handle RandomChoiceLink::factory(const Handle& base)
-{
-	if (RandomChoiceLinkCast(base)) return base;
-	return Handle(createRandomChoiceLink(base->getOutgoingSet()));
-}
-
-// This runs when the shared lib is loaded.  The factory
-// must get registered early, b efore anyone can do anything else.
-static __attribute__ ((constructor)) void init(void)
-{
-   classserver().addFactory(RANDOM_CHOICE_LINK, &RandomChoiceLink::factory);
-}
+DEFINE_LINK_FACTORY(RandomChoiceLink, RANDOM_CHOICE_LINK)
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/core/RandomChoice.h
+++ b/opencog/atoms/core/RandomChoice.h
@@ -62,8 +62,8 @@ namespace opencog
 class RandomChoiceLink : public FunctionLink
 {
 public:
-	RandomChoiceLink(const HandleSeq&);
-	RandomChoiceLink(Link &l);
+	RandomChoiceLink(const HandleSeq&, Type=RANDOM_CHOICE_LINK);
+	RandomChoiceLink(const Link &l);
 
 	// Return a pointer to the atom being specified.
 	virtual Handle execute(AtomSpace* = NULL) const;

--- a/opencog/atoms/core/RandomChoice.h
+++ b/opencog/atoms/core/RandomChoice.h
@@ -69,6 +69,8 @@ public:
 
 	// Return a pointer to the atom being specified.
 	virtual Handle execute(AtomSpace* = NULL) const;
+
+	static Handle factory(const Handle&);
 };
 
 typedef std::shared_ptr<RandomChoiceLink> RandomChoiceLinkPtr;

--- a/opencog/atoms/core/RandomChoice.h
+++ b/opencog/atoms/core/RandomChoice.h
@@ -62,9 +62,7 @@ namespace opencog
 class RandomChoiceLink : public FunctionLink
 {
 public:
-	RandomChoiceLink(const HandleSeq&,
-	           TruthValuePtr tv = TruthValue::DEFAULT_TV());
-
+	RandomChoiceLink(const HandleSeq&);
 	RandomChoiceLink(Link &l);
 
 	// Return a pointer to the atom being specified.

--- a/opencog/atoms/core/RandomNumber.cc
+++ b/opencog/atoms/core/RandomNumber.cc
@@ -108,17 +108,6 @@ Handle RandomNumberLink::execute(AtomSpace * as) const
 	return as->add_atom(createNumberNode(ary));
 }
 
-Handle RandomNumberLink::factory(const Handle& base)
-{
-	if (RandomNumberLinkCast(base)) return base;
-	return Handle(createRandomNumberLink(base->getOutgoingSet()));
-}
-
-// This runs when the shared lib is loaded.  The factory
-// must get registered early, b efore anyone can do anything else.
-static __attribute__ ((constructor)) void init(void)
-{
-   classserver().addFactory(RANDOM_NUMBER_LINK, &RandomNumberLink::factory);
-}
+DEFINE_LINK_FACTORY(RandomeNumberLink, RANDOM_NUMBER_LINK);
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/core/RandomNumber.cc
+++ b/opencog/atoms/core/RandomNumber.cc
@@ -108,4 +108,17 @@ Handle RandomNumberLink::execute(AtomSpace * as) const
 	return as->add_atom(createNumberNode(ary));
 }
 
+Handle RandomNumberLink::factory(const Handle& base)
+{
+	if (RandomNumberLinkCast(base)) return base;
+	return Handle(createRandomNumberLink(base->getOutgoingSet()));
+}
+
+// This runs when the shared lib is loaded.  The factory
+// must get registered early, b efore anyone can do anything else.
+static __attribute__ ((constructor)) void init(void)
+{
+   classserver().addFactory(RANDOM_NUMBER_LINK, &RandomNumberLink::factory);
+}
+
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/core/RandomNumber.cc
+++ b/opencog/atoms/core/RandomNumber.cc
@@ -34,29 +34,30 @@ static MT19937RandGen randy(616432);
 
 void RandomNumberLink::init()
 {
-	if (_outgoing.size() != 2)
-		throw SyntaxException(TRACE_INFO,
-			"Expecting a numerical min and max; got %s",
-			toString().c_str());
-}
-
-RandomNumberLink::RandomNumberLink(const HandleSeq& oset)
-	: FunctionLink(RANDOM_NUMBER_LINK, oset)
-{
-	init();
-}
-
-RandomNumberLink::RandomNumberLink(Link &l)
-	: FunctionLink(l)
-{
 	// Type must be as expected
-	Type tscope = l.getType();
+	Type tscope = getType();
 	if (not classserver().isA(tscope, RANDOM_NUMBER_LINK))
 	{
 		const std::string& tname = classserver().getTypeName(tscope);
 		throw InvalidParamException(TRACE_INFO,
 			"Expecting an RandomNumberLink, got %s", tname.c_str());
 	}
+
+	if (_outgoing.size() != 2)
+		throw SyntaxException(TRACE_INFO,
+			"Expecting a numerical min and max; got %s",
+			toString().c_str());
+}
+
+RandomNumberLink::RandomNumberLink(const HandleSeq& oset, Type t)
+	: FunctionLink(oset, t)
+{
+	init();
+}
+
+RandomNumberLink::RandomNumberLink(const Link &l)
+	: FunctionLink(l)
+{
 	init();
 }
 

--- a/opencog/atoms/core/RandomNumber.cc
+++ b/opencog/atoms/core/RandomNumber.cc
@@ -40,9 +40,8 @@ void RandomNumberLink::init()
 			toString().c_str());
 }
 
-RandomNumberLink::RandomNumberLink(const HandleSeq& oset,
-                       TruthValuePtr tv)
-	: FunctionLink(RANDOM_NUMBER_LINK, oset, tv)
+RandomNumberLink::RandomNumberLink(const HandleSeq& oset)
+	: FunctionLink(RANDOM_NUMBER_LINK, oset)
 {
 	init();
 }
@@ -108,6 +107,6 @@ Handle RandomNumberLink::execute(AtomSpace * as) const
 	return as->add_atom(createNumberNode(ary));
 }
 
-DEFINE_LINK_FACTORY(RandomeNumberLink, RANDOM_NUMBER_LINK);
+DEFINE_LINK_FACTORY(RandomNumberLink, RANDOM_NUMBER_LINK);
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/core/RandomNumber.h
+++ b/opencog/atoms/core/RandomNumber.h
@@ -55,6 +55,8 @@ public:
 
 	// Return a pointer to the atom being specified.
 	virtual Handle execute(AtomSpace* = NULL) const;
+
+	static Handle factory(const Handle&);
 };
 
 typedef std::shared_ptr<RandomNumberLink> RandomNumberLinkPtr;

--- a/opencog/atoms/core/RandomNumber.h
+++ b/opencog/atoms/core/RandomNumber.h
@@ -48,9 +48,7 @@ protected:
 	void init();
 
 public:
-	RandomNumberLink(const HandleSeq&,
-	           TruthValuePtr tv = TruthValue::DEFAULT_TV());
-
+	RandomNumberLink(const HandleSeq&);
 	RandomNumberLink(Link &l);
 
 	// Return a pointer to the atom being specified.

--- a/opencog/atoms/core/RandomNumber.h
+++ b/opencog/atoms/core/RandomNumber.h
@@ -48,8 +48,8 @@ protected:
 	void init();
 
 public:
-	RandomNumberLink(const HandleSeq&);
-	RandomNumberLink(Link &l);
+	RandomNumberLink(const HandleSeq&, Type=RANDOM_NUMBER_LINK);
+	RandomNumberLink(const Link &l);
 
 	// Return a pointer to the atom being specified.
 	virtual Handle execute(AtomSpace* = NULL) const;

--- a/opencog/atoms/core/ScopeLink.cc
+++ b/opencog/atoms/core/ScopeLink.cc
@@ -39,14 +39,8 @@ void ScopeLink::init(void)
 	extract_variables(_outgoing);
 }
 
-ScopeLink::ScopeLink(const HandleSeq& oset)
-	: Link(SCOPE_LINK, oset)
-{
-	init();
-}
-
 ScopeLink::ScopeLink(const Handle& vars, const Handle& body)
-	: Link(SCOPE_LINK, HandleSeq({vars, body}))
+	: Link(HandleSeq({vars, body}), SCOPE_LINK)
 {
 	init();
 }
@@ -71,20 +65,20 @@ bool ScopeLink::skip_init(Type t)
 }
 
 ScopeLink::ScopeLink(Type t, const Handle& body)
-	: Link(t, HandleSeq({body}))
+	: Link(HandleSeq({body}), t)
 {
 	if (skip_init(t)) return;
 	init();
 }
 
-ScopeLink::ScopeLink(Type t, const HandleSeq& oset)
-	: Link(t, oset)
+ScopeLink::ScopeLink(const HandleSeq& oset, Type t)
+	: Link(oset, t)
 {
 	if (skip_init(t)) return;
 	init();
 }
 
-ScopeLink::ScopeLink(Link &l)
+ScopeLink::ScopeLink(const Link &l)
 	: Link(l)
 {
 	if (skip_init(l.getType())) return;
@@ -389,7 +383,7 @@ Handle ScopeLink::alpha_conversion(HandleSeq vars, Handle vardecl) const
 		hs.insert(hs.begin(), vardecl);
 
 	// Create the alpha converted scope link
-	return classserver().factory(Handle(createLink(getType(), hs)));
+	return classserver().factory(Handle(createLink(hs, getType())));
 }
 
 /* ================================================================= */
@@ -408,19 +402,6 @@ bool ScopeLink::operator!=(const Atom& a) const
 	return not operator==(a);
 }
 
-/* ================================================================= */
-
-Handle ScopeLink::factory(const Handle& h)
-{
-	if (ScopeLinkCast(h)) return h;
-	return Handle(createScopeLink(h->getType(), h->getOutgoingSet()));
-}
-
-// This runs when the shared lib is loaded.  The factory
-// must get registered early, b efore anyone can do anything else.
-static __attribute__ ((constructor)) void init(void)
-{
-   classserver().addFactory(SCOPE_LINK, &ScopeLink::factory);
-}
+DEFINE_LINK_FACTORY(ScopeLink, SCOPE_LINK);
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/core/ScopeLink.cc
+++ b/opencog/atoms/core/ScopeLink.cc
@@ -28,8 +28,6 @@
 #include <opencog/atoms/TypeNode.h>
 #include <opencog/atoms/core/FreeLink.h>
 #include <opencog/atoms/core/LambdaLink.h>
-#include <opencog/atoms/core/PutLink.h>
-#include <opencog/atoms/core/ImplicationScopeLink.h>
 #include <opencog/atoms/pattern/PatternLink.h>
 #include <opencog/atomutils/TypeUtils.h>
 
@@ -43,16 +41,14 @@ void ScopeLink::init(void)
 	extract_variables(_outgoing);
 }
 
-ScopeLink::ScopeLink(const HandleSeq& oset,
-                     TruthValuePtr tv)
-	: Link(SCOPE_LINK, oset, tv)
+ScopeLink::ScopeLink(const HandleSeq& oset)
+	: Link(SCOPE_LINK, oset)
 {
 	init();
 }
 
-ScopeLink::ScopeLink(const Handle& vars, const Handle& body,
-                     TruthValuePtr tv)
-	: Link(SCOPE_LINK, HandleSeq({vars, body}), tv)
+ScopeLink::ScopeLink(const Handle& vars, const Handle& body)
+	: Link(SCOPE_LINK, HandleSeq({vars, body}))
 {
 	init();
 }
@@ -76,17 +72,15 @@ bool ScopeLink::skip_init(Type t)
 	return false;
 }
 
-ScopeLink::ScopeLink(Type t, const Handle& body,
-                     TruthValuePtr tv)
-	: Link(t, HandleSeq({body}), tv)
+ScopeLink::ScopeLink(Type t, const Handle& body)
+	: Link(t, HandleSeq({body}))
 {
 	if (skip_init(t)) return;
 	init();
 }
 
-ScopeLink::ScopeLink(Type t, const HandleSeq& oset,
-                     TruthValuePtr tv)
-	: Link(t, oset, tv)
+ScopeLink::ScopeLink(Type t, const HandleSeq& oset)
+	: Link(t, oset)
 {
 	if (skip_init(t)) return;
 	init();
@@ -425,15 +419,6 @@ ScopeLinkPtr ScopeLink::factory(const Handle& h)
 
 ScopeLinkPtr ScopeLink::factory(Type t, const HandleSeq& seq)
 {
-	if (PUT_LINK == t)
-		return createPutLink(seq);
-
-	if (LAMBDA_LINK == t)
-		return createLambdaLink(seq);
-
-	if (classserver().isA(t, IMPLICATION_SCOPE_LINK))
-		return createImplicationScopeLink(t, seq);
-
 	if (classserver().isA(t, PATTERN_LINK))
 		return PatternLink::factory(t, seq);
 

--- a/opencog/atoms/core/ScopeLink.h
+++ b/opencog/atoms/core/ScopeLink.h
@@ -61,9 +61,6 @@ protected:
 
 	ScopeLink(Type, const Handle&);
 
-public:
-	// XXX Need to make this public, so that the factory can call it!
-	ScopeLink(Type, const HandleSeq&);
 protected:
 	void init(void);
 	void extract_variables(const HandleSeq& oset);
@@ -75,9 +72,9 @@ protected:
 	virtual ContentHash compute_hash() const;
 
 public:
-	ScopeLink(const HandleSeq&);
+	ScopeLink(const HandleSeq&, Type=SCOPE_LINK);
 	ScopeLink(const Handle& varcdecls, const Handle& body);
-	ScopeLink(Link &l);
+	ScopeLink(const Link &l);
 
 	// Return the list of variables we are holding.
 	const Variables& get_variables(void) const { return _varlist; }

--- a/opencog/atoms/core/ScopeLink.h
+++ b/opencog/atoms/core/ScopeLink.h
@@ -59,13 +59,11 @@ protected:
 	/// Variables bound in the body.
 	Variables _varlist;
 
-	ScopeLink(Type, const Handle&,
-	          TruthValuePtr tv = TruthValue::DEFAULT_TV());
+	ScopeLink(Type, const Handle&);
 
 public:
 	// XXX Need to make this public, so that the factory can call it!
-	ScopeLink(Type, const HandleSeq&,
-	          TruthValuePtr tv = TruthValue::DEFAULT_TV());
+	ScopeLink(Type, const HandleSeq&);
 protected:
 	void init(void);
 	void extract_variables(const HandleSeq& oset);
@@ -77,12 +75,8 @@ protected:
 	virtual ContentHash compute_hash() const;
 
 public:
-	ScopeLink(const HandleSeq&,
-	          TruthValuePtr tv = TruthValue::DEFAULT_TV());
-
-	ScopeLink(const Handle& varcdecls, const Handle& body,
-	          TruthValuePtr tv = TruthValue::DEFAULT_TV());
-
+	ScopeLink(const HandleSeq&);
+	ScopeLink(const Handle& varcdecls, const Handle& body);
 	ScopeLink(Link &l);
 
 	// Return the list of variables we are holding.

--- a/opencog/atoms/core/ScopeLink.h
+++ b/opencog/atoms/core/ScopeLink.h
@@ -145,8 +145,7 @@ public:
 	virtual bool operator==(const Atom&) const;
 	virtual bool operator!=(const Atom&) const;
 
-	static ScopeLinkPtr factory(const Handle&);
-	static ScopeLinkPtr factory(Type, const HandleSeq&);
+	static Handle factory(const Handle&);
 };
 
 static inline ScopeLinkPtr ScopeLinkCast(const Handle& h)

--- a/opencog/atoms/core/SleepLink.cc
+++ b/opencog/atoms/core/SleepLink.cc
@@ -32,9 +32,8 @@
 
 using namespace opencog;
 
-SleepLink::SleepLink(const HandleSeq& oset,
-                       TruthValuePtr tv)
-	: FunctionLink(SLEEP_LINK, oset, tv)
+SleepLink::SleepLink(const HandleSeq& oset)
+	: FunctionLink(SLEEP_LINK, oset)
 {
 	if (1 != oset.size())
 		throw SyntaxException(TRACE_INFO,

--- a/opencog/atoms/core/SleepLink.cc
+++ b/opencog/atoms/core/SleepLink.cc
@@ -32,20 +32,28 @@
 
 using namespace opencog;
 
-SleepLink::SleepLink(const HandleSeq& oset)
-	: FunctionLink(SLEEP_LINK, oset)
+SleepLink::SleepLink(const HandleSeq& oset, Type t)
+	: FunctionLink(oset, t)
 {
+	// Type must be as expected
+	if (not classserver().isA(t, SLEEP_LINK))
+	{
+		const std::string& tname = classserver().getTypeName(t);
+		throw InvalidParamException(TRACE_INFO,
+			"Expecting an SleepLink, got %s", tname.c_str());
+	}
+
 	if (1 != oset.size())
 		throw SyntaxException(TRACE_INFO,
 			"SleepLink expects only one argument");
 
-	Type t = oset[0]->getType();
-	if (NUMBER_NODE != t and classserver().isA(t, FUNCTION_LINK))
+	Type tf = oset[0]->getType();
+	if (NUMBER_NODE != tf and classserver().isA(tf, FUNCTION_LINK))
 		throw SyntaxException(TRACE_INFO,
 			"Expecting a NumberNode or something that returns a NumberNode");
 }
 
-SleepLink::SleepLink(Link &l)
+SleepLink::SleepLink(const Link &l)
 	: FunctionLink(l)
 {
 	// Type must be as expected

--- a/opencog/atoms/core/SleepLink.cc
+++ b/opencog/atoms/core/SleepLink.cc
@@ -92,17 +92,6 @@ Handle SleepLink::execute(AtomSpace * as) const
 	return as->add_atom(createNumberNode(secs));
 }
 
-Handle SleepLink::factory(const Handle& base)
-{
-	if (SleepLinkCast(base)) return base;
-	return Handle(createSleepLink(base->getOutgoingSet()));
-}
-
-// This runs when the shared lib is loaded.  The factory
-// must get registered early, b efore anyone can do anything else.
-static __attribute__ ((constructor)) void init(void)
-{
-   classserver().addFactory(SLEEP_LINK, &SleepLink::factory);
-}
+DEFINE_LINK_FACTORY(SleepLink, SLEEP_LINK)
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/core/SleepLink.cc
+++ b/opencog/atoms/core/SleepLink.cc
@@ -92,4 +92,17 @@ Handle SleepLink::execute(AtomSpace * as) const
 	return as->add_atom(createNumberNode(secs));
 }
 
+Handle SleepLink::factory(const Handle& base)
+{
+	if (SleepLinkCast(base)) return base;
+	return Handle(createSleepLink(base->getOutgoingSet()));
+}
+
+// This runs when the shared lib is loaded.  The factory
+// must get registered early, b efore anyone can do anything else.
+static __attribute__ ((constructor)) void init(void)
+{
+   classserver().addFactory(SLEEP_LINK, &SleepLink::factory);
+}
+
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/core/SleepLink.h
+++ b/opencog/atoms/core/SleepLink.h
@@ -38,9 +38,7 @@ namespace opencog
 class SleepLink : public FunctionLink
 {
 public:
-	SleepLink(const HandleSeq&,
-	           TruthValuePtr tv = TruthValue::DEFAULT_TV());
-
+	SleepLink(const HandleSeq&);
 	SleepLink(Link &l);
 
 	// Return a pointer to the atom being specified.

--- a/opencog/atoms/core/SleepLink.h
+++ b/opencog/atoms/core/SleepLink.h
@@ -38,8 +38,8 @@ namespace opencog
 class SleepLink : public FunctionLink
 {
 public:
-	SleepLink(const HandleSeq&);
-	SleepLink(Link &l);
+	SleepLink(const HandleSeq&, Type=SLEEP_LINK);
+	SleepLink(const Link &l);
 
 	// Return a pointer to the atom being specified.
 	virtual Handle execute(AtomSpace* = NULL) const;

--- a/opencog/atoms/core/SleepLink.h
+++ b/opencog/atoms/core/SleepLink.h
@@ -45,6 +45,8 @@ public:
 
 	// Return a pointer to the atom being specified.
 	virtual Handle execute(AtomSpace* = NULL) const;
+
+	static Handle factory(const Handle&);
 };
 
 typedef std::shared_ptr<SleepLink> SleepLinkPtr;

--- a/opencog/atoms/core/StateLink.cc
+++ b/opencog/atoms/core/StateLink.cc
@@ -35,16 +35,14 @@ void StateLink::init()
 	FreeLink::init();
 }
 
-StateLink::StateLink(const HandleSeq& oset,
-                     TruthValuePtr tv)
-	: UniqueLink(STATE_LINK, oset, tv)
+StateLink::StateLink(const HandleSeq& oset)
+	: UniqueLink(STATE_LINK, oset)
 {
 	init();
 }
 
-StateLink::StateLink(const Handle& name, const Handle& defn,
-                     TruthValuePtr tv)
-	: UniqueLink(STATE_LINK, HandleSeq({name, defn}), tv)
+StateLink::StateLink(const Handle& name, const Handle& defn)
+	: UniqueLink(STATE_LINK, HandleSeq({name, defn}))
 {
 	init();
 }
@@ -74,5 +72,7 @@ Handle StateLink::get_link(const Handle& alias)
 {
 	return get_unique(alias, STATE_LINK, true);
 }
+
+DEFINE_LINK_FACTORY(StateLink, STATE_LINK);
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/core/StateLink.cc
+++ b/opencog/atoms/core/StateLink.cc
@@ -35,19 +35,19 @@ void StateLink::init()
 	FreeLink::init();
 }
 
-StateLink::StateLink(const HandleSeq& oset)
-	: UniqueLink(STATE_LINK, oset)
+StateLink::StateLink(const HandleSeq& oset, Type t)
+	: UniqueLink(oset, t)
 {
 	init();
 }
 
 StateLink::StateLink(const Handle& name, const Handle& defn)
-	: UniqueLink(STATE_LINK, HandleSeq({name, defn}))
+	: UniqueLink(HandleSeq({name, defn}), STATE_LINK)
 {
 	init();
 }
 
-StateLink::StateLink(Link &l)
+StateLink::StateLink(const Link &l)
 	: UniqueLink(l)
 {
 	init();

--- a/opencog/atoms/core/StateLink.h
+++ b/opencog/atoms/core/StateLink.h
@@ -47,10 +47,10 @@ class StateLink : public UniqueLink
 protected:
 	void init();
 public:
-	StateLink(const HandleSeq&);
+	StateLink(const HandleSeq&, Type=STATE_LINK);
 	StateLink(const Handle& alias, const Handle& body);
 
-	StateLink(Link &l);
+	StateLink(const Link&);
 	Handle get_alias(void) const { return _outgoing[0]; }
 	Handle get_state(void) const { return _outgoing[1]; }
 

--- a/opencog/atoms/core/StateLink.h
+++ b/opencog/atoms/core/StateLink.h
@@ -47,11 +47,8 @@ class StateLink : public UniqueLink
 protected:
 	void init();
 public:
-	StateLink(const HandleSeq&,
-	           TruthValuePtr tv = TruthValue::DEFAULT_TV());
-
-	StateLink(const Handle& alias, const Handle& body,
-	           TruthValuePtr tv = TruthValue::DEFAULT_TV());
+	StateLink(const HandleSeq&);
+	StateLink(const Handle& alias, const Handle& body);
 
 	StateLink(Link &l);
 	Handle get_alias(void) const { return _outgoing[0]; }
@@ -75,6 +72,8 @@ public:
 	 */
 	static Handle get_link(const Handle& alias);
 	static Handle get_state(const Handle& alias);
+
+	static Handle factory(const Handle&);
 };
 
 typedef std::shared_ptr<StateLink> StateLinkPtr;

--- a/opencog/atoms/core/TimeLink.cc
+++ b/opencog/atoms/core/TimeLink.cc
@@ -69,4 +69,17 @@ Handle TimeLink::execute(AtomSpace * as) const
 	return as->add_atom(createNumberNode(now));
 }
 
+Handle TimeLink::factory(const Handle& base)
+{
+	if (TimeLinkCast(base)) return base;
+	return Handle(createTimeLink(base->getOutgoingSet()));
+}
+
+// This runs when the shared lib is loaded.  The factory
+// must get registered early, b efore anyone can do anything else.
+static __attribute__ ((constructor)) void init(void)
+{
+   classserver().addFactory(TIME_LINK, &TimeLink::factory);
+}
+
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/core/TimeLink.cc
+++ b/opencog/atoms/core/TimeLink.cc
@@ -69,17 +69,6 @@ Handle TimeLink::execute(AtomSpace * as) const
 	return as->add_atom(createNumberNode(now));
 }
 
-Handle TimeLink::factory(const Handle& base)
-{
-	if (TimeLinkCast(base)) return base;
-	return Handle(createTimeLink(base->getOutgoingSet()));
-}
-
-// This runs when the shared lib is loaded.  The factory
-// must get registered early, b efore anyone can do anything else.
-static __attribute__ ((constructor)) void init(void)
-{
-   classserver().addFactory(TIME_LINK, &TimeLink::factory);
-}
+DEFINE_LINK_FACTORY(TimeLink, TIME_LINK)
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/core/TimeLink.cc
+++ b/opencog/atoms/core/TimeLink.cc
@@ -29,15 +29,23 @@
 
 using namespace opencog;
 
-TimeLink::TimeLink(const HandleSeq& oset)
-	: FunctionLink(TIME_LINK, oset)
+TimeLink::TimeLink(const HandleSeq& oset, Type t)
+	: FunctionLink(oset, t)
 {
+	// Type must be as expected
+	if (not classserver().isA(t, TIME_LINK))
+	{
+		const std::string& tname = classserver().getTypeName(t);
+		throw InvalidParamException(TRACE_INFO,
+			"Expecting an TimeLink, got %s", tname.c_str());
+	}
+
 	if (0 < oset.size())
 		throw SyntaxException(TRACE_INFO,
 			"TimeLink does not expect any arguments");
 }
 
-TimeLink::TimeLink(Link &l)
+TimeLink::TimeLink(const Link &l)
 	: FunctionLink(l)
 {
 	// Type must be as expected

--- a/opencog/atoms/core/TimeLink.cc
+++ b/opencog/atoms/core/TimeLink.cc
@@ -29,9 +29,8 @@
 
 using namespace opencog;
 
-TimeLink::TimeLink(const HandleSeq& oset,
-                       TruthValuePtr tv)
-	: FunctionLink(TIME_LINK, oset, tv)
+TimeLink::TimeLink(const HandleSeq& oset)
+	: FunctionLink(TIME_LINK, oset)
 {
 	if (0 < oset.size())
 		throw SyntaxException(TRACE_INFO,

--- a/opencog/atoms/core/TimeLink.h
+++ b/opencog/atoms/core/TimeLink.h
@@ -44,6 +44,8 @@ public:
 
 	// Return a pointer to the atom being specified.
 	virtual Handle execute(AtomSpace* = NULL) const;
+
+	static Handle factory(const Handle&);
 };
 
 typedef std::shared_ptr<TimeLink> TimeLinkPtr;

--- a/opencog/atoms/core/TimeLink.h
+++ b/opencog/atoms/core/TimeLink.h
@@ -37,9 +37,7 @@ namespace opencog
 class TimeLink : public FunctionLink
 {
 public:
-	TimeLink(const HandleSeq&,
-	           TruthValuePtr tv = TruthValue::DEFAULT_TV());
-
+	TimeLink(const HandleSeq&);
 	TimeLink(Link &l);
 
 	// Return a pointer to the atom being specified.

--- a/opencog/atoms/core/TimeLink.h
+++ b/opencog/atoms/core/TimeLink.h
@@ -37,8 +37,8 @@ namespace opencog
 class TimeLink : public FunctionLink
 {
 public:
-	TimeLink(const HandleSeq&);
-	TimeLink(Link &l);
+	TimeLink(const HandleSeq&, Type=TIME_LINK);
+	TimeLink(const Link&);
 
 	// Return a pointer to the atom being specified.
 	virtual Handle execute(AtomSpace* = NULL) const;

--- a/opencog/atoms/core/TypedAtomLink.cc
+++ b/opencog/atoms/core/TypedAtomLink.cc
@@ -57,19 +57,19 @@ void TypedAtomLink::init()
 
 }
 
-TypedAtomLink::TypedAtomLink(const HandleSeq& oset)
-	: UniqueLink(TYPED_ATOM_LINK, oset)
+TypedAtomLink::TypedAtomLink(const HandleSeq& oset, Type t)
+	: UniqueLink(oset, t)
 {
 	init();
 }
 
 TypedAtomLink::TypedAtomLink(const Handle& name, const Handle& defn)
-	: UniqueLink(TYPED_ATOM_LINK, HandleSeq({name, defn}))
+	: UniqueLink(HandleSeq({name, defn}), TYPED_ATOM_LINK)
 {
 	init();
 }
 
-TypedAtomLink::TypedAtomLink(Link &l)
+TypedAtomLink::TypedAtomLink(const Link &l)
 	: UniqueLink(l)
 {
 	init();

--- a/opencog/atoms/core/TypedAtomLink.cc
+++ b/opencog/atoms/core/TypedAtomLink.cc
@@ -57,16 +57,14 @@ void TypedAtomLink::init()
 
 }
 
-TypedAtomLink::TypedAtomLink(const HandleSeq& oset,
-                             TruthValuePtr tv)
-	: UniqueLink(TYPED_ATOM_LINK, oset, tv)
+TypedAtomLink::TypedAtomLink(const HandleSeq& oset)
+	: UniqueLink(TYPED_ATOM_LINK, oset)
 {
 	init();
 }
 
-TypedAtomLink::TypedAtomLink(const Handle& name, const Handle& defn,
-                             TruthValuePtr tv)
-	: UniqueLink(TYPED_ATOM_LINK, HandleSeq({name, defn}), tv)
+TypedAtomLink::TypedAtomLink(const Handle& name, const Handle& defn)
+	: UniqueLink(TYPED_ATOM_LINK, HandleSeq({name, defn}))
 {
 	init();
 }
@@ -87,5 +85,7 @@ Handle TypedAtomLink::get_type(const Handle& atom)
 	Handle uniq(get_unique(atom, TYPED_ATOM_LINK, false));
 	return uniq->getOutgoingAtom(1);
 }
+
+DEFINE_LINK_FACTORY(TypedAtomLink, TYPED_ATOM_LINK);
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/core/TypedAtomLink.h
+++ b/opencog/atoms/core/TypedAtomLink.h
@@ -50,10 +50,10 @@ class TypedAtomLink : public UniqueLink
 protected:
 	void init();
 public:
-	TypedAtomLink(const HandleSeq&);
+	TypedAtomLink(const HandleSeq&, Type=TYPED_ATOM_LINK);
 	TypedAtomLink(const Handle& alias, const Handle& body);
 
-	TypedAtomLink(Link &l);
+	TypedAtomLink(const Link &l);
 	Handle get_atom(void) const { return _outgoing[0]; }
 	Handle get_type(void) const { return _outgoing[1]; }
 
@@ -66,7 +66,7 @@ public:
 	 *
 	 * return <type-specification>
 	 */
-	static Handle get_type(const Handle& atom);
+	static Handle get_type(const Handle&);
 
 	static Handle factory(const Handle&);
 };

--- a/opencog/atoms/core/TypedAtomLink.h
+++ b/opencog/atoms/core/TypedAtomLink.h
@@ -50,11 +50,8 @@ class TypedAtomLink : public UniqueLink
 protected:
 	void init();
 public:
-	TypedAtomLink(const HandleSeq&,
-	           TruthValuePtr tv = TruthValue::DEFAULT_TV());
-
-	TypedAtomLink(const Handle& alias, const Handle& body,
-	           TruthValuePtr tv = TruthValue::DEFAULT_TV());
+	TypedAtomLink(const HandleSeq&);
+	TypedAtomLink(const Handle& alias, const Handle& body);
 
 	TypedAtomLink(Link &l);
 	Handle get_atom(void) const { return _outgoing[0]; }
@@ -70,6 +67,8 @@ public:
 	 * return <type-specification>
 	 */
 	static Handle get_type(const Handle& atom);
+
+	static Handle factory(const Handle&);
 };
 
 typedef std::shared_ptr<TypedAtomLink> TypedAtomLinkPtr;

--- a/opencog/atoms/core/UniqueLink.cc
+++ b/opencog/atoms/core/UniqueLink.cc
@@ -59,9 +59,8 @@ void UniqueLink::init(bool allow_open)
 	}
 }
 
-UniqueLink::UniqueLink(Type type, const HandleSeq& oset,
-                       TruthValuePtr tv)
-	: FreeLink(type, oset, tv)
+UniqueLink::UniqueLink(Type type, const HandleSeq& oset)
+	: FreeLink(type, oset)
 {
 	if (not classserver().isA(type, UNIQUE_LINK))
 	{
@@ -75,16 +74,14 @@ UniqueLink::UniqueLink(Type type, const HandleSeq& oset,
 	init(true);
 }
 
-UniqueLink::UniqueLink(const HandleSeq& oset,
-                       TruthValuePtr tv)
-	: FreeLink(UNIQUE_LINK, oset, tv)
+UniqueLink::UniqueLink(const HandleSeq& oset)
+	: FreeLink(UNIQUE_LINK, oset)
 {
 	init(true);
 }
 
-UniqueLink::UniqueLink(const Handle& name, const Handle& defn,
-                       TruthValuePtr tv)
-	: FreeLink(UNIQUE_LINK, HandleSeq({name, defn}), tv)
+UniqueLink::UniqueLink(const Handle& name, const Handle& defn)
+	: FreeLink(UNIQUE_LINK, HandleSeq({name, defn}))
 {
 	init(true);
 }
@@ -135,5 +132,7 @@ Handle UniqueLink::get_unique(const Handle& alias, Type type,
 	                            "Cannot find defined hypergraph for atom %s",
 	                            alias->toString().c_str());
 }
+
+DEFINE_LINK_FACTORY(UniqueLink, UNIQUE_LINK)
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/core/UniqueLink.cc
+++ b/opencog/atoms/core/UniqueLink.cc
@@ -59,8 +59,8 @@ void UniqueLink::init(bool allow_open)
 	}
 }
 
-UniqueLink::UniqueLink(Type type, const HandleSeq& oset)
-	: FreeLink(type, oset)
+UniqueLink::UniqueLink(const HandleSeq& oset, Type type)
+	: FreeLink(oset, type)
 {
 	if (not classserver().isA(type, UNIQUE_LINK))
 	{
@@ -74,19 +74,13 @@ UniqueLink::UniqueLink(Type type, const HandleSeq& oset)
 	init(true);
 }
 
-UniqueLink::UniqueLink(const HandleSeq& oset)
-	: FreeLink(UNIQUE_LINK, oset)
-{
-	init(true);
-}
-
 UniqueLink::UniqueLink(const Handle& name, const Handle& defn)
-	: FreeLink(UNIQUE_LINK, HandleSeq({name, defn}))
+	: FreeLink(HandleSeq({name, defn}), UNIQUE_LINK)
 {
 	init(true);
 }
 
-UniqueLink::UniqueLink(Link &l)
+UniqueLink::UniqueLink(const Link &l)
 	: FreeLink(l)
 {
 	// Type must be as expected

--- a/opencog/atoms/core/UniqueLink.h
+++ b/opencog/atoms/core/UniqueLink.h
@@ -48,19 +48,17 @@ class UniqueLink : public FreeLink
 protected:
 	void init(bool);
 	static Handle get_unique(const Handle&, Type, bool);
-	UniqueLink(Type, const HandleSeq&,
-	           TruthValuePtr tv = TruthValue::DEFAULT_TV());
+	UniqueLink(Type, const HandleSeq&);
 
 public:
-	UniqueLink(const HandleSeq&,
-	           TruthValuePtr tv = TruthValue::DEFAULT_TV());
-
-	UniqueLink(const Handle& alias, const Handle& body,
-	           TruthValuePtr tv = TruthValue::DEFAULT_TV());
+	UniqueLink(const HandleSeq&);
+	UniqueLink(const Handle& alias, const Handle& body);
 
 	UniqueLink(Link &l);
 
 	Handle get_alias(void) const { return _outgoing[0]; }
+
+	static Handle factory(const Handle&);
 };
 
 typedef std::shared_ptr<UniqueLink> UniqueLinkPtr;

--- a/opencog/atoms/core/UniqueLink.h
+++ b/opencog/atoms/core/UniqueLink.h
@@ -48,13 +48,12 @@ class UniqueLink : public FreeLink
 protected:
 	void init(bool);
 	static Handle get_unique(const Handle&, Type, bool);
-	UniqueLink(Type, const HandleSeq&);
 
 public:
-	UniqueLink(const HandleSeq&);
+	UniqueLink(const HandleSeq&, Type=UNIQUE_LINK);
 	UniqueLink(const Handle& alias, const Handle& body);
 
-	UniqueLink(Link &l);
+	UniqueLink(const Link &l);
 
 	Handle get_alias(void) const { return _outgoing[0]; }
 

--- a/opencog/atoms/core/VariableList.cc
+++ b/opencog/atoms/core/VariableList.cc
@@ -58,9 +58,13 @@ void VariableList::validate_vardecl(const HandleSeq& oset)
 			return;
 		}
 		else
+		{
 			throw InvalidParamException(TRACE_INFO,
-				"Expected a VariableNode or a TypedVariableLink, got: %s",
-					classserver().getTypeName(t).c_str());
+				"Expected a VariableNode or a TypedVariableLink, got: %s"
+				"\nVariableList is %s",
+					classserver().getTypeName(t).c_str(),
+					toString().c_str());
+		}
 	}
 	build_index();
 }

--- a/opencog/atoms/core/VariableList.cc
+++ b/opencog/atoms/core/VariableList.cc
@@ -70,30 +70,31 @@ void VariableList::validate_vardecl(const HandleSeq& oset)
 }
 
 VariableList::VariableList(const Handle& hvardecls)
-	: Link(VARIABLE_LIST,
+	: Link(
 	    // Either it is a VariableList, or its a naked variable, or
 	    // its a typed variable.
 	    hvardecls->getType() == VARIABLE_LIST ?
-	          hvardecls->getOutgoingSet() : HandleSeq({hvardecls}))
+	          hvardecls->getOutgoingSet() : HandleSeq({hvardecls}),
+	    VARIABLE_LIST)
 {
 	validate_vardecl(getOutgoingSet());
 }
 
-VariableList::VariableList(const HandleSeq& oset)
-	: Link(VARIABLE_LIST, oset)
+VariableList::VariableList(const HandleSeq& oset, Type t)
+	: Link(oset, t)
 {
-	validate_vardecl(oset);
-}
-
-VariableList::VariableList(Type t, const HandleSeq& oset)
-	: Link(t, oset)
-{
+	if (not classserver().isA(t, VARIABLE_LIST))
+	{
+		const std::string& tname = classserver().getTypeName(t);
+		throw InvalidParamException(TRACE_INFO,
+			"Expecting a VariableList, got %s", tname.c_str());
+	}
 	// derived classes have a different initialization order
 	if (VARIABLE_LIST != t) return;
 	validate_vardecl(oset);
 }
 
-VariableList::VariableList(Link &l)
+VariableList::VariableList(const Link &l)
 	: Link(l)
 {
 	// Type must be as expected

--- a/opencog/atoms/core/VariableList.cc
+++ b/opencog/atoms/core/VariableList.cc
@@ -65,28 +65,24 @@ void VariableList::validate_vardecl(const HandleSeq& oset)
 	build_index();
 }
 
-VariableList::VariableList(const Handle& hvardecls,
-                           TruthValuePtr tv)
+VariableList::VariableList(const Handle& hvardecls)
 	: Link(VARIABLE_LIST,
 	    // Either it is a VariableList, or its a naked variable, or
 	    // its a typed variable.
 	    hvardecls->getType() == VARIABLE_LIST ?
-	          hvardecls->getOutgoingSet() : HandleSeq({hvardecls}),
-	    tv)
+	          hvardecls->getOutgoingSet() : HandleSeq({hvardecls}))
 {
 	validate_vardecl(getOutgoingSet());
 }
 
-VariableList::VariableList(const HandleSeq& oset,
-                           TruthValuePtr tv)
-	: Link(VARIABLE_LIST, oset, tv)
+VariableList::VariableList(const HandleSeq& oset)
+	: Link(VARIABLE_LIST, oset)
 {
 	validate_vardecl(oset);
 }
 
-VariableList::VariableList(Type t, const HandleSeq& oset,
-                           TruthValuePtr tv)
-	: Link(t, oset, tv)
+VariableList::VariableList(Type t, const HandleSeq& oset)
+	: Link(t, oset)
 {
 	// derived classes have a different initialization order
 	if (VARIABLE_LIST != t) return;
@@ -344,5 +340,7 @@ std::string opencog::oc_to_string(const VariableListPtr& vlp)
 	else
 		return oc_to_string(vlp->getHandle());
 }
+
+DEFINE_LINK_FACTORY(VariableList, VARIABLE_LIST)
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/core/VariableList.h
+++ b/opencog/atoms/core/VariableList.h
@@ -56,17 +56,12 @@ protected:
 	void validate_vardecl(const Handle&);
 	void validate_vardecl(const HandleSeq&);
 
-	VariableList(Type, const HandleSeq&,
-	             TruthValuePtr tv = TruthValue::DEFAULT_TV());
+	VariableList(Type, const HandleSeq&);
 
 	void build_index(void);
 public:
-	VariableList(const Handle& hvardecls,
-	             TruthValuePtr tv = TruthValue::DEFAULT_TV());
-
-	VariableList(const HandleSeq& vardecls,
-	             TruthValuePtr tv = TruthValue::DEFAULT_TV());
-
+	VariableList(const Handle& hvardecls);
+	VariableList(const HandleSeq& vardecls);
 	VariableList(Link&);
 
 	// Return the list of variables we are holding.
@@ -93,6 +88,8 @@ public:
 	// exception is thrown.
 	Handle substitute(const Handle& tree, const HandleSeq& vals) const
 		{ return _varlist.substitute(tree, vals); }
+
+	static Handle factory(const Handle&);
 };
 
 typedef std::shared_ptr<VariableList> VariableListPtr;

--- a/opencog/atoms/core/VariableList.h
+++ b/opencog/atoms/core/VariableList.h
@@ -60,9 +60,9 @@ protected:
 
 	void build_index(void);
 public:
+	VariableList(const HandleSeq& vardecls, Type=VARIABLE_LIST);
 	VariableList(const Handle& hvardecls);
-	VariableList(const HandleSeq& vardecls);
-	VariableList(Link&);
+	VariableList(const Link&);
 
 	// Return the list of variables we are holding.
 	const Variables& get_variables(void) const { return _varlist; }

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -220,7 +220,7 @@ Handle FreeVariables::substitute_scoped(const Handle& term,
 				oset.emplace_back(substitute_scoped(h, args, silent,
 				                                    hidden_map, quotation));
 			}
-			return classserver().factory(Handle(createLink(term->getType(), oset)));
+			return classserver().factory(Handle(createLink(oset, term->getType())));
 		}
 	}
 
@@ -244,7 +244,7 @@ Handle FreeVariables::substitute_scoped(const Handle& term,
 				substitute_scoped(h, args, silent, index_map, quotation));
 	}
 
-	return classserver().factory(Handle(createLink(term->getType(), oset)));
+	return classserver().factory(Handle(createLink(oset, term->getType())));
 }
 
 /* ================================================================= */
@@ -588,7 +588,7 @@ Handle Variables::get_vardecl() const
 			for (Type t : sit->second)
 				types.push_back(Handle(createTypeNode(t)));
 			Handle types_h = types.size() == 1 ? types[0]
-				: Handle(createLink(TYPE_CHOICE, types));
+				: Handle(createLink(types, TYPE_CHOICE));
 			vars.push_back(Handle(createLink(TYPED_VARIABLE_LINK,
 			                                 var, types_h)));
 			continue;

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -81,7 +81,7 @@ void VarScraper::find_vars(HandleSeq& varseq, OrderedHandleSet& varset,
 			// do the bound-variable extraction.
 			ScopeLinkPtr sco(ScopeLinkCast(h));
 			if (nullptr == sco)
-				sco = ScopeLink::factory(t, h->getOutgoingSet());
+				sco = ScopeLinkCast(classserver().factory(h));
 			const Variables& vees = sco->get_variables();
 			for (const Handle& v : vees.varseq) _bound_vars.insert(v);
 		}
@@ -220,7 +220,7 @@ Handle FreeVariables::substitute_scoped(const Handle& term,
 				oset.emplace_back(substitute_scoped(h, args, silent,
 				                                    hidden_map, quotation));
 			}
-			return Handle(ScopeLink::factory(term->getType(), oset));
+			return classserver().factory(Handle(createLink(term->getType(), oset)));
 		}
 	}
 
@@ -244,10 +244,7 @@ Handle FreeVariables::substitute_scoped(const Handle& term,
 				substitute_scoped(h, args, silent, index_map, quotation));
 	}
 
-	if (classserver().isA(ty, SCOPE_LINK))
-		return Handle(ScopeLink::factory(term->getType(), oset));
-
-	return Handle(createLink(term->getType(), oset));
+	return classserver().factory(Handle(createLink(term->getType(), oset)));
 }
 
 /* ================================================================= */

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -42,9 +42,13 @@
 
 using namespace opencog;
 
-EvaluationLink::EvaluationLink(const HandleSeq& oset)
-    : FreeLink(EVALUATION_LINK, oset)
+EvaluationLink::EvaluationLink(const HandleSeq& oset, Type t)
+    : FreeLink(oset, t)
 {
+	if (EVALUATION_LINK != t)
+		throw RuntimeException(TRACE_INFO,
+		    "Expecting an EvaluationLink");
+
 	// The "canonical" EvaluationLink structure is:
 	//    EvaluationLink
 	//        PredicateNode "foo"
@@ -83,14 +87,13 @@ EvaluationLink::EvaluationLink(const Handle& schema, const Handle& args)
 	}
 }
 
-EvaluationLink::EvaluationLink(Link& l)
+EvaluationLink::EvaluationLink(const Link& l)
     : FreeLink(l)
 {
 	Type tscope = l.getType();
-	if (EVALUATION_LINK != tscope) {
+	if (EVALUATION_LINK != tscope)
 		throw RuntimeException(TRACE_INFO,
 		    "Expecting an EvaluationLink");
-	}
 }
 
 // Pattern matching hack. The pattern matcher returns sets of atoms;

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -45,8 +45,16 @@ using namespace opencog;
 EvaluationLink::EvaluationLink(const HandleSeq& oset)
     : FreeLink(EVALUATION_LINK, oset)
 {
-	if ((2 != oset.size()) or
-	   (LIST_LINK != oset[1]->getType()))
+	// The "canonical" EvaluationLink structure is:
+	//    EvaluationLink
+	//        PredicateNode "foo"
+	//        ListLink
+	//           ...
+	//
+	// However, patterns can have variables for either the
+	// ListLink, or the PredicateNode, or both.
+	if (2 != oset.size())
+	   // or (LIST_LINK != oset[1]->getType()))
 	{
 		throw RuntimeException(TRACE_INFO,
 		    "EvaluationLink must have predicate and args!");

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -635,4 +635,8 @@ TruthValuePtr EvaluationLink::do_evaluate(AtomSpace* as,
 	      schema.c_str());
 }
 
-DEFINE_LINK_FACTORY(EvaluationLink, EVALUATION_LINK)
+// The EvaluationLink factory, if allowed to run, just screws up
+// all sorts of unit test cases, and causes a large variety of
+// faults.  I suppose that perhaps this needs to be fixed, but its
+// daunting at this time.
+// DEFINE_LINK_FACTORY(EvaluationLink, EVALUATION_LINK)

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -42,9 +42,8 @@
 
 using namespace opencog;
 
-EvaluationLink::EvaluationLink(const HandleSeq& oset,
-                               TruthValuePtr tv)
-    : FreeLink(EVALUATION_LINK, oset, tv)
+EvaluationLink::EvaluationLink(const HandleSeq& oset)
+    : FreeLink(EVALUATION_LINK, oset)
 {
 	if ((2 != oset.size()) or
 	   (LIST_LINK != oset[1]->getType()))
@@ -54,9 +53,8 @@ EvaluationLink::EvaluationLink(const HandleSeq& oset,
 	}
 }
 
-EvaluationLink::EvaluationLink(const Handle& schema, const Handle& args,
-                               TruthValuePtr tv)
-    : FreeLink(EVALUATION_LINK, schema, args, tv)
+EvaluationLink::EvaluationLink(const Handle& schema, const Handle& args)
+    : FreeLink(EVALUATION_LINK, schema, args)
 {
 	if (LIST_LINK != args->getType()) {
 		throw RuntimeException(TRACE_INFO,
@@ -615,3 +613,5 @@ TruthValuePtr EvaluationLink::do_evaluate(AtomSpace* as,
 	     "Cannot evaluate unknown GroundedPredicateNode: %s",
 	      schema.c_str());
 }
+
+DEFINE_LINK_FACTORY(EvaluationLink, EVALUATION_LINK)

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -53,12 +53,25 @@ EvaluationLink::EvaluationLink(const HandleSeq& oset)
 	//
 	// However, patterns can have variables for either the
 	// ListLink, or the PredicateNode, or both.
+	//
+	// ... except reality is worse: many examples include
+	// badly-formed EvaluationLinks, on-purpose.  So, before
+	// we can do any sort of strict checking here, we would
+	// need fix all those wiki pages, examples, etc.
+	// As of this writing (March 2017), there are seven unit
+	// tests that create EvaluationLinks whose size() is not 2:
+	//    PutLinkUTest GetLinkUTest BuggySelfGroundUTest
+	//    StackMoreUTest ConstantClausesUTest PersistUTest
+	//    MultiPersistUTest
+	//
+/********
 	if (2 != oset.size())
 	   // or (LIST_LINK != oset[1]->getType()))
 	{
 		throw RuntimeException(TRACE_INFO,
 		    "EvaluationLink must have predicate and args!");
 	}
+*********/
 }
 
 EvaluationLink::EvaluationLink(const Handle& schema, const Handle& args)

--- a/opencog/atoms/execution/EvaluationLink.h
+++ b/opencog/atoms/execution/EvaluationLink.h
@@ -36,12 +36,8 @@ class AtomSpace;
 class EvaluationLink : public FreeLink
 {
 public:
-	EvaluationLink(const HandleSeq& oset,
-	     TruthValuePtr tv = TruthValue::DEFAULT_TV());
-
-	EvaluationLink(const Handle& schema, const Handle& args,
-	     TruthValuePtr tv = TruthValue::DEFAULT_TV());
-
+	EvaluationLink(const HandleSeq& oset);
+	EvaluationLink(const Handle& schema, const Handle& args);
 	EvaluationLink(Link& l);
 
 	TruthValuePtr evaluate(AtomSpace* as) {
@@ -58,6 +54,8 @@ public:
 	                                 const HandleSeq& schema_and_args);
 	static TruthValuePtr do_evaluate(AtomSpace*,
 	                                const Handle& schema, const Handle& args);
+
+	static Handle factory(const Handle&);
 };
 
 typedef std::shared_ptr<EvaluationLink> EvaluationLinkPtr;

--- a/opencog/atoms/execution/EvaluationLink.h
+++ b/opencog/atoms/execution/EvaluationLink.h
@@ -36,9 +36,9 @@ class AtomSpace;
 class EvaluationLink : public FreeLink
 {
 public:
-	EvaluationLink(const HandleSeq& oset);
+	EvaluationLink(const HandleSeq&, Type=EVALUATION_LINK);
 	EvaluationLink(const Handle& schema, const Handle& args);
-	EvaluationLink(Link& l);
+	EvaluationLink(const Link& l);
 
 	TruthValuePtr evaluate(AtomSpace* as) {
 	    return do_evaluate(as, getHandle());

--- a/opencog/atoms/execution/ExecSCM.cc
+++ b/opencog/atoms/execution/ExecSCM.cc
@@ -54,12 +54,11 @@ static Handle ss_reduce(AtomSpace* atomspace, const Handle& h)
 	if (NUMBER_NODE == t) return Handle(h);
 
 	if (not classserver().isA(t, FOLD_LINK))
-	{
 		throw InvalidParamException(TRACE_INFO,
 			"Expecting a FoldLink (PlusLink, TimesLink, etc");
-	}
 
-	FoldLinkPtr fff(FoldLink::factory(h));
+	auto fact = classserver().getFactory(t);
+	FoldLinkPtr fff(FoldLinkCast((*fact)(h)));
 	Handle hr(fff->reduce());
 
 	if (DELETE_LINK == hr->getType())

--- a/opencog/atoms/execution/ExecutionOutputLink.cc
+++ b/opencog/atoms/execution/ExecutionOutputLink.cc
@@ -43,9 +43,8 @@ public:
     static void* getFunc(std::string libName,std::string funcName);
 };
 
-ExecutionOutputLink::ExecutionOutputLink(const HandleSeq& oset,
-                                         TruthValuePtr tv)
-	: FunctionLink(EXECUTION_OUTPUT_LINK, oset, tv)
+ExecutionOutputLink::ExecutionOutputLink(const HandleSeq& oset)
+	: FunctionLink(EXECUTION_OUTPUT_LINK, oset)
 {
 	if (2 != oset.size())
 		throw SyntaxException(TRACE_INFO,
@@ -63,9 +62,8 @@ ExecutionOutputLink::ExecutionOutputLink(const HandleSeq& oset,
 }
 
 ExecutionOutputLink::ExecutionOutputLink(const Handle& schema,
-                                         const Handle& args,
-                                         TruthValuePtr tv)
-	: FunctionLink(EXECUTION_OUTPUT_LINK, schema, args, tv)
+                                         const Handle& args)
+	: FunctionLink(EXECUTION_OUTPUT_LINK, schema, args)
 {
 	Type stype = schema->getType();
 	if (GROUNDED_SCHEMA_NODE != stype and
@@ -219,6 +217,8 @@ void ExecutionOutputLink::lang_lib_fun(const std::string& schema,
 	} else
 		fun = schema.substr(pos);
 }
+
+DEFINE_LINK_FACTORY(ExecutionOutputLink, EXECUTION_OUTPUT_LINK)
 
 std::unordered_map<std::string, void*> LibraryManager::_librarys;
 std::unordered_map<std::string, void*> LibraryManager::_functions;

--- a/opencog/atoms/execution/ExecutionOutputLink.cc
+++ b/opencog/atoms/execution/ExecutionOutputLink.cc
@@ -43,9 +43,13 @@ public:
     static void* getFunc(std::string libName,std::string funcName);
 };
 
-ExecutionOutputLink::ExecutionOutputLink(const HandleSeq& oset)
-	: FunctionLink(EXECUTION_OUTPUT_LINK, oset)
+ExecutionOutputLink::ExecutionOutputLink(const HandleSeq& oset, Type t)
+	: FunctionLink(oset, t)
 {
+	if (EXECUTION_OUTPUT_LINK != t)
+		throw SyntaxException(TRACE_INFO,
+			"Expection an ExecutionOutputLink!");
+
 	if (2 != oset.size())
 		throw SyntaxException(TRACE_INFO,
 			"ExecutionOutputLink must have schema and args! Got arity=%d",
@@ -76,7 +80,7 @@ ExecutionOutputLink::ExecutionOutputLink(const Handle& schema,
 	}
 }
 
-ExecutionOutputLink::ExecutionOutputLink(Link& l)
+ExecutionOutputLink::ExecutionOutputLink(const Link& l)
 	: FunctionLink(l)
 {
 	Type tscope = l.getType();

--- a/opencog/atoms/execution/ExecutionOutputLink.h
+++ b/opencog/atoms/execution/ExecutionOutputLink.h
@@ -50,18 +50,16 @@ private:
 	                         std::string& lib,
 	                         std::string& fun);;
 public:
-	ExecutionOutputLink(const HandleSeq& oset,
-	     TruthValuePtr tv = TruthValue::DEFAULT_TV());
-
-	ExecutionOutputLink(const Handle& schema, const Handle& args,
-	     TruthValuePtr tv = TruthValue::DEFAULT_TV());
-
+	ExecutionOutputLink(const HandleSeq& oset);
+	ExecutionOutputLink(const Handle& schema, const Handle& args);
 	ExecutionOutputLink(Link& l);
 
 	virtual Handle execute(AtomSpace* = NULL) const;
 
 	Handle get_schema(void) const { return getOutgoingAtom(0); }
 	Handle get_args(void) const { return getOutgoingAtom(1); }
+
+	static Handle factory(const Handle&);
 };
 
 typedef std::shared_ptr<ExecutionOutputLink> ExecutionOutputLinkPtr;

--- a/opencog/atoms/execution/ExecutionOutputLink.h
+++ b/opencog/atoms/execution/ExecutionOutputLink.h
@@ -50,9 +50,9 @@ private:
 	                         std::string& lib,
 	                         std::string& fun);;
 public:
-	ExecutionOutputLink(const HandleSeq& oset);
+	ExecutionOutputLink(const HandleSeq&, Type=EXECUTION_OUTPUT_LINK);
 	ExecutionOutputLink(const Handle& schema, const Handle& args);
-	ExecutionOutputLink(Link& l);
+	ExecutionOutputLink(const Link& l);
 
 	virtual Handle execute(AtomSpace* = NULL) const;
 

--- a/opencog/atoms/execution/Instantiator.cc
+++ b/opencog/atoms/execution/Instantiator.cc
@@ -393,7 +393,7 @@ Handle Instantiator::walk_tree(const Handle& expr)
 			// Also, the number of arguments is not fixed, its always variadic.
 			// Perform substitution on all arguments before applying the
 			// function itself.
-			FunctionLinkPtr flp(FunctionLink::factory(expr));
+			FunctionLinkPtr flp(FunctionLink::castfactory(expr));
 			return flp->execute(_as);
 		}
 	}

--- a/opencog/atoms/execution/Instantiator.cc
+++ b/opencog/atoms/execution/Instantiator.cc
@@ -23,8 +23,6 @@
 
 #include <opencog/atoms/core/DefineLink.h>
 #include <opencog/atoms/core/LambdaLink.h>
-// #include <opencog/atoms/core/MapLink.h>
-#include "MapLink.h"  // fucking python
 #include <opencog/atoms/core/PutLink.h>
 #include <opencog/atoms/execution/ExecutionOutputLink.h>
 #include <opencog/atoms/execution/EvaluationLink.h>
@@ -343,13 +341,16 @@ Handle Instantiator::walk_tree(const Handle& expr)
 			// function itself.
 			HandleSeq oset_results;
 			walk_sequence(oset_results, expr->getOutgoingSet());
-			FoldLinkPtr flp(FoldLink::factory(t, oset_results));
+			auto fact = classserver().getFactory(t);
+			Handle fh((*fact)(Handle(createLink(t, oset_results))));
+			FoldLinkPtr flp(FoldLinkCast(fh));
 			return flp->execute(_as);
 		}
 		else
 		{
 			Handle hexpr(beta_reduce(expr, *_vmap));
-			FoldLinkPtr flp(FoldLink::factory(hexpr));
+			hexpr = classserver().factory(hexpr);
+			FoldLinkPtr flp(FoldLinkCast(hexpr));
 			return flp->execute(_as);
 		}
 	}
@@ -357,18 +358,6 @@ Handle Instantiator::walk_tree(const Handle& expr)
 	// Fire any other function links, not handled above.
 	if (classserver().isA(t, FUNCTION_LINK))
 	{
-		// MapLink is a FunctionLink, but circular shared-library
-		// dependencies prevent the factory from handling it.
-		// Anyway, we avoid doing eager evaluation on the MapLink,
-		// It can do that, itself. If we did do eager evaluation of the
-		// MapLink, we'd need to get eager only on its argument list,
-		// and not on its body.
-		if (classserver().isA(t, MAP_LINK))
-		{
-			FunctionLinkPtr flp(createMapLink(expr->getOutgoingSet()));
-			return flp->execute(_as);
-		}
-
 		if (_eager)
 		{
 			// Perform substitution on all arguments before applying the
@@ -383,7 +372,9 @@ Handle Instantiator::walk_tree(const Handle& expr)
 			HandleSeq oset_results;
 			walk_sequence(oset_results, expr->getOutgoingSet());
 
-			FunctionLinkPtr flp(FunctionLink::factory(t, oset_results));
+			auto fact = classserver().getFactory(t);
+			FunctionLinkPtr flp(FunctionLinkCast(
+				(*fact)(Handle(createLink(t, oset_results)))));
 			return flp->execute(_as);
 		}
 		else
@@ -393,7 +384,8 @@ Handle Instantiator::walk_tree(const Handle& expr)
 			// Also, the number of arguments is not fixed, its always variadic.
 			// Perform substitution on all arguments before applying the
 			// function itself.
-			FunctionLinkPtr flp(FunctionLink::castfactory(expr));
+			FunctionLinkPtr flp(FunctionLinkCast(
+				classserver().factory(expr)));
 			return flp->execute(_as);
 		}
 	}

--- a/opencog/atoms/execution/Instantiator.cc
+++ b/opencog/atoms/execution/Instantiator.cc
@@ -341,8 +341,7 @@ Handle Instantiator::walk_tree(const Handle& expr)
 			// function itself.
 			HandleSeq oset_results;
 			walk_sequence(oset_results, expr->getOutgoingSet());
-			auto fact = classserver().getFactory(t);
-			Handle fh((*fact)(Handle(createLink(t, oset_results))));
+			Handle fh(classserver().factory(Handle(createLink(t, oset_results))));
 			FoldLinkPtr flp(FoldLinkCast(fh));
 			return flp->execute(_as);
 		}
@@ -372,9 +371,8 @@ Handle Instantiator::walk_tree(const Handle& expr)
 			HandleSeq oset_results;
 			walk_sequence(oset_results, expr->getOutgoingSet());
 
-			auto fact = classserver().getFactory(t);
 			FunctionLinkPtr flp(FunctionLinkCast(
-				(*fact)(Handle(createLink(t, oset_results)))));
+				classserver().factory(Handle(createLink(t, oset_results)))));
 			return flp->execute(_as);
 		}
 		else
@@ -428,7 +426,8 @@ mere_recursive_call:
 	bool changed = walk_sequence(oset_results, expr->getOutgoingSet());
 	if (changed)
 	{
-		LinkPtr subl = createLink(t, oset_results, expr->getTruthValue());
+		LinkPtr subl = createLink(t, oset_results);
+		subl->copyValues(expr);
 		return Handle(_as->add_atom(subl));
 	}
 	return expr;

--- a/opencog/atoms/execution/Instantiator.cc
+++ b/opencog/atoms/execution/Instantiator.cc
@@ -341,7 +341,7 @@ Handle Instantiator::walk_tree(const Handle& expr)
 			// function itself.
 			HandleSeq oset_results;
 			walk_sequence(oset_results, expr->getOutgoingSet());
-			Handle fh(classserver().factory(Handle(createLink(t, oset_results))));
+			Handle fh(classserver().factory(Handle(createLink(oset_results, t))));
 			FoldLinkPtr flp(FoldLinkCast(fh));
 			return flp->execute(_as);
 		}
@@ -372,7 +372,7 @@ Handle Instantiator::walk_tree(const Handle& expr)
 			walk_sequence(oset_results, expr->getOutgoingSet());
 
 			FunctionLinkPtr flp(FunctionLinkCast(
-				classserver().factory(Handle(createLink(t, oset_results)))));
+				classserver().factory(Handle(createLink(oset_results, t)))));
 			return flp->execute(_as);
 		}
 		else
@@ -426,7 +426,7 @@ mere_recursive_call:
 	bool changed = walk_sequence(oset_results, expr->getOutgoingSet());
 	if (changed)
 	{
-		LinkPtr subl = createLink(t, oset_results);
+		LinkPtr subl = createLink(oset_results, t);
 		subl->copyValues(expr);
 		return Handle(_as->add_atom(subl));
 	}

--- a/opencog/atoms/execution/MapLink.cc
+++ b/opencog/atoms/execution/MapLink.cc
@@ -94,35 +94,36 @@ void MapLink::init(void)
 	// FunctionLink::init();
 }
 
-MapLink::MapLink(const HandleSeq& oset)
-	: FunctionLink(MAP_LINK, oset)
-{
-	init();
-}
-
 MapLink::MapLink(const Handle& vars, const Handle& body)
-	: FunctionLink(MAP_LINK, HandleSeq({vars, body}))
+	: FunctionLink(HandleSeq({vars, body}), MAP_LINK)
 {
 	init();
 }
 
 MapLink::MapLink(Type t, const Handle& body)
-	: FunctionLink(t, HandleSeq({body}))
+	: FunctionLink(HandleSeq({body}), t)
 {
 	// Derived types have a different initialization sequence.
 	if (MAP_LINK != t) return;
 	init();
 }
 
-MapLink::MapLink(Type t, const HandleSeq& oset)
-	: FunctionLink(t, oset)
+MapLink::MapLink(const HandleSeq& oset, Type t)
+	: FunctionLink(oset, t)
 {
+	if (not classserver().isA(t, MAP_LINK))
+	{
+		const std::string& tname = classserver().getTypeName(t);
+		throw SyntaxException(TRACE_INFO,
+			"Expecting a MapLink, got %s", tname.c_str());
+	}
+
 	// Derived types have a different initialization sequence.
 	if (MAP_LINK != t) return;
 	init();
 }
 
-MapLink::MapLink(Link &l)
+MapLink::MapLink(const Link &l)
 	: FunctionLink(l)
 {
 	// Type must be as expected
@@ -296,7 +297,7 @@ bool MapLink::extract(const Handle& termpat,
 			}
 
 			// If we are here, we've got a match. Record it.
-			LinkPtr glp(createLink(LIST_LINK, glob_seq));
+			LinkPtr glp(createLink(glob_seq, LIST_LINK));
 			valmap.emplace(std::make_pair(glob, glp->getHandle()));
 		}
 		else
@@ -354,7 +355,7 @@ Handle MapLink::rewrite_one(const Handle& cterm, AtomSpace* scratch) const
 	// variable.
 	size_t nv = valseq.size();
 	if (1 < nv)
-		return Handle(createLink(LIST_LINK, valseq));
+		return Handle(createLink(valseq, LIST_LINK));
 	else if (1 == nv)
 		return valseq[0];
 	return Handle::UNDEFINED;
@@ -377,7 +378,7 @@ Handle MapLink::execute(AtomSpace* scratch) const
 			Handle mone = rewrite_one(h, scratch);
 			if (nullptr != mone) remap.emplace_back(mone);
 		}
-		return Handle(createLink(argtype, remap));
+		return Handle(createLink(remap, argtype));
 	}
 
 	// Its a singleton. Just remap that.

--- a/opencog/atoms/execution/MapLink.cc
+++ b/opencog/atoms/execution/MapLink.cc
@@ -94,29 +94,28 @@ void MapLink::init(void)
 	// FunctionLink::init();
 }
 
-MapLink::MapLink(const HandleSeq& oset, TruthValuePtr tv)
-	: FunctionLink(MAP_LINK, oset, tv)
+MapLink::MapLink(const HandleSeq& oset)
+	: FunctionLink(MAP_LINK, oset)
 {
 	init();
 }
 
-MapLink::MapLink(const Handle& vars, const Handle& body,
-                       TruthValuePtr tv)
-	: FunctionLink(MAP_LINK, HandleSeq({vars, body}), tv)
+MapLink::MapLink(const Handle& vars, const Handle& body)
+	: FunctionLink(MAP_LINK, HandleSeq({vars, body}))
 {
 	init();
 }
 
-MapLink::MapLink(Type t, const Handle& body, TruthValuePtr tv)
-	: FunctionLink(t, HandleSeq({body}), tv)
+MapLink::MapLink(Type t, const Handle& body)
+	: FunctionLink(t, HandleSeq({body}))
 {
 	// Derived types have a different initialization sequence.
 	if (MAP_LINK != t) return;
 	init();
 }
 
-MapLink::MapLink(Type t, const HandleSeq& oset, TruthValuePtr tv)
-	: FunctionLink(t, oset, tv)
+MapLink::MapLink(Type t, const HandleSeq& oset)
+	: FunctionLink(t, oset)
 {
 	// Derived types have a different initialization sequence.
 	if (MAP_LINK != t) return;
@@ -384,5 +383,7 @@ Handle MapLink::execute(AtomSpace* scratch) const
 	// Its a singleton. Just remap that.
 	return rewrite_one(valh, scratch);
 }
+
+DEFINE_LINK_FACTORY(MapLink, MAP_LINK)
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/execution/MapLink.h
+++ b/opencog/atoms/execution/MapLink.h
@@ -55,7 +55,6 @@ protected:
 	void init(void);
 
 	MapLink(Type, const Handle&);
-	MapLink(Type, const HandleSeq&);
 
 	bool extract(const Handle&, const Handle&,
 	             HandleMap&,
@@ -64,9 +63,9 @@ protected:
 	Handle rewrite_one(const Handle&, AtomSpace*) const;
 
 public:
-	MapLink(const HandleSeq&);
+	MapLink(const HandleSeq&, Type=MAP_LINK);
 	MapLink(const Handle& pattern, const Handle& term);
-	MapLink(Link &l);
+	MapLink(const Link &l);
 
 	// Align the pattern and the term side-by-side, and extract the
 	// values that match up with the variables.  If the term is not of

--- a/opencog/atoms/execution/MapLink.h
+++ b/opencog/atoms/execution/MapLink.h
@@ -54,11 +54,8 @@ protected:
 
 	void init(void);
 
-	MapLink(Type, const Handle&,
-	           TruthValuePtr tv = TruthValue::DEFAULT_TV());
-
-	MapLink(Type, const HandleSeq&,
-	           TruthValuePtr tv = TruthValue::DEFAULT_TV());
+	MapLink(Type, const Handle&);
+	MapLink(Type, const HandleSeq&);
 
 	bool extract(const Handle&, const Handle&,
 	             HandleMap&,
@@ -67,18 +64,16 @@ protected:
 	Handle rewrite_one(const Handle&, AtomSpace*) const;
 
 public:
-	MapLink(const HandleSeq&,
-	        TruthValuePtr tv = TruthValue::DEFAULT_TV());
-
-	MapLink(const Handle& pattern, const Handle& term,
-	        TruthValuePtr tv = TruthValue::DEFAULT_TV());
-
+	MapLink(const HandleSeq&);
+	MapLink(const Handle& pattern, const Handle& term);
 	MapLink(Link &l);
 
 	// Align the pattern and the term side-by-side, and extract the
 	// values that match up with the variables.  If the term is not of
 	// the same type as the pattern, return the undefined handle.
 	virtual Handle execute(AtomSpace* = NULL) const;
+
+	static Handle factory(const Handle&);
 };
 
 typedef std::shared_ptr<MapLink> MapLinkPtr;

--- a/opencog/atoms/pattern/BindLink.cc
+++ b/opencog/atoms/pattern/BindLink.cc
@@ -38,26 +38,24 @@ void BindLink::init(void)
 	_pat.redex_name = "anonymous BindLink";
 }
 
-BindLink::BindLink(const HandleSeq& hseq, TruthValuePtr tv)
-	: PatternLink(BIND_LINK, hseq, tv)
+BindLink::BindLink(const HandleSeq& hseq)
+	: PatternLink(BIND_LINK, hseq)
 {
 	init();
 }
 
 BindLink::BindLink(const Handle& vardecl,
                    const Handle& body,
-                   const Handle& rewrite,
-                   TruthValuePtr tv)
-	: BindLink(HandleSeq{vardecl, body, rewrite}, tv)
+                   const Handle& rewrite)
+	: BindLink(HandleSeq{vardecl, body, rewrite})
 {}
 
-BindLink::BindLink(const Handle& body, const Handle& rewrite,
-                   TruthValuePtr tv)
-	: BindLink(HandleSeq{body, rewrite}, tv)
+BindLink::BindLink(const Handle& body, const Handle& rewrite)
+	: BindLink(HandleSeq{body, rewrite})
 {}
 
-BindLink::BindLink(Type t, const HandleSeq& hseq, TruthValuePtr tv)
-	: PatternLink(t, hseq, tv)
+BindLink::BindLink(Type t, const HandleSeq& hseq)
+	: PatternLink(t, hseq)
 {
 	init();
 }
@@ -110,5 +108,9 @@ void BindLink::extract_variables(const HandleSeq& oset)
 	// Initialize _varlist with the scoped variables
 	init_scoped_variables(oset[0]);
 }
+
+/* ================================================================= */
+
+DEFINE_LINK_FACTORY(BindLink, BIND_LINK)
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/pattern/BindLink.cc
+++ b/opencog/atoms/pattern/BindLink.cc
@@ -31,17 +31,19 @@ using namespace opencog;
 
 void BindLink::init(void)
 {
+	Type t = getType();
+	if (not classserver().isA(t, BIND_LINK))
+	{
+		const std::string& tname = classserver().getTypeName(t);
+		throw InvalidParamException(TRACE_INFO,
+			"Expecting a BindLink, got %s", tname.c_str());
+	}
+
 	extract_variables(_outgoing);
 	unbundle_clauses(_body);
 	common_init();
 	setup_components();
 	_pat.redex_name = "anonymous BindLink";
-}
-
-BindLink::BindLink(const HandleSeq& hseq)
-	: PatternLink(BIND_LINK, hseq)
-{
-	init();
 }
 
 BindLink::BindLink(const Handle& vardecl,
@@ -54,23 +56,15 @@ BindLink::BindLink(const Handle& body, const Handle& rewrite)
 	: BindLink(HandleSeq{body, rewrite})
 {}
 
-BindLink::BindLink(Type t, const HandleSeq& hseq)
-	: PatternLink(t, hseq)
+BindLink::BindLink(const HandleSeq& hseq, Type t)
+	: PatternLink(hseq, t)
 {
 	init();
 }
 
-BindLink::BindLink(Link &l)
+BindLink::BindLink(const Link &l)
 	: PatternLink(l)
 {
-	Type t = l.getType();
-	if (not classserver().isA(t, BIND_LINK))
-	{
-		const std::string& tname = classserver().getTypeName(t);
-		throw InvalidParamException(TRACE_INFO,
-			"Expecting a BindLink, got %s", tname.c_str());
-	}
-
 	init();
 }
 

--- a/opencog/atoms/pattern/BindLink.h
+++ b/opencog/atoms/pattern/BindLink.h
@@ -46,7 +46,7 @@ protected:
 
 public:
 	BindLink(const HandleSeq&);
-	BindLink(const Handle& vardecl, const Handle& body, const Handle& rewrite)
+	BindLink(const Handle& vardecl, const Handle& body, const Handle& rewrite);
 	BindLink(const Handle& body, const Handle& rewrite);
 	explicit BindLink(Link &l);
 

--- a/opencog/atoms/pattern/BindLink.h
+++ b/opencog/atoms/pattern/BindLink.h
@@ -42,21 +42,18 @@ protected:
 	// will initialize the rewrite term _implicand.
 	void extract_variables(const HandleSeq& oset);
 
-	BindLink(Type, const HandleSeq&,
-	         TruthValuePtr tv=TruthValue::DEFAULT_TV());
+	BindLink(Type, const HandleSeq&);
 
 public:
-	BindLink(const HandleSeq&,
-	         TruthValuePtr tv=TruthValue::DEFAULT_TV());
-	BindLink(const Handle& vardecl, const Handle& body, const Handle& rewrite,
-	         TruthValuePtr tv=TruthValue::DEFAULT_TV());
-	BindLink(const Handle& body, const Handle& rewrite,
-	         TruthValuePtr tv=TruthValue::DEFAULT_TV());
-
+	BindLink(const HandleSeq&);
+	BindLink(const Handle& vardecl, const Handle& body, const Handle& rewrite)
+	BindLink(const Handle& body, const Handle& rewrite);
 	explicit BindLink(Link &l);
 
 	bool imply(PatternMatchCallback&, bool check_connectivity=true);
 	const Handle& get_implicand(void) { return _implicand; }
+
+	static Handle factory(const Handle&);
 };
 
 typedef std::shared_ptr<BindLink> BindLinkPtr;

--- a/opencog/atoms/pattern/BindLink.h
+++ b/opencog/atoms/pattern/BindLink.h
@@ -42,13 +42,11 @@ protected:
 	// will initialize the rewrite term _implicand.
 	void extract_variables(const HandleSeq& oset);
 
-	BindLink(Type, const HandleSeq&);
-
 public:
-	BindLink(const HandleSeq&);
+	BindLink(const HandleSeq&, Type=BIND_LINK);
 	BindLink(const Handle& vardecl, const Handle& body, const Handle& rewrite);
 	BindLink(const Handle& body, const Handle& rewrite);
-	explicit BindLink(Link &l);
+	explicit BindLink(const Link &l);
 
 	bool imply(PatternMatchCallback&, bool check_connectivity=true);
 	const Handle& get_implicand(void) { return _implicand; }

--- a/opencog/atoms/pattern/DualLink.cc
+++ b/opencog/atoms/pattern/DualLink.cc
@@ -30,6 +30,14 @@ using namespace opencog;
 
 void DualLink::init(void)
 {
+	Type t = getType();
+	if (not classserver().isA(t, DUAL_LINK))
+	{
+		const std::string& tname = classserver().getTypeName(t);
+		throw InvalidParamException(TRACE_INFO,
+			"Expecting a DualLink, got %s", tname.c_str());
+	}
+
 	_pat.redex_name = "anonymous DualLink";
 
 	_num_virts = 1;
@@ -55,29 +63,15 @@ void DualLink::init(void)
 	make_term_trees();
 }
 
-DualLink::DualLink(const HandleSeq& hseq)
-	: PatternLink(DUAL_LINK, hseq)
+DualLink::DualLink(const HandleSeq& hseq, Type t)
+	: PatternLink(hseq, t)
 {
 	init();
 }
 
-DualLink::DualLink(Type t, const HandleSeq& hseq)
-	: PatternLink(t, hseq)
-{
-	init();
-}
-
-DualLink::DualLink(Link &l)
+DualLink::DualLink(const Link &l)
 	: PatternLink(l)
 {
-	Type t = l.getType();
-	if (not classserver().isA(t, DUAL_LINK))
-	{
-		const std::string& tname = classserver().getTypeName(t);
-		throw InvalidParamException(TRACE_INFO,
-			"Expecting a DualLink, got %s", tname.c_str());
-	}
-
 	init();
 }
 

--- a/opencog/atoms/pattern/DualLink.cc
+++ b/opencog/atoms/pattern/DualLink.cc
@@ -55,15 +55,14 @@ void DualLink::init(void)
 	make_term_trees();
 }
 
-DualLink::DualLink(const HandleSeq& hseq, TruthValuePtr tv)
-	: PatternLink(DUAL_LINK, hseq, tv)
+DualLink::DualLink(const HandleSeq& hseq)
+	: PatternLink(DUAL_LINK, hseq)
 {
 	init();
 }
 
-DualLink::DualLink(Type t, const HandleSeq& hseq,
-                   TruthValuePtr tv)
-	: PatternLink(t, hseq, tv)
+DualLink::DualLink(Type t, const HandleSeq& hseq)
+	: PatternLink(t, hseq)
 {
 	init();
 }
@@ -81,5 +80,7 @@ DualLink::DualLink(Link &l)
 
 	init();
 }
+
+DEFINE_LINK_FACTORY(DualLink, DUAL_LINK)
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/pattern/DualLink.h
+++ b/opencog/atoms/pattern/DualLink.h
@@ -33,11 +33,9 @@ class DualLink : public PatternLink
 {
 protected:
 	void init(void);
-	DualLink(Type, const HandleSeq&);
-
 public:
-	DualLink(const HandleSeq&);
-	DualLink(Link &l);
+	DualLink(const HandleSeq&, Type=DUAL_LINK);
+	DualLink(const Link &l);
 
 	static Handle factory(const Handle&);
 };

--- a/opencog/atoms/pattern/DualLink.h
+++ b/opencog/atoms/pattern/DualLink.h
@@ -33,15 +33,13 @@ class DualLink : public PatternLink
 {
 protected:
 	void init(void);
-
-	DualLink(Type, const HandleSeq&,
-	         TruthValuePtr tv = TruthValue::DEFAULT_TV());
+	DualLink(Type, const HandleSeq&);
 
 public:
-	DualLink(const HandleSeq&,
-	         TruthValuePtr tv = TruthValue::DEFAULT_TV());
-
+	DualLink(const HandleSeq&);
 	DualLink(Link &l);
+
+	static Handle factory(const Handle&);
 };
 
 typedef std::shared_ptr<DualLink> DualLinkPtr;

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -964,4 +964,11 @@ Handle PatternLink::factory(const Handle& h)
 	return Handle(createPatternLink(h->getType(), h->getOutgoingSet()));
 }
 
+// This runs when the shared lib is loaded.  The factory
+// must get registered early, b efore anyone can do anything else.
+static __attribute__ ((constructor)) void init(void)
+{
+   classserver().addFactory(PATTERN_LINK, &PatternLink::factory);
+}
+
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -248,28 +248,26 @@ PatternLink::PatternLink(const OrderedHandleSet& vars,
 
 /* ================================================================= */
 
-PatternLink::PatternLink(const HandleSeq& hseq, TruthValuePtr tv)
-	: ScopeLink(PATTERN_LINK, hseq, tv)
+PatternLink::PatternLink(const HandleSeq& hseq)
+	: ScopeLink(PATTERN_LINK, hseq)
 {
 	init();
 }
 
-PatternLink::PatternLink(const Handle& body, TruthValuePtr tv)
-	: ScopeLink(PATTERN_LINK, HandleSeq({body}), tv)
+PatternLink::PatternLink(const Handle& body)
+	: ScopeLink(PATTERN_LINK, HandleSeq({body}))
 {
 	init();
 }
 
-PatternLink::PatternLink(const Handle& vars, const Handle& body,
-                         TruthValuePtr tv)
-	: ScopeLink(PATTERN_LINK, HandleSeq({vars, body}), tv)
+PatternLink::PatternLink(const Handle& vars, const Handle& body)
+	: ScopeLink(PATTERN_LINK, HandleSeq({vars, body}))
 {
 	init();
 }
 
-PatternLink::PatternLink(Type t, const HandleSeq& hseq,
-                         TruthValuePtr tv)
-	: ScopeLink(t, hseq, tv)
+PatternLink::PatternLink(Type t, const HandleSeq& hseq)
+	: ScopeLink(t, hseq)
 {
 	// BindLink uses a different initialization sequence.
 	if (BIND_LINK == t) return;
@@ -958,34 +956,12 @@ void PatternLink::debug_log(void) const
 
 /* ================================================================= */
 
-PatternLinkPtr PatternLink::factory(const Handle& h)
+Handle PatternLink::factory(const Handle& h)
 {
-	// If h is of the right form already, its just a matter of calling
-	// it.  Otherwise, we have to create
-	PatternLinkPtr plp(PatternLinkCast(h));
-	if (plp) return plp;
+	// Just cast, if possible.
+	if (PatternLinkCast(h)) return h;
 
-	if (nullptr == h)
-		throw RuntimeException(TRACE_INFO, "Null pointer exception!");
-
-	return factory(h->getType(), h->getOutgoingSet());
-}
-
-// Basic type factory.
-PatternLinkPtr PatternLink::factory(Type t, const HandleSeq& seq)
-{
-	if (BIND_LINK == t)
-		return createBindLink(seq);
-	if (DUAL_LINK == t)
-		return createDualLink(seq);
-
-	// Handle all of the others
-	if (classserver().isA(t, PATTERN_LINK))
-		return createPatternLink(t, seq);
-
-	throw SyntaxException(TRACE_INFO,
-		"PatternLink is not a factory for %s",
-		classserver().getTypeName(t).c_str());
+	return createPatternLink(h->getType(), h->getOutgoingSet());
 }
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -961,7 +961,7 @@ Handle PatternLink::factory(const Handle& h)
 	// Just cast, if possible.
 	if (PatternLinkCast(h)) return h;
 
-	return createPatternLink(h->getType(), h->getOutgoingSet());
+	return Handle(createPatternLink(h->getType(), h->getOutgoingSet()));
 }
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/pattern/PatternLink.h
+++ b/opencog/atoms/pattern/PatternLink.h
@@ -135,11 +135,6 @@ protected:
 	void common_init(void);
 	void setup_components(void);
 
-public:
-	// XXX the factory needs to call thus, and thus needs to be public!
-	// Only derived classes can call this
-	PatternLink(Type, const HandleSeq&);
-
 protected:
 	// utility debug print
 	static void prt(const Handle& h)
@@ -148,12 +143,11 @@ protected:
 	}
 
 public:
-	PatternLink(const HandleSeq&);
+	PatternLink(const HandleSeq&, Type=PATTERN_LINK);
 	PatternLink(const Handle& body);
 	PatternLink(const Handle& varcdecls, const Handle& body);
 	PatternLink(const Variables&, const Handle&);
-
-	PatternLink(Link &l);
+	PatternLink(const Link &l);
 
 	// Used only to set up multi-component links.
 	// DO NOT call this! (unless you are the component handler).

--- a/opencog/atoms/pattern/PatternLink.h
+++ b/opencog/atoms/pattern/PatternLink.h
@@ -135,11 +135,8 @@ protected:
 	void common_init(void);
 	void setup_components(void);
 
-public:
 	// Only derived classes can call this
-	// XXX Need to make this public, so that the factory can call it!
-	PatternLink(Type, const HandleSeq&,
-	            TruthValuePtr tv = TruthValue::DEFAULT_TV());
+	PatternLink(Type, const HandleSeq&);
 
 protected:
 	// utility debug print
@@ -149,15 +146,9 @@ protected:
 	}
 
 public:
-	PatternLink(const HandleSeq&,
-	            TruthValuePtr tv = TruthValue::DEFAULT_TV());
-
-	PatternLink(const Handle& body,
-	            TruthValuePtr tv = TruthValue::DEFAULT_TV());
-
-	PatternLink(const Handle& varcdecls, const Handle& body,
-	            TruthValuePtr tv = TruthValue::DEFAULT_TV());
-
+	PatternLink(const HandleSeq&);
+	PatternLink(const Handle& body);
+	PatternLink(const Handle& varcdecls, const Handle& body);
 	PatternLink(const Variables&, const Handle&);
 
 	PatternLink(Link &l);
@@ -185,8 +176,7 @@ public:
 
 	void debug_log(void) const;
 
-	static PatternLinkPtr factory(const Handle&);
-	static PatternLinkPtr factory(Type, const HandleSeq&);
+	static Handle factory(const Handle&);
 };
 
 static inline PatternLinkPtr PatternLinkCast(const Handle& h)

--- a/opencog/atoms/pattern/PatternLink.h
+++ b/opencog/atoms/pattern/PatternLink.h
@@ -135,6 +135,8 @@ protected:
 	void common_init(void);
 	void setup_components(void);
 
+public:
+	// XXX the factory needs to call thus, and thus needs to be public!
 	// Only derived classes can call this
 	PatternLink(Type, const HandleSeq&);
 

--- a/opencog/atoms/reduct/ArithmeticLink.cc
+++ b/opencog/atoms/reduct/ArithmeticLink.cc
@@ -29,24 +29,22 @@
 
 using namespace opencog;
 
-ArithmeticLink::ArithmeticLink(const HandleSeq& oset, TruthValuePtr tv)
-    : FoldLink(ARITHMETIC_LINK, oset, tv)
+ArithmeticLink::ArithmeticLink(const HandleSeq& oset)
+    : FoldLink(ARITHMETIC_LINK, oset)
 {
 	init();
 }
 
-ArithmeticLink::ArithmeticLink(Type t, const HandleSeq& oset,
-                   TruthValuePtr tv)
-    : FoldLink(t, oset, tv)
+ArithmeticLink::ArithmeticLink(Type t, const HandleSeq& oset)
+    : FoldLink(t, oset)
 {
 	if (not classserver().isA(t, ARITHMETIC_LINK))
 		throw InvalidParamException(TRACE_INFO, "Expecting a ArithmeticLink");
 	init();
 }
 
-ArithmeticLink::ArithmeticLink(Type t, const Handle& a, const Handle& b,
-                   TruthValuePtr tv)
-    : FoldLink(t, a, b, tv)
+ArithmeticLink::ArithmeticLink(Type t, const Handle& a, const Handle& b)
+    : FoldLink(t, a, b)
 {
 	if (not classserver().isA(t, ARITHMETIC_LINK))
 		throw InvalidParamException(TRACE_INFO, "Expecting a ArithmeticLink");
@@ -126,7 +124,8 @@ Handle ArithmeticLink::reorder(void)
 	for (const Handle& h : exprs) result.push_back(h);
 	for (const Handle& h : numbers) result.push_back(h);
 
-	Handle h(FoldLink::factory(getType(), result));
+	auto fact = classserver().getFactory(_type);
+	Handle h((*fact)(Handle(createLink(_type, result))));
 	if (NULL == _atom_space) return h;
 
 	return _atom_space->add_atom(h);

--- a/opencog/atoms/reduct/ArithmeticLink.cc
+++ b/opencog/atoms/reduct/ArithmeticLink.cc
@@ -29,39 +29,30 @@
 
 using namespace opencog;
 
-ArithmeticLink::ArithmeticLink(const HandleSeq& oset)
-    : FoldLink(ARITHMETIC_LINK, oset)
+ArithmeticLink::ArithmeticLink(const HandleSeq& oset, Type t)
+    : FoldLink(oset, t)
 {
-	init();
-}
-
-ArithmeticLink::ArithmeticLink(Type t, const HandleSeq& oset)
-    : FoldLink(t, oset)
-{
-	if (not classserver().isA(t, ARITHMETIC_LINK))
-		throw InvalidParamException(TRACE_INFO, "Expecting a ArithmeticLink");
 	init();
 }
 
 ArithmeticLink::ArithmeticLink(Type t, const Handle& a, const Handle& b)
     : FoldLink(t, a, b)
 {
-	if (not classserver().isA(t, ARITHMETIC_LINK))
-		throw InvalidParamException(TRACE_INFO, "Expecting a ArithmeticLink");
 	init();
 }
 
-ArithmeticLink::ArithmeticLink(Link& l)
+ArithmeticLink::ArithmeticLink(const Link& l)
     : FoldLink(l)
 {
-	Type tscope = l.getType();
-	if (not classserver().isA(tscope, ARITHMETIC_LINK))
-		throw InvalidParamException(TRACE_INFO, "Expecting a ArithmeticLink");
 	init();
 }
 
 void ArithmeticLink::init(void)
 {
+	Type tscope = getType();
+	if (not classserver().isA(tscope, ARITHMETIC_LINK))
+		throw InvalidParamException(TRACE_INFO, "Expecting a ArithmeticLink");
+
 	knild = std::numeric_limits<double>::quiet_NaN();
 }
 
@@ -124,8 +115,7 @@ Handle ArithmeticLink::reorder(void)
 	for (const Handle& h : exprs) result.push_back(h);
 	for (const Handle& h : numbers) result.push_back(h);
 
-	auto fact = classserver().getFactory(_type);
-	Handle h((*fact)(Handle(createLink(_type, result))));
+	Handle h(classserver().factory(Handle(createLink(result, getType()))));
 	if (NULL == _atom_space) return h;
 
 	return _atom_space->add_atom(h);

--- a/opencog/atoms/reduct/ArithmeticLink.h
+++ b/opencog/atoms/reduct/ArithmeticLink.h
@@ -43,14 +43,13 @@ protected:
 	virtual double konsd(double, double) const = 0;
 
 	void init(void);
-	ArithmeticLink(Type, const HandleSeq& oset);
 	ArithmeticLink(Type, const Handle& a, const Handle& b);
 
 	NumberNodePtr unwrap_set(Handle) const;
 	virtual Handle do_execute(AtomSpace*, const HandleSeq&) const;
 public:
-	ArithmeticLink(const HandleSeq& oset);
-	ArithmeticLink(Link& l);
+	ArithmeticLink(const HandleSeq& oset, Type=ARITHMETIC_LINK);
+	ArithmeticLink(const Link& l);
 
 	virtual Handle reorder(void);
    virtual Handle reduce(void);

--- a/opencog/atoms/reduct/ArithmeticLink.h
+++ b/opencog/atoms/reduct/ArithmeticLink.h
@@ -43,17 +43,13 @@ protected:
 	virtual double konsd(double, double) const = 0;
 
 	void init(void);
-	ArithmeticLink(Type, const HandleSeq& oset,
-	         TruthValuePtr tv = TruthValue::DEFAULT_TV());
-
-	ArithmeticLink(Type, const Handle& a, const Handle& b,
-	         TruthValuePtr tv = TruthValue::DEFAULT_TV());
+	ArithmeticLink(Type, const HandleSeq& oset);
+	ArithmeticLink(Type, const Handle& a, const Handle& b);
 
 	NumberNodePtr unwrap_set(Handle) const;
 	virtual Handle do_execute(AtomSpace*, const HandleSeq&) const;
 public:
-	ArithmeticLink(const HandleSeq& oset,
-	         TruthValuePtr tv = TruthValue::DEFAULT_TV());
+	ArithmeticLink(const HandleSeq& oset);
 	ArithmeticLink(Link& l);
 
 	virtual Handle reorder(void);

--- a/opencog/atoms/reduct/DivideLink.cc
+++ b/opencog/atoms/reduct/DivideLink.cc
@@ -88,4 +88,5 @@ Handle DivideLink::do_execute(AtomSpace* as, const HandleSeq& oset) const
 	return createNumberNode(na->get_value() / nb->get_value())->getHandle();
 }
 
+DEFINE_LINK_FACTORY(DivideLink, DIVIDE_LINK)
 // ============================================================

--- a/opencog/atoms/reduct/DivideLink.cc
+++ b/opencog/atoms/reduct/DivideLink.cc
@@ -28,17 +28,9 @@
 
 using namespace opencog;
 
-DivideLink::DivideLink(const HandleSeq& oset)
-    : TimesLink(DIVIDE_LINK, oset)
+DivideLink::DivideLink(const HandleSeq& oset, Type t)
+    : TimesLink(oset, t)
 {
-	init();
-}
-
-DivideLink::DivideLink(Type t, const HandleSeq& oset)
-    : TimesLink(t, oset)
-{
-	if (not classserver().isA(t, DIVIDE_LINK))
-		throw InvalidParamException(TRACE_INFO, "Expecting a DivideLink");
 	init();
 }
 
@@ -51,22 +43,21 @@ DivideLink::DivideLink(const Handle& a, const Handle& b)
 DivideLink::DivideLink(Type t, const Handle& a, const Handle& b)
     : TimesLink(t, a, b)
 {
-	if (not classserver().isA(t, DIVIDE_LINK))
-		throw InvalidParamException(TRACE_INFO, "Expecting a DivideLink");
 	init();
 }
 
-DivideLink::DivideLink(Link& l)
+DivideLink::DivideLink(const Link& l)
     : TimesLink(l)
 {
-	Type tscope = l.getType();
-	if (not classserver().isA(tscope, DIVIDE_LINK))
-		throw InvalidParamException(TRACE_INFO, "Expecting a DivideLink");
 	init();
 }
 
 void DivideLink::init(void)
 {
+	Type tscope = getType();
+	if (not classserver().isA(tscope, DIVIDE_LINK))
+		throw InvalidParamException(TRACE_INFO, "Expecting a DivideLink");
+
 	size_t sz = _outgoing.size();
 	if (2 < sz or 0 == sz)
 		throw InvalidParamException(TRACE_INFO,

--- a/opencog/atoms/reduct/DivideLink.cc
+++ b/opencog/atoms/reduct/DivideLink.cc
@@ -28,30 +28,28 @@
 
 using namespace opencog;
 
-DivideLink::DivideLink(const HandleSeq& oset, TruthValuePtr tv)
-    : TimesLink(DIVIDE_LINK, oset, tv)
+DivideLink::DivideLink(const HandleSeq& oset)
+    : TimesLink(DIVIDE_LINK, oset)
 {
 	init();
 }
 
-DivideLink::DivideLink(Type t, const HandleSeq& oset, TruthValuePtr tv)
-    : TimesLink(t, oset, tv)
+DivideLink::DivideLink(Type t, const HandleSeq& oset)
+    : TimesLink(t, oset)
 {
 	if (not classserver().isA(t, DIVIDE_LINK))
 		throw InvalidParamException(TRACE_INFO, "Expecting a DivideLink");
 	init();
 }
 
-DivideLink::DivideLink(const Handle& a, const Handle& b,
-                   TruthValuePtr tv)
-    : TimesLink(DIVIDE_LINK, a, b, tv)
+DivideLink::DivideLink(const Handle& a, const Handle& b)
+    : TimesLink(DIVIDE_LINK, a, b)
 {
 	init();
 }
 
-DivideLink::DivideLink(Type t, const Handle& a, const Handle& b,
-                   TruthValuePtr tv)
-    : TimesLink(t, a, b, tv)
+DivideLink::DivideLink(Type t, const Handle& a, const Handle& b)
+    : TimesLink(t, a, b)
 {
 	if (not classserver().isA(t, DIVIDE_LINK))
 		throw InvalidParamException(TRACE_INFO, "Expecting a DivideLink");
@@ -89,4 +87,5 @@ Handle DivideLink::do_execute(AtomSpace* as, const HandleSeq& oset) const
 }
 
 DEFINE_LINK_FACTORY(DivideLink, DIVIDE_LINK)
+
 // ============================================================

--- a/opencog/atoms/reduct/DivideLink.h
+++ b/opencog/atoms/reduct/DivideLink.h
@@ -54,6 +54,8 @@ public:
 	DivideLink(const HandleSeq& oset,
 	         TruthValuePtr tv = TruthValue::DEFAULT_TV());
 	DivideLink(Link& l);
+
+	static Handle factory(const Handle&);
 };
 
 typedef std::shared_ptr<DivideLink> DivideLinkPtr;

--- a/opencog/atoms/reduct/DivideLink.h
+++ b/opencog/atoms/reduct/DivideLink.h
@@ -40,19 +40,13 @@ class DivideLink : public TimesLink
 {
 protected:
 	void init(void);
-	DivideLink(Type, const HandleSeq& oset,
-	         TruthValuePtr tv = TruthValue::DEFAULT_TV());
-
-	DivideLink(Type, const Handle& a, const Handle& b,
-	         TruthValuePtr tv = TruthValue::DEFAULT_TV());
+	DivideLink(Type, const HandleSeq& oset);
+	DivideLink(Type, const Handle& a, const Handle& b);
 
 	virtual Handle do_execute(AtomSpace*, const HandleSeq&) const;
 public:
-	DivideLink(const Handle& a, const Handle& b,
-	         TruthValuePtr tv = TruthValue::DEFAULT_TV());
-
-	DivideLink(const HandleSeq& oset,
-	         TruthValuePtr tv = TruthValue::DEFAULT_TV());
+	DivideLink(const Handle& a, const Handle& b);
+	DivideLink(const HandleSeq& oset);
 	DivideLink(Link& l);
 
 	static Handle factory(const Handle&);

--- a/opencog/atoms/reduct/DivideLink.h
+++ b/opencog/atoms/reduct/DivideLink.h
@@ -40,14 +40,13 @@ class DivideLink : public TimesLink
 {
 protected:
 	void init(void);
-	DivideLink(Type, const HandleSeq& oset);
 	DivideLink(Type, const Handle& a, const Handle& b);
 
 	virtual Handle do_execute(AtomSpace*, const HandleSeq&) const;
 public:
 	DivideLink(const Handle& a, const Handle& b);
-	DivideLink(const HandleSeq& oset);
-	DivideLink(Link& l);
+	DivideLink(const HandleSeq& oset, Type=DIVIDE_LINK);
+	DivideLink(const Link& l);
 
 	static Handle factory(const Handle&);
 };

--- a/opencog/atoms/reduct/FoldLink.cc
+++ b/opencog/atoms/reduct/FoldLink.cc
@@ -29,23 +29,22 @@
 
 using namespace opencog;
 
-FoldLink::FoldLink(const HandleSeq& oset, TruthValuePtr tv)
-    : FunctionLink(FOLD_LINK, oset, tv)
+FoldLink::FoldLink(const HandleSeq& oset)
+    : FunctionLink(FOLD_LINK, oset)
 {
 	init();
 }
 
-FoldLink::FoldLink(Type t, const HandleSeq& oset, TruthValuePtr tv)
-    : FunctionLink(t, oset, tv)
+FoldLink::FoldLink(Type t, const HandleSeq& oset)
+    : FunctionLink(t, oset)
 {
 	if (not classserver().isA(t, FOLD_LINK))
 		throw InvalidParamException(TRACE_INFO, "Expecting a FoldLink");
 	init();
 }
 
-FoldLink::FoldLink(Type t, const Handle& a, const Handle& b,
-                   TruthValuePtr tv)
-    : FunctionLink(t, a, b, tv)
+FoldLink::FoldLink(Type t, const Handle& a, const Handle& b)
+    : FunctionLink(t, a, b)
 {
 	if (not classserver().isA(t, FOLD_LINK))
 		throw InvalidParamException(TRACE_INFO, "Expecting a FoldLink");
@@ -135,7 +134,8 @@ Handle FoldLink::reduce(void)
 
 		if (classserver().isA(t, FOLD_LINK))
 		{
-			FoldLinkPtr fff(factory(h));
+			auto fact = classserver().getFactory(t);
+			FoldLinkPtr fff(FoldLinkCast((*fact)(h)));
 			Handle redh = fff->reduce();
 			if (h != redh)
 			{
@@ -211,8 +211,13 @@ Handle FoldLink::reduce(void)
 			Handle foo(createLink(getType(), rere));
 			if (_atom_space)
 				foo = _atom_space->add_atom(foo);
+			else
+			{
+				auto fact = classserver().getFactory(getType());
+				foo = (*fact)(foo);
+			}
+			FoldLinkPtr flp(FoldLinkCast(foo));
 
-			FoldLinkPtr flp = factory(foo);
 			DO_RETURN(Handle(flp->reduce()));
 		}
 	}

--- a/opencog/atoms/reduct/FoldLink.cc
+++ b/opencog/atoms/reduct/FoldLink.cc
@@ -25,11 +25,7 @@
 #include <opencog/atoms/base/atom_types.h>
 #include <opencog/atoms/base/ClassServer.h>
 #include <opencog/atoms/NumberNode.h>
-#include "DivideLink.h"
 #include "FoldLink.h"
-#include "MinusLink.h"
-#include "PlusLink.h"
-#include "TimesLink.h"
 
 using namespace opencog;
 
@@ -229,31 +225,3 @@ Handle FoldLink::reduce(void)
 }
 
 // ===========================================================
-
-FoldLinkPtr FoldLink::factory(const Handle& h)
-{
-	// If h is of the right form already, its just a matter of calling
-	// it.  Otherwise, we have to create
-	FoldLinkPtr flp(FoldLinkCast(h));
-	if (flp) return flp;
-
-	if (nullptr == h)
-		throw RuntimeException(TRACE_INFO, "Null FoldLink handle!");
-
-	return FoldLink::factory(h->getType(), h->getOutgoingSet());
-}
-
-// Basic type factory.
-FoldLinkPtr FoldLink::factory(Type t, const HandleSeq& seq)
-{
-	if (DIVIDE_LINK == t)
-		return createDivideLink(seq);
-	if (MINUS_LINK == t)
-		return createMinusLink(seq);
-	if (PLUS_LINK == t)
-		return createPlusLink(seq);
-	if (TIMES_LINK == t)
-		return createTimesLink(seq);
-
-	throw RuntimeException(TRACE_INFO, "Not a FoldLink!");
-}

--- a/opencog/atoms/reduct/FoldLink.cc
+++ b/opencog/atoms/reduct/FoldLink.cc
@@ -29,38 +29,30 @@
 
 using namespace opencog;
 
-FoldLink::FoldLink(const HandleSeq& oset)
-    : FunctionLink(FOLD_LINK, oset)
+FoldLink::FoldLink(const HandleSeq& oset, Type t)
+    : FunctionLink(oset, t)
 {
-	init();
-}
-
-FoldLink::FoldLink(Type t, const HandleSeq& oset)
-    : FunctionLink(t, oset)
-{
-	if (not classserver().isA(t, FOLD_LINK))
-		throw InvalidParamException(TRACE_INFO, "Expecting a FoldLink");
 	init();
 }
 
 FoldLink::FoldLink(Type t, const Handle& a, const Handle& b)
     : FunctionLink(t, a, b)
 {
-	if (not classserver().isA(t, FOLD_LINK))
-		throw InvalidParamException(TRACE_INFO, "Expecting a FoldLink");
 	init();
 }
 
-FoldLink::FoldLink(Link& l)
+FoldLink::FoldLink(const Link& l)
     : FunctionLink(l)
 {
-	Type tscope = l.getType();
-	if (not classserver().isA(tscope, FOLD_LINK))
-		throw InvalidParamException(TRACE_INFO, "Expecting a FoldLink");
 	init();
 }
 
-void FoldLink::init(void) {}
+void FoldLink::init(void)
+{
+	Type tscope = getType();
+	if (not classserver().isA(tscope, FOLD_LINK))
+		throw InvalidParamException(TRACE_INFO, "Expecting a FoldLink");
+}
 
 // ===============================================================
 
@@ -208,13 +200,12 @@ Handle FoldLink::reduce(void)
 			// so that knil gets placed into the atomspace
 			// when reduce is called; else the knil
 			// compares up above fail.
-			Handle foo(createLink(getType(), rere));
+			Handle foo(createLink(rere, getType()));
 			if (_atom_space)
 				foo = _atom_space->add_atom(foo);
 			else
 			{
-				auto fact = classserver().getFactory(getType());
-				foo = (*fact)(foo);
+				foo = classserver().factory(foo);
 			}
 			FoldLinkPtr flp(FoldLinkCast(foo));
 
@@ -226,7 +217,7 @@ Handle FoldLink::reduce(void)
 	if (not did_reduce)
 		return getHandle();
 
-	DO_RETURN(Handle(createLink(getType(), reduct)));
+	DO_RETURN(Handle(createLink(reduct, getType())));
 }
 
 // ===========================================================

--- a/opencog/atoms/reduct/FoldLink.h
+++ b/opencog/atoms/reduct/FoldLink.h
@@ -48,12 +48,11 @@ protected:
 	Type distributive_type = NOTYPE;
 
 	void init(void);
-	FoldLink(Type, const HandleSeq& oset);
 	FoldLink(Type, const Handle& a, const Handle& b);
 
 public:
-	FoldLink(const HandleSeq& oset);
-	FoldLink(Link& l);
+	FoldLink(const HandleSeq&, Type=FOLD_LINK);
+	FoldLink(const Link& l);
 
    virtual Handle reduce(void);
 };

--- a/opencog/atoms/reduct/FoldLink.h
+++ b/opencog/atoms/reduct/FoldLink.h
@@ -59,9 +59,6 @@ public:
 	FoldLink(Link& l);
 
    virtual Handle reduce(void);
-
-	static FoldLinkPtr factory(const Handle&);
-	static FoldLinkPtr factory(Type, const HandleSeq&);
 };
 
 static inline FoldLinkPtr FoldLinkCast(const Handle& h)

--- a/opencog/atoms/reduct/FoldLink.h
+++ b/opencog/atoms/reduct/FoldLink.h
@@ -48,14 +48,11 @@ protected:
 	Type distributive_type = NOTYPE;
 
 	void init(void);
-	FoldLink(Type, const HandleSeq& oset,
-	         TruthValuePtr tv = TruthValue::DEFAULT_TV());
+	FoldLink(Type, const HandleSeq& oset);
+	FoldLink(Type, const Handle& a, const Handle& b);
 
-	FoldLink(Type, const Handle& a, const Handle& b,
-	         TruthValuePtr tv = TruthValue::DEFAULT_TV());
 public:
-	FoldLink(const HandleSeq& oset,
-	         TruthValuePtr tv = TruthValue::DEFAULT_TV());
+	FoldLink(const HandleSeq& oset);
 	FoldLink(Link& l);
 
    virtual Handle reduce(void);

--- a/opencog/atoms/reduct/MinusLink.cc
+++ b/opencog/atoms/reduct/MinusLink.cc
@@ -88,4 +88,6 @@ Handle MinusLink::do_execute(AtomSpace* as, const HandleSeq& oset) const
 	return createNumberNode(na->get_value() - nb->get_value())->getHandle();
 }
 
+DEFINE_LINK_FACTORY(MinusLink, MINUS_LINK)
+
 // ============================================================

--- a/opencog/atoms/reduct/MinusLink.cc
+++ b/opencog/atoms/reduct/MinusLink.cc
@@ -28,30 +28,28 @@
 
 using namespace opencog;
 
-MinusLink::MinusLink(const HandleSeq& oset, TruthValuePtr tv)
-    : PlusLink(MINUS_LINK, oset, tv)
+MinusLink::MinusLink(const HandleSeq& oset)
+    : PlusLink(MINUS_LINK, oset)
 {
 	init();
 }
 
-MinusLink::MinusLink(Type t, const HandleSeq& oset, TruthValuePtr tv)
-    : PlusLink(t, oset, tv)
+MinusLink::MinusLink(Type t, const HandleSeq& oset)
+    : PlusLink(t, oset)
 {
 	if (not classserver().isA(t, MINUS_LINK))
 		throw InvalidParamException(TRACE_INFO, "Expecting a MinusLink");
 	init();
 }
 
-MinusLink::MinusLink(const Handle& a, const Handle& b,
-                   TruthValuePtr tv)
-    : PlusLink(MINUS_LINK, a, b, tv)
+MinusLink::MinusLink(const Handle& a, const Handle& b)
+    : PlusLink(MINUS_LINK, a, b)
 {
 	init();
 }
 
-MinusLink::MinusLink(Type t, const Handle& a, const Handle& b,
-                   TruthValuePtr tv)
-    : PlusLink(t, a, b, tv)
+MinusLink::MinusLink(Type t, const Handle& a, const Handle& b)
+    : PlusLink(t, a, b)
 {
 	if (not classserver().isA(t, MINUS_LINK))
 		throw InvalidParamException(TRACE_INFO, "Expecting a MinusLink");

--- a/opencog/atoms/reduct/MinusLink.cc
+++ b/opencog/atoms/reduct/MinusLink.cc
@@ -28,17 +28,9 @@
 
 using namespace opencog;
 
-MinusLink::MinusLink(const HandleSeq& oset)
-    : PlusLink(MINUS_LINK, oset)
+MinusLink::MinusLink(const HandleSeq& oset, Type t)
+    : PlusLink(oset, t)
 {
-	init();
-}
-
-MinusLink::MinusLink(Type t, const HandleSeq& oset)
-    : PlusLink(t, oset)
-{
-	if (not classserver().isA(t, MINUS_LINK))
-		throw InvalidParamException(TRACE_INFO, "Expecting a MinusLink");
 	init();
 }
 
@@ -51,22 +43,21 @@ MinusLink::MinusLink(const Handle& a, const Handle& b)
 MinusLink::MinusLink(Type t, const Handle& a, const Handle& b)
     : PlusLink(t, a, b)
 {
-	if (not classserver().isA(t, MINUS_LINK))
-		throw InvalidParamException(TRACE_INFO, "Expecting a MinusLink");
 	init();
 }
 
-MinusLink::MinusLink(Link& l)
+MinusLink::MinusLink(const Link& l)
     : PlusLink(l)
 {
-	Type tscope = l.getType();
-	if (not classserver().isA(tscope, MINUS_LINK))
-		throw InvalidParamException(TRACE_INFO, "Expecting a MinusLink");
 	init();
 }
 
 void MinusLink::init(void)
 {
+	Type tscope = getType();
+	if (not classserver().isA(tscope, MINUS_LINK))
+		throw InvalidParamException(TRACE_INFO, "Expecting a MinusLink");
+
 	size_t sz = _outgoing.size();
 	if (2 < sz or 0 == sz)
 		throw InvalidParamException(TRACE_INFO,

--- a/opencog/atoms/reduct/MinusLink.h
+++ b/opencog/atoms/reduct/MinusLink.h
@@ -54,6 +54,8 @@ public:
 	MinusLink(const HandleSeq& oset,
 	         TruthValuePtr tv = TruthValue::DEFAULT_TV());
 	MinusLink(Link& l);
+
+	static Handle factory(const Handle&);
 };
 
 typedef std::shared_ptr<MinusLink> MinusLinkPtr;

--- a/opencog/atoms/reduct/MinusLink.h
+++ b/opencog/atoms/reduct/MinusLink.h
@@ -40,19 +40,13 @@ class MinusLink : public PlusLink
 {
 protected:
 	void init(void);
-	MinusLink(Type, const HandleSeq& oset,
-	         TruthValuePtr tv = TruthValue::DEFAULT_TV());
-
-	MinusLink(Type, const Handle& a, const Handle& b,
-	         TruthValuePtr tv = TruthValue::DEFAULT_TV());
+	MinusLink(Type, const HandleSeq& oset);
+	MinusLink(Type, const Handle& a, const Handle& b);
 
 	virtual Handle do_execute(AtomSpace*, const HandleSeq&) const;
 public:
-	MinusLink(const Handle& a, const Handle& b,
-	         TruthValuePtr tv = TruthValue::DEFAULT_TV());
-
-	MinusLink(const HandleSeq& oset,
-	         TruthValuePtr tv = TruthValue::DEFAULT_TV());
+	MinusLink(const Handle& a, const Handle& b);
+	MinusLink(const HandleSeq& oset);
 	MinusLink(Link& l);
 
 	static Handle factory(const Handle&);

--- a/opencog/atoms/reduct/MinusLink.h
+++ b/opencog/atoms/reduct/MinusLink.h
@@ -40,14 +40,13 @@ class MinusLink : public PlusLink
 {
 protected:
 	void init(void);
-	MinusLink(Type, const HandleSeq& oset);
 	MinusLink(Type, const Handle& a, const Handle& b);
 
 	virtual Handle do_execute(AtomSpace*, const HandleSeq&) const;
 public:
 	MinusLink(const Handle& a, const Handle& b);
-	MinusLink(const HandleSeq& oset);
-	MinusLink(Link& l);
+	MinusLink(const HandleSeq&, Type=MINUS_LINK);
+	MinusLink(const Link&);
 
 	static Handle factory(const Handle&);
 };

--- a/opencog/atoms/reduct/PlusLink.cc
+++ b/opencog/atoms/reduct/PlusLink.cc
@@ -28,30 +28,28 @@
 
 using namespace opencog;
 
-PlusLink::PlusLink(const HandleSeq& oset, TruthValuePtr tv)
-    : ArithmeticLink(PLUS_LINK, oset, tv)
+PlusLink::PlusLink(const HandleSeq& oset)
+    : ArithmeticLink(PLUS_LINK, oset)
 {
 	init();
 }
 
-PlusLink::PlusLink(Type t, const HandleSeq& oset, TruthValuePtr tv)
-    : ArithmeticLink(t, oset, tv)
+PlusLink::PlusLink(Type t, const HandleSeq& oset)
+    : ArithmeticLink(t, oset)
 {
 	if (not classserver().isA(t, PLUS_LINK))
 		throw InvalidParamException(TRACE_INFO, "Expecting a PlusLink");
 	init();
 }
 
-PlusLink::PlusLink(const Handle& a, const Handle& b,
-                   TruthValuePtr tv)
-    : ArithmeticLink(PLUS_LINK, a, b, tv)
+PlusLink::PlusLink(const Handle& a, const Handle& b)
+    : ArithmeticLink(PLUS_LINK, a, b)
 {
 	init();
 }
 
-PlusLink::PlusLink(Type t, const Handle& a, const Handle& b,
-                   TruthValuePtr tv)
-    : ArithmeticLink(t, a, b, tv)
+PlusLink::PlusLink(Type t, const Handle& a, const Handle& b)
+    : ArithmeticLink(t, a, b)
 {
 	if (not classserver().isA(t, PLUS_LINK))
 		throw InvalidParamException(TRACE_INFO, "Expecting a PlusLink");

--- a/opencog/atoms/reduct/PlusLink.cc
+++ b/opencog/atoms/reduct/PlusLink.cc
@@ -166,4 +166,5 @@ Handle PlusLink::kons(const Handle& fi, const Handle& fj)
 	return Handle(createPlusLink(fi, fj)->reorder());
 }
 
+DEFINE_LINK_FACTORY(PlusLink, PLUS_LINK);
 // ============================================================

--- a/opencog/atoms/reduct/PlusLink.cc
+++ b/opencog/atoms/reduct/PlusLink.cc
@@ -28,17 +28,9 @@
 
 using namespace opencog;
 
-PlusLink::PlusLink(const HandleSeq& oset)
-    : ArithmeticLink(PLUS_LINK, oset)
+PlusLink::PlusLink(const HandleSeq& oset, Type t)
+    : ArithmeticLink(oset, t)
 {
-	init();
-}
-
-PlusLink::PlusLink(Type t, const HandleSeq& oset)
-    : ArithmeticLink(t, oset)
-{
-	if (not classserver().isA(t, PLUS_LINK))
-		throw InvalidParamException(TRACE_INFO, "Expecting a PlusLink");
 	init();
 }
 
@@ -51,22 +43,21 @@ PlusLink::PlusLink(const Handle& a, const Handle& b)
 PlusLink::PlusLink(Type t, const Handle& a, const Handle& b)
     : ArithmeticLink(t, a, b)
 {
-	if (not classserver().isA(t, PLUS_LINK))
-		throw InvalidParamException(TRACE_INFO, "Expecting a PlusLink");
 	init();
 }
 
-PlusLink::PlusLink(Link& l)
+PlusLink::PlusLink(const Link& l)
     : ArithmeticLink(l)
 {
-	Type tscope = l.getType();
-	if (not classserver().isA(tscope, PLUS_LINK))
-		throw InvalidParamException(TRACE_INFO, "Expecting a PlusLink");
 	init();
 }
 
 void PlusLink::init(void)
 {
+	Type tscope = getType();
+	if (not classserver().isA(tscope, PLUS_LINK))
+		throw InvalidParamException(TRACE_INFO, "Expecting a PlusLink");
+
 	knild = 0.0;
 	knil = Handle(createNumberNode("0"));
 
@@ -147,14 +138,14 @@ Handle PlusLink::kons(const Handle& fi, const Handle& fj)
 			// a_plus is now (a+1) or (a+b) as described above.
 			// We need to insert into the atomspace, else reduce() horks
 			// up the knil compares during reduction.
-			Handle foo(createLink(PLUS_LINK, rest));
+			Handle foo(createLink(rest, PLUS_LINK));
 			if (_atom_space)
 				foo = _atom_space->add_atom(foo);
 
 			PlusLinkPtr ap = PlusLinkCast(foo);
 			Handle a_plus(ap->reduce());
 
-			return Handle(createTimesLink(exx, a_plus));
+			return Handle(createTimesLink(a_plus, exx));
 		}
 	}
 

--- a/opencog/atoms/reduct/PlusLink.h
+++ b/opencog/atoms/reduct/PlusLink.h
@@ -55,6 +55,8 @@ public:
 	PlusLink(const HandleSeq& oset,
 	         TruthValuePtr tv = TruthValue::DEFAULT_TV());
 	PlusLink(Link& l);
+
+	static Handle factory(const Handle&);
 };
 
 typedef std::shared_ptr<PlusLink> PlusLinkPtr;

--- a/opencog/atoms/reduct/PlusLink.h
+++ b/opencog/atoms/reduct/PlusLink.h
@@ -42,13 +42,12 @@ protected:
 	virtual Handle kons(const Handle&, const Handle&);
 
 	void init(void);
-	PlusLink(Type, const HandleSeq& oset);
 	PlusLink(Type, const Handle& a, const Handle& b);
 
 public:
 	PlusLink(const Handle& a, const Handle& b);
-	PlusLink(const HandleSeq& oset);
-	PlusLink(Link& l);
+	PlusLink(const HandleSeq&, Type=PLUS_LINK);
+	PlusLink(const Link&);
 
 	static Handle factory(const Handle&);
 };

--- a/opencog/atoms/reduct/PlusLink.h
+++ b/opencog/atoms/reduct/PlusLink.h
@@ -42,18 +42,12 @@ protected:
 	virtual Handle kons(const Handle&, const Handle&);
 
 	void init(void);
-	PlusLink(Type, const HandleSeq& oset,
-	         TruthValuePtr tv = TruthValue::DEFAULT_TV());
-
-	PlusLink(Type, const Handle& a, const Handle& b,
-	         TruthValuePtr tv = TruthValue::DEFAULT_TV());
+	PlusLink(Type, const HandleSeq& oset);
+	PlusLink(Type, const Handle& a, const Handle& b);
 
 public:
-	PlusLink(const Handle& a, const Handle& b,
-	         TruthValuePtr tv = TruthValue::DEFAULT_TV());
-
-	PlusLink(const HandleSeq& oset,
-	         TruthValuePtr tv = TruthValue::DEFAULT_TV());
+	PlusLink(const Handle& a, const Handle& b);
+	PlusLink(const HandleSeq& oset);
 	PlusLink(Link& l);
 
 	static Handle factory(const Handle&);

--- a/opencog/atoms/reduct/TimesLink.cc
+++ b/opencog/atoms/reduct/TimesLink.cc
@@ -103,4 +103,6 @@ Handle TimesLink::kons(const Handle& fi, const Handle& fj)
 	return Handle(createTimesLink(fi, fj)->reorder());
 }
 
+DEFINE_LINK_FACTORY(TimesLink, TIMES_LINK)
+
 // ============================================================

--- a/opencog/atoms/reduct/TimesLink.cc
+++ b/opencog/atoms/reduct/TimesLink.cc
@@ -27,32 +27,30 @@
 
 using namespace opencog;
 
-TimesLink::TimesLink(const HandleSeq& oset, TruthValuePtr tv)
-    : ArithmeticLink(TIMES_LINK, oset, tv)
+TimesLink::TimesLink(const HandleSeq& oset)
+    : ArithmeticLink(TIMES_LINK, oset)
 {
 	init();
 }
 
-TimesLink::TimesLink(Type t, const HandleSeq& oset, TruthValuePtr tv)
-    : ArithmeticLink(t, oset, tv)
-{
-	if (not classserver().isA(t, TIMES_LINK))
-		throw InvalidParamException(TRACE_INFO, "Expecting a TimesLink");
-	init();
-}
-
-TimesLink::TimesLink(Type t, const Handle& a, const Handle& b,
-                   TruthValuePtr tv)
-    : ArithmeticLink(t, a, b, tv)
+TimesLink::TimesLink(Type t, const HandleSeq& oset)
+    : ArithmeticLink(t, oset)
 {
 	if (not classserver().isA(t, TIMES_LINK))
 		throw InvalidParamException(TRACE_INFO, "Expecting a TimesLink");
 	init();
 }
 
-TimesLink::TimesLink(const Handle& a, const Handle& b,
-                   TruthValuePtr tv)
-    : ArithmeticLink(TIMES_LINK, a, b, tv)
+TimesLink::TimesLink(Type t, const Handle& a, const Handle& b)
+    : ArithmeticLink(t, a, b)
+{
+	if (not classserver().isA(t, TIMES_LINK))
+		throw InvalidParamException(TRACE_INFO, "Expecting a TimesLink");
+	init();
+}
+
+TimesLink::TimesLink(const Handle& a, const Handle& b)
+    : ArithmeticLink(TIMES_LINK, a, b)
 {
 	init();
 }

--- a/opencog/atoms/reduct/TimesLink.cc
+++ b/opencog/atoms/reduct/TimesLink.cc
@@ -27,25 +27,15 @@
 
 using namespace opencog;
 
-TimesLink::TimesLink(const HandleSeq& oset)
-    : ArithmeticLink(TIMES_LINK, oset)
+TimesLink::TimesLink(const HandleSeq& oset, Type t)
+    : ArithmeticLink(oset, t)
 {
-	init();
-}
-
-TimesLink::TimesLink(Type t, const HandleSeq& oset)
-    : ArithmeticLink(t, oset)
-{
-	if (not classserver().isA(t, TIMES_LINK))
-		throw InvalidParamException(TRACE_INFO, "Expecting a TimesLink");
 	init();
 }
 
 TimesLink::TimesLink(Type t, const Handle& a, const Handle& b)
     : ArithmeticLink(t, a, b)
 {
-	if (not classserver().isA(t, TIMES_LINK))
-		throw InvalidParamException(TRACE_INFO, "Expecting a TimesLink");
 	init();
 }
 
@@ -55,17 +45,18 @@ TimesLink::TimesLink(const Handle& a, const Handle& b)
 	init();
 }
 
-TimesLink::TimesLink(Link& l)
+TimesLink::TimesLink(const Link& l)
     : ArithmeticLink(l)
 {
-	Type tscope = l.getType();
-	if (not classserver().isA(tscope, TIMES_LINK))
-		throw InvalidParamException(TRACE_INFO, "Expecting a TimesLink");
 	init();
 }
 
 void TimesLink::init(void)
 {
+	Type tscope = getType();
+	if (not classserver().isA(tscope, TIMES_LINK))
+		throw InvalidParamException(TRACE_INFO, "Expecting a TimesLink");
+
 	knild = 1.0;
 	knil = Handle(createNumberNode("1"));
 }

--- a/opencog/atoms/reduct/TimesLink.h
+++ b/opencog/atoms/reduct/TimesLink.h
@@ -42,18 +42,12 @@ protected:
 	Handle kons(const Handle&, const Handle&);
 
 	void init(void);
-	TimesLink(Type, const HandleSeq& oset,
-	         TruthValuePtr tv = TruthValue::DEFAULT_TV());
+	TimesLink(Type, const HandleSeq& oset);
+	TimesLink(Type, const Handle& a, const Handle& b);
 
-	TimesLink(Type, const Handle& a, const Handle& b,
-	         TruthValuePtr tv = TruthValue::DEFAULT_TV());
 public:
-	TimesLink(const HandleSeq& oset,
-	         TruthValuePtr tv = TruthValue::DEFAULT_TV());
-
-	TimesLink(const Handle& a, const Handle& b,
-	         TruthValuePtr tv = TruthValue::DEFAULT_TV());
-
+	TimesLink(const HandleSeq& oset);
+	TimesLink(const Handle& a, const Handle& b);
 	TimesLink(Link& l);
 
 	static Handle factory(const Handle&);

--- a/opencog/atoms/reduct/TimesLink.h
+++ b/opencog/atoms/reduct/TimesLink.h
@@ -42,13 +42,12 @@ protected:
 	Handle kons(const Handle&, const Handle&);
 
 	void init(void);
-	TimesLink(Type, const HandleSeq& oset);
 	TimesLink(Type, const Handle& a, const Handle& b);
 
 public:
-	TimesLink(const HandleSeq& oset);
+	TimesLink(const HandleSeq&, Type=TIMES_LINK);
 	TimesLink(const Handle& a, const Handle& b);
-	TimesLink(Link& l);
+	TimesLink(const Link&);
 
 	static Handle factory(const Handle&);
 };

--- a/opencog/atoms/reduct/TimesLink.h
+++ b/opencog/atoms/reduct/TimesLink.h
@@ -55,6 +55,8 @@ public:
 	         TruthValuePtr tv = TruthValue::DEFAULT_TV());
 
 	TimesLink(Link& l);
+
+	static Handle factory(const Handle&);
 };
 
 typedef std::shared_ptr<TimesLink> TimesLinkPtr;

--- a/opencog/atomspace/AtomSpace.cc
+++ b/opencog/atomspace/AtomSpace.cc
@@ -292,7 +292,7 @@ Handle AtomSpace::add_link(Type t, const HandleSeq& outgoing, bool async)
     // If it is a DeleteLink, then the addition will fail. Deal with it.
     Handle rh;
     try {
-        rh = _atom_table.add(createLink(t, outgoing), async);
+        rh = _atom_table.add(createLink(outgoing, t), async);
     }
     catch (const DeleteException& ex) {
         // Atom deletion has not been implemented in the backing store

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -413,8 +413,12 @@ AtomPtr AtomTable::cast_factory(Type atom_type, AtomPtr atom)
     // Handle FreeLinks only after special treatment for State,
     // Delete, above.
     } else if (classserver().isA(atom_type, FREE_LINK)) {
-        if (nullptr == FreeLinkCast(atom))
+        if (nullptr == FreeLinkCast(atom)) {
+            auto fact = classserver().getFactory(atom_type);
+            if (fact) return (*fact) (Handle(atom));
+
             return FreeLink::factory(Handle(atom));
+        }
     }
     return atom;
 }

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -41,7 +41,6 @@
 #include <opencog/atoms/NumberNode.h>
 #include <opencog/atoms/TypeNode.h>
 #include <opencog/atoms/core/DeleteLink.h>
-#include <opencog/atoms/core/FreeLink.h>
 #include <opencog/atoms/core/StateLink.h>
 #include <opencog/atoms/core/VariableList.h>
 #include <opencog/atoms/execution/EvaluationLink.h>
@@ -404,22 +403,11 @@ AtomPtr AtomTable::cast_factory(Type atom_type, AtomPtr atom)
         return delp;
     }
 
-    // Handle MapLinks before FreeLink
-    else if (EXECUTION_OUTPUT_LINK == atom_type) {
-    } else if (MAP_LINK == atom_type) {
-        // if (nullptr == TypedAtomLinkCast(atom))
-            // return createMapLink(*LinkCast(atom));
-
-    // Handle FreeLinks only after special treatment for State,
+    // Handle other link types only after special treatment for State,
     // Delete, above.
-    } else if (classserver().isA(atom_type, FREE_LINK)) {
-        if (nullptr == FreeLinkCast(atom)) {
-            auto fact = classserver().getFactory(atom_type);
-            if (fact) return (*fact) (Handle(atom));
+    auto fact = classserver().getFactory(atom_type);
+    if (fact) return (*fact) (Handle(atom));
 
-            return FreeLink::factory(Handle(atom));
-        }
-    }
     return atom;
 }
 

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -43,7 +43,6 @@
 #include <opencog/atoms/core/DeleteLink.h>
 #include <opencog/atoms/core/ScopeLink.h>
 #include <opencog/atoms/core/StateLink.h>
-#include <opencog/atoms/core/VariableList.h>
 #include <opencog/util/exceptions.h>
 #include <opencog/util/functional.h>
 #include <opencog/util/Logger.h>
@@ -304,12 +303,7 @@ Handle AtomTable::getLinkHandle(AtomPtr& a, Quotation quotation) const
     if (unquoted and classserver().isA(t, SCOPE_LINK)) {
         ScopeLinkPtr wanted = ScopeLinkCast(a);
         if (nullptr == wanted) {
-            auto fact = classserver().getFactory(t);
-            if (fact)
-                wanted = (*fact)(Handle(a));
-            else
-                wanted = ScopeLink::factory(Handle(a));
-                // XXX FIXME get rid of above line of code.
+            wanted = ScopeLinkCast(classserver().factory(Handle(a)));
         }
         ch = wanted->get_hash();
         a = wanted;
@@ -361,11 +355,6 @@ AtomPtr AtomTable::cast_factory(Type atom_type, AtomPtr atom)
     } else if (TYPE_NODE == atom_type) {
         if (nullptr == TypeNodeCast(atom))
             return createTypeNode(*NodeCast(atom));
-
-    // Links of various kinds -----------
-    } else if (VARIABLE_LIST == atom_type) {
-        if (nullptr == VariableListCast(atom))
-            return createVariableList(*LinkCast(atom));
     }
 
     // Very special handling for DeleteLink's
@@ -419,10 +408,6 @@ AtomPtr AtomTable::clone_factory(Type atom_type, AtomPtr atom)
         return createTypeNode(*NodeCast(atom));
     if (classserver().isA(atom_type, NODE))
         return createNode(*NodeCast(atom));
-
-    // Links of various kinds -----------
-    if (VARIABLE_LIST == atom_type)
-        return createVariableList(*LinkCast(atom));
 
     // The createLink *forces* cloning to occur, even if the factory
     // decided only to cast.

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -381,17 +381,7 @@ AtomPtr AtomTable::cast_factory(Type atom_type, AtomPtr atom)
 
     // Handle other link types only after special treatment for State,
     // Delete, above.
-    auto fact = classserver().getFactory(atom_type);
-    if (fact) return (*fact) (Handle(atom));
-
-    // XXX FIXME get rid of this when ready
-    if (classserver().isA(atom_type, SCOPE_LINK)) {
-        // isA because we want to force alpha-conversion.
-        if (nullptr == ScopeLinkCast(atom))
-            return ScopeLink::factory(Handle(atom));
-    }
-
-    return atom;
+    return classserver().factory(Handle(atom));
 }
 
 /// The purpose of the clone factory is to create a private, unique
@@ -409,21 +399,8 @@ AtomPtr AtomTable::clone_factory(Type atom_type, AtomPtr atom)
     if (classserver().isA(atom_type, NODE))
         return createNode(*NodeCast(atom));
 
-    // The createLink *forces* cloning to occur, even if the factory
-    // decided only to cast.
-    auto fact = classserver().getFactory(atom_type);
-    if (fact) return (*fact)(Handle(createLink(*LinkCast(atom))));
-
-    // isA because we want to force alpha-conversion.
-// XXX FIXME get rid of this wehn ready
-    if (classserver().isA(atom_type, SCOPE_LINK))
-        return ScopeLink::factory(Handle(atom));
-
-    if (classserver().isA(atom_type, LINK))
-        return createLink(*LinkCast(atom));
-
-    throw RuntimeException(TRACE_INFO,
-          "AtomTable - failed factory call!");
+    // The createLink *forces* a copy of the link to be made.
+    return classserver().factory(Handle(createLink(*LinkCast(atom))));
 }
 
 #if 0

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -304,7 +304,12 @@ Handle AtomTable::getLinkHandle(AtomPtr& a, Quotation quotation) const
     if (unquoted and classserver().isA(t, SCOPE_LINK)) {
         ScopeLinkPtr wanted = ScopeLinkCast(a);
         if (nullptr == wanted) {
-            wanted = ScopeLink::factory(Handle(a));
+            auto fact = classserver().getFactory(t);
+            if (fact)
+                wanted = (*fact)(Handle(a));
+            else
+                wanted = ScopeLink::factory(Handle(a));
+                // XXX FIXME get rid of above line of code.
         }
         ch = wanted->get_hash();
         a = wanted;
@@ -361,10 +366,6 @@ AtomPtr AtomTable::cast_factory(Type atom_type, AtomPtr atom)
     } else if (VARIABLE_LIST == atom_type) {
         if (nullptr == VariableListCast(atom))
             return createVariableList(*LinkCast(atom));
-    } else if (classserver().isA(atom_type, SCOPE_LINK)) {
-        // isA because we want to force alpha-conversion.
-        if (nullptr == ScopeLinkCast(atom))
-            return ScopeLink::factory(Handle(atom));
     }
 
     // Very special handling for DeleteLink's
@@ -394,6 +395,13 @@ AtomPtr AtomTable::cast_factory(Type atom_type, AtomPtr atom)
     auto fact = classserver().getFactory(atom_type);
     if (fact) return (*fact) (Handle(atom));
 
+    // XXX FIXME get rid of this when ready
+    if (classserver().isA(atom_type, SCOPE_LINK)) {
+        // isA because we want to force alpha-conversion.
+        if (nullptr == ScopeLinkCast(atom))
+            return ScopeLink::factory(Handle(atom));
+    }
+
     return atom;
 }
 
@@ -422,6 +430,7 @@ AtomPtr AtomTable::clone_factory(Type atom_type, AtomPtr atom)
     if (fact) return (*fact)(Handle(createLink(*LinkCast(atom))));
 
     // isA because we want to force alpha-conversion.
+// XXX FIXME get rid of this wehn ready
     if (classserver().isA(atom_type, SCOPE_LINK))
         return ScopeLink::factory(Handle(atom));
 

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -264,7 +264,7 @@ Handle AtomTable::getNodeHandle(const AtomPtr& orig) const
 
 Handle AtomTable::getHandle(Type t, const HandleSeq& seq) const
 {
-    AtomPtr a(createLink(t, seq));
+    AtomPtr a(createLink(seq, t));
     return getLinkHandle(a);
 }
 
@@ -290,7 +290,7 @@ Handle AtomTable::getLinkHandle(const AtomPtr& orig, Quotation quotation) const
         resolved_seq.emplace_back(rh);
     }
 
-    a = createLink(t, resolved_seq);
+    a = createLink(resolved_seq, t);
 
     // Start searching to see if we have this atom.
     ContentHash ch = a->get_hash();
@@ -444,7 +444,7 @@ Handle AtomTable::add(AtomPtr atom, bool async)
             if (nullptr == h.operator->()) return Handle::UNDEFINED;
             closet.emplace_back(add(h, async));
         }
-        atom = createLink(atom_type, closet);
+        atom = createLink(closet, atom_type);
         atom = clone_factory(atom_type, atom);
     }
 

--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -207,10 +207,10 @@ public:
      * @return The handle of the desired atom if found.
      */
     Handle getHandle(Type, const std::string&) const;
-    Handle getNodeHandle(AtomPtr&) const;
+    Handle getNodeHandle(const AtomPtr&) const;
     Handle getHandle(Type, const HandleSeq&) const;
-    Handle getLinkHandle(AtomPtr&, Quotation quotation = Quotation()) const;
-    Handle getHandle(AtomPtr&, Quotation quotation = Quotation()) const;
+    Handle getLinkHandle(const AtomPtr&, Quotation quotation = Quotation()) const;
+    Handle getHandle(const AtomPtr&, Quotation quotation = Quotation()) const;
     Handle getHandle(const Handle& h) const {
         AtomPtr a(h); return getHandle(a);
     }

--- a/opencog/atomutils/Substitutor.h
+++ b/opencog/atomutils/Substitutor.h
@@ -73,8 +73,8 @@ private:
 		if (not changed) return expr;
 
 		// Create a duplicate link with the substitution.
-		Handle hret(createLink(expr->getType(), oset_results));
-		hret->setTruthValue(expr->getTruthValue());
+		Handle hret(createLink(oset_results, expr->getType()));
+		hret->copyValues(expr);
 		return hret;
 	}
 

--- a/opencog/atomutils/Substitutor.h
+++ b/opencog/atomutils/Substitutor.h
@@ -73,8 +73,9 @@ private:
 		if (not changed) return expr;
 
 		// Create a duplicate link with the substitution.
-		return Handle(createLink(expr->getType(), oset_results,
-		                         expr->getTruthValue()));
+		Handle hret(createLink(expr->getType(), oset_results));
+		hret->setTruthValue(expr->getTruthValue());
+		return hret;
 	}
 
 public:

--- a/opencog/atomutils/Unify.cc
+++ b/opencog/atomutils/Unify.cc
@@ -28,6 +28,7 @@
 #include <opencog/util/algorithm.h>
 #include <opencog/atoms/base/Atom.h>
 #include <opencog/atoms/base/Node.h>
+#include <opencog/atoms/core/ScopeLink.h>
 #include <opencog/atomutils/FindUtils.h>
 
 namespace opencog {
@@ -316,10 +317,7 @@ Handle Unify::consume_ill_quotations(const Variables& variables, Handle h,
 		consumed.push_back(consume_ill_quotations(variables, outh, quotation,
 		                                          escape));
 
-	// TODO: call all factories
-	bool is_scope = classserver().isA(t, SCOPE_LINK);
-	return is_scope ? Handle(ScopeLink::factory(t, consumed))
-		: Handle(createLink(t, consumed));
+	return classserver().factory(Handle(createLink(t, consumed)));
 }
 
 bool Unify::is_bound_to_ancestor(const Variables& variables,

--- a/opencog/atomutils/Unify.cc
+++ b/opencog/atomutils/Unify.cc
@@ -317,7 +317,7 @@ Handle Unify::consume_ill_quotations(const Variables& variables, Handle h,
 		consumed.push_back(consume_ill_quotations(variables, outh, quotation,
 		                                          escape));
 
-	return classserver().factory(Handle(createLink(t, consumed)));
+	return classserver().factory(Handle(createLink(consumed, t)));
 }
 
 bool Unify::is_bound_to_ancestor(const Variables& variables,

--- a/opencog/benchmark/AtomSpaceBenchmark.cc
+++ b/opencog/benchmark/AtomSpaceBenchmark.cc
@@ -170,7 +170,7 @@ void AtomSpaceBenchmark::printTypeSizes()
          << estimateOfAtomSize(h) << endl;
 
     HandleSeq empty;
-    h = Handle(createLink(LIST_LINK, empty));
+    h = Handle(createLink(empty, LIST_LINK));
     cout << "Empty ListLink = " << estimateOfAtomSize(h) << endl;
 
     Handle na = ND(CONCEPT_NODE, "first atom");
@@ -791,7 +791,7 @@ clock_t AtomSpaceBenchmark::makeRandomLinks()
     case BENCH_TABLE: {
         clock_t tAddLinkStart = clock();
         for (unsigned int i=0; i<Nclock; i++)
-            atab->add(createLink(ta[i], og[i]), false);
+            atab->add(createLink(og[i], ta[i]), false);
         return clock() - tAddLinkStart;
     }
     case BENCH_AS: {

--- a/opencog/guile/SchemeSmobAV.cc
+++ b/opencog/guile/SchemeSmobAV.cc
@@ -51,7 +51,7 @@ std::string SchemeSmob::av_to_string(const AttentionValue *av)
 #define BUFLEN 120
 	char buff[BUFLEN];
 
-	snprintf(buff, BUFLEN, "(av %d %d %u)",
+	snprintf(buff, BUFLEN, "(av %f %f %f)",
 	         av->getSTI(), av->getLTI(), av->getVLTI());
 
 	return buff;

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
@@ -232,7 +232,7 @@ class SQLAtomStorage::Response
 				AtomPtr ra = get_recursive_if_not_exists(po);
 				resolved_oset.emplace_back(ra->getHandle());
 			}
-			LinkPtr link(createLink(p->type, resolved_oset));
+			LinkPtr link(createLink(resolved_oset, p->type));
 			store->_tlbuf.addAtom(link, p->uuid);
 			return link;
 		}
@@ -1589,7 +1589,7 @@ Handle SQLAtomStorage::getNode(Type t, const char * str)
 Handle SQLAtomStorage::doGetLink(Type t, const HandleSeq& hseq)
 {
 	// First, check to see if we already know this Link.
-	Handle link(createLink(t, hseq));
+	Handle link(createLink(hseq, t));
 	UUID uuid = _tlbuf.getUUID(link);
 	if (TLB::INVALID_UUID != uuid)
 		return _tlbuf.getAtom(uuid);

--- a/opencog/persist/zmq/atomspace/ProtocolBufferSerializer.cc
+++ b/opencog/persist/zmq/atomspace/ProtocolBufferSerializer.cc
@@ -228,13 +228,12 @@ void ProtocolBufferSerializer::serializeIndefiniteTruthValue(
 NodePtr ProtocolBufferSerializer::deserializeNode(
         const ZMQAtomMessage& atomMessage)
 {
-    TruthValuePtr tv;
+	NodePtr nodePtr(createNode(atomMessage.type(), atomMessage.name()));
     if (atomMessage.has_truthvalue()) {
+    TruthValuePtr tv;
     	tv = deserialize(atomMessage.truthvalue());
-    } else {
-    	tv = TruthValue::DEFAULT_TV();
+		nodePtr->setTruthValue(tv);
     }
-	NodePtr nodePtr(new Node(atomMessage.type(), atomMessage.name(), tv));
 	tlbuf.addAtom(nodePtr, atomMessage.handle());
     deserializeAtom(atomMessage, *nodePtr);
 
@@ -244,20 +243,18 @@ NodePtr ProtocolBufferSerializer::deserializeNode(
 LinkPtr ProtocolBufferSerializer::deserializeLink(
         const ZMQAtomMessage& atomMessage)
 {
-
 	HandleSeq oset(atomMessage.outgoing_size());
     for(int i = 0; i < atomMessage.outgoing_size(); i++)
     {
 		// oset[i] = Handle(atomMessage.outgoing(i));
     }
 
-    TruthValuePtr tv;
+	LinkPtr linkPtr(createLink(oset, atomMessage.type()));
     if (atomMessage.has_truthvalue()) {
+    TruthValuePtr tv;
     	tv = deserialize(atomMessage.truthvalue());
-    } else {
-    	tv = TruthValue::DEFAULT_TV();
+	linkPtr->setTruthValue(tv);
     }
-	LinkPtr linkPtr(new Link(atomMessage.type(), oset, tv));
 	tlbuf.addAtom(linkPtr, atomMessage.handle());
     deserializeAtom(atomMessage, *linkPtr);
 

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -283,7 +283,7 @@ bool PatternMatchEngine::ordered_compare(const PatternTermPtr& ptm,
 				}
 
 				// If we are here, we've got a match; record the glob.
-				LinkPtr glp(createLink(LIST_LINK, glob_seq));
+				LinkPtr glp(createLink(glob_seq, LIST_LINK));
 				var_grounding[glob->getHandle()] = glp->getHandle();
 			}
 			else

--- a/opencog/query/Satisfier.cc
+++ b/opencog/query/Satisfier.cc
@@ -113,7 +113,7 @@ bool SatisfyingSet::grounding(const HandleMap &var_soln,
 	{
 		vargnds.push_back(var_soln.at(hv));
 	}
-	_satisfying_set.emplace(Handle(createLink(LIST_LINK, vargnds)));
+	_satisfying_set.emplace(Handle(createLink(vargnds, LIST_LINK)));
 
 	// If we found as many as we want, then stop looking for more.
 	return (_satisfying_set.size() >= max_results);

--- a/opencog/rule-engine/InferenceSCM.cc
+++ b/opencog/rule-engine/InferenceSCM.cc
@@ -142,7 +142,7 @@ Handle InferenceSCM::get_rulebase_rules(Handle rbs)
         hs.push_back((*i).get_alias());
     }
 
-    return Handle(createLink(SET_LINK, hs));
+    return Handle(createLink(hs, SET_LINK));
 }
 
 

--- a/opencog/rule-engine/Rule.cc
+++ b/opencog/rule-engine/Rule.cc
@@ -453,8 +453,9 @@ Handle Rule::standardize_helper(AtomSpace* as, const Handle& h,
 		for (auto ho : old_outgoing)
 			new_outgoing.push_back(standardize_helper(as, ho, dict));
 
-		return as->add_atom(createLink(h->getType(), new_outgoing,
-		                               h->getTruthValue()));
+		Handle hcpy(as->add_atom(createLink(h->getType(), new_outgoing)));
+		hcpy->copyValues(h);
+		return hcpy;
 	}
 
 	// normal node does not need to be changed
@@ -469,11 +470,11 @@ Handle Rule::standardize_helper(AtomSpace* as, const Handle& h,
 		// TODO: use opencog's random generator
 		std::string new_name = h->getName() + "-"
 			+ boost::uuids::to_string(boost::uuids::random_generator()());
-		Handle hcpy = as->add_atom(createNode(h->getType(), new_name,
-		                                      h->getTruthValue()));
+
+		Handle hcpy(as->add_atom(createNode(h->getType(), new_name)));
+		hcpy->copyValues(h);
 
 		dict[h] = hcpy;
-
 		return hcpy;
 	}
 
@@ -482,11 +483,10 @@ Handle Rule::standardize_helper(AtomSpace* as, const Handle& h,
 		return dict[h];
 
 	std::string new_name = h->getName() + "-" + _name;
-	Handle hcpy = as->add_atom(createNode(h->getType(), new_name,
-	                                      h->getTruthValue()));
+	Handle hcpy(as->add_atom(createNode(h->getType(), new_name)));
+	hcpy->copyValues(h);
 
 	dict[h] = hcpy;
-
 	return hcpy;
 }
 

--- a/opencog/rule-engine/Rule.cc
+++ b/opencog/rule-engine/Rule.cc
@@ -453,7 +453,7 @@ Handle Rule::standardize_helper(AtomSpace* as, const Handle& h,
 		for (auto ho : old_outgoing)
 			new_outgoing.push_back(standardize_helper(as, ho, dict));
 
-		Handle hcpy(as->add_atom(createLink(h->getType(), new_outgoing)));
+		Handle hcpy(as->add_atom(createLink(new_outgoing, h->getType())));
 		hcpy->copyValues(h);
 		return hcpy;
 	}

--- a/tests/atoms/DefineLinkUTest.cxxtest
+++ b/tests/atoms/DefineLinkUTest.cxxtest
@@ -1,5 +1,5 @@
 /*
- * tests/atoms/DefineUTest.cxxtest
+ * tests/atoms/DefineLinkUTest.cxxtest
  *
  * Copyright (C) 2015 Nil Geisweiller
  * All Rights Reserved

--- a/tests/atomspace/AtomTableUTest.cxxtest
+++ b/tests/atomspace/AtomTableUTest.cxxtest
@@ -97,7 +97,7 @@ public:
         os.push_back(time);
         os.push_back(word);
         os.push_back(sense);
-        table->add(createLink(INHERITANCE_LINK, os), true);
+        table->add(createLink(os, INHERITANCE_LINK), true);
         table->barrier();
     }
 
@@ -221,7 +221,7 @@ public:
 
         HandleSeq os;
         os.push_back(hn1); os.push_back(hn1); os.push_back(hn2);
-        LinkPtr l1(createLink(LIST_LINK, os));
+        LinkPtr l1(createLink(os, LIST_LINK));
         Handle hl1 = table->add(l1, false);
 
         // Now, remove hn1 from the table ...
@@ -234,7 +234,7 @@ public:
         os.push_back(h3);
         os.push_back(h3);
 
-        Handle l33 = table->add(createLink(LIST_LINK, os), false);
+        Handle l33 = table->add(createLink(os, LIST_LINK), false);
         LinkPtr lptr33(LinkCast(l33));
         HandleSeq hs = lptr33->getOutgoingSet();
         printf("hs1 & hs2 ptr's: %p %p\n", hs[0].operator->(), hs[1].operator->());
@@ -254,7 +254,7 @@ public:
         HandleSeq os;
         os.push_back(word);
         os.push_back(sense);
-        LinkPtr lp = createLink(MY_INHERITANCE_LINK, os);
+        LinkPtr lp = createLink(os, MY_INHERITANCE_LINK);
         Handle lh = table->add(lp, false);
 
 #define getHandlex(N,T) getHandle(T,N)

--- a/tests/atomspace/AtomUTest.cxxtest
+++ b/tests/atomspace/AtomUTest.cxxtest
@@ -36,7 +36,7 @@ class ConcreteAtom : public Link
 {
 
 public:
-    ConcreteAtom(Type t, const HandleSeq& o) : Link(t, o) {}
+    ConcreteAtom(Type t, const HandleSeq& o) : Link(o, t) {}
 };
 
 class AtomUTest :  public CxxTest::TestSuite

--- a/tests/atomspace/LinkUTest.cxxtest
+++ b/tests/atomspace/LinkUTest.cxxtest
@@ -46,17 +46,17 @@ public:
         NodePtr n1(createNode(CONCEPT_NODE, "TEST"));
         NodePtr n2(createNode(CONCEPT_NODE, "TEST"));
         HandleSeq out1;
-        LinkPtr l1(createLink(LIST_LINK, out1));
-        LinkPtr l2(createLink(LIST_LINK, out1));
+        LinkPtr l1(createLink(out1, LIST_LINK));
+        LinkPtr l2(createLink(out1, LIST_LINK));
         TS_ASSERT(l1->getArity() == 0);
         TS_ASSERT(l2->getArity() == 0);
 
         HandleSeq out2;
         out2.push_back(n1->getHandle());
-        LinkPtr l3(createLink(LIST_LINK, out2));
-        LinkPtr l4(createLink(LIST_LINK, out2));
-        LinkPtr l5(createLink(INHERITANCE_LINK, out2));
-        LinkPtr l6(createLink(INHERITANCE_LINK, out2));
+        LinkPtr l3(createLink(out2, LIST_LINK));
+        LinkPtr l4(createLink(out2, LIST_LINK));
+        LinkPtr l5(createLink(out2, INHERITANCE_LINK));
+        LinkPtr l6(createLink(out2, INHERITANCE_LINK));
         TS_ASSERT(l3->getArity() == 1);
         TS_ASSERT(l4->getArity() == 1);
         TS_ASSERT(l5->getArity() == 1);
@@ -65,8 +65,8 @@ public:
         HandleSeq out3;
         out3.push_back(n1->getHandle());
         out3.push_back(n2->getHandle());
-        LinkPtr l7(createLink(INHERITANCE_LINK, out3));
-        LinkPtr l8(createLink(INHERITANCE_LINK, out3));
+        LinkPtr l7(createLink(out3, INHERITANCE_LINK));
+        LinkPtr l8(createLink(out3, INHERITANCE_LINK));
         TS_ASSERT(l7->getArity() == 2);
         TS_ASSERT(l8->getArity() == 2);
 

--- a/tests/persist/sql/multi-driver/BasicSaveUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/BasicSaveUTest.cxxtest
@@ -289,7 +289,7 @@ void BasicSaveUTest::single_atom_save_restore(std::string id)
     hvec.push_back(a->getHandle());
     hvec.push_back(a2->getHandle());
 
-    LinkPtr l(createLink(LIST_LINK, hvec));
+    LinkPtr l(createLink(hvec, LIST_LINK));
     store->storeAtom(l->getHandle(), true);
 
     Handle hl = store->getLink(LIST_LINK, hvec);
@@ -340,7 +340,7 @@ void BasicSaveUTest::add_to_table(int idx, AtomTable *table, std::string id)
     hvec.push_back(a3[idx]->getHandle());
     hvec.push_back(a4[idx]->getHandle());
 
-    l[idx] = createLink(SET_LINK, hvec);
+    l[idx] = createLink(hvec, SET_LINK);
     l[idx] = LinkCast(table->add(l[idx], false));
     al[idx] = l[idx];
 }
@@ -365,7 +365,7 @@ void BasicSaveUTest::check_table(int idx, AtomTable *table, std::string id)
     hvec.push_back(hb3);
     hvec.push_back(hb4);
 
-    LinkPtr lb(createLink(SET_LINK, hvec));
+    LinkPtr lb(createLink(hvec, SET_LINK));
     Handle hlb = table->getHandle(Handle(lb));
     atomCompare(al[idx], hlb, "check_table hlb");
 }
@@ -419,7 +419,7 @@ void BasicSaveUTest::do_test_fresh_atom(void)
     store->storeAtom(lf->getHandle(), true);
 
     // Store an empty ListLink.
-    LinkPtr le(createLink(LIST_LINK, HandleSeq()));
+    LinkPtr le(createLink(HandleSeq(), LIST_LINK));
     le->setTruthValue(SimpleTruthValue::createTV(0.1, 0.9));
     store->storeAtom(le->getHandle(), true);
 

--- a/tests/persist/sql/multi-driver/MultiPersistUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/MultiPersistUTest.cxxtest
@@ -356,17 +356,17 @@ void MultiPersistUTest::fetch_space(int idx, AtomSpace *space)
     hvec.push_back(hb3);
     hvec.push_back(hb4);
 
-    AtomPtr alb = createLink(hl[idx]->getType(), hvec);
+    AtomPtr alb = createLink(hvec, hl[idx]->getType());
     Handle hlb(alb->getHandle());
     space->fetch_atom(hlb);
 
     HandleSeq hv2({hlb, hb2});
-    AtomPtr alb2 = createLink(hl2[idx]->getType(), hv2);
+    AtomPtr alb2 = createLink(hv2, hl2[idx]->getType());
     Handle hlb2(alb2->getHandle());
     space->fetch_atom(hlb2);
 
     HandleSeq hv3({hb1, hlb2, hb3});
-    AtomPtr alb3 = createLink(hl3[idx]->getType(), hv3);
+    AtomPtr alb3 = createLink(hv3, hl3[idx]->getType());
     Handle hlb3(alb3->getHandle());
     space->fetch_atom(hlb3);
 }

--- a/tests/persist/sql/multi-driver/PersistUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/PersistUTest.cxxtest
@@ -295,17 +295,17 @@ void PersistUTest::fetch_space(int idx, AtomSpace *space)
     hvec.push_back(hb3);
     hvec.push_back(hb4);
 
-    AtomPtr alb = createLink(hl[idx]->getType(), hvec);
+    AtomPtr alb = createLink(hvec, hl[idx]->getType());
     Handle hlb(alb->getHandle());
     space->fetch_atom(hlb);
 
     HandleSeq hv2({hlb, hb2});
-    AtomPtr alb2 = createLink(hl2[idx]->getType(), hv2);
+    AtomPtr alb2 = createLink(hv2, hl2[idx]->getType());
     Handle hlb2(alb2->getHandle());
     space->fetch_atom(hlb2);
 
     HandleSeq hv3({hb1, hlb2, hb3});
-    AtomPtr alb3 = createLink(hl3[idx]->getType(), hv3);
+    AtomPtr alb3 = createLink(hv3, hl3[idx]->getType());
     Handle hlb3(alb3->getHandle());
     space->fetch_atom(hlb3);
 }

--- a/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
@@ -298,6 +298,7 @@ void ValueSaveUTest::check_one(ProtoAtomPtr pap, bool fetchkey)
 	printf("Got vals %s\n", atom->valuesToString().c_str());
 	ProtoAtomPtr fap = atom->getValue(key);
 
+	printf("Expecting %s\n", pap->toString());
 	TS_ASSERT(*pap == *fap);
 
 	delete as;

--- a/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
@@ -298,7 +298,7 @@ void ValueSaveUTest::check_one(ProtoAtomPtr pap, bool fetchkey)
 	printf("Got vals %s\n", atom->valuesToString().c_str());
 	ProtoAtomPtr fap = atom->getValue(key);
 
-	printf("Expecting %s\n", pap->toString());
+	printf("Expecting %s\n", pap->toString().c_str());
 	TS_ASSERT(*pap == *fap);
 
 	delete as;

--- a/tests/query/DisconnectedUTest.cxxtest
+++ b/tests/query/DisconnectedUTest.cxxtest
@@ -189,7 +189,7 @@ void DisconnectedUTest::test_cvariables(void)
 		Handle blb(createLink(AND_LINK, va));
 		Handle blt(createLink(LIST_LINK, va));
 		HandleSeq bll = {blv, blb, blt};
-		Handle bl_final(createLink(BIND_LINK, bll));
+		Handle bl_final(createLink(bll, BIND_LINK));
 		as->add_atom(bl_final);
 	}
 	catch (const InvalidParamException& ex)

--- a/tests/query/imply.h
+++ b/tests/query/imply.h
@@ -20,7 +20,7 @@ static inline Handle imply(AtomSpace* as, Handle hclauses, Handle himplicand)
 	HandleSeq vars(fv.varset.begin(), fv.varset.end());
 
 	// Stuff the variables into a proper variable list.
-	Handle hvars(createLink(VARIABLE_LIST, vars));
+	Handle hvars(createLink(vars, VARIABLE_LIST));
 
 	HandleSeq oset = {hvars, hclauses, himplicand};
 


### PR DESCRIPTION
This implements design request #1048.  Having all of the atom factories located in the AtomTable caused a number of linking and dependency issues, which have been festering for years. This should solve that.

This was supposed to be a quick, easy lazy-afternoon task, but it turned out to require a two-and-a-half day coding marathon. It boils the ocean, changes about 100 files.  Oh well.  It works, although it appears to expose some bugs in the Unifier; See issue #1165 for  description.

This requires a matching pull request opencog/opencog#2630 to compile.