### PR TITLE
Seems core_types.scm need to be in ${DATADIR}/scm/opencog/atoms/base

### DIFF
--- a/opencog/atoms/base/CMakeLists.txt
+++ b/opencog/atoms/base/CMakeLists.txt
@@ -59,5 +59,5 @@ INSTALL (FILES
 # Install the auto-generated atom types as well
 INSTALL (FILES
 	${CMAKE_CURRENT_BINARY_DIR}/core_types.scm
-   DESTINATION "${DATADIR}/scm/opencog/base"
+   DESTINATION "${DATADIR}/scm/opencog/atoms/base"
 )


### PR DESCRIPTION
Currently core_types.scm is installed in ${DATADIR}/scm/opencog/base.  Then Guile can't find it.  I guess the correct path is ${DATADIR}/scm/opencog/atoms/base.