### PR TITLE
ECAN changes

### DIFF
--- a/opencog/attentionbank/AttentionBank.cc
+++ b/opencog/attentionbank/AttentionBank.cc
@@ -44,8 +44,6 @@ AttentionBank::AttentionBank(AtomSpace* asp) :
     LTIAtomWage = config().get_int("ECAN_STARTING_ATOM_LTI_WAGE", 10);
     minAFSize = config().get_int("ECAN_MIN_AF_SIZE", 100);
 
-    _attentionalFocusBoundary = 1;
-
     _removeAtomConnection =
         asp->removeAtomSignal(
             boost::bind(&AttentionBank::remove_atom_from_index, this, _1));
@@ -271,14 +269,14 @@ double AttentionBank::getNormalisedSTI(AttentionValuePtr av,
     double val;
     // get normalizer (maxSTI - attention boundary)
     AttentionValue::sti_t s = av->getSTI();
-    if (s > getAttentionalFocusBoundary()) {
-        int normaliser = (int) getMaxSTI(average) - getAttentionalFocusBoundary();
+    if (s > get_af_max_sti()) {
+        int normaliser = (int) getMaxSTI(average) - get_af_max_sti();
         if (normaliser == 0) return 0.0;
-        val = (s - getAttentionalFocusBoundary()) / (double) normaliser;
+        val = (s - get_af_max_sti()) / (double) normaliser;
     } else {
-        int normaliser = -((int) getMinSTI(average) + getAttentionalFocusBoundary());
+        int normaliser = -((int) getMinSTI(average) + get_af_max_sti());
         if (normaliser == 0) return 0.0;
-        val = (s + getAttentionalFocusBoundary()) / (double) normaliser;
+        val = (s + get_af_max_sti()) / (double) normaliser;
     }
 
     if (clip) return std::max(-1.0, std::min(val, 1.0));
@@ -289,7 +287,7 @@ double AttentionBank::getNormalisedSTI(AttentionValuePtr av) const
 {
     AttentionValue::sti_t s = av->getSTI();
     auto normaliser =
-            s > getAttentionalFocusBoundary() ? getMaxSTI() : getMinSTI();
+            s > get_af_max_sti() ? getMaxSTI() : getMinSTI();
 
     return (s / normaliser);
 }

--- a/opencog/attentionbank/AttentionBank.h
+++ b/opencog/attentionbank/AttentionBank.h
@@ -82,13 +82,6 @@ class AttentionBank
     boost::signals2::connection _removeAtomConnection;
 
     /**
-     * Boundary at which an atom is considered within the attentional
-     * focus of opencog. Atom's with STI less than this value are
-     * not charged STI rent.
-     */
-    AttentionValue::sti_t _attentionalFocusBoundary;
-
-    /**
      * Signal emitted when an atom crosses in or out of the
      * AttentionalFocus.
      */
@@ -224,31 +217,6 @@ public:
 
     long updateLTIFunds(AttentionValue::lti_t diff) {
         return fundsLTI += diff;
-    }
-
-    /**
-     * Get attentional focus boundary, generally atoms below
-     * this threshold won't be accessed unless search methods
-     * are unsuccessful on those that are above this value.
-     *
-     * @return Short Term Importance threshold value
-     */
-    AttentionValue::sti_t getAttentionalFocusBoundary() const {
-        return _attentionalFocusBoundary;
-    }
-
-    /**
-     * Change the attentional focus boundary. Some situations
-     * may benefit from less focussed searches.
-     *
-     * @param s New threshold
-     * @return Short Term Importance threshold value
-     */
-    AttentionValue::sti_t setAttentionalFocusBoundary(
-        AttentionValue::sti_t s)
-    {
-        _attentionalFocusBoundary = s;
-        return s;
     }
 
     /**

--- a/opencog/attentionbank/AttentionBank.h
+++ b/opencog/attentionbank/AttentionBank.h
@@ -159,6 +159,14 @@ public:
             return 0;
     }
 
+    void set_af_size(int size) {
+        minAFSize = size;
+    }
+
+    int get_af_size(void) {
+        return minAFSize;
+    }
+
     /**
      * Change the attention value of an atom.
      */

--- a/opencog/attentionbank/AttentionBank.h
+++ b/opencog/attentionbank/AttentionBank.h
@@ -159,6 +159,13 @@ public:
         return get_av(h)->getVLTI();
     }
 
+    AttentionValue::sti_t get_af_max_sti(void) const {
+        if(attentionalFocus.rbegin() != attentionalFocus.rend())
+            return (attentionalFocus.rbegin()->second)->getSTI();
+        else
+            return 0;
+    }
+
     /**
      * Change the attention value of an atom.
      */
@@ -311,7 +318,6 @@ public:
      * @see getNormalisedSTI()
      */
     double getNormalisedSTI(AttentionValuePtr) const;
-
     /**
      * Retrieve the linearly normalised Short-Term Importance between 0..1
      * for a given AttentionValue.

--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -344,8 +344,6 @@ void SchemeSmob::register_procs()
 	register_proc("cog-av->alist",         1, 0, 0, C(ss_av_get_value));
 
 	// AttentionalFocus
-	register_proc("cog-af-boundary",       0, 0, 0, C(ss_af_boundary));
-	register_proc("cog-set-af-boundary!",  1, 0, 0, C(ss_set_af_boundary));
 	register_proc("cog-af",                0, 0, 0, C(ss_af));
 
 	// Atom types

--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -345,6 +345,8 @@ void SchemeSmob::register_procs()
 
 	// AttentionalFocus
 	register_proc("cog-af",                0, 0, 0, C(ss_af));
+	register_proc("cog-af-size",           0, 0, 0, C(ss_af_size));
+	register_proc("cog-set-af-size!",      1, 0, 0, C(ss_set_af_size));
 
 	// Atom types
 	register_proc("cog-get-types",         0, 0, 0, C(ss_get_types));

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -181,8 +181,6 @@ private:
 
 	// AttentionalFocus and AttentionalFocus Boundary
 	// XXX FIXME these should move to the attention bank!
-	static SCM ss_af_boundary(void);
-	static SCM ss_set_af_boundary(SCM);
 	static SCM ss_af(void);
 
 	// Free variables

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -182,6 +182,8 @@ private:
 	// AttentionalFocus and AttentionalFocus Boundary
 	// XXX FIXME these should move to the attention bank!
 	static SCM ss_af(void);
+	static SCM ss_af_size(void);
+	static SCM ss_set_af_size(SCM);
 
 	// Free variables
 	static SCM ss_get_free_variables(SCM);

--- a/opencog/guile/SchemeSmobAF.cc
+++ b/opencog/guile/SchemeSmobAF.cc
@@ -31,6 +31,30 @@
 using namespace opencog;
 
 /**
+ *   Return AttentionalFocus Size
+ **/
+SCM SchemeSmob::ss_af_size (void)
+{
+    AtomSpace* atomspace = ss_get_env_as("cog-af-size");
+    return scm_from_int(attentionbank(atomspace).get_af_size());
+}
+
+/**
+ * Set AttentionalFocus Size
+ */
+SCM SchemeSmob::ss_set_af_size (SCM ssize)
+{
+    AtomSpace* atomspace = ss_get_env_as("cog-set-af-size!");
+    if (scm_is_false(scm_integer_p(ssize)))
+        scm_wrong_type_arg_msg("cog-set-af-size", 1, ssize,
+                "integer opencog AttentionalFocus size");
+
+    int bdy = scm_to_int(ssize);
+    attentionbank(atomspace).set_af_size(bdy);
+    return scm_from_int(attentionbank(atomspace).get_af_size());
+}
+
+/**
  * Return the list of atoms in the AttentionalFocus
  */
 SCM SchemeSmob::ss_af (void)

--- a/opencog/guile/SchemeSmobAF.cc
+++ b/opencog/guile/SchemeSmobAF.cc
@@ -31,29 +31,6 @@
 using namespace opencog;
 
 /**
- * Return AttentionalFocus Boundary
- */
-SCM SchemeSmob::ss_af_boundary (void)
-{
-	AtomSpace* atomspace = ss_get_env_as("cog-af-boundary");
-	return scm_from_short(attentionbank(atomspace).getAttentionalFocusBoundary());
-}
-
-/**
- * Set AttentionalFocus Boundary
- */
-SCM SchemeSmob::ss_set_af_boundary (SCM sboundary)
-{
-	AtomSpace* atomspace = ss_get_env_as("cog-set-af-boundary!");
-	if (scm_is_false(scm_integer_p(sboundary)))
-		scm_wrong_type_arg_msg("cog-set-af-boundary", 1, sboundary,
-			"integer opencog AttentionalFocus Boundary");
-
-	short bdy = scm_to_short(sboundary);
-	return scm_from_short(attentionbank(atomspace).setAttentionalFocusBoundary(bdy));
-}
-
-/**
  * Return the list of atoms in the AttentionalFocus
  */
 SCM SchemeSmob::ss_af (void)

--- a/opencog/query/AttentionalFocusCB.cc
+++ b/opencog/query/AttentionalFocusCB.cc
@@ -21,8 +21,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/attentionbank/AttentionBank.h>
 #include "AttentionalFocusCB.h"
+#include <opencog/attentionbank/AttentionBank.h>
 
 using namespace opencog;
 
@@ -35,16 +35,13 @@ AttentionalFocusCB::AttentionalFocusCB(AtomSpace* as) :
 
 bool AttentionalFocusCB::node_match(const Handle& node1, const Handle& node2)
 {
-	return node1 == node2 and
-		attentionbank(_as).get_sti(node2) >
-		attentionbank(_as).getAttentionalFocusBoundary();
+	return node1 == node2 and attentionbank(_as).atom_is_in_AF(node2);
 }
 
 bool AttentionalFocusCB::link_match(const PatternTermPtr& ptm, const Handle& lsoln)
 {
 	return DefaultPatternMatchCB::link_match(ptm, lsoln) and
-		attentionbank(_as).get_sti(lsoln) >
-		attentionbank(_as).getAttentionalFocusBoundary();
+           attentionbank(_as).atom_is_in_AF(lsoln);
 }
 
 
@@ -56,10 +53,11 @@ IncomingSet AttentionalFocusCB::get_incoming_set(const Handle& h)
 	// AF boundary.  The PM will look only at those links that
 	// this callback returns; thus we avoid searching the low-AF
 	// parts of the hypergraph.
-	IncomingSet filtered_set;
-	for (const auto& l : incoming_set)
-		if (attentionbank(_as).get_sti(Handle(l)) > attentionbank(_as).getAttentionalFocusBoundary())
-			filtered_set.push_back(l);
+    IncomingSet filtered_set;
+    for (const auto& l : incoming_set){
+        if(attentionbank(_as).atom_is_in_AF(Handle(l)))
+            filtered_set.push_back(l);
+    }
 
 	// If nothing is in AF
 	if (filtered_set.empty())

--- a/opencog/query/AttentionalFocusCB.cc
+++ b/opencog/query/AttentionalFocusCB.cc
@@ -29,8 +29,6 @@ using namespace opencog;
 AttentionalFocusCB::AttentionalFocusCB(AtomSpace* as) :
 	DefaultPatternMatchCB(as)
 {
-	// Temporarily disable the AF mechanism during the URE development
-	// _as->setAttentionalFocusBoundary(AttentionValue::MINSTI);
 }
 
 bool AttentionalFocusCB::node_match(const Handle& node1, const Handle& node2)

--- a/opencog/scm/opencog/base/core-docs.scm
+++ b/opencog/scm/opencog/base/core-docs.scm
@@ -801,29 +801,7 @@
     any atomspace, null is returned.
 ")
 
-(set-procedure-property! cog-af-boundary 'documentation
-"
- cog-af-boundary
-    Return the AttentionalFocus Boundary of the AtomSpace (which is
-    a short integer STI value).
 
-    Example:
-
-    guile> (cog-af-boundary)
-    100
-")
-
-(set-procedure-property! cog-set-af-boundary! 'documentation
-"
- cog-set-af-boundary! STI
-    Set the AttentionalFocus Boundary of the AtomSpace (which is a
-    short integer STI value). Returns the new AttentionalFocus boundary
-    (which is a short integer STI value).
-
-    Example:
-    guile> (cog-set-af-boundary! 200)
-    200
-")
 
 (set-procedure-property! cog-af 'documentation
 "

--- a/opencog/scm/opencog/base/core-docs.scm
+++ b/opencog/scm/opencog/base/core-docs.scm
@@ -814,6 +814,30 @@
     (ConceptNode \"Databases\" (av 15752 0 0))
 ")
 
+(set-procedure-property! cog-af-size 'documentation
+ "
+  cog-af-size
+     Return the AttentionalFocus size of the AtomSpace (which is
+     an integer value).
+ 
+     Example:
+ 
+     guile> (cog-af-size)
+     100
+ ")
+  
+ (set-procedure-property! cog-set-af-size! 'documentation
+ "
+  cog-set-af-size! AF Size
+     Set the AttentionalFocus Size of the AtomSpace (which is an
+     integer value). Returns the new AttentionalFocus size
+     (which is an integer value).
+ 
+     Example:
+     guile> (cog-set-af-size! 200)
+     200
+ ")
+
 (set-procedure-property! cog-get-types 'documentation
 "
  cog-get-types

--- a/tests/atomspace/AtomSpaceAsyncUTest.cxxtest
+++ b/tests/atomspace/AtomSpaceAsyncUTest.cxxtest
@@ -508,13 +508,14 @@ public:
                                 this, _1, _2, _3));
 
         __testAFSignalsCounter = 0;
-        ab->setAttentionalFocusBoundary(100);
+        
+        auto af_sti = ab->get_af_max_sti();
 
         // Add a node to the AttentionalFocus
         Handle h = atomSpace->add_node(CONCEPT_NODE,
                                        "test");
         h->setTruthValue(SimpleTruthValue::createTV(0.01, 1));
-        ab->set_sti(h, 200);
+        ab->set_sti(h, af_sti + 200); //set it high enough to so that it will be in the AF.
         TS_ASSERT_EQUALS((int)__testAFSignalsCounter, 1);
 
         // Remove the node from the AttentionalFocus

--- a/tests/atomspace/AtomSpaceUTest.cxxtest
+++ b/tests/atomspace/AtomSpaceUTest.cxxtest
@@ -230,7 +230,7 @@ struct LTIAboveThreshold : public HandlePredicate
 template<typename InputIterator>
 HandleSeq filter_InAttentionalFocus(AtomSpace* as, InputIterator begin, InputIterator end)
 {
-    STIAboveThreshold sti_above(as, attentionbank(as).getAttentionalFocusBoundary());
+    STIAboveThreshold sti_above(as, attentionbank(as).get_af_max_sti());
     return filter(begin, end, sti_above);
 }
 

--- a/tests/attentionbank/AttentionUTest.cxxtest
+++ b/tests/attentionbank/AttentionUTest.cxxtest
@@ -48,7 +48,8 @@ class AttentionUTest :  public CxxTest::TestSuite
                 _ab.set_sti(h, i*10);
             } 
             
-            HandleSeq hseq = _ab.getTopSTIValuedHandles();
+            HandleSeq hseq;
+            _ab.get_handle_set_in_attentional_focus(std::back_inserter(hseq));
            
             TS_ASSERT_EQUALS(_as.get_size(), 50);
             TS_ASSERT_EQUALS(hseq.size(), 10);

--- a/tests/query/AttentionalFocusCBUTest.cxxtest
+++ b/tests/query/AttentionalFocusCBUTest.cxxtest
@@ -70,7 +70,6 @@ void AttentionalFocusCBUTest::setUp(void)
 void AttentionalFocusCBUTest::test_af_bindlink(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
-	attentionbank(as).setAttentionalFocusBoundary(20); //for test purpose
 	eval->eval("(load-from-path \"tests/query/af-filtering-test.scm\")");
 
 	Handle findMan = eval->eval_h("find-man");
@@ -78,5 +77,4 @@ void AttentionalFocusCBUTest::test_af_bindlink(void)
 	// first match
 	Handle answersSingle = af_bindlink(as, findMan);
 	TS_ASSERT_EQUALS(1, getarity(answersSingle));
-	TS_ASSERT_EQUALS(20, attentionbank(as).getAttentionalFocusBoundary());
 }

--- a/tests/rule-engine/ForwardChainerUTest.cxxtest
+++ b/tests/rule-engine/ForwardChainerUTest.cxxtest
@@ -37,9 +37,6 @@ public:
 		logger().set_timestamp_flag(false);
 		logger().set_print_to_stdout_flag(true);
 
-		// Disable the AF mechanism during testing!
-		attentionbank(&_as).setAttentionalFocusBoundary(AttentionValue::MINSTI);
-
 		string source_dir = string(PROJECT_SOURCE_DIR),
 			test_dir = source_dir + "/tests",
 			test_ure_dir = test_dir + "/rule-engine",


### PR DESCRIPTION
This PR changes the definition of the Attentional focus as a set of top K STI valued atoms at a certain instance of time instead of its current definition as a set of atoms above some arbitrary STI value aka attentional focus boundary. The need for these changes has been discussed F2F with @bgoertzel and @mattew Ikle, the main motivation being reducing the ramifications of dynamically updating the focus boundary.