### PR TITLE
Remove useless re-definition of AtomSet

### DIFF
--- a/opencog/attentionbank/ThreadSafeFixedIntegerIndex.h
+++ b/opencog/attentionbank/ThreadSafeFixedIntegerIndex.h
@@ -42,8 +42,6 @@ class Atom;
  */
 class ThreadSafeFixedIntegerIndex : public FixedIntegerIndex
 {
-    typedef std::unordered_set<Atom*> AtomSet;
-
     private:
         using FixedIntegerIndex::idx;
         mutable std::vector<std::unique_ptr<std::mutex>> _locks;


### PR DESCRIPTION
Which prevents from enabling REPRODUCIBLE_ATOMSPACE.