### PR TITLE
Fixup handling of constant clauses in SatisfactionLink's

### DIFF
--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -449,8 +449,13 @@ void PatternLink::validate_clauses(OrderedHandleSet& vars,
 	bool bogus = remove_constants(vars, clauses, constants);
 	if (bogus)
 	{
-		logger().warn("%s: Constant clauses removed from pattern",
-		              __FUNCTION__);
+		logger().warn("%s: Constant clauses removed from pattern %s",
+		              __FUNCTION__, toShortString().c_str());
+		for (const Handle& h: constants)
+		{
+			logger().warn("%s: Removed %s",
+		              __FUNCTION__, h->toShortString().c_str());
+		}
 	}
 
 	// Make sure that each declared variable appears in some clause.

--- a/opencog/atoms/pattern/PatternUtils.cc
+++ b/opencog/atoms/pattern/PatternUtils.cc
@@ -76,7 +76,7 @@ bool remove_constants(const OrderedHandleSet &vars,
 		    or contains_atomtype(clause, GROUNDED_SCHEMA_NODE)
 		    or contains_atomtype(clause, IDENTICAL_LINK)
 		    or contains_atomtype(clause, EQUAL_LINK)
-		    or classserver().isA(clause->getType(), EVALUATABLE_LINK)
+		    or classserver().isA(clause->getType(), EVALUATABLE_LINK))
 		{
 			++i;
 		}

--- a/opencog/atoms/pattern/PatternUtils.cc
+++ b/opencog/atoms/pattern/PatternUtils.cc
@@ -48,6 +48,14 @@ namespace opencog {
  * DefinedPredicate or DefinedSchema nodes are simply not known until
  * runtime evaluation/execution.
  *
+ * The match for EvaluatableLink's is meant to solve the problem of
+ * evaluating (SatisfactionLink (AndLink (TrueLink))) vs. evaluating
+ * (SatisfactionLink (AndLink (FalseLink))), with the first returning
+ * TRUE_TV, and the second returning FALSE_TV. Removing these 'constant'
+ * terms would alter the result of the evaluation, potentially even
+ * leaving an empty (undefined) AndLink. So we cannot really remove
+ * them.
+ *
  * Returns true if the list of clauses was modified, else returns false.
  */
 bool remove_constants(const OrderedHandleSet &vars,
@@ -67,7 +75,8 @@ bool remove_constants(const OrderedHandleSet &vars,
 		    or contains_atomtype(clause, GROUNDED_PREDICATE_NODE)
 		    or contains_atomtype(clause, GROUNDED_SCHEMA_NODE)
 		    or contains_atomtype(clause, IDENTICAL_LINK)
-		    or contains_atomtype(clause, EQUAL_LINK))
+		    or contains_atomtype(clause, EQUAL_LINK)
+		    or classserver().isA(clause->getType(), EVALUATABLE_LINK)
 		{
 			++i;
 		}


### PR DESCRIPTION
This should avoid some behavior-tree issues, seen when ROS is disabled.