### PR TITLE
Fix atom compares to null pointers.

### DIFF
--- a/opencog/atoms/base/Handle.cc
+++ b/opencog/atoms/base/Handle.cc
@@ -121,7 +121,7 @@ bool Handle::operator>= (const Handle& h) const noexcept
 // http://wiki.opencog.org/w/Development_standards#Print_OpenCog_Objects
 std::string h_to_string(const Handle& h)
 {
-	if (h == (Atom*) nullptr)
+	if (h == nullptr)
 		return "nullatom\n";
 	else
 		return h->toString();

--- a/opencog/atoms/base/Handle.h
+++ b/opencog/atoms/base/Handle.h
@@ -102,6 +102,12 @@ public:
         return false;
     }
 
+    inline bool operator==(std::nullptr_t) const noexcept {
+        return get() == 0x0;
+    }
+    inline bool operator!=(std::nullptr_t) const noexcept {
+        return get() != 0x0;
+    }
     inline bool operator==(const Atom* ap) const noexcept {
         return get() == ap;
     }

--- a/opencog/atoms/reduct/ArithmeticLink.cc
+++ b/opencog/atoms/reduct/ArithmeticLink.cc
@@ -132,7 +132,7 @@ Handle ArithmeticLink::reorder(void)
 static inline double get_double(AtomSpace *as, Handle h)
 {
 	NumberNodePtr nnn(NumberNodeCast(h));
-	if (nnn == NULL)
+	if (nnn == nullptr)
 		throw RuntimeException(TRACE_INFO,
 			  "Expecting a NumberNode, got %s",
 		     classserver().getTypeName(h->getType()).c_str());

--- a/opencog/atomutils/AtomUtils.cc
+++ b/opencog/atomutils/AtomUtils.cc
@@ -34,7 +34,7 @@ HandleSeq get_predicates(const Handle& target,
                          Type predicateType,
                          bool subClasses)
 {
-    if (target == NULL) {
+    if (target == nullptr) {
         throw InvalidParamException(TRACE_INFO,
             "get_predicates: Target handle %d doesn't refer to an Atom", target.value());
     }
@@ -76,11 +76,11 @@ HandleSeq get_predicates(const Handle& target,
 HandleSeq get_predicates_for(const Handle& target, 
                              const Handle& predicate)
 {
-    if (target == NULL) {
+    if (target == nullptr) {
         throw InvalidParamException(TRACE_INFO,
             "get_predicates_for: Target handle %d doesn't refer to an Atom", target.value());
     }
-    if (predicate == NULL) {
+    if (predicate == nullptr) {
         throw InvalidParamException(TRACE_INFO,
             "get_predicates_for: Predicate handle %d doesn't refer to an Atom", predicate.value());
     }


### PR DESCRIPTION
This should avoid certain error messages during compiles.