### PR TITLE
Allow VariableNode as type in variable declaration

### DIFF
--- a/opencog/atoms/core/VariableList.cc
+++ b/opencog/atoms/core/VariableList.cc
@@ -278,6 +278,12 @@ void VariableList::get_vartype(const Handle& htypelink)
 		ts.insert(vartype);
 		_varlist._fuzzy_typemap.insert({varname, ts});
 	}
+	else if (VARIABLE_NODE == t)
+	{
+		// This occurs when the variable type is a variable to be
+		// matched by the pattern matcher. There's nothing to do
+		// except not throwing an exception.
+	}
 	else
 	{
 		throw SyntaxException(TRACE_INFO,

--- a/tests/rule-engine/BackwardChainerUTest.cxxtest
+++ b/tests/rule-engine/BackwardChainerUTest.cxxtest
@@ -160,7 +160,6 @@ void BackwardChainerUTest::test_deduction()
 	_eval.eval("(load-from-path \"tests/rule-engine/bc-transitive-closure.scm\")");
 	randGen().seed(0);
 
-	// load 1 deduction rule
 	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfigReader::top_rbs_name);
 	Handle X = an(VARIABLE_NODE, "$X"),
 		D = an(CONCEPT_NODE, "D"),
@@ -197,7 +196,6 @@ void BackwardChainerUTest::test_deduction_tv_query()
 	_eval.eval("(load-from-path \"tests/rule-engine/bc-transitive-closure.scm\")");
 	randGen().seed(0);
 
-	// load 1 deduction rule
 	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfigReader::top_rbs_name);
 	Handle target = _eval.eval_h("(Inheritance"
 	                             "   (Concept \"A\")"
@@ -223,7 +221,6 @@ void BackwardChainerUTest::test_modus_ponens_tv_query()
 	_eval.eval("(load-from-path \"tests/rule-engine/modus-ponens-example.scm\")");
 	randGen().seed(0);
 
-	// load 1 deduction rule
 	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfigReader::top_rbs_name);
 	Handle target = an(PREDICATE_NODE, "T");
 
@@ -248,7 +245,6 @@ void BackwardChainerUTest::test_conjunction_fuzzy_evaluation_tv_query()
 	result = _eval.eval("(load-from-path \"tests/rule-engine/simple-conjunction.scm\")");
 	randGen().seed(0);
 
-	// load 1 modus ponens rule
 	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfigReader::top_rbs_name);
 
 	Handle P = an(PREDICATE_NODE, "P"),
@@ -282,7 +278,6 @@ void BackwardChainerUTest::test_conditional_instantiation_1()
 	result = _eval.eval("(load-from-path \"tests/rule-engine/bc-friends.scm\")");
 	randGen().seed(0);
 
-	// load 1 modus ponens rule
 	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfigReader::top_rbs_name);
 
 	Handle are_friends = an(PREDICATE_NODE, "are-friends"),
@@ -329,7 +324,6 @@ void BackwardChainerUTest::test_conditional_instantiation_2()
 	_eval.eval("(load-from-path \"tests/rule-engine/bc-animals.scm\")");
 	randGen().seed(0);
 
-	// load 1 modus ponens rule
 	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfigReader::top_rbs_name);
 
 	Handle green = an(CONCEPT_NODE, "green"),
@@ -364,7 +358,6 @@ void BackwardChainerUTest::test_conditional_instantiation_tv_query()
 	_eval.eval("(load-from-path \"tests/rule-engine/bc-animals.scm\")");
 	randGen().seed(500);
 
-	// load modus ponens
 	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfigReader::top_rbs_name);
 
 	Handle target =
@@ -392,7 +385,6 @@ void BackwardChainerUTest::test_impossible_criminal()
 	_eval.eval("(load-from-path \"tests/rule-engine/bc-criminal.scm\")");
 	randGen().seed(0);
 
-	// Load modus ponens rule
 	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfigReader::top_rbs_name);
 
 	Handle target =
@@ -432,7 +424,6 @@ void BackwardChainerUTest::test_criminal()
 	_eval.eval("(load-from-path \"tests/rule-engine/bc-criminal.scm\")");
 	randGen().seed(0);
 
-	// load modus ponens & deduction rules
 	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfigReader::top_rbs_name);
 
 	Handle target_var = _eval.eval_h("(VariableNode \"$who\")");
@@ -483,7 +474,6 @@ void BackwardChainerUTest::test_criminal_trace()
 	_eval.eval("(load-from-path \"tests/rule-engine/bc-criminal.scm\")");
 	randGen().seed(0);
 
-	// load modus ponens & deduction rules
 	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfigReader::top_rbs_name);
 
 	Handle target_var = _eval.eval_h("(VariableNode \"$who\")");
@@ -552,7 +542,6 @@ void BackwardChainerUTest::test_induction()
 
 	randGen().seed(500);
 
-	// load modus ponens & deduction rules
 	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfigReader::top_rbs_name);
 
 	Handle target = _eval.eval_h("bc-induction-target");
@@ -581,7 +570,6 @@ void BackwardChainerUTest::test_focus_set()
 	_eval.eval("(load-from-path \"tests/rule-engine/bc-animals.scm\")");
 	randGen().seed(500);
 
-	// load 1 modus ponens rule
 	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfigReader::top_rbs_name);
 
 	Handle green = an(CONCEPT_NODE, "green"),

--- a/tests/rule-engine/BackwardChainerUTest.cxxtest
+++ b/tests/rule-engine/BackwardChainerUTest.cxxtest
@@ -54,6 +54,7 @@ public:
 	void test_conditional_instantiation_1();
 	void test_conditional_instantiation_2();
 	void test_conditional_instantiation_tv_query();
+	void test_conditional_partial_instantiation();
 	void test_impossible_criminal();
 	void test_criminal();
 	void test_criminal_trace();
@@ -375,6 +376,61 @@ void BackwardChainerUTest::test_conditional_instantiation_tv_query()
 	logger().debug("END TEST: %s", __FUNCTION__);
 }
 
+void BackwardChainerUTest::test_conditional_partial_instantiation()
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	_as.clear();
+
+	string result = _eval.eval("(load-from-path \"tests/rule-engine/conditional-partial-instantiation-config.scm\")");
+
+	logger().debug() << "result = " << result;
+
+	result = _eval.eval("(load-from-path \"tests/rule-engine/bc-friends.scm\")");
+	randGen().seed(0);
+
+	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfigReader::top_rbs_name);
+
+	Handle target = _eval.eval_h("(ImplicationScope"
+	                             "   (TypedVariable"
+	                             "      (Variable \"$X\")"
+	                             "      (Type \"ConceptNode\"))"
+	                             "   (And"
+	                             "      (Evaluation"
+	                             "         (Predicate \"are-friends\")"
+	                             "         (List"
+	                             "            (Variable \"$X\")"
+	                             "            (Concept \"John\")))"
+	                             "      (Evaluation"
+	                             "         (Predicate \"are-friends\")"
+	                             "         (List"
+	                             "            (Concept \"John\")"
+	                             "            (Concept \"Mary\")))"
+	                             "      (Evaluation"
+	                             "         (Predicate \"is-musician\")"
+	                             "         (Variable \"$X\"))"
+	                             "      (Evaluation"
+	                             "         (Predicate \"is-musician\")"
+	                             "         (Concept \"John\"))"
+	                             "      (Evaluation"
+	                             "         (Predicate \"is-musician\")"
+	                             "         (Concept \"Mary\")))"
+	                             "   (Evaluation"
+	                             "      (Predicate \"are-friends\")"
+	                             "      (List"
+	                             "         (Variable \"$X\")"
+	                             "         (Concept \"Mary\"))))");
+
+	BackwardChainer bc(_as, top_rbs, target);
+	bc.get_config().set_maximum_iterations(5);
+	bc.do_chain();
+
+	TS_ASSERT_DELTA(target->getTruthValue()->getMean(), 1, 1e-10);
+	TS_ASSERT_DELTA(target->getTruthValue()->getConfidence(), 1, 1e-10);
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
 void BackwardChainerUTest::test_impossible_criminal()
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
@@ -584,7 +640,7 @@ void BackwardChainerUTest::test_focus_set()
 		             " (InheritanceLink"
 		             "   (ConceptNode \"tree\")"
 		             "   (ConceptNode \"plant\"))"
-		             " (ImplicationLink (stv 1.0 1.0)"
+		             " (ImplicationLink"
 		             "   (InheritanceLink"
 		             "     (VariableNode \"$P\")"
 		             "     (ConceptNode \"plant\")"

--- a/tests/rule-engine/conditional-partial-instantiation-config.scm
+++ b/tests/rule-engine/conditional-partial-instantiation-config.scm
@@ -1,0 +1,30 @@
+;;
+;; Configuration file for PLN unit test (used by
+;; BackwardChainerUTest.cxxtest)
+;;
+;; To be loaded first
+
+;; Load the rules (use load for relative path w.r.t. to that file)
+(load-from-path "tests/rule-engine/meta-rules/conditional-partial-instantiation-meta-rule.scm")
+
+;; Associate the rules to the rule base (with weights, their semantics
+;; is currently undefined, we might settled with probabilities but it's
+;; not sure)
+(MemberLink (stv 1 1)
+   conditional-partial-instantiation-meta-rule-name
+   (ConceptNode "URE")
+)
+
+;; termination criteria parameters
+(ExecutionLink
+   (SchemaNode "URE:maximum-iterations")
+   (ConceptNode "URE")
+   (NumberNode "20")
+)
+
+;; Attention allocation (set the TV strength to 0 to disable it, 1 to
+;; enable it)
+(EvaluationLink (stv 0 1)
+   (PredicateNode "URE:attention-allocation")
+   (ConceptNode "URE")
+)

--- a/tests/rule-engine/meta-rules/conditional-partial-instantiation-meta-rule.scm
+++ b/tests/rule-engine/meta-rules/conditional-partial-instantiation-meta-rule.scm
@@ -1,0 +1,114 @@
+;; =======================================================================
+;; Conditional Partial Instantiation Meta Rule
+;;
+;; ImplicationScopeLink
+;;   V1, V2, V3
+;;   P
+;;   Q
+;; |-
+;;   T2
+;;   T3
+;;   |-
+;;   ImplicationScopeLink
+;;     V1
+;;     P[V2->T2,V3->T3]
+;;     Q[V2->T2,V3->T3]
+;;
+;; The fact that there 3 variables is hardcoded for now.
+;; -----------------------------------------------------------------------
+
+(use-modules (srfi srfi-1))
+
+(use-modules (opencog exec))
+(use-modules (opencog rule-engine))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Conditional partial instantiation rule ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Hard code a 3-ary ImplicationScope turning into a unary
+;; ImplicationScope where V2 and V3 are substituted by terms.
+(define conditional-partial-instantiation-meta-rule
+  (let* ((V1 (Variable "$V1"))
+         (V2 (Variable "$V2"))
+         (V3 (Variable "$V3"))
+         (V1Type (Variable "$V1Type"))
+         (V2Type (Variable "$V2Type"))
+         (V3Type (Variable "$V3Type"))
+         (VariableT (Type "VariableNode"))
+         (TypeChoiceT (Type "TypeChoice"))
+         (TypeT (Type "TypeNode"))
+         (VariableTypeT (TypeChoice TypeChoiceT TypeT))
+         (TypedV1 (TypedVariable V1 VariableT))
+         (TypedV2 (TypedVariable V2 VariableT))
+         (TypedV3 (TypedVariable V3 VariableT))
+         (TypedV1Type (TypedVariable V1Type VariableTypeT))
+         (TypedV2Type (TypedVariable V2Type VariableTypeT))
+         (TypedV3Type (TypedVariable V3Type VariableTypeT))
+         (P (Variable "$P"))
+         (Q (Variable "$Q"))
+         ;; Meta rule variable declaration
+         (meta-vardecl (VariableList
+                         TypedV1 TypedV2 TypedV3
+                         TypedV1Type TypedV2Type TypedV3Type
+                         P Q))
+         ;; Meta rule main clause
+         (implication (Quote
+                        (ImplicationScope
+                          (Unquote (VariableList
+                            (TypedVariable V1 V1Type)
+                            (TypedVariable V2 V2Type)
+                            (TypedVariable V3 V3Type)))
+                          (Unquote P)
+                          (Unquote Q))))
+         ;; Meta rule precondition
+         (meta-precondition (Evaluation
+                              (GroundedPredicate "scm: gt-zero-confidence")
+                              implication))
+         ;; Meta rule pattern
+         (meta-pattern (And implication meta-precondition))
+         ;; Produced rule variable declaration. V2 and V3 are to be
+         ;; substituted.
+         (produced-vardecl (VariableList
+                             (TypedVariable V2 V2Type)
+                             (TypedVariable V3 V3Type)))
+         ;; Produced rule pattern. Just look for groundings of V2 and V3
+         (produced-pattern (And V2 V3))
+         ;; Produced rule rewrite. Apply formula to calculate the TV
+         ;; over the partially substituted ImplicationScope.
+         (produced-rewrite (ExecutionOutput
+                            (GroundedSchema "scm: conditional-partial-instantiation-formula")
+                            (Unquote
+                              (List
+                                ;; Conclusion
+                                (Quote
+                                  (ImplicationScope
+                                    (Unquote
+                                      (TypedVariable V1 V1Type)) ; only V1 remains
+                                    (Unquote P)
+                                    (Unquote Q)))
+                                ;; Premise
+                                implication))))
+         ;; Meta rule rewrite
+         (meta-rewrite (Quote (Bind
+                          (Unquote produced-vardecl)
+                          (Unquote produced-pattern)
+                          produced-rewrite ; the Unquote appears
+                                           ; inside it, to avoid
+                                           ; running the
+                                           ; ExecutionOutput
+                          ))))
+    (Bind
+      meta-vardecl
+      meta-pattern
+      meta-rewrite)))
+
+(define (conditional-partial-instantiation-formula PImpl Impl)
+  ;; For now merely put the TV of Impl on PImpl
+  (cog-set-tv! PImpl (cog-tv Impl)))
+
+;; Name the meta rule
+(define conditional-partial-instantiation-meta-rule-name
+  (DefinedSchemaNode "conditional-partial-instantiation-meta-rule"))
+(DefineLink conditional-partial-instantiation-meta-rule-name
+  conditional-partial-instantiation-meta-rule)


### PR DESCRIPTION
@linas this is the first PR of a series of potentially controversial PRs. Look at it carefully. You may observe that `BackwardChainerUTest::test_conditional_partial_instantiation()` does not pass without it. Let me know if that's acceptable, and if not what alternative would you suggest.