### PR TITLE
Bug-fix the incoming-set fetch from SQL function

### DIFF
--- a/opencog/atomspace/AtomSpace.cc
+++ b/opencog/atomspace/AtomSpace.cc
@@ -356,20 +356,17 @@ Handle AtomSpace::fetch_incoming_set(Handle h, bool recursive)
         throw RuntimeException(TRACE_INFO, "No backing store");
 
     h = get_atom(h);
-
-    if (nullptr == h) return Handle::UNDEFINED;
+    if (nullptr == h) return h;
 
     // Get everything from the backing store.
-    HandleSeq iset = _backing_store->getIncomingSet(h);
-    size_t isz = iset.size();
-    for (size_t i=0; i<isz; i++) {
-        Handle hi(iset[i]);
-        if (recursive) {
-            fetch_incoming_set(hi, true);
-        } else {
-            add_atom(hi);
-        }
-    }
+    _backing_store->getIncomingSet(_atom_table, h);
+
+    if (not recursive) return h;
+
+    IncomingSet vh(h->getIncomingSet());
+    for (const LinkPtr& lp : vh)
+        fetch_incoming_set(Handle(lp), true);
+
     return h;
 }
 

--- a/opencog/atomspace/BackingStore.h
+++ b/opencog/atomspace/BackingStore.h
@@ -66,7 +66,7 @@ class BackingStore
 		 * Return a vector containing the handles of the entire incoming
 		 * set of the indicated handle.
 		 */
-		virtual HandleSeq getIncomingSet(const Handle&) const = 0;
+		virtual void getIncomingSet(AtomTable&, const Handle&) = 0;
 
 		/**
 		 * Recursively store the atom and anything in it's outgoing set.

--- a/opencog/persist/README
+++ b/opencog/persist/README
@@ -6,11 +6,9 @@
 The AtomSpace may be converted from its native, in-memory C++ object
 format, into any one of a number of "flattened", non-object formats.
 These formats allow atoms to be sent to and received from remote systems,
-as well as to be saved and restored from disk, file, database, network.
+as well as to be saved and restored from various databases.
 
 Systems include:
-
-file       -- File-based storage. Strongly deprecated. Probably broken.
 
 gearman    -- Experimental support for distributed operation, using
               GearMan.
@@ -36,6 +34,16 @@ currently, needs test cases, and general work to enable/support).
 Note that additional i/o methods can be found in the "visualization"
 directory, which e.g. dump the entire atomspace into various graphics
 formats.
+
+Semantics
+---------
+The correct semantics for the save and restore of values, including
+truth values, an be subtle: during recrusive saves or loads of outgoing
+sets, should values be clobbered? Left untouched? Merged?  The various
+possibilities all have different performance implications, as well as
+usability implications. These are discussed in the README.md file for
+the SQL implementation, and semantics are explicitly tested in the SQL
+unit tests.
 
 
 Future directions:

--- a/opencog/persist/sql/AtomStorage.h
+++ b/opencog/persist/sql/AtomStorage.h
@@ -47,7 +47,7 @@ class AtomStorage
         // AtomStorage interface
         virtual Handle getNode(Type, const char *) = 0;
         virtual Handle getLink(Type, const HandleSeq&) = 0;
-        virtual HandleSeq getIncomingSet(const Handle&) = 0;
+        virtual void getIncomingSet(AtomTable&, const Handle&) = 0;
         virtual void storeAtom(const Handle&, bool synchronous = false) = 0;
         virtual void loadType(AtomTable&, Type) = 0;
         virtual void flushStoreQueue() = 0;

--- a/opencog/persist/sql/README.md
+++ b/opencog/persist/sql/README.md
@@ -188,6 +188,38 @@ pre-fetch has not been implemented.  But that's because pre-fetch is
 easy: the user can do it in their own thread :-)
 
 
+Semantics
+=========
+Exactly what to save, when saving and restoring atoms, is not entirely
+obvious.  The alternatives, and thier implications, are discussed below.
+
+* Saving a single node. Should all associated values be saved? Should
+the user get to pick which values get saved?  Its possible that the user
+only wants to save one particular value, only, so as not to clobber
+other values already in the database.  The current default is to save
+all associated values, when storing a single node.  This is only weakly
+unit-tested.
+
+* Saving a single link. When a link is saved, the outgoing set of the
+link must also be saved. Thus, the above considerations for node-values
+also apply to the outgoing set of the link, and so on, recursively, for
+the nested links.  The current default is to save all associated values,
+on the entire outgoing set, recursively, when storing a single link.
+This is only weakly unit-tested.
+
+The alternative would be to save only the outgoing set atoms, but not
+the values on them.  For the SQL backend, not saving all values could
+decrease the amount of database traffic, and thus improve performance.
+For other backends, this may not be the case, as the increased complexity
+of specifying what, exactly, to save, could really hurt performance.
+
+Its possible that some users may want to save *only* the values on the
+immediate link, but not on any of the outgoing set. There is currently no
+API for this.
+
+
+
+
 Install, Setup and Usage HOWTO
 ==============================
 There are many steps needed to install and use this. Sorry!
@@ -1104,3 +1136,9 @@ TODO
    decrease the SQL table sizes significantly, and decrease server I/O
    by factors of 2x-3x.  Another table, designed just for simple pairs,
    might help a lot, too.
+
+ * Create an API to allow the user to save only seleced values on an
+   atom.
+
+ * Create an API to allow the user to NOT perform the recursive save of
+   values in the outgoing set (of a link).

--- a/opencog/persist/sql/README.md
+++ b/opencog/persist/sql/README.md
@@ -233,22 +233,26 @@ can be fetched from the database: in the first case, all atoms of a
 given type; in the second case, all atoms in the incoming set of a
 given atom.  There are four possibilities here: (a) fetch only the
 atoms, but not any of the associated values. (b) fetch the atoms
-and the associated values, but not the values in the recursive outoging
+and the associated values, but not the values in the recursive outgoing
 sets. (c) fetch the atoms and values, and all atoms and values,
 recursively, in thier outgoing set. (d) fetch the atoms, but update
 the values only if they are atoms are new to the atomspace; i.e. do
 not clobber existing values in the atomsapce.
 
-Currently, option (c) is implemented, and is weakly unit-tested.
-It is plausible that some users may want options (a), (b) or (d).
+Currently, option (b) is implemented, and is weakly unit-tested.
+It is plausible that some users may want options (a), (c) or (d).
 Note that option (d) has several variations.
+
+In the SQL backend, option (b) mostly minimizes the network and database
+traffic.  For other kinds of backends, it might be more efficient to
+implement option (c), and just get all the data in one big gulp.
 
 * Restoring by pattern. This is not implemented, not done.  However,
 one can imagine a situation where a pattern-matcher-like interface
 is provided for the backend, so that only certain values, on certain
 atoms, in certain locations in a given pattern, are fetched.
 
-This is not doen because the pattern matcher is really quite commplex,
+This is not done because the pattern matcher is really quite commplex,
 and it seems kind-of crazy to try to put this in the backend.  There
 currently aren't any plausible scenarios, and plausible algorithms,
 that would need this capability.

--- a/opencog/persist/sql/README.md
+++ b/opencog/persist/sql/README.md
@@ -6,8 +6,8 @@ SQL Persist
 + Status update Dec 2013
 + Status update Jan 2017
 
-A simple implementation of atom persistence in SQL.  This allows not
-only saving and restoring of the atomspace, but it also allows multiple
+An implementation of atom persistence in SQL.  This allows not only
+saving and restoring of the atomspace, but it also allows multiple
 cogservers to share a common set of data.  That is, it implements a
 basic form of a distributed atomspace.
 
@@ -15,23 +15,21 @@ Status
 ======
 It works and has been used with databases containing millions of atoms,
 accessed by cogservers that ran for months to perform computations. It
-has scaled trouble-free, without any slowdown, up to four cogservers.
+has scaled, trouble-free, without any slowdown, up to four cogservers.
 No one has tried anything larger than that, yet.
 
 Features
 --------
- * Save and restore of individual atoms, and several kinds of truth values.
+ * Save and restore of individual atoms and values.
  * Bulk save-and-restore of entire AtomSpace contents.
- * Incremental save/restore (i.e. update the SQL contents as AtomSpace
-   changes).
  * Generic API, useful for inter-server communications.
 
 Missing features/ToDo items
 ---------------------------
+ * Clarify value save/restore semantics.
  * Add support for multiple atom spaces.
  * Provide optimized table layout for EvaluationLinks.
  * Add support for Space/TimeServer data.
- * Implement ProtoAtom storage.
  * See also TODO list at very bottom.
 
 Performance status
@@ -85,24 +83,51 @@ The goal of this implementation is to:
    strength of the current design is supposed to be simplicity, not
    scalability or raw performance.
 
-4) A non-design-goal (at this time) is to build a system that can scale
+4) Provide a reference implementation for save and restore semantics.
+   When saving or fetching outgoing sets, there are several choices
+   of how to handle the associated values: these can also be saved
+   or fetched, clobbering the atomspace contents, or some more
+   fine-grained control can be provided.  The choices have both
+   usability and performance implications. The choices are discussed
+   in a separate section, below.
+
+5) Discover the most minimal, simplest backingstore API. This API is
+   the API between the AtomSpace, and the persistance backend.  The
+   reason for keeping it as simple as possible is to minimize the work
+   needed to create other backends, as well as all the standard software
+   development reasons: lower complexity means fewer bugs and better
+   performance.  Lower complexity means the code is easier to understand
+   and use correctly.
+
+6) A non-design-goal (at this time) is to build a system that can scale
    to more than 100 cogserver instances.  The current design might be
    able to scale to this many, but probably not much more.  Scaling
    larger than this would probably require a fundamental redesign of
    all of opencog, starting with the atomspace.
 
-5) A non-design-goal is fully automatic save-restore of atoms.  Both
-   the save and restore of atoms must be triggered by calls to the
-   atomspace API.  The reason for this design point is that the
-   atomspace is at too low a level to be fully automatic.  It cannot
-   guess what the user really wants to do.  If it did guess, it would
-   probably guess wrong: saving atoms before the user is done with them,
-   saving atoms that get deleted microseconds later, fetching atoms
-   that the user is completely disinterested in, clogging up RAM and
-   wasting CPU time.  Some other layer, a higher level layer, needs to
-   implement a policy for save/restore.  This layer only provides a
-   mechanism.  It would be very very wrong to implement an automatic
-   policy at this layer.
+7) A non-design-goal is fully automatic save-restore of atoms.  The
+   save and restore of atoms are performed under the explicit control
+   by user-written code, invoking the save/restore API. There is no
+   automation. Control is in the user's hands.
+
+   The reason for this design point is that the atomspace is at too low
+   a level to be fully automatic.  It cannot guess what the user really
+   wants to do.  If it did try to guess, it would probably guess wrong:
+   saving atoms before the user is done with them, saving atoms that get
+   deleted microseconds later, fetching atoms that the user is completely
+   disinterested in, clogging up RAM and wasting CPU time.  The policy
+   for what to save, and when, needs to be left in control of the user
+   algorithms.
+
+   This layer only provides a mechanism.  It would be very very wrong to
+   implement an automatic policy at this layer.
+
+8) A fundamental non-goal is to provide any sort of generic object
+   persistence.  The code here is meant only to save and restore atoms
+   and values, and not generic C++ objects. The design of the AtomSpace
+   has been carefully crafted to provide two classes of objects: the
+   immutable, globally unique atoms, and the mutable valuations
+   associated to atoms.  This backend mirrors this functional split.
 
 
 Current Design
@@ -110,25 +135,14 @@ Current Design
 The core design defines only a few very simple SQL tables, and some
 readers and writers to save and restore atoms from an SQL database.
 
-Note that the core design does *not* make use of object reflection,
-nor can it store arbitrary kinds of objects. It is very definitely
-hard-wired. Yes, this can be considered to be a short-coming.
-A more general, persistent object framework (for C) can be found
-at http://estron.alioth.debian.org/  However, simplicity, at the
-cost of missing flexibility, seems more important.
-
 The current design can save/restore individual atoms, and it can
-bulk-save/bulk-restore the entire contents of an AtomTable.
-A semi-realized goal of the prototype is to implement incremental save
-and restore -- that is, to fetch atoms in a "just in time" fashion, and
-to save away atoms that are not needed in RAM (e.g. atoms with
-low/non-existent attention values). The AtomSpace BackingStore provides
-the current, minimalistic, low-function API for this.
+bulk-save/bulk-restore the entire contents of the AtomSpace. The above
+listed goals seem to be met, more or less.
 
 Features
 --------
- * The AtomStorage class is thread-safe, according to the unit tests
-and limited personal experience.
+ * The AtomStorage class is thread-safe, and multi-threaded use is
+tested in several unit tests.
 
  * Fully automated mapping of in-RAM atoms to in-storage universal
 unique identifiers (UUID's), using the TLB mechanism.
@@ -141,14 +155,14 @@ There is existing infrastructure that enables this, e.g. one can
 "malloc" ranges of UUID's.  The code has bit-rotted, for lack of use.
 
  * This implementation automatically handles clashing atom types.  That
-is, if the database is written with one set of atom types, and then the
+is, if the data is written with one set of atom types, and then the
 cogserver is stopped, the atomtypes are all changed (with some added,
-some deleted), then pulling from the database will automatically
-translate and use the new atom types. (The deleted atom types will not
-be removed from the database.  Restoring atoms with deleted atomtypes
-will cause an exception to be thrown.)
+some deleted), then during the load of the old data, the types will
+be automatically translated to use the new atom types. (The deleted
+atom types will not be removed from the database.  Restoring atoms with
+deleted atomtypes will cause an exception to be thrown.)
 
- * Non-blocking atom store requests are implemented.  Four asynchronous
+ * Non-blocking atom store requests are implemented.  Eight asynchronous
 write-back threads are used, with hi/lo watermarks for queue management.
 That is, if a user asks that an atom be stored, then the atom will be
 queued for storage, and one of these threads will perform the actual
@@ -159,11 +173,14 @@ full; in that case, the user will be blocked until the queue drains
 below the low watermark. The number of connections can be raised by
 editing the AtomStorage constructor, and recompiling.
 
-The fire-n-forget algo is implemented in the C++
+This fire-n-forget queue management algo is implemented in the C++
 `AtomStorage::storeAtom()` method.  If the backlog of unwritten atoms
 gets too large, the storeAtom() method may stall. Its currently designed
 to stall if there's a backlog of 100 or more unwritten atoms.  This can
 be changed by searching for `HIGH_WATER_MARK`, changing it and recompiling.
+
+Queue performance statistics can be printed with the `(sql-stats)`
+scheme command.
 
  * Reading always blocks: if the user asks for an atom, the call will
 not return to the user until the atom is available.  At this time,

--- a/opencog/persist/sql/README.md
+++ b/opencog/persist/sql/README.md
@@ -198,7 +198,8 @@ the user get to pick which values get saved?  Its possible that the user
 only wants to save one particular value, only, so as not to clobber
 other values already in the database.  The current default is to save
 all associated values, when storing a single node.  This is only weakly
-unit-tested.
+unit-tested; the tests are not thorough, and do not check all possible
+permuations.
 
 * Saving a single link. When a link is saved, the outgoing set of the
 link must also be saved. Thus, the above considerations for node-values
@@ -217,6 +218,40 @@ Its possible that some users may want to save *only* the values on the
 immediate link, but not on any of the outgoing set. There is currently no
 API for this.
 
+* Restoring a single node or link. The above considerations for saving
+run in the opposite direction, when restoring. Thus, for example, when
+restoring a single node, should all associated values in the AtomSpace
+be clobbered, or not?
+
+Currently, when an atom is restored, all of the associated values are
+pulled from the database, and placed in the AtomSpace, clobbering the
+previous AtomSpace contents.  This is done recursively, for links.
+This is tested, but only weakly and incompletely, in the unit tests.
+
+* Restoring by atom type; restoring incoming sets.  Groups of atoms
+can be fetched from the database: in the first case, all atoms of a
+given type; in the second case, all atoms in the incoming set of a
+given atom.  There are four possibilities here: (a) fetch only the
+atoms, but not any of the associated values. (b) fetch the atoms
+and the associated values, but not the values in the recursive outoging
+sets. (c) fetch the atoms and values, and all atoms and values,
+recursively, in thier outgoing set. (d) fetch the atoms, but update
+the values only if they are atoms are new to the atomspace; i.e. do
+not clobber existing values in the atomsapce.
+
+Currently, option (c) is implemented, and is weakly unit-tested.
+It is plausible that some users may want options (a), (b) or (d).
+Note that option (d) has several variations.
+
+* Restoring by pattern. This is not implemented, not done.  However,
+one can imagine a situation where a pattern-matcher-like interface
+is provided for the backend, so that only certain values, on certain
+atoms, in certain locations in a given pattern, are fetched.
+
+This is not doen because the pattern matcher is really quite commplex,
+and it seems kind-of crazy to try to put this in the backend.  There
+currently aren't any plausible scenarios, and plausible algorithms,
+that would need this capability.
 
 
 
@@ -1137,8 +1172,19 @@ TODO
    by factors of 2x-3x.  Another table, designed just for simple pairs,
    might help a lot, too.
 
- * Create an API to allow the user to save only seleced values on an
+ * Create an API to allow the user to save only selected values on an
    atom.
 
  * Create an API to allow the user to NOT perform the recursive save of
-   values in the outgoing set (of a link).
+   all values in the outgoing set (of a link).
+
+ * Create an API to allow the user to restore only selected values on an
+   atom.
+
+ * Create an API to allow the user to NOT perform the recursive restore
+   of all values in the outgoing set (of a link).
+
+ * Create an API that provides fine-grained control over what values
+   are fetched, when fetching atoms by type, or by incoming set.  See
+   the section entitles "Semantics", above, for the various different
+   options.

--- a/opencog/persist/sql/SQLBackingStore.cc
+++ b/opencog/persist/sql/SQLBackingStore.cc
@@ -49,9 +49,9 @@ Handle SQLBackingStore::getLink(Type t, const HandleSeq& hs) const
 	return _store->getLink(t, hs);
 }
 
-HandleSeq SQLBackingStore::getIncomingSet(const Handle& h) const
+void SQLBackingStore::getIncomingSet(AtomTable& table, const Handle& h)
 {
-	return _store->getIncomingSet(h);
+	_store->getIncomingSet(table, h);
 }
 
 void SQLBackingStore::storeAtom(const Handle& h)

--- a/opencog/persist/sql/SQLBackingStore.h
+++ b/opencog/persist/sql/SQLBackingStore.h
@@ -55,9 +55,9 @@ class SQLBackingStore : public BackingStore
 
         virtual Handle getNode(Type, const char *) const;
         virtual Handle getLink(Type, const HandleSeq&) const;
-        virtual HandleSeq getIncomingSet(const Handle&) const;
         virtual void storeAtom(const Handle&);
         virtual void loadType(AtomTable&, Type);
+        virtual void getIncomingSet(AtomTable&, const Handle&);
         virtual void barrier();
 
         void registerWith(AtomSpace*);

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
@@ -1388,7 +1388,7 @@ Handle SQLAtomStorage::get_recursive_if_not_exists(PseudoPtr p)
 /**
  * Retreive the entire incoming set of the indicated atom.
  */
-HandleSeq SQLAtomStorage::getIncomingSet(const Handle& h)
+void SQLAtomStorage::getIncomingSet(AtomTable& table, const Handle& h)
 {
 	UUID uuid = get_uuid(h);
 
@@ -1420,6 +1420,7 @@ HandleSeq SQLAtomStorage::getIncomingSet(const Handle& h)
 		[&] (const PseudoPtr& p)
 	{
 		Handle hi(get_recursive_if_not_exists(p));
+		hi = table.add(hi, false);
 		get_atom_values(hi);
 		std::lock_guard<std::mutex> lck(iset_mutex);
 		iset.emplace_back(hi);
@@ -1429,8 +1430,6 @@ HandleSeq SQLAtomStorage::getIncomingSet(const Handle& h)
 	_num_get_insets++;
 	_num_get_inlinks += iset.size();
 #endif // STORAGE_DEBUG
-
-	return iset;
 }
 
 /**

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
@@ -170,8 +170,8 @@ class SQLAtomStorage::Response
 			return false;
 		}
 
-		// Load an atom into the atom table. Clobber (don't merge)
-		// the truth values.
+		// Load an atom into the atom table. Fetch all values on the
+		// atom, but NOT on its outgoing set!
 		bool load_if_not_exists_cb(void)
 		{
 			// printf ("---- New atom found ----\n");
@@ -188,8 +188,9 @@ class SQLAtomStorage::Response
 					h = table->add(atom, false);
 					store->_tlbuf.addAtom(h, uuid);
 				}
-				// Clobber all values, including truth values.
 			}
+
+			// Clobber all values, including truth values.
 			store->get_atom_values(h);
 			return false;
 		}
@@ -1354,6 +1355,8 @@ SQLAtomStorage::PseudoPtr SQLAtomStorage::petAtom(UUID uuid)
 /// When adding links of unknown provenance, it could happen that
 /// the outgoing set of the link has not yet been loaded.  In
 /// that case, we have to load the outgoing set first.
+///
+/// Note that this does NOT fetch any values!
 Handle SQLAtomStorage::get_recursive_if_not_exists(PseudoPtr p)
 {
 	if (classserver().isA(p->type, NODE))

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
@@ -1013,10 +1013,9 @@ void SQLAtomStorage::flushStoreQueue()
 
 /* ================================================================ */
 /**
- * Recursively store the indicated atom, and all that it points to.
- * Store its truth values too. The recursive store is unconditional;
- * its assumed that all sorts of underlying truuth values have changed,
- * so that the whole thing needs to be stored.
+ * Recursively store the indicated atom and all of the values attached
+ * to it.  Also store it's outgoing set, and all of the values attached
+ * to those atoms.  The recursive store is unconditional.
  *
  * By default, the actual store is done asynchronously (in a different
  * thread); this routine merely queues up the atom. If the synchronous
@@ -1037,6 +1036,7 @@ void SQLAtomStorage::storeAtom(const Handle& h, bool synchronous)
 /**
  * Synchronously store a single atom. That is, the actual store is done
  * in the calling thread.  All values attached to the atom are also
+ * stored. All values attached to atoms in the outgoing set are also
  * stored.
  *
  * Returns the height of the atom.

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.h
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.h
@@ -210,7 +210,7 @@ class SQLAtomStorage : public AtomStorage
 		// AtomStorage interface
 		Handle getNode(Type, const char *);
 		Handle getLink(Type, const HandleSeq&);
-		HandleSeq getIncomingSet(const Handle&);
+		void getIncomingSet(AtomTable&, const Handle&);
 		void storeAtom(const Handle&, bool synchronous = false);
 		void loadType(AtomTable&, Type);
 		void flushStoreQueue();

--- a/opencog/persist/zmq/atomspace/ZMQClient.cc
+++ b/opencog/persist/zmq/atomspace/ZMQClient.cc
@@ -161,11 +161,9 @@ void ZMQClient::load(AtomTable &table) {
 /**
  * Retrieve the entire incoming set of the indicated atom.
  */
-HandleSeq ZMQClient::getIncomingSet(const Handle& h)
+void ZMQClient::getIncomingSet(AtomTable& table, const Handle& h)
 {
 	// TODO: implement
-	HandleSeq handles;
-	return handles;
 }
 
 /**

--- a/opencog/persist/zmq/atomspace/ZMQClient.h
+++ b/opencog/persist/zmq/atomspace/ZMQClient.h
@@ -79,13 +79,13 @@ class ZMQClient
 
 		// Fetch atoms from DB
 		AtomPtr getAtom(UUID);
-		HandleSeq getIncomingSet(const Handle& );
 		Handle getNode(Type, const char *);
 		Handle getLink(Type, const HandleSeq&);
 
 		// Large-scale loads and saves
 		void loadType(AtomTable &, Type); // Load *all* atoms of type
 		void load(AtomTable &); // Load entire contents of DB
+		void getIncomingSet(AtomTable&, const Handle& );
 		void store(const AtomTable &); // Store entire contents of AtomTable
 		void reserve(void);     // reserve range of UUID's
 

--- a/opencog/persist/zmq/atomspace/ZMQPersistSCM.cc
+++ b/opencog/persist/zmq/atomspace/ZMQPersistSCM.cc
@@ -48,9 +48,9 @@ class ZMQBackingStore : public BackingStore
 		virtual Handle getNode(Type, const char *) const;
 		virtual Handle getLink(Type, const HandleSeq&) const;
 		virtual AtomPtr getAtom(UUID) const;
-		virtual HandleSeq getIncomingSet(const Handle&) const;
 		virtual void storeAtom(const Handle&);
 		virtual void loadType(AtomTable&, Type);
+		virtual void getIncomingSet(AtomTable&, const Handle&);
 		virtual void barrier();
 };
 
@@ -82,9 +82,9 @@ AtomPtr ZMQBackingStore::getAtom(UUID uuid) const
 	return _store->getAtom(uuid);
 }
 
-HandleSeq ZMQBackingStore::getIncomingSet(const Handle& h) const
+void ZMQBackingStore::getIncomingSet(AtomTable& table, const Handle& h)
 {
-	return _store->getIncomingSet(h);
+	_store->getIncomingSet(table, h);
 }
 
 void ZMQBackingStore::storeAtom(const Handle& h)

--- a/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
@@ -662,8 +662,8 @@ void ValueSaveUTest::do_test_link_by_type()
 
 	Handle gbf = as->add_node(CONCEPT_NODE, "b float node");
 	Handle gbt = as->add_node(CONCEPT_NODE, "b string node");
-	Handle gbl = as->add_node(CONCEPT_NODE, "b link depth-1 node");
-	Handle gbv = as->add_node(CONCEPT_NODE, "b link depth-2 node");
+	Handle gbl = as->add_node(CONCEPT_NODE, "b depth-1 node");
+	Handle gbv = as->add_node(CONCEPT_NODE, "b depth-2 node");
 
 	Handle gcf = as->add_link(LIST_LINK, {gaf, gbf});
 	Handle gct = as->add_link(LIST_LINK, {gat, gbt});

--- a/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
@@ -469,6 +469,7 @@ void ValueSaveUTest::do_test_load_by_type()
 	// Fetch by type. This is what we are testing.
 	as->fetch_all_atoms_of_type(CONCEPT_NODE);
 
+	Handle gkey = as->add_node(PREDICATE_NODE, "some pred key");
 	Handle gaf = as->add_node(CONCEPT_NODE, "float node");
 	Handle gat = as->add_node(CONCEPT_NODE, "string node");
 	Handle gal = as->add_node(CONCEPT_NODE, "link depth-1 node");
@@ -489,10 +490,10 @@ void ValueSaveUTest::do_test_load_by_type()
 	TS_ASSERT(*gtl == *tl);
 	TS_ASSERT(*gtv == *tv);
 
-	ProtoAtomPtr gpf = gaf->getValue(key);
-	ProtoAtomPtr gpt = gat->getValue(key);
-	ProtoAtomPtr gpl = gal->getValue(key);
-	ProtoAtomPtr gpv = gav->getValue(key);
+	ProtoAtomPtr gpf = gaf->getValue(gkey);
+	ProtoAtomPtr gpt = gat->getValue(gkey);
+	ProtoAtomPtr gpl = gal->getValue(gkey);
+	ProtoAtomPtr gpv = gav->getValue(gkey);
 
 	TS_ASSERT(*gpf == *pvf);
 	TS_ASSERT(*gpt == *pvt);

--- a/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
@@ -556,50 +556,78 @@ void ValueSaveUTest::do_test_link_by_type()
 	backing->registerWith(as);
 
 	Handle key = as->add_node(PREDICATE_NODE, "some pred key");
-	Handle af = as->add_node(CONCEPT_NODE, "float node");
-	Handle at = as->add_node(CONCEPT_NODE, "string node");
-	Handle al = as->add_node(CONCEPT_NODE, "link depth-1 node");
-	Handle av = as->add_node(CONCEPT_NODE, "link depth-2 node");
+	Handle af = as->add_node(CONCEPT_NODE, "a float node");
+	Handle at = as->add_node(CONCEPT_NODE, "a string node");
+	Handle al = as->add_node(CONCEPT_NODE, "a depth-1 node");
+	Handle av = as->add_node(CONCEPT_NODE, "a depth-2 node");
+
+	Handle bf = as->add_node(CONCEPT_NODE, "b float node");
+	Handle bt = as->add_node(CONCEPT_NODE, "b string node");
+	Handle bl = as->add_node(CONCEPT_NODE, "b depth-1 node");
+	Handle bv = as->add_node(CONCEPT_NODE, "b depth-2 node");
+
+	Handle cf = as->add_link(LIST_LINK, {af, bf});
+	Handle ct = as->add_link(LIST_LINK, {at, bt});
+	Handle cl = as->add_link(LIST_LINK, {al, bl});
+	Handle cv = as->add_link(LIST_LINK, {av, bv});
 
 	// --------------------
 	// Now set some values
 	ProtoAtomPtr pvf = createFloatValue(
 		std::vector<double>({1.14, 2.24, 3.34}));
 	af->setValue(key, pvf);
+	bf->setValue(key, pvf);
+	cf->setValue(key, pvf);
 
 	TruthValuePtr tf(SimpleTruthValue::createTV(0.11, 100));
 	af->setTruthValue(tf);
+	bf->setTruthValue(tf);
+	cf->setTruthValue(tf);
 
 	// --------------------
 	ProtoAtomPtr pvt = createStringValue(
 		std::vector<std::string>({"aaa", "bb bb bb", "ccc ccc ccc"}));
 	at->setValue(key, pvt);
+	bt->setValue(key, pvt);
+	ct->setValue(key, pvt);
 
 	TruthValuePtr tt(SimpleTruthValue::createTV(0.22, 200));
 	at->setTruthValue(tt);
+	bt->setTruthValue(tt);
+	ct->setTruthValue(tt);
 
 	// --------------------
 	ProtoAtomPtr pvl = createLinkValue(
 		std::vector<ProtoAtomPtr>({pvf, pvt}));
 	al->setValue(key, pvl);
+	bl->setValue(key, pvl);
+	cl->setValue(key, pvl);
 
 	TruthValuePtr tl(SimpleTruthValue::createTV(0.33, 300));
 	al->setTruthValue(tl);
+	bl->setTruthValue(tl);
+	cl->setTruthValue(tl);
 
 	// --------------------
 	ProtoAtomPtr pvv = createLinkValue(
 		std::vector<ProtoAtomPtr>({pvl, pvl, pvf, pvt}));
 	av->setValue(key, pvv);
+	bv->setValue(key, pvv);
+	cv->setValue(key, pvv);
 
 	TruthValuePtr tv(SimpleTruthValue::createTV(0.44, 400));
 	av->setTruthValue(tv);
+	bv->setTruthValue(tv);
+	cv->setTruthValue(tv);
 
 	// --------------------
 	// Save, and close things down.
-	as->store_atom(af);
-	as->store_atom(at);
-	as->store_atom(al);
-	as->store_atom(av);
+	// Note that this store will also *recursively* store the
+	// values on the outgoing atoms, as well.
+	as->store_atom(cf);
+	as->store_atom(ct);
+	as->store_atom(cl);
+	as->store_atom(cv);
 	as->barrier();
 
 	delete as;
@@ -619,33 +647,90 @@ void ValueSaveUTest::do_test_link_by_type()
 
 	// --------------------
 	// Fetch by type. This is what we are testing.
-	as->fetch_all_atoms_of_type(CONCEPT_NODE);
 
 	Handle gkey = as->add_node(PREDICATE_NODE, "some pred key");
-	Handle gaf = as->add_node(CONCEPT_NODE, "float node");
-	Handle gat = as->add_node(CONCEPT_NODE, "string node");
-	Handle gal = as->add_node(CONCEPT_NODE, "link depth-1 node");
-	Handle gav = as->add_node(CONCEPT_NODE, "link depth-2 node");
+	Handle gaf = as->add_node(CONCEPT_NODE, "a float node");
+	Handle gat = as->add_node(CONCEPT_NODE, "a string node");
+	Handle gal = as->add_node(CONCEPT_NODE, "a depth-1 node");
+	Handle gav = as->add_node(CONCEPT_NODE, "a depth-2 node");
 
-	TS_ASSERT(*gaf == *af);
-	TS_ASSERT(*gat == *at);
-	TS_ASSERT(*gal == *al);
-	TS_ASSERT(*gav == *av);
+	// Note that the A-nodes above are added *before* the fetch;
+	// therefore, the fetch should NOT clobber the values there.
+	// However, the values on the B-nodes and the C-links should
+	// be fetched.
+	as->fetch_all_atoms_of_type(CONCEPT_NODE);
+
+	Handle gbf = as->add_node(CONCEPT_NODE, "b float node");
+	Handle gbt = as->add_node(CONCEPT_NODE, "b string node");
+	Handle gbl = as->add_node(CONCEPT_NODE, "b link depth-1 node");
+	Handle gbv = as->add_node(CONCEPT_NODE, "b link depth-2 node");
+
+	Handle gcf = as->add_link(LIST_LINK, {gaf, gbf});
+	Handle gct = as->add_link(LIST_LINK, {gat, gbt});
+	Handle gcl = as->add_link(LIST_LINK, {gal, gbl});
+	Handle gcv = as->add_link(LIST_LINK, {gav, gbv});
+
+	TS_ASSERT(*gcf == *cf);
+	TS_ASSERT(*gct == *ct);
+	TS_ASSERT(*gcl == *cl);
+	TS_ASSERT(*gcv == *cv);
 
 	TruthValuePtr gtf = gaf->getTruthValue();
 	TruthValuePtr gtt = gat->getTruthValue();
 	TruthValuePtr gtl = gal->getTruthValue();
 	TruthValuePtr gtv = gav->getTruthValue();
 
+	TS_ASSERT(*gtf == *TruthValue::DEFAULT_TV());
+	TS_ASSERT(*gtt == *TruthValue::DEFAULT_TV());
+	TS_ASSERT(*gtl == *TruthValue::DEFAULT_TV());
+	TS_ASSERT(*gtv == *TruthValue::DEFAULT_TV());
+
+	gtf = gbf->getTruthValue();
+	gtt = gbt->getTruthValue();
+	gtl = gbl->getTruthValue();
+	gtv = gbv->getTruthValue();
+
 	TS_ASSERT(*gtf == *tf);
 	TS_ASSERT(*gtt == *tt);
 	TS_ASSERT(*gtl == *tl);
 	TS_ASSERT(*gtv == *tv);
 
+	gtf = gcf->getTruthValue();
+	gtt = gct->getTruthValue();
+	gtl = gcl->getTruthValue();
+	gtv = gcv->getTruthValue();
+
+	TS_ASSERT(*gtf == *tf);
+	TS_ASSERT(*gtt == *tt);
+	TS_ASSERT(*gtl == *tl);
+	TS_ASSERT(*gtv == *tv);
+
+	// --------------------
+
 	ProtoAtomPtr gpf = gaf->getValue(gkey);
 	ProtoAtomPtr gpt = gat->getValue(gkey);
 	ProtoAtomPtr gpl = gal->getValue(gkey);
 	ProtoAtomPtr gpv = gav->getValue(gkey);
+
+	TS_ASSERT(*gpf == *pvf);
+	TS_ASSERT(*gpt == *pvt);
+	TS_ASSERT(*gpl == *pvl);
+	TS_ASSERT(*gpv == *pvv);
+
+	gpf = gbf->getValue(gkey);
+	gpt = gbt->getValue(gkey);
+	gpl = gbl->getValue(gkey);
+	gpv = gbv->getValue(gkey);
+
+	TS_ASSERT(*gpf == *pvf);
+	TS_ASSERT(*gpt == *pvt);
+	TS_ASSERT(*gpl == *pvl);
+	TS_ASSERT(*gpv == *pvv);
+
+	gpf = gcf->getValue(gkey);
+	gpt = gct->getValue(gkey);
+	gpl = gcl->getValue(gkey);
+	gpv = gcv->getValue(gkey);
 
 	TS_ASSERT(*gpf == *pvf);
 	TS_ASSERT(*gpt == *pvt);

--- a/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
@@ -119,12 +119,16 @@ class ValueSaveUTest :  public CxxTest::TestSuite
         void do_test_single_atom_save();
         void do_test_save_restore(bool);
         void check_one(ProtoAtomPtr, bool);
+        void do_test_load_by_type();
 
         void test_odbc_single_atom_save();
         void test_pq_single_atom_save();
 
         void test_odbc_save_restore();
         void test_pq_save_restore();
+
+        void test_odbc_load_by_type();
+        void test_pq_load_by_type();
 };
 
 /*
@@ -176,9 +180,31 @@ void ValueSaveUTest::test_pq_save_restore(void)
 	logger().debug("END TEST: %s", __FUNCTION__);
 }
 
+void ValueSaveUTest::test_odbc_load_by_type(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+#if HAVE_ODBC_STORAGE
+	uri = mkuri("odbc", dbname, username, passwd);
+	do_test_load_by_type();
+#endif
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+void ValueSaveUTest::test_pq_load_by_type(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+#if HAVE_PGSQL_STORAGE
+	uri = mkuri("postgres", dbname, username, passwd);
+	do_test_load_by_type();
+#endif // HAVE_PGSQL_STORAGE
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
 // ============================================================
 /**
  * A simple test case that tests the saving of various values.
+ * Test passes if the save succeeds; the accuracy of the save
+ * is not tested (i.e. there's no restore; that's in the next test.
  */
 void ValueSaveUTest::do_test_single_atom_save()
 {
@@ -289,8 +315,8 @@ void ValueSaveUTest::check_one(ProtoAtomPtr pap, bool fetchkey)
 	backing->set_store(store);
 	backing->registerWith(as);
 
-	// Storage uses a different code path if the key is not
-	// yet known when the values are fethed.  Test this code path.
+	// Storage uses a different code path if the key is not yet
+	// known when the values are fetched.  Test this code path.
 	if (fetchkey) key = as->fetch_atom(bkey);
 	atom = as->fetch_atom(batom);
 
@@ -358,6 +384,12 @@ void ValueSaveUTest::do_test_save_restore(bool fkey)
 	delete as;
 	delete backing;
 	delete store;
+}
+
+// ============================================================
+
+void ValueSaveUTest::do_test_load_by_type()
+{
 }
 
 /* ============================= END OF FILE ================= */

--- a/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
@@ -40,6 +40,8 @@
 #include <opencog/atoms/base/StringValue.h>
 #include <opencog/atoms/base/Valuation.h>
 
+#include <opencog/truthvalue/SimpleTruthValue.h>
+
 #include <opencog/persist/sql/SQLBackingStore.h>
 #include <opencog/persist/sql/multi-driver/SQLAtomStorage.h>
 
@@ -403,7 +405,7 @@ void ValueSaveUTest::do_test_load_by_type()
 
 	Handle key = as->add_node(PREDICATE_NODE, "some pred key");
 	Handle af = as->add_node(CONCEPT_NODE, "float node");
-	Handle as = as->add_node(CONCEPT_NODE, "string node");
+	Handle at = as->add_node(CONCEPT_NODE, "string node");
 	Handle al = as->add_node(CONCEPT_NODE, "link depth-1 node");
 	Handle av = as->add_node(CONCEPT_NODE, "link depth-2 node");
 
@@ -411,28 +413,71 @@ void ValueSaveUTest::do_test_load_by_type()
 	// Now set some values
 	ProtoAtomPtr pvf = createFloatValue(
 		std::vector<double>({1.14, 2.24, 3.34}));
-	af->setValue(pvf);
+	af->setValue(key, pvf);
+
+	TruthValuePtr tf(SimpleTruthValue::createTV(0.11, 100));
+	af->setTruthValue(tf);
 
 	// --------------------
 	ProtoAtomPtr pvs = createStringValue(
 		std::vector<std::string>({"aaa", "bb bb bb", "ccc ccc ccc"}));
-	as->setValue(pvs);
+	at->setValue(key, pvs);
+
+	TruthValuePtr ts(SimpleTruthValue::createTV(0.22, 200));
+	at->setTruthValue(ts);
 
 	// --------------------
 	ProtoAtomPtr pvl = createLinkValue(
 		std::vector<ProtoAtomPtr>({pvf, pvs}));
-	al->setValue(pvl);
+	al->setValue(key, pvl);
+
+	TruthValuePtr tl(SimpleTruthValue::createTV(0.33, 300));
+	al->setTruthValue(tl);
 
 	// --------------------
 	ProtoAtomPtr pvl2 = createLinkValue(
 		std::vector<ProtoAtomPtr>({pvl, pvl, pvf, pvs}));
-	av->setValue(pvl2);
+	av->setValue(key, pvl2);
 
+	TruthValuePtr tv(SimpleTruthValue::createTV(0.44, 400));
+	av->setTruthValue(tv);
+
+	// --------------------
+	// Save, and close things down.
 	as->store_atom(af);
-	as->store_atom(as);
+	as->store_atom(at);
 	as->store_atom(al);
 	as->store_atom(av);
 	as->barrier();
+
+	delete as;
+	delete backing;
+	delete store;
+
+	// --------------------
+	// Start it up again.
+
+	store = new SQLAtomStorage(uri);
+	TS_ASSERT(store->connected())
+
+	as = new AtomSpace();
+	backing = new SQLBackingStore();
+	backing->set_store(store);
+	backing->registerWith(as);
+
+	// --------------------
+	// Fetch by type. This is what we are testing.
+	as->fetch_all_atoms_of_type(CONCEPT_NODE);
+
+	Handle faf = as->add_node(CONCEPT_NODE, "float node");
+	Handle fat = as->add_node(CONCEPT_NODE, "string node");
+	Handle fal = as->add_node(CONCEPT_NODE, "link depth-1 node");
+	Handle fav = as->add_node(CONCEPT_NODE, "link depth-2 node");
+
+	TS_ASSERT(faf == af);
+	TS_ASSERT(fat == at);
+	TS_ASSERT(fal == al);
+	TS_ASSERT(fav == av);
 
 	// --------------------
 	store->kill_data();

--- a/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
@@ -390,6 +390,55 @@ void ValueSaveUTest::do_test_save_restore(bool fkey)
 
 void ValueSaveUTest::do_test_load_by_type()
 {
+	SQLAtomStorage *store = new SQLAtomStorage(uri);
+	TS_ASSERT(store->connected())
+
+	// Clear out left-over junk, just in case.
+	store->kill_data();
+
+	AtomSpace* as = new AtomSpace();
+	SQLBackingStore* backing = new SQLBackingStore();
+	backing->set_store(store);
+	backing->registerWith(as);
+
+	Handle key = as->add_node(PREDICATE_NODE, "some pred key");
+	Handle af = as->add_node(CONCEPT_NODE, "float node");
+	Handle as = as->add_node(CONCEPT_NODE, "string node");
+	Handle al = as->add_node(CONCEPT_NODE, "link depth-1 node");
+	Handle av = as->add_node(CONCEPT_NODE, "link depth-2 node");
+
+	// --------------------
+	// Now set some values
+	ProtoAtomPtr pvf = createFloatValue(
+		std::vector<double>({1.14, 2.24, 3.34}));
+	af->setValue(pvf);
+
+	// --------------------
+	ProtoAtomPtr pvs = createStringValue(
+		std::vector<std::string>({"aaa", "bb bb bb", "ccc ccc ccc"}));
+	as->setValue(pvs);
+
+	// --------------------
+	ProtoAtomPtr pvl = createLinkValue(
+		std::vector<ProtoAtomPtr>({pvf, pvs}));
+	al->setValue(pvl);
+
+	// --------------------
+	ProtoAtomPtr pvl2 = createLinkValue(
+		std::vector<ProtoAtomPtr>({pvl, pvl, pvf, pvs}));
+	av->setValue(pvl2);
+
+	as->store_atom(af);
+	as->store_atom(as);
+	as->store_atom(al);
+	as->store_atom(av);
+	as->barrier();
+
+	// --------------------
+	store->kill_data();
+	delete as;
+	delete backing;
+	delete store;
 }
 
 /* ============================= END OF FILE ================= */

--- a/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
@@ -563,9 +563,8 @@ void ValueSaveUTest::do_test_load_by_type()
 // Test the fetch_all_atoms_of_type() method in the atomspace.
 // The fetch should restore the truth values, and the other values,
 // as well.  This tests the fetching of links. This differs from
-// the above, in that the values of existing atoms in the outgoing
-// set should NOT be clobbered. But the values of non-existing
-// atoms *should* be fecthed.
+// the above, in that the values of the outgoing set should NOT
+// be fetched.
 void ValueSaveUTest::do_test_link_by_type()
 {
 	SQLAtomStorage *store = new SQLAtomStorage(uri);
@@ -775,12 +774,9 @@ void ValueSaveUTest::do_test_link_by_type()
 
 // ============================================================
 
-// Test the fetch_all_atoms_of_type() method in the atomspace.
+// Test the fetch_incoming_set() method in the atomspace.
 // The fetch should restore the truth values, and the other values,
-// as well.  This tests the fetching of links. This differs from
-// the above, in that the values of existing atoms in the outgoing
-// set should NOT be clobbered. But the values of non-existing
-// atoms *should* be fecthed.
+// as well, but only on the incoming set!
 void ValueSaveUTest::do_test_incoming()
 {
 	SQLAtomStorage *store = new SQLAtomStorage(uri);
@@ -885,7 +881,7 @@ void ValueSaveUTest::do_test_incoming()
 	backing->registerWith(as);
 
 	// --------------------
-	// Fetch by type. This is what we are testing.
+	// Fetch incoming set. This is what we are testing.
 
 	Handle gkey = as->add_node(PREDICATE_NODE, "some pred key");
 	Handle gaf = as->add_node(CONCEPT_NODE, "a float node");
@@ -897,7 +893,10 @@ void ValueSaveUTest::do_test_incoming()
 	// The B-nodes are added after the fetch. In either case,
 	// there should not be any values fetched for either A or B;
 	// only the values on the C-links should be fetched.
-	as->fetch_all_atoms_of_type(LIST_LINK);
+	as->fetch_incoming_set(gaf, false);
+	as->fetch_incoming_set(gat, false);
+	as->fetch_incoming_set(gal, false);
+	as->fetch_incoming_set(gav, false);
 
 	Handle gbf = as->add_node(CONCEPT_NODE, "b float node");
 	Handle gbt = as->add_node(CONCEPT_NODE, "b string node");

--- a/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
@@ -122,6 +122,7 @@ class ValueSaveUTest :  public CxxTest::TestSuite
         void do_test_save_restore(bool);
         void check_one(ProtoAtomPtr, bool);
         void do_test_load_by_type();
+        void do_test_link_by_type();
 
         void test_odbc_single_atom_save();
         void test_pq_single_atom_save();
@@ -131,6 +132,9 @@ class ValueSaveUTest :  public CxxTest::TestSuite
 
         void test_odbc_load_by_type();
         void test_pq_load_by_type();
+
+        void test_odbc_link_by_type();
+        void test_pq_link_by_type();
 };
 
 /*
@@ -198,6 +202,26 @@ void ValueSaveUTest::test_pq_load_by_type(void)
 #if HAVE_PGSQL_STORAGE
 	uri = mkuri("postgres", dbname, username, passwd);
 	do_test_load_by_type();
+#endif // HAVE_PGSQL_STORAGE
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+void ValueSaveUTest::test_odbc_link_by_type(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+#if HAVE_ODBC_STORAGE
+	uri = mkuri("odbc", dbname, username, passwd);
+	do_test_link_by_type();
+#endif
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+void ValueSaveUTest::test_pq_link_by_type(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+#if HAVE_PGSQL_STORAGE
+	uri = mkuri("postgres", dbname, username, passwd);
+	do_test_link_by_type();
 #endif // HAVE_PGSQL_STORAGE
 	logger().debug("END TEST: %s", __FUNCTION__);
 }
@@ -390,7 +414,135 @@ void ValueSaveUTest::do_test_save_restore(bool fkey)
 
 // ============================================================
 
+// Test the fetch_all_atoms_of_type() method in the atomspace.
+// The fetch should restore the truth values, and the other values,
+// as well.  This tests the fetchinf of nodes.
 void ValueSaveUTest::do_test_load_by_type()
+{
+	SQLAtomStorage *store = new SQLAtomStorage(uri);
+	TS_ASSERT(store->connected())
+
+	// Clear out left-over junk, just in case.
+	store->kill_data();
+
+	AtomSpace* as = new AtomSpace();
+	SQLBackingStore* backing = new SQLBackingStore();
+	backing->set_store(store);
+	backing->registerWith(as);
+
+	Handle key = as->add_node(PREDICATE_NODE, "some pred key");
+	Handle af = as->add_node(CONCEPT_NODE, "float node");
+	Handle at = as->add_node(CONCEPT_NODE, "string node");
+	Handle al = as->add_node(CONCEPT_NODE, "link depth-1 node");
+	Handle av = as->add_node(CONCEPT_NODE, "link depth-2 node");
+
+	// --------------------
+	// Now set some values
+	ProtoAtomPtr pvf = createFloatValue(
+		std::vector<double>({1.14, 2.24, 3.34}));
+	af->setValue(key, pvf);
+
+	TruthValuePtr tf(SimpleTruthValue::createTV(0.11, 100));
+	af->setTruthValue(tf);
+
+	// --------------------
+	ProtoAtomPtr pvt = createStringValue(
+		std::vector<std::string>({"aaa", "bb bb bb", "ccc ccc ccc"}));
+	at->setValue(key, pvt);
+
+	TruthValuePtr tt(SimpleTruthValue::createTV(0.22, 200));
+	at->setTruthValue(tt);
+
+	// --------------------
+	ProtoAtomPtr pvl = createLinkValue(
+		std::vector<ProtoAtomPtr>({pvf, pvt}));
+	al->setValue(key, pvl);
+
+	TruthValuePtr tl(SimpleTruthValue::createTV(0.33, 300));
+	al->setTruthValue(tl);
+
+	// --------------------
+	ProtoAtomPtr pvv = createLinkValue(
+		std::vector<ProtoAtomPtr>({pvl, pvl, pvf, pvt}));
+	av->setValue(key, pvv);
+
+	TruthValuePtr tv(SimpleTruthValue::createTV(0.44, 400));
+	av->setTruthValue(tv);
+
+	// --------------------
+	// Save, and close things down.
+	as->store_atom(af);
+	as->store_atom(at);
+	as->store_atom(al);
+	as->store_atom(av);
+	as->barrier();
+
+	delete as;
+	delete backing;
+	delete store;
+
+	// --------------------
+	// Start it up again.
+
+	store = new SQLAtomStorage(uri);
+	TS_ASSERT(store->connected())
+
+	as = new AtomSpace();
+	backing = new SQLBackingStore();
+	backing->set_store(store);
+	backing->registerWith(as);
+
+	// --------------------
+	// Fetch by type. This is what we are testing.
+	as->fetch_all_atoms_of_type(CONCEPT_NODE);
+
+	Handle gkey = as->add_node(PREDICATE_NODE, "some pred key");
+	Handle gaf = as->add_node(CONCEPT_NODE, "float node");
+	Handle gat = as->add_node(CONCEPT_NODE, "string node");
+	Handle gal = as->add_node(CONCEPT_NODE, "link depth-1 node");
+	Handle gav = as->add_node(CONCEPT_NODE, "link depth-2 node");
+
+	TS_ASSERT(*gaf == *af);
+	TS_ASSERT(*gat == *at);
+	TS_ASSERT(*gal == *al);
+	TS_ASSERT(*gav == *av);
+
+	TruthValuePtr gtf = gaf->getTruthValue();
+	TruthValuePtr gtt = gat->getTruthValue();
+	TruthValuePtr gtl = gal->getTruthValue();
+	TruthValuePtr gtv = gav->getTruthValue();
+
+	TS_ASSERT(*gtf == *tf);
+	TS_ASSERT(*gtt == *tt);
+	TS_ASSERT(*gtl == *tl);
+	TS_ASSERT(*gtv == *tv);
+
+	ProtoAtomPtr gpf = gaf->getValue(gkey);
+	ProtoAtomPtr gpt = gat->getValue(gkey);
+	ProtoAtomPtr gpl = gal->getValue(gkey);
+	ProtoAtomPtr gpv = gav->getValue(gkey);
+
+	TS_ASSERT(*gpf == *pvf);
+	TS_ASSERT(*gpt == *pvt);
+	TS_ASSERT(*gpl == *pvl);
+	TS_ASSERT(*gpv == *pvv);
+
+	// --------------------
+	store->kill_data();
+	delete as;
+	delete backing;
+	delete store;
+}
+
+// ============================================================
+
+// Test the fetch_all_atoms_of_type() method in the atomspace.
+// The fetch should restore the truth values, and the other values,
+// as well.  This tests the fetching of links. This differs from
+// the above, in that the values of existing atoms in the outgoing
+// set should NOT be clobbered. But the values of non-existing
+// atoms *should* be fecthed.
+void ValueSaveUTest::do_test_link_by_type()
 {
 	SQLAtomStorage *store = new SQLAtomStorage(uri);
 	TS_ASSERT(store->connected())

--- a/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
@@ -712,10 +712,10 @@ void ValueSaveUTest::do_test_link_by_type()
 	ProtoAtomPtr gpl = gal->getValue(gkey);
 	ProtoAtomPtr gpv = gav->getValue(gkey);
 
-	TS_ASSERT(*gpf == *pvf);
-	TS_ASSERT(*gpt == *pvt);
-	TS_ASSERT(*gpl == *pvl);
-	TS_ASSERT(*gpv == *pvv);
+	TS_ASSERT(gpf == nullptr);
+	TS_ASSERT(gpt == nullptr);
+	TS_ASSERT(gpl == nullptr);
+	TS_ASSERT(gpv == nullptr);
 
 	gpf = gbf->getValue(gkey);
 	gpt = gbt->getValue(gkey);

--- a/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
@@ -419,25 +419,25 @@ void ValueSaveUTest::do_test_load_by_type()
 	af->setTruthValue(tf);
 
 	// --------------------
-	ProtoAtomPtr pvs = createStringValue(
+	ProtoAtomPtr pvt = createStringValue(
 		std::vector<std::string>({"aaa", "bb bb bb", "ccc ccc ccc"}));
-	at->setValue(key, pvs);
+	at->setValue(key, pvt);
 
-	TruthValuePtr ts(SimpleTruthValue::createTV(0.22, 200));
-	at->setTruthValue(ts);
+	TruthValuePtr tt(SimpleTruthValue::createTV(0.22, 200));
+	at->setTruthValue(tt);
 
 	// --------------------
 	ProtoAtomPtr pvl = createLinkValue(
-		std::vector<ProtoAtomPtr>({pvf, pvs}));
+		std::vector<ProtoAtomPtr>({pvf, pvt}));
 	al->setValue(key, pvl);
 
 	TruthValuePtr tl(SimpleTruthValue::createTV(0.33, 300));
 	al->setTruthValue(tl);
 
 	// --------------------
-	ProtoAtomPtr pvl2 = createLinkValue(
-		std::vector<ProtoAtomPtr>({pvl, pvl, pvf, pvs}));
-	av->setValue(key, pvl2);
+	ProtoAtomPtr pvv = createLinkValue(
+		std::vector<ProtoAtomPtr>({pvl, pvl, pvf, pvt}));
+	av->setValue(key, pvv);
 
 	TruthValuePtr tv(SimpleTruthValue::createTV(0.44, 400));
 	av->setTruthValue(tv);
@@ -469,15 +469,35 @@ void ValueSaveUTest::do_test_load_by_type()
 	// Fetch by type. This is what we are testing.
 	as->fetch_all_atoms_of_type(CONCEPT_NODE);
 
-	Handle faf = as->add_node(CONCEPT_NODE, "float node");
-	Handle fat = as->add_node(CONCEPT_NODE, "string node");
-	Handle fal = as->add_node(CONCEPT_NODE, "link depth-1 node");
-	Handle fav = as->add_node(CONCEPT_NODE, "link depth-2 node");
+	Handle gaf = as->add_node(CONCEPT_NODE, "float node");
+	Handle gat = as->add_node(CONCEPT_NODE, "string node");
+	Handle gal = as->add_node(CONCEPT_NODE, "link depth-1 node");
+	Handle gav = as->add_node(CONCEPT_NODE, "link depth-2 node");
 
-	TS_ASSERT(faf == af);
-	TS_ASSERT(fat == at);
-	TS_ASSERT(fal == al);
-	TS_ASSERT(fav == av);
+	TS_ASSERT(*gaf == *af);
+	TS_ASSERT(*gat == *at);
+	TS_ASSERT(*gal == *al);
+	TS_ASSERT(*gav == *av);
+
+	TruthValuePtr gtf = gaf->getTruthValue();
+	TruthValuePtr gtt = gat->getTruthValue();
+	TruthValuePtr gtl = gal->getTruthValue();
+	TruthValuePtr gtv = gav->getTruthValue();
+
+	TS_ASSERT(*gtf == *tf);
+	TS_ASSERT(*gtt == *tt);
+	TS_ASSERT(*gtl == *tl);
+	TS_ASSERT(*gtv == *tv);
+
+	ProtoAtomPtr gpf = gaf->getValue(key);
+	ProtoAtomPtr gpt = gat->getValue(key);
+	ProtoAtomPtr gpl = gal->getValue(key);
+	ProtoAtomPtr gpv = gav->getValue(key);
+
+	TS_ASSERT(*gpf == *pvf);
+	TS_ASSERT(*gpt == *pvt);
+	TS_ASSERT(*gpl == *pvl);
+	TS_ASSERT(*gpv == *pvv);
 
 	// --------------------
 	store->kill_data();

--- a/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
@@ -1,7 +1,7 @@
 /*
  * tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
  *
- * Basic test of generic value save and restore.
+ * Test of save and restore of generic values.
  *
  * If this test is failing for you, then be sure to read the README in
  * this directory, and also ../../opencong/persist/README, and then
@@ -123,6 +123,7 @@ class ValueSaveUTest :  public CxxTest::TestSuite
         void check_one(ProtoAtomPtr, bool);
         void do_test_load_by_type();
         void do_test_link_by_type();
+        void do_test_incoming();
 
         void test_odbc_single_atom_save();
         void test_pq_single_atom_save();
@@ -135,6 +136,9 @@ class ValueSaveUTest :  public CxxTest::TestSuite
 
         void test_odbc_link_by_type();
         void test_pq_link_by_type();
+
+        void test_odbc_incoming();
+        void test_pq_incoming();
 };
 
 /*
@@ -222,6 +226,26 @@ void ValueSaveUTest::test_pq_link_by_type(void)
 #if HAVE_PGSQL_STORAGE
 	uri = mkuri("postgres", dbname, username, passwd);
 	do_test_link_by_type();
+#endif // HAVE_PGSQL_STORAGE
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+void ValueSaveUTest::test_odbc_incoming(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+#if HAVE_ODBC_STORAGE
+	uri = mkuri("odbc", dbname, username, passwd);
+	do_test_incoming();
+#endif
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+void ValueSaveUTest::test_pq_incoming(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+#if HAVE_PGSQL_STORAGE
+	uri = mkuri("postgres", dbname, username, passwd);
+	do_test_incoming();
 #endif // HAVE_PGSQL_STORAGE
 	logger().debug("END TEST: %s", __FUNCTION__);
 }
@@ -543,6 +567,221 @@ void ValueSaveUTest::do_test_load_by_type()
 // set should NOT be clobbered. But the values of non-existing
 // atoms *should* be fecthed.
 void ValueSaveUTest::do_test_link_by_type()
+{
+	SQLAtomStorage *store = new SQLAtomStorage(uri);
+	TS_ASSERT(store->connected())
+
+	// Clear out left-over junk, just in case.
+	store->kill_data();
+
+	AtomSpace* as = new AtomSpace();
+	SQLBackingStore* backing = new SQLBackingStore();
+	backing->set_store(store);
+	backing->registerWith(as);
+
+	Handle key = as->add_node(PREDICATE_NODE, "some pred key");
+	Handle af = as->add_node(CONCEPT_NODE, "a float node");
+	Handle at = as->add_node(CONCEPT_NODE, "a string node");
+	Handle al = as->add_node(CONCEPT_NODE, "a depth-1 node");
+	Handle av = as->add_node(CONCEPT_NODE, "a depth-2 node");
+
+	Handle bf = as->add_node(CONCEPT_NODE, "b float node");
+	Handle bt = as->add_node(CONCEPT_NODE, "b string node");
+	Handle bl = as->add_node(CONCEPT_NODE, "b depth-1 node");
+	Handle bv = as->add_node(CONCEPT_NODE, "b depth-2 node");
+
+	Handle cf = as->add_link(LIST_LINK, {af, bf});
+	Handle ct = as->add_link(LIST_LINK, {at, bt});
+	Handle cl = as->add_link(LIST_LINK, {al, bl});
+	Handle cv = as->add_link(LIST_LINK, {av, bv});
+
+	// --------------------
+	// Now set some values
+	ProtoAtomPtr pvf = createFloatValue(
+		std::vector<double>({1.14, 2.24, 3.34}));
+	af->setValue(key, pvf);
+	bf->setValue(key, pvf);
+	cf->setValue(key, pvf);
+
+	TruthValuePtr tf(SimpleTruthValue::createTV(0.11, 100));
+	af->setTruthValue(tf);
+	bf->setTruthValue(tf);
+	cf->setTruthValue(tf);
+
+	// --------------------
+	ProtoAtomPtr pvt = createStringValue(
+		std::vector<std::string>({"aaa", "bb bb bb", "ccc ccc ccc"}));
+	at->setValue(key, pvt);
+	bt->setValue(key, pvt);
+	ct->setValue(key, pvt);
+
+	TruthValuePtr tt(SimpleTruthValue::createTV(0.22, 200));
+	at->setTruthValue(tt);
+	bt->setTruthValue(tt);
+	ct->setTruthValue(tt);
+
+	// --------------------
+	ProtoAtomPtr pvl = createLinkValue(
+		std::vector<ProtoAtomPtr>({pvf, pvt}));
+	al->setValue(key, pvl);
+	bl->setValue(key, pvl);
+	cl->setValue(key, pvl);
+
+	TruthValuePtr tl(SimpleTruthValue::createTV(0.33, 300));
+	al->setTruthValue(tl);
+	bl->setTruthValue(tl);
+	cl->setTruthValue(tl);
+
+	// --------------------
+	ProtoAtomPtr pvv = createLinkValue(
+		std::vector<ProtoAtomPtr>({pvl, pvl, pvf, pvt}));
+	av->setValue(key, pvv);
+	bv->setValue(key, pvv);
+	cv->setValue(key, pvv);
+
+	TruthValuePtr tv(SimpleTruthValue::createTV(0.44, 400));
+	av->setTruthValue(tv);
+	bv->setTruthValue(tv);
+	cv->setTruthValue(tv);
+
+	// --------------------
+	// Save, and close things down.
+	// Note that this store will also *recursively* store the
+	// values on the outgoing atoms, as well.
+	as->store_atom(cf);
+	as->store_atom(ct);
+	as->store_atom(cl);
+	as->store_atom(cv);
+	as->barrier();
+
+	delete as;
+	delete backing;
+	delete store;
+
+	// --------------------
+	// Start it up again.
+
+	store = new SQLAtomStorage(uri);
+	TS_ASSERT(store->connected())
+
+	as = new AtomSpace();
+	backing = new SQLBackingStore();
+	backing->set_store(store);
+	backing->registerWith(as);
+
+	// --------------------
+	// Fetch by type. This is what we are testing.
+
+	Handle gkey = as->add_node(PREDICATE_NODE, "some pred key");
+	Handle gaf = as->add_node(CONCEPT_NODE, "a float node");
+	Handle gat = as->add_node(CONCEPT_NODE, "a string node");
+	Handle gal = as->add_node(CONCEPT_NODE, "a depth-1 node");
+	Handle gav = as->add_node(CONCEPT_NODE, "a depth-2 node");
+
+	// Note that the A-nodes above are added *before* the fetch;
+	// The B-nodes are added after the fetch. In either case,
+	// there should not be any values fetched for either A or B;
+	// only the values on the C-links should be fetched.
+	as->fetch_all_atoms_of_type(LIST_LINK);
+
+	Handle gbf = as->add_node(CONCEPT_NODE, "b float node");
+	Handle gbt = as->add_node(CONCEPT_NODE, "b string node");
+	Handle gbl = as->add_node(CONCEPT_NODE, "b depth-1 node");
+	Handle gbv = as->add_node(CONCEPT_NODE, "b depth-2 node");
+
+	Handle gcf = as->add_link(LIST_LINK, {gaf, gbf});
+	Handle gct = as->add_link(LIST_LINK, {gat, gbt});
+	Handle gcl = as->add_link(LIST_LINK, {gal, gbl});
+	Handle gcv = as->add_link(LIST_LINK, {gav, gbv});
+
+	TS_ASSERT(*gcf == *cf);
+	TS_ASSERT(*gct == *ct);
+	TS_ASSERT(*gcl == *cl);
+	TS_ASSERT(*gcv == *cv);
+
+	TruthValuePtr gtf = gaf->getTruthValue();
+	TruthValuePtr gtt = gat->getTruthValue();
+	TruthValuePtr gtl = gal->getTruthValue();
+	TruthValuePtr gtv = gav->getTruthValue();
+
+	TS_ASSERT(gtf == TruthValue::DEFAULT_TV());
+	TS_ASSERT(gtt == TruthValue::DEFAULT_TV());
+	TS_ASSERT(gtl == TruthValue::DEFAULT_TV());
+	TS_ASSERT(gtv == TruthValue::DEFAULT_TV());
+
+	gtf = gbf->getTruthValue();
+	gtt = gbt->getTruthValue();
+	gtl = gbl->getTruthValue();
+	gtv = gbv->getTruthValue();
+
+	TS_ASSERT(gtf == TruthValue::DEFAULT_TV());
+	TS_ASSERT(gtt == TruthValue::DEFAULT_TV());
+	TS_ASSERT(gtl == TruthValue::DEFAULT_TV());
+	TS_ASSERT(gtv == TruthValue::DEFAULT_TV());
+
+	gtf = gcf->getTruthValue();
+	gtt = gct->getTruthValue();
+	gtl = gcl->getTruthValue();
+	gtv = gcv->getTruthValue();
+
+	TS_ASSERT(*gtf == *tf);
+	TS_ASSERT(*gtt == *tt);
+	TS_ASSERT(*gtl == *tl);
+	TS_ASSERT(*gtv == *tv);
+
+	// --------------------
+
+	ProtoAtomPtr gpf;
+	ProtoAtomPtr gpt;
+	ProtoAtomPtr gpl;
+	ProtoAtomPtr gpv;
+
+	try { gpf = gaf->getValue(gkey); } catch(const RuntimeException&) {}
+	try { gpt = gat->getValue(gkey); } catch(const RuntimeException&) {}
+	try { gpl = gal->getValue(gkey); } catch(const RuntimeException&) {}
+	try { gpv = gav->getValue(gkey); } catch(const RuntimeException&) {}
+
+	TS_ASSERT(gpf == nullptr);
+	TS_ASSERT(gpt == nullptr);
+	TS_ASSERT(gpl == nullptr);
+	TS_ASSERT(gpv == nullptr);
+
+	try { gpf = gbf->getValue(gkey); } catch(const RuntimeException&) {}
+	try { gpt = gbt->getValue(gkey); } catch(const RuntimeException&) {}
+	try { gpl = gbl->getValue(gkey); } catch(const RuntimeException&) {}
+	try { gpv = gbv->getValue(gkey); } catch(const RuntimeException&) {}
+
+	TS_ASSERT(gpf == nullptr);
+	TS_ASSERT(gpt == nullptr);
+	TS_ASSERT(gpl == nullptr);
+	TS_ASSERT(gpv == nullptr);
+
+	gpf = gcf->getValue(gkey);
+	gpt = gct->getValue(gkey);
+	gpl = gcl->getValue(gkey);
+	gpv = gcv->getValue(gkey);
+
+	TS_ASSERT(*gpf == *pvf);
+	TS_ASSERT(*gpt == *pvt);
+	TS_ASSERT(*gpl == *pvl);
+	TS_ASSERT(*gpv == *pvv);
+
+	// --------------------
+	store->kill_data();
+	delete as;
+	delete backing;
+	delete store;
+}
+
+// ============================================================
+
+// Test the fetch_all_atoms_of_type() method in the atomspace.
+// The fetch should restore the truth values, and the other values,
+// as well.  This tests the fetching of links. This differs from
+// the above, in that the values of existing atoms in the outgoing
+// set should NOT be clobbered. But the values of non-existing
+// atoms *should* be fecthed.
+void ValueSaveUTest::do_test_incoming()
 {
 	SQLAtomStorage *store = new SQLAtomStorage(uri);
 	TS_ASSERT(store->connected())

--- a/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
@@ -655,10 +655,10 @@ void ValueSaveUTest::do_test_link_by_type()
 	Handle gav = as->add_node(CONCEPT_NODE, "a depth-2 node");
 
 	// Note that the A-nodes above are added *before* the fetch;
-	// therefore, the fetch should NOT clobber the values there.
-	// However, the values on the B-nodes and the C-links should
-	// be fetched.
-	as->fetch_all_atoms_of_type(CONCEPT_NODE);
+	// The B-nodes are added after the fetch. In either case,
+	// there should not be any values fetched for either A or B;
+	// only the values on the C-links should be fetched.
+	as->fetch_all_atoms_of_type(LIST_LINK);
 
 	Handle gbf = as->add_node(CONCEPT_NODE, "b float node");
 	Handle gbt = as->add_node(CONCEPT_NODE, "b string node");
@@ -680,20 +680,20 @@ void ValueSaveUTest::do_test_link_by_type()
 	TruthValuePtr gtl = gal->getTruthValue();
 	TruthValuePtr gtv = gav->getTruthValue();
 
-	TS_ASSERT(*gtf == *TruthValue::DEFAULT_TV());
-	TS_ASSERT(*gtt == *TruthValue::DEFAULT_TV());
-	TS_ASSERT(*gtl == *TruthValue::DEFAULT_TV());
-	TS_ASSERT(*gtv == *TruthValue::DEFAULT_TV());
+	TS_ASSERT(gtf == TruthValue::DEFAULT_TV());
+	TS_ASSERT(gtt == TruthValue::DEFAULT_TV());
+	TS_ASSERT(gtl == TruthValue::DEFAULT_TV());
+	TS_ASSERT(gtv == TruthValue::DEFAULT_TV());
 
 	gtf = gbf->getTruthValue();
 	gtt = gbt->getTruthValue();
 	gtl = gbl->getTruthValue();
 	gtv = gbv->getTruthValue();
 
-	TS_ASSERT(*gtf == *tf);
-	TS_ASSERT(*gtt == *tt);
-	TS_ASSERT(*gtl == *tl);
-	TS_ASSERT(*gtv == *tv);
+	TS_ASSERT(gtf == TruthValue::DEFAULT_TV());
+	TS_ASSERT(gtt == TruthValue::DEFAULT_TV());
+	TS_ASSERT(gtl == TruthValue::DEFAULT_TV());
+	TS_ASSERT(gtv == TruthValue::DEFAULT_TV());
 
 	gtf = gcf->getTruthValue();
 	gtt = gct->getTruthValue();
@@ -707,25 +707,30 @@ void ValueSaveUTest::do_test_link_by_type()
 
 	// --------------------
 
-	ProtoAtomPtr gpf = gaf->getValue(gkey);
-	ProtoAtomPtr gpt = gat->getValue(gkey);
-	ProtoAtomPtr gpl = gal->getValue(gkey);
-	ProtoAtomPtr gpv = gav->getValue(gkey);
+	ProtoAtomPtr gpf;
+	ProtoAtomPtr gpt;
+	ProtoAtomPtr gpl;
+	ProtoAtomPtr gpv;
+
+	try { gpf = gaf->getValue(gkey); } catch(const RuntimeException&) {}
+	try { gpt = gat->getValue(gkey); } catch(const RuntimeException&) {}
+	try { gpl = gal->getValue(gkey); } catch(const RuntimeException&) {}
+	try { gpv = gav->getValue(gkey); } catch(const RuntimeException&) {}
 
 	TS_ASSERT(gpf == nullptr);
 	TS_ASSERT(gpt == nullptr);
 	TS_ASSERT(gpl == nullptr);
 	TS_ASSERT(gpv == nullptr);
 
-	gpf = gbf->getValue(gkey);
-	gpt = gbt->getValue(gkey);
-	gpl = gbl->getValue(gkey);
-	gpv = gbv->getValue(gkey);
+	try { gpf = gbf->getValue(gkey); } catch(const RuntimeException&) {}
+	try { gpt = gbt->getValue(gkey); } catch(const RuntimeException&) {}
+	try { gpl = gbl->getValue(gkey); } catch(const RuntimeException&) {}
+	try { gpv = gbv->getValue(gkey); } catch(const RuntimeException&) {}
 
-	TS_ASSERT(*gpf == *pvf);
-	TS_ASSERT(*gpt == *pvt);
-	TS_ASSERT(*gpl == *pvl);
-	TS_ASSERT(*gpv == *pvv);
+	TS_ASSERT(gpf == nullptr);
+	TS_ASSERT(gpt == nullptr);
+	TS_ASSERT(gpl == nullptr);
+	TS_ASSERT(gpv == nullptr);
 
 	gpf = gcf->getValue(gkey);
 	gpt = gct->getValue(gkey);


### PR DESCRIPTION
The semantics of save & restore of atoms and values is not unique; several ways to do it exist.  See the longer README file, the section on 'semanitics' for the issues.  Basically, its about saving & restoring values on atoms in the outgoing set of a link that is being fetched.