### PR TITLE
Add class for computing similarities.

### DIFF
--- a/opencog/guile/SchemeSmobNew.cc
+++ b/opencog/guile/SchemeSmobNew.cc
@@ -134,6 +134,8 @@ SCM SchemeSmob::handle_to_scm (const Handle& h)
 
 SCM SchemeSmob::protom_to_scm (const ProtoAtomPtr& pa)
 {
+	if (nullptr == pa) return SCM_EOL;
+
 	// Use new so that the smart pointer increments!
 	ProtoAtomPtr* pap = new ProtoAtomPtr(pa);
 	scm_gc_register_allocation(sizeof(pa));

--- a/opencog/matrix/CMakeLists.txt
+++ b/opencog/matrix/CMakeLists.txt
@@ -9,6 +9,7 @@ ADD_GUILE_MODULE (FILES
 	fold-api.scm
 	loop-api.scm
 	object-api.scm
+	similarity-api.scm
 	support.scm
 	report-api.scm
 	thresh-pca.scm

--- a/opencog/matrix/README.md
+++ b/opencog/matrix/README.md
@@ -61,9 +61,13 @@ Q: Why isn't this in C++?  Surely, numerical computations would be
 
 A: Yes, probably. But its a lot easier to write scheme code than
    it is to write C++ code, and so prototyping in scheme just made
-   more sense. It was just-plain simpler, faster, easier. You are
-   invited to take the lessons learned, and re-implement in C++.
-   The number #1 most important lesson is that the filter object
+   more sense. It was just-plain simpler, faster, easier (for me).
+   You are invited to take the lessons learned, and re-implement
+   in C++.
+
+Q: What were the lessons learned?
+
+A: The number #1 most important lesson is that the filter object
    is the most important object: it controls what data you want
    to keep, and what data you want to discard, and it needs to
    run "underneath", as a foundation to everything else.
@@ -72,7 +76,9 @@ Q: Really, C++ is sooo fast...
 
 A: Yes, but since the data is stored in values associated with
    atoms in the atomspace, adding numbers together is NOT the
-   bottleneck. Accessing Atom Values *is* the bottleneck. Soooo...
+   bottleneck. Accessing Atom Values *is* the bottleneck. Finding
+   a good performance optimization for the atom values framework
+   is a lot harder.
 
 Q: Why don't you just export all your data to SciPy or to Gnu R, or to
    Octave, or MatLab, for that matter, and just do your data analytics
@@ -113,8 +119,7 @@ A: You would use Rcpp at http://dirk.eddelbuettel.com/code/rcpp.html
    structures can be accessed as easily at the C++ level, and used in
    the normal manner. The mapping of data types works in both
    directions. It is as straightforward to pass data from R to C++,
-   as it is it return data from C++ to R. The following two sections
-   list supported data types.
+   as it is it return data from C++ to R.
 
 
 Generic Programming

--- a/opencog/matrix/cosine-api.scm
+++ b/opencog/matrix/cosine-api.scm
@@ -1,0 +1,44 @@
+;
+; cosine-api.scm
+;
+; Provide framework to fetch/store similarity values.
+;
+; Copyright (c) 2017 Linas Vepstas
+;
+; ---------------------------------------------------------------------
+; OVERVIEW
+; --------
+; There is a generic need to work with similarity values between pairs
+; of things. These are usually CPU-intensive to compute, and are usually
+; non-sparse: i.e. the similarity between N items requires an NxN
+; matrix.  The below provides an API to work with similarities.
+; Specifically, it provides an API so that similarities can be stored
+; in the atomspace (i.e. so that they don't need to be recomputed).
+;
+; ---------------------------------------------------------------------
+;
+(use-modules (srfi srfi-1))
+(use-modules (opencog))
+
+; ---------------------------------------------------------------------
+; ---------------------------------------------------------------------
+;
+; Extend the LLOBJ with additional methods to loop over all pairs
+; in a matrix.
+;
+(define-public (add-similarity-api LLOBJ)
+
+	; We need 'left-basis, provided by add-pair-stars
+	(let ((wldobj (add-pair-stars LLOBJ)))
+
+		; Methods on this class.
+		(lambda (message . args)
+			(case message
+				((map-pair)       (apply map-right-outer args))
+
+				(else             (apply LLOBJ (cons message args))))
+		))
+)
+
+; ---------------------------------------------------------------------
+; ---------------------------------------------------------------------

--- a/opencog/matrix/cosine-api.scm
+++ b/opencog/matrix/cosine-api.scm
@@ -15,6 +15,22 @@
 ; Specifically, it provides an API so that similarities can be stored
 ; in the atomspace (i.e. so that they don't need to be recomputed).
 ;
+; It is assumed that similarity scores are symmetric, so that exchanging
+; left and right give the same answer.  Thus, an UnorderedLink is best for
+; storing the pair. Specifically, the SimilarityLink.  So,
+;
+;    SimilarityLink
+;        Atom "this"
+;        Atom "that"
+;
+; and
+;
+;    SimilarityLink
+;        Atom "that"
+;        Atom "this"
+;
+; are both exactly the same atom.
+;
 ; ---------------------------------------------------------------------
 ;
 (use-modules (srfi srfi-1))
@@ -27,16 +43,35 @@
 ; in a matrix.
 ;
 (define-public (add-similarity-api LLOBJ)
+"
+  add-similarity-api - Add API to batch-compute and access similarity
+  values between rows or columns of the LLOBJ.  This creates
+  a new NON-sparse matrix that can be understood as a kind-of matrix
+  product of LLOBJ with it's transpose.
 
+  If TRANSP? is #f, then the matrix 
+"
 	; We need 'left-basis, provided by add-pair-stars
 	(let ((wldobj (add-pair-stars LLOBJ)))
+
+		(define pair-sim-type 'SimilarityLink)
+		(define cos-key (PredicateNode "*-Cosine Distance Key-*"))
+
+		; fetch-sim-pairs - fetch all SimilarityLinks from the database.
+		(define (fetch-sim-pairs)
+			(define start-time (current-time))
+			(load-atoms-of-type pair-sim-type)
+			(format #t "Elapsed time to load sims: ~A secs\n"
+				(- (current-time) start-time)))
 
 		; Methods on this class.
 		(lambda (message . args)
 			(case message
-				((map-pair)       (apply map-right-outer args))
+				((pair-type)      pair-sim-type)
+				((fetch-pairs)    (fetch-sim-pairs))
 
-				(else             (apply LLOBJ (cons message args))))
+				; (else             (apply LLOBJ (cons message args))))
+				(else (error "Bad method call on similarity API:" message))))
 		))
 )
 

--- a/opencog/matrix/matrix.scm
+++ b/opencog/matrix/matrix.scm
@@ -18,4 +18,5 @@
 (load "matrix/entropy.scm")
 (load "matrix/compute-mi.scm")
 (load "matrix/filter.scm")
+(load "matrix/similarity-api.scm")
 (load "matrix/thresh-pca.scm")

--- a/opencog/matrix/similarity-api.scm
+++ b/opencog/matrix/similarity-api.scm
@@ -127,9 +127,10 @@
 	(ID #f)
 	(CUTOFF 0.5)
 	(SIM-FUN
-		(if MTM?
-			(lambda (x y) (LLOBJ 'left-cosine x y))
-			(lambda (x y) (LLOBJ 'right-cosine x y))))
+		(let ((acc (add-pair-cosine-compute LLOBJ)))
+			(if MTM?
+				(lambda (x y) (acc 'left-cosine x y))
+				(lambda (x y) (acc 'right-cosine x y)))))
 	)
 "
   batch-similarity - Add API to batch-compute similarity values between

--- a/opencog/matrix/similarity-api.scm
+++ b/opencog/matrix/similarity-api.scm
@@ -35,7 +35,7 @@
 ;
 (use-modules (srfi srfi-1))
 (use-modules (ice-9 optargs)) ; for define*-public
-(use-modules (opencog))
+(use-modules (opencog) (opencog persist))
 
 ; ---------------------------------------------------------------------
 ; ---------------------------------------------------------------------
@@ -43,7 +43,7 @@
 ; Extend the LLOBJ with additional methods to loop over all pairs
 ; in a matrix.
 ;
-(define-public (add-similarity-api LLOBJ MTM?
+(define*-public (add-similarity-api LLOBJ MTM?
 	#:optional
 	(ID #f)
 	(CUTOFF 0.5)
@@ -129,9 +129,9 @@
 				((set-pair-similarity) (apply set-sim args))
 				((compute-similarity)  (apply compute-sim args))
 
-				; (else             (apply LLOBJ (cons message args))))
-				(else (error "Bad method call on similarity API:" message))))
-		))
+				; (else             (apply LLOBJ (cons message args)))
+				(else (error "Bad method call on similarity API:" message))
+		)))
 )
 
 ; ---------------------------------------------------------------------

--- a/opencog/matrix/similarity-api.scm
+++ b/opencog/matrix/similarity-api.scm
@@ -161,37 +161,14 @@
 					simv)))
 
 		; Compute and store the similarity between the ITRM, and the
-		; other items in the ITEM-LIST.  Do NOT actually cache the similarity
-		; value, if it is less than CUTOFF.  This is used to avoid having
-		; N-squared pairs cluttering the atomspace.
+		; other items in the ITEM-LIST.  Do NOT actually cache the
+		; similarity value, if it is less than CUTOFF.  This is used
+		; to avoid having N-squared pairs cluttering the atomspace.
 		;
-		(define (batch-sim WORD WORD-LIST CUTOFF)
-
-			(define cnt 0)
-
-			(define (get-angle SIM)
-				(define pi 3.14159265358979)
-				; Stupid-ass guile return a small imaginary number when taking
-				; the arccos of 1.0. WTF.  So we need to take the real part!!
-				(* 2.0 (/ (real-part (acos SIM)) pi))
-			)
-
-			(define (set-sim WORD-A WORD-B SIM)
-				(cog-set-value!
-					(sim-pair WORD-A WORD-B) cos-key
-					(FloatValue SIM (get-angle SIM))))
-
+		(define (batch-simlist ITEM ITEM-LIST)
 			(for-each
-				(lambda (wrd)
-					(define sim (cset-vec-cosine WORD wrd))
-					(if (and (< CUTOFF sim) (not (equal? WORD wrd)))
-						(begin
-							(set! cnt (+ 1 cnt))
-							(store-atom (set-sim WORD wrd sim)))))
-				WORD-LIST)
-		
-			cnt
-		)
+				(lambda (item) (compute-sim ITEM item))
+				WORD-LIST))
 
 		; batch-sim-pairs - batch compute a bunch of them.
 		(define (batch-sim-pairs)

--- a/opencog/matrix/similarity-api.scm
+++ b/opencog/matrix/similarity-api.scm
@@ -43,7 +43,7 @@
 ; Extend the LLOBJ with additional methods to access similarity scores.
 ;
 (define*-public (add-similarity-api LLOBJ MTM?
-	#:optional (ID #f)
+	#:optional (ID #f))
 "
   add-similarity-api - Add API to access similarity values between
   rows or columns of the LLOBJ.  This creates a new NON-sparse matrix
@@ -143,7 +143,7 @@
 "
 	; We need 'left-basis, provided by add-pair-stars
 	(let* ((wldobj (add-pair-stars LLOBJ))
-			(simobj (add-similarity-api wldobj))
+			(simobj (add-similarity-api wldobj MTM? ID))
 			(pair-sim-type (simobj 'pair-type))
 		)
 
@@ -154,10 +154,10 @@
 		(define (compute-sim A B)
 			(define mpr (cog-link pair-sim-type A B))
 			(if (not (null? mpr))
-				(sim-obj 'pair-similarity mpr)
+				(simobj 'pair-similarity mpr)
 				(let ((simv (SIM-FUN A B)))
 					(if (< 0.5 simv)
-						(sim-obj 'set-pair-similarity (cog-new-link pair-sim-type A B) simv))
+						(simobj 'set-pair-similarity (cog-new-link pair-sim-type A B) simv))
 					simv)))
 
 		; Compute and store the similarity between the ITEM, and the
@@ -168,7 +168,7 @@
 		(define (batch-simlist ITEM ITEM-LIST)
 			(for-each
 				(lambda (item) (compute-sim ITEM item))
-				WORD-LIST)
+				ITEM-LIST)
 			(length ITEM-LIST) ; bogus return value
 		)
 
@@ -230,7 +230,7 @@
 
 			(define (do-one-and-rpt ITM-LST)
 				; These sets are not thread-safe but I don't care.
-				(set! prs (+ prs (batch-simlist (car ITM-LST) (cdr ITM-LST) CUTOFF)))
+				(set! prs (+ prs (batch-simlist (car ITM-LST) (cdr ITM-LST))))
 				(set! done (+ done 1))
 				(if (eqv? 0 (modulo done 20))
 					(let* ((elapsed (- (current-time) start))

--- a/opencog/matrix/similarity-api.scm
+++ b/opencog/matrix/similarity-api.scm
@@ -175,9 +175,9 @@
 		; Loop over the entire list of items, and compute similarity
 		; scores between pairs of them.  This might take a very long time!
 		; Serial version, see also parallel version below.
-		(define (batch-sim-pairs ITM-LIST)
+		(define (batch-sim-pairs ITEM-LIST)
 
-			(define len (length ITM-LIST))
+			(define len (length ITEM-LIST))
 			(define tot (* 0.5 len (- len 1)))
 			(define done 0)
 			(define prs 0)
@@ -207,17 +207,13 @@
 				)))
 
 			; tail-recursive list-walker.
-			(define (make-pairs WRD-LST)
-				(if (not (null? WRD-LST))
+			(define (make-pairs ITM-LST)
+				(if (not (null? ITM-LST))
 					(begin
-						(do-one-and-rpt WRD-LST)
-						(make-pairs (cdr WRD-LST)))))
+						(do-one-and-rpt ITM-LST)
+						(make-pairs (cdr ITM-LST)))))
 
-			(make-pairs WORD-LIST)
-)
-		; batch-sim-pairs - batch compute a bunch of them.
-		(define (batch-sim-pairs)
-			(define 
+			(make-pairs ITEM-LIST)
 		)
 
 		; Methods on this class.
@@ -234,16 +230,11 @@
 ; ---------------------------------------------------------------------
 ; ---------------------------------------------------------------------
 
-; ---------------------------------------------------------------------
-
-
-; ---------------------------------------------------------------------
-
 ; Loop over the entire list of words, and compute similarity scores
 ; for them.  Hacked parallel version.
-(define (para-batch-sim-pairs WORD-LIST CUTOFF)
+(define (para-batch-sim-pairs ITEM-LIST CUTOFF)
 
-	(define len (length WORD-LIST))
+	(define len (length ITEM-LIST))
 	(define tot (* 0.5 len (- len 1)))
 	(define done 0)
 	(define prs 0)
@@ -290,32 +281,7 @@
 				(call-with-new-thread (lambda () (make-pairs WRD-LST)))
 				(launch (cdr WRD-LST) (- CNT 1)))))
 
-	(launch WORD-LIST nthreads)
+	(launch ITEM-LIST nthreads)
 
 	(format #t "Started ~d threads\n" nthreads)
 )
-
-; ---------------------------------------------------------------------
-; Example usage:
-;
-; (use-modules (opencog) (opencog persist) (opencog persist-sql))
-; (use-modules (opencog nlp) (opencog nlp learn))
-; (sql-open "postgres:///en_pairs_sim?user=linas")
-; (sql-open "postgres:///en_pairs_supersim?user=linas")
-; (use-modules (opencog cogserver))
-; (start-cogserver "opencog2.conf")
-; (fetch-all-words)
-; (define pca (make-pseudo-cset-api))
-; (pca 'fetch-pairs)
-; (define ac (get-all-cset-words))
-; (length ac)
-; 37413
-; (define ad (get-all-disjuncts))
-; (length ad)
-; 291637
-;
-; (define firm (filter (lambda (wrd) (< 8.0 (cset-vec-word-len wrd))) ac))
-; (length firm)
-; 1985
-;
-; (batch-sim-pairs firm)

--- a/opencog/matrix/similarity-api.scm
+++ b/opencog/matrix/similarity-api.scm
@@ -66,7 +66,7 @@
 				(string-append "Similarity Matrix " ID)
 				(string-append
 					(if MTM? "Left" "Right")
-					(" Cosine Similarity Matrix"))))
+					" Cosine Similarity Matrix")))
 
 		; The type of the rows and columns in the composite matrix.
 		(define item-type

--- a/opencog/matrix/similarity-api.scm
+++ b/opencog/matrix/similarity-api.scm
@@ -294,8 +294,7 @@
 				((batch-compute)       (batch))
 				((paralel-batch)       (apply para-batch args))
 
-				; (else             (apply LLOBJ (cons message args)))
-				(else (error "Bad method call on similarity API:" message))
+				(else                  (apply LLOBJ (cons message args)))
 		)))
 )
 

--- a/opencog/scm/opencog.scm
+++ b/opencog/scm/opencog.scm
@@ -110,5 +110,5 @@
 (load-from-path "opencog/base/debug-trace.scm")
 
 ; Obsolete functions
-(define-public (cog-atom X) '())
-(define-public (cog-undefined-handle) '())
+(define-public (cog-atom X) "obsolete function" '())
+(define-public (cog-undefined-handle) "obsolete function" '())


### PR DESCRIPTION
The similarity between pairs of rows or columns can be thought of as a pair-wise relation. This slaps a pair API onto that relationship,  finally obsoleting some  code in the opencog repo.