### PR TITLE
Revert DontExecLink consumption

### DIFF
--- a/opencog/atoms/execution/Instantiator.cc
+++ b/opencog/atoms/execution/Instantiator.cc
@@ -422,8 +422,8 @@ Handle Instantiator::walk_tree(const Handle& expr, bool silent)
 	// beta-reduce it, but don't execute it. Consume the DontExecLink.
 	if (DONT_EXEC_LINK == t)
 	{
-		if (_vmap->empty()) return expr->getOutgoingAtom(0);
-		return beta_reduce(expr->getOutgoingAtom(0), *_vmap);
+		if (_vmap->empty()) return expr;
+		return beta_reduce(expr, *_vmap);
 	}
 
 	// None of the above. Create a duplicate link, but with an outgoing

--- a/tests/query/DontExecUTest.cxxtest
+++ b/tests/query/DontExecUTest.cxxtest
@@ -83,7 +83,7 @@ void DontExecUTest::test_DontExecLink_consumption()
 	Handle bl = eval.eval_h("bl");
 	Handle result = bindlink(&as, bl);
 	Handle simple_bl = eval.eval_h("simple-bl");
-	Handle expected = al(SET_LINK, simple_bl);
+	Handle expected = al(SET_LINK, al(DONT_EXEC_LINK, simple_bl));
 
 	logger().debug() << "result = " << oc_to_string(result);
 	logger().debug() << "expected = " << oc_to_string(expected);


### PR DESCRIPTION
Revert (but keep the unit test) #1303, so consumption occurs. Relates to #1304 . 