### PR TITLE
Fix alpha equivalence multispace

### DIFF
--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -279,17 +279,20 @@ Handle AtomTable::getLinkHandle(const AtomPtr& orig, Quotation quotation) const
     quotation.update(t);
 
     // Make sure all the atoms in the outgoing set are in a valid
-    // format. One of the troublemakers here is the NumberNode,
-    // which will hash incorrectly, unless its in proper format.
-    // The other troublemaker is any ScopeLink.
-    HandleSeq resolved_seq;
-    for (const Handle& ho : seq) {
-        Handle rh(getHandle(ho, quotation));
-        if (not rh) return Handle::UNDEFINED;
-        resolved_seq.emplace_back(rh);
-    }
+    // format. One of the troublemakers here is the NumberNode, which
+    // will hash incorrectly, unless its in proper format. We exclude
+    // unquoted scope links from it, otherwise it will prematurely
+    // abort and possibly miss alpha equivalent atom in _atom_store.
+    if (not unquoted or not classserver().isA(t, SCOPE_LINK)) {
+        HandleSeq resolved_seq;
+        for (const Handle& ho : seq) {
+            Handle rh(getHandle(ho, quotation));
+            if (not rh) return Handle::UNDEFINED;
+            resolved_seq.emplace_back(rh);
+        }
 
-    a = createLink(resolved_seq, t);
+        a = createLink(resolved_seq, t);
+    }
 
     // Start searching to see if we have this atom.
     ContentHash ch = a->get_hash();

--- a/tests/atomspace/MultiSpaceUTest.cxxtest
+++ b/tests/atomspace/MultiSpaceUTest.cxxtest
@@ -474,7 +474,7 @@ public:
 
 		// Add (Exists (Member X A))
 		Handle as_A = as.add_node(CONCEPT_NODE, "A");
-		Handle as_X = ex.add_node(VARIABLE_NODE, "X");
+		Handle as_X = as.add_node(VARIABLE_NODE, "X");
 		Handle as_XA = as.add_link(MEMBER_LINK, as_X, as_A);
 		Handle as_S = as.add_link(SCOPE_LINK, as_XA);
 


### PR DESCRIPTION
Possible fix for #1226 by excluding unquoted scope link from resolution, that way it manages to reach the _atom_store look up a few lines below and find the alpha equivalent scope in the parent space.

@linas I suppose that rather than having a negative conditional to exclude cases from resolution, we should have a positive conditional with all cases that require resolution (like NumberNode as the comment suggest). Anyway, it fixes the problem and doesn't break any unit test so I assume it's good enough for now but I let it on you to decide whether it should be merged or not.
