### PR TITLE
Add silent exception in do execute

### DIFF
--- a/opencog/atoms/core/Variables.h
+++ b/opencog/atoms/core/Variables.h
@@ -181,7 +181,7 @@ struct Variables : public FreeVariables
 	// filtering, where type mis-checks are expected and normal.
 	Handle substitute(const Handle& tree,
 	                  const HandleSeq& vals,
-	                  bool silent = false) const;
+	                  bool silent=false) const;
 
 	// Extend this variable set by adding in the given variable set.
 	void extend(const Variables&);

--- a/opencog/atoms/execution/EvaluationLink.h
+++ b/opencog/atoms/execution/EvaluationLink.h
@@ -51,9 +51,11 @@ public:
 	                                     AtomSpace* scratch,
 	                                     bool silent=false);
 	static TruthValuePtr do_evaluate(AtomSpace*,
-	                                 const HandleSeq& schema_and_args);
+	                                 const HandleSeq& schema_and_args,
+	                                 bool silent=false);
 	static TruthValuePtr do_evaluate(AtomSpace*,
-	                                const Handle& schema, const Handle& args);
+	                                 const Handle& schema, const Handle& args,
+	                                 bool silent=false);
 
 	static Handle factory(const Handle&);
 };

--- a/opencog/atoms/execution/ExecutionOutputLink.cc
+++ b/opencog/atoms/execution/ExecutionOutputLink.cc
@@ -193,11 +193,18 @@ Handle ExecutionOutputLink::do_execute(AtomSpace* as,
 	// code returns nothing, then a null-pointer-dereference is
 	// likely, a bit later down the line, leading to a crash.
 	// So head this off at the pass.
-	if (nullptr == result)
+	if (nullptr == result) {
+		// If silent is true, return a simpler and non-logged
+		// exception, which may, in some contexts, be considerably
+		// faster than the one below.
+		if (silent)
+			throw NotEvaluatableException;
+
 		throw RuntimeException(TRACE_INFO,
 		        "Invalid return value from schema %s\nArgs: %s",
 		        gsn->toString().c_str(),
 		        cargs->toString().c_str());
+	}
 
 	LAZY_LOG_FINE << "Result: " << oc_to_string(result);
 	return result;

--- a/opencog/atoms/execution/ExecutionOutputLink.cc
+++ b/opencog/atoms/execution/ExecutionOutputLink.cc
@@ -103,9 +103,9 @@ ExecutionOutputLink::ExecutionOutputLink(const Link& l)
 /// This method will then invoke "func_name" on the provided ListLink
 /// of arguments to the function.
 ///
-Handle ExecutionOutputLink::execute(AtomSpace* as) const
+Handle ExecutionOutputLink::execute(AtomSpace* as, bool silent) const
 {
-	return do_execute(as, _outgoing[0], _outgoing[1]);
+	return do_execute(as, _outgoing[0], _outgoing[1], silent);
 }
 
 /// do_execute -- execute the SchemaNode of the ExecutionOutputLink
@@ -115,7 +115,9 @@ Handle ExecutionOutputLink::execute(AtomSpace* as) const
 /// Executes the GroundedSchemaNode, supplying the args as argument
 ///
 Handle ExecutionOutputLink::do_execute(AtomSpace* as,
-                         const Handle& gsn, const Handle& cargs)
+                                       const Handle& gsn,
+                                       const Handle& cargs,
+                                       bool silent)
 {
 	LAZY_LOG_FINE << "Execute gsn: " << gsn->toShortString()
 	              << "with arguments: " << cargs->toShortString();
@@ -125,7 +127,7 @@ Handle ExecutionOutputLink::do_execute(AtomSpace* as,
 	// to do lazy execution correctly. Right now, forcing is the policy.
 	// We could add "scm-lazy:" and "py-lazy:" URI's for user-defined
 	// functions smart enough to do lazy evaluation.
-	Handle args = force_execute(as, cargs);
+	Handle args = force_execute(as, cargs, silent);
 
 	// Get the schema name.
 	const std::string& schema = gsn->getName();
@@ -194,7 +196,6 @@ Handle ExecutionOutputLink::do_execute(AtomSpace* as,
 	// likely, a bit later down the line, leading to a crash.
 	// So head this off at the pass.
 	if (nullptr == result) {
-		bool silent = true;
 		// If silent is true, return a simpler and non-logged
 		// exception, which may, in some contexts, be considerably
 		// faster than the one below.

--- a/opencog/atoms/execution/ExecutionOutputLink.cc
+++ b/opencog/atoms/execution/ExecutionOutputLink.cc
@@ -194,11 +194,12 @@ Handle ExecutionOutputLink::do_execute(AtomSpace* as,
 	// likely, a bit later down the line, leading to a crash.
 	// So head this off at the pass.
 	if (nullptr == result) {
+		bool silent = true;
 		// If silent is true, return a simpler and non-logged
 		// exception, which may, in some contexts, be considerably
 		// faster than the one below.
 		if (silent)
-			throw NotEvaluatableException;
+			throw NotEvaluatableException();
 
 		throw RuntimeException(TRACE_INFO,
 		        "Invalid return value from schema %s\nArgs: %s",

--- a/opencog/atoms/execution/ExecutionOutputLink.h
+++ b/opencog/atoms/execution/ExecutionOutputLink.h
@@ -55,7 +55,7 @@ public:
 	ExecutionOutputLink(const Handle& schema, const Handle& args);
 	ExecutionOutputLink(const Link& l);
 
-	virtual Handle execute(AtomSpace* as=NULL, bool silent=true) const;
+	virtual Handle execute(AtomSpace* as=NULL, bool silent=false) const;
 
 	Handle get_schema(void) const { return getOutgoingAtom(0); }
 	Handle get_args(void) const { return getOutgoingAtom(1); }

--- a/opencog/atoms/execution/ExecutionOutputLink.h
+++ b/opencog/atoms/execution/ExecutionOutputLink.h
@@ -36,8 +36,8 @@ namespace opencog
 class ExecutionOutputLink : public FunctionLink
 {
 private:
-	static Handle do_execute(AtomSpace*, const Handle& schema,
-	                                     const Handle& args);
+	static Handle do_execute(AtomSpace*, const Handle& schema, const Handle& args,
+	                         bool silent=false);
 
 public:
 	/**
@@ -55,7 +55,7 @@ public:
 	ExecutionOutputLink(const Handle& schema, const Handle& args);
 	ExecutionOutputLink(const Link& l);
 
-	virtual Handle execute(AtomSpace* = NULL) const;
+	virtual Handle execute(AtomSpace* as=NULL, bool silent=true) const;
 
 	Handle get_schema(void) const { return getOutgoingAtom(0); }
 	Handle get_args(void) const { return getOutgoingAtom(1); }

--- a/opencog/atoms/execution/Force.cc
+++ b/opencog/atoms/execution/Force.cc
@@ -48,13 +48,13 @@ using namespace opencog;
 /// Users who do not want to pollute the atomspace should use a
 /// temporary (scratch) atomspace.
 ///
-Handle opencog::force_execute(AtomSpace* as, const Handle& cargs)
+Handle opencog::force_execute(AtomSpace* as, const Handle& cargs, bool silent)
 {
 	Instantiator inst(as);
 
 	if (LIST_LINK != cargs->getType())
 	{
-	   Handle args(inst.execute(cargs));
+		Handle args(inst.execute(cargs, silent));
 		if (args != cargs)
 			args = as->add_atom(args);
 		return args;
@@ -65,7 +65,7 @@ Handle opencog::force_execute(AtomSpace* as, const Handle& cargs)
 	bool changed = false;
 	for (const Handle& ho : cargs->getOutgoingSet())
 	{
-		Handle nh(inst.execute(ho));
+		Handle nh(inst.execute(ho, silent));
 		// nh might be NULL if ho was a DeleteLink
 		if (nullptr == nh)
 		{

--- a/opencog/atoms/execution/Force.h
+++ b/opencog/atoms/execution/Force.h
@@ -32,7 +32,7 @@ namespace opencog
  */
 
 // Handy-dandy utility function
-Handle force_execute(AtomSpace*, const Handle&);
+Handle force_execute(AtomSpace*, const Handle&, bool silent=false);
 
 /** @}*/
 }

--- a/opencog/atoms/execution/Instantiator.h
+++ b/opencog/atoms/execution/Instantiator.h
@@ -97,7 +97,8 @@ public:
 		_vmap = nullptr;
 	}
 
-	Handle instantiate(const Handle& expr, const HandleMap &vars, bool silent=false);
+	Handle instantiate(const Handle& expr, const HandleMap &vars,
+	                   bool silent=false);
 	Handle execute(const Handle& expr, bool silent=false)
 	{
 		return instantiate(expr, HandleMap(), silent);

--- a/opencog/atoms/execution/Instantiator.h
+++ b/opencog/atoms/execution/Instantiator.h
@@ -79,8 +79,8 @@ private:
 	 * by default.
 	 */
 	bool _eager = true;
-	Handle walk_tree(const Handle& tree);
-	bool walk_sequence(HandleSeq&, const HandleSeq&);
+	Handle walk_tree(const Handle& tree, bool silent=false);
+	bool walk_sequence(HandleSeq&, const HandleSeq&, bool silent=false);
 
 public:
 	Instantiator(AtomSpace* as) : _as(as), _vmap(nullptr) {}
@@ -97,10 +97,10 @@ public:
 		_vmap = nullptr;
 	}
 
-	Handle instantiate(const Handle& expr, const HandleMap &vars);
-	Handle execute(const Handle& expr)
+	Handle instantiate(const Handle& expr, const HandleMap &vars, bool silent=false);
+	Handle execute(const Handle& expr, bool silent=false)
 	{
-		return instantiate(expr, HandleMap());
+		return instantiate(expr, HandleMap(), silent);
 	}
 };
 

--- a/opencog/query/Implicator.cc
+++ b/opencog/query/Implicator.cc
@@ -129,7 +129,7 @@ static Handle do_imply(AtomSpace* as,
 	if (0 == pat.mandatory.size() and 0 < pat.optionals.size()
 	    and not intu->optionals_present())
 	{
-		Handle h = impl.inst.execute(impl.implicand);
+		Handle h = impl.inst.execute(impl.implicand, true);
 		impl.insert_result(h);
 	}
 

--- a/opencog/query/Implicator.cc
+++ b/opencog/query/Implicator.cc
@@ -56,7 +56,7 @@ bool Implicator::grounding(const HandleMap &var_soln,
 	// difficult to insure so meanwhile this try-catch is used. See
 	// issue #950 and pull req #962. XXX FIXME later.
 	try {
-		Handle h = inst.instantiate(implicand, var_soln);
+		Handle h = inst.instantiate(implicand, var_soln, true);
 		insert_result(h);
 	} catch(...) {}
 

--- a/opencog/rule-engine/forwardchainer/FocusSetPMCB.h
+++ b/opencog/rule-engine/forwardchainer/FocusSetPMCB.h
@@ -56,7 +56,7 @@ public:
     virtual bool grounding(const HandleMap &var_soln,
                            const HandleMap &term_soln)
     {
-        Handle h = _inst->instantiate(implicand, var_soln);
+        Handle h = _inst->instantiate(implicand, var_soln, true);
 
         if (h != Handle::UNDEFINED)
             _result_list.push_back(h);


### PR DESCRIPTION
@linas you need to review that one carefully.

It adds a silent flag in ExecutionOutputLink::execute and related callers and callees. The silent flag is set to false by default. However some callers like `Implicator::grounding` call it (via instantiate) with silent set to true, which might be considered too silent.