### PR TITLE
Given a key, fetch all atoms having values at that key.

### DIFF
--- a/opencog/atomspace/AtomSpace.cc
+++ b/opencog/atomspace/AtomSpace.cc
@@ -409,7 +409,7 @@ void AtomSpace::fetch_valuations(Handle key, bool get_all_values)
     if (nullptr == key) return;
 
     // Get everything from the backing store.
-    _backing_store->getValutations(_atom_table, key, get_all_values);
+    _backing_store->getValuations(_atom_table, key, get_all_values);
 }
 
 bool AtomSpace::remove_atom(Handle h, bool recursive)

--- a/opencog/atomspace/AtomSpace.cc
+++ b/opencog/atomspace/AtomSpace.cc
@@ -400,6 +400,18 @@ Handle AtomSpace::fetch_incoming_by_type(Handle h, Type t)
     return h;
 }
 
+void AtomSpace::fetch_valuations(Handle key, bool get_all_values)
+{
+    if (nullptr == _backing_store)
+        throw RuntimeException(TRACE_INFO, "No backing store");
+
+    key = get_atom(key);
+    if (nullptr == key) return;
+
+    // Get everything from the backing store.
+    _backing_store->getValutations(_atom_table, key, get_all_values);
+}
+
 bool AtomSpace::remove_atom(Handle h, bool recursive)
 {
     if (_backing_store) {

--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -246,15 +246,13 @@ public:
     Handle get_atom(const Handle& h) const { return _atom_table.getHandle(h); }
 
     /**
-     * Load *all* atoms of the given type, but only if they are not
-     * already in the AtomTable.
+     * Use the backing store to load all atoms of the given atom type.
      */
     void fetch_all_atoms_of_type(Type t) {
         if (NULL == _backing_store)
             throw RuntimeException(TRACE_INFO, "No backing store");
         _backing_store->loadType(_atom_table, t);
     }
-
 
     /**
      * Use the backing store to load the entire incoming set of the
@@ -269,9 +267,22 @@ public:
     /**
      * Use the backing store to load the incoming set of the
      * atom, but only those atoms of the given type.
-     * The fetch is not recursive.
+     * The fetch is not recursive; that is, only the immediate,
+     * single-level incoming set is fetched.
      */
     Handle fetch_incoming_by_type(Handle, Type);
+
+    /**
+     * Use the backing store to load all atoms that have a value
+     * set for the indicated key.  This is typically used to load
+     * up a slice of a dataset: viz, to avoid loading any other atoms.
+     *
+     * If the boolean flag is set to true, then all values on the
+     * atom are fetched; otherwise, only that one value is fetched.
+     * This can save a lot of RAM, if the atoms have a lot of misc.
+     * values attached to them.
+     */
+    void fetch_valuations(Handle, bool = false);
 
     /**
      * Recursively store the atom to the backing store.

--- a/opencog/atomspace/BackingStore.h
+++ b/opencog/atomspace/BackingStore.h
@@ -75,6 +75,13 @@ class BackingStore
 		virtual void getIncomingByType(AtomTable&, const Handle&, Type) = 0;
 
 		/**
+		 * Put all atoms having a value for the key into the atomtable.
+		 * If the bool flag is set, then all values on the atom are
+		 * fetched.
+		 */
+		virtual void getValuations(AtomTable&, const Handle&, bool) = 0;
+
+		/**
 		 * Recursively store the atom and anything in it's outgoing set.
 		 * If the atom is already in storage, this will update it's
 		 * truth value, etc.

--- a/opencog/matrix/thresh-pca.scm
+++ b/opencog/matrix/thresh-pca.scm
@@ -269,7 +269,7 @@
      L(x,y) = N(x,y) / sqrt(sum_u N^2(u,y))
 
   which has the property that L(x,y) is a vector of unit length when y is
-  treated as a paramter (i.e. when y is held fixed).  The dot-product of
+  treated as a parameter (i.e. when y is held fixed).  The dot-product of
   two unit-length vectors is just the cosine of the angle between them, and
   so this can be used to construct the left cosine-similarity as
 

--- a/opencog/persist/guile/PersistSCM.cc
+++ b/opencog/persist/guile/PersistSCM.cc
@@ -89,9 +89,15 @@ Handle PersistSCM::fetch_incoming_by_type(Handle h, Type t)
 	return h;
 }
 
+void PersistSCM::fetch_valuations(Handle key, bool get_all_values)
+{
+	AtomSpace *as = SchemeSmob::ss_get_env_as("fetch-valuations");
+	as->fetch_valuations(key, get_all_values);
+}
+
 /**
  * Store the single atom to the backing store hanging off the
-  atom-space
+ * atom-space.
  */
 Handle PersistSCM::store_atom(Handle h)
 {

--- a/opencog/persist/guile/PersistSCM.h
+++ b/opencog/persist/guile/PersistSCM.h
@@ -43,7 +43,7 @@ private:
 	Handle fetch_atom(Handle);
 	Handle fetch_incoming_set(Handle);
 	Handle fetch_incoming_by_type(Handle, Type);
-	void fetchh_valuations(Handle, bool);
+	void fetch_valuations(Handle, bool);
 	Handle store_atom(Handle);
 	void load_type(Type);
 	void barrier(void);

--- a/opencog/persist/guile/PersistSCM.h
+++ b/opencog/persist/guile/PersistSCM.h
@@ -43,6 +43,7 @@ private:
 	Handle fetch_atom(Handle);
 	Handle fetch_incoming_set(Handle);
 	Handle fetch_incoming_by_type(Handle, Type);
+	void fetchh_valuations(Handle, bool);
 	Handle store_atom(Handle);
 	void load_type(Type);
 	void barrier(void);

--- a/opencog/persist/sql/AtomStorage.h
+++ b/opencog/persist/sql/AtomStorage.h
@@ -49,6 +49,7 @@ class AtomStorage
         virtual Handle getLink(Type, const HandleSeq&) = 0;
         virtual void getIncomingSet(AtomTable&, const Handle&) = 0;
         virtual void getIncomingByType(AtomTable&, const Handle&, Type) = 0;
+        virtual void getValuations(AtomTable&, const Handle&, bool) = 0;
         virtual void storeAtom(const Handle&, bool synchronous = false) = 0;
         virtual void loadType(AtomTable&, Type) = 0;
         virtual void flushStoreQueue() = 0;

--- a/opencog/persist/sql/SQLBackingStore.cc
+++ b/opencog/persist/sql/SQLBackingStore.cc
@@ -59,6 +59,11 @@ void SQLBackingStore::getIncomingByType(AtomTable& table, const Handle& h, Type 
 	_store->getIncomingByType(table, h, t);
 }
 
+void SQLBackingStore::getValuations(AtomTable& table, const Handle& key, bool get_all)
+{
+	_store->getValuations(table, key, get_all);
+}
+
 void SQLBackingStore::storeAtom(const Handle& h)
 {
 	_store->storeAtom(h);

--- a/opencog/persist/sql/SQLBackingStore.h
+++ b/opencog/persist/sql/SQLBackingStore.h
@@ -59,6 +59,7 @@ class SQLBackingStore : public BackingStore
         virtual void loadType(AtomTable&, Type);
         virtual void getIncomingSet(AtomTable&, const Handle&);
         virtual void getIncomingByType(AtomTable&, const Handle&, Type);
+        virtual void getValuations(AtomTable&, const Handle&, bool);
         virtual void barrier();
 
         void registerWith(AtomSpace*);

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
@@ -335,6 +335,8 @@ class SQLAtomStorage::Response
 			{
 				PseudoPtr pu(store->petAtom(uuid));
 				h = store->get_recursive_if_not_exists(pu);
+				h = table->add(h, false);
+				store->_tlbuf.addAtom(h, uuid);
 			}
 
 			// If user wanted all the values, then go get them.
@@ -1625,6 +1627,7 @@ void SQLAtomStorage::getValuations(AtomTable& table,
 
 	Response rp(conn_pool);
 	rp.store = this;
+	rp.table = &table;
 	rp.katom = key;
 	rp.get_all_values = get_all_values;
 	rp.exec(buff);

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
@@ -127,19 +127,23 @@ class SQLAtomStorage::Response
 		bool create_atom_column_cb(const char *colname, const char * colvalue)
 		{
 			// printf ("%s = %s\n", colname, colvalue);
-			if (!strcmp(colname, "type"))
+			// if (!strcmp(colname, "type"))
+			if ('t' == colname[0])
 			{
 				itype = atoi(colvalue);
 			}
-			else if (!strcmp(colname, "name"))
+			// else if (!strcmp(colname, "name"))
+			else if ('n' == colname[0])
 			{
 				name = colvalue;
 			}
-			else if (!strcmp(colname, "outgoing"))
+			// else if (!strcmp(colname, "outgoing"))
+			else if ('o' == colname[0])
 			{
 				outlist = colvalue;
 			}
-			else if (!strcmp(colname, "uuid"))
+			// else if (!strcmp(colname, "uuid"))
+			else if ('u' == colname[0])
 			{
 				uuid = strtoul(colvalue, NULL, 10);
 			}
@@ -266,27 +270,33 @@ class SQLAtomStorage::Response
 		bool get_value_column_cb(const char *colname, const char * colvalue)
 		{
 			// printf ("value -- %s = %s\n", colname, colvalue);
-			if (!strcmp(colname, "floatvalue"))
+			// if (!strcmp(colname, "floatvalue"))
+			if ('f' == colname[0])
 			{
 				fltval = colvalue;
 			}
-			else if (!strcmp(colname, "stringvalue"))
+			// else if (!strcmp(colname, "stringvalue"))
+			else if ('s' == colname[0])
 			{
 				strval = colvalue;
 			}
-			else if (!strcmp(colname, "linkvalue"))
+			// else if (!strcmp(colname, "linkvalue"))
+			else if ('l' == colname[0])
 			{
 				lnkval = colvalue;
 			}
-			else if (!strcmp(colname, "type"))
+			// else if (!strcmp(colname, "type"))
+			else if ('t' == colname[0])
 			{
 				vtype = atoi(colvalue);
 			}
-			else if (!strcmp(colname, "key"))
+			// else if (!strcmp(colname, "key"))
+			else if ('k' == colname[0])
 			{
 				key = atol(colvalue);
 			}
-			else if (!strcmp(colname, "atom"))
+			// else if (!strcmp(colname, "atom"))
+			else if ('a' == colname[0])
 			{
 				uuid = atol(colvalue);
 			}

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
@@ -1564,6 +1564,10 @@ void SQLAtomStorage::getIncomingByType(AtomTable& table, const Handle& h, Type t
 	getIncoming(table, buff);
 }
 
+void SQLAtomStorage::getValuations(AtomTable& table,
+                                   const Handle& key, bool get_all_values)
+{
+}
 
 /**
  * Fetch the Node with the indicated type and name.

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.h
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.h
@@ -225,6 +225,7 @@ class SQLAtomStorage : public AtomStorage
 		Handle getLink(Type, const HandleSeq&);
 		void getIncomingSet(AtomTable&, const Handle&);
 		void getIncomingByType(AtomTable&, const Handle&, Type t);
+		void getValuations(AtomTable&, const Handle&, bool get_all);
 		void storeAtom(const Handle&, bool synchronous = false);
 		void loadType(AtomTable&, Type);
 		void flushStoreQueue();

--- a/opencog/persist/sql/multi-driver/atom.sql
+++ b/opencog/persist/sql/multi-driver/atom.sql
@@ -119,6 +119,9 @@ CREATE TABLE Valuations (
 -- Index for the fast lookup of all valuations for a given atom.
 CREATE INDEX ON Valuations (atom);
 
+-- Index for the fast lookup of all valuations with a given key.
+CREATE INDEX ON Valuations (key);
+
 -- A recursive overflow table, if recursive values did not directly
 -- fit into the Valuation table.
 CREATE TABLE Values (

--- a/opencog/persist/zmq/atomspace/ZMQClient.cc
+++ b/opencog/persist/zmq/atomspace/ZMQClient.cc
@@ -171,6 +171,12 @@ void ZMQClient::getIncomingByType(AtomTable& table, const Handle& h, Type t)
 	// TODO: implement
 }
 
+void ZMQClient::getValuations(AtomTable& table,
+                              const Handle& key, bool get_all_values)
+{
+	// TODO: implement
+}
+
 /**
  * Fetch Node from database, with the indicated type and name.
  * If there is no such node, NULL is returned.

--- a/opencog/persist/zmq/atomspace/ZMQClient.h
+++ b/opencog/persist/zmq/atomspace/ZMQClient.h
@@ -87,6 +87,7 @@ class ZMQClient
 		void load(AtomTable &); // Load entire contents of DB
 		void getIncomingSet(AtomTable&, const Handle&);
 		void getIncomingByType(AtomTable&, const Handle&, Type);
+		void getValuations(AtomTable&, const Handle&, bool);
 		void store(const AtomTable &); // Store entire contents of AtomTable
 		void reserve(void);     // reserve range of UUID's
 

--- a/opencog/persist/zmq/atomspace/ZMQPersistSCM.cc
+++ b/opencog/persist/zmq/atomspace/ZMQPersistSCM.cc
@@ -52,6 +52,7 @@ class ZMQBackingStore : public BackingStore
 		virtual void loadType(AtomTable&, Type);
 		virtual void getIncomingSet(AtomTable&, const Handle&);
 		virtual void getIncomingByType(AtomTable&, const Handle&, Type);
+		virtual void getValuations(AtomTable&, const Handle&, bool);
 		virtual void barrier();
 };
 
@@ -91,6 +92,11 @@ void ZMQBackingStore::getIncomingSet(AtomTable& table, const Handle& h)
 void ZMQBackingStore::getIncomingByType(AtomTable& table, const Handle& h, Type t)
 {
 	_store->getIncomingByType(table, h, t);
+}
+
+void ZMQBackingStore::getValuations(AtomTable& table, const Handle& key, bool get_all)
+{
+	_store->getValuations(table, key, get_all);
 }
 
 void ZMQBackingStore::storeAtom(const Handle& h)

--- a/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
@@ -124,7 +124,7 @@ class ValueSaveUTest :  public CxxTest::TestSuite
         void do_test_load_by_type();
         void do_test_link_by_type();
         void do_test_incoming();
-        void do_test_load_by_key();
+        void do_test_load_by_key(bool);
 
         void test_odbc_single_atom_save();
         void test_pq_single_atom_save();
@@ -143,6 +143,9 @@ class ValueSaveUTest :  public CxxTest::TestSuite
 
         void test_odbc_load_by_key();
         void test_pq_load_by_key();
+
+        void test_odbc_load_all_key();
+        void test_pq_load_all_key();
 };
 
 /*
@@ -259,7 +262,7 @@ void ValueSaveUTest::test_odbc_load_by_key(void)
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 #if HAVE_ODBC_STORAGE
 	uri = mkuri("odbc", dbname, username, passwd);
-	do_test_load_by_key();
+	do_test_load_by_key(false);
 #endif
 	logger().debug("END TEST: %s", __FUNCTION__);
 }
@@ -269,7 +272,27 @@ void ValueSaveUTest::test_pq_load_by_key(void)
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 #if HAVE_PGSQL_STORAGE
 	uri = mkuri("postgres", dbname, username, passwd);
-	do_test_load_by_key();
+	do_test_load_by_key(false);
+#endif // HAVE_PGSQL_STORAGE
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+void ValueSaveUTest::test_odbc_load_all_key(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+#if HAVE_ODBC_STORAGE
+	uri = mkuri("odbc", dbname, username, passwd);
+	do_test_load_by_key(true);
+#endif
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+void ValueSaveUTest::test_pq_load_all_key(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+#if HAVE_PGSQL_STORAGE
+	uri = mkuri("postgres", dbname, username, passwd);
+	do_test_load_by_key(true);
 #endif // HAVE_PGSQL_STORAGE
 	logger().debug("END TEST: %s", __FUNCTION__);
 }
@@ -1021,7 +1044,7 @@ void ValueSaveUTest::do_test_incoming()
 // Test the fetch_valuations() method in the atomspace.
 // The fetch should restore only certain values, and NOT the
 // truth values.
-void ValueSaveUTest::do_test_load_by_key()
+void ValueSaveUTest::do_test_load_by_key(bool get_all_values)
 {
 	SQLAtomStorage *store = new SQLAtomStorage(uri);
 	TS_ASSERT(store->connected())
@@ -1100,7 +1123,7 @@ void ValueSaveUTest::do_test_load_by_key()
 	// --------------------
 	// Fetch by type. This is what we are testing.
 	Handle gkey = as->add_node(PREDICATE_NODE, "some pred key");
-	as->fetch_valuations(gkey);
+	as->fetch_valuations(gkey, get_all_values);
 
 	Handle gaf = as->add_node(CONCEPT_NODE, "float node");
 	Handle gat = as->add_node(CONCEPT_NODE, "string node");
@@ -1117,16 +1140,26 @@ void ValueSaveUTest::do_test_load_by_key()
 	TruthValuePtr gtl = gal->getTruthValue();
 	TruthValuePtr gtv = gav->getTruthValue();
 
-	TS_ASSERT(*gtf != *tf);
-	TS_ASSERT(*gtt != *tt);
-	TS_ASSERT(*gtl != *tl);
-	TS_ASSERT(*gtv != *tv);
+	if (get_all_values)
+	{
+		TS_ASSERT(*gtf == *tf);
+		TS_ASSERT(*gtt == *tt);
+		TS_ASSERT(*gtl == *tl);
+		TS_ASSERT(*gtv == *tv);
+	}
+	else
+	{
+		TS_ASSERT(*gtf != *tf);
+		TS_ASSERT(*gtt != *tt);
+		TS_ASSERT(*gtl != *tl);
+		TS_ASSERT(*gtv != *tv);
 
-	// We expect the truth values to be untouched.
-	TS_ASSERT(*gtf == *TruthValue::DEFAULT_TV());
-	TS_ASSERT(*gtt == *TruthValue::DEFAULT_TV());
-	TS_ASSERT(*gtl == *TruthValue::DEFAULT_TV());
-	TS_ASSERT(*gtv == *TruthValue::DEFAULT_TV());
+		// We expect the truth values to be untouched.
+		TS_ASSERT(gtf == TruthValue::DEFAULT_TV());
+		TS_ASSERT(gtt == TruthValue::DEFAULT_TV());
+		TS_ASSERT(gtl == TruthValue::DEFAULT_TV());
+		TS_ASSERT(gtv == TruthValue::DEFAULT_TV());
+	}
 
 	ProtoAtomPtr gpf = gaf->getValue(gkey);
 	ProtoAtomPtr gpt = gat->getValue(gkey);

--- a/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
@@ -1133,6 +1133,11 @@ void ValueSaveUTest::do_test_load_by_key()
 	ProtoAtomPtr gpl = gal->getValue(gkey);
 	ProtoAtomPtr gpv = gav->getValue(gkey);
 
+	TS_ASSERT(gpf != nullptr);
+	TS_ASSERT(gpt != nullptr);
+	TS_ASSERT(gpl != nullptr);
+	TS_ASSERT(gpv != nullptr);
+
 	TS_ASSERT(*gpf == *pvf);
 	TS_ASSERT(*gpt == *pvt);
 	TS_ASSERT(*gpl == *pvl);

--- a/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
@@ -124,6 +124,7 @@ class ValueSaveUTest :  public CxxTest::TestSuite
         void do_test_load_by_type();
         void do_test_link_by_type();
         void do_test_incoming();
+        void do_test_load_by_key();
 
         void test_odbc_single_atom_save();
         void test_pq_single_atom_save();
@@ -139,6 +140,9 @@ class ValueSaveUTest :  public CxxTest::TestSuite
 
         void test_odbc_incoming();
         void test_pq_incoming();
+
+        void test_odbc_load_by_key();
+        void test_pq_load_by_key();
 };
 
 /*
@@ -246,6 +250,26 @@ void ValueSaveUTest::test_pq_incoming(void)
 #if HAVE_PGSQL_STORAGE
 	uri = mkuri("postgres", dbname, username, passwd);
 	do_test_incoming();
+#endif // HAVE_PGSQL_STORAGE
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+void ValueSaveUTest::test_odbc_load_by_key(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+#if HAVE_ODBC_STORAGE
+	uri = mkuri("odbc", dbname, username, passwd);
+	do_test_load_by_key();
+#endif
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+void ValueSaveUTest::test_pq_load_by_key(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+#if HAVE_PGSQL_STORAGE
+	uri = mkuri("postgres", dbname, username, passwd);
+	do_test_load_by_key();
 #endif // HAVE_PGSQL_STORAGE
 	logger().debug("END TEST: %s", __FUNCTION__);
 }
@@ -442,7 +466,7 @@ void ValueSaveUTest::do_test_save_restore(bool fkey)
 
 // Test the fetch_all_atoms_of_type() method in the atomspace.
 // The fetch should restore the truth values, and the other values,
-// as well.  This tests the fetchinf of nodes.
+// as well.  This tests the fetching of nodes.
 void ValueSaveUTest::do_test_load_by_type()
 {
 	SQLAtomStorage *store = new SQLAtomStorage(uri);
@@ -979,6 +1003,135 @@ void ValueSaveUTest::do_test_incoming()
 	gpt = gct->getValue(gkey);
 	gpl = gcl->getValue(gkey);
 	gpv = gcv->getValue(gkey);
+
+	TS_ASSERT(*gpf == *pvf);
+	TS_ASSERT(*gpt == *pvt);
+	TS_ASSERT(*gpl == *pvl);
+	TS_ASSERT(*gpv == *pvv);
+
+	// --------------------
+	store->kill_data();
+	delete as;
+	delete backing;
+	delete store;
+}
+
+// ============================================================
+
+// Test the fetch_valuations() method in the atomspace.
+// The fetch should restore only certain values, and NOT the
+// truth values.
+void ValueSaveUTest::do_test_load_by_key()
+{
+	SQLAtomStorage *store = new SQLAtomStorage(uri);
+	TS_ASSERT(store->connected())
+
+	// Clear out left-over junk, just in case.
+	store->kill_data();
+
+	AtomSpace* as = new AtomSpace();
+	SQLBackingStore* backing = new SQLBackingStore();
+	backing->set_store(store);
+	backing->registerWith(as);
+
+	Handle key = as->add_node(PREDICATE_NODE, "some pred key");
+	Handle af = as->add_node(CONCEPT_NODE, "float node");
+	Handle at = as->add_node(CONCEPT_NODE, "string node");
+	Handle al = as->add_node(CONCEPT_NODE, "link depth-1 node");
+	Handle av = as->add_node(CONCEPT_NODE, "link depth-2 node");
+
+	// --------------------
+	// Now set some values
+	ProtoAtomPtr pvf = createFloatValue(
+		std::vector<double>({1.1098765432109876, 2.1234567890123456e37,
+		                     3.2109876543210987e-250}));
+	af->setValue(key, pvf);
+
+	TruthValuePtr tf(SimpleTruthValue::createTV(0.11, 100));
+	af->setTruthValue(tf);
+
+	// --------------------
+	ProtoAtomPtr pvt = createStringValue(
+		std::vector<std::string>({"aaa", "bb bb bb", "ccc ccc ccc"}));
+	at->setValue(key, pvt);
+
+	TruthValuePtr tt(SimpleTruthValue::createTV(0.22, 200));
+	at->setTruthValue(tt);
+
+	// --------------------
+	ProtoAtomPtr pvl = createLinkValue(
+		std::vector<ProtoAtomPtr>({pvf, pvt}));
+	al->setValue(key, pvl);
+
+	TruthValuePtr tl(SimpleTruthValue::createTV(0.33, 300));
+	al->setTruthValue(tl);
+
+	// --------------------
+	ProtoAtomPtr pvv = createLinkValue(
+		std::vector<ProtoAtomPtr>({pvl, pvl, pvf, pvt}));
+	av->setValue(key, pvv);
+
+	TruthValuePtr tv(SimpleTruthValue::createTV(0.44, 400));
+	av->setTruthValue(tv);
+
+	// --------------------
+	// Save, and close things down.
+	as->store_atom(af);
+	as->store_atom(at);
+	as->store_atom(al);
+	as->store_atom(av);
+	as->barrier();
+
+	delete as;
+	delete backing;
+	delete store;
+
+	// --------------------
+	// Start it up again.
+
+	store = new SQLAtomStorage(uri);
+	TS_ASSERT(store->connected())
+
+	as = new AtomSpace();
+	backing = new SQLBackingStore();
+	backing->set_store(store);
+	backing->registerWith(as);
+
+	// --------------------
+	// Fetch by type. This is what we are testing.
+	Handle gkey = as->add_node(PREDICATE_NODE, "some pred key");
+	as->fetch_valuations(gkey);
+
+	Handle gaf = as->add_node(CONCEPT_NODE, "float node");
+	Handle gat = as->add_node(CONCEPT_NODE, "string node");
+	Handle gal = as->add_node(CONCEPT_NODE, "link depth-1 node");
+	Handle gav = as->add_node(CONCEPT_NODE, "link depth-2 node");
+
+	TS_ASSERT(*gaf == *af);
+	TS_ASSERT(*gat == *at);
+	TS_ASSERT(*gal == *al);
+	TS_ASSERT(*gav == *av);
+
+	TruthValuePtr gtf = gaf->getTruthValue();
+	TruthValuePtr gtt = gat->getTruthValue();
+	TruthValuePtr gtl = gal->getTruthValue();
+	TruthValuePtr gtv = gav->getTruthValue();
+
+	TS_ASSERT(*gtf != *tf);
+	TS_ASSERT(*gtt != *tt);
+	TS_ASSERT(*gtl != *tl);
+	TS_ASSERT(*gtv != *tv);
+
+	// We expect the truth values to be untouched.
+	TS_ASSERT(*gtf == *TruthValue::DEFAULT_TV());
+	TS_ASSERT(*gtt == *TruthValue::DEFAULT_TV());
+	TS_ASSERT(*gtl == *TruthValue::DEFAULT_TV());
+	TS_ASSERT(*gtv == *TruthValue::DEFAULT_TV());
+
+	ProtoAtomPtr gpf = gaf->getValue(gkey);
+	ProtoAtomPtr gpt = gat->getValue(gkey);
+	ProtoAtomPtr gpl = gal->getValue(gkey);
+	ProtoAtomPtr gpv = gav->getValue(gkey);
 
 	TS_ASSERT(*gpf == *pvf);
 	TS_ASSERT(*gpt == *pvt);


### PR DESCRIPTION
For example, if you've stored some value at the key "foobar", this will fetch all atoms that have that key set, and then fetch the value to go with it.  This allows large subsets of a dataset to be loaded without loading all of it.  For example, if a database of word-pairs has a truth value for each pair, (e.g. a count) and also a frequency, and also an MI value, and also a cosine-distance value, this allows only one of these to be fetched, without loading up the others, thus avoiding filling up RAM with unwanted data.

Yes, using too much RAM is becoming a big problem... taking too long to load is also a big problem.