### PR TITLE
Remove TV merge functions from Atom.h

### DIFF
--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -268,19 +268,6 @@ public:
     //! Sets the TruthValue object of the atom.
     void setTruthValue(TruthValuePtr);
 
-    /** merge truth value into this */
-    void merge(const TruthValuePtr&, const MergeCtrl& mc=MergeCtrl());
-
-    /**
-     * Merge truth value, return Handle for this.
-     * This allows oneliners such as:
-     *   Handle h = atomSpace->addNode(FOO_NODE, "foo")->tvmerge(tv);
-     */
-    inline Handle tvmerge(const TruthValuePtr& tv) {
-        merge(tv);
-        return getHandle();
-    }
-
     /// Associate `value` to `key` for this atom.
     void setValue(const Handle& key, const ProtoAtomPtr& value);
     /// Get value at `key` for this atom.

--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -337,6 +337,8 @@ void SchemeSmob::register_procs()
 	register_proc("cog-tv-mean",           1, 0, 0, C(ss_tv_get_mean));
 	register_proc("cog-tv-confidence",     1, 0, 0, C(ss_tv_get_confidence));
 	register_proc("cog-tv-count",          1, 0, 0, C(ss_tv_get_count));
+	register_proc("cog-tv-merge!",         2, 0, 0, C(ss_tv_merge));
+	register_proc("cog-tv-merge-hi-conf!", 2, 0, 0, C(ss_tv_merge_hi_conf));
 
 	// Atom Spaces
 	register_proc("cog-new-atomspace",     0, 1, 0, C(ss_new_as));

--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -295,8 +295,6 @@ void SchemeSmob::register_procs()
 
 	// TV property setters on atoms
 	register_proc("cog-set-tv!",           2, 0, 0, C(ss_set_tv));
-	register_proc("cog-merge-tv!",         2, 0, 0, C(ss_merge_tv));
-	register_proc("cog-merge-hi-conf-tv!", 2, 0, 0, C(ss_merge_hi_conf_tv));
 	register_proc("cog-inc-count!",        2, 0, 0, C(ss_inc_count));
 
 	// Attention values on atoms

--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -335,8 +335,8 @@ void SchemeSmob::register_procs()
 	register_proc("cog-tv-mean",           1, 0, 0, C(ss_tv_get_mean));
 	register_proc("cog-tv-confidence",     1, 0, 0, C(ss_tv_get_confidence));
 	register_proc("cog-tv-count",          1, 0, 0, C(ss_tv_get_count));
-	register_proc("cog-tv-merge!",         2, 0, 0, C(ss_tv_merge));
-	register_proc("cog-tv-merge-hi-conf!", 2, 0, 0, C(ss_tv_merge_hi_conf));
+	register_proc("cog-tv-merge",          2, 0, 0, C(ss_tv_merge));
+	register_proc("cog-tv-merge-hi-conf",  2, 0, 0, C(ss_tv_merge_hi_conf));
 
 	// Atom Spaces
 	register_proc("cog-new-atomspace",     0, 1, 0, C(ss_new_as));

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -107,8 +107,6 @@ private:
 	static SCM ss_set_av(SCM, SCM);
 	static SCM ss_set_tv(SCM, SCM);
 	static SCM ss_set_value(SCM, SCM, SCM);
-	static SCM ss_merge_tv(SCM, SCM); // XXX kill thism
-	static SCM ss_merge_hi_conf_tv(SCM, SCM); // XXX kill this
 	static SCM ss_inc_count(SCM, SCM);
 	static SCM ss_inc_vlti(SCM);
 	static SCM ss_dec_vlti(SCM);

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -107,8 +107,8 @@ private:
 	static SCM ss_set_av(SCM, SCM);
 	static SCM ss_set_tv(SCM, SCM);
 	static SCM ss_set_value(SCM, SCM, SCM);
-	static SCM ss_merge_tv(SCM, SCM);
-	static SCM ss_merge_hi_conf_tv(SCM, SCM);
+	static SCM ss_merge_tv(SCM, SCM); // XXX kill thism
+	static SCM ss_merge_hi_conf_tv(SCM, SCM); // XXX kill this
 	static SCM ss_inc_count(SCM, SCM);
 	static SCM ss_inc_vlti(SCM);
 	static SCM ss_dec_vlti(SCM);
@@ -158,6 +158,8 @@ private:
 	static SCM ss_tv_get_mean(SCM);
 	static SCM ss_tv_get_confidence(SCM);
 	static SCM ss_tv_get_count(SCM);
+	static SCM ss_tv_merge(SCM, SCM);
+	static SCM ss_tv_merge_hi_conf(SCM, SCM);
 
 	// Atom Spaces
 	static SCM ss_new_as(SCM);

--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -117,28 +117,6 @@ SCM SchemeSmob::ss_set_tv (SCM satom, SCM stv)
 	return satom;
 }
 
-SCM SchemeSmob::ss_merge_tv (SCM satom, SCM stv)
-{
-	Handle h = verify_handle(satom, "cog-merge-tv!");
-	TruthValuePtr tv = verify_tv(stv, "cog-merge-tv!", 2);
-
-	h->merge(tv);
-	scm_remember_upto_here_1(stv);
-	return satom;
-}
-
-// XXX FIXME -- this should NOT be a part of the API, it should be
-// a utility function!
-SCM SchemeSmob::ss_merge_hi_conf_tv (SCM satom, SCM stv)
-{
-	Handle h = verify_handle(satom, "cog-merge-hi-conf-tv!");
-	TruthValuePtr tv = verify_tv(stv, "cog-merge-hi-conf-tv!", 2);
-
-	h->merge(tv, MergeCtrl(MergeCtrl::TVFormula::HIGHER_CONFIDENCE));
-	scm_remember_upto_here_1(stv);
-	return satom;
-}
-
 // Increment the count, keeping mean and confidence as-is.
 // Converts existing truth value to a CountTruthValue.
 SCM SchemeSmob::ss_inc_count (SCM satom, SCM scnt)

--- a/opencog/guile/SchemeSmobTV.cc
+++ b/opencog/guile/SchemeSmobTV.cc
@@ -494,16 +494,16 @@ SCM SchemeSmob::ss_tv_get_count(SCM s)
 
 SCM SchemeSmob::ss_tv_merge (SCM sta, SCM stb)
 {
-	TruthValuePtr tva = verify_tv(sta, "cog-tv-merge!", 1);
-	TruthValuePtr tvb = verify_tv(stb, "cog-tv-merge!", 2);
+	TruthValuePtr tva = verify_tv(sta, "cog-tv-merge", 1);
+	TruthValuePtr tvb = verify_tv(stb, "cog-tv-merge", 2);
 
 	return tv_to_scm(tva->merge(tvb));
 }
 
 SCM SchemeSmob::ss_tv_merge_hi_conf (SCM sta, SCM stb)
 {
-	TruthValuePtr tva = verify_tv(sta, "cog-tv-merge-hi-conf!", 1);
-	TruthValuePtr tvb = verify_tv(stb, "cog-tv-merge-hi-conf!", 2);
+	TruthValuePtr tva = verify_tv(sta, "cog-tv-merge-hi-conf", 1);
+	TruthValuePtr tvb = verify_tv(stb, "cog-tv-merge-hi-conf", 2);
 
 	return tv_to_scm(tva->merge(tvb,
 		MergeCtrl(MergeCtrl::TVFormula::HIGHER_CONFIDENCE)));

--- a/opencog/guile/SchemeSmobTV.cc
+++ b/opencog/guile/SchemeSmobTV.cc
@@ -491,4 +491,22 @@ SCM SchemeSmob::ss_tv_get_count(SCM s)
 	return scm_from_double(tv->getCount());
 }
 
+
+SCM SchemeSmob::ss_tv_merge (SCM sta, SCM stb)
+{
+	TruthValuePtr tva = verify_tv(sta, "cog-tv-merge!", 1);
+	TruthValuePtr tvb = verify_tv(stb, "cog-tv-merge!", 2);
+
+	return tv_to_scm(tva->merge(tvb));
+}
+
+SCM SchemeSmob::ss_tv_merge_hi_conf (SCM sta, SCM stb)
+{
+	TruthValuePtr tva = verify_tv(sta, "cog-tv-merge-hi-conf!", 1);
+	TruthValuePtr tvb = verify_tv(stb, "cog-tv-merge-hi-conf!", 2);
+
+	return tv_to_scm(tva->merge(tvb,
+		MergeCtrl(MergeCtrl::TVFormula::HIGHER_CONFIDENCE)));
+}
+
 /* ===================== END OF FILE ============================ */

--- a/opencog/scm/opencog/base/av-tv.scm
+++ b/opencog/scm/opencog/base/av-tv.scm
@@ -5,6 +5,8 @@
 ; and the attentional allocation system
 ;
 ; Utilities provided:
+; -- cog-merge-tv! -- merge truth values on atom
+; -- cog-merge-hi-conf-tv! -- different merge style
 ; -- cog-af-length -- Length of list of atoms in the attentional focus
 ; -- cog-av-sti -- Return the STI of an atom
 ; -- cog-sti-above -- Filter atoms with STI above a threshold
@@ -23,6 +25,18 @@
 ;
 ; Copyright (c) 2014 Cosmo Harrigan
 ;
+
+; -----------------------------------------------------------------------
+(define-public (cog-merge-tv! ATOM TV)
+" cog-merge-tv! -- merge truth values on atom"
+	(cog-set-tv! ATOM (cog-tv-merge (cog-tv ATOM) TV))
+)
+
+; -----------------------------------------------------------------------
+(define-public (cog-merge-hi-conf-tv! ATOM TV)
+" cog-merge-hi-conf-tv! -- merge truth values on atom"
+	(cog-set-tv! ATOM (cog-tv-merge-hi-conf (cog-tv ATOM) TV))
+)
 
 ; -----------------------------------------------------------------------
 ; cog-af-length

--- a/opencog/scm/opencog/base/av-tv.scm
+++ b/opencog/scm/opencog/base/av-tv.scm
@@ -39,90 +39,126 @@
 )
 
 ; -----------------------------------------------------------------------
-; cog-af-length
-; Length of the list of atoms in the attentional focus
-(define-public (cog-af-length) (length (cog-af)))
+(define-public (cog-af-length)
+" cog-af-length -- Length of the list of atoms in the attentional focus."
+	(length (cog-af)))
 
 ; -----------------------------------------------------------------------
-; cog-av-sti
-; Return the STI of an atom
-(define-public (cog-av-sti x) (cdr (assoc 'sti (cog-av->alist (cog-av x)))))
+(define-public (cog-av-sti x)
+" cog-av-sti -- Return the STI of an atom."
+	(cdr (assoc 'sti (cog-av->alist (cog-av x)))))
 
 ; -----------------------------------------------------------------------
-; cog-sti-above
-; Given a threshold 'y' and a list of atoms 'z', returns a list of atoms
-; with STI above the threshold
-(define-public (cog-sti-above y z) (filter (lambda (x) (> (cog-av-sti x) y)) z))
+(define-public (cog-sti-above y z)
+"
+  cog-sti-above
+  Given a threshold 'y' and a list of atoms 'z', returns a list of atoms
+  with STI above the threshold
+"
+	(filter (lambda (x) (> (cog-av-sti x) y)) z))
 
 ; -----------------------------------------------------------------------
-; cog-sti-below
-; Given a threshold 'y' and a list of atoms 'z', returns a list of atoms
-; with STI below the threshold
-(define-public (cog-sti-below y z) (filter (lambda (x) (< (cog-av-sti x) y)) z))
+(define-public (cog-sti-below y z)
+"
+  cog-sti-below
+  Given a threshold 'y' and a list of atoms 'z', returns a list of atoms
+  with STI below the threshold
+"
+	(filter (lambda (x) (< (cog-av-sti x) y)) z))
 
 ; -----------------------------------------------------------------------
-; cog-stv-strength
-; Return the truth value strength of an atom
-; (Compatible with atoms that have a SimpleTruthValue)
-(define-public (cog-stv-strength x) (cdr (assoc 'mean (cog-tv->alist (cog-tv x)))))
+(define-public (cog-stv-strength x)
+"
+  cog-stv-strength
+  Return the truth value strength of an atom
+  (Compatible with atoms that have a SimpleTruthValue)
+"
+	(cdr (assoc 'mean (cog-tv->alist (cog-tv x)))))
 
 ; -----------------------------------------------------------------------
-; cog-stv-strength-above
-; Given a threshold 'y' and a list of atoms 'z', returns a list of atoms with
-; truth value strength above the threshold
-; (Compatible with atoms that have a SimpleTruthValue)
-(define-public (cog-stv-strength-above y z) (filter (lambda (x) (> (cog-stv-strength x) y)) z))
+(define-public (cog-stv-strength-above y z)
+"
+  cog-stv-strength-above
+  Given a threshold 'y' and a list of atoms 'z', returns a list of atoms with
+  truth value strength above the threshold
+  (Compatible with atoms that have a SimpleTruthValue)
+"
+	(filter (lambda (x) (> (cog-stv-strength x) y)) z))
 
 ; -----------------------------------------------------------------------
-; cog-stv-strength-below
-; Given a threshold 'y' and a list of atoms 'z', returns a list of atoms with
-; truth value strength above the threshold
-; (Compatible with atoms that have a SimpleTruthValue)
-(define-public (cog-stv-strength-below y z) (filter (lambda (x) (< (cog-stv-strength x) y)) z))
+(define-public (cog-stv-strength-below y z)
+"
+  cog-stv-strength-below
+  Given a threshold 'y' and a list of atoms 'z', returns a list of atoms with
+  truth value strength above the threshold
+  (Compatible with atoms that have a SimpleTruthValue)
+"
+	(filter (lambda (x) (< (cog-stv-strength x) y)) z))
 
 ; -----------------------------------------------------------------------
-; cog-stv-confidence
-; Return the truth value confidence of an atom
-; (Compatible with atoms that have a SimpleTruthValue)
-(define-public (cog-stv-confidence x) (cdr (assoc 'confidence (cog-tv->alist (cog-tv x)))))
+(define-public (cog-stv-confidence x)
+"
+  cog-stv-confidence
+  Return the truth value confidence of an atom
+  (Compatible with atoms that have a SimpleTruthValue)
+"
+	(cdr (assoc 'confidence (cog-tv->alist (cog-tv x)))))
 
 ; -----------------------------------------------------------------------
-; cog-stv-confidence-above
-; Given a threshold 'y' and a list of atoms 'z', returns a list of atoms with
-; truth value confidence above the threshold
-; (Compatible with atoms that have a SimpleTruthValue)
-(define-public (cog-stv-confidence-above y z) (filter (lambda (x) (> (cog-stv-confidence x) y)) z))
+(define-public (cog-stv-confidence-above y z)
+"
+  cog-stv-confidence-above
+  Given a threshold 'y' and a list of atoms 'z', returns a list of atoms with
+  truth value confidence above the threshold
+  (Compatible with atoms that have a SimpleTruthValue)
+"
+	(filter (lambda (x) (> (cog-stv-confidence x) y)) z))
 
 ; -----------------------------------------------------------------------
-; cog-stv-confidence-below
-; Given a threshold 'y' and a list of atoms 'z', returns a list of atoms with
-; truth value confidence above the threshold
-; (Compatible with atoms that have a SimpleTruthValue)
-(define-public (cog-stv-confidence-below y z) (filter (lambda (x) (< (cog-stv-confidence x) y)) z))
+(define-public (cog-stv-confidence-below y z)
+"
+  cog-stv-confidence-below
+  Given a threshold 'y' and a list of atoms 'z', returns a list of atoms with
+  truth value confidence above the threshold
+  (Compatible with atoms that have a SimpleTruthValue)
+"
+	(filter (lambda (x) (< (cog-stv-confidence x) y)) z))
 
 ; -----------------------------------------------------------------------
-; cog-stv-count
-; Return the truth value count of an atom
-; (Compatible with atoms that have a SimpleTruthValue)
-(define-public (cog-stv-count x) (cdr (assoc 'count (cog-tv->alist (cog-tv x)))))
+(define-public (cog-stv-count x)
+"
+  cog-stv-count
+  Return the truth value count of an atom
+  (Compatible with atoms that have a SimpleTruthValue)
+"
+	(cdr (assoc 'count (cog-tv->alist (cog-tv x)))))
 
 ; -----------------------------------------------------------------------
-; cog-stv-count-above
-; Given a threshold 'y' and a list of atoms 'z', returns a list of atoms with
-; truth value count above the threshold
-; (Compatible with atoms that have a SimpleTruthValue)
-(define-public (cog-stv-count-above y z) (filter (lambda (x) (> (cog-stv-count x) y)) z))
+(define-public (cog-stv-count-above y z)
+"
+  cog-stv-count-above
+  Given a threshold 'y' and a list of atoms 'z', returns a list of atoms with
+  truth value count above the threshold
+  (Compatible with atoms that have a SimpleTruthValue)
+"
+	(filter (lambda (x) (> (cog-stv-count x) y)) z))
 
 ; -----------------------------------------------------------------------
-; cog-stv-count-below
-; Given a threshold 'y' and a list of atoms 'z', returns a list of atoms with
-; truth value count above the threshold
-; (Compatible with atoms that have a SimpleTruthValue)
-(define-public (cog-stv-count-below y z) (filter (lambda (x) (< (cog-stv-count x) y)) z))
+(define-public (cog-stv-count-below y z)
+"
+  cog-stv-count-below
+  Given a threshold 'y' and a list of atoms 'z', returns a list of atoms with
+  truth value count above the threshold
+  (Compatible with atoms that have a SimpleTruthValue)
+"
+	(filter (lambda (x) (< (cog-stv-count x) y)) z))
 
 ; -----------------------------------------------------------------------
-; cog-stv-positive-filter
-; Given a list of atoms, returns a list containing the subset that has
-; truth value count > 0 and truth value strength > 0
-; (Compatible with atoms that have a SimpleTruthValue)
-(define-public (cog-stv-positive-filter x) (cog-stv-strength-above 0 (cog-stv-count-above 0 x)))
+(define-public (cog-stv-positive-filter x)
+"
+  cog-stv-positive-filter
+  Given a list of atoms, returns a list containing the subset that has
+  truth value count > 0 and truth value strength > 0
+  (Compatible with atoms that have a SimpleTruthValue)
+"
+	(cog-stv-strength-above 0 (cog-stv-count-above 0 x)))


### PR DESCRIPTION
This does not remove any capability -- one can still merge TV's directly.  This just removes some the C++ wrappers from class Atom, where they provided almost no value-add, and mostly clogged up the API.
