### PR TITLE
Handle TruthValue and ProtoAtoms in define_scheme_primitive

### DIFF
--- a/opencog/guile/SchemePrimitive.h
+++ b/opencog/guile/SchemePrimitive.h
@@ -284,6 +284,11 @@ protected:
 		SCM arg = scm_list_ref(args, scm_from_size_t(idx));
 		return SchemeSmob::verify_tv(arg, scheme_name, idx);
 	}
+	ProtoAtomPtr scm_to(SCM args, size_t idx, const ProtoAtomPtr) const
+	{
+		SCM arg = scm_list_ref(args, scm_from_size_t(idx));
+		return SchemeSmob::verify_protom(arg, scheme_name, idx);
+	}
 	Logger* scm_to(SCM args, size_t idx, const Logger*) const
 	{
 		SCM arg = scm_list_ref(args, scm_from_size_t(idx));
@@ -385,6 +390,10 @@ protected:
 	SCM scm_from(TruthValuePtr tv)
 	{
 		return SchemeSmob::tv_to_scm(tv);
+	}
+	SCM scm_from(const ProtoAtomPtr& pa)
+	{
+		return SchemeSmob::protom_to_scm(pa);
 	}
 	SCM scm_from(Logger* lg)
 	{

--- a/opencog/guile/SchemePrimitive.h
+++ b/opencog/guile/SchemePrimitive.h
@@ -279,6 +279,11 @@ protected:
 		SCM arg = scm_list_ref(args, scm_from_size_t(idx));
 		return SchemeSmob::verify_atomspace(arg, scheme_name, idx);
 	}
+	TruthValuePtr scm_to(SCM args, size_t idx, const TruthValuePtr) const
+	{
+		SCM arg = scm_list_ref(args, scm_from_size_t(idx));
+		return SchemeSmob::verify_tv(arg, scheme_name, idx);
+	}
 	Logger* scm_to(SCM args, size_t idx, const Logger*) const
 	{
 		SCM arg = scm_list_ref(args, scm_from_size_t(idx));


### PR DESCRIPTION
For those who are adding scheme bindings using define_scheme_primitive,  and want to pass TruthValue or ProtoAtoms as arguments.