### PR TITLE
Scheme should not print extracted atoms.

### DIFF
--- a/tests/scm/SCMPrimitiveUTest.cxxtest
+++ b/tests/scm/SCMPrimitiveUTest.cxxtest
@@ -176,6 +176,8 @@ void SCMPrimitiveUTest::test_throw(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
+	eval->eval("(define nnn (cog-new-node 'ConceptNode \"Hello World!\"))");
+
 	// Test the throw of an assertion. This should cause an evaluation
 	// error. (In the shell, stuff would get printed to terminal)
 	MyExampleClass *mtc = new MyExampleClass(as, 42);


### PR DESCRIPTION
This is a fix for issue #127.   Atoms that are not in any atomspace are possible; the C++ API explicitly allows this. However, the scheme API was designed with the assumption that all atoms are always in an atomspace, and so printing atoms that have been removed is ... confusing.