### PR TITLE
Fix poor performance of getIncomingSet()

### DIFF
--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -342,6 +342,14 @@ void Atom::insert_atom(const LinkPtr& a)
 {
     if (NULL == _incoming_set) return;
     std::lock_guard<std::mutex> lck (_mtx);
+
+    // We must NEVER insert more than one type into a bucket; otherwise
+    // getIncomingByType() will find more than one type, which would
+    // require filtering, which would destroy performance.
+    Type t = a->getType();
+    if (_incoming_set->_iset.bucket_count() <= t)
+        _incoming_set->_iset.rehash(t);
+
     _incoming_set->_iset.insert(a);
 #ifdef INCOMING_SET_SIGNALS
     _incoming_set->_addAtomSignal(shared_from_this(), a);

--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -344,7 +344,7 @@ void Atom::drop_incoming_set()
 // require filtering, which would destroy performance.
 void Atom::InSet::checksz(Type t)
 {
-    if (_least < t) _least = t;
+    if (t < _least) _least = t;
     Type wantsz = t - _least + 1;
     if (_iset.bucket_count() < wantsz)
         _iset.rehash(wantsz);

--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -344,10 +344,15 @@ void Atom::drop_incoming_set()
 // require filtering, which would destroy performance.
 void Atom::InSet::checksz(Type t)
 {
-    if (t < _least) _least = t;
-    Type wantsz = t - _least + 1;
-    if (_iset.bucket_count() < wantsz)
-        _iset.rehash(wantsz);
+    Type currsz = _iset.bucket_count();
+    Type needsz = t - _least + 1;
+    if (t < _least)
+    {
+        needsz = currsz + (_least - t);
+        _least = t;
+    }
+    if (currsz < needsz)
+        _iset.rehash(needsz);
 }
 
 /// Add an atom to the incoming set.

--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -374,6 +374,14 @@ void Atom::swap_atom(const LinkPtr& old, const LinkPtr& neu)
 {
     if (NULL == _incoming_set) return;
     std::lock_guard<std::mutex> lck (_mtx);
+
+    // We must NEVER insert more than one type into a bucket; otherwise
+    // getIncomingByType() will find more than one type, which would
+    // require filtering, which would destroy performance.
+    Type t = neu->getType();
+    if (_incoming_set->_iset.bucket_count() <= t)
+        _incoming_set->_iset.rehash(t);
+
 #ifdef INCOMING_SET_SIGNALS
     _incoming_set->_removeAtomSignal(shared_from_this(), old);
 #endif /* INCOMING_SET_SIGNALS */

--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -68,6 +68,15 @@ hash<opencog::WinkPtr>::operator()(const opencog::WinkPtr& w) const noexcept
     return h->getType();
 }
 
+bool
+equal_to<opencog::WinkPtr>::operator()(const opencog::WinkPtr& lw,
+                                       const opencog::WinkPtr& rw) const noexcept
+{
+    opencog::Handle hl(lw.lock());
+    opencog::Handle hr(rw.lock());
+    return hl == hr;
+}
+
 } // namespace std
 
 namespace opencog {

--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -55,6 +55,21 @@
 
 #undef Type
 
+namespace std {
+
+// The hash of a weak pointer is just the atom type. Actually,
+// it *has* to be the atom type, as otherwise the hash buckets
+// won't be correct, and getIncomingByType() will fail to be fast.
+opencog::Type
+hash<opencog::WinkPtr>::operator()(const opencog::WinkPtr& w) const noexcept
+{
+    opencog::LinkPtr h(w.lock());
+    if (nullptr == h) return 0;
+    return h->getType();
+}
+
+} // namespace std
+
 namespace opencog {
 
 Atom::~Atom()

--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -408,10 +408,10 @@ IncomingSet Atom::getIncomingSet(AtomSpace* as) const
     return iset;
 }
 
-IncomingSet Atom::getIncomingSetByType(Type type, bool subclass) const
+IncomingSet Atom::getIncomingSetByType(Type type) const
 {
     HandleSeq inhs;
-    getIncomingSetByType(std::back_inserter(inhs), type, subclass);
+    getIncomingSetByType(std::back_inserter(inhs), type);
     IncomingSet inlinks;
     for (const Handle& h : inhs)
         inlinks.emplace_back(LinkCast(h));

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -355,10 +355,10 @@ public:
         // The only occupied buckets are between _least and
         // bucket_count() - _least.
         if (type < _incoming_set->_least) return result;
-        Type bkt = type - _incoming_set->_least;
-        if (_incoming_set->_iset.bucket_count() <= bkt) return result;
+        Type bkts = type - _incoming_set->_least;
+        if (_incoming_set->_iset.bucket_count() <= bkts) return result;
 
-        auto end = _incoming_set->_iset.end(bkt);
+        auto end = _incoming_set->_iset.end(type);
         for (auto w = _incoming_set->_iset.begin(type); w != end; w++)
         {
             Handle h(w->lock());

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -59,18 +59,15 @@ template<> struct hash<opencog::WinkPtr>
     opencog::Type operator()(const opencog::WinkPtr& w) const noexcept;
 };
 
-// Equality is simple type equality
+// Equality is equality of the underlying atoms. The unordered set
+// uses this to distinguish atoms of the same type.
 template<> struct equal_to<opencog::WinkPtr>
 {
     typedef bool result_type;
     typedef opencog::WinkPtr first_argument;
     typedef opencog::WinkPtr second_argument;
-    bool operator()(const opencog::WinkPtr& lw,
-                    const opencog::WinkPtr& rw) const noexcept
-    {
-        return hash<opencog::WinkPtr>{}(lw) ==
-               hash<opencog::WinkPtr>{}(rw);
-    }
+    bool operator()(const opencog::WinkPtr&,
+                    const opencog::WinkPtr&) const noexcept;
 };
 
 } // namespace std

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -355,11 +355,12 @@ public:
         // The only occupied buckets are between _least and
         // bucket_count() - _least.
         if (type < _incoming_set->_least) return result;
-        Type bkts = type - _incoming_set->_least;
-        if (_incoming_set->_iset.bucket_count() <= bkts) return result;
+        Type nbkts = _incoming_set->_iset.bucket_count();
+        if (nbkts <= type - _incoming_set->_least) return result;
+        Type bkt = type % nbkts;
 
-        auto end = _incoming_set->_iset.end(type);
-        for (auto w = _incoming_set->_iset.begin(type); w != end; w++)
+        auto end = _incoming_set->_iset.end(bkt);
+        for (auto w = _incoming_set->_iset.begin(bkt); w != end; w++)
         {
             Handle h(w->lock());
             if (h) { *result = h; result ++; }

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -350,22 +350,13 @@ public:
 
         // If it is empty, we are done. This is a mandatory check,
         // before the iterators below can be used.
-        Type nbkt = _incoming_set->_iset.bucket_count();
-        if (0 == nbkt) return result;
+        if (_incoming_set->_iset.bucket_count() <= type) return result;
 
-        // Get the hash bucket that holds atoms of the desired type.
-        // Unfortunately, that bucket might also hold atoms of a type
-        // that we don't want, so we still have to filter. XXX This
-        // kind of wrecks the whole point of this optimization.  We
-        // really really need to have 1-to-1 correspondance between
-        // buckets and types. XXX FIXME.
-        Type bkt = type % nbkt;
-        auto end = _incoming_set->_iset.end(bkt);
-        for (auto w = _incoming_set->_iset.begin(bkt); w != end; w++)
+        auto end = _incoming_set->_iset.end(type);
+        for (auto w = _incoming_set->_iset.begin(type); w != end; w++)
         {
             Handle h(w->lock());
-            if (nullptr == h) continue;
-            if (h->getType() == type) { *result = h; result ++; }
+            if (h) { *result = h; result ++; }
         }
         return result;
     }

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -53,18 +53,14 @@ class AtomTable;
 //! arity of Links, represented as short integer (16 bits)
 typedef unsigned short Arity;
 
+//! We use a std:vector instead of std::set for IncomingSet, because
+//! virtually all access will be either insert, or iterate, so we get
+//! O(1) performance. Note that sometimes incoming sets can be huge,
+//! millions of atoms.
 class Link;
 typedef std::shared_ptr<Link> LinkPtr;
 typedef std::vector<LinkPtr> IncomingSet; // use vector; see below.
-typedef std::weak_ptr<Link> WinkPtr;
-typedef std::set<WinkPtr, std::owner_less<WinkPtr> > WincomingSet;
 typedef boost::signals2::signal<void (AtomPtr, LinkPtr)> AtomPairSignal;
-
-// We use a std:vector instead of std::set for IncomingSet, because
-// virtually all access will be either insert, or iterate, so we get
-// O(1) performance. We use std::set for WincomingSet, because we want
-// both good insert and good remove performance.  Note that sometimes
-// incoming sets can be huge (millions of atoms).
 
 /**
  * Atoms are the basic implementational unit in the system that
@@ -81,7 +77,11 @@ class Atom
     friend class DeleteLink;      // Needs to call getAtomTable()
     friend class ProtocolBufferSerializer; // Needs to de/ser-ialize an Atom
 
-private:
+    // We use std::set for WincomingSet, because we want both good insert
+    // and good remove performance.
+    typedef std::weak_ptr<Link> WinkPtr;
+    typedef std::set<WinkPtr, std::owner_less<WinkPtr> > WincomingSet;
+
     //! Sets the AtomSpace in which this Atom is inserted.
     void setAtomSpace(AtomSpace *);
 

--- a/opencog/cython/opencog/atom.pyx
+++ b/opencog/cython/opencog/atom.pyx
@@ -209,22 +209,20 @@ cdef class Atom(object):
                 yield Atom(void_from_candle(current_c_handle),self)
                 inc(c_handle_iter)
 
-    def incoming_by_type(self, Type type, subtype = True):
+    def incoming_by_type(self, Type type):
         cdef vector[cHandle] handle_vector
-        cdef bint subt = subtype
         cdef cAtom* atom_ptr = self.handle.atom_ptr()
         if atom_ptr == NULL:   # avoid null-pointer deref
             return None
-        atom_ptr.getIncomingSetByType(back_inserter(handle_vector), type, subt)
+        atom_ptr.getIncomingSetByType(back_inserter(handle_vector), type)
         return convert_handle_seq_to_python_list(handle_vector, self.atomspace)
 
-    def xincoming_by_type(self, Type type, subtype = True):
+    def xincoming_by_type(self, Type type):
         cdef vector[cHandle] handle_vector
-        cdef bint subt = subtype
         cdef cAtom* atom_ptr = self.handle.atom_ptr()
         if atom_ptr == NULL:   # avoid null-pointer deref
             return None
-        atom_ptr.getIncomingSetByType(back_inserter(handle_vector), type, subt)
+        atom_ptr.getIncomingSetByType(back_inserter(handle_vector), type)
 
         # This code is the same for all the x iterators but there is no
         # way in Cython to yield out of a cdef function and no way to pass a

--- a/opencog/cython/opencog/atomspace.pxd
+++ b/opencog/cython/opencog/atomspace.pxd
@@ -113,7 +113,7 @@ cdef extern from "opencog/atoms/base/Atom.h" namespace "opencog":
         tv_ptr getTruthValue()
         void setTruthValue(tv_ptr tvp)
 
-        output_iterator getIncomingSetByType(output_iterator, Type type, bint subclass)
+        output_iterator getIncomingSetByType(output_iterator, Type type)
 
         # Conditionally-valid methods. Not defined for all atoms.
         string getName()

--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -293,7 +293,7 @@ SCM SchemeSmob::ss_incoming_by_type (SCM satom, SCM stype)
 	Type t = verify_atom_type(stype, "cog-incoming-by-type", 2);
 
 	HandleSeq iset;
-	h->getIncomingSetByType(std::back_inserter(iset), t, false);
+	h->getIncomingSetByType(std::back_inserter(iset), t);
 	SCM head = SCM_EOL;
 	for (const Handle& ih : iset)
 	{

--- a/tests/atomutils/AtomUtilsUTest.cxxtest
+++ b/tests/atomutils/AtomUtilsUTest.cxxtest
@@ -49,19 +49,21 @@ public:
 void AtomUtilsUTest::test_get_predicates()
 {
 	AtomSpace as;
-	Handle
-		programmer = as.add_node(CONCEPT_NODE, "programmer"),
-		bacon = as.add_node(CONCEPT_NODE, "bacon"),
-		programmer_bacon = as.add_link(LIST_LINK, programmer, bacon),
-		eats = as.add_node(PREDICATE_NODE, "eats"),
-		programmerEatsBacon = as.add_link(EVALUATION_LINK, eats,
-		                                  programmer_bacon),
-		lover = as.add_node(GROUNDED_PREDICATE_NODE, "lover"),
-		programmerBaconLover = as.add_link(EVALUATION_LINK, lover,
-		                                   programmer_bacon),
-		anotherNode = as.add_node(CONCEPT_NODE, "pigs"),
-		anotherLink = as.add_link(LIST_LINK, anotherNode, bacon);
-		
+	Handle programmer = as.add_node(CONCEPT_NODE, "programmer");
+	Handle bacon = as.add_node(CONCEPT_NODE, "bacon");
+	Handle programmer_bacon = as.add_link(LIST_LINK, programmer, bacon);
+
+	Handle eats = as.add_node(PREDICATE_NODE, "eats");
+	Handle programmerEatsBacon = as.add_link(EVALUATION_LINK, eats,
+	                                         programmer_bacon);
+
+	Handle lover = as.add_node(GROUNDED_PREDICATE_NODE, "lover");
+	Handle programmerBaconLover = as.add_link(EVALUATION_LINK, lover,
+	                                          programmer_bacon);
+
+	Handle anotherNode = as.add_node(CONCEPT_NODE, "pigs");
+	Handle anotherLink = as.add_link(LIST_LINK, anotherNode, bacon);
+
 	// Test get_predicates(default).
 	HandleSeq baconReferences {programmerEatsBacon, programmerBaconLover};
 	TS_ASSERT_EQUALS(get_predicates(bacon), baconReferences);

--- a/tests/atomutils/AtomUtilsUTest.cxxtest
+++ b/tests/atomutils/AtomUtilsUTest.cxxtest
@@ -44,6 +44,14 @@ public:
 	void test_get_predicates_for();
 };
 
+OrderedHandleSet cvt(HandleSeq predlist)
+{
+	OrderedHandleSet preds;
+	for (auto it = predlist.begin(); it != predlist.end(); it++)
+		preds.insert(*it);
+	return preds;
+}
+
 
 // Test get_outgoing_nodes()
 void AtomUtilsUTest::test_get_predicates()
@@ -53,10 +61,12 @@ void AtomUtilsUTest::test_get_predicates()
 	Handle bacon = as.add_node(CONCEPT_NODE, "bacon");
 	Handle programmer_bacon = as.add_link(LIST_LINK, programmer, bacon);
 
+	// eats (programmers, bacon)
 	Handle eats = as.add_node(PREDICATE_NODE, "eats");
 	Handle programmerEatsBacon = as.add_link(EVALUATION_LINK, eats,
 	                                         programmer_bacon);
 
+	// lover (programmers, bacon)
 	Handle lover = as.add_node(GROUNDED_PREDICATE_NODE, "lover");
 	Handle programmerBaconLover = as.add_link(EVALUATION_LINK, lover,
 	                                          programmer_bacon);
@@ -65,8 +75,8 @@ void AtomUtilsUTest::test_get_predicates()
 	Handle anotherLink = as.add_link(LIST_LINK, anotherNode, bacon);
 
 	// Test get_predicates(default).
-	HandleSeq baconReferences {programmerEatsBacon, programmerBaconLover};
-	TS_ASSERT_EQUALS(get_predicates(bacon), baconReferences);
+	OrderedHandleSet baconReferences {programmerEatsBacon, programmerBaconLover};
+	TS_ASSERT_EQUALS(cvt(get_predicates(bacon)), baconReferences);
 
 	// Test get_predicates with specific type.
 	HandleSeq baconLovers {programmerBaconLover};
@@ -109,18 +119,18 @@ void AtomUtilsUTest::test_get_predicates_for()
 		programmerEatsBacon = as.add_link(EVALUATION_LINK, eats, programmer_bacon);
 		
 	// Test for dog IsA.
-	HandleSeq dogIsA {dogIsAMammal, dogIsACanine, dogIsAAnimal};
-	TS_ASSERT_EQUALS(get_predicates_for(dog, isA), dogIsA);
+	OrderedHandleSet dogIsA {dogIsAMammal, dogIsACanine, dogIsAAnimal};
+	TS_ASSERT_EQUALS(cvt(get_predicates_for(dog, isA)), dogIsA);
 
 	// Test for dog eats.
-	HandleSeq dogEats {dogEatsBacon};
-	TS_ASSERT_EQUALS(get_predicates_for(dog, eats), dogEats);
+	OrderedHandleSet dogEats {dogEatsBacon};
+	TS_ASSERT_EQUALS(cvt(get_predicates_for(dog, eats)), dogEats);
 
 	// Test for programmer eats.
-	HandleSeq programmerEats {programmerEatsBacon};
-	TS_ASSERT_EQUALS(get_predicates_for(programmer, eats), programmerEats);
+	OrderedHandleSet programmerEats {programmerEatsBacon};
+	TS_ASSERT_EQUALS(cvt(get_predicates_for(programmer, eats)), programmerEats);
 
 	// Test for eats bacon.
-	HandleSeq eatsBacon {dogEatsBacon, programmerEatsBacon};
-	TS_ASSERT_EQUALS(get_predicates_for(bacon, eats), eatsBacon);
+	OrderedHandleSet eatsBacon {dogEatsBacon, programmerEatsBacon};
+	TS_ASSERT_EQUALS(cvt(get_predicates_for(bacon, eats)), eatsBacon);
 }


### PR DESCRIPTION
A lot of algorithms depend on getIncomingSet(), and it's performance was poor.  The earlier version used an rb-tree, the new version uses a hash table, with one hash bucket per atom type.  Thus, getting all atoms of a given type is as simple as getting the appropriate hash bucket, and returning just that.  No more filtering required, which should help a lot when incoming sets become huge.