### PR TITLE
Inference control policy

### DIFF
--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -245,7 +245,7 @@ public:
     }
 
     // Return the size of an atom. 1 if a node, 1 + sizes of its
-    // outgoings if a link.
+    // outgoings if a link. It does not discount redundant atoms.
     virtual size_t size() const = 0;
 
     virtual const HandleSeq& getOutgoingSet() const {

--- a/opencog/atoms/base/Handle.h
+++ b/opencog/atoms/base/Handle.h
@@ -38,6 +38,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include <opencog/util/Counter.h>
 #include <opencog/atoms/base/types.h>
 
 // Comment this out if you want to enforce more determinism in the
@@ -192,6 +193,9 @@ typedef std::set<HandleMap> HandleMapSet;
 
 //! a sequence of handle pairs
 typedef std::vector<HandlePair> HandlePairSeq;
+
+//! a map from handle to double
+typedef Counter<Handle, double> HandleCounter;
 
 //! a handle iterator
 typedef std::iterator<std::forward_iterator_tag, Handle> HandleIterator;

--- a/opencog/atomutils/FindUtils.cc
+++ b/opencog/atomutils/FindUtils.cc
@@ -320,6 +320,28 @@ HandleSet get_free_variables(const HandleSeq& hs, Quotation quotation)
 	return results;
 }
 
+HandleSet get_all_uniq_atoms(const Handle& h)
+{
+	// Base cases
+	if (!h)
+		return {};
+	if (h->isNode())
+		return {h};
+
+	// Recursive cases
+	if (h->isLink()) {
+		HandleSet results({h});
+		for (const Handle& child : h->getOutgoingSet()) {
+			HandleSet aas = get_all_uniq_atoms(child);
+			results.insert(aas.begin(), aas.end());
+		}
+		return results;
+	}
+
+	// Please the compiler
+	return {};
+}
+
 bool is_closed(const Handle& h, Quotation quotation)
 {
 	return get_free_variables(h, quotation).empty();

--- a/opencog/atomutils/FindUtils.h
+++ b/opencog/atomutils/FindUtils.h
@@ -303,6 +303,11 @@ HandleSet get_free_variables(const HandleSeq& hs,
                              Quotation quotation=Quotation());
 
 /**
+ * Return the set of all atoms in h, itself and all its descendents.
+ */
+HandleSet get_all_uniq_atoms(const Handle& h);
+
+/**
  * Return true if h has no free variable (unscoped or unquoted) in it,
  * false otherwise.
  */

--- a/opencog/rule-engine/CMakeLists.txt
+++ b/opencog/rule-engine/CMakeLists.txt
@@ -4,6 +4,7 @@
 ADD_LIBRARY(ruleengine
 	backwardchainer/BackwardChainer
 	backwardchainer/TraceRecorder
+	backwardchainer/ControlPolicy
 	backwardchainer/BackwardChainerPMCB
 	backwardchainer/BIT
 	backwardchainer/Fitness

--- a/opencog/rule-engine/CMakeLists.txt
+++ b/opencog/rule-engine/CMakeLists.txt
@@ -5,6 +5,8 @@ ADD_LIBRARY(ruleengine
 	backwardchainer/BackwardChainer
 	backwardchainer/TraceRecorder
 	backwardchainer/ControlPolicy
+	backwardchainer/MixtureModel
+	backwardchainer/ActionSelection
 	backwardchainer/BackwardChainerPMCB
 	backwardchainer/BIT
 	backwardchainer/Fitness

--- a/opencog/rule-engine/InferenceSCM.cc
+++ b/opencog/rule-engine/InferenceSCM.cc
@@ -59,6 +59,7 @@ protected:
 	 * @param target       The target atom with which to start the chaining from.
 	 * @param vardecl      The variable declaration, if any, of the target.
 	 * @param trace_as     AtomSpace where to record the back-inference traces
+	 * @param control_as   AtomSpace where to find the inference control rules
 	 * @param focus_set    A SetLink containing the atoms to which forward
 	 *                     chaining will be applied.  If the set link is
 	 *                     empty, chaining will be invoked on the entire
@@ -71,6 +72,8 @@ protected:
 	                            Handle vardecl,
 	                            bool trace_enabled,
 	                            AtomSpace* trace_as,
+	                            bool control_enabled,
+	                            AtomSpace* control_as,
 	                            Handle focus_set);
 
 	Handle get_rulebase_rules(Handle rbs);
@@ -137,6 +140,8 @@ Handle InferenceSCM::do_backward_chaining(Handle rbs,
                                           Handle vardecl,
                                           bool trace_enabled,
                                           AtomSpace* trace_as,
+                                          bool control_enabled,
+                                          AtomSpace* control_as,
                                           Handle focus_link)
 {
     // A ListLink means that the variable declaration is undefined
@@ -146,8 +151,11 @@ Handle InferenceSCM::do_backward_chaining(Handle rbs,
     if (not trace_enabled)
 	    trace_as = nullptr;
 
+    if (not control_enabled)
+	    control_as = nullptr;
+
     AtomSpace *as = SchemeSmob::ss_get_env_as("cog-mandatory-args-bc");
-    BackwardChainer bc(*as, rbs, target, vardecl, trace_as, focus_link);
+    BackwardChainer bc(*as, rbs, target, vardecl, trace_as, control_as, focus_link);
 
     bc.do_chain();
 

--- a/opencog/rule-engine/backwardchainer/ActionSelection.cc
+++ b/opencog/rule-engine/backwardchainer/ActionSelection.cc
@@ -1,0 +1,37 @@
+/*
+ * MixtureModel.cc
+ *
+ * Copyright (C) 2017 OpenCog Foundation
+ *
+ * Authors: Nil Geisweiller
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "ActionSelection.h"
+
+using namespace opencog;
+
+ActionSelection::ActionSelection(const HandleTVMap& action_tvs)
+{
+	// TODO
+}
+
+HandleCounter ActionSelection::distribution()
+{
+	// TODO
+	return HandleCounter();
+}

--- a/opencog/rule-engine/backwardchainer/ActionSelection.h
+++ b/opencog/rule-engine/backwardchainer/ActionSelection.h
@@ -1,0 +1,65 @@
+/*
+ * ActionSelection.h
+ *
+ * Copyright (C) 2017 OpenCog Foundation
+ *
+ * Authors: Nil Geisweiller
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#ifndef OPENCOG_ACTIONSELECTION_H_
+#define OPENCOG_ACTIONSELECTION_H_
+
+#include <opencog/atoms/base/Handle.h>
+#include <opencog/truthvalue/TruthValue.h>
+
+namespace opencog
+{
+
+//! a map from handles to truth values
+typedef std::map<Handle, TruthValuePtr> HandleTVMap;
+
+/**
+ * Class containing methods to calculate distribution over actions
+ * given the TruthValue that each action fulfills the objective of
+ * interest.
+ */
+class ActionSelection
+{
+public:
+	ActionSelection(const HandleTVMap& action_tvs);
+
+	/**
+	 * Return the action distribution, a probability over each action
+	 * to be used for sampling the next action. The distribution tries
+	 * to reflect the optimal balance between exploration and
+	 * exploitation.
+	 *
+	 * TODO: add documentation (taken from the pln
+	 * inference-control-learning README.md example).
+	 */
+	HandleCounter distribution();
+
+	/**
+	 * Perform random action selection according to the action
+	 * distribution.
+	 */
+	Handle operator()();
+};
+
+} // namespace opencog
+
+#endif /* OPENCOG_ACTIONSELECTION_H_ */

--- a/opencog/rule-engine/backwardchainer/CMakeLists.txt
+++ b/opencog/rule-engine/backwardchainer/CMakeLists.txt
@@ -2,6 +2,8 @@ INSTALL (FILES
 	BackwardChainer.h
 	TraceRecorder.h
 	ControlPolicy.h
+	MixtureModel.h
+	ActionSelection.h
 	BackwardChainerPMCB.h
 	BIT.h
     Fitness.h

--- a/opencog/rule-engine/backwardchainer/CMakeLists.txt
+++ b/opencog/rule-engine/backwardchainer/CMakeLists.txt
@@ -1,6 +1,7 @@
 INSTALL (FILES
 	BackwardChainer.h
 	TraceRecorder.h
+	ControlPolicy.h
 	BackwardChainerPMCB.h
 	BIT.h
     Fitness.h

--- a/opencog/rule-engine/backwardchainer/ControlPolicy.cc
+++ b/opencog/rule-engine/backwardchainer/ControlPolicy.cc
@@ -1,0 +1,106 @@
+/*
+ * ControlPolicy.cc
+ *
+ * Copyright (C) 2017 OpenCog Foundation
+ *
+ * Authors: Nil Geisweiller
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "ControlPolicy.h"
+
+#include <opencog/util/random.h>
+
+#include "../URELogger.h"
+
+using namespace opencog;
+
+ControlPolicy::ControlPolicy(const RuleSet& rs, const BIT& bit,
+                             AtomSpace* control_as) :
+	rules(rs), _bit(bit), _control_as(control_as) {}
+
+RuleTypedSubstitutionPair ControlPolicy::select_rule(AndBIT& andbit,
+                                                     BITNode& bitleaf)
+{
+	// The rule is randomly selected amongst the valid ones, with
+	// probability of selection being proportional to its weight.
+	const RuleTypedSubstitutionMap valid_rules = get_valid_rules(andbit, bitleaf);
+	if (valid_rules.empty()) {
+		bitleaf.exhausted = true;
+		return {Rule(), Unify::TypedSubstitution()};;
+	}
+
+	// Log all valid rules and their weights
+	if (ure_logger().is_debug_enabled()) {
+		std::stringstream ss;
+		ss << "The following weighted rules are valid:";
+		for (const auto& r : valid_rules)
+			ss << std::endl << r.first.get_weight() << " " << r.first.get_name();
+		LAZY_URE_LOG_DEBUG << ss.str();
+	}
+
+	return select_rule(andbit, bitleaf, valid_rules);
+}
+
+RuleTypedSubstitutionMap ControlPolicy::get_valid_rules(const AndBIT& andbit,
+                                                        const BITNode& bitleaf)
+{
+	// Generate all valid rules
+	RuleTypedSubstitutionMap valid_rules;
+	for (const Rule& rule : rules) {
+		// For now ignore meta rules as they are forwardly applied in
+		// expand_bit()
+		if (rule.is_meta())
+			continue;
+
+		// Get the leaf vardecl from fcs. We don't want to filter it
+		// because otherwise the typed substitution obtained may miss some
+		// variables in the FCS declaration that needs to be substituted
+		// during expension.
+		Handle vardecl;
+		if (andbit.fcs)
+			vardecl = BindLinkCast(andbit.fcs)->get_vardecl();
+
+		RuleTypedSubstitutionMap unified_rules
+			= rule.unify_target(bitleaf.body, vardecl);
+
+		// Insert only rules with positive probability of success
+		RuleTypedSubstitutionMap pos_rules;
+		for (const auto& rule : unified_rules) {
+			double p = (_bit.is_in(rule, bitleaf) ? 0.0 : 1.0)
+				* rule.first.get_weight();
+			if (p > 0) pos_rules.insert(rule);
+		}
+
+		valid_rules.insert(pos_rules.begin(), pos_rules.end());
+	}
+	return valid_rules;
+}
+
+RuleTypedSubstitutionPair ControlPolicy::select_rule(const AndBIT& andbit,
+                                                     const BITNode& bitleaf,
+                                                     const RuleTypedSubstitutionMap& rules)
+{
+	// Build weight vector to do weighted random selection
+	std::vector<double> weights;
+	for (const auto& rule : rules)
+		weights.push_back(rule.first.get_weight());
+
+	// No rule exhaustion, sample one according to the distribution
+	std::discrete_distribution<size_t> dist(weights.begin(), weights.end());
+	return rand_element(rules, dist);
+}

--- a/opencog/rule-engine/backwardchainer/ControlPolicy.cc
+++ b/opencog/rule-engine/backwardchainer/ControlPolicy.cc
@@ -24,10 +24,15 @@
 #include "ControlPolicy.h"
 
 #include <opencog/util/random.h>
+#include <opencog/query/BindLinkAPI.h>
 
+#include "TraceRecorder.h"
 #include "../URELogger.h"
 
 using namespace opencog;
+
+#define al _query_as.add_link
+#define an _query_as.add_node
 
 ControlPolicy::ControlPolicy(const RuleSet& rs, const BIT& bit,
                              AtomSpace* control_as) :
@@ -78,15 +83,26 @@ RuleTypedSubstitutionMap ControlPolicy::get_valid_rules(const AndBIT& andbit,
 		RuleTypedSubstitutionMap unified_rules
 			= rule.unify_target(bitleaf.body, vardecl);
 
-		// Insert only rules with positive probability of success
-		RuleTypedSubstitutionMap pos_rules;
-		for (const auto& rule : unified_rules) {
-			double p = (_bit.is_in(rule, bitleaf) ? 0.0 : 1.0)
-				* rule.first.get_weight();
-			if (p > 0) pos_rules.insert(rule);
+		// Remove rules already in the BIT, or that happen to have a
+		// null weight.
+		for (RuleTypedSubstitutionMap::iterator it = unified_rules.begin();
+		     it != unified_rules.end();) {
+			double w = (_bit.is_in(*it, bitleaf) ? 0.0 : 1.0)
+				* it->first.get_weight();
+			if (w <= 0)
+				it = unified_rules.erase(it);
+			else
+				++it;
 		}
 
-		valid_rules.insert(pos_rules.begin(), pos_rules.end());
+		// Reweight and insert
+		double N(unified_rules.size());
+		for (std::pair<Rule, Unify::TypedSubstitution> pos_rule : unified_rules) {
+			// Divide the weights of the rules by their numbers so
+		    // that the sum equals the initial rule weight.
+			pos_rule.first.set_weight(pos_rule.first.get_weight() / N);
+			valid_rules.insert(pos_rule);
+		}
 	}
 	return valid_rules;
 }
@@ -97,10 +113,163 @@ RuleTypedSubstitutionPair ControlPolicy::select_rule(const AndBIT& andbit,
 {
 	// Build weight vector to do weighted random selection
 	std::vector<double> weights;
-	for (const auto& rule : rules)
-		weights.push_back(rule.first.get_weight());
 
-	// No rule exhaustion, sample one according to the distribution
+	// If a control policy atomspace is provided then calculate the
+	// distribution according to the provided control rules. Otherwise
+	// use the default rule weights.
+	if (_control_as)
+		weights = learn_rule_weights(andbit, bitleaf, rules);
+	else
+		for (const auto& rule : rules)
+			weights.push_back(rule.first.get_weight());
+
+	// Sample one according to the distribution
 	std::discrete_distribution<size_t> dist(weights.begin(), weights.end());
 	return rand_element(rules, dist);
 }
+
+std::vector<double> ControlPolicy::learn_rule_weights(const AndBIT& andbit,
+                                                      const BITNode& bitleaf,
+                                                      const RuleTypedSubstitutionMap& rules)
+{
+	std::vector<double> weights;
+	HandleSet ra = rule_aliases(rules);
+	for (const Handle& rule : ra)
+		HandleSet pattern_free_control_rules =
+			fetch_pattern_free_expansion_control_rules(rule);
+	// TODO
+	return weights;
+}
+
+HandleSet ControlPolicy::rule_aliases(const RuleTypedSubstitutionMap& rules)
+{
+	HandleSet aliases;
+	for (auto& rule : rules)
+		aliases.insert(rule.first.get_alias());
+	return aliases;
+}
+
+HandleSet ControlPolicy::fetch_pattern_free_expansion_control_rules(Handle rule)
+{
+	Handle query = mk_pattern_free_expansion_control_rules_query(rule);
+	Handle result = bindlink(_control_as, query);
+	HandleSeq outgoings(result->getOutgoingSet());
+	HandleSet results(outgoings.begin(), outgoings.end());
+	return results;
+}
+
+HandleSet ControlPolicy::fetch_pattern_expansion_control_rules(Handle rule)
+{
+	Handle query = mk_pattern_expansion_control_rules_query(rule);
+	Handle result = bindlink(_control_as, query);
+	HandleSeq outgoings(result->getOutgoingSet());
+	HandleSet results(outgoings.begin(), outgoings.end());
+	return results;
+}
+
+Handle ControlPolicy::mk_vardecl_vardecl(Handle vardecl_var)
+{
+	return al(TYPED_VARIABLE_LINK,
+	          vardecl_var,
+	          al(TYPE_CHOICE,
+	             an(TYPE_NODE, "VariableList"),
+	             an(TYPE_NODE, "VariableNode"),
+	             an(TYPE_NODE, "TypedVariableLink")));
+}
+
+Handle ControlPolicy::mk_list_of_args_vardecl(Handle args_var)
+{
+	return al(TYPED_VARIABLE_LINK,
+	          args_var,
+	          an(TYPE_NODE, "ListLink"));
+}
+
+Handle ControlPolicy::mk_expand_exec(Handle expand_args_var)
+{
+	Handle expand_schema = an(SCHEMA_NODE,
+	                          TraceRecorder::expand_andbit_predicate_name);
+	return al(EXECUTION_LINK,
+	          expand_schema,
+	          al(UNQUOTE_LINK, expand_args_var));
+}
+
+Handle ControlPolicy::mk_preproof_eval(Handle preproof_args_var)
+{
+	Handle preproof_pred = an(PREDICATE_NODE, preproof_predicate_name);
+	return al(EVALUATION_LINK,
+	          preproof_pred,
+	          al(UNQUOTE_LINK, preproof_args_var));
+}
+
+Handle ControlPolicy::mk_pattern_free_expansion_control_rules_query(Handle rule)
+{
+	Handle vardecl_var = an(VARIABLE_NODE, "$vardecl"),
+		vardecl_vardecl = mk_vardecl_vardecl(vardecl_var),
+
+		expand_args_var = an(VARIABLE_NODE, "$expand_args"),
+		expand_args_vardecl = mk_list_of_args_vardecl(expand_args_var),
+		expand_exec = mk_expand_exec(expand_args_var),
+
+		preproof_args_var = an(VARIABLE_NODE, "$preproof_args"),
+		preproof_args_vardecl = mk_list_of_args_vardecl(preproof_args_var),
+		preproof_eval = mk_preproof_eval(preproof_args_var),
+
+		// ImplicationScope to retrieve
+		expand_preproof_impl = al(QUOTE_LINK,
+		                          al(IMPLICATION_SCOPE_LINK,
+		                             al(UNQUOTE_LINK, vardecl_var),
+		                             expand_exec,
+		                             preproof_eval)),
+
+		// BindLink of ImplicationScope to retrieve
+		expand_preproof_impl_bl = al(BIND_LINK,
+		                             al(VARIABLE_LIST,
+		                                vardecl_vardecl,
+		                                expand_args_vardecl,
+		                                preproof_args_vardecl),
+		                             expand_preproof_impl,
+		                             expand_preproof_impl);
+
+	return expand_preproof_impl_bl;
+}
+
+Handle ControlPolicy::mk_pattern_expansion_control_rules_query(Handle rule)
+{
+	Handle vardecl_var = an(VARIABLE_NODE, "$vardecl"),
+		vardecl_vardecl = mk_vardecl_vardecl(vardecl_var),
+
+		expand_args_var = an(VARIABLE_NODE, "$expand_args"),
+		expand_args_vardecl = mk_list_of_args_vardecl(expand_args_var),
+		expand_exec = mk_expand_exec(expand_args_var),
+
+		preproof_args_var = an(VARIABLE_NODE, "$preproof_args"),
+		preproof_args_vardecl = mk_list_of_args_vardecl(preproof_args_var),
+		preproof_eval = mk_preproof_eval(preproof_args_var),
+
+		// ImplicationScope with a pattern in its antecedent to
+		// retrieve
+		pattern_var = an(VARIABLE_NODE, "$pattern"),
+		pat_expand_preproof_impl = al(QUOTE_LINK,
+		                              al(IMPLICATION_SCOPE_LINK,
+		                                 al(UNQUOTE_LINK, vardecl_var),
+		                                 al(AND_LINK,
+		                                    expand_exec,
+		                                    al(UNQUOTE_LINK, pattern_var)),
+		                                 preproof_eval)),
+
+		// Bind of ImplicationScope with a pattern in its antecedent
+		// to retrieve
+		pat_expand_preproof_impl_bl = al(BIND_LINK,
+		                                 al(VARIABLE_LIST,
+		                                    vardecl_vardecl,
+		                                    expand_args_vardecl,
+		                                    preproof_args_vardecl,
+		                                    pattern_var),
+		                                 pat_expand_preproof_impl,
+		                                 pat_expand_preproof_impl);
+
+	return pat_expand_preproof_impl_bl;
+}
+
+#undef al
+#undef an

--- a/opencog/rule-engine/backwardchainer/ControlPolicy.cc
+++ b/opencog/rule-engine/backwardchainer/ControlPolicy.cc
@@ -139,7 +139,7 @@ std::vector<double> ControlPolicy::control_rule_weights(
 			fetch_active_expansion_control_rules(rule);
 
 		// Calculate the truth value of its mixture model
-		// TODO: set cpx_penalty and compressability.
+		// TODO: set cpx_penalty and compressiveness.
 		success_tvs[rule] = MixtureModel(active_ctrl_rules)();
 	}
 

--- a/opencog/rule-engine/backwardchainer/ControlPolicy.h
+++ b/opencog/rule-engine/backwardchainer/ControlPolicy.h
@@ -64,8 +64,13 @@ private:
 	// Reference to the BackwardChainer BIT
 	const BIT& _bit;
 
-	// AtomSpace holding the inference control rules
+	// AtomSpace holding the inference control rules (or simply
+	// control rules for short).
 	AtomSpace* _control_as;
+
+	// AtomSpace holding the pattern matcher queries to fetch the
+	// various control rule
+	AtomSpace _query_as;
 	
 	/**
 	 * Return all valid rules, in the sense that they may possibly be
@@ -80,6 +85,105 @@ private:
 	RuleTypedSubstitutionPair select_rule(const AndBIT& andbit,
 	                                      const BITNode& bitleaf,
 	                                      const RuleTypedSubstitutionMap& rules);
+
+	/**
+	 * Given a list of valid rules, use the control rules in
+	 * _control_as to infer/learn the weights of the optimal policy
+	 * (in Thomson sampling sense).
+	 *
+	 * TODO: add documentation (taken from the pln
+	 * inference-control-learning README.md example).
+	 */
+	std::vector<double> learn_rule_weights(const AndBIT& andbit,
+	                                       const BITNode& bitleaf,
+	                                       const RuleTypedSubstitutionMap& rules);
+
+	/**
+	 * Return the set of rule aliases, as aliases of inference rules
+	 * are used in control rules.
+	 */
+	HandleSet rule_aliases(const RuleTypedSubstitutionMap& rules);
+
+	/**
+	 * Fetch control rules from _control_as involved in BIT
+	 * expansion. Informally that if and-BIT, A, expands into B from L
+	 * with the given rule then B has a probability TV of being a
+	 * preproof of T. Formally
+	 *
+	 * ImplicationScope <TV>
+	 *  VariableList
+	 *    Variable "$T"  ;; Theorem/target to prove
+	 *    TypedVariable  ;; and-BIT to expand
+	 *      Variable "$A"
+	 *      Type "BindLink"
+	 *    Variable "$L"  ;; Leaf from A to expand
+	 *    TypedVariable  ;; Resulting and-BIT from the expansion of L from A with rule R
+	 *      Variable "$B"
+	 *      Type "BindLink"
+	 *  Execution
+	 *    Schema "expand-and-BIT"
+	 *    List
+	 *      BontExec Variable "$A"
+	 *      Variable "$L"
+	 *      DontExec <rule>
+	 *    DontExec Variable "$B"
+	 *  Evaluation
+	 *    Predicate "preproof"
+	 *    List
+	 *      DontExec Variable "$B"
+	 *      Variable "$T"
+	 *
+	 * Although this rule is likely to be very useful in practice we
+	 * still keep it as it may provide some initial guidance when no
+	 * predictive patterns have been extracted from the inference
+	 * history so far. It may also provide a reference when building
+	 * the mixture model in case the so called patterns are actually
+	 * overfit.
+	 */
+	HandleSet fetch_pattern_free_expansion_control_rules(Handle rule);
+
+	/**
+	 * Fetch control rules from _control_as involved in BIT
+	 * expansion. Informally that if and-BIT, A, expands into B from L
+	 * with the given rule, and follow some pattern, then B has a
+	 * probability TV of being a preproof of T. Formally
+	 *
+	 * ImplicationScope <TV>
+	 *  VariableList
+	 *    Variable "$T"  ;; Theorem/target to prove
+	 *    TypedVariable  ;; and-BIT to expand
+	 *      Variable "$A"
+	 *      Type "BindLink"
+	 *    Variable "$L"  ;; Leaf from A to expand
+	 *    TypedVariable  ;; Resulting and-BIT from the expansion of L from A with rule R
+	 *      Variable "$B"
+	 *      Type "BindLink"
+	 *  And
+	 *    Execution
+	 *      Schema "expand-and-BIT"
+	 *      List
+	 *        BontExec Variable "$A"
+	 *        Variable "$L"
+	 *        DontExec <rule>
+	 *      DontExec Variable "$B"
+	 *    <pattern>
+	 *  Evaluation
+	 *    Predicate "preproof"
+	 *    List
+	 *      DontExec Variable "$B"
+	 *      Variable "$T"
+	 */
+	HandleSet fetch_pattern_expansion_control_rules(Handle rule);
+
+	/**
+	 * Helpers to build various hypergraphs used to build various queries
+	 */
+	Handle mk_vardecl_vardecl(Handle vardecl_var);
+	Handle mk_list_of_args_vardecl(Handle args_var);
+	Handle mk_expand_exec(Handle expand_args_var);
+	Handle mk_preproof_eval(Handle preproof_args_var);
+	Handle mk_pattern_free_expansion_control_rules_query(Handle rule);
+	Handle mk_pattern_expansion_control_rules_query(Handle rule);
 };
 
 

--- a/opencog/rule-engine/backwardchainer/ControlPolicy.h
+++ b/opencog/rule-engine/backwardchainer/ControlPolicy.h
@@ -1,0 +1,88 @@
+/*
+ * ControlPolicy.h
+ *
+ * Copyright (C) 2017 OpenCog Foundation
+ *
+ * Authors: Nil Geisweiller
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#ifndef OPENCOG_CONTROLPOLICY_H_
+#define OPENCOG_CONTROLPOLICY_H_
+
+#include <opencog/atomspace/AtomSpace.h>
+
+#include "BIT.h"
+#include "../Rule.h"
+
+namespace opencog
+{
+
+class ControlPolicy
+{
+public:
+	ControlPolicy(const RuleSet& rules, const BIT& bit,
+	              AtomSpace* control_as=nullptr);
+
+	const std::string preproof_predicate_name = "URE:BC:preproof";
+
+	RuleSet rules;
+
+	/**
+	 * Select a valid rule given a target. The selected is a new
+	 * object because a new rule is created, its variables are
+	 * uniquely renamed, possibly some partial substitutions are
+	 * applied.
+	 *
+	 * Unless a control_as is provided at construction time, the
+	 * Selection is random amongst the valid rules and weighted
+	 * according to their weights.
+	 *
+	 * TODO: add comments about inference control policy, see
+	 * README.md of
+	 * <OPENCOG_ROOT>/examples/pln/inference-control-learning
+	 *
+	 * The andbit and bitleaf are not const because if the rules are
+	 * exhausted it will set its exhausted flag to false.
+	 */
+	RuleTypedSubstitutionPair select_rule(AndBIT& andbit, BITNode& bitleaf);
+
+private:
+	// Reference to the BackwardChainer BIT
+	const BIT& _bit;
+
+	// AtomSpace holding the inference control rules
+	AtomSpace* _control_as;
+	
+	/**
+	 * Return all valid rules, in the sense that they may possibly be
+	 * used to infer the target.
+	 */
+	RuleTypedSubstitutionMap get_valid_rules(const AndBIT& andbit,
+	                                         const BITNode& bitleaf);
+
+	/**
+	 * Select a rule for expansion amongst a set of valid ones.
+	 */
+	RuleTypedSubstitutionPair select_rule(const AndBIT& andbit,
+	                                      const BITNode& bitleaf,
+	                                      const RuleTypedSubstitutionMap& rules);
+};
+
+
+} // namespace opencog
+
+#endif /* OPENCOG_CONTROLPOLICY_H_ */

--- a/opencog/rule-engine/backwardchainer/MixtureModel.cc
+++ b/opencog/rule-engine/backwardchainer/MixtureModel.cc
@@ -23,9 +23,16 @@
 
 #include "MixtureModel.h"
 
+#include <boost/math/special_functions/binomial.hpp>
+#include <boost/range/algorithm/transform.hpp>
+#include <boost/range/numeric.hpp>
+
 #include <opencog/atomutils/FindUtils.h>
+#include <opencog/truthvalue/SimpleTruthValue.h>
 
 using namespace opencog;
+
+using boost::math::binomial_coefficient;
 
 MixtureModel::MixtureModel(const HandleSet& mds, double cpx, double cmp) :
 	models(mds), cpx_penalty(cpx), compressiveness(cmp)
@@ -35,16 +42,43 @@ MixtureModel::MixtureModel(const HandleSet& mds, double cpx, double cmp) :
 
 TruthValuePtr MixtureModel::operator()()
 {
-	// TODO
+	std::vector<TruthValuePtr> tvs;
 	std::vector<double> weights;
-	return TruthValuePtr();
+	for (const Handle model : models) {
+		// Get model's TV
+		TruthValuePtr tv = model->getTruthValue();
+		tvs.push_back(tv);
+
+		// Calculate model's weight
+		double count = tv->getCount(),
+			pos_count = tv->getMean() * count, // TODO correct when mean is fixed
+			binom = binomial_coefficient<double>(count, pos_count);
+		weights.push_back(prior_estimate(model) * (count+1) * binom);
+	}
+	return weighted_average(tvs, weights);
 }
 
 TruthValuePtr MixtureModel::weighted_average(const std::vector<TruthValuePtr>& tvs,
                                              const std::vector<double>& weights) const
 {
-	// TODO
-	return TruthValuePtr();
+	// Normalize the weights and get the TV means
+	double total = boost::accumulate(weights, 0.0);
+	std::vector<double> norm_weights, means;
+	boost::transform(weights, std::back_inserter(norm_weights),
+	                 [total](double w) { return w / total; });
+	boost::transform(tvs, std::back_inserter(means),
+	                 [](const TruthValuePtr& tv) { return tv->getMean(); });
+
+	// For now the formula is extremely approximative, instead we
+	// could fit the mixture by a beta distribution, either
+	// analytically (Extended Beta Distribution in R by Grun et al) or
+	// numerically (Fitting Beta Distribution Based on Sample Data by
+	// AbouRisk et al). Or, better, this should be moved in the truth
+	// value API because a TV might not necessarily be a beta
+	// distribution.
+	double mean = boost::inner_product(norm_weights, means, 0.0);
+	double confidence = 0.2;    // TODO
+	return SimpleTruthValue::createSTV(mean, confidence);
 }
 
 double MixtureModel::prior_estimate(const Handle& model)

--- a/opencog/rule-engine/backwardchainer/MixtureModel.cc
+++ b/opencog/rule-engine/backwardchainer/MixtureModel.cc
@@ -1,0 +1,66 @@
+/*
+ * MixtureModel.cc
+ *
+ * Copyright (C) 2017 OpenCog Foundation
+ *
+ * Authors: Nil Geisweiller
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "MixtureModel.h"
+
+#include <opencog/atomutils/FindUtils.h>
+
+using namespace opencog;
+
+MixtureModel::MixtureModel(const HandleSet& mds, double cpx, double cmp) :
+	models(mds), cpx_penalty(cpx), compressability(cmp)
+{
+	data_set_size = infer_data_set_size();
+}
+
+TruthValuePtr MixtureModel::operator()()
+{
+	// TODO
+	return TruthValuePtr();
+}
+
+double MixtureModel::infer_data_set_size()
+{
+	double max_count = 0.0;
+	for (const Handle& model : models)
+		max_count = std::max(max_count, model->getTruthValue()->getCount());
+	return max_count;
+}
+
+double MixtureModel::prior_estimate(const Handle& model)
+{
+	HandleSet all_atoms(get_all_uniq_atoms(model));
+	double partial_length = all_atoms.size();
+	double remain_count = data_set_size - model->getTruthValue()->getCount();
+	return prior(partial_length + compressed_estimate(remain_count));
+}
+
+double MixtureModel::compressed_estimate(double remain_count)
+{
+	return std::pow(remain_count, 1.0 - compressability);
+}
+
+double MixtureModel::prior(double length)
+{
+	return exp(-cpx_penalty*length);
+}

--- a/opencog/rule-engine/backwardchainer/MixtureModel.h
+++ b/opencog/rule-engine/backwardchainer/MixtureModel.h
@@ -1,0 +1,122 @@
+/*
+ * MixtureModel.h
+ *
+ * Copyright (C) 2017 OpenCog Foundation
+ *
+ * Authors: Nil Geisweiller
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#ifndef OPENCOG_MIXTUREMODEL_H_
+#define OPENCOG_MIXTUREMODEL_H_
+
+#include <opencog/atoms/base/Handle.h>
+#include <opencog/truthvalue/TruthValue.h>
+
+namespace opencog
+{
+
+/**
+ * Class containing methods to calculate the TruthValue of constructed
+ * from the mixture of a set of active partial models. Since these
+ * models might be active over different training sets, the mixture
+ * needs to take into account how complexity is hidden in the part of
+ * the model explaining the remaining data.
+ */
+class MixtureModel
+{
+public:
+	// Set of active models. Active means that they fulfill the
+	// preconditions of the data to explain.
+	HandleSet models;
+
+	// Parameter to control the complexity penalty over the control
+	// rules. Ranges from 0, no penalty to +inf, infinit
+	// penalty. Affect the calculation of the control rule prior, see
+	// the control_rule_prior method. Used to calculate the TV of
+	// success in case multiple control rules are active.
+	double cpx_penalty;
+
+	// Parameter to estimate the length of a whole model given a
+	// partial model + unexplained data. Ranges from 0 to 1, 0 being
+	// no compressability at all of the unexplained data, 1 being full
+	// compressability.
+	double compressability;
+
+	// Size of the complete data set, including all observations used
+	// to build the models. For simplicity we're gonna assume that it
+	// is the max of all counts over the models. Meaning that to do
+	// well, at least one model has to be complete, however bad this
+	// model might be.
+	double data_set_size;
+
+	/**
+	 * Ctor
+	 */
+	MixtureModel(const HandleSet& models,
+	             double cpx_penalty=1.0,
+	             double compressability=0.0);
+
+	/**
+	 * Calculate the TV of the consequent of the mixture model.
+	 */
+	TruthValuePtr operator()();
+
+	/**
+	 * Infer the data set size by taking the max count of all models
+	 * (it works assuming that one of them is complete).
+	 */
+	double infer_data_set_size();
+
+	/**
+	 * Given a model, calculate it's prior estimate. In the case of a
+	 * partial model, the length is estimated
+	 */
+	double prior_estimate(const Handle& model);
+
+	/**
+	 * Given the size of the data set that isn't explained by a model,
+	 * estimate the complexity of a model that would explain them
+	 * perfectly. The heuristic used here is
+	 *
+	 * remaing_count^(1 - compressability)
+	 *
+	 * One can see that if compressability is null, then no compress
+	 * occurs, the model is the data set itself, if compressability
+	 * equals 1, then it return 1, which is the maximum compression,
+	 * all data can be explained with just one bit.
+	 */
+	double compressed_estimate(double remaining_count);
+
+	/**
+	 * Given the length of a model, calculate its prior
+	 *
+	 * exp(-cpx_penalty*length)
+	 *
+	 * where cpx_penalty is a complexity penalty parameter (0 for no
+	 * penalty, +inf for infinit penalty), and length is the size of
+	 * the model, the total number of atoms involved in its
+	 * definition.
+	 *
+	 * The prior doesn't have to sum up to 1 because the probability
+	 * estimates are normalized.
+	 */
+	double prior(double length);
+};
+
+} // namespace opencog
+
+#endif /* OPENCOG_MIXTUREMODEL_H_ */

--- a/opencog/rule-engine/backwardchainer/MixtureModel.h
+++ b/opencog/rule-engine/backwardchainer/MixtureModel.h
@@ -133,8 +133,9 @@ public:
 	TruthValuePtr operator()();
 
 	/**
-	 * Given a list of TVs and a list of associated weights, produce a
-	 * TVs that approximate the weighted average of the given TVs.
+	 * Given a list of TVs and a list of associated weights, that do
+	 * not need to sum up to 1, produce a TVs that approximates the
+	 * normalized weighted average of the given TVs.
 	 *
 	 * For now a Simple Truth Value will be produced, meaning that it
 	 * will probably badly reflect the actually distribution, but

--- a/opencog/rule-engine/backwardchainer/TraceRecorder.cc
+++ b/opencog/rule-engine/backwardchainer/TraceRecorder.cc
@@ -25,6 +25,11 @@
 
 using namespace opencog;
 
+const std::string TraceRecorder::target_predicate_name = "URE:BC:target";
+const std::string TraceRecorder::andbit_predicate_name = "URE:BC:and-BIT";
+const std::string TraceRecorder::expand_andbit_predicate_name = "URE:BC:expand-and-BIT";
+const std::string TraceRecorder::proof_predicate_name = "URE:BC:proof";
+
 TraceRecorder::TraceRecorder(AtomSpace* tr_as) : _trace_as(tr_as) {}
 
 void TraceRecorder::target(const Handle& target)

--- a/opencog/rule-engine/backwardchainer/TraceRecorder.h
+++ b/opencog/rule-engine/backwardchainer/TraceRecorder.h
@@ -20,8 +20,8 @@
  * Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-#ifndef TRACERECORDER_H_
-#define TRACERECORDER_H_
+#ifndef OPENCOG_TRACERECORDER_H_
+#define OPENCOG_TRACERECORDER_H_
 
 #include <opencog/atomspace/AtomSpace.h>
 
@@ -147,4 +147,4 @@ private:
 
 } // namespace opencog
 
-#endif /* BACKWARDCHAINER_H_ */
+#endif /* OPENCOG_TRACERECORDER_H_ */

--- a/opencog/rule-engine/backwardchainer/TraceRecorder.h
+++ b/opencog/rule-engine/backwardchainer/TraceRecorder.h
@@ -34,12 +34,12 @@ namespace opencog
 class TraceRecorder
 {
 public:
-	TraceRecorder(AtomSpace* tr_as);
+	static const std::string target_predicate_name;
+	static const std::string andbit_predicate_name;
+	static const std::string expand_andbit_predicate_name;
+	static const std::string proof_predicate_name;
 
-	const std::string target_predicate_name = "URE:BC:target";
-	const std::string andbit_predicate_name = "URE:BC:and-BIT";
-	const std::string expand_andbit_predicate_name = "URE:BC:expand-and-BIT";
-	const std::string proof_predicate_name = "URE:BC:proof";
+	TraceRecorder(AtomSpace* tr_as);
 
 	// Record that an atom is a target
 	//

--- a/opencog/scm/opencog/rule-engine/rule-engine-utils.scm
+++ b/opencog/scm/opencog/rule-engine/rule-engine-utils.scm
@@ -47,7 +47,9 @@
 "
   (cog-mandatory-args-fc rbs source vardecl focus-set))
 
-(define* (cog-bc rbs target #:key (vardecl (List)) (trace-as #f) (focus-set (Set)))
+(define* (cog-bc rbs target
+                 #:key
+                 (vardecl (List)) (trace-as #f) (control-as #f) (focus-set (Set)))
 "
   Backward Chainer call.
 
@@ -57,17 +59,22 @@
 
   target: Target to proof.
 
-  tas: optional AtomSpace to record the back-inference traces.
+  vardecl: optional variable declaration of the target (in case it has
+           variables)
 
-  vd: optional variable declaration of the target (in case it has
-      variables)
+  trace-as: optional AtomSpace to record the back-inference traces.
 
-  fs: optional focus-set, a SetLink with all atoms to consider
-      for forward chaining (NOT IMPLEMENTED).
+  control-as: optional AtomSpace storing inference control rules.
+
+  focus-set: optional focus-set, a SetLink with all atoms to consider
+             for forward chaining (NOT IMPLEMENTED).
 "
   (let* ((trace-enabled (cog-atomspace? trace-as))
-         (tas (if trace-enabled trace-as (cog-atomspace))))
-  (cog-mandatory-args-bc rbs target vardecl trace-enabled tas focus-set)))
+         (control-enabled (cog-atomspace? control-as))
+         (tas (if trace-enabled trace-as (cog-atomspace)))
+         (cas (if control-enabled control-as (cog-atomspace))))
+  (cog-mandatory-args-bc rbs target vardecl
+                         trace-enabled tas control-enabled cas focus-set)))
 
 (define-public (ure-define-add-rule rbs rule-name rule weight)
 "

--- a/tests/rule-engine/BackwardChainerUTest.cxxtest
+++ b/tests/rule-engine/BackwardChainerUTest.cxxtest
@@ -65,6 +65,7 @@ public:
 
 void BackwardChainerUTest::setUp()
 {
+	// TODO: move that in the ctor
 	string cur_pp_dir = string(PROJECT_SOURCE_DIR),
 		cur_p_dir = cur_pp_dir + "/tests",
 		cur_dir = cur_p_dir + "/rule-engine";
@@ -104,14 +105,17 @@ void BackwardChainerUTest::test_select_rule_1()
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
+	// TODO: move that in setUp
 	reset_bc();
 
 	Handle target_h = _eval.eval_h("(Inheritance"
 	                               "   (Concept \"A\")"
 	                               "   (Concept \"B\"))");
 	BITNode target(target_h);
+	AndBIT andbit;
 
-	RuleTypedSubstitutionPair selected_rule = _bc->select_rule(target);
+	RuleTypedSubstitutionPair selected_rule =
+		_bc->_control.select_rule(andbit, target);
 
 	TS_ASSERT_EQUALS(selected_rule.first.get_name(), "bc-deduction-rule");
 }
@@ -127,8 +131,10 @@ void BackwardChainerUTest::test_select_rule_2()
 	                               "   (Concept \"A\")"
 	                               "   (Variable \"$X\"))");
 	BITNode target(target_h);
+	AndBIT andbit;
 
-	RuleTypedSubstitutionPair selected_rule = _bc->select_rule(target);
+	RuleTypedSubstitutionPair selected_rule =
+		_bc->_control.select_rule(andbit, target);
 
 	TS_ASSERT_EQUALS(selected_rule.first.get_name(), "bc-deduction-rule");
 }
@@ -146,8 +152,10 @@ void BackwardChainerUTest::test_select_rule_3()
 		                         "   (Variable \"$C\")"
 		                         "   (Type \"InheritanceLink\"))");
 	BITNode target(target_h);
+	AndBIT andbit(_as, target_h, vardecl_h);
 
-	RuleTypedSubstitutionPair selected_rule = _bc->select_rule(target, vardecl_h);
+	RuleTypedSubstitutionPair selected_rule =
+		_bc->_control.select_rule(andbit, target);
 
 	TS_ASSERT_EQUALS(selected_rule.first.get_name(), "bc-deduction-rule");
 }
@@ -598,7 +606,7 @@ void BackwardChainerUTest::test_criminal_trace()
 		17025922688105268679U, 16237370205818075250U, 13060619487639450045U,
 			14172591710384300158U, 14741649033484653578U, 11564898315305997225U};
 	AndBITFitness trace_fitness(AndBITFitness::Trace, trace);
-	BackwardChainer bc(_as, top_rbs, target, vardecl, nullptr,
+	BackwardChainer bc(_as, top_rbs, target, vardecl, nullptr, nullptr,
 	                   Handle::UNDEFINED, BITNodeFitness(), trace_fitness);
 	bc.get_config().set_maximum_iterations(50);
 	bc.do_chain();
@@ -689,7 +697,7 @@ void BackwardChainerUTest::test_focus_set()
 		             " )"
 		             ")");
 
-	BackwardChainer bc(_as, top_rbs, target, vardecl, nullptr, focus_set);
+	BackwardChainer bc(_as, top_rbs, target, vardecl, nullptr, nullptr, focus_set);
 
 	Handle soln1 = _eval.eval_h("(InheritanceLink"
 	                            "  (ConceptNode \"tree\")"


### PR DESCRIPTION
Implement rule base control for the Backward Chainer.

It is still incomplete (only handles inference rule decision), and the rule selection algorithm needs improvements. In particular it is expected that it may require to implement distributional TVs to work well.

However the general framework is I believe rather solid and should probably be used for OpenPsi (specifically the classes `MixtureModel` used for combining rules, and `ActionSelection` for selecting actions, well balancing exploitation vs exploration).