### PR TITLE
Code simplification in the wake of #1359

### DIFF
--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -194,6 +194,9 @@ void Atom::copyValues(const Handle& other)
         ProtoAtomPtr p = other->getValue(k);
         setValue(k, p);
     }
+
+    // Hacky but true: manually update the truth value, also.
+    setTruthValue(other->getTruthValue());
 }
 
 std::string Atom::valuesToString() const
@@ -434,7 +437,7 @@ std::string Atom::idToString() const
 {
     return
         std::string("[") + std::to_string(get_hash()) + "]" +
-        std::string("[") + std::to_string(_atom_space? _atom_space->_atom_table.get_uuid() : -1) + "]";
+        std::string("[") + (_atom_space? std::to_string(_atom_space->_atom_table.get_uuid()) : std::string("-1")) + "]";
 }
 
 std::string oc_to_string(const IncomingSet& iset)

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -263,7 +263,7 @@ Handle AtomTable::getLinkHandle(const AtomPtr& orig, Quotation quotation) const
     const HandleSeq &seq = a->getOutgoingSet();
 
     // Update quotation for the outgoing given the atom type
-    quotation.update(t);
+    // quotation.update(t);
 
     // Make sure all the atoms in the outgoing set are in the atomspace.
     // If any are not are not, then reject the whhole mess.

--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -80,6 +80,7 @@ class AtomTable
     friend class ::AtomSpaceUTest;
 
 private:
+    ClassServer& _classserver;
 
     // Single, global mutex for locking the indexes.
     // Its recursive because we need to lock twice during atom insertion
@@ -278,7 +279,7 @@ public:
         opencog::setting_omp(opencog::num_threads());
     }
 
-    /* Exposes the type iterators so we can do more complicated 
+    /* Exposes the type iterators so we can do more complicated
      * looping without having to create a vector to hold the handles.
      *
      * @param The desired type.

--- a/tests/atomspace/AtomSpaceUTest.cxxtest
+++ b/tests/atomspace/AtomSpaceUTest.cxxtest
@@ -961,7 +961,66 @@ public:
         TS_ASSERT_EQUALS(namedAtoms.size(), 3);
     }
 
-    // Helpers for testPreconstructed
+    // Helpers for testQuoteLink
+    Handle make_node(Type type, std::string name)
+    {
+        return Handle(createNode(type, name));
+    }
+    Handle make_link(Type type, Handle h)
+    {
+        return Handle(createLink(type, h));
+    }
+    Handle make_link(Type type, Handle h1, Handle h2)
+    {
+        return Handle(createLink(type, h1, h2));
+    }
+    Handle make_link(Type type, Handle h1, Handle h2, Handle h3)
+    {
+        return Handle(createLink(type, h1, h2, h3));
+    }
+
+    void testQuoteLink()
+    {
+        TypeIndex& type_index = atomSpace->get_atomtable().typeIndex;
+
+        Handle A = make_node(CONCEPT_NODE, "A"),
+            B = make_node(CONCEPT_NODE, "B"),
+            AB = make_link(INHERITANCE_LINK, A, B),
+            DAB = make_link(AND_LINK, AB, AB),
+            as_DAB = atomSpace->add_atom(DAB);
+        TS_ASSERT(not type_index.contains_duplicate());
+
+        Handle QA = make_link(QUOTE_LINK, A),
+            QAQA = make_link(LIST_LINK, QA, QA),
+            as_QAQA= atomSpace->add_atom(QAQA);
+        TS_ASSERT(not type_index.contains_duplicate());
+
+        Handle V = make_node(VARIABLE_NODE, "$V"),
+            P = make_node(VARIABLE_NODE, "$P"),
+            Q = make_node(VARIABLE_NODE, "$Q"),
+            UV = make_link(UNQUOTE_LINK, V),
+            UP = make_link(UNQUOTE_LINK, P),
+            UQ = make_link(UNQUOTE_LINK, Q),
+            IS = make_link(IMPLICATION_SCOPE_LINK, UV, UP, UQ),
+            QIS = make_link(QUOTE_LINK, IS),
+            QISQIS = make_link(LIST_LINK, QIS, QIS),
+            as_QISQIS= atomSpace->add_atom(QISQIS);
+        TS_ASSERT(not type_index.contains_duplicate());
+
+        Handle GPN = make_node(GROUNDED_PREDICATE_NODE, "GPN"),
+            EVAL = make_link(EVALUATION_LINK, GPN, QIS),
+            AL = make_link(AND_LINK, QIS, EVAL),
+            as_AL = atomSpace->add_atom(AL);
+        TS_ASSERT(not type_index.contains_duplicate());
+
+        Handle S = make_link(SCOPE_LINK, UV, A),
+            QS = make_link(QUOTE_LINK, S),
+            QSQS = make_link(LIST_LINK, QS, QS),
+            as_QSQS= atomSpace->add_atom(QSQS);
+        TS_ASSERT(not type_index.contains_duplicate());
+    }
+
+    // Helpers for testPreconstructedQuote
     Handle factory_node(Type type, std::string name)
     {
         return classserver().factory(Handle(createNode(type, name)));
@@ -978,9 +1037,10 @@ public:
     {
         return classserver().factory(Handle(createLink(type, h1, h2, h3)));
     }
+
     // Create atom structures not in any atomspace, then add the
     // preconstructed structures to the atomspace.
-    void testPreconstructed()
+    void testPreconstructedQuote()
     {
         TypeIndex& type_index = atomSpace->get_atomtable().typeIndex;
 

--- a/tests/atomspace/MultiSpaceUTest.cxxtest
+++ b/tests/atomspace/MultiSpaceUTest.cxxtest
@@ -126,17 +126,17 @@ public:
 		TS_ASSERT(*h3->getTruthValue() == *tv);
 
 		// Fetch three atoms in three different atomspaces
-		Handle h1n1 = as1.add_node(CONCEPT_NODE, "uni-1");
-		Handle h1n2 = as1.add_node(NUMBER_NODE, "2.2222");
-		Handle h1n3 = as1.add_node(VARIABLE_NODE, "uni-3");
+		Handle h1n1 = as1.get_node(CONCEPT_NODE, "uni-1");
+		Handle h1n2 = as1.get_node(NUMBER_NODE, "2.2222");
+		Handle h1n3 = as1.get_node(VARIABLE_NODE, "uni-3");
 
-		Handle h2n1 = as2.add_node(CONCEPT_NODE, "uni-1");
-		Handle h2n2 = as2.add_node(NUMBER_NODE, "2.2222");
-		Handle h2n3 = as2.add_node(VARIABLE_NODE, "uni-3");
+		Handle h2n1 = as2.get_node(CONCEPT_NODE, "uni-1");
+		Handle h2n2 = as2.get_node(NUMBER_NODE, "2.2222");
+		Handle h2n3 = as2.get_node(VARIABLE_NODE, "uni-3");
 
-		Handle h3n1 = as3.add_node(CONCEPT_NODE, "uni-1");
-		Handle h3n2 = as3.add_node(NUMBER_NODE, "2.2222");
-		Handle h3n3 = as3.add_node(VARIABLE_NODE, "uni-3");
+		Handle h3n1 = as3.get_node(CONCEPT_NODE, "uni-1");
+		Handle h3n2 = as3.get_node(NUMBER_NODE, "2.2222");
+		Handle h3n3 = as3.get_node(VARIABLE_NODE, "uni-3");
 
 		// They should NOT match one-another
 		// They should have become copies.

--- a/tests/atomspace/MultiSpaceUTest.cxxtest
+++ b/tests/atomspace/MultiSpaceUTest.cxxtest
@@ -464,37 +464,4 @@ public:
 		TS_ASSERT(haa_copy == haa);
 		TS_ASSERT(hec_copy == hec);
 	}
-
-	// Make sure that values are copied if an atom for an inherited
-	// space is copied back to the atomspace it inherits.
-	void testCopyValues()
-	{
-		AtomSpace as;
-		AtomSpace ex(&as);
-
-		// Add (Exists (Member X A))
-		Handle as_A = as.add_node(CONCEPT_NODE, "A");
-		Handle as_X = as.add_node(VARIABLE_NODE, "X");
-		Handle as_XA = as.add_link(MEMBER_LINK, as_X, as_A);
-		Handle as_S = as.add_link(SCOPE_LINK, as_XA);
-
-		// Add (Exists (Member Y A))
-		Handle ex_A = ex.add_node(CONCEPT_NODE, "A");
-		Handle ex_Y = ex.add_node(VARIABLE_NODE, "Y");
-		Handle ex_YA = ex.add_link(MEMBER_LINK, ex_Y, ex_A);
-		Handle ex_S = ex.add_link(SCOPE_LINK, ex_YA);
-
-		// Modify ex_A truth value, add it back to as and check that
-		// its tv has been updated as well.
-		ex_A->setTruthValue(SimpleTruthValue::createSTV(1.0, 1.0));
-		Handle as_ex_A = as.add_atom(ex_A);
-		TS_ASSERT(as_ex_A->getTruthValue()->getConfidence() > 0.9);
-
-		// Modify (Exists (Member Y A)) truth value, add it back to
-		// as, and (since it is alpha equivalent) check that its tv
-		// has been updated as well.
-		ex_S->setTruthValue(SimpleTruthValue::createSTV(1.0, 1.0));
-		Handle as_ex_S = as.add_atom(ex_S);
-		TS_ASSERT(as_ex_S->getTruthValue()->getConfidence() > 0.9);
-	}
 };


### PR DESCRIPTION
The pull req #1359 purportedly fixes #1342,  but let the code path somewhat complicated. This simplifies the code path.  As a side effect, it makes it clear that the Quotation device does nothing at all; it should probably be removed.  See opencog/atomspace/AtomTable.cc lines 265-280 for this change.

This pull req also does some other assorted cleanup.  It also removes a mis-designed unit test.