### PR TITLE
Support scope link walk tree

### DIFF
--- a/opencog/atoms/base/CMakeLists.txt
+++ b/opencog/atoms/base/CMakeLists.txt
@@ -20,6 +20,7 @@ ADD_LIBRARY (atombase
 	LinkValue.cc
 	Node.cc
 	Quotation.cc
+	Context.cc
 	StringValue.cc
 	Valuation.cc
 )
@@ -48,6 +49,7 @@ INSTALL (FILES
 	Node.h
 	ProtoAtom.h
 	Quotation.h
+	Context.h
 	StringValue.h
 	types.h
 	Valuation.h

--- a/opencog/atoms/base/Context.cc
+++ b/opencog/atoms/base/Context.cc
@@ -1,0 +1,99 @@
+/*
+ * opencog/atoms/base/Context.h
+ *
+ * Copyright (C) 2017 OpenCog Foundation
+ * All Rights Reserved
+ *
+ * Written by Nil Geisweiller
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "Context.h"
+
+#include <opencog/util/algorithm.h>
+#include <opencog/atoms/base/Atom.h>
+#include <opencog/atoms/core/Variables.h>
+#include <opencog/atoms/core/ScopeLink.h>
+
+#include <sstream>
+
+namespace opencog {
+
+Context::Context(const Quotation& q, const OrderedHandleSet& s)
+	: quotation(q), shadow(s) {}
+
+void Context::update(const Handle& h)
+{
+	Type t = h->getType();
+
+	// Update shadow
+	if (quotation.is_unquoted() and classserver().isA(t, SCOPE_LINK)) {
+		// Insert the new shadowing variables from the scope link
+		const Variables& variables = ScopeLinkCast(h)->get_variables();
+		shadow.insert(variables.varset.begin(), variables.varset.end());
+	}
+
+	// Update quotation
+	quotation.update(t);
+}
+
+bool Context::is_free_variable(const Handle& h) const
+{
+	return (h->getType() == VARIABLE_NODE)
+		and quotation.is_unquoted()
+		and not is_in(h, shadow);
+}
+
+bool Context::operator==(const Context& context) const
+{
+	return (quotation == context.quotation)
+		and ohs_content_eq(shadow, context.shadow);
+}
+
+bool Context::operator<(const Context& context) const
+{
+	return quotation < context.quotation
+		or (quotation == context.quotation and shadow < context.shadow);
+}
+
+bool ohs_content_eq(const OrderedHandleSet& lhs, const OrderedHandleSet& rhs)
+{
+	if (lhs.size() != rhs.size())
+		return false;
+
+	auto lit = lhs.begin();
+	auto rit = rhs.begin();
+	while (lit != lhs.end()) {
+		if (not content_eq(*lit, *rit))
+			return false;
+		++lit; ++rit;
+	}
+	return true;
+}
+
+std::string oc_to_string(const Context& c)
+{
+	std::stringstream ss;
+	if (c == Context())
+		ss << "none" << std::endl;
+	else
+		ss << "quotation: " << oc_to_string(c.quotation) << std::endl
+		   << "shadow:" << std::endl << oc_to_string(c.shadow);
+	return ss.str();
+}
+
+} // namespace opencog

--- a/opencog/atoms/base/Context.cc
+++ b/opencog/atoms/base/Context.cc
@@ -51,6 +51,21 @@ void Context::update(const Handle& h)
 	quotation.update(t);
 }
 
+bool Context::is_quoted() const
+{
+	return quotation.is_quoted();
+}
+
+bool Context::is_unquoted() const
+{
+	return quotation.is_unquoted();
+}
+
+bool Context::consumable(Type t) const
+{
+	return quotation.consumable(t);
+}
+
 bool Context::is_free_variable(const Handle& h) const
 {
 	return (h->getType() == VARIABLE_NODE)

--- a/opencog/atoms/base/Context.h
+++ b/opencog/atoms/base/Context.h
@@ -1,0 +1,97 @@
+/*
+ * opencog/atoms/base/Context.h
+ *
+ * Copyright (C) 2017 OpenCog Foundation
+ * All Rights Reserved
+ *
+ * Written by Nil Geisweiller
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef _OPENCOG_CONTEXT_H
+#define _OPENCOG_CONTEXT_H
+
+#include <boost/operators.hpp>
+
+#include <opencog/atoms/base/Handle.h>
+#include <opencog/atoms/base/atom_types.h>
+#include <opencog/atoms/base/Quotation.h>
+#include <string>
+
+namespace opencog
+{
+
+/** \addtogroup grp_atomspace
+ *  @{
+ */
+
+/**
+ * A context holds the quotation state and the current shadowing
+ * variables of a atom (typically coming from ancestor scopes).
+ *
+ * The context is important to have for both unification, in
+ * particular sub-unification, see Unify::subunify, and closure,
+ * see Unify::substitution_closure, because quoted or shadowed
+ * variables should not be substituted.
+ *
+ * This notion of context is distinct and unrelated to
+ * ContextLink.
+ */
+struct Context : public boost::totally_ordered<Context>
+{
+	// Default ctor
+	Context(const Quotation& quotation=Quotation(),
+	        const OrderedHandleSet& shadow=OrderedHandleSet());
+
+	// Quotation state
+	Quotation quotation;
+
+	// Set of shadowing variables
+	OrderedHandleSet shadow;
+
+	/**
+	 * Update the context over an atom. That is if the atom is a
+	 * consumable quotation then update the context quotation. If
+	 * the atom is a scope link then update the context shadow.
+	 */
+	void update(const Handle& h);
+
+	/**
+	 * Return true iff the given atom in that context is a free
+	 * variable, that is unquoted and unshadowed.
+	 */
+	bool is_free_variable(const Handle& h) const;
+
+	/**
+	 * Comparison.
+	 */
+	bool operator==(const Context& context) const;
+	bool operator<(const Context& context) const;
+};
+
+// Compare by context instead of pointer. We probably want this to be
+// the default, until then this function is here for that.
+bool ohs_content_eq(const OrderedHandleSet& lhs, const OrderedHandleSet& rhs);
+
+// For gdb, see
+// http://wiki.opencog.org/w/Development_standards#Print_OpenCog_Objects
+std::string oc_to_string(const Context& c);
+	
+/** @}*/
+} // namespace opencog
+
+#endif // _OPENCOG_QUOTATION_H

--- a/opencog/atoms/base/Context.h
+++ b/opencog/atoms/base/Context.h
@@ -71,6 +71,14 @@ struct Context : public boost::totally_ordered<Context>
 	void update(const Handle& h);
 
 	/**
+	 * Short hands for usual Quotation class methods. Note all
+	 * Quotations methods are here, feel free to add as convenient.
+	 */
+	bool is_quoted() const;
+	bool is_unquoted() const;
+	bool consumable(Type t) const;
+
+	/**
 	 * Return true iff the given atom in that context is a free
 	 * variable, that is unquoted and unshadowed.
 	 */

--- a/opencog/atoms/execution/Instantiator.h
+++ b/opencog/atoms/execution/Instantiator.h
@@ -26,7 +26,7 @@
 
 #include <opencog/atomspace/AtomSpace.h>
 
-#include <opencog/atoms/base/Quotation.h>
+#include <opencog/atoms/base/Context.h>
 
 /**
  * class Instantiator -- create grounded expressions from ungrounded ones.
@@ -55,7 +55,7 @@ private:
 	 * (e.g. GetLink, BindLink), since these handle QuoteLinks within
 	 * their own scope. We must avoid damaging quotes for these atoms.
 	 */
-	Quotation _quotation;
+	Context _context;
 	int _avoid_discarding_quotes_level = 0;
 
 	/**

--- a/opencog/atomutils/Unify.h
+++ b/opencog/atomutils/Unify.h
@@ -31,6 +31,7 @@
 #include <opencog/atoms/base/Handle.h>
 #include <opencog/atoms/base/atom_types.h>
 #include <opencog/atoms/base/Quotation.h>
+#include <opencog/atoms/base/Context.h>
 #include <opencog/atoms/core/Variables.h>
 #include <opencog/atoms/core/VariableList.h>
 #include <opencog/atoms/pattern/BindLink.h>
@@ -43,48 +44,6 @@ class Unify
 	friend class UnifyUTest;
 
 public:
-	// A context holds the quotation state and the current shadowing
-	// variables of a atom (typically coming from ancestor scopes).
-	//
-	// The context is important to have for both unification, in
-	// particular sub-unification, see Unify::subunify, and closure,
-	// see Unify::substitution_closure, because quoted or shadowed
-	// variables should not be substituted.
-	//
-	// This notion of context is distinct and unrelated to
-	// ContextLink.
-	struct Context : public boost::totally_ordered<Context>
-	{
-		// Default ctor
-		Context(const Quotation& quotation=Quotation(),
-		        const OrderedHandleSet& shadow=OrderedHandleSet());
-
-		// Quotation state
-		Quotation quotation;
-
-		// Set of shadowing variables
-		OrderedHandleSet shadow;
-
-		/**
-		 * Update the context over an atom. That is if the atom is a
-		 * consumable quotation then update the context quotation. If
-		 * the atom is a scope link then update the context shadow.
-		 */
-		void update(const Handle& h);
-
-		/**
-		 * Return true iff the given atom in that context is a free
-		 * variable, that is unquoted and unshadowed.
-		 */
-		bool is_free_variable(const Handle& h) const;
-
-		/**
-		 * Comparison.
-		 */
-		bool operator==(const Context& context) const;
-		bool operator<(const Context& context) const;
-	};
-
 	// Contextual Handle
 	//
 	// TODO: the notion of equality between 2 CHandles might one where
@@ -716,7 +675,6 @@ private:
 /**
  * Till content equality between atoms become the default.
  */
-bool ohs_content_eq(const OrderedHandleSet& lhs, const OrderedHandleSet& rhs);
 bool hm_content_eq(const HandleMap& lhs, const HandleMap& rhs);
 bool hchm_content_eq(const Unify::HandleCHandleMap& lhs,
                      const Unify::HandleCHandleMap& rhs);
@@ -746,7 +704,6 @@ VariableListPtr gen_varlist(const Unify::CHandle& ch);
 Variables merge_variables(const Variables& lv, const Variables& rv);
 Handle merge_vardecl(const Handle& l_vardecl, const Handle& r_vardecl);
 
-std::string oc_to_string(const Unify::Context& c);
 std::string oc_to_string(const Unify::CHandle& ch);
 std::string oc_to_string(const Unify::Block& pb);
 std::string oc_to_string(const Unify::Partition& hshm);

--- a/tests/atomutils/UnifyUTest.cxxtest
+++ b/tests/atomutils/UnifyUTest.cxxtest
@@ -24,6 +24,7 @@
 #include <opencog/util/Logger.h>
 
 #include <opencog/atomutils/Unify.h>
+#include <opencog/atoms/base/Context.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/guile/SchemeEval.h>
 
@@ -238,7 +239,7 @@ void UnifyUTest::test_join_2()
 		             "    (VariableNode \"$X\")"
 		             "    (ConceptNode \"treatment-1\")))");
 
-	Unify::Context C(Quotation(), {X});
+	Context C(Quotation(), {X});
 	Unify::CHandle Cimplicant_vardecl(implicant_vardecl, C),
 		Cimplicant_body(implicant_body, C);
 
@@ -310,7 +311,7 @@ void UnifyUTest::test_join_3()
 		             "    (VariableNode \"$X\")"
 		             "    (ConceptNode \"treatment-1\")))");
 
-	Unify::Context C(Quotation(), {X});
+	Context C(Quotation(), {X});
 	Unify::CHandle Cimplicant_vardecl(implicant_vardecl, C),
 		Cimplicant_body(implicant_body, C);
 
@@ -770,7 +771,7 @@ void UnifyUTest::test_unify_complex_1()
 		             "    (VariableNode \"$X\")"
 		             "    (ConceptNode \"treatment-1\")))");
 
-	Unify::Context C(Quotation(), {X});
+	Context C(Quotation(), {X});
 	Unify::CHandle Cimplicant_vardecl(implicant_vardecl, C),
 		Cimplicant_body(implicant_body, C);
 
@@ -898,7 +899,7 @@ void UnifyUTest::test_unify_complex_2()
 		             "    (ListLink"
 		             "      (VariableNode \"$X\")"
 		             "      (VariableNode \"$Y-6f50cc6a\"))))");
-	Unify::Context C(Quotation(), {X});
+	Context C(Quotation(), {X});
 	Unify::CHandle CP(P, C);
 	Unify::CHandle Cconjunction(conjunction, C);
 
@@ -1004,7 +1005,7 @@ void UnifyUTest::test_unify_complex_3()
 		             "    (VariableNode \"$X\")"
 		             "    (ConceptNode \"compound-A\")))");
 
-	Unify::Context C(Quotation(), {X});
+	Context C(Quotation(), {X});
 	Unify::CHandle Cvardecl(vardecl, C), Cimplicant_body(implicant_body, C);
 
 	Unify unify(lhs, rhs, lhs_vardecl, rhs_vardecl);
@@ -1155,7 +1156,7 @@ void UnifyUTest::test_unify_complex_4()
 		             "    (VariableNode \"$X\")"
 		             "    (ConceptNode \"treatment-1\")))");
 
-	Unify::Context C(Quotation(), {X});
+	Context C(Quotation(), {X});
 	Unify::CHandle Cimplicant_vardecl(implicant_vardecl, C),
 		Cimplicant_body(implicant_body, C);
 
@@ -1242,7 +1243,7 @@ void UnifyUTest::test_unify_complex_5()
 		             "    (VariableNode \"$X\")"
 		             "    (ConceptNode \"treatment-1\")))");
 
-	Unify::Context C(Quotation(), {X});
+	Context C(Quotation(), {X});
 	Unify::CHandle CQ(Q, C),
         Clambda_vardecl(lambda_vardecl, C),
 		Ctake_treatment_1(take_treatment_1, C);
@@ -1382,7 +1383,7 @@ void UnifyUTest::test_unify_complex_6()
 		             "    (VariableNode \"$X\")"
 		             "    (ConceptNode \"treatment-1\")))");
 
-	Unify::Context C(Quotation(), {X});
+	Context C(Quotation(), {X});
 	Unify::CHandle CQ(Q, C),
         Clambda_vardecl(lambda_vardecl, C),
 		Ctake_treatment_1(take_treatment_1, C);
@@ -1470,7 +1471,7 @@ void UnifyUTest::test_unify_complex_7()
 		             "  )"
 		             ")");
 
-	Unify::Context C(Quotation(), {X});
+	Context C(Quotation(), {X});
 	Unify::CHandle CX_vardecl(X_vardecl, C), Cbody(body, C);
 
 	Unify unify(target, alpha_pat, vardecl, alpha_vardecl);

--- a/tests/query/ScopeUTest.cxxtest
+++ b/tests/query/ScopeUTest.cxxtest
@@ -22,9 +22,13 @@
 
 #include <opencog/guile/SchemeEval.h>
 #include <opencog/atomspace/AtomSpace.h>
+#include <opencog/query/BindLinkAPI.h>
 #include <opencog/util/Logger.h>
 
 using namespace opencog;
+
+#define an as->add_node
+#define al as->add_link
 
 class ScopeUTest: public CxxTest::TestSuite
 {
@@ -66,7 +70,8 @@ _exit(rc); // XXX hack to avoid double-free in __run_exit_handlers
 	void test_search_alt(void);
 	void test_pushpop(void);
 	void test_quote(void);
-	void test_hide(void);
+	void test_hide_1(void);
+	void test_hide_2(void);
 };
 
 void ScopeUTest::tearDown(void)
@@ -215,8 +220,8 @@ void ScopeUTest::test_quote(void)
 	Handle list = eval->eval_h("(cog-bind blist)");
 	Handle andl = eval->eval_h("(cog-bind bland)");
 
-	Handle elist = eval->eval_h("(SetLink (OrderedLink p-lamb q-lamb)) ");
-	Handle eandl = eval->eval_h("(SetLink (UnorderedLink p-lamb q-lamb)) ");
+	Handle elist = eval->eval_h("(SetLink (OrderedLink p-lamb q-lamb))");
+	Handle eandl = eval->eval_h("(SetLink (UnorderedLink p-lamb q-lamb))");
 
 	TS_ASSERT_EQUALS(list, elist);
 	TS_ASSERT_EQUALS(andl, eandl);
@@ -226,7 +231,7 @@ void ScopeUTest::test_quote(void)
 /*
  * Test the hiding of bound variables.
  */
-void ScopeUTest::test_hide(void)
+void ScopeUTest::test_hide_1(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
@@ -260,3 +265,23 @@ void ScopeUTest::test_hide(void)
 
 	logger().debug("END TEST: %s", __FUNCTION__);
 }
+
+void ScopeUTest::test_hide_2()
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	std::string eval_result = eval->eval("(load-from-path \"tests/query/scope-hide.scm\")");
+	Handle rule = eval->eval_h("rule");
+	Handle result = bindlink(as, rule);
+	Handle expected = al(SET_LINK, rule->getOutgoingAtom(2));
+
+	std::cout << "result = " << oc_to_string(result);
+	std::cout << "expected = " << oc_to_string(expected);
+
+	TS_ASSERT_EQUALS(result, expected);
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+#undef an
+#undef al

--- a/tests/query/scope-hide.scm
+++ b/tests/query/scope-hide.scm
@@ -22,3 +22,71 @@
 ;; defined after the above, for this unit test to actually test
 ;; something valid.
 (define getv (Get (LocalQuote (ForAllLink (Variable "$V") (Variable "$B")))))
+
+;; This is to make sure that the following ill-formed scope link isn't
+;; created
+;;
+;; (ImplicationScopeLink
+;;   (TypedVariableLink
+;;     (ConceptNode "ChurchOfEngland")
+;;     (TypeChoice
+;;       (TypeNode "ConceptNode")
+;;       (TypeNode "SchemaNode")
+;;       (TypeNode "PredicateNode")
+;;     )
+;;   )
+;;   (MemberLink
+;;     (ConceptNode "ChurchOfEngland")
+;;     (ConceptNode "AnglicanChurch")
+;;   )
+;;   (EvaluationLink
+;;     (PredicateNode "subOrganization")
+;;     (ListLink
+;;       (ConceptNode "ChurchOfEngland")
+;;       (ConceptNode "ChurchOfEngland")
+;;     )
+;;   )
+;; )
+
+(MemberLink
+  (ConceptNode "ChurchOfEngland")
+  (ConceptNode "AnglicanChurch")
+)
+
+(define rule
+   (BindLink
+      (TypedVariableLink
+         (VariableNode "?C")
+         (TypeChoice
+            (TypeNode "ConceptNode")
+            (TypeNode "SchemaNode")
+            (TypeNode "PredicateNode")
+         )
+      )
+      (MemberLink
+         (VariableNode "?C")
+         (ConceptNode "AnglicanChurch")
+      )
+      (ImplicationScopeLink
+         (TypedVariableLink
+            (VariableNode "?C")
+            (TypeChoice
+               (TypeNode "ConceptNode")
+               (TypeNode "SchemaNode")
+               (TypeNode "PredicateNode")
+            )
+         )
+         (MemberLink
+            (VariableNode "?C")
+            (ConceptNode "AnglicanChurch")
+         )
+         (EvaluationLink
+            (PredicateNode "subOrganization")
+            (ListLink
+               (VariableNode "?C")
+               (ConceptNode "ChurchOfEngland")
+            )
+         )
+      )
+   )
+)

--- a/tests/query/scope-quote.scm
+++ b/tests/query/scope-quote.scm
@@ -42,6 +42,22 @@
 ; The AndLink variant -- same as above, except uses AndLink.
 (AndLink p-lamb q-lamb)
 
+(define A1-lamb
+  (QuoteLink
+    (LambdaLink
+      (UnquoteLink
+        (VariableNode "$TyVs-one"))
+      (UnquoteLink
+        (VariableNode "$A1")))))
+
+(define A2-lamb
+  (QuoteLink
+    (LambdaLink
+      (UnquoteLink
+        (VariableNode "$TyVs-two"))
+      (UnquoteLink
+        (VariableNode "$A2")))))
+
 ; The pattern matcher, looks for the List variant
 (define blist
   (BindLink
@@ -63,26 +79,12 @@
     )
     ; pattern
     (ListLink
-      (QuoteLink
-        (LambdaLink
-          (UnquoteLink
-            (VariableNode "$TyVs-one"))
-          (UnquoteLink
-            (VariableNode "$A1"))))
-      (QuoteLink
-        (LambdaLink
-          (UnquoteLink
-            (VariableNode "$TyVs-two"))
-          (UnquoteLink
-            (VariableNode "$A2")))))
+      A1-lamb
+      A2-lamb)
     ; result
     (OrderedLink
-      (LambdaLink
-        (VariableNode "$TyVs-one")
-        (VariableNode "$A1"))
-      (LambdaLink
-        (VariableNode "$TyVs-two")
-        (VariableNode "$A2"))))
+      A1-lamb
+      A2-lamb))
 )
 
 ; The pattern matcher, looks for the And variant. Notice that
@@ -121,10 +123,6 @@
             (VariableNode "$A2")))))
     ; output result
     (UnorderedLink
-      (LambdaLink
-        (VariableNode "$TyVs-one")
-        (VariableNode "$A1"))
-      (LambdaLink
-        (VariableNode "$TyVs-two")
-        (VariableNode "$A2"))))
+      A1-lamb
+      A2-lamb))
 )


### PR DESCRIPTION
`Instantiator::walk_tree` did not support variable hidden (shadowed) by a scope link, resulting in some wrong behaviors, see `ScopeUTest::test_hide_2()` for an example of such.

@linas I'm confident enough to merge, you may want to have a look it though.