### PR TITLE
Relax ExecutionOutputLink checks

### DIFF
--- a/opencog/atoms/execution/ExecutionOutputLink.cc
+++ b/opencog/atoms/execution/ExecutionOutputLink.cc
@@ -45,9 +45,8 @@ public:
 
 void ExecutionOutputLink::check_schema(const Handle& schema) const
 {
-	if (DEFINED_SCHEMA_NODE != schema->getType() and
-	    LAMBDA_LINK != schema->getType() and
-	    GROUNDED_SCHEMA_NODE != schema->getType())
+	if (not classserver().isA(schema->getType(), SCHEMA_NODE) and
+	    LAMBDA_LINK != schema->getType())
 	{
 		throw SyntaxException(TRACE_INFO,
 		                      "ExecutionOutputLink must have schema! Got %s",

--- a/opencog/atoms/execution/ExecutionOutputLink.cc
+++ b/opencog/atoms/execution/ExecutionOutputLink.cc
@@ -101,14 +101,19 @@ ExecutionOutputLink::ExecutionOutputLink(const Link& l)
 ///
 Handle ExecutionOutputLink::execute(AtomSpace* as, bool silent) const
 {
+	if (_outgoing[0]->getType() != GROUNDED_SCHEMA_NODE) {
+		LAZY_LOG_FINE << "Not a grounded schema. Do not execute it";
+		return getHandle();
+	}
+
 	return do_execute(as, _outgoing[0], _outgoing[1], silent);
 }
 
 /// do_execute -- execute the SchemaNode of the ExecutionOutputLink
 ///
 /// Expects "gsn" to be a GroundedSchemaNode or a DefinedSchemaNode
-/// Expects "args" to be a ListLink
-/// Executes the GroundedSchemaNode, supplying the args as argument
+/// Expects "cargs" to be a ListLink unless there is only one argument
+/// Executes the GroundedSchemaNode, supplying cargs as arguments
 ///
 Handle ExecutionOutputLink::do_execute(AtomSpace* as,
                                        const Handle& gsn,

--- a/opencog/atoms/execution/ExecutionOutputLink.cc
+++ b/opencog/atoms/execution/ExecutionOutputLink.cc
@@ -43,6 +43,18 @@ public:
     static void* getFunc(std::string libName,std::string funcName);
 };
 
+void ExecutionOutputLink::check_schema(const Handle& schema) const
+{
+	if (DEFINED_SCHEMA_NODE != schema->getType() and
+	    LAMBDA_LINK != schema->getType() and
+	    GROUNDED_SCHEMA_NODE != schema->getType())
+	{
+		throw SyntaxException(TRACE_INFO,
+		                      "ExecutionOutputLink must have schema! Got %s",
+		                      schema->toString().c_str());
+	}
+}
+
 ExecutionOutputLink::ExecutionOutputLink(const HandleSeq& oset, Type t)
 	: FunctionLink(oset, t)
 {
@@ -55,29 +67,14 @@ ExecutionOutputLink::ExecutionOutputLink(const HandleSeq& oset, Type t)
 			"ExecutionOutputLink must have schema and args! Got arity=%d",
 			oset.size());
 
-	if (DEFINED_SCHEMA_NODE != oset[0]->getType() and
-	    LAMBDA_LINK != oset[0]->getType() and
-	    GROUNDED_SCHEMA_NODE != oset[0]->getType())
-	{
-		throw SyntaxException(TRACE_INFO,
-			"ExecutionOutputLink must have schema! Got %s",
-			oset[0]->toString().c_str());
-	}
+	check_schema(oset[0]);
 }
 
 ExecutionOutputLink::ExecutionOutputLink(const Handle& schema,
                                          const Handle& args)
 	: FunctionLink(EXECUTION_OUTPUT_LINK, schema, args)
 {
-	Type stype = schema->getType();
-	if (GROUNDED_SCHEMA_NODE != stype and
-	    LAMBDA_LINK != stype and
-	    DEFINED_SCHEMA_NODE != stype)
-	{
-		throw SyntaxException(TRACE_INFO,
-			"ExecutionOutputLink expecting schema, got %s",
-			schema->toString().c_str());
-	}
+	check_schema(schema);
 }
 
 ExecutionOutputLink::ExecutionOutputLink(const Link& l)

--- a/opencog/atoms/execution/ExecutionOutputLink.h
+++ b/opencog/atoms/execution/ExecutionOutputLink.h
@@ -39,6 +39,8 @@ private:
 	static Handle do_execute(AtomSpace*, const Handle& schema, const Handle& args,
 	                         bool silent=false);
 
+	void check_schema(const Handle& schema) const;
+
 public:
 	/**
 	 * Given a grounded schema name like "py: foo", extract

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -642,16 +642,25 @@ void PatternLink::unbundle_virtual(const OrderedHandleSet& vars,
 
 		for (const Handle& sh : feol.varset)
 		{
-			_pat.executable_terms.insert(sh);
-			_pat.executable_holders.insert(sh);
-			add_to_map(_pat.in_executable, sh, sh);
-			// But they're virtual only if they have two or more
-			// unquoted, bound variables in them. Otherwise, they
-			// can be evaluated on the spot.
-			if (2 <= num_unquoted_in_tree(sh, vars))
+			// There is an exception with ExecutionOutputLink that
+			// needs to have a grounded schema node in order to be
+			// executable. If they have non grounded schema node then
+			// their execution is themselves (i.e. they are not
+			// executable).
+			if (sh->getType() != EXECUTION_OUTPUT_LINK or
+			    sh->getOutgoingAtom(0)->getType() == GROUNDED_SCHEMA_NODE)
 			{
-				is_virtual = true;
-				is_black = true;
+				_pat.executable_terms.insert(sh);
+				_pat.executable_holders.insert(sh);
+				add_to_map(_pat.in_executable, sh, sh);
+				// But they're virtual only if they have two or more
+				// unquoted, bound variables in them. Otherwise, they
+				// can be evaluated on the spot.
+				if (2 <= num_unquoted_in_tree(sh, vars))
+				{
+					is_virtual = true;
+					is_black = true;
+				}
 			}
 		}
 		for (const Handle& sh : feol.holders)


### PR DESCRIPTION
Consider `ExecutionOutputLink` as executable iff its schema is grounded.

@linas, I don't think there's anything harmful here, but you probably ought to review it.

Ultimately we'll want to execute ungrounded schemata as well, but it seems subtle enough that we'd rather have that taken care of by another component (probably the URE with dedicated rules I assume).