### PR TITLE
Move quotations and contexts to a slightly better home.

### DIFF
--- a/opencog/atoms/base/CMakeLists.txt
+++ b/opencog/atoms/base/CMakeLists.txt
@@ -19,8 +19,6 @@ ADD_LIBRARY (atombase
 	Link.cc
 	LinkValue.cc
 	Node.cc
-	Quotation.cc
-	Context.cc
 	StringValue.cc
 	Valuation.cc
 )
@@ -48,8 +46,6 @@ INSTALL (FILES
 	LinkValue.h
 	Node.h
 	ProtoAtom.h
-	Quotation.h
-	Context.h
 	StringValue.h
 	types.h
 	Valuation.h

--- a/opencog/atoms/core/CMakeLists.txt
+++ b/opencog/atoms/core/CMakeLists.txt
@@ -4,6 +4,7 @@ INCLUDE_DIRECTORIES( ${CMAKE_CURRENT_BINARY_DIR})
 
 ADD_LIBRARY (atomcore
 	ArityLink.cc
+	Context.cc
 	DefineLink.cc
 	DeleteLink.cc
 	FreeLink.cc
@@ -12,6 +13,7 @@ ADD_LIBRARY (atomcore
 	LambdaLink.cc
 	NumberNode.cc
 	PutLink.cc
+	Quotation.cc
 	RandomChoice.cc
 	RandomNumber.cc
 	ScopeLink.cc
@@ -39,6 +41,7 @@ INSTALL (TARGETS atomcore
 
 INSTALL (FILES
 	ArityLink.h
+	Context.h
 	DefineLink.h
 	DeleteLink.h
 	FreeLink.h
@@ -46,6 +49,7 @@ INSTALL (FILES
 	LambdaLink.h
 	NumberNode.h
 	PutLink.h
+	Quotation.h
 	RandomChoice.h
 	RandomNumber.h
 	ScopeLink.h

--- a/opencog/atoms/core/Context.cc
+++ b/opencog/atoms/core/Context.cc
@@ -1,5 +1,5 @@
 /*
- * opencog/atoms/base/Context.h
+ * opencog/atoms/core/Context.cc
  *
  * Copyright (C) 2017 OpenCog Foundation
  * All Rights Reserved

--- a/opencog/atoms/core/Context.h
+++ b/opencog/atoms/core/Context.h
@@ -1,5 +1,5 @@
 /*
- * opencog/atoms/base/Context.h
+ * opencog/atoms/core/Context.h
  *
  * Copyright (C) 2017 OpenCog Foundation
  * All Rights Reserved
@@ -25,15 +25,15 @@
 #ifndef _OPENCOG_CONTEXT_H
 #define _OPENCOG_CONTEXT_H
 
+#include <list>
+#include <string>
+
 #include <boost/operators.hpp>
 
-#include <opencog/atoms/base/Handle.h>
 #include <opencog/atoms/base/atom_types.h>
-#include <opencog/atoms/base/Quotation.h>
+#include <opencog/atoms/base/Handle.h>
+#include <opencog/atoms/core/Quotation.h>
 #include <opencog/atoms/core/Variables.h>
-
-#include <string>
-#include <list>
 
 namespace opencog
 {

--- a/opencog/atoms/core/Quotation.cc
+++ b/opencog/atoms/core/Quotation.cc
@@ -1,5 +1,5 @@
 /*
- * opencog/atoms/base/Quotation.h
+ * opencog/atoms/core/Quotation.cc
  *
  * Copyright (C) 2016 OpenCog Foundation
  * All Rights Reserved
@@ -22,8 +22,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include "Quotation.h"
 #include <sstream>
+#include "Quotation.h"
 
 namespace opencog {
 

--- a/opencog/atoms/core/Quotation.h
+++ b/opencog/atoms/core/Quotation.h
@@ -1,5 +1,5 @@
 /*
- * opencog/atoms/base/Quotation.h
+ * opencog/atoms/core/Quotation.h
  *
  * Copyright (C) 2016 OpenCog Foundation
  * All Rights Reserved
@@ -25,10 +25,10 @@
 #ifndef _OPENCOG_QUOTATION_H
 #define _OPENCOG_QUOTATION_H
 
+#include <string>
 #include <boost/operators.hpp>
 
 #include <opencog/atoms/base/atom_types.h>
-#include <string>
 
 namespace opencog
 {

--- a/opencog/atoms/core/ScopeLink.h
+++ b/opencog/atoms/core/ScopeLink.h
@@ -23,8 +23,8 @@
 #ifndef _OPENCOG_SCOPE_LINK_H
 #define _OPENCOG_SCOPE_LINK_H
 
+#include <opencog/atoms/core/Quotation.h>
 #include <opencog/atoms/core/VariableList.h>
-#include <opencog/atoms/base/Quotation.h>
 
 namespace opencog
 {

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -24,7 +24,7 @@
 #include <opencog/atoms/base/Atom.h>
 #include <opencog/atoms/base/Link.h>
 #include <opencog/atoms/base/ClassServer.h>
-#include <opencog/atoms/base/Quotation.h>
+#include <opencog/atoms/core/Quotation.h>
 #include <opencog/atomutils/TypeUtils.h>
 #include <opencog/atoms/core/TypeNode.h>
 

--- a/opencog/atoms/core/Variables.h
+++ b/opencog/atoms/core/Variables.h
@@ -27,7 +27,7 @@
 #include <set>
 
 #include <opencog/atoms/base/Handle.h>
-#include <opencog/atoms/base/Quotation.h>
+#include <opencog/atoms/core/Quotation.h>
 
 namespace opencog
 {

--- a/opencog/atoms/execution/Instantiator.h
+++ b/opencog/atoms/execution/Instantiator.h
@@ -26,7 +26,7 @@
 
 #include <opencog/atomspace/AtomSpace.h>
 
-#include <opencog/atoms/base/Context.h>
+#include <opencog/atoms/core/Context.h>
 
 /**
  * class Instantiator -- create grounded expressions from ungrounded ones.

--- a/opencog/atoms/pattern/PatternLink.h
+++ b/opencog/atoms/pattern/PatternLink.h
@@ -25,10 +25,10 @@
 
 #include <unordered_map>
 
-#include <opencog/atoms/base/Quotation.h>
-#include <opencog/atoms/pattern/Pattern.h>
+#include <opencog/atoms/core/Quotation.h>
 #include <opencog/atoms/core/ScopeLink.h>
 #include <opencog/atoms/core/VariableList.h>
+#include <opencog/atoms/pattern/Pattern.h>
 #include <opencog/query/PatternMatchCallback.h>
 
 namespace opencog

--- a/opencog/atoms/pattern/PatternTerm.h
+++ b/opencog/atoms/pattern/PatternTerm.h
@@ -31,7 +31,7 @@
 
 #include <opencog/atoms/base/Handle.h>
 #include <opencog/atoms/base/Link.h>
-#include <opencog/atoms/base/Quotation.h>
+#include <opencog/atoms/core/Quotation.h>
 
 namespace opencog {
 

--- a/opencog/atomutils/FindUtils.h
+++ b/opencog/atomutils/FindUtils.h
@@ -37,7 +37,7 @@
 #include <opencog/atoms/base/Handle.h>
 #include <opencog/atoms/base/Link.h>
 #include <opencog/atoms/base/types.h>
-#include <opencog/atoms/base/Quotation.h>
+#include <opencog/atoms/core/Quotation.h>
 #include <opencog/atoms/core/ScopeLink.h>
 
 namespace opencog {

--- a/opencog/atomutils/Unify.h
+++ b/opencog/atomutils/Unify.h
@@ -30,8 +30,8 @@
 
 #include <opencog/atoms/base/Handle.h>
 #include <opencog/atoms/base/atom_types.h>
-#include <opencog/atoms/base/Quotation.h>
-#include <opencog/atoms/base/Context.h>
+#include <opencog/atoms/core/Quotation.h>
+#include <opencog/atoms/core/Context.h>
 #include <opencog/atoms/core/Variables.h>
 #include <opencog/atoms/core/VariableList.h>
 #include <opencog/atoms/pattern/BindLink.h>

--- a/opencog/query/DefaultPatternMatchCB.h
+++ b/opencog/query/DefaultPatternMatchCB.h
@@ -26,9 +26,9 @@
 #define _OPENCOG_DEFAULT_PATTERN_MATCH_H
 
 #include <opencog/atoms/base/types.h>
-#include <opencog/atoms/base/Quotation.h>
-#include <opencog/atomspace/AtomSpace.h>
+#include <opencog/atoms/core/Quotation.h>
 #include <opencog/atoms/execution/Instantiator.h>
+#include <opencog/atomspace/AtomSpace.h>
 #include <opencog/query/PatternMatchCallback.h>
 #include <opencog/query/PatternMatchEngine.h>
 

--- a/opencog/query/InitiateSearchCB.h
+++ b/opencog/query/InitiateSearchCB.h
@@ -26,7 +26,7 @@
 #define _OPENCOG_INITIATE_SEARCH_H
 
 #include <opencog/atoms/base/types.h>
-#include <opencog/atoms/base/Quotation.h>
+#include <opencog/atoms/core/Quotation.h>
 #include <opencog/atoms/pattern/PatternLink.h>
 #include <opencog/query/PatternMatchCallback.h>
 #include <opencog/query/PatternMatchEngine.h>

--- a/opencog/rule-engine/Rule.cc
+++ b/opencog/rule-engine/Rule.cc
@@ -27,13 +27,13 @@
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 
-#include <opencog/atomspace/AtomSpace.h>
-#include <opencog/atoms/base/Node.h>
 #include <opencog/atoms/base/Link.h>
-#include <opencog/atoms/base/Quotation.h>
+#include <opencog/atoms/base/Node.h>
 #include <opencog/atoms/core/DefineLink.h>
+#include <opencog/atoms/core/Quotation.h>
 #include <opencog/atoms/pattern/BindLink.h>
 
+#include <opencog/atomspace/AtomSpace.h>
 #include <opencog/atomutils/TypeUtils.h>
 #include <opencog/atomutils/Unify.h>
 

--- a/tests/atomutils/UnifyUTest.cxxtest
+++ b/tests/atomutils/UnifyUTest.cxxtest
@@ -23,8 +23,8 @@
 
 #include <opencog/util/Logger.h>
 
+#include <opencog/atoms/core/Context.h>
 #include <opencog/atomutils/Unify.h>
-#include <opencog/atoms/base/Context.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/guile/SchemeEval.h>
 


### PR DESCRIPTION
The correct solution is probably to permanently eliminate QuoteLink
and LocalQuoteLink.  In retrospect, they were calamitously bad design
ideas.