### PR TITLE
Simplify handle set

### DIFF
--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -220,15 +220,15 @@ ProtoAtomPtr Atom::getValue(const Handle& key) const
     return _atom_space->_value_table.getValue(key, getHandle());
 }
 
-std::set<Handle> Atom::getKeys() const
+HandleSet Atom::getKeys() const
 {
-    if (nullptr == _atom_space) return std::set<Handle>();
+    if (nullptr == _atom_space) return HandleSet();
     return _atom_space->_value_table.getKeys(getHandle());
 }
 
 void Atom::copyValues(const Handle& other)
 {
-    std::set<Handle> okeys(other->getKeys());
+    HandleSet okeys(other->getKeys());
     for (const Handle& k: okeys)
     {
         ProtoAtomPtr p = other->getValue(k);
@@ -243,7 +243,7 @@ std::string Atom::valuesToString() const
 {
     std::string rv;
 
-    std::set<Handle> keys(getKeys());
+    HandleSet keys(getKeys());
     for (const Handle& k: keys)
     {
         ProtoAtomPtr p = getValue(k);

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -287,7 +287,7 @@ public:
     ProtoAtomPtr getValue(const Handle& key) const;
 
     /// Get the set of all keys in use for this Atom.
-    std::set<Handle> getKeys() const;
+    HandleSet getKeys() const;
 
     /// Copy all the values from the other atom to this one.
     void copyValues(const Handle&);

--- a/opencog/atoms/base/Context.cc
+++ b/opencog/atoms/base/Context.cc
@@ -34,7 +34,7 @@
 namespace opencog {
 
 Context::Context(const Quotation& q,
-                 const OrderedHandleSet& s,
+                 const HandleSet& s,
                  bool i, const VariablesStack& v)
 	: quotation(q), shadow(s), store_scope_variables(i), scope_variables(v) {}
 
@@ -100,7 +100,7 @@ bool Context::operator<(const Context& other) const
 		    or (shadow == other.shadow and scope_variables < other.scope_variables));
 }
 
-bool ohs_content_eq(const OrderedHandleSet& lhs, const OrderedHandleSet& rhs)
+bool ohs_content_eq(const HandleSet& lhs, const HandleSet& rhs)
 {
 	if (lhs.size() != rhs.size())
 		return false;

--- a/opencog/atoms/base/Context.h
+++ b/opencog/atoms/base/Context.h
@@ -59,7 +59,7 @@ struct Context : public boost::totally_ordered<Context>
 
 	// Default ctor
 	Context(const Quotation& quotation=Quotation(),
-	        const OrderedHandleSet& shadow=OrderedHandleSet(),
+	        const HandleSet& shadow=HandleSet(),
 	        bool store_scope_variables=true,
 	        const VariablesStack& scope_variables=VariablesStack());
 	Context(bool store_scope_variables);
@@ -68,7 +68,7 @@ struct Context : public boost::totally_ordered<Context>
 	Quotation quotation;
 
 	// Set of shadowing variables
-	OrderedHandleSet shadow;
+	HandleSet shadow;
 
 	// Flag to ignore pushing scope variables to avoid that cost when
 	// not necessary
@@ -109,7 +109,7 @@ struct Context : public boost::totally_ordered<Context>
 
 // Compare by content instead of pointer. We probably want this to be
 // the default, until then this function is here for that.
-bool ohs_content_eq(const OrderedHandleSet& lhs, const OrderedHandleSet& rhs);
+bool ohs_content_eq(const HandleSet& lhs, const HandleSet& rhs);
 
 // For gdb, see
 // http://wiki.opencog.org/w/Development_standards#Print_OpenCog_Objects

--- a/opencog/atoms/base/Handle.cc
+++ b/opencog/atoms/base/Handle.cc
@@ -148,7 +148,7 @@ std::string hss_to_string(const HandleSeqSeq& hss)
 	}
 	return ss.str();
 }
-std::string ohs_to_string(const OrderedHandleSet& ohs)
+std::string ohs_to_string(const HandleSet& ohs)
 {
 	std::stringstream ss; std::operator<<(ss, ohs); return ss.str();
 }
@@ -246,7 +246,7 @@ std::string oc_to_string(const HandleSeqSeq& hss)
 {
 	return hss_to_string(hss);
 }
-std::string oc_to_string(const OrderedHandleSet& ohs)
+std::string oc_to_string(const HandleSet& ohs)
 {
 	return ohs_to_string(ohs);
 }
@@ -299,7 +299,7 @@ ostream& operator<<(ostream& out, const T& hs) { \
 	return out; \
 }
 GEN_HANDLE_CONTAINER_OSTREAM_OPERATOR(opencog::HandleSeq)
-GEN_HANDLE_CONTAINER_OSTREAM_OPERATOR(opencog::OrderedHandleSet)
+GEN_HANDLE_CONTAINER_OSTREAM_OPERATOR(opencog::HandleSet)
 GEN_HANDLE_CONTAINER_OSTREAM_OPERATOR(opencog::UnorderedHandleSet)
 
 } // ~namespace std

--- a/opencog/atoms/base/Handle.h
+++ b/opencog/atoms/base/Handle.h
@@ -171,10 +171,11 @@ typedef std::vector<Handle> HandleSeq;
 //! a list of lists of handles
 typedef std::vector<HandleSeq> HandleSeqSeq;
 
-//! a set of handles
-typedef std::set<Handle> OrderedHandleSet;
+//! a set of handles. Default handle set container. Usually takes less
+//! RAM and has faster iteration.
+typedef std::set<Handle> HandleSet;
 
-//! a hash table
+//! a hash table. Usually has faster insertion.
 typedef std::unordered_set<Handle> UnorderedHandleSet;
 
 //! an ordered map from Handle to Handle set
@@ -268,7 +269,7 @@ std::string h_to_string(const Handle& h);
 std::string hp_to_string(const HandlePair& hp);
 std::string hs_to_string(const HandleSeq& hs);
 std::string hss_to_string(const HandleSeqSeq& hss);
-std::string ohs_to_string(const OrderedHandleSet& ohs);
+std::string ohs_to_string(const HandleSet& ohs);
 std::string uhs_to_string(const UnorderedHandleSet& uhs);
 std::string hmap_to_string(const HandleMap& hm);
 std::string hmultimap_to_string(const HandleMultimap& hmm);
@@ -287,7 +288,7 @@ std::string oc_to_string(const Handle& h);
 std::string oc_to_string(const HandlePair& hp);
 std::string oc_to_string(const HandleSeq& hs);
 std::string oc_to_string(const HandleSeqSeq& hss);
-std::string oc_to_string(const OrderedHandleSet& ohs);
+std::string oc_to_string(const HandleSet& ohs);
 std::string oc_to_string(const UnorderedHandleSet& uhs);
 std::string oc_to_string(const HandleMap& hm);
 std::string oc_to_string(const HandleMultimap& hmm);
@@ -301,7 +302,7 @@ std::string oc_to_string(const AtomPtr& aptr);
 
 namespace std {
 ostream& operator<<(ostream&, const opencog::HandleSeq&);
-ostream& operator<<(ostream&, const opencog::OrderedHandleSet&);
+ostream& operator<<(ostream&, const opencog::HandleSet&);
 ostream& operator<<(ostream&, const opencog::UnorderedHandleSet&);
 
 #ifdef THIS_USED_TO_WORK_GREAT_BUT_IS_BROKEN_IN_GCC472

--- a/opencog/atoms/core/VariableList.cc
+++ b/opencog/atoms/core/VariableList.cc
@@ -251,8 +251,8 @@ void VariableList::get_vartype(const Handle& htypelink)
 	else if (TYPE_CHOICE == t)
 	{
 		std::set<Type> typeset;
-		OrderedHandleSet deepset;
-		OrderedHandleSet fuzzset;
+		HandleSet deepset;
+		HandleSet fuzzset;
 
 		const HandleSeq& tset = vartype->getOutgoingSet();
 		size_t tss = tset.size();
@@ -309,7 +309,7 @@ void VariableList::get_vartype(const Handle& htypelink)
 				"Unexpected contents in SignatureLink\n"
 				"Expected arity==1, got %s", vartype->toString().c_str());
 
-		OrderedHandleSet ts;
+		HandleSet ts;
 		ts.insert(vartype);
 		_varlist._deep_typemap.insert({varname, ts});
 	}
@@ -321,7 +321,7 @@ void VariableList::get_vartype(const Handle& htypelink)
 				"Unexpected contents in FuzzyLink\n"
 				"Expected arity==1, got %s", vartype->toString().c_str());
 
-		OrderedHandleSet ts;
+		HandleSet ts;
 		ts.insert(vartype);
 		_varlist._fuzzy_typemap.insert({varname, ts});
 	}

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -37,8 +37,8 @@ namespace opencog {
 struct VarScraper
 {
 	Quotation _quotation;
-	OrderedHandleSet _bound_vars;
-	void find_vars(HandleSeq&, OrderedHandleSet&, const HandleSeq&);
+	HandleSet _bound_vars;
+	void find_vars(HandleSeq&, HandleSet&, const HandleSeq&);
 };
 
 /* ================================================================= */
@@ -50,7 +50,7 @@ struct VarScraper
 // Note: the algo used here is nearly identical to that in
 // ScopeLink::term_hash() -- if you modify this, then modify that
 // one too.
-void VarScraper::find_vars(HandleSeq& varseq, OrderedHandleSet& varset,
+void VarScraper::find_vars(HandleSeq& varseq, HandleSet& varset,
                            const HandleSeq& oset)
 {
 	for (const Handle& h : oset)
@@ -70,7 +70,7 @@ void VarScraper::find_vars(HandleSeq& varseq, OrderedHandleSet& varset,
 
 		bool issco = _quotation.is_unquoted()
 			and classserver().isA(t, SCOPE_LINK);
-		OrderedHandleSet bsave;
+		HandleSet bsave;
 		if (issco)
 		{
 			// Save the current set of bound variables...
@@ -436,7 +436,7 @@ bool Variables::is_type(const Handle& var, const Handle& val) const
 		_deep_typemap.find(var);
 	if (_deep_typemap.end() != dit)
 	{
-		const OrderedHandleSet &sigset = dit->second;
+		const HandleSet &sigset = dit->second;
 		for (const Handle& sig : sigset)
 		{
 			if (value_is_type(sig, val)) return true;
@@ -449,7 +449,7 @@ bool Variables::is_type(const Handle& var, const Handle& val) const
 		_fuzzy_typemap.find(var);
 	if (_fuzzy_typemap.end() != fit)
 	{
-		// const OrderedHandleSet &fuzzset = dit->second;
+		// const HandleSet &fuzzset = dit->second;
 		throw RuntimeException(TRACE_INFO,
 			"Not implemented! TODO XXX FIXME");
 		ret = false;

--- a/opencog/atoms/core/Variables.h
+++ b/opencog/atoms/core/Variables.h
@@ -57,7 +57,7 @@ struct FreeVariables
 	/// used to implement the variable substitution (aka beta-reduction
 	/// aka "PutLink") method.
 	HandleSeq varseq;
-	OrderedHandleSet varset;
+	HandleSet varset;
 	typedef std::map<Handle, unsigned int> IndexMap;
 	IndexMap index;
 
@@ -113,7 +113,7 @@ protected:
 };
 
 typedef std::map<Handle, const std::set<Type>> VariableTypeMap;
-typedef std::map<Handle, const OrderedHandleSet> VariableDeepTypeMap;
+typedef std::map<Handle, const HandleSet> VariableDeepTypeMap;
 typedef std::map<Handle, const std::pair<double, double>> GlobIntervalMap;
 
 /// The Variables struct defines a list of typed variables "unbundled"

--- a/opencog/atoms/execution/MapLink.h
+++ b/opencog/atoms/execution/MapLink.h
@@ -44,10 +44,10 @@ class MapLink : public FunctionLink
 protected:
 	ScopeLinkPtr _pattern;
 	const Variables* _mvars;
-	const OrderedHandleSet* _varset;
+	const HandleSet* _varset;
 
 	// Globby terms are terms that contain a GlobNode
-	OrderedHandleSet _globby_terms;     // Smallest term that has a glob.
+	HandleSet _globby_terms;     // Smallest term that has a glob.
 
 	bool _is_impl;
 	Handle _rewrite;

--- a/opencog/atoms/pattern/Pattern.h
+++ b/opencog/atoms/pattern/Pattern.h
@@ -92,34 +92,34 @@ struct Pattern
 	// The optional clauses don't have to be grounded, but they might be.
 	// This is where the absent clauses are held, so e.g. if these do get
 	// grounded, they might be rejected (depending on the callback).
-	OrderedHandleSet optionals;    // Optional clauses
+	HandleSet optionals;    // Optional clauses
 
 	// Black-box clauses. These are clauses that contain GPN's. These
 	// have to drop into scheme or python to get evaluated, which means
 	// that they will be slow.  So, we leave these for last, so that the
 	// faster clauses can run first, and rule out un-needed evaluations.
-	OrderedHandleSet black;       // Black-box clauses
+	HandleSet black;       // Black-box clauses
 
 	// Evaluatable terms are those that hold a GroundedPredicateNode
 	// (GPN) in them, or are stand-ins (e.g. GreaterThanLink, EqualLink).
-	OrderedHandleSet evaluatable_terms;   // smallest term that is evaluatable
-	OrderedHandleSet evaluatable_holders; // holds something evaluatable.
+	HandleSet evaluatable_terms;   // smallest term that is evaluatable
+	HandleSet evaluatable_holders; // holds something evaluatable.
 
 	// Executable terms are those that inherit from FunctionLink;
 	// this includes ExecutionOutputLink's.
-	OrderedHandleSet executable_terms;    // smallest term that is executable
-	OrderedHandleSet executable_holders;  // holds something executable.
+	HandleSet executable_terms;    // smallest term that is executable
+	HandleSet executable_holders;  // holds something executable.
 
 	// Defined terms are terms that are a DefinedPredicateNode (DPN)
 	// or a DefineSchemaNode (DSN).
-	OrderedHandleSet defined_terms;    // The DPN/DSN itself.
+	HandleSet defined_terms;    // The DPN/DSN itself.
 
 	// Globby terms are terms that contain a GlobNode
-	OrderedHandleSet globby_terms;     // Smallest term that has a glob.
+	HandleSet globby_terms;     // Smallest term that has a glob.
 
 	// Terms that may be grounded in an imprecise way. Similar to a
 	// GlobNode, but uses a different algorithm.
-	OrderedHandleSet fuzzy_terms;
+	HandleSet fuzzy_terms;
 
 	// Maps; the value is the largest (evaluatable or executable)
 	// term containing the variable. Its a multimap, because

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -171,11 +171,11 @@ PatternLink::PatternLink(const Variables& vars, const Handle& body)
 /// Special constructor used only to make single concrete pattern
 /// components.  We are given the pre-computed components; we only
 /// have to store them.
-PatternLink::PatternLink(const OrderedHandleSet& vars,
+PatternLink::PatternLink(const HandleSet& vars,
                          const VariableTypeMap& typemap,
                          const GlobIntervalMap& intervalmap,
                          const HandleSeq& compo,
-                         const OrderedHandleSet& opts)
+                         const HandleSet& opts)
 	: ScopeLink(HandleSeq(), PATTERN_LINK)
 {
 	// First, lets deal with the vars. We have discarded the original
@@ -241,7 +241,7 @@ PatternLink::PatternLink(const OrderedHandleSet& vars,
 /// a list of clauses to solve.  This is currently kind-of crippled,
 /// since no variable type restricions are possible, and no optionals,
 /// either.  This is used only for backwards-compatibility API's.
-PatternLink::PatternLink(const OrderedHandleSet& vars,
+PatternLink::PatternLink(const HandleSet& vars,
                          const HandleSeq& clauses)
 	: ScopeLink(HandleSeq(), PATTERN_LINK)
 {
@@ -441,7 +441,7 @@ void PatternLink::locate_globs(HandleSeq& clauses)
  * Every clause should contain at least one variable in it; clauses
  * that are constants and can be trivially discarded.
  */
-void PatternLink::validate_clauses(OrderedHandleSet& vars,
+void PatternLink::validate_clauses(HandleSet& vars,
                                    HandleSeq& clauses,
                                    HandleSeq& constants)
 
@@ -484,7 +484,7 @@ void PatternLink::validate_clauses(OrderedHandleSet& vars,
  * Given the initial list of variables and clauses, separate these into
  * the mandatory, optional and fuzzy clauses.
  */
-void PatternLink::extract_optionals(const OrderedHandleSet &vars,
+void PatternLink::extract_optionals(const HandleSet &vars,
                                     const HandleSeq &component)
 {
 	// Split in positive and negative clauses
@@ -569,11 +569,11 @@ static void add_to_map(std::unordered_multimap<Handle, Handle>& map,
 /// those variables are grounded by different disconnected graph
 /// components; the combinatoric explosion has to be handled...
 ///
-void PatternLink::unbundle_virtual(const OrderedHandleSet& vars,
+void PatternLink::unbundle_virtual(const HandleSet& vars,
                                    const HandleSeq& clauses,
                                    HandleSeq& fixed_clauses,
                                    HandleSeq& virtual_clauses,
-                                   OrderedHandleSet& black_clauses)
+                                   HandleSet& black_clauses)
 {
 	for (const Handle& clause: clauses)
 	{
@@ -830,12 +830,12 @@ void PatternLink::make_map_recursive(const Handle& root, const Handle& h)
 /// then any clauses in which they appear cannot ever be evaluated,
 /// leading to an undefined condition.  So, explicitly check and throw
 /// an error if a pattern is ill-formed.
-void PatternLink::check_satisfiability(const OrderedHandleSet& vars,
-                                       const std::vector<OrderedHandleSet>& compvars)
+void PatternLink::check_satisfiability(const HandleSet& vars,
+                                       const std::vector<HandleSet>& compvars)
 {
 	// Compute the set-union of all component vars.
-	OrderedHandleSet vunion;
-	for (const OrderedHandleSet& vset : compvars)
+	HandleSet vunion;
+	for (const HandleSet& vset : compvars)
 		vunion.insert(vset.begin(), vset.end());
 
 	// Is every variable in some component? If not, then throw.

--- a/opencog/atoms/pattern/PatternLink.h
+++ b/opencog/atoms/pattern/PatternLink.h
@@ -93,7 +93,7 @@ protected:
 
 	size_t _num_comps;
 	HandleSeqSeq _components;
-	std::vector<OrderedHandleSet> _component_vars;
+	std::vector<HandleSet> _component_vars;
 	HandleSeq _component_patterns;
 
 	void unbundle_clauses(const Handle& body);
@@ -102,18 +102,18 @@ protected:
 
 	void locate_defines(HandleSeq& clauses);
 	void locate_globs(HandleSeq& clauses);
-	void validate_clauses(OrderedHandleSet& vars,
+	void validate_clauses(HandleSet& vars,
 	                      HandleSeq& clauses,
 	                      HandleSeq& constants);
 
-	void extract_optionals(const OrderedHandleSet &vars,
+	void extract_optionals(const HandleSet &vars,
 	                       const HandleSeq &component);
 
-	void unbundle_virtual(const OrderedHandleSet& vars,
+	void unbundle_virtual(const HandleSet& vars,
 	                      const HandleSeq& clauses,
 	                      HandleSeq& concrete_clauses,
 	                      HandleSeq& virtual_clauses,
-	                      OrderedHandleSet& black_clauses);
+	                      HandleSet& black_clauses);
 
 	bool add_dummies();
 
@@ -124,8 +124,8 @@ protected:
 	void make_connectivity_map(const HandleSeq&);
 	void make_map_recursive(const Handle&, const Handle&);
 	void check_connectivity(const HandleSeqSeq&);
-	void check_satisfiability(const OrderedHandleSet&,
-	                          const std::vector<OrderedHandleSet>&);
+	void check_satisfiability(const HandleSet&,
+	                          const std::vector<HandleSet>&);
 
 	void make_term_trees();
 	void make_term_tree_recursive(const Handle&, Handle,
@@ -151,14 +151,14 @@ public:
 
 	// Used only to set up multi-component links.
 	// DO NOT call this! (unless you are the component handler).
-	PatternLink(const OrderedHandleSet& vars,
+	PatternLink(const HandleSet& vars,
 	            const VariableTypeMap& typemap,
 	            const GlobIntervalMap& intervalmap,
 	            const HandleSeq& component,
-	            const OrderedHandleSet& optionals);
+	            const HandleSet& optionals);
 
 	// A backwards-compatibility constructor. Do not use.
-	PatternLink(const OrderedHandleSet&,
+	PatternLink(const HandleSet&,
 	            const HandleSeq&);
 
 	// Return the list of variables we are holding.

--- a/opencog/atoms/pattern/PatternUtils.cc
+++ b/opencog/atoms/pattern/PatternUtils.cc
@@ -58,7 +58,7 @@ namespace opencog {
  *
  * Returns true if the list of clauses was modified, else returns false.
  */
-bool remove_constants(const OrderedHandleSet &vars,
+bool remove_constants(const HandleSet &vars,
                       HandleSeq &clauses,
                       HandleSeq &constants)
 {
@@ -84,7 +84,7 @@ bool remove_constants(const OrderedHandleSet &vars,
 	return modified;
 }
 
-bool is_constant(const OrderedHandleSet& vars, const Handle& clause)
+bool is_constant(const HandleSet& vars, const Handle& clause)
 {
 	return not (any_unquoted_unscoped_in_tree(clause, vars)
 	            or contains_atomtype(clause, DEFINED_PREDICATE_NODE)
@@ -138,10 +138,10 @@ bool is_constant(const OrderedHandleSet& vars, const Handle& clause)
  * in them.  These end up in their own component, which can be
  * extremely confusing.
  */
-void get_connected_components(const OrderedHandleSet& vars,
+void get_connected_components(const HandleSet& vars,
                               const HandleSeq& clauses,
                               HandleSeqSeq& components,
-                              std::vector<OrderedHandleSet>& component_vars)
+                              std::vector<HandleSet>& component_vars)
 {
 	HandleSeq todo(clauses);
 
@@ -160,7 +160,7 @@ void get_connected_components(const OrderedHandleSet& vars,
 			size_t nc = components.size();
 			for (size_t i = 0; i<nc; i++)
 			{
-				OrderedHandleSet& cur_vars(component_vars[i]);
+				HandleSet& cur_vars(component_vars[i]);
 				// If clause cl is connected to this component, then add it
 				// to this component.
 				if (any_unquoted_in_tree(cl, cur_vars))

--- a/opencog/atoms/pattern/PatternUtils.h
+++ b/opencog/atoms/pattern/PatternUtils.h
@@ -38,18 +38,18 @@ namespace opencog {
 
 // Make sure that variables can be found in the clauses.
 // See C file for description
-bool remove_constants(const OrderedHandleSet& vars,
+bool remove_constants(const HandleSet& vars,
                       HandleSeq& clauses,
                       HandleSeq& constants);
 
 // Return true if the clause is constant
-bool is_constant(const OrderedHandleSet& vars, const Handle& clause);
+bool is_constant(const HandleSet& vars, const Handle& clause);
 
 // See C file for description
-void get_connected_components(const OrderedHandleSet& vars,
+void get_connected_components(const HandleSet& vars,
                               const HandleSeq& clauses,
                               HandleSeqSeq& compset,
-                              std::vector<OrderedHandleSet>& compvars);
+                              std::vector<HandleSet>& compvars);
 
 } // namespace opencog
 

--- a/opencog/atomspace/ValuationTable.cc
+++ b/opencog/atomspace/ValuationTable.cc
@@ -48,7 +48,7 @@ void ValuationTable::addValuation(const ValuationPtr& vp)
 	auto ikeys = _keyset.find(atom);
 	if (ikeys == _keyset.end())
 	{
-		std::set<Handle> keys;
+		HandleSet keys;
 		keys.insert(key);
 		_keyset.insert(make_pair(atom, keys));
 	}
@@ -95,7 +95,7 @@ ProtoAtomPtr ValuationTable::getValue(const Handle& key, const Handle& atom)
 // searching the _vindex, instead, which would be slower but more memory
 // efficient.  The point is that the only user of this function is going
 // to be the peristence framework, and so we should optimize for that.
-std::set<Handle> ValuationTable::getKeys(const Handle& atom)
+HandleSet ValuationTable::getKeys(const Handle& atom)
 {
 	std::lock_guard<std::mutex> lck(_mtx);
 

--- a/opencog/atomspace/ValuationTable.h
+++ b/opencog/atomspace/ValuationTable.h
@@ -52,7 +52,7 @@ private:
 	mutable std::mutex _mtx;
 
 	std::unordered_map<HandlePair, ValuationPtr> _vindex;
-	std::unordered_map<Handle, std::set<Handle>> _keyset;
+	std::unordered_map<Handle, HandleSet> _keyset;
 
 	/**
 	 * Override and declare copy constructor and equals operator as
@@ -66,12 +66,12 @@ public:
 	ValuationTable();
 	~ValuationTable();
 
-   void addValuation(const ValuationPtr&);
-   void addValuation(const Handle&, const Handle&, const ProtoAtomPtr&);
+	void addValuation(const ValuationPtr&);
+	void addValuation(const Handle&, const Handle&, const ProtoAtomPtr&);
 	ValuationPtr getValuation(const Handle&, const Handle&);
 	ProtoAtomPtr getValue(const Handle&, const Handle&);
 
-	std::set<Handle> getKeys(const Handle&);
+	HandleSet getKeys(const Handle&);
 };
 
 /** @}*/

--- a/opencog/atomutils/FindUtils.cc
+++ b/opencog/atomutils/FindUtils.cc
@@ -54,7 +54,7 @@ FindAtoms::FindAtoms(const Handle& atom)
 	  _target_atoms({atom})
 {}
 
-FindAtoms::FindAtoms(const OrderedHandleSet& selection)
+FindAtoms::FindAtoms(const HandleSet& selection)
 	: _target_types(),
 	  _target_atoms(selection)
 {}
@@ -167,7 +167,7 @@ bool is_unscoped_in_tree(const Handle& tree, const Handle& atom)
 	if (not tree->isLink()) return false;
 	ScopeLinkPtr stree(ScopeLinkCast(tree));
 	if (nullptr != stree) {
-		const OrderedHandleSet& varset = stree->get_variables().varset;
+		const HandleSet& varset = stree->get_variables().varset;
 		if (varset.find(atom) != varset.cend())
 			return false;
 	}
@@ -203,7 +203,7 @@ bool is_free_in_any_tree(const HandleSeq& hs, const Handle& atom)
 	return is_unquoted_unscoped_in_any_tree(hs, atom);
 }
 
-bool any_atom_in_tree(const Handle& tree, const OrderedHandleSet& atoms)
+bool any_atom_in_tree(const Handle& tree, const HandleSet& atoms)
 {
 	for (const Handle& n: atoms)
 	{
@@ -212,7 +212,7 @@ bool any_atom_in_tree(const Handle& tree, const OrderedHandleSet& atoms)
 	return false;
 }
 
-bool any_unquoted_in_tree(const Handle& tree, const OrderedHandleSet& atoms)
+bool any_unquoted_in_tree(const Handle& tree, const HandleSet& atoms)
 {
 	for (const Handle& n: atoms)
 	{
@@ -221,7 +221,7 @@ bool any_unquoted_in_tree(const Handle& tree, const OrderedHandleSet& atoms)
 	return false;
 }
 
-bool any_unscoped_in_tree(const Handle& tree, const OrderedHandleSet& atoms)
+bool any_unscoped_in_tree(const Handle& tree, const HandleSet& atoms)
 {
 	for (const Handle& n: atoms)
 		if (is_unscoped_in_tree(tree, n)) return true;
@@ -229,7 +229,7 @@ bool any_unscoped_in_tree(const Handle& tree, const OrderedHandleSet& atoms)
 }
 
 bool any_unquoted_unscoped_in_tree(const Handle& tree,
-                                   const OrderedHandleSet& atoms)
+                                   const HandleSet& atoms)
 {
 	for (const Handle& n: atoms)
 		if (is_unquoted_in_tree(tree, n) and is_unscoped_in_tree(tree, n))
@@ -238,7 +238,7 @@ bool any_unquoted_unscoped_in_tree(const Handle& tree,
 }
 
 unsigned int num_unquoted_in_tree(const Handle& tree,
-                                  const OrderedHandleSet& atoms)
+                                  const HandleSet& atoms)
 {
 	unsigned int count = 0;
 	for (const Handle& n: atoms)
@@ -285,7 +285,7 @@ bool contains_atomtype(const Handle& clause, Type atom_type, Quotation quotation
 	return false;
 }
 
-OrderedHandleSet get_free_variables(const Handle& h, Quotation quotation)
+HandleSet get_free_variables(const Handle& h, Quotation quotation)
 {
 	Type t = h->getType();
 
@@ -298,23 +298,23 @@ OrderedHandleSet get_free_variables(const Handle& h, Quotation quotation)
 	// Recursive cases
 	OC_ASSERT(h->isLink());
 	quotation.update(t);
-	OrderedHandleSet results = get_free_variables(h->getOutgoingSet(), quotation);
+	HandleSet results = get_free_variables(h->getOutgoingSet(), quotation);
 	// If the link was a scope link then remove the scoped
 	// variables from the free variables found.
 	ScopeLinkPtr sh(ScopeLinkCast(h));
 	if (nullptr != sh) {
-		const OrderedHandleSet& varset = sh->get_variables().varset;
+		const HandleSet& varset = sh->get_variables().varset;
 		for (auto& v : varset)
 			results.erase(v);
 	}
 	return results;
 }
 
-OrderedHandleSet get_free_variables(const HandleSeq& hs, Quotation quotation)
+HandleSet get_free_variables(const HandleSeq& hs, Quotation quotation)
 {
-	OrderedHandleSet results;
+	HandleSet results;
 	for (const Handle& h : hs) {
-		OrderedHandleSet free_var = get_free_variables(h, quotation);
+		HandleSet free_var = get_free_variables(h, quotation);
 		results.insert(free_var.begin(), free_var.end());
 	}
 	return results;

--- a/opencog/atomutils/FindUtils.h
+++ b/opencog/atomutils/FindUtils.h
@@ -90,14 +90,14 @@ class FindAtoms
 {
 public:
 	std::set<Type> stopset;
-	OrderedHandleSet varset;
-	OrderedHandleSet holders;
-	OrderedHandleSet least_holders;
+	HandleSet varset;
+	HandleSet holders;
+	HandleSet least_holders;
 
 	FindAtoms(Type t, bool subclass = false);
 	FindAtoms(Type ta, Type tb, bool subclass = false);
 	FindAtoms(const Handle& atom);
-	FindAtoms(const OrderedHandleSet& selection);
+	FindAtoms(const HandleSet& selection);
 
 	/**
 	 * Given a handle to be searched, create a set of all of the
@@ -118,7 +118,7 @@ private:
 
 private:
 	std::set<Type> _target_types;
-	OrderedHandleSet _target_atoms;
+	HandleSet _target_atoms;
 };
 
 /**
@@ -224,7 +224,7 @@ bool is_free_in_any_tree(const HandleSeq& hs, const Handle& atom);
  * the tree (that is, in the tree spanned by the outgoing set.)
  */
 bool any_atom_in_tree(const Handle& tree,
-                      const OrderedHandleSet& atoms);
+                      const HandleSet& atoms);
 
 /**
  * Return true if any of the indicated atoms occur somewhere in
@@ -234,21 +234,21 @@ bool any_atom_in_tree(const Handle& tree,
  * longer a variable.
  */
 bool any_unquoted_in_tree(const Handle& tree,
-                          const OrderedHandleSet& atoms);
+                          const HandleSet& atoms);
 
 /**
  * Return true if any of the atoms (variables) occur unscoped
  * somewhere in the tree.
  */
 bool any_unscoped_in_tree(const Handle& tree,
-                          const OrderedHandleSet& atoms);
+                          const HandleSet& atoms);
 
 /**
  * Return true if any of the atoms (variables) occur unquoted and
  * unscoped somewhere in the tree.
  */
 bool any_unquoted_unscoped_in_tree(const Handle& tree,
-                                   const OrderedHandleSet& atoms);
+                                   const HandleSet& atoms);
 
 /**
  * Return how many of the indicated atoms occur somewhere in
@@ -258,7 +258,7 @@ bool any_unquoted_unscoped_in_tree(const Handle& tree,
  * longer a variable.
  */
 unsigned int num_unquoted_in_tree(const Handle& tree,
-                                  const OrderedHandleSet& atoms);
+                                  const HandleSet& atoms);
 
 /**
  * Return true if the indicated atom occurs somewhere in any of the trees.
@@ -297,10 +297,10 @@ bool contains_atomtype(const Handle& clause, Type atom_type,
  * returns {VariableNode "$X"}, because although $X is scoped by the
  * lambda it is also unscoped in the And.
  */
-OrderedHandleSet get_free_variables(const Handle& h,
-                                    Quotation quotation=Quotation());
-OrderedHandleSet get_free_variables(const HandleSeq& hs,
-                                    Quotation quotation=Quotation());
+HandleSet get_free_variables(const Handle& h,
+                             Quotation quotation=Quotation());
+HandleSet get_free_variables(const HandleSeq& hs,
+                             Quotation quotation=Quotation());
 
 /**
  * Return true if h has no free variable (unscoped or unquoted) in it,

--- a/opencog/atomutils/TypeUtils.cc
+++ b/opencog/atomutils/TypeUtils.cc
@@ -384,7 +384,7 @@ std::set<Type> type_intersection(const std::set<Type>& lhs,
 
 VariableListPtr gen_varlist(const Handle& h)
 {
-	OrderedHandleSet vars = get_free_variables(h);
+	HandleSet vars = get_free_variables(h);
 	return createVariableList(HandleSeq(vars.begin(), vars.end()));
 }
 

--- a/opencog/atomutils/Unify.cc
+++ b/opencog/atomutils/Unify.cc
@@ -51,9 +51,9 @@ bool Unify::CHandle::is_free_variable() const
 	return context.is_free_variable(handle);
 }
 
-OrderedHandleSet Unify::CHandle::get_free_variables() const
+HandleSet Unify::CHandle::get_free_variables() const
 {
-	OrderedHandleSet free_vars =
+	HandleSet free_vars =
 		opencog::get_free_variables(handle, context.quotation);
 	return set_difference(free_vars, context.shadow);
 }
@@ -469,7 +469,7 @@ Handle Unify::remove_constant_clauses(const Handle& vardecl,
                                       const Handle& clauses)
 {
 	VariableListPtr vl = createVariableList(vardecl);
-	OrderedHandleSet vars = vl->get_variables().varset;
+	HandleSet vars = vl->get_variables().varset;
 
 	// Remove constant clauses
 	Type t = clauses->getType();
@@ -936,7 +936,7 @@ HandleMap strip_context(const Unify::HandleCHandleMap& hchm)
  */
 VariableListPtr gen_varlist(const Unify::CHandle& ch)
 {
-	OrderedHandleSet free_vars = ch.get_free_variables();
+	HandleSet free_vars = ch.get_free_variables();
 	return createVariableList(HandleSeq(free_vars.begin(), free_vars.end()));
 }
 

--- a/opencog/atomutils/Unify.h
+++ b/opencog/atomutils/Unify.h
@@ -72,7 +72,7 @@ public:
 		/**
 		 * Return the set of free visible variables from that context.
 		 */
-		OrderedHandleSet get_free_variables() const;
+		HandleSet get_free_variables() const;
 
 		/**
 		 * Return iterator of the variable declaration containing a given

--- a/opencog/guile/SchemeSmobValue.cc
+++ b/opencog/guile/SchemeSmobValue.cc
@@ -251,7 +251,7 @@ SCM SchemeSmob::ss_keys (SCM satom)
 	Handle atom(verify_handle(satom, "cog-value"));
 
 	SCM rv = SCM_EOL;
-	std::set<Handle> keys = atom->getKeys();
+	HandleSet keys = atom->getKeys();
 	for (const Handle& k : keys)
 	{
 		rv = scm_cons (handle_to_scm(k), rv);

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
@@ -892,7 +892,7 @@ void SQLAtomStorage::deleteValue(VUID vuid)
 /// Store ALL of the values associated with the atom.
 void SQLAtomStorage::store_atom_values(const Handle& atom)
 {
-	std::set<Handle> keys = atom->getKeys();
+	HandleSet keys = atom->getKeys();
 	for (const Handle& key: keys)
 	{
 		// Skip the truth-value; it's special-cased below.

--- a/opencog/query/DefaultPatternMatchCB.cc
+++ b/opencog/query/DefaultPatternMatchCB.cc
@@ -376,7 +376,7 @@ void DefaultPatternMatchCB::post_link_mismatch(const Handle& lpat,
 bool DefaultPatternMatchCB::is_self_ground(const Handle& ptrn,
                                            const Handle& grnd,
                                            const HandleMap& term_gnds,
-                                           const OrderedHandleSet& varset,
+                                           const HandleSet& varset,
                                            Quotation quotation)
 {
 	Type ptype = ptrn->getType();
@@ -445,14 +445,14 @@ bool DefaultPatternMatchCB::is_self_ground(const Handle& ptrn,
 		// Step 1: Look to see if the scope link binds any of the
 		// variables that the pattern also binds.
 		const Variables& slv = ScopeLinkCast(grnd)->get_variables();
-		OrderedHandleSet hidden = opencog::set_intersection(slv.varset, varset);
+		HandleSet hidden = opencog::set_intersection(slv.varset, varset);
 
 		// Step 2: If there are hidden variables, then remove them
 		// before recursing donwards.
 		if (0 < hidden.size())
 		{
 			// Make a copy with visible variables only
-			OrderedHandleSet vcopy = opencog::set_difference(varset, hidden);
+			HandleSet vcopy = opencog::set_difference(varset, hidden);
 
 			// Recurse using only the visible variables.
 			for (size_t i=0; i<pari; i++)

--- a/opencog/query/DefaultPatternMatchCB.h
+++ b/opencog/query/DefaultPatternMatchCB.h
@@ -96,15 +96,15 @@ class DefaultPatternMatchCB : public virtual PatternMatchCallback
 		ClassServer& _classserver;
 
 		const Variables* _vars = NULL;
-		const OrderedHandleSet* _dynamic = NULL;
+		const HandleSet* _dynamic = NULL;
 		bool _have_evaluatables = false;
-		const OrderedHandleSet* _globs = NULL;
+		const HandleSet* _globs = NULL;
 
 		bool _have_variables;
 		Handle _pattern_body;
 
 		bool is_self_ground(const Handle&, const Handle&,
-		                    const HandleMap&, const OrderedHandleSet&,
+		                    const HandleMap&, const HandleSet&,
 		                    Quotation quotation=Quotation());
 
 		// Variables that should be ignored, because they are bound

--- a/opencog/query/InitiateSearchCB.cc
+++ b/opencog/query/InitiateSearchCB.cc
@@ -246,7 +246,7 @@ InitiateSearchCB::find_starter_recursive(const Handle& h, size_t& depth,
  * exist in the atomspace, anyway.
  */
 Handle InitiateSearchCB::find_thinnest(const HandleSeq& clauses,
-                                       const OrderedHandleSet& evl,
+                                       const HandleSet& evl,
                                        Handle& starter_term,
                                        size_t& bestclause)
 {

--- a/opencog/query/InitiateSearchCB.h
+++ b/opencog/query/InitiateSearchCB.h
@@ -61,7 +61,7 @@ protected:
 
 	const Variables* _variables;
 	const Pattern* _pattern;
-	const OrderedHandleSet* _dynamic;
+	const HandleSet* _dynamic;
 
 	PatternLinkPtr _pl;
 	void jit_analyze(PatternMatchEngine *);
@@ -82,7 +82,7 @@ protected:
 	virtual Handle find_starter_recursive(const Handle&, size_t&, Handle&,
 	                                      size_t&);
 	virtual Handle find_thinnest(const HandleSeq&,
-	                             const OrderedHandleSet&,
+	                             const HandleSet&,
 	                             Handle&, size_t&);
 	virtual void find_rarest(const Handle&, Handle&, size_t&,
 	                         Quotation quotation=Quotation());

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1552,7 +1552,7 @@ void PatternMatchEngine::get_next_untried_clause(void)
 // of this "optimization" can add un-necessarily to the overhead.
 //
 unsigned int PatternMatchEngine::thickness(const Handle& clause,
-                                           const OrderedHandleSet& live)
+                                           const HandleSet& live)
 {
 	// If there are only zero or one ungrounded vars, then any clause
 	// will do. Blow this pop stand.
@@ -1587,7 +1587,7 @@ bool PatternMatchEngine::get_next_thinnest_clause(bool search_virtual,
 	bool unsolved = false;
 
 	// Make a list of the as-yet ungrounded variables.
-	OrderedHandleSet ungrounded_vars;
+	HandleSet ungrounded_vars;
 
 	// Grounded variables ordered by the size of their grounding incoming set
 	std::multimap<std::size_t, Handle> thick_vars;
@@ -1979,7 +1979,7 @@ void PatternMatchEngine::log_solution(
 /**
  * For debug logging only
  */
-void PatternMatchEngine::log_term(const OrderedHandleSet &vars,
+void PatternMatchEngine::log_term(const HandleSet &vars,
                                   const HandleSeq &clauses)
 {
 	logger().fine("Clauses:");
@@ -1993,7 +1993,7 @@ void PatternMatchEngine::log_term(const OrderedHandleSet &vars,
 void PatternMatchEngine::log_solution(const HandleMap &vars,
                                       const HandleMap &clauses) {}
 
-void PatternMatchEngine::log_term(const OrderedHandleSet &vars,
+void PatternMatchEngine::log_term(const HandleSet &vars,
                                   const HandleSeq &clauses) {}
 #endif
 

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -134,11 +134,11 @@ private:
 	bool clause_accepted;
 	void get_next_untried_clause(void);
 	bool get_next_thinnest_clause(bool, bool, bool);
-	unsigned int thickness(const Handle&, const OrderedHandleSet&);
+	unsigned int thickness(const Handle&, const HandleSet&);
 	Handle next_clause;
 	Handle next_joint;
 	// Set of clauses for which a grounding is currently being attempted.
-	typedef OrderedHandleSet IssuedSet;
+	typedef HandleSet IssuedSet;
 	IssuedSet issued;     // stacked on issued_stack
 
 	// -------------------------------------------
@@ -228,7 +228,7 @@ public:
 	static void log_solution(const HandleMap &vars,
 	                         const HandleMap &clauses);
 
-	static void log_term(const OrderedHandleSet &vars,
+	static void log_term(const HandleSet &vars,
 	                     const HandleSeq &clauses);
 };
 

--- a/opencog/query/Recognizer.cc
+++ b/opencog/query/Recognizer.cc
@@ -68,7 +68,7 @@ class Recognizer :
 		bool loose_match(const Handle&, const Handle&);
 
 	public:
-		OrderedHandleSet _rules;
+		HandleSet _rules;
 
 		Recognizer(AtomSpace* as) :
 			DefaultPatternMatchCB(as) {}

--- a/opencog/query/Satisfier.h
+++ b/opencog/query/Satisfier.h
@@ -95,7 +95,7 @@ class SatisfyingSet :
 		SatisfyingSet(AtomSpace* as) :
 			InitiateSearchCB(as), DefaultPatternMatchCB(as), max_results(SIZE_MAX) {}
 		HandleSeq _varseq;
-		OrderedHandleSet _satisfying_set;
+		HandleSet _satisfying_set;
 		size_t max_results;
 
 		virtual void set_pattern(const Variables& vars,

--- a/opencog/rule-engine/Rule.cc
+++ b/opencog/rule-engine/Rule.cc
@@ -348,7 +348,7 @@ Rule Rule::gen_standardize_apart(AtomSpace* as)
 	HandleMap dict;
 
 	Handle vdecl = get_vardecl();
-	OrderedHandleSet varset;
+	HandleSet varset;
 
 	if (VariableListCast(vdecl))
 		varset = VariableListCast(vdecl)->get_variables().varset;

--- a/opencog/rule-engine/backwardchainer/BIT.cc
+++ b/opencog/rule-engine/backwardchainer/BIT.cc
@@ -166,7 +166,7 @@ bool AndBIT::has_cycle() const
 	return has_cycle(BindLinkCast(fcs)->get_implicand());
 }
 
-bool AndBIT::has_cycle(const Handle& h, OrderedHandleSet ancestors) const
+bool AndBIT::has_cycle(const Handle& h, HandleSet ancestors) const
 {
 	if (h->getType() == EXECUTION_OUTPUT_LINK) {
 		Handle arg = h->getOutgoingAtom(1);
@@ -357,12 +357,12 @@ AndBIT::insert_bitnode(Handle leaf, const BITNodeFitness& fitness)
 	return it;
 }
 
-OrderedHandleSet AndBIT::get_leaves() const
+HandleSet AndBIT::get_leaves() const
 {
 	return get_leaves(fcs);
 }
 
-OrderedHandleSet AndBIT::get_leaves(const Handle& h) const
+HandleSet AndBIT::get_leaves(const Handle& h) const
 {
 	Type t = h->getType();
 	if (t == BIND_LINK) {
@@ -372,20 +372,20 @@ OrderedHandleSet AndBIT::get_leaves(const Handle& h) const
 	} else if (t == EXECUTION_OUTPUT_LINK) {
 		// All arguments except the first one are potential target leaves
 		Handle args = h->getOutgoingAtom(1);
-		OrderedHandleSet leaves;
+		HandleSet leaves;
 		if (args->getType() == LIST_LINK) {
 			OC_ASSERT(args->getArity() > 0);
 			for (Arity i = 1; i < args->getArity(); i++) {
-				OrderedHandleSet aleaves = get_leaves(args->getOutgoingAtom(i));
+				HandleSet aleaves = get_leaves(args->getOutgoingAtom(i));
 				leaves.insert(aleaves.begin(), aleaves.end());
 			}
 		}
 		return leaves;
 	} else if (t == SET_LINK) {
 		// All atoms wrapped in a SetLink are potential target leaves
-		OrderedHandleSet leaves;
+		HandleSet leaves;
 		for (const Handle& el : h->getOutgoingSet()) {
-			OrderedHandleSet el_leaves = get_leaves(el);
+			HandleSet el_leaves = get_leaves(el);
 			leaves.insert(el_leaves.begin(), el_leaves.end());
 		}
 		return leaves;
@@ -394,11 +394,11 @@ OrderedHandleSet AndBIT::get_leaves(const Handle& h) const
 		// not a leaf (maybe it could but it would over complicate the
 		// rest and bring no benefit since we can always expand a
 		// parent and-BIT that has no such ExecutionOutputLink).
-		return OrderedHandleSet{};
+		return HandleSet{};
 	}
 
 	// Here it must be a leaf so return it
-	return OrderedHandleSet{h};
+	return HandleSet{h};
 }
 
 Handle AndBIT::substitute_unified_variables(const Handle& leaf,

--- a/opencog/rule-engine/backwardchainer/BIT.h
+++ b/opencog/rule-engine/backwardchainer/BIT.h
@@ -155,7 +155,7 @@ public:
 	 * present in the same branch path, so is [14389148767193402296][1].
 	 */
 	bool has_cycle() const;
-	bool has_cycle(const Handle& h, OrderedHandleSet ancestors = {}) const;
+	bool has_cycle(const Handle& h, HandleSet ancestors = {}) const;
 
 	/**
 	 * Comparison operators. For operator< compare fcs by size, or by
@@ -282,8 +282,8 @@ private:
 	 * leaves cover the previous intermediary targets), of an
 	 * FCS.
 	 */
-	OrderedHandleSet get_leaves() const;
-	OrderedHandleSet get_leaves(const Handle& h) const;
+	HandleSet get_leaves() const;
+	HandleSet get_leaves(const Handle& h) const;
 
 	/**
 	 * Given a FCS, a leaf of it and a rule and its associated typed

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.h
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.h
@@ -208,7 +208,7 @@ private:
 
 	RuleSet _rules;
 
-	OrderedHandleSet _results;
+	HandleSet _results;
 };
 
 

--- a/tests/atoms/ScopeLinkUTest.cxxtest
+++ b/tests/atoms/ScopeLinkUTest.cxxtest
@@ -80,7 +80,7 @@ void ScopeLinkUTest::test_get_variables_1()
 	ScopeLinkPtr sc = ScopeLinkCast(sch);
 
 	auto got = sc->get_variables().varset;
-	auto exp = OrderedHandleSet{X};
+	auto exp = HandleSet{X};
 
 	printf("Got %s\n", ohs_to_string(got).c_str());
 	printf("Excepted %s\n", ohs_to_string(exp).c_str());
@@ -104,7 +104,7 @@ void ScopeLinkUTest::test_get_variables_2()
 	ScopeLinkPtr sc = ScopeLinkCast(sch);
 
 	auto got = sc->get_variables().varset;
-	auto exp = OrderedHandleSet{X};
+	auto exp = HandleSet{X};
 
 	printf("Got %s\n", ohs_to_string(got).c_str());
 	printf("Excepted %s\n", ohs_to_string(exp).c_str());
@@ -128,7 +128,7 @@ void ScopeLinkUTest::test_get_variables_3()
 	ScopeLinkPtr sc = ScopeLinkCast(sch);
 
 	auto got = sc->get_variables().varset;
-	auto exp = OrderedHandleSet{X};
+	auto exp = HandleSet{X};
 
 	printf("Got %s\n", ohs_to_string(got).c_str());
 	printf("Excepted %s\n", ohs_to_string(exp).c_str());

--- a/tests/atomspace/ValuationTableUTest.cxxtest
+++ b/tests/atomspace/ValuationTableUTest.cxxtest
@@ -88,7 +88,7 @@ public:
 		vtable->addValuation(kb, blah, fvalue);
 		vtable->addValuation(kc, blah, fvalue);
 
-		std::set<Handle> keys = vtable->getKeys(blah);
+		HandleSet keys = vtable->getKeys(blah);
 
 		TS_ASSERT_EQUALS(3, keys.size());
 		TS_ASSERT(keys.end() != keys.find(ka));

--- a/tests/atomutils/AtomUtilsUTest.cxxtest
+++ b/tests/atomutils/AtomUtilsUTest.cxxtest
@@ -44,9 +44,9 @@ public:
 	void test_get_predicates_for();
 };
 
-OrderedHandleSet cvt(HandleSeq predlist)
+HandleSet cvt(HandleSeq predlist)
 {
-	OrderedHandleSet preds;
+	HandleSet preds;
 	for (auto it = predlist.begin(); it != predlist.end(); it++)
 		preds.insert(*it);
 	return preds;
@@ -75,7 +75,7 @@ void AtomUtilsUTest::test_get_predicates()
 	Handle anotherLink = as.add_link(LIST_LINK, anotherNode, bacon);
 
 	// Test get_predicates(default).
-	OrderedHandleSet baconReferences {programmerEatsBacon, programmerBaconLover};
+	HandleSet baconReferences {programmerEatsBacon, programmerBaconLover};
 	TS_ASSERT_EQUALS(cvt(get_predicates(bacon)), baconReferences);
 
 	// Test get_predicates with specific type.
@@ -119,18 +119,18 @@ void AtomUtilsUTest::test_get_predicates_for()
 		programmerEatsBacon = as.add_link(EVALUATION_LINK, eats, programmer_bacon);
 		
 	// Test for dog IsA.
-	OrderedHandleSet dogIsA {dogIsAMammal, dogIsACanine, dogIsAAnimal};
+	HandleSet dogIsA {dogIsAMammal, dogIsACanine, dogIsAAnimal};
 	TS_ASSERT_EQUALS(cvt(get_predicates_for(dog, isA)), dogIsA);
 
 	// Test for dog eats.
-	OrderedHandleSet dogEats {dogEatsBacon};
+	HandleSet dogEats {dogEatsBacon};
 	TS_ASSERT_EQUALS(cvt(get_predicates_for(dog, eats)), dogEats);
 
 	// Test for programmer eats.
-	OrderedHandleSet programmerEats {programmerEatsBacon};
+	HandleSet programmerEats {programmerEatsBacon};
 	TS_ASSERT_EQUALS(cvt(get_predicates_for(programmer, eats)), programmerEats);
 
 	// Test for eats bacon.
-	OrderedHandleSet eatsBacon {dogEatsBacon, programmerEatsBacon};
+	HandleSet eatsBacon {dogEatsBacon, programmerEatsBacon};
 	TS_ASSERT_EQUALS(cvt(get_predicates_for(bacon, eats)), eatsBacon);
 }

--- a/tests/atomutils/FindUtilsUTest.cxxtest
+++ b/tests/atomutils/FindUtilsUTest.cxxtest
@@ -129,5 +129,5 @@ void FindUtilsUTest::test_is_free_in_tree()
 
 void FindUtilsUTest::test_get_free_variables()
 {
-	TS_ASSERT_EQUALS(get_free_variables(quoted_lambda), OrderedHandleSet({X, Y}));
+	TS_ASSERT_EQUALS(get_free_variables(quoted_lambda), HandleSet({X, Y}));
 }

--- a/tests/query/PatternUTest.cxxtest
+++ b/tests/query/PatternUTest.cxxtest
@@ -243,7 +243,7 @@ void PatternUTest::test_simple_link(void)
 	Handle hvar = an(VARIABLE_NODE, "variable node");
 	Handle he = al(INHERITANCE_LINK, hconst_1, hvar);
 
-	OrderedHandleSet vars;
+	HandleSet vars;
 	vars.insert(hvar);
 
 	HandleSeq preds;
@@ -296,7 +296,7 @@ void PatternUTest::test_two_links(void)
 
 	Handle hv = al(VARIABLE_LIST, hx);
 
-	OrderedHandleSet vars;
+	HandleSet vars;
 	vars.insert(hx);
 
 	HandleSeq preds;
@@ -355,7 +355,7 @@ void PatternUTest::test_eval(void)
 
 	heval = al(EVALUATION_LINK, hprn, hl);
 
-	OrderedHandleSet vars;
+	HandleSet vars;
 	vars.insert(hprn);
 	vars.insert(h2);
 
@@ -380,7 +380,7 @@ void PatternUTest::test_eval(void)
 
 	hshort_eval = al(EVALUATION_LINK, hprns, hls);
 
-	OrderedHandleSet svars;
+	HandleSet svars;
 	svars.insert(hprns);
 	svars.insert(h2);
 

--- a/tests/query/StackUTest.cxxtest
+++ b/tests/query/StackUTest.cxxtest
@@ -179,7 +179,7 @@ void StackUTest::test_stack(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	OrderedHandleSet vars;
+	HandleSet vars;
 	vars.insert(svar);
 	vars.insert(wvar);
 

--- a/tests/query/imply.h
+++ b/tests/query/imply.h
@@ -43,7 +43,7 @@ static inline Handle imply(AtomSpace* as, Handle hclauses, Handle himplicand)
  * variables and clauses, using the indicated callback.
  */
 static inline void match(PatternMatchCallback& pmcb,
-                         const OrderedHandleSet &vars,
+                         const HandleSet &vars,
                          const HandleSeq &clauses)
 {
 	PatternLinkPtr slp(createPatternLink(vars, clauses));

--- a/tests/rule-engine/BITUTest.cxxtest
+++ b/tests/rule-engine/BITUTest.cxxtest
@@ -92,10 +92,10 @@ void BITUTest::tearDown()
 void BITUTest::test_get_leaves()
 {
 	AndBIT andbit(_eval.eval_h("fcs-1"));
-	OrderedHandleSet result;
+	HandleSet result;
 	for (const auto& el : andbit.leaf2bitnode)
 		result.insert(el.first);
-	OrderedHandleSet expected = {
+	HandleSet expected = {
 		_eval.eval_h("(LambdaLink"
 		             "  (TypedVariableLink"
 		             "    (VariableNode \"$X\")"


### PR DESCRIPTION
Addressing opencog/atomspace#1287

Rename OrderedHandleSet to HandleSet that can be considered the default handle set container (smaller RAM usage and faster iteration, however UnorderedHandleSet has faster insertion).