### PR TITLE
Fix BC trace UTest

### DIFF
--- a/opencog/atoms/base/Handle.h
+++ b/opencog/atoms/base/Handle.h
@@ -169,6 +169,9 @@ typedef std::pair<Handle, Handle> HandlePair;
 //! a list of handles
 typedef std::vector<Handle> HandleSeq;
 
+//! a set of lists of handles
+typedef std::set<HandleSeq> HandleSeqSet;
+
 //! a list of lists of handles
 typedef std::vector<HandleSeq> HandleSeqSeq;
 

--- a/opencog/rule-engine/backwardchainer/ControlPolicy.cc
+++ b/opencog/rule-engine/backwardchainer/ControlPolicy.cc
@@ -322,8 +322,7 @@ Handle ControlPolicy::mk_list_of_args_vardecl(const Handle& args_var)
 
 Handle ControlPolicy::mk_expand_exec(const Handle& expand_args_var)
 {
-	Handle expand_schema = an(SCHEMA_NODE,
-	                          TraceRecorder::expand_andbit_predicate_name);
+	Handle expand_schema = an(SCHEMA_NODE, TraceRecorder::expand_andbit_schema_name);
 	return al(EXECUTION_LINK,
 	          expand_schema,
 	          al(UNQUOTE_LINK, expand_args_var));

--- a/opencog/rule-engine/backwardchainer/TraceRecorder.cc
+++ b/opencog/rule-engine/backwardchainer/TraceRecorder.cc
@@ -22,24 +22,56 @@
  */
 
 #include "TraceRecorder.h"
+#include <opencog/util/algorithm.h>
 
 using namespace opencog;
 
 const std::string TraceRecorder::target_predicate_name = "URE:BC:target";
 const std::string TraceRecorder::andbit_predicate_name = "URE:BC:and-BIT";
-const std::string TraceRecorder::expand_andbit_predicate_name = "URE:BC:expand-and-BIT";
+const std::string TraceRecorder::expand_andbit_schema_name = "URE:BC:expand-and-BIT";
 const std::string TraceRecorder::proof_predicate_name = "URE:BC:proof";
 
-TraceRecorder::TraceRecorder(AtomSpace* tr_as) : _trace_as(tr_as) {}
+TraceRecorder::TraceRecorder(AtomSpace* tr_as) : _trace_as(tr_as) {
+	if (_trace_as) {
+		_target_predicate =
+			_trace_as->add_node(PREDICATE_NODE, target_predicate_name);
+		_andbit_predicate =
+			_trace_as->add_node(PREDICATE_NODE, andbit_predicate_name);
+		_expand_andbit_schema =
+			_trace_as->add_node(SCHEMA_NODE, expand_andbit_schema_name);
+		_proof_predicate =
+			_trace_as->add_node(PREDICATE_NODE, proof_predicate_name);
+	}
+}
+
+HandleSeqSet TraceRecorder::traces()
+{
+	HandleSeqSet trs;
+	for (const Handle& fcs_proof : get_fcs_proofs())
+		set_union(trs, traces(fcs_proof));
+	return trs;
+}
+
+HandleSeqSet TraceRecorder::traces(const Handle& fcs)
+{
+	HandleSeqSet trs;
+	for (const Handle& h : get_expansion_sources(fcs)) {
+		for (HandleSeq hs : traces(h)) {
+			hs.push_back(fcs);
+			trs.insert(hs);
+		}
+	}
+	return trs;
+}
 
 void TraceRecorder::target(const Handle& target)
 {
-	add_evaluation(target_predicate_name, target, TruthValue::TRUE_TV());
+	add_evaluation(_target_predicate, target, TruthValue::TRUE_TV());
 }
 
 void TraceRecorder::andbit(const AndBIT& andbit)
 {
-	add_evaluation(andbit_predicate_name,
+	add_evaluation(_andbit_predicate,
 	               dont_exec(andbit.fcs),
 	               TruthValue::TRUE_TV());
 }
@@ -47,7 +79,7 @@ void TraceRecorder::andbit(const AndBIT& andbit)
 void TraceRecorder::expansion(const Handle& andbit_fcs, const Handle& bitleaf_body,
                               const Rule& rule, const AndBIT& new_andbit)
 {
-	add_execution(expand_andbit_predicate_name,
+	add_execution(_expand_andbit_schema,
 	              dont_exec(andbit_fcs), bitleaf_body,
 	              dont_exec(rule.get_alias()),
 	              dont_exec(new_andbit.fcs), TruthValue::TRUE_TV());
@@ -55,7 +87,7 @@ void TraceRecorder::expansion(const Handle& andbit_fcs, const Handle& bitleaf_bo
 
 void TraceRecorder::proof(const Handle& andbit_fcs, const Handle& target_result)
 {
-	add_evaluation(proof_predicate_name,
+	add_evaluation(_proof_predicate,
 	               dont_exec(andbit_fcs), target_result,
 	               target_result->getTruthValue());
 }
@@ -68,20 +100,19 @@ Handle TraceRecorder::dont_exec(const Handle& h)
 	return _trace_as->add_link(DONT_EXEC_LINK, h);
 }
 
-Handle TraceRecorder::add_execution(const std::string& schema_name,
+Handle TraceRecorder::add_execution(const Handle& schema,
                                     const Handle& input, const Handle& output,
                                     TruthValuePtr tv)
 {
 	if (not _trace_as)
 		return Handle::UNDEFINED;
 
-	Handle schema = _trace_as->add_node(SCHEMA_NODE, schema_name);
 	Handle execution = _trace_as->add_link(EXECUTION_LINK, schema, input, output);
 	execution->setTruthValue(tv);
 	return execution;
 }
 
-Handle TraceRecorder::add_execution(const std::string& schema_name,
+Handle TraceRecorder::add_execution(const Handle& schema,
                                     const Handle& input1,
                                     const Handle& input2,
                                     const Handle& input3,
@@ -92,23 +123,22 @@ Handle TraceRecorder::add_execution(const std::string& schema_name,
 		return Handle::UNDEFINED;
 
 	Handle inputs = _trace_as->add_link(LIST_LINK, input1, input2, input3);
-	return add_execution(schema_name, inputs, output, tv);
+	return add_execution(schema, inputs, output, tv);
 }
 
-Handle TraceRecorder::add_evaluation(const std::string& predicate_name,
+Handle TraceRecorder::add_evaluation(const Handle& predicate,
                                      const Handle& argument,
                                      TruthValuePtr tv)
 {
 	if (not _trace_as)
 		return Handle::UNDEFINED;
 	
-	Handle predicate = _trace_as->add_node(PREDICATE_NODE, predicate_name);
 	Handle evaluation = _trace_as->add_link(EVALUATION_LINK, predicate, argument);
 	evaluation->setTruthValue(tv);
 	return evaluation;
 }
 
-Handle TraceRecorder::add_evaluation(const std::string& predicate_name,
+Handle TraceRecorder::add_evaluation(const Handle& predicate,
                                      const Handle& arg1, const Handle& arg2,
                                      TruthValuePtr tv)
 {
@@ -116,5 +146,22 @@ Handle TraceRecorder::add_evaluation(const std::string& predicate_name,
 		return Handle::UNDEFINED;
 
 	Handle arguments = _trace_as->add_link(LIST_LINK, arg1, arg2);
-	return add_evaluation(predicate_name, arguments, tv);
+	return add_evaluation(predicate, arguments, tv);
+}
+
+HandleSet TraceRecorder::get_expansion_sources(const Handle& fcs_target)
+{
+	HandleSet sources;
+	for (auto& exec_link : fcs_target->getIncomingSetByType(EXECUTION_LINK))
+		if (exec_link->getOutgoingAtom(0) == _expand_andbit_schema)
+			sources.insert(exec_link->getOutgoingAtom(1)->getOutgoingAtom(0));
+	return sources;
+}
+
+HandleSet TraceRecorder::get_fcs_proofs()
+{
+	HandleSet fcs_proofs;
+	for (auto& eval_link : _proof_predicate->getIncomingSetByType(EVALUATION_LINK))
+		fcs_proofs.insert(eval_link->getOutgoingAtom(1)->getOutgoingAtom(0));
+	return fcs_proofs;
 }

--- a/opencog/rule-engine/backwardchainer/TraceRecorder.cc
+++ b/opencog/rule-engine/backwardchainer/TraceRecorder.cc
@@ -54,10 +54,20 @@ HandleSeqSet TraceRecorder::traces()
 
 HandleSeqSet TraceRecorder::traces(const Handle& fcs)
 {
+	HandleSet expansion_sources(get_expansion_sources(fcs));
+
+	// Unwrap DontExecLink around the fcs
+	Handle exec_fcs = fcs->getOutgoingAtom(0);
+
+	// Base case
+	if (expansion_sources.empty())
+		return HandleSeqSet{{exec_fcs}};
+
+	// Recursive case
 	HandleSeqSet trs;
-	for (const Handle& h : get_expansion_sources(fcs)) {
+	for (const Handle& h : expansion_sources) {
 		for (HandleSeq hs : traces(h)) {
-			hs.push_back(fcs);
+			hs.push_back(exec_fcs);
 			trs.insert(hs);
 		}
 	}

--- a/opencog/rule-engine/backwardchainer/TraceRecorder.h
+++ b/opencog/rule-engine/backwardchainer/TraceRecorder.h
@@ -36,10 +36,18 @@ class TraceRecorder
 public:
 	static const std::string target_predicate_name;
 	static const std::string andbit_predicate_name;
-	static const std::string expand_andbit_predicate_name;
+	static const std::string expand_andbit_schema_name;
 	static const std::string proof_predicate_name;
 
 	TraceRecorder(AtomSpace* tr_as);
+
+	// Return the traces of fcs leading to the recorded proofs
+	HandleSeqSet traces();
+
+	// Return traces leading to the given FCS. A trace is a sequence
+	// of Handles, each representing a FCS and chained by
+	// ExecutionLinks as recorded in the expansion method.
+	HandleSeqSet traces(const Handle& fcs);
 
 	// Record that an atom is a target
 	//
@@ -91,6 +99,9 @@ public:
 private:
 	AtomSpace* _trace_as;
 
+	Handle _target_predicate, _andbit_predicate, _expand_andbit_schema,
+		_proof_predicate;
+
 	// Wrap a DontExecLink around h
 	//
 	// DontExecLink
@@ -100,23 +111,23 @@ private:
 	// Add
 	//
 	// Execution <tv>
-	//   Schema <schema_name>
+	//   <schema>
 	//   <input>
 	//   <output>
-	Handle add_execution(const std::string& schema_name,
+	Handle add_execution(const Handle& schema,
 	                     const Handle& input, const Handle& output,
 	                     TruthValuePtr tv);
 
 	// Add
 	//
 	// Execution <tv>
-	//   Schema <schema_name>
+	//   <schema>
 	//   List
 	//     <input1>
 	//     <input2>
 	//     <input3>
 	//   <output>
-	Handle add_execution(const std::string& schema_name,
+	Handle add_execution(const Handle& schema,
 	                     const Handle& input1,
 	                     const Handle& input2,
 	                     const Handle& input3,
@@ -126,22 +137,28 @@ private:
 	// Add
 	//
 	// Evaluation <tv>
-	//   Predicate <predicate_name>
+	//   <predicate>
 	//   <argument>
-	Handle add_evaluation(const std::string& predicate_name,
+	Handle add_evaluation(const Handle& predicate,
 	                      const Handle& argument,
 	                      TruthValuePtr tv);
 
 	// Add
 	//
 	// Evaluation <tv>
-	//   Predicate <predicate_name>
+	//   <predicate>
 	//   List
 	//     <arg1>
 	//     <arg2>
-	Handle add_evaluation(const std::string& predicate_name,
+	Handle add_evaluation(const Handle& predicate,
 	                      const Handle& arg1, const Handle& arg2,
 	                      TruthValuePtr tv);
+
+	// Given a fcs, return all fcs that expands to this fcs target.
+	HandleSet get_expansion_sources(const Handle& fcs_target);
+
+	// Return the set of fcs corresponding to proofs
+	HandleSet get_fcs_proofs();
 };
 
 

--- a/tests/rule-engine/BackwardChainerUTest.cxxtest
+++ b/tests/rule-engine/BackwardChainerUTest.cxxtest
@@ -36,10 +36,10 @@ public:
 	BackwardChainerUTest() : _eval(&_as)
 	{
 		logger().set_level(Logger::DEBUG);
-		// logger().set_timestamp_flag(false);
+		logger().set_timestamp_flag(false);
 		// logger().set_sync_flag(true);
-		// logger().set_print_to_stdout_flag(true);
-		ure_logger().set_level(Logger::DEBUG);
+		logger().set_print_to_stdout_flag(true);
+		ure_logger().set_level(Logger::INFO);
 		// ure_logger().set_timestamp_flag(false);
 		// ure_logger().set_sync_flag(true);
 		// ure_logger().set_print_to_stdout_flag(true);
@@ -62,7 +62,6 @@ public:
 	void test_conditional_partial_instantiation();
 	void test_impossible_criminal();
 	void test_criminal();
-	void test_criminal_trace();
 	// TODO: re-enable the following tests
 	void test_induction();
 	void test_focus_set();
@@ -524,6 +523,7 @@ void BackwardChainerUTest::test_criminal()
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
+	// TODO: simplify this shit
 	_as.clear();
 
 	_eval.eval("(load-from-path \"tests/rule-engine/bc-criminal-config.scm\")");
@@ -543,7 +543,10 @@ void BackwardChainerUTest::test_criminal()
 	                 "   (Type \"ConceptNode\"))");
 	Handle soln = _eval.eval_h("(ConceptNode \"West\")");
 
-	BackwardChainer bc(_as, top_rbs, target, vardecl);
+	// To record the trace of the inference
+	AtomSpace trace_as;
+
+	BackwardChainer bc(_as, top_rbs, target, vardecl, &trace_as);
 	// See bc-criminal-config.scm to change the number of iterations
 	bc.do_chain();
 
@@ -556,85 +559,54 @@ void BackwardChainerUTest::test_criminal()
 	logger().debug() << "results = " << oc_to_string(results);
 	logger().debug() << "expected = " << oc_to_string(expected);
 
-	// Disable that till fixed
 	TS_ASSERT_EQUALS(results, expected);
 	TS_ASSERT_LESS_THAN(0.9, expected_target->getTruthValue()->getMean());
 	TS_ASSERT_LESS_THAN(0.9, expected_target->getTruthValue()->getConfidence());
-	// TS_ASSERT(true);
 
-	logger().debug("END TEST: %s", __FUNCTION__);
-}
+	// Extract traces and return the backward chainer with these
+	// traces, which should greatly speed it up.
+	HandleSeqSet traces = bc._trace_recorder.traces();
 
-// Like test_criminal but the trace is provided for guidance (thus
-// speeding up the inference tremendously.)
-//
-// WARNING: this test is dependent on the hash algorithm. If the latter
-// changes, then the trace must be updated.
-//
-// TODO: automate that by storing the trace while running the criminal
-// test, and merge the 2 tests.
-void BackwardChainerUTest::test_criminal_trace()
-{
-	logger().debug("BEGIN TEST: %s", __FUNCTION__);
-
+	// Clear the atomspace and reload the problem
 	_as.clear();
-
 	_eval.eval("(load-from-path \"tests/rule-engine/bc-criminal-config.scm\")");
 	_eval.eval("(load-from-path \"tests/rule-engine/criminal.scm\")");
 	randGen().seed(0);
+	target_var = _eval.eval_h("(VariableNode \"$who\")");
+	target = _eval.eval_h("(InheritanceLink"
+	                      "   (VariableNode \"$who\")"
+	                      "   (ConceptNode \"criminal\"))");
+	vardecl = _eval.eval_h("(TypedVariable"
+	                       "   (VariableNode \"$who\")"
+	                       "   (Type \"ConceptNode\"))");
+	soln = _eval.eval_h("(ConceptNode \"West\")");
 
-	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfigReader::top_rbs_name);
-
-	Handle target_var = _eval.eval_h("(VariableNode \"$who\")");
-	Handle target =
-		_eval.eval_h("(InheritanceLink"
-		             "   (VariableNode \"$who\")"
-		             "   (ConceptNode \"criminal\"))");
-	Handle vardecl =
-	    _eval.eval_h("(TypedVariable"
-	                 "   (VariableNode \"$who\")"
-	                 "   (Type \"ConceptNode\"))");
-	Handle soln = _eval.eval_h("(ConceptNode \"West\")");
-
-	// Warning: if the hash algorithm changes you need to update the
-	// trace. To do that, run test_criminal() with DEBUG log level,
-	// then apply the following on the obtained opencog.log (make sure
-	// that you have deleted the old opencog.log before running
-	// test_crimila())
-	//
-	// <ATOMSPACE_ROOT>/scripts/rule-engine/extract-bc-trace.py <FCS_SOLUTION> opencog.log > opencog-<FCS_SOLUTION>.log
-	// <ATOMSPACE_ROOT>/scripts/rule-engine/extract-values-from-trace.py opencog-<FCS_SOLUTION>.log > <FCS_SOLUTION>.trace
-	//
-	// where <FCS_SOLUTION> is the hash value of the FCS solving the
-	// criminal test.
-	//
-	// Replace all hash keys belows by the ones in file
-	// <FCS_SOLUTION>.trace, preserving the order. Don't forget to
-	// happen U at the end of each value otherwise gcc is gonna
-	// complain.
-	std::set<ContentHash> trace {
-		16984875685464684539U, 17184582226150426169U, 14017120182209734443U,
-			10076933217850647252U, 13992810162835024059U };
+	// Extract the first trace, as understandable by the trace fitness
+	std::set<ContentHash> trace;
+	logger().debug() << "trace =";
+	for (const Handle& h : *(traces.begin())) {
+		ContentHash ch = h.value();
+		trace.insert(ch);
+		logger().debug() << ch;
+	}
 	AndBITFitness trace_fitness(AndBITFitness::Trace, trace);
-	BackwardChainer bc(_as, top_rbs, target, vardecl, nullptr, nullptr,
-	                   Handle::UNDEFINED, BITNodeFitness(), trace_fitness);
-	bc.get_config().set_maximum_iterations(50);
-	bc.do_chain();
+	BackwardChainer tr_bc(_as, top_rbs, target, vardecl, nullptr, nullptr,
+	                      Handle::UNDEFINED, BITNodeFitness(), trace_fitness);
+	tr_bc.get_config().set_maximum_iterations(50);
+	tr_bc.do_chain();
 
-	Handle results = bc.get_results(),
-		expected_target =  _eval.eval_h("(InheritanceLink"
-		                                "   (ConceptNode \"West\")"
-		                                "   (ConceptNode \"criminal\"))"),
-		expected = al(SET_LINK, expected_target);
+	results = tr_bc.get_results();
+	expected_target =  _eval.eval_h("(InheritanceLink"
+	                                "   (ConceptNode \"West\")"
+	                                "   (ConceptNode \"criminal\"))");
+	expected = al(SET_LINK, expected_target);
 
 	logger().debug() << "results = " << oc_to_string(results);
 	logger().debug() << "expected = " << oc_to_string(expected);
 
-	// Disable that till fixed
 	TS_ASSERT_EQUALS(results, expected);
 	TS_ASSERT_LESS_THAN(0.9, expected_target->getTruthValue()->getMean());
 	TS_ASSERT_LESS_THAN(0.9, expected_target->getTruthValue()->getConfidence());
-	// TS_ASSERT(true);
 
 	logger().debug("END TEST: %s", __FUNCTION__);
 }


### PR DESCRIPTION
Now the trace BC is resilient to changes in atom hash keys and thus shouldn't break often as it used to.