### PR TITLE
Support backtracking to a glob-containing clause in pattern matcher

### DIFF
--- a/opencog/query/InitiateSearchCB.cc
+++ b/opencog/query/InitiateSearchCB.cc
@@ -398,9 +398,9 @@ bool InitiateSearchCB::neighbor_search(PatternMatchEngine *pme)
 			              << h->toShortString();})
 			bool found = pme->explore_neighborhood(_root, _starter_term, h);
 
-			// If the starter term has globs in it and it's possible to
-			// ground it to the same candidate in a different way, go for
-			// it, before moving on to the next candidates.
+			// If the starter term (or any other term we've explored) has globs
+			// in it and it's possible to ground it to the same candidate
+			// differently, go for it, before moving on to the next candidates.
 			if (not found and pme->has_more_to_explore())
 				pme->explore_neighborhood(_root, _starter_term, h);
 
@@ -643,6 +643,13 @@ bool InitiateSearchCB::link_type_search(PatternMatchEngine *pme)
 		              << "Loop candidate (" << ++i << "/" << hsz << "):\n"
 		              << h->toShortString();})
 		bool found = pme->explore_neighborhood(_root, _starter_term, h);
+
+		// If the starter term (or any other term we've explored) has globs
+		// in it and it's possible to ground it to the same candidate
+		// differently, go for it, before moving on to the next candidates.
+		if (not found and pme->has_more_to_explore())
+			pme->explore_neighborhood(_root, _starter_term, h);
+
 		if (found) return true;
 	}
 	return false;
@@ -814,6 +821,13 @@ bool InitiateSearchCB::variable_search(PatternMatchEngine *pme)
 		              << "Loop candidate (" << ++i << "/" << hsz << "):\n"
 		              << h->toShortString();})
 		bool found = pme->explore_neighborhood(_root, _starter_term, h);
+
+		// If the starter term (or any other term we've explored) has globs
+		// in it and it's possible to ground it to the same candidate
+		// differently, go for it, before moving on to the next candidates.
+		if (not found and pme->has_more_to_explore())
+			pme->explore_neighborhood(_root, _starter_term, h);
+
 		if (found) return true;
 	}
 

--- a/opencog/query/InitiateSearchCB.cc
+++ b/opencog/query/InitiateSearchCB.cc
@@ -398,6 +398,12 @@ bool InitiateSearchCB::neighbor_search(PatternMatchEngine *pme)
 			              << h->toShortString();})
 			bool found = pme->explore_neighborhood(_root, _starter_term, h);
 
+			// If the starter term has globs in it and it's possible to
+			// ground it to the same candidate in a different way, go for
+			// it, before moving on to the next candidates.
+			if (not found and pme->has_more_to_explore())
+				pme->explore_neighborhood(_root, _starter_term, h);
+
 			// Terminate search if satisfied.
 			if (found) return true;
 		}

--- a/opencog/query/InitiateSearchCB.cc
+++ b/opencog/query/InitiateSearchCB.cc
@@ -402,7 +402,7 @@ bool InitiateSearchCB::neighbor_search(PatternMatchEngine *pme)
 			// in it and it's possible to ground it to the same candidate
 			// differently, go for it, before moving on to the next candidates.
 			if (not found and pme->has_more_to_explore())
-				pme->explore_neighborhood(_root, _starter_term, h);
+				found = pme->explore_neighborhood(_root, _starter_term, h);
 
 			// Terminate search if satisfied.
 			if (found) return true;
@@ -648,7 +648,7 @@ bool InitiateSearchCB::link_type_search(PatternMatchEngine *pme)
 		// in it and it's possible to ground it to the same candidate
 		// differently, go for it, before moving on to the next candidates.
 		if (not found and pme->has_more_to_explore())
-			pme->explore_neighborhood(_root, _starter_term, h);
+			found = pme->explore_neighborhood(_root, _starter_term, h);
 
 		if (found) return true;
 	}
@@ -826,7 +826,7 @@ bool InitiateSearchCB::variable_search(PatternMatchEngine *pme)
 		// in it and it's possible to ground it to the same candidate
 		// differently, go for it, before moving on to the next candidates.
 		if (not found and pme->has_more_to_explore())
-			pme->explore_neighborhood(_root, _starter_term, h);
+			found = pme->explore_neighborhood(_root, _starter_term, h);
 
 		if (found) return true;
 	}

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -683,7 +683,7 @@ bool PatternMatchEngine::glob_compare(const PatternTermSeq& osp,
                                       const HandleSeq& osg)
 {
 	bool match = true;
-	GlobSeq gseq = {osp, osg};
+	GlobSeq gpair = {osp, osg};
 	size_t osp_size = osp.size();
 	size_t osg_size = osg.size();
 
@@ -696,7 +696,7 @@ bool PatternMatchEngine::glob_compare(const PatternTermSeq& osp,
 	size_t jg = 0;
 
 	// Resume from the previous state, if any
-	auto ss = glob_state.find(gseq);
+	auto ss = glob_state.find(gpair);
 	if (ss != glob_state.end())
 	{
 		glob_grd = (ss->second).first;
@@ -725,7 +725,7 @@ bool PatternMatchEngine::glob_compare(const PatternTermSeq& osp,
 			ip = glob_pos.top().first - 1;
 			jg = glob_pos.top().second - 1;
 			glob_pos.pop();
-			glob_state[gseq] = {glob_grd, glob_pos};
+			glob_state[gpair] = {glob_grd, glob_pos};
 
 			// Clear any groundings for the last glob we've seen.
 			var_grounding.erase(osp[ip+1]->getHandle());
@@ -739,7 +739,7 @@ bool PatternMatchEngine::glob_compare(const PatternTermSeq& osp,
 			if (ohp == osg[jg]) return false;
 
 			glob_pos.push({ip, jg});
-			glob_state[gseq] = {glob_grd, glob_pos};
+			glob_state[gpair] = {glob_grd, glob_pos};
 
 			size_t last_grd = SIZE_MAX;
 			auto gi = glob_grd.find(ohp);
@@ -756,7 +756,7 @@ bool PatternMatchEngine::glob_compare(const PatternTermSeq& osp,
 					// of atoms, it's not a match.
 					glob_grd.erase(ohp);
 					glob_pos.pop();
-					glob_state[gseq] = {glob_grd, glob_pos};
+					glob_state[gpair] = {glob_grd, glob_pos};
 					last_grd = SIZE_MAX;
 
 					// Reject the candidate if we cannot find a
@@ -789,7 +789,7 @@ bool PatternMatchEngine::glob_compare(const PatternTermSeq& osp,
 				if (grd_end)
 				{
 					glob_grd[ohp] = 0;
-					glob_state[gseq] = {glob_grd, glob_pos};
+					glob_state[gpair] = {glob_grd, glob_pos};
 					var_grounding.erase(ohp);
 					continue;
 				}
@@ -802,7 +802,7 @@ bool PatternMatchEngine::glob_compare(const PatternTermSeq& osp,
 				{
 					jg --;
 					glob_grd[ohp] = 0;
-					glob_state[gseq] = {glob_grd, glob_pos};
+					glob_state[gpair] = {glob_grd, glob_pos};
 					var_grounding.erase(ohp);
 					continue;
 				}
@@ -813,7 +813,7 @@ bool PatternMatchEngine::glob_compare(const PatternTermSeq& osp,
 			if (grd_end)
 			{
 				glob_grd[ohp] = 0;
-				glob_state[gseq] = {glob_grd, glob_pos};
+				glob_state[gpair] = {glob_grd, glob_pos};
 				reset();
 				continue;
 			}
@@ -840,7 +840,7 @@ bool PatternMatchEngine::glob_compare(const PatternTermSeq& osp,
 
 			jg --;
 			glob_grd[ohp] = glob_seq.size();
-			glob_state[gseq] = {glob_grd, glob_pos};
+			glob_state[gpair] = {glob_grd, glob_pos};
 
 			// If we can't match more, or it doesn't satisfy the
 			// lower bound restriction, try again.
@@ -1969,10 +1969,8 @@ void PatternMatchEngine::clear_current_state(void)
 
 	issued.clear();
 
-// TODO
 	// Clear the glob state
-//	glob_grd.clear();
-//	glob_state.clear();
+	glob_state.clear();
 }
 
 bool PatternMatchEngine::explore_constant_evaluatables(const HandleSeq& clauses)

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -498,11 +498,11 @@ bool PatternMatchEngine::unorder_compare(const PatternTermPtr& ptm,
 	const HandleSeq& osg = hg->getOutgoingSet();
 	PatternTermSeq osp = ptm->getOutgoingSet();
 	size_t arity = osp.size();
-	bool has_glob_in_pat = has_glob(ptm->getHandle());
+	bool has_glob = (0 < _pat->globby_terms.count(ptm->getHandle()));
 
 	// They've got to be the same size, at the least!
 	// unless there are globs in the pattern
-	if (osg.size() != arity and not has_glob_in_pat)
+	if (osg.size() != arity and not has_glob)
 		return _pmc.fuzzy_match(ptm->getHandle(), hg);
 
 	// Test for case A, described above.
@@ -535,7 +535,7 @@ bool PatternMatchEngine::unorder_compare(const PatternTermPtr& ptm,
 		solution_push();
 		bool match = true;
 
-		if (has_glob_in_pat)
+		if (has_glob)
 		{
 			match = glob_compare(mutation, osg);
 		}
@@ -858,11 +858,6 @@ bool PatternMatchEngine::glob_compare(const PatternTermSeq& osp,
 		else
 		{
 			// If we are here, we are not comparing to a glob.
-
-			// TODO
-			// If this is a VariableNode that we have seen before,
-			// clear its previous grounding before doing any
-			// comparison?? But...
 
 			// If we have already gone through all the atoms in
 			// the candidate, or the current pair does not match,

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1965,9 +1965,6 @@ void PatternMatchEngine::clear_current_state(void)
 	_perm_state.clear();
 
 	issued.clear();
-
-	// Clear the glob state
-	glob_state.clear();
 }
 
 bool PatternMatchEngine::explore_constant_evaluatables(const HandleSeq& clauses)

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -764,6 +764,7 @@ bool PatternMatchEngine::glob_compare(const PatternTermSeq& osp,
 					// of the globs we have seen.
 					if (glob_grd.size() == 0)
 					{
+						glob_state.erase(gpair);
 						match = false;
 						break;
 					}
@@ -872,6 +873,7 @@ bool PatternMatchEngine::glob_compare(const PatternTermSeq& osp,
 				// can be done, we can just reject it now.
 				if (glob_grd.size() == 0)
 				{
+					glob_state.erase(gpair);
 					match = false;
 					break;
 				}

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1517,6 +1517,12 @@ bool PatternMatchEngine::do_next_clause(void)
 	if (nullptr == curr_root)
 	{
 		found = _pmc.grounding(var_grounding, clause_grounding);
+
+		// Since the PM may move on and try to search for more groundings,
+		// clear the glob_state here to prevent it from going back to the
+		// exact same candidate again, we are done with it by now.
+		glob_state.clear();
+
 		DO_LOG(logger().fine("==================== FINITO! accepted=%d", found);)
 		DO_LOG(log_solution(var_grounding, clause_grounding);)
 	}

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -70,9 +70,6 @@ private:
 	bool is_black(const Handle& h) {
 		return (_pat->black.count(h) != 0); }
 
-	bool has_glob(const Handle& h) {
-		return (_pat->globby_terms.count(h) != 0); }
-
 	// -------------------------------------------
 	// Recursive redex support. These are stacks of the clauses
 	// above, that are being searched.

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -70,6 +70,9 @@ private:
 	bool is_black(const Handle& h) {
 		return (_pat->black.count(h) != 0); }
 
+	bool has_glob(const Handle& h) {
+		return (_pat->globby_terms.count(h) != 0); }
+
 	// -------------------------------------------
 	// Recursive redex support. These are stacks of the clauses
 	// above, that are being searched.
@@ -111,7 +114,7 @@ private:
 	bool choose_next;
 
 	// -------------------------------------------
-	// Unordered Link suppoprt
+	// Unordered Link support
 	typedef std::pair<PatternTermPtr, Handle> Unorder; // Choice
 	typedef PatternTermSeq Permutation;
 	typedef std::map<Unorder, Permutation> PermState; // ChoiceState
@@ -126,6 +129,23 @@ private:
 	bool have_more;
 	std::map<Unorder, int> perm_count;
 	std::stack<std::map<Unorder, int>> perm_count_stack;
+
+	// --------------------------------------------
+	// Glob state management
+
+	// Record what sequences we are comparing now
+	typedef std::pair<PatternTermSeq, HandleSeq> GlobSeq;
+
+	// Record where the glob is (a branchpoint)
+	typedef std::pair<size_t, size_t> GlobPos;
+	typedef std::stack<GlobPos> GlobPosStack;
+
+	// Record how many atoms has been gruonded to the glob
+	typedef std::map<Handle, size_t> GlobGrd;
+
+	typedef std::pair<GlobGrd, GlobPosStack> GlobState;
+
+	std::map<GlobSeq, GlobState> glob_state;
 
 	// --------------------------------------------
 	// Methods and state that select the next clause to be grounded.

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -242,6 +242,12 @@ public:
 	// connected by an AndLink.
 	bool explore_constant_evaluatables(const HandleSeq& clauses);
 
+	// It's possible to have more than one valid way to ground
+	// a term with globs in it, so this returns true if that
+	// is the case.
+	bool has_more_to_explore() {
+		return glob_state.size() > 0; }
+
 	// Handy-dandy utilities
 	static void log_solution(const HandleMap &vars,
 	                         const HandleMap &clauses);


### PR DESCRIPTION
For a term that has globs in it, there may be more than one valid way to ground those globs to the same candidate. If at some point the pattern matcher discovers that the grounding of that term conflicts with some other term in the same pattern, it should backtrack and try to ground the term in another way, this is what this PR attempts to do.
But this is incomplete, I need more time to understand different parts of the pattern matcher code