### PR TITLE
Scheme bindings support multiple loggers

### DIFF
--- a/opencog/guile/CMakeLists.txt
+++ b/opencog/guile/CMakeLists.txt
@@ -15,6 +15,7 @@ ADD_LIBRARY (smob
 	SchemeSmobNew.cc
 	SchemeSmobTV.cc
 	SchemeSmobValue.cc
+	SchemeSmobLogger.cc
 )
 
 ADD_LIBRARY (logger

--- a/opencog/guile/CMakeLists.txt
+++ b/opencog/guile/CMakeLists.txt
@@ -36,6 +36,7 @@ TARGET_LINK_LIBRARIES(logger
 	smob
 	${GUILE_LIBRARIES}
 	${COGUTIL_LIBRARY}
+    ruleengine # for the ure logger
 )
 
 TARGET_LINK_LIBRARIES(randgen

--- a/opencog/guile/LoggerSCM.cc
+++ b/opencog/guile/LoggerSCM.cc
@@ -22,6 +22,7 @@
  */
 
 #include <opencog/util/Logger.h>
+#include <opencog/rule-engine/URELogger.h>
 #include <opencog/guile/SchemeModule.h>
 #include "SchemePrimitive.h"
 
@@ -37,99 +38,128 @@ class LoggerSCM : public ModuleWrap
 protected:
 	virtual void init();
 
-	std::string do_logger_set_level(const std::string& level);
-	std::string do_logger_get_level(void);
-	std::string do_logger_set_filename(const std::string& filename);
-	std::string do_logger_get_filename(void);
-	bool do_logger_set_stdout(bool);
-	bool do_logger_set_sync(bool);
-	bool do_logger_set_timestamp(bool);
-	void do_logger_error(const std::string& msg);
-	void do_logger_warn(const std::string& msg);
-	void do_logger_info(const std::string& msg);
-	void do_logger_debug(const std::string& msg);
-	void do_logger_fine(const std::string& msg);
+	Logger* do_default_logger();
+	Logger* do_ure_logger();
+	std::string do_logger_set_level(Logger*, const std::string& level);
+	std::string do_logger_get_level(const Logger*);
+	std::string do_logger_set_filename(Logger*, const std::string& filename);
+	std::string do_logger_get_filename(const Logger*);
+	std::string do_logger_set_component(Logger*, const std::string& component);
+	std::string do_logger_get_component(const Logger*);
+	bool do_logger_set_stdout(Logger*, bool);
+	bool do_logger_set_sync(Logger*, bool);
+	bool do_logger_set_timestamp(Logger*, bool);
+	void do_logger_error(Logger*, const std::string& msg);
+	void do_logger_warn(Logger*, const std::string& msg);
+	void do_logger_info(Logger*, const std::string& msg);
+	void do_logger_debug(Logger*, const std::string& msg);
+	void do_logger_fine(Logger*, const std::string& msg);
 
 public:
 	LoggerSCM();
 };
 
+/// Get the default logger.
+Logger* LoggerSCM::do_default_logger()
+{
+	return &logger();
+}
+
+/// Get the URE logger.
+Logger* LoggerSCM::do_ure_logger()
+{
+	return &ure_logger();
+}
 
 /// Set level, return previous level.
-std::string LoggerSCM::do_logger_set_level(const std::string& level)
+std::string LoggerSCM::do_logger_set_level(Logger* lg, const std::string& level)
 {
 	std::string prev_level;
-	prev_level = Logger::get_level_string(logger().get_level());
-	logger().set_level(Logger::get_level_from_string(level));
+	prev_level = Logger::get_level_string(lg->get_level());
+	lg->set_level(Logger::get_level_from_string(level));
 	return prev_level;
 }
 
-std::string LoggerSCM::do_logger_get_level(void)
+std::string LoggerSCM::do_logger_get_level(const Logger* lg)
 {
-	return Logger::get_level_string(logger().get_level());
+	return Logger::get_level_string(lg->get_level());
 }
 
 /// Set logfile, return previous file.
-std::string LoggerSCM::do_logger_set_filename(const std::string& filename)
+std::string LoggerSCM::do_logger_set_filename(Logger* lg, const std::string& filename)
 {
 	std::string old_file;
-	old_file = logger().get_filename();
-	logger().set_filename(filename);
+	old_file = lg->get_filename();
+	lg->set_filename(filename);
 	return old_file;
 }
 
-std::string LoggerSCM::do_logger_get_filename()
+std::string LoggerSCM::do_logger_get_filename(const Logger* lg)
 {
-	return logger().get_filename();
+	return lg->get_filename();
 }
 
-bool LoggerSCM::do_logger_set_stdout(bool enable)
+/// Set component, return previous component.
+std::string LoggerSCM::do_logger_set_component(Logger* lg, const std::string& component)
 {
-	// bool previous_setting = logger().get_print_to_stdout_flag();
+	std::string old_component;
+	old_component = lg->get_component();
+	lg->set_component(component);
+	return old_component;
+}
+
+std::string LoggerSCM::do_logger_get_component(const Logger* lg)
+{
+	return lg->get_component();
+}
+
+bool LoggerSCM::do_logger_set_stdout(Logger* lg, bool enable)
+{
+	// bool previous_setting = lg->get_print_to_stdout_flag();
 	bool previous_setting = enable;
-	logger().set_print_to_stdout_flag(enable);
+	lg->set_print_to_stdout_flag(enable);
 	return previous_setting;
 }
 
-bool LoggerSCM::do_logger_set_sync(bool enable)
+bool LoggerSCM::do_logger_set_sync(Logger* lg, bool enable)
 {
-	// bool previous_setting = logger().get_sync_flag();
+	// bool previous_setting = lg->get_sync_flag();
 	bool previous_setting = enable;
-	logger().set_sync_flag(enable);
+	lg->set_sync_flag(enable);
 	return previous_setting;
 }
 
-bool LoggerSCM::do_logger_set_timestamp(bool enable)
+bool LoggerSCM::do_logger_set_timestamp(Logger* lg, bool enable)
 {
-	// bool previous_setting = logger().get_timestamp_flag();
+	// bool previous_setting = lg->get_timestamp_flag();
 	bool previous_setting = enable;
-	logger().set_timestamp_flag(enable);
+	lg->set_timestamp_flag(enable);
 	return previous_setting;
 }
 
-void LoggerSCM::do_logger_error(const std::string& msg)
+void LoggerSCM::do_logger_error(Logger* lg, const std::string& msg)
 {
-	logger().error(msg);
+	lg->error(msg);
 }
 
-void LoggerSCM::do_logger_warn(const std::string& msg)
+void LoggerSCM::do_logger_warn(Logger* lg, const std::string& msg)
 {
-	logger().warn(msg);
+	lg->warn(msg);
 }
 
-void LoggerSCM::do_logger_info(const std::string& msg)
+void LoggerSCM::do_logger_info(Logger* lg, const std::string& msg)
 {
-	logger().info(msg);
+	lg->info(msg);
 }
 
-void LoggerSCM::do_logger_debug(const std::string& msg)
+void LoggerSCM::do_logger_debug(Logger* lg, const std::string& msg)
 {
-	logger().debug(msg);
+	lg->debug(msg);
 }
 
-void LoggerSCM::do_logger_fine(const std::string& msg)
+void LoggerSCM::do_logger_fine(Logger* lg, const std::string& msg)
 {
-	logger().fine(msg);
+	lg->fine(msg);
 }
 
 } /*end of namespace opencog*/
@@ -140,29 +170,42 @@ LoggerSCM::LoggerSCM() : ModuleWrap("opencog logger") {}
 /// Thus, all the definitions below happen in that module.
 void LoggerSCM::init(void)
 {
-	define_scheme_primitive("cog-logger-set-level!",
+	define_scheme_primitive("default-logger",
+		&LoggerSCM::do_default_logger, this, "logger");
+	define_scheme_primitive("ure-logger",
+		&LoggerSCM::do_ure_logger, this, "logger");
+
+	define_scheme_primitive("cog-logger-set-level-ptr!",
 		&LoggerSCM::do_logger_set_level, this, "logger");
-	define_scheme_primitive("cog-logger-get-level",
+	define_scheme_primitive("cog-logger-get-level-ptr",
 		&LoggerSCM::do_logger_get_level, this, "logger");
-	define_scheme_primitive("cog-logger-set-filename!",
+
+	define_scheme_primitive("cog-logger-set-filename-ptr!",
 		&LoggerSCM::do_logger_set_filename, this, "logger");
-	define_scheme_primitive("cog-logger-get-filename",
+	define_scheme_primitive("cog-logger-get-filename-ptr",
 		&LoggerSCM::do_logger_get_filename, this, "logger");
-	define_scheme_primitive("cog-logger-set-stdout!",
+
+	define_scheme_primitive("cog-logger-set-component-ptr!",
+		&LoggerSCM::do_logger_set_component, this, "logger");
+	define_scheme_primitive("cog-logger-get-component-ptr",
+		&LoggerSCM::do_logger_get_component, this, "logger");
+
+	define_scheme_primitive("cog-logger-set-stdout-ptr!",
 		&LoggerSCM::do_logger_set_stdout, this, "logger");
-	define_scheme_primitive("cog-logger-set-sync!",
+	define_scheme_primitive("cog-logger-set-sync-ptr!",
 		&LoggerSCM::do_logger_set_sync, this, "logger");
-	define_scheme_primitive("cog-logger-set-timestamp!",
+	define_scheme_primitive("cog-logger-set-timestamp-ptr!",
 		&LoggerSCM::do_logger_set_timestamp, this, "logger");
-	define_scheme_primitive("cog-logger-error-str",
+
+	define_scheme_primitive("cog-logger-error-ptr",
 		&LoggerSCM::do_logger_error, this, "logger");
-	define_scheme_primitive("cog-logger-warn-str",
+	define_scheme_primitive("cog-logger-warn-ptr",
 		&LoggerSCM::do_logger_warn, this, "logger");
-	define_scheme_primitive("cog-logger-info-str",
+	define_scheme_primitive("cog-logger-info-ptr",
 		&LoggerSCM::do_logger_info, this, "logger");
-	define_scheme_primitive("cog-logger-debug-str",
+	define_scheme_primitive("cog-logger-debug-ptr",
 		&LoggerSCM::do_logger_debug, this, "logger");
-	define_scheme_primitive("cog-logger-fine-str",
+	define_scheme_primitive("cog-logger-fine-ptr",
 		&LoggerSCM::do_logger_fine, this, "logger");
 }
 

--- a/opencog/guile/LoggerSCM.cc
+++ b/opencog/guile/LoggerSCM.cc
@@ -175,37 +175,37 @@ void LoggerSCM::init(void)
 	define_scheme_primitive("cog-ure-logger",
 		&LoggerSCM::do_ure_logger, this, "logger");
 
-	define_scheme_primitive("cog-logger-set-level-with-logger!",
+	define_scheme_primitive("cog-logger-set-level-of-logger!",
 		&LoggerSCM::do_logger_set_level, this, "logger");
-	define_scheme_primitive("cog-logger-get-level-with-logger",
+	define_scheme_primitive("cog-logger-get-level-of-logger",
 		&LoggerSCM::do_logger_get_level, this, "logger");
 
-	define_scheme_primitive("cog-logger-set-filename-with-logger!",
+	define_scheme_primitive("cog-logger-set-filename-of-logger!",
 		&LoggerSCM::do_logger_set_filename, this, "logger");
-	define_scheme_primitive("cog-logger-get-filename-with-logger",
+	define_scheme_primitive("cog-logger-get-filename-of-logger",
 		&LoggerSCM::do_logger_get_filename, this, "logger");
 
-	define_scheme_primitive("cog-logger-set-component-with-logger!",
+	define_scheme_primitive("cog-logger-set-component-of-logger!",
 		&LoggerSCM::do_logger_set_component, this, "logger");
-	define_scheme_primitive("cog-logger-get-component-with-logger",
+	define_scheme_primitive("cog-logger-get-component-of-logger",
 		&LoggerSCM::do_logger_get_component, this, "logger");
 
-	define_scheme_primitive("cog-logger-set-stdout-with-logger!",
+	define_scheme_primitive("cog-logger-set-stdout-of-logger!",
 		&LoggerSCM::do_logger_set_stdout, this, "logger");
-	define_scheme_primitive("cog-logger-set-sync-with-logger!",
+	define_scheme_primitive("cog-logger-set-sync-of-logger!",
 		&LoggerSCM::do_logger_set_sync, this, "logger");
-	define_scheme_primitive("cog-logger-set-timestamp-with-logger!",
+	define_scheme_primitive("cog-logger-set-timestamp-of-logger!",
 		&LoggerSCM::do_logger_set_timestamp, this, "logger");
 
-	define_scheme_primitive("cog-logger-error-with-logger",
+	define_scheme_primitive("cog-logger-error-of-logger",
 		&LoggerSCM::do_logger_error, this, "logger");
-	define_scheme_primitive("cog-logger-warn-with-logger",
+	define_scheme_primitive("cog-logger-warn-of-logger",
 		&LoggerSCM::do_logger_warn, this, "logger");
-	define_scheme_primitive("cog-logger-info-with-logger",
+	define_scheme_primitive("cog-logger-info-of-logger",
 		&LoggerSCM::do_logger_info, this, "logger");
-	define_scheme_primitive("cog-logger-debug-with-logger",
+	define_scheme_primitive("cog-logger-debug-of-logger",
 		&LoggerSCM::do_logger_debug, this, "logger");
-	define_scheme_primitive("cog-logger-fine-with-logger",
+	define_scheme_primitive("cog-logger-fine-of-logger",
 		&LoggerSCM::do_logger_fine, this, "logger");
 }
 

--- a/opencog/guile/LoggerSCM.cc
+++ b/opencog/guile/LoggerSCM.cc
@@ -170,42 +170,42 @@ LoggerSCM::LoggerSCM() : ModuleWrap("opencog logger") {}
 /// Thus, all the definitions below happen in that module.
 void LoggerSCM::init(void)
 {
-	define_scheme_primitive("default-logger",
+	define_scheme_primitive("cog-default-logger",
 		&LoggerSCM::do_default_logger, this, "logger");
-	define_scheme_primitive("ure-logger",
+	define_scheme_primitive("cog-ure-logger",
 		&LoggerSCM::do_ure_logger, this, "logger");
 
-	define_scheme_primitive("cog-logger-set-level-ptr!",
+	define_scheme_primitive("cog-logger-set-level-with-logger!",
 		&LoggerSCM::do_logger_set_level, this, "logger");
-	define_scheme_primitive("cog-logger-get-level-ptr",
+	define_scheme_primitive("cog-logger-get-level-with-logger",
 		&LoggerSCM::do_logger_get_level, this, "logger");
 
-	define_scheme_primitive("cog-logger-set-filename-ptr!",
+	define_scheme_primitive("cog-logger-set-filename-with-logger!",
 		&LoggerSCM::do_logger_set_filename, this, "logger");
-	define_scheme_primitive("cog-logger-get-filename-ptr",
+	define_scheme_primitive("cog-logger-get-filename-with-logger",
 		&LoggerSCM::do_logger_get_filename, this, "logger");
 
-	define_scheme_primitive("cog-logger-set-component-ptr!",
+	define_scheme_primitive("cog-logger-set-component-with-logger!",
 		&LoggerSCM::do_logger_set_component, this, "logger");
-	define_scheme_primitive("cog-logger-get-component-ptr",
+	define_scheme_primitive("cog-logger-get-component-with-logger",
 		&LoggerSCM::do_logger_get_component, this, "logger");
 
-	define_scheme_primitive("cog-logger-set-stdout-ptr!",
+	define_scheme_primitive("cog-logger-set-stdout-with-logger!",
 		&LoggerSCM::do_logger_set_stdout, this, "logger");
-	define_scheme_primitive("cog-logger-set-sync-ptr!",
+	define_scheme_primitive("cog-logger-set-sync-with-logger!",
 		&LoggerSCM::do_logger_set_sync, this, "logger");
-	define_scheme_primitive("cog-logger-set-timestamp-ptr!",
+	define_scheme_primitive("cog-logger-set-timestamp-with-logger!",
 		&LoggerSCM::do_logger_set_timestamp, this, "logger");
 
-	define_scheme_primitive("cog-logger-error-ptr",
+	define_scheme_primitive("cog-logger-error-with-logger",
 		&LoggerSCM::do_logger_error, this, "logger");
-	define_scheme_primitive("cog-logger-warn-ptr",
+	define_scheme_primitive("cog-logger-warn-with-logger",
 		&LoggerSCM::do_logger_warn, this, "logger");
-	define_scheme_primitive("cog-logger-info-ptr",
+	define_scheme_primitive("cog-logger-info-with-logger",
 		&LoggerSCM::do_logger_info, this, "logger");
-	define_scheme_primitive("cog-logger-debug-ptr",
+	define_scheme_primitive("cog-logger-debug-with-logger",
 		&LoggerSCM::do_logger_debug, this, "logger");
-	define_scheme_primitive("cog-logger-fine-ptr",
+	define_scheme_primitive("cog-logger-fine-with-logger",
 		&LoggerSCM::do_logger_fine, this, "logger");
 }
 

--- a/opencog/guile/SchemePrimitive.h
+++ b/opencog/guile/SchemePrimitive.h
@@ -16,10 +16,13 @@
 #include <tuple>
 #include <utility>
 
+#include <libguile.h>
+
+#include <opencog/util/Logger.h>
+
 #include <opencog/atoms/base/Handle.h>
 #include <opencog/truthvalue/TruthValue.h>
 #include <opencog/guile/SchemeSmob.h>
-#include <libguile.h>
 #include <opencog/atoms/base/ClassServer.h>
 
 // Copied/pasted from gcc 4.9 utility. Remove as soon as C++14 is
@@ -27,7 +30,7 @@
 #if __cplusplus <= 201103L
 
 namespace std {
-	  /// Class template integer_sequence
+  /// Class template integer_sequence
   template<typename _Tp, _Tp... _Idx>
     struct integer_sequence
     {
@@ -272,6 +275,11 @@ protected:
 		SCM arg = scm_list_ref(args, scm_from_size_t(idx));
 		return SchemeSmob::verify_atomspace(arg, scheme_name, idx);
 	}
+	Logger* scm_to(SCM args, size_t idx, const Logger*) const
+	{
+		SCM arg = scm_list_ref(args, scm_from_size_t(idx));
+		return SchemeSmob::verify_logger(arg, scheme_name, idx);
+	}
 
 	// Get the Ith argument and convert it to a C++ object.
 	template<std::size_t I>
@@ -367,6 +375,10 @@ protected:
 	SCM scm_from(TruthValuePtr tv)
 	{
 		return SchemeSmob::tv_to_scm(tv);
+	}
+	SCM scm_from(Logger* lg)
+	{
+		return SchemeSmob::logger_to_scm(lg);
 	}
 
 	virtual SCM invoke (SCM args)

--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -117,6 +117,16 @@ SCM SchemeSmob::equalp_misc(SCM a, SCM b)
 			if (as == bs) return SCM_BOOL_T;
 			return SCM_BOOL_F;
 		}
+		case COG_LOGGER:
+		{
+			Logger* al = (Logger *) SCM_SMOB_DATA(a);
+			Logger* bl = (Logger *) SCM_SMOB_DATA(b);
+			scm_remember_upto_here_1(a);
+			scm_remember_upto_here_1(b);
+			/* Just a simple pointer comparison */
+			if (al == bl) return SCM_BOOL_T;
+			return SCM_BOOL_F;
+		}
 		case COG_AV:
 		{
 			AttentionValue* av = (AttentionValue *) SCM_SMOB_DATA(a);

--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -374,6 +374,10 @@ void SchemeSmob::register_procs()
 	// Free variables
 	register_proc("cog-free-variables",    1, 0, 0, C(ss_get_free_variables));
 	register_proc("cog-closed?",           1, 0, 0, C(ss_is_closed));
+
+	// Logger
+	// Ideally this should be in LoggerSCM.cc
+	register_proc("cog-logger?",           1, 0, 0, C(ss_logger_p));
 }
 
 void SchemeSmob::register_proc(const char* name, int req, int opt, int rst, scm_t_subr fcn)

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -48,6 +48,7 @@ private:
 		COG_PROTOM = 1, // values or atoms - smart pointer
 		COG_AV,         // attention values
 		COG_AS,         // atom spaces
+		COG_LOGGER,     // logger
 		COG_EXTEND      // callbacks into C++ code.
 	};
 
@@ -71,6 +72,7 @@ private:
 	static SCM handle_to_scm(const Handle&);
 	static SCM protom_to_scm(const ProtoAtomPtr&);
 	static SCM tv_to_scm(const TruthValuePtr&);
+	static SCM logger_to_scm(Logger* lg);
 	static Handle scm_to_handle(SCM);
 	static ProtoAtomPtr scm_to_protom(SCM);
 	static TruthValuePtr scm_to_tv(SCM);
@@ -169,6 +171,7 @@ private:
 	static SCM make_as(AtomSpace *);
 	static void release_as(AtomSpace *);
 	static AtomSpace* ss_to_atomspace(SCM);
+	static Logger* ss_to_logger(SCM);
 	static std::mutex as_mtx;
 	static std::map<AtomSpace*, int> deleteable_as;
 	static void as_ref_count(SCM, AtomSpace *);
@@ -202,6 +205,7 @@ private:
 	// validate arguments coming from scheme passing into C++
 	static void throw_exception(const std::exception&, const char *, SCM);
 	static AtomSpace* verify_atomspace(SCM, const char *, int pos = 1);
+	static Logger* verify_logger(SCM, const char *, int pos = 1);
 	static Type verify_atom_type(SCM, const char *, int pos = 1);
 	static Handle verify_handle(SCM, const char *, int pos = 1);
 	static ProtoAtomPtr verify_protom(SCM, const char *, int pos = 1);
@@ -239,6 +243,7 @@ public:
 	// Utility printing functions
 	static std::string to_string(const Handle&);
 	static std::string as_to_string(const AtomSpace *);
+	static std::string logger_to_string(const Logger *);
 	static std::string av_to_string(const AttentionValue *);
 	static std::string tv_to_string(const TruthValuePtr&);
 };

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -72,7 +72,6 @@ private:
 	static SCM handle_to_scm(const Handle&);
 	static SCM protom_to_scm(const ProtoAtomPtr&);
 	static SCM tv_to_scm(const TruthValuePtr&);
-	static SCM logger_to_scm(Logger* lg);
 	static Handle scm_to_handle(SCM);
 	static ProtoAtomPtr scm_to_protom(SCM);
 	static TruthValuePtr scm_to_tv(SCM);
@@ -171,7 +170,6 @@ private:
 	static SCM make_as(AtomSpace *);
 	static void release_as(AtomSpace *);
 	static AtomSpace* ss_to_atomspace(SCM);
-	static Logger* ss_to_logger(SCM);
 	static std::mutex as_mtx;
 	static std::map<AtomSpace*, int> deleteable_as;
 	static void as_ref_count(SCM, AtomSpace *);
@@ -202,10 +200,15 @@ private:
 	static AttentionValue *get_av_from_list(SCM);
 	static AtomSpace *get_as_from_list(SCM);
 
+	// Logger
+	static SCM logger_to_scm(Logger* lg);
+	static Logger* ss_to_logger(SCM);
+	static SCM ss_logger_p(SCM s);
+	static std::string logger_to_string(const Logger *);
+	
 	// validate arguments coming from scheme passing into C++
 	static void throw_exception(const std::exception&, const char *, SCM);
 	static AtomSpace* verify_atomspace(SCM, const char *, int pos = 1);
-	static Logger* verify_logger(SCM, const char *, int pos = 1);
 	static Type verify_atom_type(SCM, const char *, int pos = 1);
 	static Handle verify_handle(SCM, const char *, int pos = 1);
 	static ProtoAtomPtr verify_protom(SCM, const char *, int pos = 1);
@@ -227,6 +230,7 @@ private:
 	                           const char *msg = "size integer");
 	static double verify_real (SCM, const char *, int pos = 1,
 	                           const char *msg = "real number");
+	static Logger* verify_logger(SCM, const char *, int pos = 1);
 
 	static SCM atomspace_fluid;
 	static void ss_set_env_as(AtomSpace *);
@@ -243,7 +247,6 @@ public:
 	// Utility printing functions
 	static std::string to_string(const Handle&);
 	static std::string as_to_string(const AtomSpace *);
-	static std::string logger_to_string(const Logger *);
 	static std::string av_to_string(const AttentionValue *);
 	static std::string tv_to_string(const TruthValuePtr&);
 };

--- a/opencog/guile/SchemeSmobAS.cc
+++ b/opencog/guile/SchemeSmobAS.cc
@@ -36,17 +36,6 @@ std::string SchemeSmob::as_to_string(const AtomSpace *as)
 }
 
 /* ============================================================== */
-
-std::string SchemeSmob::logger_to_string(const Logger *l)
-{
-#define BUFLEN 120
-	char buff[BUFLEN];
-
-	snprintf(buff, BUFLEN, "#<logger %p>", l);
-	return buff;
-}
-
-/* ============================================================== */
 /**
  * Create SCM object wrapping the atomspace.
  * Do NOT take over memory management of it!
@@ -196,23 +185,6 @@ AtomSpace* SchemeSmob::ss_to_atomspace(SCM sas)
 }
 
 /* ============================================================== */
-/* Cast SCM to logger */
-
-Logger* SchemeSmob::ss_to_logger(SCM sl)
-{
-	if (not SCM_SMOB_PREDICATE(SchemeSmob::cog_misc_tag, sl))
-		return nullptr;
-
-	scm_t_bits misctype = SCM_SMOB_FLAGS(sl);
-	if (COG_LOGGER != misctype)
-		return nullptr;
-
-	Logger* l = (Logger *) SCM_SMOB_DATA(sl);
-	scm_remember_upto_here_1(sl);
-	return l;
-}
-
-/* ============================================================== */
 
 AtomSpace* SchemeSmob::verify_atomspace(SCM sas, const char * subrname, int pos)
 {
@@ -221,17 +193,6 @@ AtomSpace* SchemeSmob::verify_atomspace(SCM sas, const char * subrname, int pos)
       scm_wrong_type_arg_msg(subrname, pos, sas, "opencog atomspace");
 
    return as;
-}
-
-/* ============================================================== */
-
-Logger* SchemeSmob::verify_logger(SCM sl, const char * subrname, int pos)
-{
-   Logger* l = ss_to_logger(sl);
-   if (nullptr == l)
-      scm_wrong_type_arg_msg(subrname, pos, sl, "opencog logger");
-
-   return l;
 }
 
 /* ============================================================== */

--- a/opencog/guile/SchemeSmobAS.cc
+++ b/opencog/guile/SchemeSmobAS.cc
@@ -11,6 +11,7 @@
 
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/guile/SchemeSmob.h>
+#include <opencog/util/oc_assert.h>
 
 using namespace opencog;
 
@@ -31,6 +32,17 @@ std::string SchemeSmob::as_to_string(const AtomSpace *as)
 	char buff[BUFLEN];
 
 	snprintf(buff, BUFLEN, "#<atomspace %p>", as);
+	return buff;
+}
+
+/* ============================================================== */
+
+std::string SchemeSmob::logger_to_string(const Logger *l)
+{
+#define BUFLEN 120
+	char buff[BUFLEN];
+
+	snprintf(buff, BUFLEN, "#<logger %p>", l);
 	return buff;
 }
 
@@ -184,6 +196,23 @@ AtomSpace* SchemeSmob::ss_to_atomspace(SCM sas)
 }
 
 /* ============================================================== */
+/* Cast SCM to logger */
+
+Logger* SchemeSmob::ss_to_logger(SCM sl)
+{
+	if (not SCM_SMOB_PREDICATE(SchemeSmob::cog_misc_tag, sl))
+		return nullptr;
+
+	scm_t_bits misctype = SCM_SMOB_FLAGS(sl);
+	if (COG_LOGGER != misctype)
+		return nullptr;
+
+	Logger* l = (Logger *) SCM_SMOB_DATA(sl);
+	scm_remember_upto_here_1(sl);
+	return l;
+}
+
+/* ============================================================== */
 
 AtomSpace* SchemeSmob::verify_atomspace(SCM sas, const char * subrname, int pos)
 {
@@ -192,6 +221,17 @@ AtomSpace* SchemeSmob::verify_atomspace(SCM sas, const char * subrname, int pos)
       scm_wrong_type_arg_msg(subrname, pos, sas, "opencog atomspace");
 
    return as;
+}
+
+/* ============================================================== */
+
+Logger* SchemeSmob::verify_logger(SCM sl, const char * subrname, int pos)
+{
+   Logger* l = ss_to_logger(sl);
+   if (nullptr == l)
+      scm_wrong_type_arg_msg(subrname, pos, sl, "opencog logger");
+
+   return l;
 }
 
 /* ============================================================== */

--- a/opencog/guile/SchemeSmobGC.cc
+++ b/opencog/guile/SchemeSmobGC.cc
@@ -23,6 +23,7 @@ SCM SchemeSmob::mark_misc(SCM misc_smob)
 	{
 		case COG_PROTOM: // Nothing to do here ...
 		case COG_AS: // Nothing to do here ...
+		case COG_LOGGER: // Nothing to do here ...
 		case COG_AV: // Nothing to do here ...
 		case COG_EXTEND: // Nothing to do here ...
 			return SCM_BOOL_F;
@@ -104,6 +105,12 @@ std::string SchemeSmob::misc_to_string(SCM node)
 		case COG_AS:
 		{
 			std::string str(as_to_string((AtomSpace *) SCM_SMOB_DATA(node)));
+			scm_remember_upto_here_1(node);
+			return str;
+		}
+		case COG_LOGGER:
+		{
+			std::string str(logger_to_string((Logger *) SCM_SMOB_DATA(node)));
 			scm_remember_upto_here_1(node);
 			return str;
 		}

--- a/opencog/guile/SchemeSmobLogger.cc
+++ b/opencog/guile/SchemeSmobLogger.cc
@@ -1,0 +1,84 @@
+/*
+ * SchemeSmobLogger.c
+ *
+ * Scheme small objects (SMOBS) for atom spaces.
+ *
+ * Copyright (c) 2017 OpenCog Foundation
+ */
+
+#include <cstddef>
+#include <libguile.h>
+
+#include <opencog/guile/SchemeSmob.h>
+#include <opencog/util/Logger.h>
+#include <opencog/util/oc_assert.h>
+
+using namespace opencog;
+
+/* ============================================================== */
+
+std::string SchemeSmob::logger_to_string(const Logger *l)
+{
+#define BUFLEN 120
+	char buff[BUFLEN];
+
+	snprintf(buff, BUFLEN, "#<logger %p>", l);
+	return buff;
+}
+
+SCM SchemeSmob::logger_to_scm(Logger* lg)
+{
+	SCM smob;
+	SCM_NEWSMOB (smob, cog_misc_tag, lg);
+	SCM_SET_SMOB_FLAGS(smob, COG_LOGGER);
+	return smob;
+}
+
+/* ============================================================== */
+/**
+ * Return true if the scm is a logger
+ */
+SCM SchemeSmob::ss_logger_p(SCM s)
+{
+	if (SCM_SMOB_PREDICATE(SchemeSmob::cog_misc_tag, s))
+	{
+		scm_t_bits misctype = SCM_SMOB_FLAGS(s);
+		switch (misctype)
+		{
+			case COG_LOGGER:
+				return SCM_BOOL_T;
+
+			default:
+				return SCM_BOOL_F;
+		}
+	}
+	return SCM_BOOL_F;
+}
+
+/* ============================================================== */
+/* Cast SCM to logger */
+
+Logger* SchemeSmob::ss_to_logger(SCM sl)
+{
+	if (not SCM_SMOB_PREDICATE(SchemeSmob::cog_misc_tag, sl))
+		return nullptr;
+
+	scm_t_bits misctype = SCM_SMOB_FLAGS(sl);
+	if (COG_LOGGER != misctype)
+		return nullptr;
+
+	Logger* l = (Logger *) SCM_SMOB_DATA(sl);
+	scm_remember_upto_here_1(sl);
+	return l;
+}
+
+/* ============================================================== */
+
+Logger* SchemeSmob::verify_logger(SCM sl, const char * subrname, int pos)
+{
+   Logger* l = ss_to_logger(sl);
+   if (nullptr == l)
+      scm_wrong_type_arg_msg(subrname, pos, sl, "opencog logger");
+
+   return l;
+}

--- a/opencog/guile/SchemeSmobNew.cc
+++ b/opencog/guile/SchemeSmobNew.cc
@@ -144,6 +144,14 @@ SCM SchemeSmob::protom_to_scm (const ProtoAtomPtr& pa)
 	return smob;
 }
 
+SCM SchemeSmob::logger_to_scm (Logger* lg)
+{
+	SCM smob;
+	SCM_NEWSMOB (smob, cog_misc_tag, lg);
+	SCM_SET_SMOB_FLAGS(smob, COG_LOGGER);
+	return smob;
+}
+
 ProtoAtomPtr SchemeSmob::scm_to_protom (SCM sh)
 {
 	if (not SCM_SMOB_PREDICATE(SchemeSmob::cog_misc_tag, sh))

--- a/opencog/guile/SchemeSmobNew.cc
+++ b/opencog/guile/SchemeSmobNew.cc
@@ -144,14 +144,6 @@ SCM SchemeSmob::protom_to_scm (const ProtoAtomPtr& pa)
 	return smob;
 }
 
-SCM SchemeSmob::logger_to_scm (Logger* lg)
-{
-	SCM smob;
-	SCM_NEWSMOB (smob, cog_misc_tag, lg);
-	SCM_SET_SMOB_FLAGS(smob, COG_LOGGER);
-	return smob;
-}
-
 ProtoAtomPtr SchemeSmob::scm_to_protom (SCM sh)
 {
 	if (not SCM_SMOB_PREDICATE(SchemeSmob::cog_misc_tag, sh))

--- a/opencog/scm/opencog/logger.scm
+++ b/opencog/scm/opencog/logger.scm
@@ -16,20 +16,20 @@
 (export
 	cog-default-logger
 	cog-ure-logger
-	cog-logger-get-filename-with-logger
-	cog-logger-get-level-with-logger
-	cog-logger-get-component-with-logger
-	cog-logger-set-filename-with-logger!
-	cog-logger-set-level-with-logger!
-	cog-logger-set-component-with-logger!
-	cog-logger-set-stdout-with-logger!
-	cog-logger-set-sync-with-logger!
-	cog-logger-set-timestamp-with-logger!
-	cog-logger-error-with-logger
-	cog-logger-warn-with-logger
-	cog-logger-info-with-logger
-	cog-logger-debug-with-logger
-	cog-logger-fine-with-logger
+	cog-logger-get-filename-of-logger
+	cog-logger-get-level-of-logger
+	cog-logger-get-component-of-logger
+	cog-logger-set-filename-of-logger!
+	cog-logger-set-level-of-logger!
+	cog-logger-set-component-of-logger!
+	cog-logger-set-stdout-of-logger!
+	cog-logger-set-sync-of-logger!
+	cog-logger-set-timestamp-of-logger!
+	cog-logger-error-of-logger
+	cog-logger-warn-of-logger
+	cog-logger-info-of-logger
+	cog-logger-debug-of-logger
+	cog-logger-fine-of-logger
 )
 
 ;; Documentation for the functions implemented as C++ code
@@ -46,46 +46,46 @@
     Return the rule-engine logger.
 ")
 
-(set-procedure-property! cog-logger-get-filename-with-logger 'documentation
+(set-procedure-property! cog-logger-get-filename-of-logger 'documentation
 "
- cog-logger-get-filename-with-logger LOGGER
+ cog-logger-get-filename-of-logger LOGGER
     Return the filename of LOGGER.
 ")
 
-(set-procedure-property! cog-logger-get-level-with-logger 'documentation
+(set-procedure-property! cog-logger-get-level-of-logger 'documentation
 "
- cog-logger-get-level-with-logger LOGGER
+ cog-logger-get-level-of-logger LOGGER
     Return the logging level of LOGGER.
 ")
 
-(set-procedure-property! cog-logger-get-component-with-logger 'documentation
+(set-procedure-property! cog-logger-get-component-of-logger 'documentation
 "
- cog-logger-get-component-with-logger LOGGER
+ cog-logger-get-component-of-logger LOGGER
     Return the component name of LOGGER.
 ")
 
-(set-procedure-property! cog-logger-set-filename-with-logger! 'documentation
+(set-procedure-property! cog-logger-set-filename-of-logger! 'documentation
 "
- cog-logger-set-filename-with-logger! LOGGER FILENAME
+ cog-logger-set-filename-of-logger! LOGGER FILENAME
     Change the filename of LOGGER to FILENAME.
     Return the previous filename.
 ")
 
-(set-procedure-property! cog-logger-set-level-with-logger! 'documentation
+(set-procedure-property! cog-logger-set-level-of-logger! 'documentation
 "
  cog-logger-set-level! LOGGER LEVEL
     Set the logging level of LOGGER to LEVEL.
     Returns the previous logging level.
 ")
 
-(set-procedure-property! cog-logger-set-stdout-with-logger! 'documentation
+(set-procedure-property! cog-logger-set-stdout-of-logger! 'documentation
 "
  cog-logger-set-stdout! LOGGER BOOL
     If BOOL is #t, send log messages to stdout; else don't.
     Returns the previous setting.
 ")
 
-(set-procedure-property! cog-logger-set-sync-with-logger! 'documentation
+(set-procedure-property! cog-logger-set-sync-of-logger! 'documentation
 "
  cog-logger-set-sync! LOGGER BOOL
     If BOOL is #t, write message to log file synchronously; else don't.
@@ -97,7 +97,7 @@
     Returns the previous setting.
 ")
 
-(set-procedure-property! cog-logger-set-timestamp-with-logger! 'documentation
+(set-procedure-property! cog-logger-set-timestamp-of-logger! 'documentation
 "
  cog-logger-set-timestamp! LOGGER BOOL
     If BOOL is #t, then a timestamp will be written with each log
@@ -127,7 +127,7 @@
     Return the filename of LOGGER if provided.
     If not provided then use the default logger.
 "
-  (apply cog-logger-get-filename-with-logger (add-default-logger args)))
+  (apply cog-logger-get-filename-of-logger (apply add-default-logger args)))
 
 (define (cog-logger-get-level . args)
 "
@@ -135,7 +135,7 @@
     Return the logging level of LOGGER if provided.
     If not provided then use the default logger.
 "
-  (cog-logger-get-level-with-logger (add-default-logger args)))
+  (apply cog-logger-get-level-of-logger (apply add-default-logger args)))
 
 (define (cog-logger-get-component . args)
 "
@@ -143,7 +143,7 @@
     Return the component name of LOGGER if provided.
     If not provided then use the default logger.
 "
-  (cog-logger-get-component-with-logger (add-default-logger args)))
+  (apply cog-logger-get-component-of-logger (apply add-default-logger args)))
 
 (define (cog-logger-set-filename! . args)
 "
@@ -153,7 +153,7 @@
 
     Return the previous filename.
 "
-  cog-logger-set-filename-with-logger! (add-default-logger args)))
+  (apply cog-logger-set-filename-of-logger! (apply add-default-logger args)))
 
 (define (cog-logger-set-level! . args)
 "
@@ -163,7 +163,7 @@
 
     Returns the previous logging level.
 "
-  cog-logger-set-level-with-logger! (add-default-logger args)))
+  (apply cog-logger-set-level-of-logger! (apply add-default-logger args)))
 
 (define (cog-logger-set-component! . args)
 "
@@ -173,7 +173,7 @@
 
     Returns the previous component name.
 "
-  cog-logger-set-component-with-logger! (add-default-logger args)))
+  (apply cog-logger-set-component-of-logger! (apply add-default-logger args)))
 
 (define (cog-logger-set-stdout! . args)
 "
@@ -183,7 +183,7 @@
 
     Returns the previous setting.
 "
-  cog-logger-set-stdout-with-logger! (add-default-logger args)))
+  (apply cog-logger-set-stdout-of-logger! (apply add-default-logger args)))
 
 (define (cog-logger-set-sync! . args)
 "
@@ -197,7 +197,7 @@
 
     Returns the previous setting.
 "
-  cog-logger-set-sync-with-logger! (add-default-logger args)))
+  (apply cog-logger-set-sync-of-logger! (apply add-default-logger args)))
 
 (define (cog-logger-set-timestamp! . args)
 "
@@ -208,7 +208,7 @@
 
     Returns the previous setting.
 "
-  cog-logger-set-timestamp-with-logger! (add-default-logger args)))
+  (apply cog-logger-set-timestamp-of-logger! (apply add-default-logger args)))
 
 (define (cog-logger-error . args)
 "
@@ -217,7 +217,7 @@
     The MSG can be in any ice-9 printing format.
     If LOGGER is not provided then use the default logger.
 "
-  (cog-logger-error-with-format (add-default-logger args)))
+  (apply cog-logger-error-with-format (apply add-default-logger args)))
 
 (define (cog-logger-error-with-format logger msg . args)
 "
@@ -225,7 +225,7 @@
     Print MSG into the log file, at the \"error\" logging level.
     The MSG can be in any ice-9 printing format.
 "
-  (cog-logger-error-with-logger logger (apply format #f msg args)))
+  (cog-logger-error-of-logger logger (apply format #f msg args)))
 
 (define (cog-logger-warn . args)
 "
@@ -234,7 +234,7 @@
     The MSG can be in any ice-9 printing format.
     If LOGGER is not provided then use the default logger.
 "
-  (cog-logger-warn-with-format (add-default-logger args)))
+  (apply cog-logger-warn-with-format (apply add-default-logger args)))
 
 (define (cog-logger-warn-with-format logger msg . args)
 "
@@ -242,7 +242,7 @@
     Print MSG into the log file, at the \"warn\" logging level.
     The MSG can be in any ice-9 printing format.
 "
-  (cog-logger-warn-with-logger logger (apply format #f msg args)))
+  (cog-logger-warn-of-logger logger (apply format #f msg args)))
 
 (define (cog-logger-info . args)
 "
@@ -251,7 +251,7 @@
     The MSG can be in any ice-9 printing format.
     If LOGGER is not provided then use the default logger.
 "
-  (cog-logger-info-with-format (add-default-logger args)))
+  (apply cog-logger-info-with-format (apply add-default-logger args)))
 
 (define (cog-logger-info-with-format logger msg . args)
 "
@@ -259,7 +259,7 @@
     Print MSG into the log file, at the \"info\" logging level.
     The MSG can be in any ice-9 printing format.
 "
-  (cog-logger-info-with-logger logger (apply format #f msg args)))
+  (cog-logger-info-of-logger logger (apply format #f msg args)))
 
 (define (cog-logger-debug . args)
 "
@@ -268,7 +268,7 @@
     The MSG can be in any ice-9 printing format.
     If LOGGER is not provided then use the default logger.
 "
-  (cog-logger-debug-with-format (add-default-logger args)))
+  (apply cog-logger-debug-with-format (apply add-default-logger args)))
 
 (define (cog-logger-debug-with-format logger msg . args)
 "
@@ -276,7 +276,7 @@
     Print MSG into the log file, at the \"debug\" logging level.
     The MSG can be in any ice-9 printing format.
 "
-  (cog-logger-debug-with-logger logger (apply format #f msg args)))
+  (cog-logger-debug-of-logger logger (apply format #f msg args)))
 
 (define (cog-logger-fine . args)
 "
@@ -285,7 +285,7 @@
     The MSG can be in any ice-9 printing format.
     If LOGGER is not provided then use the default logger.
 "
-  (cog-logger-fine-with-format (add-default-logger args)))
+  (apply cog-logger-fine-with-format (apply add-default-logger args)))
 
 (define (cog-logger-fine-with-format logger msg . args)
 "
@@ -293,9 +293,17 @@
     Print MSG into the log file, at the \"fine\" logging level.
     The MSG can be in any ice-9 printing format.
 "
-  (cog-logger-fine-with-logger logger (apply format #f msg args)))
+  (cog-logger-fine-of-logger logger (apply format #f msg args)))
 
 (export cog-logger-get-filename
+        cog-logger-get-level
+        cog-logger-get-component
+        cog-logger-set-filename!
+        cog-logger-set-level!
+        cog-logger-set-component!
+        cog-logger-set-stdout!
+        cog-logger-set-sync!
+        cog-logger-set-timestamp!
         cog-logger-error
         cog-logger-warn
         cog-logger-info

--- a/opencog/scm/opencog/logger.scm
+++ b/opencog/scm/opencog/logger.scm
@@ -14,10 +14,14 @@
 ; Declare everything the C++ library provides; this avoid compile-time
 ; warnings when this file gets compiled.
 (export
+	default-logger
+	ure-logger
 	cog-logger-get-filename-ptr
 	cog-logger-get-level-ptr
+	cog-logger-get-component-ptr
 	cog-logger-set-filename-ptr!
 	cog-logger-set-level-ptr!
+	cog-logger-set-component-ptr!
 	cog-logger-set-stdout-ptr!
 	cog-logger-set-sync-ptr!
 	cog-logger-set-timestamp-ptr!
@@ -28,7 +32,13 @@
 	cog-logger-fine-ptr
 )
 
-; Documentation for the functions implemented as C++ code
+;; Documentation for the functions implemented as C++ code
+
+(set-procedure-property! default-logger 'documentation
+"
+
+")
+
 (set-procedure-property! cog-logger-get-filename-ptr 'documentation
 "
  cog-logger-get-filename-ptr LOGGER

--- a/opencog/scm/opencog/logger.scm
+++ b/opencog/scm/opencog/logger.scm
@@ -14,57 +14,57 @@
 ; Declare everything the C++ library provides; this avoid compile-time
 ; warnings when this file gets compiled.
 (export
-	cog-logger-get-filename
-	cog-logger-get-level
-	cog-logger-set-filename!
-	cog-logger-set-level!
-	cog-logger-set-stdout!
-	cog-logger-set-sync!
-	cog-logger-set-timestamp!
-	cog-logger-error-str
-	cog-logger-warn-str
-	cog-logger-info-str
-	cog-logger-debug-str
-	cog-logger-fine-str
+	cog-logger-get-filename-ptr
+	cog-logger-get-level-ptr
+	cog-logger-set-filename-ptr!
+	cog-logger-set-level-ptr!
+	cog-logger-set-stdout-ptr!
+	cog-logger-set-sync-ptr!
+	cog-logger-set-timestamp-ptr!
+	cog-logger-error-ptr
+	cog-logger-warn-ptr
+	cog-logger-info-ptr
+	cog-logger-debug-ptr
+	cog-logger-fine-ptr
 )
 
 ; Documentation for the functions implemented as C++ code
-(set-procedure-property! cog-logger-get-filename 'documentation
+(set-procedure-property! cog-logger-get-filename-ptr 'documentation
 "
- cog-logger-get-filename
+ cog-logger-get-filename-ptr LOGGER
     Return the name of the current logfile.
 ")
 
-(set-procedure-property! cog-logger-get-level 'documentation
+(set-procedure-property! cog-logger-get-level-ptr 'documentation
 "
- cog-logger-get-level
+ cog-logger-get-level-ptr LOGGER
     Return the current logging level.
 ")
 
-(set-procedure-property! cog-logger-set-filename! 'documentation
+(set-procedure-property! cog-logger-set-filename-ptr! 'documentation
 "
- cog-logger-set-filename! FILENAME
-    Change the current logger file to FILENAME.
+ cog-logger-set-filename-ptr! LOGGER FILENAME
+    Change the current LOGGER filename to FILENAME.
     Return the previous filename.
 ")
 
-(set-procedure-property! cog-logger-set-level! 'documentation
+(set-procedure-property! cog-logger-set-level-ptr! 'documentation
 "
- cog-logger-set-level! LEVEL
+ cog-logger-set-level! LOGGER LEVEL
     Set the current logging level to LEVEL.
     Returns the previous logging level.
 ")
 
-(set-procedure-property! cog-logger-set-stdout! 'documentation
+(set-procedure-property! cog-logger-set-stdout-ptr! 'documentation
 "
- cog-logger-set-stdout! BOOL
+ cog-logger-set-stdout! LOGGER BOOL
     If BOOL is #t, send log messages to stdout; else don't.
     Returns the previous setting.
 ")
 
-(set-procedure-property! cog-logger-set-sync! 'documentation
+(set-procedure-property! cog-logger-set-sync-ptr! 'documentation
 "
- cog-logger-set-sync! BOOL
+ cog-logger-set-sync! LOGGER BOOL
     If BOOL is #t, write message to log file synchronously; else don't.
     That is, if sync is set, then the message will be written and the
     file flushed, before the log request returns. Otherwise, logging
@@ -74,16 +74,17 @@
     Returns the previous setting.
 ")
 
-(set-procedure-property! cog-logger-set-timestamp! 'documentation
+(set-procedure-property! cog-logger-set-timestamp-ptr! 'documentation
 "
- cog-logger-set-timestamp! BOOL
+ cog-logger-set-timestamp! LOGGER BOOL
     If BOOL is #t, then a timetampe will be written with each log
     message; else not.
 
     Returns the previous setting.
 ")
 
-; Helper functions, using ice-9 format in logger functions.
+; Helper functions, using default logger and ice-9 format in logger
+; functions. TODO
 
 (use-modules (ice-9 format))
 
@@ -93,7 +94,7 @@
     Print MSG into the logfile, at the \"error\" logging level.
     The MSG can be in any ice-9 printing format.
 "
-  (cog-logger-error-str (apply format #f msg args)))
+  (cog-logger-error-ptr (apply format #f msg args)))
 
 (define (cog-logger-warn msg . args)
 "
@@ -101,7 +102,7 @@
     Print MSG into the logfile, at the \"warning\" logging level.
     The MSG can be in any ice-9 printing format.
 "
-  (cog-logger-warn-str (apply format #f msg args)))
+  (cog-logger-warn-ptr (apply format #f msg args)))
 
 (define (cog-logger-info msg . args)
 "
@@ -109,13 +110,13 @@
     Print MSG into the logfile, at the \"info\" logging level.
     The MSG can be in any ice-9 printing format.
 "
-  (cog-logger-info-str (apply format #f msg args)))
+  (cog-logger-info-ptr (apply format #f msg args)))
 
 (define (cog-logger-debug msg . args)
-  (cog-logger-debug-str (apply format #f msg args)))
+  (cog-logger-debug-ptr (apply format #f msg args)))
 
 (define (cog-logger-fine msg . args)
-  (cog-logger-fine-str (apply format #f msg args)))
+  (cog-logger-fine-ptr (apply format #f msg args)))
 
 (export cog-logger-error
         cog-logger-warn

--- a/opencog/scm/opencog/logger.scm
+++ b/opencog/scm/opencog/logger.scm
@@ -14,65 +14,78 @@
 ; Declare everything the C++ library provides; this avoid compile-time
 ; warnings when this file gets compiled.
 (export
-	default-logger
-	ure-logger
-	cog-logger-get-filename-ptr
-	cog-logger-get-level-ptr
-	cog-logger-get-component-ptr
-	cog-logger-set-filename-ptr!
-	cog-logger-set-level-ptr!
-	cog-logger-set-component-ptr!
-	cog-logger-set-stdout-ptr!
-	cog-logger-set-sync-ptr!
-	cog-logger-set-timestamp-ptr!
-	cog-logger-error-ptr
-	cog-logger-warn-ptr
-	cog-logger-info-ptr
-	cog-logger-debug-ptr
-	cog-logger-fine-ptr
+	cog-default-logger
+	cog-ure-logger
+	cog-logger-get-filename-with-logger
+	cog-logger-get-level-with-logger
+	cog-logger-get-component-with-logger
+	cog-logger-set-filename-with-logger!
+	cog-logger-set-level-with-logger!
+	cog-logger-set-component-with-logger!
+	cog-logger-set-stdout-with-logger!
+	cog-logger-set-sync-with-logger!
+	cog-logger-set-timestamp-with-logger!
+	cog-logger-error-with-logger
+	cog-logger-warn-with-logger
+	cog-logger-info-with-logger
+	cog-logger-debug-with-logger
+	cog-logger-fine-with-logger
 )
 
 ;; Documentation for the functions implemented as C++ code
 
-(set-procedure-property! default-logger 'documentation
+(set-procedure-property! cog-default-logger 'documentation
 "
-
+ cog-default-logger
+    Return the default logger.
 ")
 
-(set-procedure-property! cog-logger-get-filename-ptr 'documentation
+(set-procedure-property! cog-ure-logger 'documentation
 "
- cog-logger-get-filename-ptr LOGGER
-    Return the name of the current logfile.
+ cog-ure-logger
+    Return the rule-engine logger.
 ")
 
-(set-procedure-property! cog-logger-get-level-ptr 'documentation
+(set-procedure-property! cog-logger-get-filename-with-logger 'documentation
 "
- cog-logger-get-level-ptr LOGGER
-    Return the current logging level.
+ cog-logger-get-filename-with-logger LOGGER
+    Return the filename of LOGGER.
 ")
 
-(set-procedure-property! cog-logger-set-filename-ptr! 'documentation
+(set-procedure-property! cog-logger-get-level-with-logger 'documentation
 "
- cog-logger-set-filename-ptr! LOGGER FILENAME
-    Change the current LOGGER filename to FILENAME.
+ cog-logger-get-level-with-logger LOGGER
+    Return the logging level of LOGGER.
+")
+
+(set-procedure-property! cog-logger-get-component-with-logger 'documentation
+"
+ cog-logger-get-component-with-logger LOGGER
+    Return the component name of LOGGER.
+")
+
+(set-procedure-property! cog-logger-set-filename-with-logger! 'documentation
+"
+ cog-logger-set-filename-with-logger! LOGGER FILENAME
+    Change the filename of LOGGER to FILENAME.
     Return the previous filename.
 ")
 
-(set-procedure-property! cog-logger-set-level-ptr! 'documentation
+(set-procedure-property! cog-logger-set-level-with-logger! 'documentation
 "
  cog-logger-set-level! LOGGER LEVEL
-    Set the current logging level to LEVEL.
+    Set the logging level of LOGGER to LEVEL.
     Returns the previous logging level.
 ")
 
-(set-procedure-property! cog-logger-set-stdout-ptr! 'documentation
+(set-procedure-property! cog-logger-set-stdout-with-logger! 'documentation
 "
  cog-logger-set-stdout! LOGGER BOOL
     If BOOL is #t, send log messages to stdout; else don't.
     Returns the previous setting.
 ")
 
-(set-procedure-property! cog-logger-set-sync-ptr! 'documentation
+(set-procedure-property! cog-logger-set-sync-with-logger! 'documentation
 "
  cog-logger-set-sync! LOGGER BOOL
     If BOOL is #t, write message to log file synchronously; else don't.
@@ -84,51 +97,206 @@
     Returns the previous setting.
 ")
 
-(set-procedure-property! cog-logger-set-timestamp-ptr! 'documentation
+(set-procedure-property! cog-logger-set-timestamp-with-logger! 'documentation
 "
  cog-logger-set-timestamp! LOGGER BOOL
-    If BOOL is #t, then a timetampe will be written with each log
+    If BOOL is #t, then a timestamp will be written with each log
     message; else not.
 
     Returns the previous setting.
 ")
 
 ; Helper functions, using default logger and ice-9 format in logger
-; functions. TODO
+; functions.
 
 (use-modules (ice-9 format))
 
-(define (cog-logger-error msg . args)
+(define (add-default-logger . args)
 "
- cog-logger-error MSG ARGS
-    Print MSG into the logfile, at the \"error\" logging level.
+ add-defaultlogger [LOGGER] [ARG1] ... [ARGn]
+    Return the list of argument with the default logger
+    prepended to it if LOGGER was not provided.
+"
+  (if (and (< 0 (length args)) (cog-logger? (car args)))
+      args
+      (cons (cog-default-logger) args)))
+
+(define (cog-logger-get-filename . args)
+"
+ cog-logger-get-filename [LOGGER]
+    Return the filename of LOGGER if provided.
+    If not provided then use the default logger.
+"
+  (apply cog-logger-get-filename-with-logger (add-default-logger args)))
+
+(define (cog-logger-get-level . args)
+"
+ cog-logger-get-level [LOGGER]
+    Return the logging level of LOGGER if provided.
+    If not provided then use the default logger.
+"
+  (cog-logger-get-level-with-logger (add-default-logger args)))
+
+(define (cog-logger-get-component . args)
+"
+ cog-logger-get-level [LOGGER]
+    Return the component name of LOGGER if provided.
+    If not provided then use the default logger.
+"
+  (cog-logger-get-component-with-logger (add-default-logger args)))
+
+(define (cog-logger-set-filename! . args)
+"
+ cog-logger-set-filename! [LOGGER] FILENAME
+    Change the filename of LOGGER to FILENAME.
+    If LOGGER is not provided then use the default logger.
+
+    Return the previous filename.
+"
+  cog-logger-set-filename-with-logger! (add-default-logger args)))
+
+(define (cog-logger-set-level! . args)
+"
+ cog-logger-set-level! [LOGGER] LEVEL
+    Change the logging level of LOGGER to LEVEL.
+    If LOGGER is not provided then use the default logger.
+
+    Returns the previous logging level.
+"
+  cog-logger-set-level-with-logger! (add-default-logger args)))
+
+(define (cog-logger-set-component! . args)
+"
+ cog-logger-set-component! [LOGGER] COMPONENT
+    Change the component name of LOGGER to COMPONENT.
+    If LOGGER is not provided then use the default logger.
+
+    Returns the previous component name.
+"
+  cog-logger-set-component-with-logger! (add-default-logger args)))
+
+(define (cog-logger-set-stdout! . args)
+"
+ cog-logger-set-stdout! [LOGGER] STDOUT
+    If BOOL is #t, send log messages to stdout; else don't.
+    If LOGGER is not provided then use the default logger
+
+    Returns the previous setting.
+"
+  cog-logger-set-stdout-with-logger! (add-default-logger args)))
+
+(define (cog-logger-set-sync! . args)
+"
+ cog-logger-set-sync! [LOGGER] BOOL
+    If BOOL is #t, write message to log file synchronously; else don't.
+    That is, if sync is set, then the message will be written and the
+    file flushed, before the log request returns. Otherwise, logging
+    is carried out in a separate thread (to minimize latency impact on
+    the current thread).
+    If LOGGER is not provided then use the default logger.
+
+    Returns the previous setting.
+"
+  cog-logger-set-sync-with-logger! (add-default-logger args)))
+
+(define (cog-logger-set-timestamp! . args)
+"
+ cog-logger-set-timestamp! [LOGGER] BOOL
+    If BOOL is #t, then a timestamp will be written with each log
+    message; else not.
+    If LOGGER is not provided then use the default logger.
+
+    Returns the previous setting.
+"
+  cog-logger-set-timestamp-with-logger! (add-default-logger args)))
+
+(define (cog-logger-error . args)
+"
+ cog-logger-error [LOGGER] MSG ARGS
+    Print MSG into the log file, at the \"error\" logging level.
+    The MSG can be in any ice-9 printing format.
+    If LOGGER is not provided then use the default logger.
+"
+  (cog-logger-error-with-format (add-default-logger args)))
+
+(define (cog-logger-error-with-format logger msg . args)
+"
+ cog-logger-error LOGGER MSG ARGS
+    Print MSG into the log file, at the \"error\" logging level.
     The MSG can be in any ice-9 printing format.
 "
-  (cog-logger-error-ptr (apply format #f msg args)))
+  (cog-logger-error-with-logger logger (apply format #f msg args)))
 
-(define (cog-logger-warn msg . args)
+(define (cog-logger-warn . args)
 "
- cog-logger-error MSG ARGS
-    Print MSG into the logfile, at the \"warning\" logging level.
+ cog-logger-warn [LOGGER] MSG ARGS
+    Print MSG into the log file, at the \"warn\" logging level.
+    The MSG can be in any ice-9 printing format.
+    If LOGGER is not provided then use the default logger.
+"
+  (cog-logger-warn-with-format (add-default-logger args)))
+
+(define (cog-logger-warn-with-format logger msg . args)
+"
+ cog-logger-warn LOGGER MSG ARGS
+    Print MSG into the log file, at the \"warn\" logging level.
     The MSG can be in any ice-9 printing format.
 "
-  (cog-logger-warn-ptr (apply format #f msg args)))
+  (cog-logger-warn-with-logger logger (apply format #f msg args)))
 
-(define (cog-logger-info msg . args)
+(define (cog-logger-info . args)
 "
- cog-logger-error MSG ARGS
-    Print MSG into the logfile, at the \"info\" logging level.
+ cog-logger-info [LOGGER] MSG ARGS
+    Print MSG into the log file, at the \"info\" logging level.
+    The MSG can be in any ice-9 printing format.
+    If LOGGER is not provided then use the default logger.
+"
+  (cog-logger-info-with-format (add-default-logger args)))
+
+(define (cog-logger-info-with-format logger msg . args)
+"
+ cog-logger-info LOGGER MSG ARGS
+    Print MSG into the log file, at the \"info\" logging level.
     The MSG can be in any ice-9 printing format.
 "
-  (cog-logger-info-ptr (apply format #f msg args)))
+  (cog-logger-info-with-logger logger (apply format #f msg args)))
 
-(define (cog-logger-debug msg . args)
-  (cog-logger-debug-ptr (apply format #f msg args)))
+(define (cog-logger-debug . args)
+"
+ cog-logger-debug [LOGGER] MSG ARGS
+    Print MSG into the log file, at the \"debug\" logging level.
+    The MSG can be in any ice-9 printing format.
+    If LOGGER is not provided then use the default logger.
+"
+  (cog-logger-debug-with-format (add-default-logger args)))
 
-(define (cog-logger-fine msg . args)
-  (cog-logger-fine-ptr (apply format #f msg args)))
+(define (cog-logger-debug-with-format logger msg . args)
+"
+ cog-logger-debug LOGGER MSG ARGS
+    Print MSG into the log file, at the \"debug\" logging level.
+    The MSG can be in any ice-9 printing format.
+"
+  (cog-logger-debug-with-logger logger (apply format #f msg args)))
 
-(export cog-logger-error
+(define (cog-logger-fine . args)
+"
+ cog-logger-fine [LOGGER] MSG ARGS
+    Print MSG into the log file, at the \"fine\" logging level.
+    The MSG can be in any ice-9 printing format.
+    If LOGGER is not provided then use the default logger.
+"
+  (cog-logger-fine-with-format (add-default-logger args)))
+
+(define (cog-logger-fine-with-format logger msg . args)
+"
+ cog-logger-fine LOGGER MSG ARGS
+    Print MSG into the log file, at the \"fine\" logging level.
+    The MSG can be in any ice-9 printing format.
+"
+  (cog-logger-fine-with-logger logger (apply format #f msg args)))
+
+(export cog-logger-get-filename
+        cog-logger-error
         cog-logger-warn
         cog-logger-info
         cog-logger-debug


### PR DESCRIPTION
Now one can use multiple loggers. The scheme functions haven't changed, instead they have been completed with an optional first argument representing the logger. If no argument is provided then the default logger is considered. For instance
```
(cog-logger-set-level! (cog-ure-logger) "fine")
```
change the URE logger level to fine, while
```
(cog-logger-set-level! "fine")
```
change the default logger level to debug.