### PR TITLE
Improve performance of valuation table by using hash table

### DIFF
--- a/opencog/atoms/base/Handle.h
+++ b/opencog/atoms/base/Handle.h
@@ -154,16 +154,6 @@ bool content_eq(const opencog::Handle& lh,
 //! Boost needs this function to be called by exactly this name.
 std::size_t hash_value(Handle const&);
 
-//! gcc-4.7.2 needs this, because std::hash<opencog::Handle> no longer works.
-//! (See very bottom of this file).
-struct handle_hash : public std::unary_function<Handle, size_t>
-{
-   size_t operator()(const Handle& h) const
-   {
-       return hash_value(h);
-   }
-};
-
 struct handle_less
 {
    bool operator()(const Handle& hl, const Handle& hr) const
@@ -188,7 +178,7 @@ typedef std::set<Handle> OrderedHandleSet;
 typedef std::pair<Handle, Handle> HandlePair;
 
 //! a hash that associates the handle to its unique identificator
-typedef std::unordered_set<Handle, handle_hash> UnorderedHandleSet;
+typedef std::unordered_set<Handle> UnorderedHandleSet;
 
 //! an ordered map from Handle to Handle set
 typedef std::map<Handle, UnorderedHandleSet> HandleMultimap;
@@ -325,9 +315,7 @@ ostream& operator<<(ostream&, const opencog::UnorderedHandleSet&);
 // broke is that it fails to typedef result_type and argument_type,
 // which ... somehow used to work automagically?? It doesn't any more.
 // I have no clue why gcc-4.7.2 broke this, and neither does google or
-// stackoverflow.  You have two choices: use handle_hash, above, or
-// cross your fingers, and hope the definition in the #else clause,
-// below, works.
+// stackoverflow.
 
 template<>
 inline std::size_t

--- a/opencog/atoms/base/Handle.h
+++ b/opencog/atoms/base/Handle.h
@@ -358,6 +358,24 @@ struct hash<opencog::HandlePair>
     { return hash_value(hp.first) + hash_value(hp.second); }
 };
 
+// content-based equality
+template<>
+struct equal_to<opencog::HandlePair>
+{
+    typedef bool result_type;
+    typedef opencog::HandlePair first_argument;
+    typedef opencog::HandlePair second_argument;
+    bool
+    operator()(const opencog::HandlePair& lhp,
+               const opencog::HandlePair& rhp) const noexcept
+    {
+        if (lhp == rhp) return true;
+        std::equal_to<opencog::Handle> eq;
+        return eq.operator()(lhp.first, rhp.first) and
+               eq.operator()(lhp.second, rhp.second);
+    }
+};
+
 #endif // THIS_USED_TO_WORK_GREAT_BUT_IS_BROKEN_IN_GCC472
 
 } // ~namespace std

--- a/opencog/atoms/base/Handle.h
+++ b/opencog/atoms/base/Handle.h
@@ -174,10 +174,7 @@ typedef std::vector<HandleSeq> HandleSeqSeq;
 //! a set of handles
 typedef std::set<Handle> OrderedHandleSet;
 
-//! a pair of handles
-typedef std::pair<Handle, Handle> HandlePair;
-
-//! a hash that associates the handle to its unique identificator
+//! a hash table
 typedef std::unordered_set<Handle> UnorderedHandleSet;
 
 //! an ordered map from Handle to Handle set
@@ -191,9 +188,6 @@ typedef std::vector<HandleMap> HandleMapSeq;
 
 //! a set of ordered handle maps
 typedef std::set<HandleMap> HandleMapSet;
-
-//! a pair of handles
-typedef std::pair<Handle, Handle> HandlePair;
 
 //! a sequence of handle pairs
 typedef std::vector<HandlePair> HandlePairSeq;
@@ -352,6 +346,16 @@ struct equal_to<opencog::Handle>
         if (nullptr == lh or nullptr == rh) return false;
         return opencog::content_eq(lh, rh);
     }
+};
+
+template<>
+struct hash<opencog::HandlePair>
+{
+    typedef std::size_t result_type;
+    typedef opencog::HandlePair argument_type;
+    std::size_t
+    operator()(const opencog::HandlePair& hp) const noexcept
+    { return hash_value(hp.first) + hash_value(hp.second); }
 };
 
 #endif // THIS_USED_TO_WORK_GREAT_BUT_IS_BROKEN_IN_GCC472

--- a/opencog/atomspace/ValuationTable.cc
+++ b/opencog/atomspace/ValuationTable.cc
@@ -91,7 +91,7 @@ ProtoAtomPtr ValuationTable::getValue(const Handle& key, const Handle& atom)
 //
 // XXX FIXME this implementation is ... poor. Its probably just enough
 // to store all keys in use, instead of all keys for a given atom.
-// i.e. this uses too much RAM, and we could get away wtih just
+// i.e. this uses too much RAM, and we could get away with just
 // searching the _vindex, instead, which would be slower but more memory
 // efficient.  The point is that the only user of this function is going
 // to be the peristence framework, and so we should optimize for that.

--- a/opencog/atomspace/ValuationTable.h
+++ b/opencog/atomspace/ValuationTable.h
@@ -52,7 +52,7 @@ private:
 	mutable std::mutex _mtx;
 
 	std::map<std::pair<Handle, Handle>, ValuationPtr> _vindex;
-	std::map<Handle, std::set<Handle>> _keyset;
+	std::unordered_map<Handle, std::set<Handle>> _keyset;
 
 	/**
 	 * Override and declare copy constructor and equals operator as

--- a/opencog/atomspace/ValuationTable.h
+++ b/opencog/atomspace/ValuationTable.h
@@ -51,7 +51,7 @@ private:
 	// Single, global mutex for locking the indexes.
 	mutable std::mutex _mtx;
 
-	std::map<std::pair<Handle, Handle>, ValuationPtr> _vindex;
+	std::unordered_map<HandlePair, ValuationPtr> _vindex;
 	std::unordered_map<Handle, std::set<Handle>> _keyset;
 
 	/**


### PR DESCRIPTION
Switch valuation table from rb-tree to hash table.

Also, some minor cleanup of the Handle class.