### PR TITLE
Have URE helpers support rule tv rather than scalar (weight)

### DIFF
--- a/examples/rule-engine/simple/crisp-config.scm
+++ b/examples/rule-engine/simple/crisp-config.scm
@@ -25,9 +25,10 @@
 ; Associate the rules to the rule base (with weights, their semantics
 ; is currently undefined, we might settled with probabilities but it's
 ; not sure)
-(define crisp-rules (list (list crisp-modus-ponens-rule-name 0.4)
-                          (list crisp-deduction-rule-name 0.6))
-)
+(define crisp-modus-ponens-tv (stv 0.4 0.9))
+(define crisp-deduction-tv (stv 0.6 0.9))
+(define crisp-rules (list (list crisp-modus-ponens-rule-name crisp-modus-ponens-tv)
+                          (list crisp-deduction-rule-name crisp-deduction-tv)))
 (ure-add-rules crisp-rbs crisp-rules)
 
 ; Termination criteria parameters

--- a/examples/rule-engine/simple/crisp-deduction-config.scm
+++ b/examples/rule-engine/simple/crisp-deduction-config.scm
@@ -21,10 +21,8 @@
 (define (crisp-deduction-bc target)
   (cog-bc crisp-deduction-rbs target))
 
-;; Associate the rules to the rule base (with weights, their semantics
-;; is currently undefined, we might settled with probabilities but it's
-;; not sure)
-(ure-add-rules crisp-deduction-rbs (list (list crisp-deduction-rule-name 0.6)))
+;; Associate the rules to the rule base
+(ure-add-rules crisp-deduction-rbs (list crisp-deduction-rule-name))
 
 ;; Termination criteria parameters
 (ure-set-num-parameter crisp-deduction-rbs "URE:maximum-iterations" 20)

--- a/tests/rule-engine/fc-config.scm
+++ b/tests/rule-engine/fc-config.scm
@@ -28,9 +28,10 @@
 ; Associate the rules to the rule base (with weights, their semantics
 ; is currently undefined, we might settled with probabilities but it's
 ; not sure)
-(define fc-rules (list (list crisp-modus-ponens-rule-name 0.4)
-                       (list fc-deduction-rule-name 0.6))
-)
+(define crisp-modus-ponens-tv (stv 0.4 0.9))
+(define crisp-deduction-tv (stv 0.6 0.9))
+(define fc-rules (list (list crisp-modus-ponens-rule-name crisp-modus-ponens-tv)
+                       (list fc-deduction-rule-name crisp-deduction-tv)))
 (ure-add-rules fc-rbs fc-rules)
 
 ; Termination criteria parameters

--- a/tests/rule-engine/fc-deduction-config.scm
+++ b/tests/rule-engine/fc-deduction-config.scm
@@ -28,7 +28,7 @@
 ;; Associate the rules to the rule base (with weights, their semantics
 ;; is currently undefined, we might settled with probabilities but it's
 ;; not sure)
-(ure-add-rules fc-deduction-rbs (list (list fc-deduction-rule-name 0.6)))
+(ure-add-rules fc-deduction-rbs (list fc-deduction-rule-name))
 
 ;; Termination criteria parameters
 (ure-set-num-parameter fc-deduction-rbs "URE:maximum-iterations" 20)


### PR DESCRIPTION
Also `ure-add-rules` works without associating any TV. In such case the TV on the member link is the default.