### PR TITLE
Fix serious SQL data corruption bug.

### DIFF
--- a/opencog/atoms/base/FloatValue.cc
+++ b/opencog/atoms/base/FloatValue.cc
@@ -49,7 +49,11 @@ std::string FloatValue::toString(const std::string& indent) const
 {
 	std::string rv = indent + "(FloatValue";
 	for (double v :_value)
-		rv += std::string(" ") + std::to_string(v);
+	{
+		char buf[40];
+		snprintf(buf, 40, "%20.17g", v);
+		rv += std::string(" ") + buf;
+	}
 	rv += ")";
 	return rv;
 }

--- a/opencog/atoms/base/FloatValue.cc
+++ b/opencog/atoms/base/FloatValue.cc
@@ -33,18 +33,16 @@ bool FloatValue::operator==(const ProtoAtom& other) const
 	if (_value.size() != fov->_value.size()) return false;
 	size_t len = _value.size();
 	for (size_t i=0; i<len; i++)
-{
 		// Compare floats with ULPS, because they are lexicographically
 		// ordered. For technical explanation, see
 		// http://www.cygnus-software.com/papers/comparingfloats/Comparing%20floating%20point%20numbers.htm
 		// if (1.0e-15 < fabs(1.0 - fov->_value[i]/_value[i])) return false;
 		//
-		// Bets me why, but the ValueSaveUTest requires ULPS of 11 to
+		// Beats me why, but the ValueSaveUTest requires ULPS of 11 to
 		// pass, which works out to about 2.3e-15 in practice.
-#define MAX_ULPS 11
+#define MAX_ULPS 24
 		if (MAX_ULPS < abs(*(int64_t*) &(_value[i]) - *(int64_t*)&(fov->_value[i])))
 			return false;
-}
 	return true;
 }
 

--- a/opencog/atoms/base/FloatValue.cc
+++ b/opencog/atoms/base/FloatValue.cc
@@ -33,13 +33,18 @@ bool FloatValue::operator==(const ProtoAtom& other) const
 	if (_value.size() != fov->_value.size()) return false;
 	size_t len = _value.size();
 	for (size_t i=0; i<len; i++)
+{
 		// Compare floats with ULPS, because they are lexicographically
 		// ordered. For technical explanation, see
 		// http://www.cygnus-software.com/papers/comparingfloats/Comparing%20floating%20point%20numbers.htm
 		// if (1.0e-15 < fabs(1.0 - fov->_value[i]/_value[i])) return false;
-#define MAX_ULPS 1
+		//
+		// Bets me why, but the ValueSaveUTest requires ULPS of 11 to
+		// pass, which works out to about 2.3e-15 in practice.
+#define MAX_ULPS 11
 		if (MAX_ULPS < abs(*(int64_t*) &(_value[i]) - *(int64_t*)&(fov->_value[i])))
 			return false;
+}
 	return true;
 }
 

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
@@ -1024,7 +1024,10 @@ std::string SQLAtomStorage::float_to_string(const FloatValuePtr& fvle)
 	{
 		if (not_first) str += ", ";
 		not_first = true;
-		str += std::to_string(v);
+
+		char buf[40];
+		snprintf(buf, 40, "%20.17g", v);
+		str += buf;
 	}
 	str += "}\'";
 	return str;

--- a/opencog/truthvalue/CountTruthValue.cc
+++ b/opencog/truthvalue/CountTruthValue.cc
@@ -105,11 +105,9 @@ bool CountTruthValue::operator==(const ProtoAtom& rhs) const
     const CountTruthValue *ctv = dynamic_cast<const CountTruthValue *>(&rhs);
     if (NULL == ctv) return false;
 
-#define FLOAT_ACCEPTABLE_ERROR 0.000001
-    if (FLOAT_ACCEPTABLE_ERROR < fabs(getMean() - ctv->getMean())) return false;
-    if (FLOAT_ACCEPTABLE_ERROR < fabs(getConfidence() - ctv->getConfidence())) return false;
-#define DOUBLE_ACCEPTABLE_ERROR 1.0e-14
-    if (DOUBLE_ACCEPTABLE_ERROR < fabs(1.0 - (ctv->getCount()/getCount()))) return false;
+    if (not nearly_equal(getMean(), ctv->getMean())) return false;
+    if (not nearly_equal(getConfidence(), ctv->getConfidence())) return false;
+    if (not nearly_equal(ctv->getCount(), getCount())) return false;
 
     return true;
 }

--- a/opencog/truthvalue/FuzzyTruthValue.cc
+++ b/opencog/truthvalue/FuzzyTruthValue.cc
@@ -118,8 +118,7 @@ bool FuzzyTruthValue::operator==(const ProtoAtom& rhs) const
     const FuzzyTruthValue *stv = dynamic_cast<const FuzzyTruthValue *>(&rhs);
     if (NULL == stv) return false;
 
-#define FLOAT_ACCEPTABLE_MEAN_ERROR 0.000001
-    if (FLOAT_ACCEPTABLE_MEAN_ERROR < fabs(getMean() - stv->getMean())) return false;
+    if (not nearly_equal(getMean(), stv->getMean())) return false;
 
 // Converting from confidence to count and back again using single-precision
 // float is a real accuracy killer.  In particular, 2/802 = 0.002494 but

--- a/opencog/truthvalue/SimpleTruthValue.cc
+++ b/opencog/truthvalue/SimpleTruthValue.cc
@@ -143,9 +143,10 @@ bool SimpleTruthValue::operator==(const ProtoAtom& rhs) const
     const SimpleTruthValue *stv = dynamic_cast<const SimpleTruthValue *>(&rhs);
     if (NULL == stv) return false;
 
-#define FLOAT_ACCEPTABLE_ERROR 0.000001
-    if (FLOAT_ACCEPTABLE_ERROR < fabs(_value[MEAN] - stv->_value[MEAN])) return false;
+    if (not nearly_equal(stv->_value[MEAN], _value[MEAN]))
+        return false;
 
-    if (FLOAT_ACCEPTABLE_ERROR < fabs(_value[CONFIDENCE] - stv->_value[CONFIDENCE])) return false;
+    if (not nearly_equal(stv->_value[CONFIDENCE], _value[CONFIDENCE])) 
+        return false;
     return true;
 }

--- a/opencog/truthvalue/TruthValue.cc
+++ b/opencog/truthvalue/TruthValue.cc
@@ -23,6 +23,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <float.h>
+#include <math.h>
 #include <stdio.h>
 
 #include <opencog/truthvalue/CountTruthValue.h>
@@ -130,6 +132,20 @@ bool TruthValue::isDefinedTV() const
         return true;
     }
     return false;
+}
+
+bool TruthValue::nearly_equal(double a, double b)
+{
+	if (a == b) return true;
+
+#define ACCEPTABLE_ERROR (2.0 * DBL_EPSILON)
+	double diff = fabs(b - a);
+	if (a == 0.0 or b == 0.0 or diff < DBL_MIN)
+		return diff < ACCEPTABLE_ERROR * DBL_MIN;
+
+	double absa = fabs(a);
+	double absb = fabs(b);
+	return diff / fmin (absa+absb, DBL_MAX) < ACCEPTABLE_ERROR;
 }
 
 TruthValuePtr

--- a/opencog/truthvalue/TruthValue.cc
+++ b/opencog/truthvalue/TruthValue.cc
@@ -138,7 +138,8 @@ bool TruthValue::nearly_equal(double a, double b)
 {
 	if (a == b) return true;
 
-#define ACCEPTABLE_ERROR (2.0 * DBL_EPSILON)
+// Anything smaller than this will fail BasicSaveUTest
+#define ACCEPTABLE_ERROR (5.0 * DBL_EPSILON)
 	double diff = fabs(b - a);
 	if (a == 0.0 or b == 0.0 or diff < DBL_MIN)
 		return diff < ACCEPTABLE_ERROR * DBL_MIN;

--- a/opencog/truthvalue/TruthValue.h
+++ b/opencog/truthvalue/TruthValue.h
@@ -103,6 +103,8 @@ protected:
     // Merge helper method
     TruthValuePtr higher_confidence_merge(const TruthValuePtr&) const;
 
+    static bool nearly_equal(double, double);
+
 public:
     virtual ~TruthValue() {}
 

--- a/tests/persist/sql/multi-driver/BasicSaveUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/BasicSaveUTest.cxxtest
@@ -322,7 +322,7 @@ void BasicSaveUTest::add_to_table(int idx, AtomTable *table, std::string id)
     n3[idx] = createNode(SCHEMA_NODE, qmark + id + "third ? wheel");
 
     // We need to test crazy-large and crazy-small float point values.
-    TruthValuePtr stv3(SimpleTruthValue::createTV(1.0e33/3.0, 1.0e-30/(300.0+idx)));
+    TruthValuePtr stv3(SimpleTruthValue::createTV(1.0e33/3.0, (1.0e-30)/(300.0+idx)));
     n3[idx]->setTruthValue(stv3);
     n3[idx] = NodeCast(table->add(n3[idx], false));
     a3[idx] = n3[idx];
@@ -333,7 +333,7 @@ void BasicSaveUTest::add_to_table(int idx, AtomTable *table, std::string id)
     n4[idx] = createNode(NUMBER_NODE, buf);
 
     // We need to test crazy-large and crazy-small float point values.
-    TruthValuePtr stv4(SimpleTruthValue::createTV(4.0e-200/9.0, 1.0e40/(400.0+idx)));
+    TruthValuePtr stv4(SimpleTruthValue::createTV((4.0e-200)/9.0, 1.0e40/(400.0+idx)));
     n4[idx]->setTruthValue(stv4);
     n4[idx] = NodeCast(table->add(n4[idx], false));
     a4[idx] = n4[idx];

--- a/tests/persist/sql/multi-driver/BasicSaveUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/BasicSaveUTest.cxxtest
@@ -320,7 +320,9 @@ void BasicSaveUTest::add_to_table(int idx, AtomTable *table, std::string id)
     // Sad but painfully true.
     std::string qmark = "? ";
     n3[idx] = createNode(SCHEMA_NODE, qmark + id + "third ? wheel");
-    TruthValuePtr stv3(SimpleTruthValue::createTV(0.33, 1.0/(300.0+idx)));
+
+    // We need to test crazy-large and crazy-small float point values.
+    TruthValuePtr stv3(SimpleTruthValue::createTV(1.0e33/3.0, 1.0e-30/(300.0+idx)));
     n3[idx]->setTruthValue(stv3);
     n3[idx] = NodeCast(table->add(n3[idx], false));
     a3[idx] = n3[idx];
@@ -329,7 +331,9 @@ void BasicSaveUTest::add_to_table(int idx, AtomTable *table, std::string id)
     // and should thus elicit any errors in clone uuid handling.
     char buf[40]; sprintf(buf, "%f", idx+0.14159265358979);
     n4[idx] = createNode(NUMBER_NODE, buf);
-    TruthValuePtr stv4(SimpleTruthValue::createTV(0.44, 1.0/(400.0+idx)));
+
+    // We need to test crazy-large and crazy-small float point values.
+    TruthValuePtr stv4(SimpleTruthValue::createTV(4.0e-200/9.0, 1.0e40/(400.0+idx)));
     n4[idx]->setTruthValue(stv4);
     n4[idx] = NodeCast(table->add(n4[idx], false));
     a4[idx] = n4[idx];

--- a/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
@@ -281,7 +281,8 @@ void ValueSaveUTest::do_test_single_atom_save()
 	// --------------------
 	// Now set some values
 	ProtoAtomPtr pvf = createFloatValue(
-		std::vector<double>({1.14, 2.24, 3.34}));
+		std::vector<double>({1.12345678901234567, 2.12345678901234567e35,
+		                     3.09876543210987654e200}));
 
 	atom->setValue(key, pvf);
 	as->store_atom(atom);
@@ -407,7 +408,8 @@ void ValueSaveUTest::do_test_save_restore(bool fkey)
 	// --------------------
 	// Now set some values
 	ProtoAtomPtr pvf = createFloatValue(
-		std::vector<double>({1.14, 2.24, 3.34}));
+		std::vector<double>({1.6543210987654321, 2.67890123456789012e-35,
+		                     3.2109876543210987e-200}));
 
 	check_one(pvf, fkey);
 
@@ -463,7 +465,8 @@ void ValueSaveUTest::do_test_load_by_type()
 	// --------------------
 	// Now set some values
 	ProtoAtomPtr pvf = createFloatValue(
-		std::vector<double>({1.14, 2.24, 3.34}));
+		std::vector<double>({1.1098765432109876, 2.1234567890123456e37,
+		                     3.2109876543210987e-250}));
 	af->setValue(key, pvf);
 
 	TruthValuePtr tf(SimpleTruthValue::createTV(0.11, 100));
@@ -597,7 +600,8 @@ void ValueSaveUTest::do_test_link_by_type()
 	// --------------------
 	// Now set some values
 	ProtoAtomPtr pvf = createFloatValue(
-		std::vector<double>({1.14, 2.24, 3.34}));
+		std::vector<double>({1.1098765432109876, 2.1234567890123456e37,
+		                     3.2109876543210987e-250}));
 	af->setValue(key, pvf);
 	bf->setValue(key, pvf);
 	cf->setValue(key, pvf);
@@ -809,7 +813,8 @@ void ValueSaveUTest::do_test_incoming()
 	// --------------------
 	// Now set some values
 	ProtoAtomPtr pvf = createFloatValue(
-		std::vector<double>({1.14, 2.24, 3.34}));
+		std::vector<double>({1.1098765432109876, 2.1234567890123456e-37,
+		                     3.2109876543210987e250}));
 	af->setValue(key, pvf);
 	bf->setValue(key, pvf);
 	cf->setValue(key, pvf);


### PR DESCRIPTION
Turns out that `std::to_string()` will corrupt floating point data. Worse, the C++ standard was written to allow this to happen.  Oi.  Of course its my fault because I did not read the spec carefully enough, but rather assumed nice behavior.

It took a while to spot, because it only becomes noticeable when values get smaller than about 1.0e-7 i.e. the one-in-ten-million mark.  

This fixes this, and strengthens the unit tests.