### PR TITLE
Fix handle comparision

### DIFF
--- a/opencog/atoms/base/Handle.cc
+++ b/opencog/atoms/base/Handle.cc
@@ -92,7 +92,7 @@ int Handle::compare(const Handle& h1, const Handle& h2)
 	return 0;
 }
 
-bool Handle::operator< (const Handle& h) const noexcept
+bool Handle::operator<(const Handle& h) const noexcept
 {
 	if (get() == h.get()) return false;
 	if (get() == nullptr) return true;

--- a/opencog/atoms/base/Handle.cc
+++ b/opencog/atoms/base/Handle.cc
@@ -84,33 +84,21 @@ std::size_t hash_value(Handle const& h)
 
 int Handle::compare(const Handle& h1, const Handle& h2)
 {
-	ContentHash ch1 = hash_value(h1);
-	ContentHash ch2 = hash_value(h2);
-	if (ch1 < ch2) return -1;
-	if (ch1 > ch2) return 1;
+	if (h1.get() == h2.get()) return 0;
+	if (h1.get() == nullptr) return -1;
+	if (h2.get() == nullptr) return +1;
+	if (h1->operator<(*h2)) return -1;
+	if (h2->operator<(*h1)) return +1;
 	return 0;
 }
 
 bool Handle::operator< (const Handle& h) const noexcept
 {
-	return hash_value(*this) < hash_value(h);
+	if (get() == h.get()) return false;
+	if (get() == nullptr) return true;
+	if (h.get() == nullptr) return false;
+	return get()->operator<(*h);
 }
-
-bool Handle::operator<= (const Handle& h) const noexcept
-{
-	return hash_value(*this) <= hash_value(h);
-}
-
-bool Handle::operator> (const Handle& h) const noexcept
-{
-	return hash_value(*this) > hash_value(h);
-}
-
-bool Handle::operator>= (const Handle& h) const noexcept
-{
-	return hash_value(*this) >= hash_value(h);
-}
-
 
 // The rest of this file is devoted to printing utilities used only
 // during GDB debugging.  Thus, you won't find these anywhere in the

--- a/opencog/atoms/base/Handle.h
+++ b/opencog/atoms/base/Handle.h
@@ -236,16 +236,7 @@ struct handle_seq_ptr_less
 {
     bool operator()(const HandleSeq* hsl, const HandleSeq* hsr) const
     {
-        size_t sl = hsl->size();
-        size_t sr = hsr->size();
-        if (sl != sr) return sl < sr;
-        for (size_t i=0; i<sl; i++)
-        {
-            ContentHash chsl = hash_value(hsl->operator[](i));
-            ContentHash chsr = hash_value(hsr->operator[](i));
-            if (chsl != chsr) return chsl < chsr;
-        }
-        return false;
+        return handle_seq_less().operator()(*hsl, *hsr);
     }
 };
 

--- a/opencog/atoms/base/Handle.h
+++ b/opencog/atoms/base/Handle.h
@@ -123,9 +123,6 @@ public:
         return get() != h.get();
     }
     bool operator< (const Handle& h) const noexcept;
-    bool operator> (const Handle& h) const noexcept;
-    bool operator<=(const Handle& h) const noexcept;
-    bool operator>=(const Handle& h) const noexcept;
 
     /**
      * Returns a negative value, zero or a positive value if the first
@@ -159,7 +156,7 @@ struct handle_less
 {
    bool operator()(const Handle& hl, const Handle& hr) const
    {
-       return hash_value(hl) < hash_value(hr);
+       return hl.operator<(hr);
    }
 };
 
@@ -229,9 +226,7 @@ struct handle_seq_less
         if (sl != sr) return sl < sr;
         for (size_t i=0; i<sl; i++)
         {
-            ContentHash chsl = hash_value(hsl[i]);
-            ContentHash chsr = hash_value(hsr[i]);
-            if (chsl != chsr) return chsl < chsr;
+            if (hsl[i] != hsl[i]) return hsl[i].operator<(hsr[i]);
         }
         return false;
     }
@@ -334,8 +329,7 @@ struct hash<opencog::Handle>
 {
     typedef std::size_t result_type;
     typedef opencog::Handle argument_type;
-    std::size_t
-    operator()(const opencog::Handle& h) const noexcept
+    std::size_t operator()(const opencog::Handle& h) const noexcept
     { return hash_value(h); }
 };
 

--- a/opencog/atoms/base/Link.cc
+++ b/opencog/atoms/base/Link.cc
@@ -137,6 +137,8 @@ bool Link::operator==(const Atom& other) const
 // Content-based ordering.
 bool Link::operator<(const Atom& other) const
 {
+    if (this == &other) return false;
+
     ContentHash cht = get_hash();
     ContentHash cho = other.get_hash();
     if (cht != cho) return cht < cho;

--- a/opencog/atoms/base/Link.cc
+++ b/opencog/atoms/base/Link.cc
@@ -137,8 +137,9 @@ bool Link::operator==(const Atom& other) const
 // Content-based ordering.
 bool Link::operator<(const Atom& other) const
 {
-    if (get_hash() < other.get_hash()) return true;
-    if (other.get_hash() < get_hash()) return false;
+    ContentHash cht = get_hash();
+    ContentHash cho = other.get_hash();
+    if (cht != cho) return cht < cho;
 
     // We get to here only if the hashes are equal.
     // Compare the contents directly, for this

--- a/opencog/atoms/base/Node.cc
+++ b/opencog/atoms/base/Node.cc
@@ -87,6 +87,8 @@ bool Node::operator==(const Atom& other) const
 
 bool Node::operator<(const Atom& other) const
 {
+    if (this == &other) return false;
+
     ContentHash cht = get_hash();
     ContentHash cho = other.get_hash();
     if (cht != cho) return cht < cho;

--- a/opencog/atoms/base/Node.cc
+++ b/opencog/atoms/base/Node.cc
@@ -87,8 +87,9 @@ bool Node::operator==(const Atom& other) const
 
 bool Node::operator<(const Atom& other) const
 {
-    if (get_hash() < other.get_hash()) return true;
-    if (other.get_hash() < get_hash()) return false;
+    ContentHash cht = get_hash();
+    ContentHash cho = other.get_hash();
+    if (cht != cho) return cht < cho;
 
     // We get to here only if the hashes are equal.
     // Compare the contents directly, for this


### PR DESCRIPTION
The handle-comparison operators were broken.  Thus, std::set<Handle> misbehaved and incorrectly merged non-identical atoms.  This is a serious bug, which potentially affects a lot of subsystems in subtle ways, typically by causing them to fail to explore all possibilities.