### PR TITLE
 Add missing API function: get all keys on atom.

### DIFF
--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -303,6 +303,7 @@ void SchemeSmob::register_procs()
 	register_proc("cog-outgoing-set",      1, 0, 0, C(ss_outgoing_set));
 	register_proc("cog-outgoing-by-type",  2, 0, 0, C(ss_outgoing_by_type));
 	register_proc("cog-outgoing-atom",     2, 0, 0, C(ss_outgoing_atom));
+	register_proc("cog-keys",              1, 0, 0, C(ss_keys));
 	register_proc("cog-value",             2, 0, 0, C(ss_value));
 	register_proc("cog-tv",                1, 0, 0, C(ss_tv));
 	register_proc("cog-av",                1, 0, 0, C(ss_av));

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -118,6 +118,7 @@ private:
 	static SCM ss_as(SCM);
 	static SCM ss_av(SCM);
 	static SCM ss_tv(SCM);
+	static SCM ss_keys(SCM);
 	static SCM ss_value(SCM, SCM);
 	static SCM ss_incoming_set(SCM);
 	static SCM ss_incoming_by_type(SCM, SCM);

--- a/opencog/guile/SchemeSmobValue.cc
+++ b/opencog/guile/SchemeSmobValue.cc
@@ -245,6 +245,20 @@ SCM SchemeSmob::ss_value (SCM satom, SCM skey)
 	return SCM_EOL;
 }
 
+/** Return all of the keys on the atom */
+SCM SchemeSmob::ss_keys (SCM satom)
+{
+	Handle atom(verify_handle(satom, "cog-value"));
+
+	SCM rv = SCM_EOL;
+	std::set<Handle> keys = atom->getKeys();
+	for (const Handle& k : keys)
+	{
+		rv = scm_cons (handle_to_scm(k), rv);
+	}
+	return rv;
+}
+
 /* ============================================================== */
 /** Return a scheme list of the values associated with the value */
 

--- a/opencog/scm/opencog/base/core-docs.scm
+++ b/opencog/scm/opencog/base/core-docs.scm
@@ -711,7 +711,9 @@
 (set-procedure-property! cog-keys 'documentation
 "
  cog-keys ATOM
-    Return a list of all of the keys attached to ATOM.
+    Return a list of all of the keys attached to ATOM. In order to get
+    all of the values attached to an atom, one must first find the keys
+    that are used to anchor them. This function returns these.
 
     Example:
        guile> (cog-set-value!

--- a/opencog/scm/opencog/base/core-docs.scm
+++ b/opencog/scm/opencog/base/core-docs.scm
@@ -714,7 +714,10 @@
     Return a list of all of the keys attached to ATOM.
 
     Example:
-        guile> (cog-keys (Concept \"abc\"))
+       guile> (cog-set-value!
+                 (Concept \"abc\") (Predicate \"key\")
+                 (FloatValue 1 2 3))
+       guile> (cog-keys (Concept \"abc\"))
 ")
 
 (set-procedure-property! cog-value 'documentation
@@ -725,9 +728,9 @@
 
     Example:
        guile> (cog-set-value!
-                 (Concept \"abc\") (Concept \"key\")
+                 (Concept \"abc\") (Predicate \"key\")
                  (FloatValue 1 2 3))
-       guile> (cog-value (Concept \"abc\") (Concept \"key\"))
+       guile> (cog-value (Concept \"abc\") (Predicate \"key\"))
        (FloatValue 1.000000 2.000000 3.00000)
 ")
 

--- a/opencog/scm/opencog/base/core-docs.scm
+++ b/opencog/scm/opencog/base/core-docs.scm
@@ -708,6 +708,15 @@
        )
 ")
 
+(set-procedure-property! cog-keys 'documentation
+"
+ cog-keys ATOM
+    Return a list of all of the keys attached to ATOM.
+
+    Example:
+        guile> (cog-keys (Concept \"abc\"))
+")
+
 (set-procedure-property! cog-value 'documentation
 "
  cog-value ATOM KEY


### PR DESCRIPTION
To get all the values attached to an atom, one needs to know what keys are used to anchor them. This function gets all the keys.