### PR TITLE
Store atom values with the atom itself.

### DIFF
--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -37,6 +37,7 @@
 #include <opencog/atoms/base/Atom.h>
 #include <opencog/atoms/base/ClassServer.h>
 #include <opencog/atoms/base/Link.h>
+#include <opencog/atoms/base/Node.h>
 
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/atomspace/AtomTable.h>
@@ -100,12 +101,14 @@ Atom::~Atom()
 // Whole lotta truthiness going on here.  Does it really need to be
 // this complicated!?
 
-void Atom::setTruthValue(TruthValuePtr newTV)
+static Handle truth_key(createNode(PREDICATE_NODE, "*-TruthValueKey-*"));
+
+void Atom::setTruthValue(const TruthValuePtr& newTV)
 {
     if (nullptr == newTV) return;
 
     // If both old and new are e.g. DEFAULT_TV, then do nothing.
-    if (_truthValue.get() == newTV.get()) return;
+    if (getValue(truth_key).get() == newTV.get()) return;
 
     // We need to guarantee that the signal goes out with the
     // correct truth value.  That is, another setter could be changing
@@ -116,9 +119,7 @@ void Atom::setTruthValue(TruthValuePtr newTV)
     // writing this at a time. std:shared_ptr is NOT thread-safe against
     // multiple writers: see "Example 5" in
     // http://www.boost.org/doc/libs/1_53_0/libs/smart_ptr/shared_ptr.htm#ThreadSafety
-    std::unique_lock<std::mutex> lck(_mtx);
-    _truthValue = newTV;
-    lck.unlock();
+    setValue (truth_key, ProtoAtomCast(newTV));
 
     if (_atom_space != nullptr) {
         TVCHSigl& tvch = _atom_space->_atom_table.TVChangedSignal();
@@ -128,40 +129,45 @@ void Atom::setTruthValue(TruthValuePtr newTV)
 
 TruthValuePtr Atom::getTruthValue() const
 {
-    // OK. The atomic thread-safety of shared-pointers is subtle. See
-    // http://www.boost.org/doc/libs/1_53_0/libs/smart_ptr/shared_ptr.htm#ThreadSafety
-    // and http://cppwisdom.quora.com/shared_ptr-is-almost-thread-safe
-    // What it boils down to here is that we must *always* make a copy
-    // of _truthValue before we use it, since it can go out of scope
-    // because it can get set in another thread.  Viz, using it to
-    // dereference can return a raw pointer to an object that has been
-    // deconstructed.  The AtomSpaceAsyncUTest will hit this, as will
-    // the multi-threaded async atom store in the SQL peristance backend.
-    // Furthermore, we must make a copy while holding the lock! Got that?
-
-    std::lock_guard<std::mutex> lck(_mtx);
-    TruthValuePtr local(_truthValue);
-    return local;
+    return TruthValueCast(getValue(truth_key));
 }
 
 // ==============================================================
 // Setting values associated with this atom.
 void Atom::setValue(const Handle& key, const ProtoAtomPtr& value)
 {
-    if (nullptr == _atom_space) return;
-    _atom_space->_value_table.addValuation(key, getHandle(), value);
+    std::lock_guard<std::mutex> lck(_mtx);
+    _values[key] = value;
 }
 
 ProtoAtomPtr Atom::getValue(const Handle& key) const
 {
-    if (nullptr == _atom_space) return nullptr;
-    return _atom_space->_value_table.getValue(key, getHandle());
+    // OK. The atomic thread-safety of shared-pointers is subtle. See
+    // http://www.boost.org/doc/libs/1_53_0/libs/smart_ptr/shared_ptr.htm#ThreadSafety
+    // and http://cppwisdom.quora.com/shared_ptr-is-almost-thread-safe
+    // What it boils down to here is that we must *always* make a copy
+    // of the value before we use it, since it can go out of scope
+    // because it can get set in another thread.  Viz, using it to
+    // dereference can return a raw pointer to an object that has been
+    // deconstructed.  The AtomSpaceAsyncUTest will hit this, as will
+    // the multi-threaded async atom store in the SQL peristance backend.
+    // Furthermore, we must make a copy while holding the lock! Got that?
+
+    ProtoAtomPtr pap;
+    std::lock_guard<std::mutex> lck(_mtx);
+    auto pr = _values.find(key);
+    if (_values.end() != pr) pap = pr->second;
+    return pap;
 }
 
 HandleSet Atom::getKeys() const
 {
-    if (nullptr == _atom_space) return HandleSet();
-    return _atom_space->_value_table.getKeys(getHandle());
+    HandleSet keyset;
+    std::lock_guard<std::mutex> lck(_mtx);
+    for (const auto& pr : _values)
+        keyset.insert(pr.first);
+
+    return keyset;
 }
 
 void Atom::copyValues(const Handle& other)
@@ -172,9 +178,6 @@ void Atom::copyValues(const Handle& other)
         ProtoAtomPtr p = other->getValue(k);
         setValue(k, p);
     }
-
-    // Special case for truth values
-    setTruthValue(other->getTruthValue());
 }
 
 std::string Atom::valuesToString() const

--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -101,14 +101,18 @@ Atom::~Atom()
 // Whole lotta truthiness going on here.  Does it really need to be
 // this complicated!?
 
-static Handle truth_key(createNode(PREDICATE_NODE, "*-TruthValueKey-*"));
+static const Handle& truth_key(void)
+{
+	static Handle tk(createNode(PREDICATE_NODE, "*-TruthValueKey-*"));
+	return tk;
+}
 
 void Atom::setTruthValue(const TruthValuePtr& newTV)
 {
     if (nullptr == newTV) return;
 
     // If both old and new are e.g. DEFAULT_TV, then do nothing.
-    if (getValue(truth_key).get() == newTV.get()) return;
+    if (getValue(truth_key()).get() == newTV.get()) return;
 
     // We need to guarantee that the signal goes out with the
     // correct truth value.  That is, another setter could be changing
@@ -119,7 +123,7 @@ void Atom::setTruthValue(const TruthValuePtr& newTV)
     // writing this at a time. std:shared_ptr is NOT thread-safe against
     // multiple writers: see "Example 5" in
     // http://www.boost.org/doc/libs/1_53_0/libs/smart_ptr/shared_ptr.htm#ThreadSafety
-    setValue (truth_key, ProtoAtomCast(newTV));
+    setValue (truth_key(), ProtoAtomCast(newTV));
 
     if (_atom_space != nullptr) {
         TVCHSigl& tvch = _atom_space->_atom_table.TVChangedSignal();
@@ -129,7 +133,7 @@ void Atom::setTruthValue(const TruthValuePtr& newTV)
 
 TruthValuePtr Atom::getTruthValue() const
 {
-    return TruthValueCast(getValue(truth_key));
+    return TruthValueCast(getValue(truth_key()));
 }
 
 // ==============================================================

--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -133,7 +133,9 @@ void Atom::setTruthValue(const TruthValuePtr& newTV)
 
 TruthValuePtr Atom::getTruthValue() const
 {
-    return TruthValueCast(getValue(truth_key()));
+    ProtoAtomPtr pap(getValue(truth_key()));
+    if (nullptr == pap) return TruthValue::DEFAULT_TV();
+    return TruthValueCast(pap);
 }
 
 // ==============================================================

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -127,7 +127,8 @@ protected:
 
     AtomSpace *_atom_space;
 
-    mutable TruthValuePtr _truthValue;
+    /// All of the values on the atom, including the TV.
+    mutable std::map<const Handle, ProtoAtomPtr> _values;
 
     // Lock, used to serialize changes.
     // This costs 40 bytes per atom.  Tried using a single, global lock,
@@ -149,8 +150,7 @@ protected:
       : ProtoAtom(t),
         _flags(0),
         _content_hash(Handle::INVALID_HASH),
-        _atom_space(nullptr),
-        _truthValue(TruthValue::DEFAULT_TV())
+        _atom_space(nullptr)
     {}
 
     // The incoming set is not tracked by the garbage collector;
@@ -266,7 +266,7 @@ public:
     TruthValuePtr getTruthValue() const;
 
     //! Sets the TruthValue object of the atom.
-    void setTruthValue(TruthValuePtr);
+    void setTruthValue(const TruthValuePtr&);
 
     /// Associate `value` to `key` for this atom.
     void setValue(const Handle& key, const ProtoAtomPtr& value);

--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -32,7 +32,6 @@
 
 #include <opencog/atomspace/AtomTable.h>
 #include <opencog/atomspace/BackingStore.h>
-#include <opencog/atomspace/ValuationTable.h>
 
 namespace opencog
 {
@@ -69,7 +68,6 @@ class AtomSpace
     AtomSpace(const AtomSpace&);
 
     AtomTable _atom_table;
-    ValuationTable _value_table;
     /**
      * Used to fetch atoms from disk.
      */

--- a/opencog/atomspace/CMakeLists.txt
+++ b/opencog/atomspace/CMakeLists.txt
@@ -9,7 +9,9 @@ ADD_LIBRARY (atomspace
 	BackingStore.cc
 	FixedIntegerIndex.cc
 	TypeIndex.cc
-	ValuationTable.cc
+
+	# Valuations are now stored in the atom itself.
+	# ValuationTable.cc
 
 	# The below are no longer used, but we will
 	# keep them around for a little while longer... just in case!?
@@ -46,7 +48,6 @@ INSTALL (FILES
 	BackingStore.h
 	FixedIntegerIndex.h
 	TypeIndex.h
-	ValuationTable.h
 	version.h
 	DESTINATION "include/opencog/atomspace"
 )

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
@@ -302,13 +302,6 @@ class SQLAtomStorage::Response
 
 			ProtoAtomPtr pap = store->doUnpackValue(*this);
 			atom->setValue(hkey, pap);
-
-			// Special case for truth values
-			if (classserver().isA(pap->getType(), TRUTH_VALUE))
-			{
-				TruthValuePtr tv(std::dynamic_pointer_cast<TruthValue>(pap));
-				atom->setTruthValue(tv);
-			}
 			return false;
 		}
 
@@ -895,23 +888,14 @@ void SQLAtomStorage::store_atom_values(const Handle& atom)
 	HandleSet keys = atom->getKeys();
 	for (const Handle& key: keys)
 	{
-		// Skip the truth-value; it's special-cased below.
-		if (key == tvpred) continue;
 		ProtoAtomPtr pap = atom->getValue(key);
 		storeValuation(key, atom, pap);
 	}
 
 	// Special-case for TruthValues. Can we get rid of this someday?
+	// Delete default TV's, else storage will get clogged with them.
 	TruthValuePtr tv(atom->getTruthValue());
-
-	// Don't clog storage with default TV's
-	if (tv->isDefaultTV())
-	{
-		deleteValuation(tvpred, atom);
-		return;
-	}
-
-	storeValuation(tvpred, atom, ProtoAtomCast(tv));
+	if (tv->isDefaultTV()) deleteValuation(tvpred, atom);
 }
 
 /// Get ALL of the values associated with an atom.

--- a/tests/atomspace/CMakeLists.txt
+++ b/tests/atomspace/CMakeLists.txt
@@ -25,4 +25,6 @@ ADD_CXXTEST(UseCountUTest)
 ADD_CXXTEST(MultiSpaceUTest)
 ADD_CXXTEST(RemoveUTest)
 ADD_CXXTEST(ThreadSafeHandleMapUTest)
-ADD_CXXTEST(ValuationTableUTest)
+
+# The ValuationTable is no longer used or even built, so don't test it.
+# ADD_CXXTEST(ValuationTableUTest)

--- a/tests/persist/sql/multi-driver/FetchUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/FetchUTest.cxxtest
@@ -264,7 +264,7 @@ void FetchUTest::test_stuff(void)
 	eval = SchemeEval::get_evaluator(_as);
 	eval->eval(sql_open);
 
-	// AAA should have been update, as above.
+	// AAA should have been updated, as above.
 	eval->eval(R"((fetch-atom (Concept "AAA")))");
 	tv = eval->eval_tv(R"((cog-tv (Concept "AAA")))");
 	etv = SimpleTruthValue::createTV(0.3, 0.33);


### PR DESCRIPTION
During prototyping, atom values got stored in a special location attached to the atomspace. This seems to be a bit wasteful for both both RAM and CPU cycles; so store them with the Atom, directly.  Really should have done this from the get-go.