### PR TITLE
Control the number of matches being made for a GlobNode in pattern matching

### DIFF
--- a/examples/pattern-matcher/glob.scm
+++ b/examples/pattern-matcher/glob.scm
@@ -88,3 +88,102 @@
 
 ; This will find the match (Number 42); it will NOT match (Concept "you")
 ; (cog-execute! love-type-glob)
+
+; -----------------------------------------------------------------
+; Globs can have interval restriction
+
+(define love-interval-glob
+    (BindLink
+        (TypedVariable (Glob "$star") (IntervalLink (Number 0) (Number 1)))
+        (ListLink
+            (Concept "I")
+            (Concept "love")
+            (Glob "$star"))
+        (ListLink
+            (Concept "Hey!")
+            (Concept "I")
+            (Concept "like")
+            (Glob "$star")
+            (Concept "also"))))
+
+; This will find both (Number 42) and (Concept "like") but not anything else
+; as they are not in the interval of zero to one
+; (cog-execute! love-interval-glob)
+
+; -----------------------------------------------------------------
+; Globs can have both type and interval restrictions by using TypeSetLink
+
+(define love-typeset-glob
+    (BindLink
+        (TypedVariable (Glob "$star")
+            (TypeSetLink (IntervalLink (Number 0) (Number -1)) (Type "ConceptNode")))
+        (ListLink
+            (Concept "I")
+            (Concept "love")
+            (Glob "$star"))
+        (ListLink
+            (Concept "Hey!")
+            (Concept "I")
+            (Concept "like")
+            (Glob "$star")
+            (Concept "also"))))
+
+; This will find only ConceptNodes, and the interval is zero to infinity
+; so it should find both (Concept "like") and
+; (Concept "teddy") (Concept "bear") (Concept "a") (Concept "lot")
+; (cog-execute! love-typeset-glob)
+
+; -----------------------------------------------------------------
+; Slightly more complicated
+
+; Populate the atomspace for the next test case
+(ListLink
+    (Concept "I")
+    (Concept "need")
+    (Concept "you")
+    (Concept "now"))
+
+(ListLink
+    (Concept "they")
+    (Concept "think")
+    (Concept "I")
+    (Concept "hate")
+    (Concept "you"))
+
+; Here we have three GlobNodes
+; $x can be grounded to nothing or as many as possible
+; $y has to be grounded to one and only one ConceptNode
+; $z can be grounded to nothing or as many as possible
+(define love-three-globs
+    (BindLink
+        (VariableList
+            (TypedVariable (Glob "$x") (IntervalLink (Number 0) (Number -1)))
+            (TypedVariable (Glob "$y")
+                (TypeSetLink (Type "ConceptNode") (IntervalLink (Number 1) (Number 1))))
+            (TypedVariable (Glob "$z") (IntervalLink (Number 0) (Number -1))))
+        (ListLink
+            (Glob "$x")
+            (Concept "I")
+            (Glob "$y")
+            (Concept "you")
+            (Glob "$z"))
+        (ListLink
+            (Concept "Hey!")
+            (Concept "I")
+            (Glob "$y")
+            (Concept "you")
+            (Concept "also"))))
+
+; This will find three possible groundings
+; 1) $x = (Concept "they") (Concept "think")
+;    $y = (Concept "hate")
+;    $z = <none>
+;
+; 2) $x = <none>
+;    $y = (Concept "need")
+;    $z = (Concept "now")
+;
+; 3) $x = <none>
+;    $y = (Concept "love")
+;    $z = <none>
+; (cog-execute! love-three-globs)

--- a/opencog/atoms/core/VariableList.cc
+++ b/opencog/atoms/core/VariableList.cc
@@ -218,9 +218,6 @@ void VariableList::get_vartype(const Handle& htypelink)
 				"Expected only IntervalLink and TypeNode, got %s",
 				h->toString().c_str());
 		}
-
-// JJJ
-std::cout << "Exiting... vartype:\n" << vartype->toShortString() << std::endl;
 	}
 
 	// The vartype is either a single type name, or a list of typenames.

--- a/opencog/atoms/core/VariableList.cc
+++ b/opencog/atoms/core/VariableList.cc
@@ -215,7 +215,7 @@ void VariableList::get_vartype(const Handle& htypelink)
 
 			else throw SyntaxException(TRACE_INFO,
 				"Unexpected contents in TypedSetLink\n"
-				"Expected only IntervalLink and TypeNode, got %s",
+				"Expected IntervalLink and TypeNode, got %s",
 				h->toString().c_str());
 		}
 	}

--- a/opencog/atoms/core/VariableList.cc
+++ b/opencog/atoms/core/VariableList.cc
@@ -24,6 +24,7 @@
 #include <opencog/atoms/base/ClassServer.h>
 #include <opencog/atoms/TypeNode.h>
 #include <opencog/atoms/core/DefineLink.h>
+#include <opencog/atoms/NumberNode.h>
 
 #include "VariableList.h"
 
@@ -167,12 +168,59 @@ void VariableList::get_vartype(const Handle& htypelink)
 	Handle varname(oset[0]);
 	Handle vartype(oset[1]);
 
-	// If its a defined type, unbundle it.
+	Type nt = varname->getType();
 	Type t = vartype->getType();
+
+	// Specifying how many atoms can be matched to a GlobNode, if any
+	HandleSeq intervals;
+
+	// If its a defined type, unbundle it.
 	if (DEFINED_TYPE_NODE == t)
 	{
 		vartype = DefineLink::get_definition(vartype);
 		t = vartype->getType();
+	}
+
+	// For GlobNode, we can specify either the interval or the type, e.g.
+	//
+	// TypedVariableLink
+	//   GlobNode  "$foo"
+	//   IntervalLink
+	//     NumberNode  2
+	//     NumberNode  3
+	//
+	// or both under a TypeSetLink, e.g.
+	//
+	// TypedVariableLink
+	//   GlobNode  "$foo"
+	//   TypeSetLink
+	//     IntervalLink
+	//       NumberNode  2
+	//       NumberNode  3
+	//     TypeNode "ConceptNode"
+	if (GLOB_NODE == nt and TYPE_SET_LINK == t)
+	{
+		for (const Handle& h : vartype->getOutgoingSet())
+		{
+			Type th = h->getType();
+
+			if (INTERVAL_LINK == th)
+				intervals = h->getOutgoingSet();
+
+			else if (TYPE_NODE == th)
+			{
+				vartype = h;
+				t = th;
+			}
+
+			else throw SyntaxException(TRACE_INFO,
+				"Unexpected contents in TypedSetLink\n"
+				"Expected only IntervalLink and TypeNode, got %s",
+				h->toString().c_str());
+		}
+
+// JJJ
+std::cout << "Exiting... vartype:\n" << vartype->toShortString() << std::endl;
 	}
 
 	// The vartype is either a single type name, or a list of typenames.
@@ -284,12 +332,23 @@ void VariableList::get_vartype(const Handle& htypelink)
 		// matched by the pattern matcher. There's nothing to do
 		// except not throwing an exception.
 	}
+	else if (GLOB_NODE == nt and INTERVAL_LINK == t)
+	{
+		intervals = vartype->getOutgoingSet();
+	}
 	else
 	{
 		throw SyntaxException(TRACE_INFO,
 			"Unexpected contents in TypedVariableLink\n"
 			"Expected type specifier (e.g. TypeNode, TypeChoice, etc.), got %s",
 			classserver().getTypeName(t).c_str());
+	}
+
+	if (0 < intervals.size())
+	{
+		_varlist._glob_intervalmap.insert({varname,
+			std::make_pair(NumberNodeCast(intervals[0])->get_value(),
+				NumberNodeCast(intervals[1])->get_value())});
 	}
 
 	_varlist.varset.insert(varname);

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -352,6 +352,18 @@ bool Variables::is_equal(const Variables& other, size_t index) const
 
 	// XXX TODO fuzzy?
 
+	// If intervals specified, intervals must match.
+	auto iime = _glob_intervalmap.find(vme);
+	auto ioth = other._glob_intervalmap.find(voth);
+	if (iime == _glob_intervalmap.end() and
+	    ioth != other._glob_intervalmap.end()) return false;
+
+	if (iime != _glob_intervalmap.end())
+	{
+		if (ioth == other._glob_intervalmap.end()) return false;
+		if (iime->second != ioth->second) return false;
+	}
+
 	// If we got to here, everything must be OK.
 	return true;
 }
@@ -692,6 +704,8 @@ Handle Variables::get_vardecl() const
 			OC_ASSERT(false, "TODO: support fuzzy type info");
 			continue;
 		}
+
+		// TODO: _glob_intervalmap?
 
 		// No type info
 		vars.push_back(var);

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -501,7 +501,7 @@ bool Variables::is_interval(const Handle& glob, size_t n) const
 	{
 		const std::pair<double, double>& intervals = iit->second;
 
-		// Return true if it's within the itnerval
+		// Return true if it's within the interval
 		// lower bound = intervals.first
 		// upper bound = intervals.second (negative value means infinity)
 		if (n >= intervals.first and

--- a/opencog/atoms/core/Variables.h
+++ b/opencog/atoms/core/Variables.h
@@ -183,6 +183,10 @@ struct Variables : public FreeVariables
 	// restrictions (if any).
 	bool is_type(const HandleSeq& hseq) const;
 
+	// Return true if the it satisfies the interval restrictions.
+	// Return false otherwise.
+	bool is_interval(const Handle& glob, size_t n) const;
+
 	// Given the tree `tree` containing variables in it, create and
 	// return a new tree with the indicated values `vals` substituted
 	// for the variables. The vals must pass the typecheck, else an

--- a/opencog/atoms/core/Variables.h
+++ b/opencog/atoms/core/Variables.h
@@ -114,6 +114,7 @@ protected:
 
 typedef std::map<Handle, const std::set<Type>> VariableTypeMap;
 typedef std::map<Handle, const OrderedHandleSet> VariableDeepTypeMap;
+typedef std::map<Handle, const std::pair<double, double>> GlobIntervalMap;
 
 /// The Variables struct defines a list of typed variables "unbundled"
 /// from the hypergraph in which they normally occur. The goal of this
@@ -137,6 +138,10 @@ struct Variables : public FreeVariables
 	VariableTypeMap _simple_typemap;
 	VariableDeepTypeMap _deep_typemap;
 	VariableDeepTypeMap _fuzzy_typemap;
+
+	/// To restrict how many atoms should be matched for each of the
+	/// GlobNodes in the pattern.
+	GlobIntervalMap _glob_intervalmap;
 
 	/// Return true iff all variables are well typed. For now only
 	/// simple types are supported, specifically if some variable is

--- a/opencog/query/DefaultPatternMatchCB.cc
+++ b/opencog/query/DefaultPatternMatchCB.cc
@@ -276,14 +276,8 @@ bool DefaultPatternMatchCB::link_match(const PatternTermPtr& ptm,
 	if (pattype != soltype) return false;
 
 	// Reject mis-sized compares, unless the pattern has a glob in it.
-	if (0 == _globs->count(lpat))
-	{
-		if (lpat->getArity() != lsoln->getArity()) return false;
-	}
-	else
-	{
-		if (lpat->getArity() > lsoln->getArity()) return false;
-	}
+	if (0 == _globs->count(lpat) and lpat->getArity() != lsoln->getArity())
+		return false;
 
 	// If the link is a ScopeLink, we need to deal with the
 	// alpha-conversion of the bound variables in the scope link.

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -290,7 +290,7 @@ bool PatternMatchEngine::ordered_compare(const PatternTermPtr& ptm,
 										glob_seq.push_back(osg[jg]);
 										jg ++;
 									}
-									// It's beyond the upper limit -- reject
+									// It's beyond the upper bound; reject
 									else
 									{
 										match = false;
@@ -315,6 +315,13 @@ bool PatternMatchEngine::ordered_compare(const PatternTermPtr& ptm,
 							jg --;
 							continue;
 						}
+					}
+					else if (not _varlist->is_interval(ohp, 1))
+					{
+						// If we are here, we get a glob that has zero as
+						// the upper bound of the interval, why not...
+						jg --;
+						continue;
 					}
 					else
 					{

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -230,7 +230,13 @@ bool PatternMatchEngine::ordered_compare(const PatternTermPtr& ptm,
 		for (size_t ip=0, jg=0; ip<osp_size or jg<osg_size; ip++, jg++)
 		{
 			if (ip == osp_size) ip --;
-			if (jg == osg_size) jg --;
+
+			bool grd_end = false;
+			if (jg == osg_size)
+			{
+				grd_end = true;
+				jg --;
+			}
 
 			bool tc = false;
 			const Handle& ohp(osp[ip]->getHandle());
@@ -261,7 +267,7 @@ bool PatternMatchEngine::ordered_compare(const PatternTermPtr& ptm,
 					// interval is zero, so the glob can be grounded
 					// to nothing.
 
-					// Just in case someone put a zero as the upper bound...
+					// Just in case if the upper bound is zero...
 					if (not _varlist->is_interval(ohp, 1))
 					{
 						jg --;
@@ -269,7 +275,7 @@ bool PatternMatchEngine::ordered_compare(const PatternTermPtr& ptm,
 					}
 
 					// If the post_glob matches with the current candidate,
-					// the glob is grounded to nothing.
+					// we are done.
 					if (tree_compare(glob, osg[jg], CALL_GLOB) and
 					    have_post and
 					    tree_compare(post_glob, osg[jg], CALL_GLOB))
@@ -278,9 +284,10 @@ bool PatternMatchEngine::ordered_compare(const PatternTermPtr& ptm,
 						continue;
 					}
 
-					// If we have gone through all the candidates and
-					// the glob has a lower bound of zero, we are done.
-					if (jg+1 == osg_size) continue;
+					// Since the glob has a lower bound of zero, if we
+					// already have gone through all the candidates at
+					// this point, we are done.
+					if (grd_end) continue;
 				}
 
 				// If we are here, the glob we are looking at has to be
@@ -318,8 +325,8 @@ bool PatternMatchEngine::ordered_compare(const PatternTermPtr& ptm,
 				}
 
 				// If up to this point there are still atoms in
-				// either the osp or osg, this is probably not
-				// a match, so reject it.
+				// either osp or osg, this is probably not a
+				// match, so reject it.
 				if ((ip+1 == osp_size and jg+1 < osg_size) or
 				    (ip+1 < osp_size  and jg+1 == osg_size))
 				{

--- a/tests/query/GlobUTest.cxxtest
+++ b/tests/query/GlobUTest.cxxtest
@@ -62,6 +62,9 @@ _exit(rc); // XXX hack to avoid double-free in __run_exit_handlers
 	void test_glob_middle(void);
 	void test_glob_final(void);
 	void test_glob_type(void);
+	void test_glob_interval(void);
+	void test_glob_typeset(void);
+	void test_glob_three_globs(void);
 };
 
 void GlobUTest::tearDown(void)
@@ -172,6 +175,117 @@ void GlobUTest::test_glob_type(void)
 		"    (ConceptNode \"I\")"
 		"    (ConceptNode \"like\")"
 		"    (NumberNode  42)"
+		"    (ConceptNode \"also\")))"
+	);
+	TS_ASSERT_EQUALS(love, response);
+
+	// ----
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+/*
+ * Test a glob with interval restrictions
+ */
+void GlobUTest::test_glob_interval(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	eval->eval("(load-from-path \"tests/query/glob-basic.scm\")");
+
+	Handle love = eval->eval_h("(cog-execute! love-interval-glob)");
+	printf("love-interval-glob %s\n", love->toString().c_str());
+	TS_ASSERT_EQUALS(2, love->getArity());
+
+	Handle response = eval->eval_h(
+		"(SetLink"
+		"  (ListLink"
+		"    (ConceptNode \"Hey!\")"
+		"    (ConceptNode \"I\")"
+		"    (ConceptNode \"like\")"
+		"    (NumberNode  42)"
+		"    (ConceptNode \"also\"))"
+		"  (ListLink"
+		"    (ConceptNode \"Hey!\")"
+		"    (ConceptNode \"I\")"
+		"    (ConceptNode \"like\")"
+		"    (Concept \"you\")"
+		"    (ConceptNode \"also\")))"
+	);
+	TS_ASSERT_EQUALS(love, response);
+
+	// ----
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+/*
+ * Test a glob with both type and interval restrictions
+ */
+void GlobUTest::test_glob_typeset(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	eval->eval("(load-from-path \"tests/query/glob-basic.scm\")");
+
+	Handle love = eval->eval_h("(cog-execute! love-typeset-glob)");
+	printf("love-typeset-glob %s\n", love->toString().c_str());
+	TS_ASSERT_EQUALS(2, love->getArity());
+
+	Handle response = eval->eval_h(
+		"(SetLink"
+		"  (ListLink"
+		"    (ConceptNode \"Hey!\")"
+		"    (ConceptNode \"I\")"
+		"    (ConceptNode \"like\")"
+		"    (ConceptNode \"teddy\")"
+		"    (ConceptNode \"bears\")"
+		"    (ConceptNode \"a\")"
+		"    (ConceptNode \"lot\")"
+		"    (ConceptNode \"also\"))"
+		"  (ListLink"
+		"    (ConceptNode \"Hey!\")"
+		"    (ConceptNode \"I\")"
+		"    (ConceptNode \"like\")"
+		"    (Concept \"you\")"
+		"    (ConceptNode \"also\")))"
+	);
+	TS_ASSERT_EQUALS(love, response);
+
+	// ----
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+/*
+ * A slightly more complicated case
+ */
+void GlobUTest::test_glob_three_globs(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	eval->eval("(load-from-path \"tests/query/glob-basic.scm\")");
+
+	Handle love = eval->eval_h("(cog-execute! love-three-globs)");
+	printf("love-three-globs %s\n", love->toString().c_str());
+	TS_ASSERT_EQUALS(3, love->getArity());
+
+	Handle response = eval->eval_h(
+		"(SetLink"
+		"  (ListLink"
+		"    (ConceptNode \"Hey!\")"
+		"    (ConceptNode \"I\")"
+		"    (ConceptNode \"hate\")"
+		"    (Concept \"you\")"
+		"    (ConceptNode \"also\"))"
+		"  (ListLink"
+		"    (ConceptNode \"Hey!\")"
+		"    (ConceptNode \"I\")"
+		"    (ConceptNode \"need\")"
+		"    (Concept \"you\")"
+		"    (ConceptNode \"also\"))"
+		"  (ListLink"
+		"    (ConceptNode \"Hey!\")"
+		"    (ConceptNode \"I\")"
+		"    (ConceptNode \"love\")"
+		"    (Concept \"you\")"
 		"    (ConceptNode \"also\")))"
 	);
 	TS_ASSERT_EQUALS(love, response);

--- a/tests/query/glob-basic.scm
+++ b/tests/query/glob-basic.scm
@@ -25,6 +25,19 @@
 	(Concept "a")
 	(Concept "lot"))
 
+(ListLink
+	(Concept "I")
+	(Concept "need")
+	(Concept "you")
+	(Concept "now"))
+
+(ListLink
+	(Concept "they")
+	(Concept "think")
+	(Concept "I")
+	(Concept "hate")
+	(Concept "you"))
+
 (ListLink (Concept "I") (Concept "love") (Number 42))
 
 ;; Two different re-write rules. The first rule, immediately below,
@@ -58,15 +71,74 @@
 ; Globs can be typed, just like variables:
 
 (define love-type-glob
-   (BindLink
-      (TypedVariable (Glob "$star") (Type "NumberNode"))
-      (ListLink
-         (Concept "I")
-         (Concept "love")
-         (Glob "$star"))
-      (ListLink
-         (Concept "Hey!")
-         (Concept "I")
-         (Concept "like")
-         (Glob "$star")
-         (Concept "also"))))
+	(BindLink
+		(TypedVariable (Glob "$star") (Type "NumberNode"))
+		(ListLink
+			(Concept "I")
+			(Concept "love")
+			(Glob "$star"))
+		(ListLink
+			(Concept "Hey!")
+			(Concept "I")
+			(Concept "like")
+			(Glob "$star")
+			(Concept "also"))))
+
+; -----------------------------------------------------------------
+; Globs that have interval restriction
+
+(define love-interval-glob
+	(BindLink
+		(TypedVariable (Glob "$star") (IntervalLink (Number 0) (Number 1)))
+		(ListLink
+			(Concept "I")
+			(Concept "love")
+			(Glob "$star"))
+		(ListLink
+			(Concept "Hey!")
+			(Concept "I")
+			(Concept "like")
+			(Glob "$star")
+			(Concept "also"))))
+
+; -----------------------------------------------------------------
+; Globs that have both type and interval restrictions
+; type == ConceptNode and interval == zero to infinity
+
+(define love-typeset-glob
+	(BindLink
+		(TypedVariable (Glob "$star")
+			(TypeSetLink (IntervalLink (Number 0) (Number -1)) (Type "ConceptNode")))
+		(ListLink
+			(Concept "I")
+			(Concept "love")
+			(Glob "$star"))
+		(ListLink
+			(Concept "Hey!")
+			(Concept "I")
+			(Concept "like")
+			(Glob "$star")
+			(Concept "also"))))
+
+; -----------------------------------------------------------------
+; Slightly more complicated
+
+(define love-three-globs
+	(BindLink
+		(VariableList
+			(TypedVariable (Glob "$x") (IntervalLink (Number 0) (Number -1)))
+			(TypedVariable (Glob "$y")
+				(TypeSetLink (Type "ConceptNode") (IntervalLink (Number 1) (Number 1))))
+			(TypedVariable (Glob "$z") (IntervalLink (Number 0) (Number -1))))
+		(ListLink
+			(Glob "$x")
+			(Concept "I")
+			(Glob "$y")
+			(Concept "you")
+			(Glob "$z"))
+		(ListLink
+			(Concept "Hey!")
+			(Concept "I")
+			(Glob "$y")
+			(Concept "you")
+			(Concept "also"))))

--- a/tests/query/glob-basic.scm
+++ b/tests/query/glob-basic.scm
@@ -85,7 +85,7 @@
 			(Concept "also"))))
 
 ; -----------------------------------------------------------------
-; Globs that have interval restriction
+; Globs can have interval restriction
 
 (define love-interval-glob
 	(BindLink
@@ -102,7 +102,7 @@
 			(Concept "also"))))
 
 ; -----------------------------------------------------------------
-; Globs that have both type and interval restrictions
+; Globs can have both type and interval restrictions by using TypeSetLink
 ; type == ConceptNode and interval == zero to infinity
 
 (define love-typeset-glob


### PR DESCRIPTION
This can be done by using `IntervalLink` e.g.
```
(TypedVariable
  (Glob "$star")
  (IntervalLink (Number 0) (Number 1))
```
We can also have type restriction as well by using `TypeSetLink` e.g.
```
(TypedVariable
  (Glob "$star")
  (TypeSetLink
    (IntervalLink (Number 0) (Number -1))
    (Type "ConceptNode")))
```

I have also updated the Pattern Matcher to adapt the changes, seems to work for various simple cases.