### PR TITLE
Rename set_union by set_insertion

### DIFF
--- a/opencog/rule-engine/backwardchainer/TraceRecorder.cc
+++ b/opencog/rule-engine/backwardchainer/TraceRecorder.cc
@@ -48,7 +48,7 @@ HandleSeqSet TraceRecorder::traces()
 {
 	HandleSeqSet trs;
 	for (const Handle& fcs_proof : get_fcs_proofs())
-		set_union(trs, traces(fcs_proof));
+		set_insertion(trs, traces(fcs_proof));
 	return trs;
 }
 


### PR DESCRIPTION
Turns out gcc isn't able to disambiguate that.