### PR TITLE
Use rule alias instead of definition in expansion trace

### DIFF
--- a/opencog/rule-engine/backwardchainer/TraceRecorder.cc
+++ b/opencog/rule-engine/backwardchainer/TraceRecorder.cc
@@ -44,7 +44,7 @@ void TraceRecorder::expansion(const Handle& andbit_fcs, const Handle& bitleaf_bo
 {
 	add_execution(expand_andbit_predicate_name,
 	              dont_exec(andbit_fcs), bitleaf_body,
-	              dont_exec(rule.get_definition()),
+	              dont_exec(rule.get_alias()),
 	              dont_exec(new_andbit.fcs), TruthValue::TRUE_TV());
 }
 


### PR DESCRIPTION
To be more human readable. This might be a problem though for rules
that have no names, or to find patterns within rules (though its
definition should be expandable for such purpose).