### PR TITLE
Add testCopyValues highlighting multiatomspace alpha equivalence bug

### DIFF
--- a/tests/atomspace/MultiSpaceUTest.cxxtest
+++ b/tests/atomspace/MultiSpaceUTest.cxxtest
@@ -25,6 +25,8 @@
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/truthvalue/SimpleTruthValue.h>
 
+#include <cxxtest/TestSuite.h>
+
 using namespace opencog;
 
 // Test support for multiple atomspaces.
@@ -462,5 +464,33 @@ public:
 		TS_ASSERT(haa_copy == haa);
 		TS_ASSERT(hec_copy == hec);
 	}
-};
 
+	// Make sure that values are copied if an atom for an inherited
+	// space is copied back to the atomspace it inherits.
+	void testCopyValues()
+	{
+		AtomSpace as;
+		AtomSpace ex(&as);
+
+		// Add (Exists (Member X A))
+		Handle as_A = as.add_node(CONCEPT_NODE, "A");
+		Handle as_X = ex.add_node(VARIABLE_NODE, "X");
+		Handle as_XA = as.add_link(MEMBER_LINK, as_X, as_A);
+		Handle as_S = as.add_link(SCOPE_LINK, as_XA);
+
+		// Add (Exists (Member Y A))
+		Handle ex_Y = as.add_node(VARIABLE_NODE, "Y");
+		Handle ex_YA = ex.add_link(MEMBER_LINK, ex_Y, as_A);
+		Handle ex_S = ex.add_link(SCOPE_LINK, ex_YA);
+
+		// Modify (Exists (Member Y A)) truth value.
+		ex_S->setTruthValue(SimpleTruthValue::createSTV(1.0, 1.0));
+
+		// Add (Exists (Member Y A)) back to as. Since it is alpha
+		// equivalent to (Exists (Member X A)) it should modifies its
+		// truth value.
+		Handle as_ex_S = as.add_atom(ex_S);
+
+		TS_ASSERT(as_ex_S->getTruthValue()->getConfidence() > 0.9);
+	}
+};


### PR DESCRIPTION
If you add a scope S1 in atomspace A, an alpha equivalent scope S2 in atomspace B (A's child), modified the TV of S2, add it back in A, then the TV of S1 is not updated.