### PR TITLE
Add scheme utility for working with protoatom/values

### DIFF
--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -266,7 +266,6 @@ void SchemeSmob::module_init(void*)
 void SchemeSmob::register_procs()
 {
 	register_proc("cog-handle",            1, 0, 0, C(ss_handle));
-	register_proc("cog-undefined-handle",  0, 0, 0, C(ss_undefined_handle));
 	register_proc("cog-new-value",         1, 0, 1, C(ss_new_value));
 	register_proc("cog-new-node",          2, 0, 1, C(ss_new_node));
 	register_proc("cog-new-link",          1, 0, 1, C(ss_new_link));

--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -265,7 +265,6 @@ void SchemeSmob::module_init(void*)
 
 void SchemeSmob::register_procs()
 {
-	register_proc("cog-handle",            1, 0, 0, C(ss_handle));
 	register_proc("cog-new-value",         1, 0, 1, C(ss_new_value));
 	register_proc("cog-new-node",          2, 0, 1, C(ss_new_node));
 	register_proc("cog-new-link",          1, 0, 1, C(ss_new_link));
@@ -275,10 +274,14 @@ void SchemeSmob::register_procs()
 	register_proc("cog-delete-recursive",  1, 0, 1, C(ss_delete_recursive));
 	register_proc("cog-extract",           1, 0, 1, C(ss_extract));
 	register_proc("cog-extract-recursive", 1, 0, 1, C(ss_extract_recursive));
-	register_proc("cog-value?",            1, 0, 1, C(ss_value_p));
-	register_proc("cog-atom?",             1, 0, 1, C(ss_atom_p));
-	register_proc("cog-node?",             1, 0, 1, C(ss_node_p));
-	register_proc("cog-link?",             1, 0, 1, C(ss_link_p));
+
+	register_proc("cog-value?",            1, 0, 0, C(ss_value_p));
+	register_proc("cog-atom?",             1, 0, 0, C(ss_atom_p));
+	register_proc("cog-node?",             1, 0, 0, C(ss_node_p));
+	register_proc("cog-link?",             1, 0, 0, C(ss_link_p));
+
+	register_proc("cog-handle",            1, 0, 0, C(ss_handle));
+	register_proc("cog-value->list",       1, 0, 0, C(ss_value_to_list));
 
 	// Generic property setter on atoms
 	register_proc("cog-set-value!",        3, 0, 0, C(ss_set_value));

--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -265,7 +265,6 @@ void SchemeSmob::module_init(void*)
 
 void SchemeSmob::register_procs()
 {
-	register_proc("cog-atom",              1, 0, 0, C(ss_atom));
 	register_proc("cog-handle",            1, 0, 0, C(ss_handle));
 	register_proc("cog-undefined-handle",  0, 0, 0, C(ss_undefined_handle));
 	register_proc("cog-new-value",         1, 0, 1, C(ss_new_value));

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -97,9 +97,6 @@ private:
 	// Return the hash value of the atom.
 	static SCM ss_handle(SCM);
 
-	// return the int of Handle::UNDEFINED
-	static SCM ss_undefined_handle(void);
-
 	// Set properties of atoms
 	static SCM ss_set_av(SCM, SCM);
 	static SCM ss_set_tv(SCM, SCM);

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -44,11 +44,10 @@ class SchemeSmob
 private:
 
 	enum {
-		COG_UUID = 1, // unsigned long int
-		COG_PROTOM,   // values or atoms - smart pointer
-		COG_AV,       // attention values
-		COG_AS,       // atom spaces
-		COG_EXTEND    // callbacks into C++ code.
+		COG_PROTOM = 1, // values or atoms - smart pointer
+		COG_AV,         // attention values
+		COG_AS,         // atom spaces
+		COG_EXTEND      // callbacks into C++ code.
 	};
 
 	static std::atomic_flag is_inited;
@@ -79,7 +78,7 @@ private:
 	static std::vector<ProtoAtomPtr> scm_to_protom_list (SCM);
 	static std::vector<std::string> scm_to_string_list (SCM);
 
-	// Atom creation and deletion functions
+	// Value, atom creation and deletion functions
 	static SCM ss_new_value(SCM, SCM);
 	static SCM ss_new_node(SCM, SCM, SCM);
 	static SCM ss_new_link(SCM, SCM);
@@ -95,8 +94,7 @@ private:
 	static SCM ss_link_p(SCM);
 	static SCM _radix_ten;
 
-	// Atoms to ints, and back.
-	static SCM ss_atom(SCM);
+	// Return the hash value of the atom.
 	static SCM ss_handle(SCM);
 
 	// return the int of Handle::UNDEFINED

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -97,6 +97,9 @@ private:
 	// Return the hash value of the atom.
 	static SCM ss_handle(SCM);
 
+	// Get list endcoded in a value
+	static SCM ss_value_to_list(SCM);
+
 	// Set properties of atoms
 	static SCM ss_set_av(SCM, SCM);
 	static SCM ss_set_tv(SCM, SCM);
@@ -174,6 +177,7 @@ private:
 	static SCM ss_av_get_value(SCM);
 
 	// AttentionalFocus and AttentionalFocus Boundary
+	// XXX FIXME these should move to the attention bank!
 	static SCM ss_af_boundary(void);
 	static SCM ss_set_af_boundary(SCM);
 	static SCM ss_af(void);
@@ -181,9 +185,6 @@ private:
 	// Free variables
 	static SCM ss_get_free_variables(SCM);
 	static SCM ss_is_closed(SCM);
-
-	// Callback into misc C++ code.
-	static SCM ss_ad_hoc(SCM, SCM);
 
 	// Misc utilities
 	static std::string to_string(SCM);

--- a/opencog/guile/SchemeSmobNew.cc
+++ b/opencog/guile/SchemeSmobNew.cc
@@ -173,28 +173,7 @@ Handle SchemeSmob::scm_to_handle (SCM sh)
 
 /* ============================================================== */
 /**
- * Create a new scheme object, holding the atom uuid
- */
-SCM SchemeSmob::ss_atom (SCM suuid)
-{
-	scm_misc_error("cog-atom", "Obsolete! Do not use!", suuid);
-	return SCM_EOL;
-#ifdef OLD_DEAD_CODE
-	if (scm_is_false(scm_integer_p(suuid)))
-		scm_wrong_type_arg_msg("cog-atom", 1, suuid, "integer opencog uuid");
-
-	// SCM_RETURN_NEWSMOB (cog_uuid_tag, suuid);
-	UUID uuid = scm_to_ulong(suuid);
-	if (INVALID_UUID == uuid)
-		scm_wrong_type_arg_msg("cog-atom", 1, suuid, "valid opencog uuid");
-
-	return handle_to_scm(Handle(uuid));
-#endif
-}
-
-/* ============================================================== */
-/**
- * Return uuid of atom
+ * Return hash of atom
  */
 SCM SchemeSmob::ss_handle (SCM satom)
 {

--- a/opencog/guile/SchemeSmobNew.cc
+++ b/opencog/guile/SchemeSmobNew.cc
@@ -185,15 +185,6 @@ SCM SchemeSmob::ss_handle (SCM satom)
 }
 
 /* ============================================================== */
-/**
- * Return 0 -- WTF what for?? who uses this?
- */
-SCM SchemeSmob::ss_undefined_handle (void)
-{
-	return scm_from_ulong(0);
-}
-
-/* ============================================================== */
 /** Return true if s is an atom. Invalid handles are not atoms. */
 
 SCM SchemeSmob::ss_atom_p (SCM s)

--- a/opencog/guile/SchemeSmobValue.cc
+++ b/opencog/guile/SchemeSmobValue.cc
@@ -243,4 +243,11 @@ SCM SchemeSmob::ss_value (SCM satom, SCM skey)
 	return SCM_EOL;
 }
 
+/* ============================================================== */
+/** Return a scheme list of the values associated with the value */
+
+SCM SchemeSmob::ss_value_to_list (SCM s)
+{
+	return SCM_EOL;
+}
 /* ===================== END OF FILE ============================ */

--- a/opencog/scm/core-docs.scm
+++ b/opencog/scm/core-docs.scm
@@ -330,39 +330,16 @@
     ordinary scheme list.
 ")
 
-(set-procedure-property! cog-atom 'documentation
-"
- cog-atom UUID
-    Reference the atom identified by the integer-valued UUID.
-")
-
 (set-procedure-property! cog-handle 'documentation
 "
  cog-handle ATOM
-    Return the UUID (which is an integer) of ATOM.
-
-    It may be useful to remember that scheme indicates hexadecimal
-    numbers by preceeding them with #x, and so, for example,
-    (cog-atom #x2c949b) gets the handle associated with hex 2c949b.
+    Return the hash of ATOM. The hash is a 64-bit integer, computed
+    from the component parts of the atom (but not it's values), that
+    can be used in hash tables or other algorithms that require a hash.
 
     Example:
-       ; Create two atoms, and get thier handles:
-       guile> (define x (cog-new-node 'ConceptNode \"abc\"))
-       guile> (define y (cog-new-node 'ConceptNode \"def\"))
-       guile> (cog-handle x)
-       113
-       guile> (cog-handle y)
-       114
-
-       ; Get the atom corresponding to handle number 114
-       guile> (cog-atom 114)
-       (ConceptNode \"abc\")
-
-       ; Verify that handles are truly integers
-       guile> (integer? x)
-       #f
-       guile> (integer? (cog-handle x))
-       #t
+       guile> (cog-handle (Concept \"abc\"))
+       999283543311182409
 ")
 
 (set-procedure-property! cog-inc-count! 'documentation

--- a/opencog/scm/core-docs.scm
+++ b/opencog/scm/core-docs.scm
@@ -700,6 +700,20 @@
        #f
 ")
 
+(set-procedure-property! cog-value->list 'documentation
+"
+ cog-value->list VALUE
+    Return a guile list holding the values in the opencog VALUE.
+    If VALUE is a Link, this returns the outgoing set.
+    If VALUE is a Node, this returns list containing the node name.
+    If VALUE is a StringValue, FloatValue or LinkValue, this returns
+    the associated list of values.
+
+    Example:
+       guile> (cog-value->list (FloatValue 0.1 0.2 0.3))
+       (0.1 0.2 0.3)
+")
+
 (set-procedure-property! cog-as 'documentation
 "
  cog-as ATOM

--- a/opencog/scm/opencog.scm
+++ b/opencog/scm/opencog.scm
@@ -83,3 +83,7 @@
 (load-from-path "av-tv.scm")
 (load-from-path "file-utils.scm")
 (load-from-path "debug-trace.scm")
+
+; Obsolete function
+(define-public (cog-atom X) '())
+(define-public (cog-undefined-handle X) '())

--- a/tests/scm/BasicSCMUTest.cxxtest
+++ b/tests/scm/BasicSCMUTest.cxxtest
@@ -401,10 +401,13 @@ void BasicSCMUTest::test_value_list(void)
 	boo = eval->eval("(equal? (cog-value->list s) '(\"a\" \"bb\" \"ccc\"))");
 	TSM_ASSERT("Failed string list equality", boo == "#t\n");
 
-	boo = eval->eval("(equal? (cog-value->list l) '(f h s k t))");
+	boo = eval->eval("(equal? (cog-value->list l) (list f h s k t))");
 	TSM_ASSERT("Failed value list equality", boo == "#t\n");
 
-	boo = eval->eval("(equal? (cog-value->list ll) '(h k h))");
+	boo = eval->eval("(equal? (cog-value->list ll) (list h k h))");
+	TSM_ASSERT("Failed ListLink equality", boo == "#t\n");
+
+	boo = eval->eval("(equal? (cog-value->list ll) (cog-outgoing-set ll))");
 	TSM_ASSERT("Failed outgoing set equality", boo == "#t\n");
 
 	boo = eval->eval("(equal? (cog-value->list h) '(\"foo\"))");

--- a/tests/scm/BasicSCMUTest.cxxtest
+++ b/tests/scm/BasicSCMUTest.cxxtest
@@ -85,6 +85,7 @@ class BasicSCMUTest :  public CxxTest::TestSuite
 
 	// Values
 	void test_values(void);
+	void test_value_list(void);
 
 	// TVs
 	void check_truth_value(const TruthValuePtr& tv);
@@ -368,6 +369,49 @@ void BasicSCMUTest::test_values(void)
 	ProtoAtomPtr lv3 = eval->eval_v("(cog-value h k)");
 	TSM_ASSERT("Failed to get value", not eval->eval_error());
 	TSM_ASSERT("Failed to get correct value", *l == *lv3);
+}
+
+// ============================================================
+
+void BasicSCMUTest::test_value_list(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	eval->eval("(define h (Concept \"foo\"))");
+	TSM_ASSERT("Failed to create atom", not eval->eval_error());
+	eval->eval("(define k (Predicate \"key\"))");
+	TSM_ASSERT("Failed to create key", not eval->eval_error());
+	eval->eval("(define ll (ListLink h k h))");
+	TSM_ASSERT("Failed to create key", not eval->eval_error());
+	eval->eval("(define f (FloatValue 0.1 0.2 0.3))");
+	TSM_ASSERT("Failed to create float", not eval->eval_error());
+	eval->eval("(define s (StringValue \"a\" \"bb\" \"ccc\"))");
+	TSM_ASSERT("Failed to create string", not eval->eval_error());
+	eval->eval("(define ss (StringValue \"ddd\" \"eee\" \"fff\"))");
+	TSM_ASSERT("Failed to create string", not eval->eval_error());
+	eval->eval("(define t (stv 0.5 0.8))");
+	TSM_ASSERT("Failed to create TV", not eval->eval_error());
+	eval->eval("(define l (LinkValue f h s k t))");
+	TSM_ASSERT("Failed to create string", not eval->eval_error());
+
+	// -------
+	std::string boo = eval->eval("(equal? (cog-value->list f) '(0.1 0.2 0.3))");
+	TSM_ASSERT("Failed float list equality", boo == "#t\n");
+
+	boo = eval->eval("(equal? (cog-value->list s) '(\"a\" \"bb\" \"ccc\"))");
+	TSM_ASSERT("Failed string list equality", boo == "#t\n");
+
+	boo = eval->eval("(equal? (cog-value->list l) '(f h s k t))");
+	TSM_ASSERT("Failed value list equality", boo == "#t\n");
+
+	boo = eval->eval("(equal? (cog-value->list ll) '(h k h))");
+	TSM_ASSERT("Failed outgoing set equality", boo == "#t\n");
+
+	boo = eval->eval("(equal? (cog-value->list h) '(\"foo\"))");
+	TSM_ASSERT("Failed name list equality", boo == "#t\n");
+
+	boo = eval->eval("(equal? (cog-value->list k) '(\"key\"))");
+	TSM_ASSERT("Failed key name equality", boo == "#t\n");
 }
 
 // ============================================================


### PR DESCRIPTION
The new `cog-value->list` function converts an opencog value to a scheme list.

This commit also remove some obsolete functions.
