### PR TITLE
Update the recognizer to read scoped glob-restrictions

### DIFF
--- a/opencog/query/Recognizer.cc
+++ b/opencog/query/Recognizer.cc
@@ -278,7 +278,28 @@ bool Recognizer::fuzzy_match(const Handle& npat_h, const Handle& nsoln_h)
 		if (GLOB_NODE != osg[jg]->getType())
 		{
 			if (loose_match(osp[ip], osg[jg])) continue;
-			return false;
+
+			// Sometimes we end up here because the glob
+			// in the previous iteration failed to
+			// match anything, so although we are not
+			// looking at a glob right now, we still
+			// need to do the below check...
+
+			// If we have gone through all the scopes,
+			// it's not a match and we are done.
+			if (ks+1 == _soln_vars.size())
+				return false;
+			// Otherwise reset everything and try again
+			// with the next scope.
+			else
+			{
+				// The for-loop increment will turn them back to zero.
+				ip = -1;
+				jg = -1;
+				ks++;
+				svar = _soln_vars[ks];
+				continue;
+			}
 		}
 
 		// If we are here, we have a glob in the soln.
@@ -330,6 +351,7 @@ bool Recognizer::fuzzy_match(const Handle& npat_h, const Handle& nsoln_h)
 			match_cnt++;
 			ip++;
 		}
+
 		// If ip ran past the end, then the post was not found. This is
 		// a mismatch.
 		if (not (ip < max_size))

--- a/opencog/query/Recognizer.cc
+++ b/opencog/query/Recognizer.cc
@@ -182,7 +182,26 @@ bool Recognizer::node_match(const Handle& npat_h, const Handle& nsoln_h)
 {
 	if (npat_h == nsoln_h) return true;
 	Type tso = nsoln_h->getType();
-	if (VARIABLE_NODE == tso or GLOB_NODE == tso) return true;
+	if (VARIABLE_NODE == tso) return true;
+	if (GLOB_NODE == tso)
+	{
+		if (0 < _soln_vars.size())
+		{
+			// Check if it satisfies the type restrictions, if any
+			if (std::all_of(_soln_vars.begin(), _soln_vars.end(),
+				[&](const Variables& v) {
+					return (not v.is_type(nsoln_h, npat_h)); }))
+				return false;
+
+			// Check if it satisfies the interval restrictions, if any
+			if (std::all_of(_soln_vars.begin(), _soln_vars.end(),
+				[&](const Variables& v) {
+					return (not v.is_interval(nsoln_h, 1)); }))
+				return false;
+		}
+		// No reason to reject
+		return true;
+	}
 	return false;
 }
 

--- a/opencog/query/Recognizer.cc
+++ b/opencog/query/Recognizer.cc
@@ -57,7 +57,7 @@ class Recognizer :
    public virtual DefaultPatternMatchCB
 {
 	private:
-		Variables _soln_vars;
+		std::vector<Variables> _soln_vars;
 		void get_glob_decl(const Handle&);
 
 	protected:
@@ -118,7 +118,7 @@ void Recognizer::get_glob_decl(const Handle& h)
 			ScopeLinkPtr sl(ScopeLinkCast(s));
 			if (NULL == sl)
 				sl = createScopeLink(*LinkCast(s));
-			_soln_vars = sl->get_variables();
+			_soln_vars.push_back(sl->get_variables());
 		}
 	}
 	else
@@ -188,6 +188,7 @@ bool Recognizer::node_match(const Handle& npat_h, const Handle& nsoln_h)
 
 bool Recognizer::link_match(const PatternTermPtr& ptm, const Handle& lsoln)
 {
+	_soln_vars.clear();
 	const Handle& lpat = ptm->getHandle();
 
 	// Self-compares always proceed.


### PR DESCRIPTION
So take a simple example, if we have:
```
(Satisfaction
  (TypedVariable
    (Glob "$x")
    (Type "PredicateNode"))
  (List (Concept "A") (Glob "$x") (Concept "C")))

(Satisfaction
  (TypedVariable
    (Glob "$y")
    (Type "ConceptNode"))
  (List (Concept "A") (Glob "$y") (Concept "C")))
```

and if we do:
```
(cog-execute! (Dual (List (Concept "A") (Concept "B") (Concept "C"))))
```

It will get only the second one as it satisfies the type restriction.