### PR TITLE
Filtered datasets get unique ID's

### DIFF
--- a/opencog/matrix/README.md
+++ b/opencog/matrix/README.md
@@ -12,7 +12,7 @@ where `x` and `y` are atoms), and we have some sort of count `N(x,y)`
 of how often that particular pair was observed.  We typically are then
 interested in various statistical measures: usually starting with the
 normalized frequency `p(x,y)` (that is, the probability, likelihood)
-of how often the pair `(x,y)` occured (likelihood of observing the pair).
+of how often the pair `(x,y)` occurred (likelihood of observing the pair).
 These counts and frequencies can be viewed as a sparse correlation
 matrix, and the goal here is to do all the typical things that one
 might do with such a matrix.  That's what the code in this directory
@@ -44,11 +44,11 @@ The tools implemented here include:
  * computing and caching mutual information between rows and columns
  * computing cosine similarity between rows or columns.
  * performing PCA (principal component analysis) in the matrix.
- * performing cuts, to remove unwanted rows, coumns and individual entries.
+ * performing cuts, to remove unwanted rows, columns and individual entries.
 
 To use these tools, all you need to do is to specify a low-level
 object that describes the matrix. It needs to provide some very simple
-but important mthods: the `'left-type` and `'right-type` methods,
+but important methods: the `'left-type` and `'right-type` methods,
 that return the atom type of the rows and the columns; a `'pair-type`
 method that returns the atom-type of the pair, and a `'pair-count`
 method that returns the count, given the pair.
@@ -56,12 +56,12 @@ method that returns the count, given the pair.
 
 FAQ
 ---
-Q: Why isn't this in C++?  Surely, numericaal computations would be
+Q: Why isn't this in C++?  Surely, numerical computations would be
    a lot faster in C++, right?
 
 A: Yes, probably. But its a lot easier to write scheme code than
    it is to write C++ code, and so prototyping in scheme just made
-   more sense. It was just-plain simpler, faster, esier. You are
+   more sense. It was just-plain simpler, faster, easier. You are
    invited to take the lessons learned, and re-implement in C++.
    The number #1 most important lesson is that the filter object
    is the most important object: it controls what data you want
@@ -70,23 +70,23 @@ A: Yes, probably. But its a lot easier to write scheme code than
 
 Q: Really, C++ is sooo fast...
 
-A: Yes, but since the data is stored in values assocaited with
+A: Yes, but since the data is stored in values associated with
    atoms in the atomspace, adding numbers together is NOT the
    bottleneck. Accessing Atom Values *is* the bottleneck. Soooo...
 
 Q: Why don't you just export all your data to SciPy or to Gnu R, or to
    Octave, or MatLab, for that matter, and just do your data analytics
    there?  That way, you don't need to re-implement all these basic
-   statistical algorithms.
+   statistical algorithms!
 
 A: That sounds nice, but frankly, it's too much work for me. Maybe you
    can do this.  Seriously, its just a lot easier (for me) to create
-   and use the code here, than to struggle mightlily with those packages.
+   and use the code here, than to struggle mightily with those packages.
 
-   Also: realize that the end-goal of opencog is not to export data
+   Also: realize that the end-goal of OpenCog is not to export data
    once, analyze it once, and be done. Rather, the goal is to constantly
    and continuously monitor external, real-world events, pull them into
-   the atomspace, crunch it incessently, and update knowledge of the
+   the atomspace, crunch it incessantly, and update knowledge of the
    external world as a result. This rules out GUI tools for data
    processing (because there's no GUI in a server) and it rules out
    popsicle-stick architectures as being a bit hokey.
@@ -96,7 +96,7 @@ A: That sounds nice, but frankly, it's too much work for me. Maybe you
    This can blow through huge amounts of RAM. Can SciPy actually deal
    with datasets this big?  It gets worse, because typically, you want
    to work with different cuts and filters, where you discard much of
-   the data, or average together different parts: can you relly afford
+   the data, or average together different parts: can you really afford
    the RAM needed to export all of these different cut and filtered
    datasets?  Maybe you can, its just not trivial.
 
@@ -109,7 +109,7 @@ A: You would use Rcpp at http://dirk.eddelbuettel.com/code/rcpp.html
    provided by R. Rcpp provides matching C++ classes for a large
    number of basic R data types. Hence, a package author can keep his
    data in normal R data structures without having to worry about
-   translation or transfering to C++. At the same time, the data
+   translation or transferring to C++. At the same time, the data
    structures can be accessed as easily at the C++ level, and used in
    the normal manner. The mapping of data types works in both
    directions. It is as straightforward to pass data from R to C++,
@@ -139,7 +139,7 @@ https://en.wikipedia.org/wiki/Generic_programming
 This code is written in scheme.  I know some of you want to use python
 instead, while others would prefer C++.  More generally, it would
 probably be useful to set things up so that external, third-party
-software systems (such as scipy or Gnu Octave or tensorflow) could
+software systems (such as SciPy or Gnu Octave or tensorflow) could
 be used to perform the analysis.  Now that you've got the general
 idea... you can go do this!
 
@@ -163,7 +163,7 @@ Basic definitions
 
 Let `N(x,y)` be the observed count on the pair of atoms `(x,y)`.
 
-The `add-pair-count-api` class provides an API to report the parital
+The `add-pair-count-api` class provides an API to report the partial
 sums `N(x,*) = sum_y N(x,y)` and likewise `N(*,y)`.  If you think of
 `N(x,y)` as a matrix, these are the totals for the entries in each
 row or column of the matrix. Likewise, `N(*,*) = sum_x sum_y N(x,y)`.
@@ -205,7 +205,7 @@ calling the function on each pair.
 
 The `make-compute-count` class provides methods to compute the partial
 sums `N(*,y)` and `N(x,*)` and cache the resulting values on atoms where
-they can be quickly retreived. The location of the cached values are
+they can be quickly retrieved. The location of the cached values are
 exactly where they can be found by the `add-pair-count-api`, above.
 
 The `make-compute-freq` class provides methods to compute and cache
@@ -223,7 +223,7 @@ three classes above, and unleashes them on a dataset: first computing
 the row and column partial counts, then computing the frequencies, and
 then computing and caching the mutual information.  For large datasets,
 e.g. tens of millions of atoms, this can take hours to run.  Thus, for
-this reaso, the cached values are then saved to the currrently-open
+this reason, the cached values are then saved to the currently-open
 database, so that these results become available later.
 
 Computing support and entropy
@@ -268,8 +268,8 @@ The class also provides the Jaccard similarity
             sum_x max (N(x,y), N(x,z))
 ```
 
-The `add-tuple-math` class provides methods for applying aribitrary
-functions to arebitrary sets of rows or columns. The simplest examples
+The `add-tuple-math` class provides methods for applying arbitrary
+functions to arbitrary sets of rows or columns. The simplest examples
 include taking the sums and differences of columns, taking the
 element-by-element min or max of a set of columns, counting the number
 of entries that are simultaneously non-zero in sets of columns, etc.

--- a/opencog/matrix/filter.scm
+++ b/opencog/matrix/filter.scm
@@ -9,13 +9,28 @@
 ; ---------------------------------------------------------------------
 ; OVERVIEW
 ; --------
-; Some types of analysis, e.g. the thresholding-PCA code, will provide
-; better results if some of the noise in the data is removed.  In this
-; case, noise is considered to be any rows or columns that have subtotal
-; column counts below a certain value: anything that was observed very
-; infrequently.
+; Large datasets are inherently likely to contain "noise" and spurious
+; data that might be unwanted during data analysis. For example, the
+; dataset might contian a large number of atoms that were observed only
+; once or twice; these are likely to be junk and should be removed
+; before data analysis begins.
 ;
-; This overloads the "star" API to provide the filtered dataset.
+; The code here provides this filtering ability. Several types of
+; filters are provided:
+; -- a knockout filter, that knocks out designated rows and columns.
+; -- a min-count filter, that knocks out rows and columns whose
+;    marginal counts are below a minimum, as well as individual matrix
+;    entries that are below a per-entry minimum.
+; -- a generic callback-defined filter, that knocks out rows, columns
+;    and individual entries based on callback predicates.
+;
+; Note that these filters are all "on demand": they do NOT copy the
+; dataset and then compute a smaller version of it.  Instead, they
+; overload the "star" API, altering the methods used to fetch rows,
+; columns and individual entries.  Since all the other matrix access
+; routines use the "star" API to gain access to the matrix and it's
+; marginals, this works!
+;
 ; ---------------------------------------------------------------------
 
 (use-modules (srfi srfi-1))
@@ -151,7 +166,7 @@
   the same row and column addressability that star-object does, but
   just returns fewer rows and columns.
 
-  Thhe filtering is done 'on demand', on a row-by-row, column-by-column
+  The filtering is done 'on demand', on a row-by-row, column-by-column
   basis.  Currenly, computations for the left and right stars are not
   cached, and are recomputed for each request.  Currently, this seems
   like a reasonable thing to do.

--- a/opencog/matrix/filter.scm
+++ b/opencog/matrix/filter.scm
@@ -123,6 +123,12 @@
 			(if (PAIR-PRED PAIR) (LLOBJ 'pair-count PAIR) 0))
 
 		; ---------------
+		(define (get-name)
+			(string-append (LLOBJ 'name) " " ID-STR))
+		(define (get-id)
+			(string-append (LLOBJ 'id) " " ID-STR))
+
+		; ---------------
 		; Return a pointer to each method that this class overloads.
 		(define (provides meth)
 			(case meth
@@ -138,6 +144,8 @@
 		; Methods on this class.
 		(lambda (message . args)
 			(case message
+				((name)             (get-name))
+				((id)               (get-id))
 				((left-stars)       (apply cache-left-stars args))
 				((right-stars)      (apply cache-right-stars args))
 				((left-basis)       (get-left-basis))
@@ -171,9 +179,8 @@
   just returns fewer rows, columns and individual entries.
 
   The filtering is done 'on demand', on a row-by-row, column-by-column
-  basis.  Currenly, computations for the left and right stars are not
-  cached, and are recomputed for each request.  Currently, this seems
-  like a reasonable thing to do.
+  basis.  Computations of the left and right stars are cached, sot that
+  they are not recomputed for each request.
 
   Note that by removing rows and columns, the frequencies will no longer
   sum to 1.0. Likewise, row and column subtotals, entropies and mutual

--- a/opencog/matrix/object-api.scm
+++ b/opencog/matrix/object-api.scm
@@ -148,7 +148,7 @@
 ;        (EvaluationLink (Predicate "foo")
 ;           (ListLink (AnyNode "left-wild") (AnyNode "right-wild"))))
 ;
-;     ; Retreive, from storage, the entire matrix, including the
+;     ; Retrieve, from storage, the entire matrix, including the
 ;     ; subtotal and total anchor atoms.  In this example, its enough
 ;     ; to get the incoming set of (Predicate "foo"), but this need
 ;     ; not generally be the case.
@@ -158,9 +158,13 @@
 ;     ; Methods on the class. To call these, quote the method name.
 ;     ; Example: (OBJ 'left-wildcard WORD) calls the
 ;     ; get-left-wildcard function, passing WORD as the argument.
+;     ;
+;     ; The name is a string printed at the top of generated reports.
+;     ; The id is a short string used to create unique filter ids and names.
 ;     (lambda (message . args)
 ;        (apply (case message
-;              ((name) "Demo Kind of Object")
+;              ((name) "A Kind of Demonstration Object")
+;              ((id)   "demo")
 ;              ((left-type) get-left-type)
 ;              ((right-type) get-right-type)
 ;              ((pair-type) get-pair-type)

--- a/opencog/matrix/object-api.scm
+++ b/opencog/matrix/object-api.scm
@@ -521,7 +521,12 @@
 "
 	; ----------------------------------------------------
 	; Key under which the frequency values are stored.
-	(define freq-key (PredicateNode "*-FrequencyKey-*"))
+	(define freq-name
+		(if (LLOBJ 'filters?)
+			(string-append "*-FrequencyKey " (LLOBJ 'id))
+			"*-FrequencyKey-*"))
+
+	(define freq-key (PredicateNode freq-name))
 
 	; Return the observed frequency on ATOM
 	(define (get-freq ATOM)
@@ -548,7 +553,12 @@
 
 	; ----------------------------------------------------
 	; Key under which the entropy values are stored.
-	(define entropy-key (PredicateNode "*-Entropy Key-*"))
+	(define entr-name
+		(if (LLOBJ 'filters?)
+			(string-append "*-Entropy Key " (LLOBJ 'id))
+			"*-Entropy Key-*"))
+
+	(define entropy-key (PredicateNode entr-name))
 
 	; Return the total entropy on ATOM
 	(define (get-total-entropy ATOM)
@@ -564,7 +574,12 @@
 
 	; ----------------------------------------------------
 	; The key under which the MI is stored.
-	(define mi-key (PredicateNode "*-Mutual Info Key-*"))
+	(define mi-name
+		(if (LLOBJ 'filters?)
+			(string-append "*-Mutual Info Key " (LLOBJ 'id))
+			"*-Mutual Info Key-*"))
+
+	(define mi-key (PredicateNode mi-name))
 
 	; Get the (floating-point) mutual information on ATOM.
 	(define (get-total-mi ATOM)
@@ -696,12 +711,6 @@
 	; Return the atom that holds this value.
 	(define (set-right-wild-mi ITEM MI FRMI)
 		(set-mi (LLOBJ 'right-wildcard ITEM) MI FRMI))
-
-	; ----------------------------------------------------
-	; This fails totally on filtered datasets.
-	(if (LLOBJ 'filters?)
-		(throw 'bad-use 'add-pair-freq-api
-			"Can't use the count API object with filtered datasets!"))
 
 	; ----------------------------------------------------
 	; Methods on this class.

--- a/opencog/matrix/report-api.scm
+++ b/opencog/matrix/report-api.scm
@@ -42,7 +42,7 @@
   'left-dim         -- The number of rows
   'right-dim        -- The number of columns
   'num-pairs        -- The number of non-zero entries
-  'total-count      -- Total number fo observations on all pairs
+  'total-count      -- Total number of observations on all pairs
                        (Identical to the 'wild-wild-count on the
                        count-api object)
 
@@ -113,9 +113,7 @@
     calls 'hubbiness' (his hubbiness is the 2nd central moment, if
     I recall correctly).
 "
-	(let* ((llobj LLOBJ)
-
-			(cntobj (add-pair-count-api LLOBJ))
+	(let* ((cntobj (add-pair-count-api LLOBJ))
 			(totcnt (cntobj 'wild-wild-count))
 			(wild-atom (LLOBJ 'wild-wild))
 		)
@@ -235,7 +233,7 @@
 				((set-left-norms)      (apply set-left-norms args))
 				((set-right-norms)     (apply set-right-norms args))
 
-				(else (apply llobj (cons message args)))
+				(else                  (apply LLOBJ (cons message args)))
 			))
 	)
 )
@@ -247,8 +245,7 @@
   add-central-compute LLOBJ - Extend LLOBJ with methods to compute
   misc graph-centrality statistics.
 "
-	(let* ((llobj LLOBJ)
-			(wild-obj (add-pair-stars LLOBJ))
+	(let* ((wild-obj (add-pair-stars LLOBJ))
 			(len-obj (add-support-api wild-obj))
 			(frq-obj (add-pair-freq-api wild-obj))
 			(rpt-obj (add-report-api wild-obj))
@@ -383,7 +380,7 @@
 				((right-rms-count)   (get-right-rms-count))
 				((cache-all)         (cache-all))
 
-				(else (apply llobj (cons message args)))
+				(else                (apply LLOBJ (cons message args)))
 			))
 	)
 )

--- a/opencog/matrix/report-api.scm
+++ b/opencog/matrix/report-api.scm
@@ -116,11 +116,15 @@
 	(let* ((cntobj (add-pair-count-api LLOBJ))
 			(totcnt (cntobj 'wild-wild-count))
 			(wild-atom (LLOBJ 'wild-wild))
+			(is-filtered? (LLOBJ 'filters?))
 		)
 
 		; ----------------------------------------------------
 		; Key under which the matrix dimensions are stored.
-		(define dim-key (PredicateNode "*-Dimension Key-*"))
+		(define dim-key (PredicateNode
+			(if is-filtered?
+				(string-append "*-Dimension Key " (LLOBJ 'id))
+				"*-Dimension Key-*")))
 
 		(define (set-size LEFT RIGHT NPAIRS)
 			(cog-set-value! wild-atom dim-key (FloatValue LEFT RIGHT NPAIRS)))
@@ -140,7 +144,10 @@
 
 		; ----------------------------------------------------
 		; Key under which the matrix entropies are stored.
-		(define ent-key (PredicateNode "*-Total Entropy Key-*"))
+		(define ent-key (PredicateNode
+			(if is-filtered?
+				(string-append "*-Total Entropy Key " (LLOBJ 'id))
+				"*-Total Entropy Key-*")))
 
 		(define (set-entropy LEFT RIGHT TOT)
 			(cog-set-value! wild-atom ent-key (FloatValue LEFT RIGHT TOT)))
@@ -156,7 +163,10 @@
 
 		; ----------------------------------------------------
 		; Key under which the matrix MI are stored.
-		(define mi-key (PredicateNode "*-Total MI Key-*"))
+		(define mi-key (PredicateNode
+			(if is-filtered?
+				(string-append "*-Total MI Key " (LLOBJ 'id))
+				"*-Total MI Key-*")))
 
 		(define (set-mi TOT)
 			(cog-set-value! wild-atom mi-key (FloatValue TOT)))
@@ -166,8 +176,14 @@
 
 		; ----------------------------------------------------
 		; Key under which the matrix l_p norms are stored.
-		(define l-norm-key (PredicateNode "*-Left Norm Key-*"))
-		(define r-norm-key (PredicateNode "*-Right Norm Key-*"))
+		(define l-norm-key (PredicateNode
+			(if is-filtered?
+				(string-append "*-Left Norm Key " (LLOBJ 'id))
+				"*-Left Norm Key-*")))
+		(define r-norm-key (PredicateNode
+			(if is-filtered?
+				(string-append "*-Right Norm Key " (LLOBJ 'id))
+				"*-Right Norm Key-*")))
 
 		(define (set-left-norms L0 L1 L2 RMS)
 			(cog-set-value! wild-atom l-norm-key

--- a/opencog/matrix/support.scm
+++ b/opencog/matrix/support.scm
@@ -24,7 +24,12 @@
 "
 	; ----------------------------------------------------
 	; Key under which the matrix l_p norms are stored.
-	(define norm-key (PredicateNode "*-Norm Key-*"))
+	(define key-name
+		(if (LLOBJ 'filters?)
+			(string-append "*-Norm Key " (LLOBJ 'id))
+			"*-Norm Key-*"))
+
+	(define norm-key (PredicateNode key-name))
 
 	(define (set-norms ATOM L0 L1 L2)
 		(cog-set-value! ATOM norm-key (FloatValue L0 L1 L2)))


### PR DESCRIPTION
Filtered datasets need to have unique ID's indicating what they are.  The problem is that, when computing marginal probabilities (row and column subtotals), the value depends on what fraction of the data remains, after the junk has been filtered out.  These marginals must be given different names, so as not to confuse them with one-another.