### PR TITLE
Additional fixes for SQL & Values

### DIFF
--- a/opencog/atoms/base/Handle.h
+++ b/opencog/atoms/base/Handle.h
@@ -154,16 +154,6 @@ bool content_eq(const opencog::Handle& lh,
 //! Boost needs this function to be called by exactly this name.
 std::size_t hash_value(Handle const&);
 
-//! gcc-4.7.2 needs this, because std::hash<opencog::Handle> no longer works.
-//! (See very bottom of this file).
-struct handle_hash : public std::unary_function<Handle, size_t>
-{
-   size_t operator()(const Handle& h) const
-   {
-       return hash_value(h);
-   }
-};
-
 struct handle_less
 {
    bool operator()(const Handle& hl, const Handle& hr) const
@@ -188,7 +178,7 @@ typedef std::set<Handle> OrderedHandleSet;
 typedef std::pair<Handle, Handle> HandlePair;
 
 //! a hash that associates the handle to its unique identificator
-typedef std::unordered_set<Handle, handle_hash> UnorderedHandleSet;
+typedef std::unordered_set<Handle> UnorderedHandleSet;
 
 //! an ordered map from Handle to Handle set
 typedef std::map<Handle, UnorderedHandleSet> HandleMultimap;
@@ -325,9 +315,7 @@ ostream& operator<<(ostream&, const opencog::UnorderedHandleSet&);
 // broke is that it fails to typedef result_type and argument_type,
 // which ... somehow used to work automagically?? It doesn't any more.
 // I have no clue why gcc-4.7.2 broke this, and neither does google or
-// stackoverflow.  You have two choices: use handle_hash, above, or
-// cross your fingers, and hope the definition in the #else clause,
-// below, works.
+// stackoverflow.
 
 template<>
 inline std::size_t

--- a/opencog/atoms/base/Handle.h
+++ b/opencog/atoms/base/Handle.h
@@ -174,10 +174,7 @@ typedef std::vector<HandleSeq> HandleSeqSeq;
 //! a set of handles
 typedef std::set<Handle> OrderedHandleSet;
 
-//! a pair of handles
-typedef std::pair<Handle, Handle> HandlePair;
-
-//! a hash that associates the handle to its unique identificator
+//! a hash table
 typedef std::unordered_set<Handle> UnorderedHandleSet;
 
 //! an ordered map from Handle to Handle set
@@ -191,9 +188,6 @@ typedef std::vector<HandleMap> HandleMapSeq;
 
 //! a set of ordered handle maps
 typedef std::set<HandleMap> HandleMapSet;
-
-//! a pair of handles
-typedef std::pair<Handle, Handle> HandlePair;
 
 //! a sequence of handle pairs
 typedef std::vector<HandlePair> HandlePairSeq;
@@ -352,6 +346,16 @@ struct equal_to<opencog::Handle>
         if (nullptr == lh or nullptr == rh) return false;
         return opencog::content_eq(lh, rh);
     }
+};
+
+template<>
+struct hash<opencog::HandlePair>
+{
+    typedef std::size_t result_type;
+    typedef opencog::HandlePair argument_type;
+    std::size_t
+    operator()(const opencog::HandlePair& hp) const noexcept
+    { return hash_value(hp.first) + hash_value(hp.second); }
 };
 
 #endif // THIS_USED_TO_WORK_GREAT_BUT_IS_BROKEN_IN_GCC472

--- a/opencog/atomspace/ValuationTable.cc
+++ b/opencog/atomspace/ValuationTable.cc
@@ -91,7 +91,7 @@ ProtoAtomPtr ValuationTable::getValue(const Handle& key, const Handle& atom)
 //
 // XXX FIXME this implementation is ... poor. Its probably just enough
 // to store all keys in use, instead of all keys for a given atom.
-// i.e. this uses too much RAM, and we could get away wtih just
+// i.e. this uses too much RAM, and we could get away with just
 // searching the _vindex, instead, which would be slower but more memory
 // efficient.  The point is that the only user of this function is going
 // to be the peristence framework, and so we should optimize for that.

--- a/opencog/atomspace/ValuationTable.h
+++ b/opencog/atomspace/ValuationTable.h
@@ -52,7 +52,7 @@ private:
 	mutable std::mutex _mtx;
 
 	std::map<std::pair<Handle, Handle>, ValuationPtr> _vindex;
-	std::map<Handle, std::set<Handle>> _keyset;
+	std::unordered_map<Handle, std::set<Handle>> _keyset;
 
 	/**
 	 * Override and declare copy constructor and equals operator as

--- a/opencog/atomspace/ValuationTable.h
+++ b/opencog/atomspace/ValuationTable.h
@@ -51,7 +51,7 @@ private:
 	// Single, global mutex for locking the indexes.
 	mutable std::mutex _mtx;
 
-	std::map<std::pair<Handle, Handle>, ValuationPtr> _vindex;
+	std::unordered_map<HandlePair, ValuationPtr> _vindex;
 	std::unordered_map<Handle, std::set<Handle>> _keyset;
 
 	/**

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
@@ -1534,7 +1534,9 @@ HandleSeq SQLAtomStorage::getIncomingSet(const Handle& h)
 	_num_get_inatoms += iset.size();
 #endif // STORAGE_DEBUG
 
-xxxxxxxxx
+	for (const Handle& hi : iset)
+		get_atom_values(hi);
+
 	return iset;
 }
 

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
@@ -1534,7 +1534,7 @@ HandleSeq SQLAtomStorage::getIncomingSet(const Handle& h)
 	_num_get_inatoms += iset.size();
 #endif // STORAGE_DEBUG
 
-	for (const Handle& hi : iset)
+	for (Handle& hi : iset)
 		get_atom_values(hi);
 
 	return iset;

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
@@ -582,6 +582,7 @@ void SQLAtomStorage::store_atomtable_id(const AtomTable& at)
 /// It also simplifies, ever-so-slightly, the update of valuations.
 void SQLAtomStorage::deleteValuation(const Handle& key, const Handle& atom)
 {
+xxxxxxx
 	char buff[BUFSZ];
 	snprintf(buff, BUFSZ,
 		"SELECT * FROM Valuations WHERE key = %lu AND atom = %lu;",
@@ -1509,13 +1510,7 @@ HandleSeq SQLAtomStorage::getIncomingSet(const Handle& h)
 {
 	HandleSeq iset;
 
-	// Get the correct UUID; its possible that we don't know it yet.
-	UUID uuid = _tlbuf.getUUID(h);
-	if (TLB::INVALID_UUID == uuid)
-	{
-		Handle hg(doGetAtom(h));
-		uuid = _tlbuf.getUUID(hg);
-	}
+	UUID uuid = get_uuid(h);
 
 	char buff[BUFSZ];
 	snprintf(buff, BUFSZ,
@@ -1540,6 +1535,7 @@ HandleSeq SQLAtomStorage::getIncomingSet(const Handle& h)
 	_num_get_inatoms += iset.size();
 #endif // STORAGE_DEBUG
 
+xxxxxxxxx
 	return iset;
 }
 
@@ -1634,21 +1630,6 @@ Handle SQLAtomStorage::getLink(Type t, const HandleSeq& hs)
 	Handle hg(doGetLink(t, hs));
 	if (hg) get_atom_values(hg);
 	return hg;
-}
-
-Handle SQLAtomStorage::doGetAtom(const Handle& h)
-{
-	if (h->isNode())
-	{
-		Handle hg(doGetNode(h->getType(), h->getName().c_str()));
-		return hg;
-	}
-	if (h->isLink())
-	{
-		Handle hg(doGetLink(h->getType(), h->getOutgoingSet()));
-		return hg;
-	}
-	return Handle::UNDEFINED;
 }
 
 /**

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
@@ -582,11 +582,10 @@ void SQLAtomStorage::store_atomtable_id(const AtomTable& at)
 /// It also simplifies, ever-so-slightly, the update of valuations.
 void SQLAtomStorage::deleteValuation(const Handle& key, const Handle& atom)
 {
-xxxxxxx
 	char buff[BUFSZ];
 	snprintf(buff, BUFSZ,
 		"SELECT * FROM Valuations WHERE key = %lu AND atom = %lu;",
-		_tlbuf.getUUID(key), _tlbuf.getUUID(atom));
+		get_uuid(key), get_uuid(atom));
 
 	Response rp(conn_pool);
 	rp.vtype = 0;
@@ -611,7 +610,7 @@ xxxxxxx
 	{
 		snprintf(buff, BUFSZ,
 			"DELETE FROM Valuations WHERE key = %lu AND atom = %lu;",
-			_tlbuf.getUUID(key), _tlbuf.getUUID(atom));
+			get_uuid(key), get_uuid(atom));
 
 		rp.exec(buff);
 	}
@@ -637,10 +636,10 @@ void SQLAtomStorage::storeValuation(const Handle& key,
 
 	// Get UUID from the TLB.
 	char kidbuff[BUFSZ];
-	snprintf(kidbuff, BUFSZ, "%lu", _tlbuf.getUUID(key));
+	snprintf(kidbuff, BUFSZ, "%lu", get_uuid(key));
 
 	char aidbuff[BUFSZ];
-	UUID auid = _tlbuf.getUUID(atom);
+	UUID auid = get_uuid(atom);
 	snprintf(aidbuff, BUFSZ, "%lu", auid);
 
 	// The prior valuation, if any, will be deleted firest,
@@ -760,8 +759,8 @@ ProtoAtomPtr SQLAtomStorage::getValuation(const Handle& key,
 	char buff[BUFSZ];
 	snprintf(buff, BUFSZ,
 		"SELECT * FROM Valuations WHERE key = %lu AND atom = %lu;",
-		_tlbuf.getUUID(key),
-		_tlbuf.getUUID(atom));
+		get_uuid(key),
+		get_uuid(atom));
 
 	return doGetValue(buff);
 }
@@ -921,7 +920,7 @@ void SQLAtomStorage::get_atom_values(Handle& atom)
 	char buff[BUFSZ];
 	snprintf(buff, BUFSZ,
 		"SELECT * FROM Valuations WHERE atom = %lu;",
-		_tlbuf.getUUID(atom));
+		get_uuid(atom));
 
 	Response rp(conn_pool);
 	rp.exec(buff);

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.h
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.h
@@ -91,7 +91,6 @@ class SQLAtomStorage : public AtomStorage
 		PseudoPtr getAtom(const char *, int);
 		PseudoPtr petAtom(UUID);
 
-		Handle doGetAtom(const Handle&);
 		Handle doGetNode(Type, const char *);
 		Handle doGetLink(Type, const HandleSeq&);
 


### PR DESCRIPTION
This contains three distinct fixes:
1) the SQL backend was not fetching values when fetching teh incoming set
2) the valuation table was slow when it got large; switch to over to a hashtable.
3) Minor cleanup of declarations in the Handle class.