### PR TITLE
More constant clause removal in bc

### DIFF
--- a/opencog/atomutils/TypeUtils.cc
+++ b/opencog/atomutils/TypeUtils.cc
@@ -355,9 +355,6 @@ std::set<Type> type_intersection(const std::set<Type>& lhs,
 	return res;
 }
 
-/**
- * Generate a VariableList of the free variables of a given atom h.
- */
 VariableListPtr gen_varlist(const Handle& h)
 {
 	OrderedHandleSet vars = get_free_variables(h);
@@ -369,25 +366,25 @@ Handle gen_vardecl(const Handle& h)
 	return Handle(gen_varlist(h));
 }
 
-/**
- * Given an atom h and its variable declaration vardecl, turn the
- * vardecl into a VariableList if not already, and if undefined,
- * generate a VariableList of the free variables of h.
- */
 VariableListPtr gen_varlist(const Handle& h, const Handle& vardecl)
 {
 	if (not vardecl)
 		return gen_varlist(h);
-	else {
-		Type vardecl_t = vardecl->getType();
-		if (vardecl_t == VARIABLE_LIST)
-			return VariableListCast(vardecl);
-		else {
-			OC_ASSERT(vardecl_t == VARIABLE_NODE
-			          or vardecl_t == TYPED_VARIABLE_LINK);
-			return createVariableList(vardecl);
-		}
-	}
+
+	Type vardecl_t = vardecl->getType();
+	if (vardecl_t == VARIABLE_LIST)
+		return VariableListCast(vardecl);
+
+	OC_ASSERT(vardecl_t == VARIABLE_NODE
+	          or vardecl_t == TYPED_VARIABLE_LINK);
+	return createVariableList(vardecl);
+}
+
+Handle gen_vardecl(const Handle& h, const Handle& vardecl)
+{
+	if (not vardecl)
+		return gen_vardecl(h);
+	return vardecl;
 }
 
 } // ~namespace opencog

--- a/opencog/atomutils/TypeUtils.h
+++ b/opencog/atomutils/TypeUtils.h
@@ -197,6 +197,11 @@ Handle gen_vardecl(const Handle& h);
  */
 VariableListPtr gen_varlist(const Handle& h, const Handle& vardecl);
 
+/**
+ * Like above but return a Handle variable declaration instead.
+ */
+Handle gen_vardecl(const Handle& h, const Handle& vardecl);
+
 /** @}*/
 }
 

--- a/opencog/rule-engine/backwardchainer/BIT.cc
+++ b/opencog/rule-engine/backwardchainer/BIT.cc
@@ -36,6 +36,7 @@
 #include <opencog/util/random.h>
 #include <opencog/atomutils/FindUtils.h>
 #include <opencog/atoms/execution/ExecutionOutputLink.h>
+#include <opencog/atoms/pattern/PatternUtils.h>
 
 #include "BIT.h"
 #include "../URELogger.h"
@@ -80,11 +81,14 @@ std::string	BITNode::to_string() const
 
 AndBIT::AndBIT() : exhausted(false) {}
 
-AndBIT::AndBIT(AtomSpace& as, const Handle& target, const Handle& vardecl,
+AndBIT::AndBIT(AtomSpace& as, const Handle& target, Handle vardecl,
                const BITNodeFitness& fitness) : exhausted(false)
 {
 	// Create initial FCS
-	HandleSeq bl{target, target};
+	vardecl = gen_vardecl(target, vardecl); // in case it is undefined
+	Handle body = Unify::remove_constant_clauses(vardecl, target);
+	HandleSeq bl{body, target};
+	vardecl = filter_vardecl(vardecl, body); // remove useless vardecl
 	if (vardecl)
 		bl.insert(bl.begin(), vardecl);
 	fcs = as.add_link(BIND_LINK, bl);

--- a/opencog/rule-engine/backwardchainer/BIT.h
+++ b/opencog/rule-engine/backwardchainer/BIT.h
@@ -100,7 +100,7 @@ public:
 	 * fitness and add it in as.
 	 */
 	AndBIT();
-	AndBIT(AtomSpace& as, const Handle& target, const Handle& vardecl,
+	AndBIT(AtomSpace& as, const Handle& target, Handle vardecl,
 	       const BITNodeFitness& fitness=BITNodeFitness());
 	/**
 	 * @brief construct a and-BIT given its FCS and complexity.


### PR DESCRIPTION
The only constant clauses I can't get rid of are the ones in meta rules like https://github.com/opencog/atomspace/blob/master/tests/rule-engine/meta-rules/conditional-instantiation-meta-rule.scm

When this rule is loaded I get
```
[WARN] validate_clauses: Constant clauses removed from pattern (BindLink
  (UnquoteLink
    (VariableNode "$TyVs") ; [649754491480800404][1]
  ) ; [9900412008889880701][1]
  (AndLink
    (UnquoteLink
      (LocalQuoteLink
        (LocalQuoteLink
          (VariableNode "$P") ; [387665797850823995][1]
        ) ; [9638903857399357579][1]
      ) ; [9666769880093115355][1]
    ) ; [9694055360647419844][1]
    (EvaluationLink
      (GroundedPredicateNode "scm: true-enough") ; [4909340809722256524][1]
      (UnquoteLink
        (VariableNode "$P") ; [387665797850823995][1]
      ) ; [9638323315259904292][1]
    ) ; [16554297673137484767][1]
  ) ; [14272313674449815882][1]
  (ExecutionOutputLink
    (GroundedSchemaNode "scm: conditional-full-instantiation-formula") ; [4305848657298870225][1]
    (UnquoteLink
      (ListLink
        (VariableNode "$Q") ; [6972375320967189345][1]
        (QuoteLink
          (ImplicationScopeLink
            (UnquoteLink
              (VariableNode "$TyVs") ; [649754491480800404][1]
            ) ; [9900412008889880701][1]
            (UnquoteLink
              (VariableNode "$P") ; [387665797850823995][1]
            ) ; [9638323315259904292][1]
            (UnquoteLink
              (VariableNode "$Q") ; [6972375320967189345][1]
            ) ; [16223032838376269642][1]
          ) ; [16542387506498072147][1]
        ) ; [16569092444912923349][1]
        (VariableNode "$P") ; [387665797850823995][1]
      ) ; [18346722694491448964][1]
    ) ; [18374008175045753453][1]
  ) ; [14923797680039655876][1]
) ; [15863120028233726156][18446744073709551615]

[WARN] validate_clauses: Removed (UnquoteLink
  (LocalQuoteLink
    (LocalQuoteLink
      (VariableNode "$P") ; [387665797850823995][1]
    ) ; [9638903857399357579][1]
  ) ; [9666769880093115355][1]
) ; [9694055360647419844][1]
```
because from the standpoint of the to-be-produced BindLink, that clause is indeed, at this point, constant, but it doesn't matter since it is quoted... This shouldn't harmful anyway.