### PR TITLE
TLB management bugfix.

### DIFF
--- a/opencog/atomspace/AtomSpace.cc
+++ b/opencog/atomspace/AtomSpace.cc
@@ -354,7 +354,9 @@ Handle AtomSpace::fetch_atom(const Handle& h)
                                      h->getOutgoingSet());
     }
 
-    if (hv)
+    // Hmm I don't quite get it ...  shouldn't hv and hc be the same
+    // atom, by now? So the below should not be needed...!?
+    if (hv and hv != hc)
     {
         hc->copyValues(hv);
         TruthValuePtr tv = hv->getTruthValue();

--- a/opencog/atomspaceutils/TLB.cc
+++ b/opencog/atomspaceutils/TLB.cc
@@ -82,7 +82,7 @@ UUID TLB::addAtom(const Handle& h, UUID uuid)
 
     // If we hold something that isn't the atomspace's version,
     // then remove it. Only the atomspace's version has the
-    // correct TV on it.
+    // correct values (including the TV) on it.
     if (hr != h)
     {
         auto pr = _handle_map.find(h);
@@ -116,7 +116,20 @@ UUID TLB::addAtom(const Handle& h, UUID uuid)
             if (uuid != pr->second)
                 throw InvalidParamException(TRACE_INFO,
                      "Atom is already in the TLB, and UUID's don't match!");
-            return uuid;
+
+            // If the atom that we are holding is in the same atomspace
+            // as the resolved atom, then we are done. Otherwise, we
+            // need to replace it with the version with the indicated
+            // atomspace. That is because atoms in different atomspaces
+            // will hold different values and TV's.
+
+            AtomSpace* has = hr->getAtomSpace();
+            AtomSpace* pas = pr->first->getAtomSpace();
+            if (pas and has and pas == has)
+                return uuid;
+
+            _handle_map.erase(pr);
+            _uuid_map.erase(uuid);
         }
         reserve_upto(uuid);
     }

--- a/opencog/atomspaceutils/TLB.cc
+++ b/opencog/atomspaceutils/TLB.cc
@@ -54,6 +54,9 @@ void TLB::clear_resolver(const AtomTable* tab)
 // the atom wins.  Seems to work, for now.
 Handle TLB::do_res(const Handle& h)
 {
+    // No-op if it's already in an atomspace.
+    if (h->getAtomSpace()) return h->getHandle();
+
     for (const AtomTable* at : _resolver) {
         Handle hr(at->getHandle(h));
         if (nullptr != hr) return hr;


### PR DESCRIPTION
When loading incoming sets from the database, the TLB ends up holding the wrong atom, resulting in failures when the atoms are explicitly fetched. This fixes that bug.