### PR TITLE
Convert the two non-trivial nodes to use a factory.

### DIFF
--- a/opencog/atoms/CMakeLists.txt
+++ b/opencog/atoms/CMakeLists.txt
@@ -4,9 +4,3 @@ ADD_SUBDIRECTORY (core)
 ADD_SUBDIRECTORY (execution)
 ADD_SUBDIRECTORY (pattern)
 ADD_SUBDIRECTORY (reduct)
-
-INSTALL (FILES
-	NumberNode.h
-	TypeNode.h
-	DESTINATION "include/opencog/atoms"
-)

--- a/opencog/atoms/core/ArityLink.cc
+++ b/opencog/atoms/core/ArityLink.cc
@@ -22,7 +22,7 @@
  */
 
 #include <opencog/atomspace/AtomSpace.h>
-#include <opencog/atoms/NumberNode.h>
+#include <opencog/atoms/core/NumberNode.h>
 
 #include "ArityLink.h"
 

--- a/opencog/atoms/core/CMakeLists.txt
+++ b/opencog/atoms/core/CMakeLists.txt
@@ -10,6 +10,7 @@ ADD_LIBRARY (atomcore
 	FunctionLink.cc
 	ImplicationScopeLink.cc
 	LambdaLink.cc
+	NumberNode.cc
 	PutLink.cc
 	RandomChoice.cc
 	RandomNumber.cc
@@ -18,6 +19,7 @@ ADD_LIBRARY (atomcore
 	StateLink.cc
 	TimeLink.cc
 	TypedAtomLink.cc
+	TypeNode.cc
 	UniqueLink.cc
 	Variables.cc
 	VariableList.cc
@@ -42,6 +44,7 @@ INSTALL (FILES
 	FreeLink.h
 	FunctionLink.h
 	LambdaLink.h
+	NumberNode.h
 	PutLink.h
 	RandomChoice.h
 	RandomNumber.h
@@ -50,6 +53,7 @@ INSTALL (FILES
 	StateLink.h
 	TimeLink.h
 	TypedAtomLink.h
+	TypeNode.h
 	UniqueLink.h
 	Variables.h
 	VariableList.h

--- a/opencog/atoms/core/NumberNode.cc
+++ b/opencog/atoms/core/NumberNode.cc
@@ -1,0 +1,26 @@
+/*
+ * opencog/atoms/core/NumberNode.cc
+ *
+ * Copyright (C) 2015 Linas Vepstas
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "NumberNode.h"
+
+using namespace opencog;
+DEFINE_NODE_FACTORY(NumberNode, NUMBER_NODE)

--- a/opencog/atoms/core/NumberNode.h
+++ b/opencog/atoms/core/NumberNode.h
@@ -1,5 +1,5 @@
 /*
- * opencog/atoms/NumberNode.h
+ * opencog/atoms/core/NumberNode.h
  *
  * Copyright (C) 2015 Linas Vepstas
  * All Rights Reserved
@@ -66,6 +66,14 @@ protected:
 	double value;
 
 public:
+	// Please to NOT use this constructor!
+	NumberNode(Type t, const std::string& s)
+		// Convert to number and back to string to avoid miscompares.
+		: Node(t, double_to_string(std::stod(s))),
+		  value(std::stod(s))
+	{}
+
+public:
 	NumberNode(const std::string& s)
 		// Convert to number and back to string to avoid miscompares.
 		: Node(NUMBER_NODE, double_to_string(std::stod(s))),
@@ -91,6 +99,8 @@ public:
 	}
 
 	double get_value(void) { return value; }
+
+	static Handle factory(const Handle&);
 };
 
 typedef std::shared_ptr<NumberNode> NumberNodePtr;

--- a/opencog/atoms/core/RandomChoice.cc
+++ b/opencog/atoms/core/RandomChoice.cc
@@ -24,8 +24,8 @@
 #include <opencog/util/mt19937ar.h>
 #include <opencog/atomspace/AtomSpace.h>
 
-#include "../NumberNode.h"
 #include "FunctionLink.h"
+#include "NumberNode.h"
 #include "RandomChoice.h"
 
 using namespace opencog;

--- a/opencog/atoms/core/RandomNumber.cc
+++ b/opencog/atoms/core/RandomNumber.cc
@@ -24,7 +24,7 @@
 #include <opencog/util/mt19937ar.h>
 
 #include <opencog/atomspace/AtomSpace.h>
-#include <opencog/atoms/NumberNode.h>
+#include <opencog/atoms/core/NumberNode.h>
 
 #include "RandomNumber.h"
 

--- a/opencog/atoms/core/ScopeLink.cc
+++ b/opencog/atoms/core/ScopeLink.cc
@@ -26,8 +26,8 @@
 #include <opencog/util/mt19937ar.h>
 #include <opencog/util/Logger.h>
 #include <opencog/atoms/base/ClassServer.h>
-#include <opencog/atoms/TypeNode.h>
 #include <opencog/atoms/core/LambdaLink.h>
+#include <opencog/atoms/core/TypeNode.h>
 
 #include "ScopeLink.h"
 

--- a/opencog/atoms/core/SleepLink.cc
+++ b/opencog/atoms/core/SleepLink.cc
@@ -25,7 +25,7 @@
 #include <time.h>
 #include <sys/time.h>
 
-#include <opencog/atoms/NumberNode.h>
+#include <opencog/atoms/core/NumberNode.h>
 #include <opencog/atomspace/AtomSpace.h>
 
 #include "SleepLink.h"

--- a/opencog/atoms/core/TimeLink.cc
+++ b/opencog/atoms/core/TimeLink.cc
@@ -22,7 +22,7 @@
 #include <time.h>
 #include <sys/time.h>
 
-#include <opencog/atoms/NumberNode.h>
+#include <opencog/atoms/core/NumberNode.h>
 #include <opencog/atomspace/AtomSpace.h>
 
 #include "TimeLink.h"

--- a/opencog/atoms/core/TypeNode.cc
+++ b/opencog/atoms/core/TypeNode.cc
@@ -1,0 +1,27 @@
+/*
+ * opencog/atoms/core/TypeNode.cc
+ *
+ * Copyright (C) 2015 Linas Vepstas
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "TypeNode.h"
+
+using namespace opencog;
+
+DEFINE_NODE_FACTORY(TypeNode, TYPE_NODE)

--- a/opencog/atoms/core/TypeNode.h
+++ b/opencog/atoms/core/TypeNode.h
@@ -48,7 +48,11 @@ public:
 		: Node(t, s),
 		  value(classserver().getType(s))
 	{
-		if (NOTYPE == value)
+		// Perform strict checking only for TypeNode.  The
+		// DefinedTypeNode, which inherits from this class,
+		// allows user-defined types which the classerver
+		// currently does not know about.
+		if (TYPE_NODE == t and NOTYPE == value)
 			throw InvalidParamException(TRACE_INFO,
 				"Not a valid typename: '%s'", s.c_str());
 	}

--- a/opencog/atoms/core/TypeNode.h
+++ b/opencog/atoms/core/TypeNode.h
@@ -1,5 +1,5 @@
 /*
- * opencog/atoms/TypeNode.h
+ * opencog/atoms/core/TypeNode.h
  *
  * Copyright (C) 2015 Linas Vepstas
  * All Rights Reserved
@@ -40,6 +40,18 @@ class TypeNode : public Node
 {
 protected:
 	Type value;
+
+public:
+	// Please do NOT use this constructor!
+	TypeNode(Type t, const std::string& s)
+		// Convert to number and back to string to avoid miscompares.
+		: Node(t, s),
+		  value(classserver().getType(s))
+	{
+		if (NOTYPE == value)
+			throw InvalidParamException(TRACE_INFO,
+				"Not a valid typename: '%s'", s.c_str());
+	}
 
 public:
 	TypeNode(const std::string& s)
@@ -86,6 +98,8 @@ public:
 	}
 
 	Type get_value(void) { return value; }
+
+	static Handle factory(const Handle&);
 };
 
 typedef std::shared_ptr<TypeNode> TypeNodePtr;

--- a/opencog/atoms/core/VariableList.cc
+++ b/opencog/atoms/core/VariableList.cc
@@ -24,9 +24,9 @@
 #include <math.h>
 
 #include <opencog/atoms/base/ClassServer.h>
-#include <opencog/atoms/TypeNode.h>
 #include <opencog/atoms/core/DefineLink.h>
-#include <opencog/atoms/NumberNode.h>
+#include <opencog/atoms/core/NumberNode.h>
+#include <opencog/atoms/core/TypeNode.h>
 
 #include "VariableList.h"
 

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -26,7 +26,7 @@
 #include <opencog/atoms/base/ClassServer.h>
 #include <opencog/atoms/base/Quotation.h>
 #include <opencog/atomutils/TypeUtils.h>
-#include <opencog/atoms/TypeNode.h>
+#include <opencog/atoms/core/TypeNode.h>
 
 #include "ScopeLink.h"
 #include "VariableList.h"

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -24,9 +24,9 @@
 
 #include <opencog/atoms/base/atom_types.h>
 #include <opencog/truthvalue/SimpleTruthValue.h>
-#include <opencog/atoms/NumberNode.h>
 #include <opencog/atoms/core/DefineLink.h>
 #include <opencog/atoms/core/LambdaLink.h>
+#include <opencog/atoms/core/NumberNode.h>
 #include <opencog/atoms/core/PutLink.h>
 #include <opencog/atoms/execution/Instantiator.h>
 #include <opencog/atoms/pattern/PatternLink.h>

--- a/opencog/atoms/reduct/ArithmeticLink.cc
+++ b/opencog/atoms/reduct/ArithmeticLink.cc
@@ -24,7 +24,7 @@
 
 #include <opencog/atoms/base/atom_types.h>
 #include <opencog/atoms/base/ClassServer.h>
-#include <opencog/atoms/NumberNode.h>
+#include <opencog/atoms/core/NumberNode.h>
 #include "ArithmeticLink.h"
 
 using namespace opencog;

--- a/opencog/atoms/reduct/DivideLink.cc
+++ b/opencog/atoms/reduct/DivideLink.cc
@@ -22,7 +22,7 @@
 
 #include <opencog/atoms/base/atom_types.h>
 #include <opencog/atoms/base/ClassServer.h>
-#include <opencog/atoms/NumberNode.h>
+#include <opencog/atoms/core/NumberNode.h>
 #include "DivideLink.h"
 #include "TimesLink.h"
 

--- a/opencog/atoms/reduct/DivideLink.h
+++ b/opencog/atoms/reduct/DivideLink.h
@@ -25,7 +25,7 @@
 
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/atoms/reduct/TimesLink.h>
-#include <opencog/atoms/NumberNode.h>
+#include <opencog/atoms/core/NumberNode.h>
 
 namespace opencog
 {

--- a/opencog/atoms/reduct/FoldLink.cc
+++ b/opencog/atoms/reduct/FoldLink.cc
@@ -24,7 +24,7 @@
 
 #include <opencog/atoms/base/atom_types.h>
 #include <opencog/atoms/base/ClassServer.h>
-#include <opencog/atoms/NumberNode.h>
+#include <opencog/atoms/core/NumberNode.h>
 #include "FoldLink.h"
 
 using namespace opencog;

--- a/opencog/atoms/reduct/MinusLink.cc
+++ b/opencog/atoms/reduct/MinusLink.cc
@@ -22,7 +22,7 @@
 
 #include <opencog/atoms/base/atom_types.h>
 #include <opencog/atoms/base/ClassServer.h>
-#include <opencog/atoms/NumberNode.h>
+#include <opencog/atoms/core/NumberNode.h>
 #include "MinusLink.h"
 #include "PlusLink.h"
 

--- a/opencog/atoms/reduct/MinusLink.h
+++ b/opencog/atoms/reduct/MinusLink.h
@@ -25,7 +25,7 @@
 
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/atoms/reduct/PlusLink.h>
-#include <opencog/atoms/NumberNode.h>
+#include <opencog/atoms/core/NumberNode.h>
 
 namespace opencog
 {

--- a/opencog/atoms/reduct/PlusLink.cc
+++ b/opencog/atoms/reduct/PlusLink.cc
@@ -22,7 +22,7 @@
 
 #include <opencog/atoms/base/atom_types.h>
 #include <opencog/atoms/base/ClassServer.h>
-#include <opencog/atoms/NumberNode.h>
+#include <opencog/atoms/core/NumberNode.h>
 #include "PlusLink.h"
 #include "TimesLink.h"
 

--- a/opencog/atoms/reduct/TimesLink.cc
+++ b/opencog/atoms/reduct/TimesLink.cc
@@ -22,7 +22,7 @@
 
 #include <opencog/atoms/base/atom_types.h>
 #include <opencog/atoms/base/ClassServer.h>
-#include <opencog/atoms/NumberNode.h>
+#include <opencog/atoms/core/NumberNode.h>
 #include "TimesLink.h"
 
 using namespace opencog;

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -38,9 +38,8 @@
 #include <opencog/atoms/base/ClassServer.h>
 #include <opencog/atoms/base/Link.h>
 #include <opencog/atoms/base/Node.h>
-#include <opencog/atoms/NumberNode.h>
-#include <opencog/atoms/TypeNode.h>
 #include <opencog/atoms/core/DeleteLink.h>
+#include <opencog/atoms/core/NumberNode.h>
 #include <opencog/atoms/core/ScopeLink.h>
 #include <opencog/atoms/core/StateLink.h>
 #include <opencog/util/exceptions.h>
@@ -223,16 +222,7 @@ AtomTable::AtomTable(const AtomTable& other)
 
 Handle AtomTable::getHandle(Type t, const std::string& n) const
 {
-    // Special types need validation.  XXX The classserver factory
-    // should be used for this.
-    AtomPtr a;
-    try {
-        if (NUMBER_NODE == t) a = createNumberNode(n);
-        else if (classserver().isA(t, TYPE_NODE)) a = createTypeNode(n);
-        else a = createNode(t,n);
-    }
-    catch (...) { return Handle::UNDEFINED; }
-
+    AtomPtr a(createNode(t,n));
     return getNodeHandle(a);
 }
 
@@ -384,15 +374,7 @@ AtomPtr AtomTable::cast_factory(Type atom_type, AtomPtr atom)
 /// copy, in that case.
 AtomPtr AtomTable::clone_factory(Type atom_type, AtomPtr atom)
 {
-    // Nodes of various kinds -----------
-    // XXX TODO: convert TypeNode and NumberNode to use factory as
-    // well.
-    if (NUMBER_NODE == atom_type)
-        return createNumberNode(*NodeCast(atom));
-    if (classserver().isA(atom_type, TYPE_NODE))
-        return createTypeNode(*NodeCast(atom));
-
-    // LgDictNode needs a factory to construct it.
+    // NumberNode, TypeNode and LgDictNode need a factory to construct.
     if (classserver().isA(atom_type, NODE))
         return classserver().factory(Handle(createNode(*NodeCast(atom))));
 

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -423,9 +423,8 @@ Handle AtomTable::add(AtomPtr atom, bool async)
         // NumberNode, TypeNode and LgDictNode need a factory to construct.
         if (classserver().isA(atom_type, NODE))
             atom = classserver().factory(Handle(createNode(*NodeCast(atom))));
-
-        // The createLink *forces* a copy of the link to be made.
-        atom = classserver().factory(Handle(createLink(*LinkCast(atom))));
+        else
+            atom = classserver().factory(Handle(createLink(*LinkCast(atom))));
     }
 
     // Lock before checking to see if this kind of atom is already in

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -229,11 +229,12 @@ Handle AtomTable::getHandle(Type t, const std::string& n) const
 Handle AtomTable::getNodeHandle(const AtomPtr& orig) const
 {
     AtomPtr a(orig);
+    // AtomPtr a(classserver().factory(Handle(*NodeCast(orig))));
     // The hash function will fail to find NumberNodes unless
     // they are in the proper format.
-    if (NUMBER_NODE == a->getType()) {
+    if (classserver().isA(a->getType(), NUMBER_NODE)) {
        if (nullptr == NumberNodeCast(a))
-           a = createNumberNode(a->getName());
+           a = createNumberNode(a->getType(), a->getName());
     }
 
     ContentHash ch = a->get_hash();

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -39,7 +39,6 @@
 #include <opencog/atoms/base/Link.h>
 #include <opencog/atoms/base/Node.h>
 #include <opencog/atoms/core/DeleteLink.h>
-#include <opencog/atoms/core/NumberNode.h>
 #include <opencog/atoms/core/ScopeLink.h>
 #include <opencog/atoms/core/StateLink.h>
 #include <opencog/util/exceptions.h>
@@ -228,14 +227,9 @@ Handle AtomTable::getHandle(Type t, const std::string& n) const
 
 Handle AtomTable::getNodeHandle(const AtomPtr& orig) const
 {
-    AtomPtr a(orig);
-    // AtomPtr a(classserver().factory(Handle(*NodeCast(orig))));
     // The hash function will fail to find NumberNodes unless
     // they are in the proper format.
-    if (classserver().isA(a->getType(), NUMBER_NODE)) {
-       if (nullptr == NumberNodeCast(a))
-           a = createNumberNode(a->getType(), a->getName());
-    }
+    AtomPtr a(classserver().factory(Handle(NodeCast(orig))));
 
     ContentHash ch = a->get_hash();
     std::lock_guard<std::recursive_mutex> lck(_mtx);

--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -141,7 +141,6 @@ private:
     AtomTable(const AtomTable&);
 
     AtomPtr cast_factory(Type atom_type, AtomPtr atom);
-    AtomPtr clone_factory(Type atom_type, AtomPtr atom);
 
 public:
 

--- a/opencog/atomutils/TypeUtils.cc
+++ b/opencog/atomutils/TypeUtils.cc
@@ -24,7 +24,7 @@
 #include <opencog/atoms/base/Link.h>
 #include <opencog/atoms/base/ClassServer.h>
 
-#include <opencog/atoms/TypeNode.h>
+#include <opencog/atoms/core/TypeNode.h>
 #include <opencog/atoms/core/DefineLink.h>
 #include <opencog/atoms/core/VariableList.h>
 

--- a/opencog/rule-engine/UREConfigReader.cc
+++ b/opencog/rule-engine/UREConfigReader.cc
@@ -23,9 +23,9 @@
 
 #include "UREConfigReader.h"
 
-#include <opencog/atoms/NumberNode.h>
-#include <opencog/query/BindLinkAPI.h>
+#include <opencog/atoms/core/NumberNode.h>
 #include <opencog/atomspaceutils/AtomSpaceUtils.h>
+#include <opencog/query/BindLinkAPI.h>
 
 using namespace std;
 using namespace opencog;

--- a/tests/atomspace/AtomSpaceAsyncUTest.cxxtest
+++ b/tests/atomspace/AtomSpaceAsyncUTest.cxxtest
@@ -279,6 +279,8 @@ public:
     {
         classserver().foreachRecursive(
             [&](Type t)->void {
+                if (classserver().isA(t, NUMBER_NODE)) return;
+                if (classserver().isA(t, TYPE_NODE)) return;
                 Handle h(as->get_handle(t, name));
                 if (h) *(result++) = h; }, NODE);
         return result;

--- a/tests/atomspace/AtomSpaceUTest.cxxtest
+++ b/tests/atomspace/AtomSpaceUTest.cxxtest
@@ -334,6 +334,9 @@ get_handles_by_name(AtomSpace* as,
     }
     classserver().foreachRecursive(
         [&](Type t)->void {
+            // Avoid illegal gets.
+            if (NUMBER_NODE == t) return;
+            if (TYPE_NODE == t) return;
             Handle h(as->get_handle(t, name));
             if (h) *(result++) = h; }, type);
 
@@ -349,7 +352,7 @@ private:
 public:
     AtomSpaceUTest() {
         logger().set_level(Logger::DEBUG);
-        logger().set_sync_flag(true);
+        // logger().set_sync_flag(true);
         logger().set_print_to_stdout_flag(true);
     }
 
@@ -523,9 +526,11 @@ public:
         // Test getHandleSet
         // OutputIterator getHandleSet(OutputIterator, Type, const string& name, bool acceptSubTypes=true) const;
 
+        logger().debug("Start subset test");
         for (int vhIdx = 0; vhIdx < NUM_VHS; vhIdx++) {
             for (int i = 0; i < NUM_NODES; i++) {
                 HandleSeq nodes;
+                logger().debug("start get handle by name %d %d", vhIdx, i);
                 get_handles_by_name(atomSpace, back_inserter(nodes), nodeNames[i], NODE, true);
                 TS_ASSERT_EQUALS(nodes.size(), 1);
                 for (int j = 0; j < NUM_NODES; j++) {

--- a/tests/atomspace/AtomSpaceUTest.cxxtest
+++ b/tests/atomspace/AtomSpaceUTest.cxxtest
@@ -348,7 +348,7 @@ private:
 
 public:
     AtomSpaceUTest() {
-        logger().set_level(Logger::INFO);
+        logger().set_level(Logger::DEBUG);
         logger().set_print_to_stdout_flag(true);
     }
 
@@ -374,8 +374,9 @@ public:
         }
     };
 
-    void testMiscellaneous() {
-        logger().debug("\ntestMiscellaneous()\n");
+    void testMiscellaneous()
+    {
+        logger().info("\nBegin testMiscellaneous()");
 
         const char* nodeNames[NUM_NODES] = {
             "Vader",
@@ -385,12 +386,13 @@ public:
             "Force",
             "Human"
         };
+
         Handle h[NUM_NODES];
         for (int i = 0; i < NUM_NODES; i++) {
             h[i] = atomSpace->add_node(CONCEPT_NODE, nodeNames[i]);
             h[i]->setTruthValue(SimpleTruthValue::createTV(0.001f, 0.99f));
         }
-        //logger().debug("Nodes created\n");
+        logger().debug("Nodes created");
 
         float ForceUser[NUM_FORCEUSER_LINKS] = {0.99f, 0.99f, 0.0f, 0.5f};
         Handle FU[NUM_FORCEUSER_LINKS];
@@ -401,7 +403,7 @@ public:
             FU[i] = atomSpace->add_link(SUBSET_LINK, temp);
             FU[i]->setTruthValue(SimpleTruthValue::createTV(ForceUser[i], 0.99f));
         }
-        //logger().debug("ForceUser links created\n");
+        logger().debug("ForceUser links created");
 
         float Human[4] = {0.99f, 0.99f, 0.5f, 0.0f};
         HandleSeq out[4];
@@ -412,36 +414,36 @@ public:
             H[i] = atomSpace->add_link(INHERITANCE_LINK, out[i]);
             H[i]->setTruthValue(SimpleTruthValue::createTV(Human[i], 0.99f));
         }
-        //logger().debug("Human links created\n");
+        logger().debug("Human links created");
 
         // Check TVS
         for (int i = 0; i < NUM_NODES; i++) {
             TruthValuePtr tv = h[i]->getTruthValue();
-            logger().debug("h: tv mean = %f, atomSpace->getMean(h[i]) = %f\n",
+            logger().debug("h: tv mean = %f, atomSpace->getMean(h[i]) = %f",
                  tv->getMean(), h[i]->getTruthValue()->getMean());
             TS_ASSERT(fabs(tv->getMean() - 0.001) < FLOAT_ACCEPTABLE_ERROR);
-            logger().debug("h: confidence = %f, diff = %f, error = %f\n", tv->getConfidence(), fabs(tv->getConfidence() - 0.99), FLOAT_ACCEPTABLE_ERROR);
+            logger().debug("h: confidence = %f, diff = %f, error = %f", tv->getConfidence(), fabs(tv->getConfidence() - 0.99), FLOAT_ACCEPTABLE_ERROR);
             TS_ASSERT(fabs(tv->getConfidence() - 0.99) < FLOAT_ACCEPTABLE_ERROR);
             if (i < NUM_FORCEUSER_LINKS) {
                 TruthValuePtr tv = FU[i]->getTruthValue();
-                logger().debug("h: tv mean = %f, atomSpace->getMean(h[i]) = %f\n",
+                logger().debug("h: tv mean = %f, atomSpace->getMean(h[i]) = %f",
                   tv->getMean(), h[i]->getTruthValue()->getMean());
                 logger().debug("FU: tv mean = %f, atomSpace->getMean(FU[i]) = %f\n",
                  tv->getMean(), FU[i]->getTruthValue()->getMean());
                 TS_ASSERT(fabs(tv->getMean() - ForceUser[i]) < FLOAT_ACCEPTABLE_ERROR);
-                logger().debug("FU: confidence = %f, diff = %f, error = %f\n", tv->getConfidence(), fabs(tv->getConfidence() - 0.99), FLOAT_ACCEPTABLE_ERROR);
+                logger().debug("FU: confidence = %f, diff = %f, error = %f", tv->getConfidence(), fabs(tv->getConfidence() - 0.99), FLOAT_ACCEPTABLE_ERROR);
                 TS_ASSERT(fabs(tv->getConfidence() - 0.99) < FLOAT_ACCEPTABLE_ERROR);
             }
             if (i < NUM_HUMAN_LINKS) {
                 TruthValuePtr tv = H[i]->getTruthValue();
-                logger().debug("h: tv mean = %f, atomSpace->getMean(h[i]) = %f\n",
+                logger().debug("h: tv mean = %f, atomSpace->getMean(h[i]) = %f",
                      tv->getMean(), h[i]->getTruthValue()->getMean());
                 TS_ASSERT(fabs(tv->getMean() - Human[i]) < FLOAT_ACCEPTABLE_ERROR);
-                logger().debug("H: confidence = %f, diff = %f, error = %f\n", tv->getConfidence(), fabs(tv->getConfidence() - 0.99), FLOAT_ACCEPTABLE_ERROR);
+                logger().debug("H: confidence = %f, diff = %f, error = %f", tv->getConfidence(), fabs(tv->getConfidence() - 0.99), FLOAT_ACCEPTABLE_ERROR);
                 TS_ASSERT(fabs(tv->getConfidence() - 0.99) < FLOAT_ACCEPTABLE_ERROR);
             }
         }
-        //logger().debug("TVS checked\n");
+        logger().debug("TVS checked");
 
         TS_ASSERT(atomSpace->get_num_nodes() == NUM_NODES);
         TS_ASSERT(atomSpace->get_num_links() == 8);
@@ -452,6 +454,7 @@ public:
             mean m;
             HandleSeq high_mean;
             getHandleSetFiltered(atomSpace, back_inserter(high_mean), ATOM, true, m);
+            logger().debug("Filter %d checked", vhIdx);
 
             //std::cout << "high mean size " << high_mean.size() << std::endl;
             //for (int jj = 0; jj < high_mean.size(); jj++) {
@@ -460,9 +463,11 @@ public:
 
             HandleSeq nodes;
             atomSpace->get_handles_by_type(back_inserter(nodes), NODE, true);
+            logger().debug("Get nodes by type %d checked", vhIdx);
 
             HandleSeq links;
             atomSpace->get_handles_by_type(back_inserter(links), LINK, true);
+            logger().debug("Get links by type %d checked", vhIdx);
 
             HandleSeq all;
             everything e;
@@ -471,6 +476,7 @@ public:
             HandleSeq AF_nodes = filter_InAttentionalFocus(atomSpace, nodes.begin(), nodes.end());
             HandleSeq AF_links = filter_InAttentionalFocus(atomSpace, links.begin(), links.end());
 
+            logger().debug("Focus %d checked", vhIdx);
             TS_ASSERT(AF_nodes.size() == 0);
             TS_ASSERT(AF_links.size() == 0);
 
@@ -494,6 +500,7 @@ public:
                     TS_ASSERT (find(all.begin(), all.end(), FU[i]) != all.end());
                 }
             }
+            logger().debug("Forceuser %d checked", vhIdx);
 
             for (int i = 0; i < NUM_HUMAN_LINKS; i++) {
                 if (vhIdx == 0 || (i % 4 == vhIdx)) {
@@ -501,6 +508,7 @@ public:
                     TS_ASSERT (find(all.begin(), all.end(), H[i]) != all.end());
                 }
             }
+            logger().debug("Human %d checked", vhIdx);
 
             for (int i = 0; i < NUM_NODES; i++) {
                 if (vhIdx == 0 || (i % 4 == vhIdx)) {
@@ -508,6 +516,7 @@ public:
                     TS_ASSERT (find(nodes.begin(), nodes.end(), h[i]) != nodes.end());
                 }
             }
+            logger().debug("Rest of them %d checked", vhIdx);
         }
 
         // Test getHandleSet
@@ -527,37 +536,39 @@ public:
                 }
             }
 
+            logger().debug("Subset %d checked", vhIdx);
             TS_ASSERT(classserver().isA(SUBSET_LINK, INHERITANCE_LINK));
 
             // Note: SUBSET_LINK is a subType of INHERITANCE_LINK
             HandleSeq links;
             get_handles_by_name(atomSpace, back_inserter(links), "", LINK, true);
-            logger().debug("1) links.size() = %d Expected = %d\n", (int) links.size(), 8);
+            logger().debug("1) links.size() = %d Expected = %d", (int) links.size(), 8);
             TS_ASSERT(links.size() == 8);
             links.clear();
             get_handles_by_name(atomSpace, back_inserter(links), "", LINK, false);
-            //logger().debug("2) links.size() = %d\n", links.size());
+            logger().debug("2) links.size() = %d", links.size());
             TS_ASSERT(links.size() == 0);
             HandleSeq allInhLinks;
             get_handles_by_name(atomSpace, back_inserter(allInhLinks), "", INHERITANCE_LINK, true);
-            //logger().info("4) allInhLinks.size() = %d (vhIdx: %d)\n", allInhLinks.size(), vhIdx);
+            logger().debug("4) allInhLinks.size() = %d (vhIdx: %d)", allInhLinks.size(), vhIdx);
             //for (unsigned int x = 0; x < allInhLinks.size(); ++x) {
             //    logger().info("allInhLinks[x]: %s\n", allInhLinks[x]->toString().c_str());
             //}
             TS_ASSERT(allInhLinks.size() == 8);
             HandleSeq justInhLinks;
             get_handles_by_name(atomSpace, back_inserter(justInhLinks), "", INHERITANCE_LINK, false);
-            //logger().info("5) justInhLinks.size() = %d (vhIdx: %d)\n", justInhLinks.size(), vhIdx);
+            logger().debug("5) justInhLinks.size() = %d (vhIdx: %d)", justInhLinks.size(), vhIdx);
             TS_ASSERT(justInhLinks.size() == 4);
             HandleSeq partOfLinks;
             get_handles_by_name(atomSpace, back_inserter(partOfLinks), "", SUBSET_LINK, true);
-            //logger().debug("5) partOfLinks.size() = %d\n", partOfLinks.size());
+            logger().debug("6) partOfLinks.size() = %d", partOfLinks.size());
             TS_ASSERT(partOfLinks.size() == 4);
             partOfLinks.clear();
             get_handles_by_name(atomSpace, back_inserter(partOfLinks), "", SUBSET_LINK, false);
-            //logger().debug("6) partOfLinks.size() = %d\n", partOfLinks.size());
+            logger().debug("7) partOfLinks.size() = %d", partOfLinks.size());
             TS_ASSERT(partOfLinks.size() == 4);
         }
+        logger().info("\nEnd testMiscellaneous()");
     }
 
     /**

--- a/tests/atomspace/AtomSpaceUTest.cxxtest
+++ b/tests/atomspace/AtomSpaceUTest.cxxtest
@@ -335,8 +335,8 @@ get_handles_by_name(AtomSpace* as,
     classserver().foreachRecursive(
         [&](Type t)->void {
             // Avoid illegal gets.
-            if (NUMBER_NODE == t) return;
-            if (TYPE_NODE == t) return;
+            if (classserver().isA(t, NUMBER_NODE)) return;
+            if (classserver().isA(t, TYPE_NODE)) return;
             Handle h(as->get_handle(t, name));
             if (h) *(result++) = h; }, type);
 

--- a/tests/atomspace/AtomSpaceUTest.cxxtest
+++ b/tests/atomspace/AtomSpaceUTest.cxxtest
@@ -349,6 +349,7 @@ private:
 public:
     AtomSpaceUTest() {
         logger().set_level(Logger::DEBUG);
+        logger().set_sync_flag(true);
         logger().set_print_to_stdout_flag(true);
     }
 

--- a/tests/scm/SCMExecutionOutputUTest.cxxtest
+++ b/tests/scm/SCMExecutionOutputUTest.cxxtest
@@ -21,9 +21,10 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/atomspace/AtomSpace.h>
 #include <opencog/atoms/base/Link.h>
 #include <opencog/atoms/base/Node.h>
+#include <opencog/atoms/core/NumberNode.h>
+#include <opencog/atomspace/AtomSpace.h>
 #include <opencog/guile/SchemeSmob.h>
 #include <opencog/guile/SchemeEval.h>
 #include <opencog/guile/SchemePrimitive.h>
@@ -31,7 +32,6 @@
 #include <opencog/atoms/execution/ExecutionOutputLink.h>
 #include <opencog/atoms/execution/EvaluationLink.h>
 #include <opencog/atoms/execution/ExecSCM.h>
-#include <opencog/atoms/NumberNode.h>
 
 using namespace opencog;
 


### PR DESCRIPTION
All of the links that needed to use a factory were converted to do so a while ago.  The two node types were not handled, as it seemed too minor to bother with.  Yet, it was an annoying piece of left-over messiness, and it seemed like a good time to fix this. 