### PR TITLE
Add context sensitive control rule

### DIFF
--- a/examples/c++-api/UREExample.cc
+++ b/examples/c++-api/UREExample.cc
@@ -2,7 +2,7 @@
 #include <opencog/rule-engine/backwardchainer/BackwardChainer.h>
 #include <opencog/rule-engine/forwardchainer/ForwardChainer.h>
 #include <opencog/guile/SchemeEval.h>
-#include <opencog/rule-engine/UREConfigReader.h>
+#include <opencog/rule-engine/UREConfig.h>
 
 using namespace opencog;
 

--- a/opencog/atomutils/Unify.cc
+++ b/opencog/atomutils/Unify.cc
@@ -865,6 +865,13 @@ bool Unify::is_satisfiable(const TypedBlock& block) const
 	return (bool)block.second;
 }
 
+bool unifiable(const Handle& lhs, const Handle& rhs,
+               const Handle& lhs_vardecl, const Handle& rhs_vardecl)
+{
+	Unify unify(lhs, rhs, lhs_vardecl, rhs_vardecl);
+	return unify().is_satisfiable();
+}
+
 bool hm_content_eq(const HandleMap& lhs, const HandleMap& rhs)
 {
 	if (lhs.size() != rhs.size())

--- a/opencog/atomutils/Unify.h
+++ b/opencog/atomutils/Unify.h
@@ -154,11 +154,11 @@ public:
 	struct SolutionSet : Partitions
 	{
 		// Default ctor
-		SolutionSet(const Partitions& p);
+		explicit SolutionSet(const Partitions& p);
 		// Helper ctor. Initialize with the empty partition as
 		// singleton, i.e. a satisfiable solution, if s == true, or
 		// the empty partition set if unsatisfiable.
-		SolutionSet(bool s=false);
+		explicit SolutionSet(bool s=false);
 
 		// Return true iff the solution set is satisfiable which is
 		// indicated by whether it is empty or not.
@@ -694,6 +694,10 @@ private:
 	 */
 	bool inherit(const std::set<Type>& lhs, const std::set<Type>& rhs) const;
 };
+
+bool unifiable(const Handle& lhs, const Handle& rhs,
+               const Handle& lhs_vardecl=Handle::UNDEFINED,
+               const Handle& rhs_vardecl=Handle::UNDEFINED);
 
 /**
  * Till content equality between atoms become the default.

--- a/opencog/rule-engine/CMakeLists.txt
+++ b/opencog/rule-engine/CMakeLists.txt
@@ -18,7 +18,7 @@ ADD_LIBRARY(ruleengine
 	InferenceSCM.cc
 	Rule.cc
 	URECommons.cc
-	UREConfigReader.cc
+	UREConfig.cc
 )
 
 ADD_DEPENDENCIES(ruleengine
@@ -40,11 +40,11 @@ ENDIF (HAVE_GUILE)
 INSTALL (TARGETS ruleengine DESTINATION "lib${LIB_DIR_SUFFIX}/opencog")
 
 INSTALL (FILES
-	UREConfigReader.h
+	UREConfig.h
 	URECommons.h
     URELogger.h
 	Rule.h
-	UREConfigReader.h
+	UREConfig.h
 	DESTINATION "include/opencog/rule-engine"
 )
 

--- a/opencog/rule-engine/InferenceSCM.cc
+++ b/opencog/rule-engine/InferenceSCM.cc
@@ -90,7 +90,7 @@ public:
 #include <opencog/rule-engine/forwardchainer/ForwardChainer.h>
 #include <opencog/rule-engine/backwardchainer/BackwardChainer.h>
 
-#include "UREConfigReader.h"
+#include "UREConfig.h"
 using namespace opencog;
 
 InferenceSCM::InferenceSCM() : ModuleWrap("opencog rule-engine") {}
@@ -171,7 +171,7 @@ Handle InferenceSCM::get_rulebase_rules(Handle rbs)
             "InferenceSCM::get_rulebase_rules - invalid rulebase!");
 
     AtomSpace *as = SchemeSmob::ss_get_env_as("cog-rbs-rules");
-    UREConfigReader ure_config(*as, rbs);
+    UREConfig ure_config(*as, rbs);
     auto rules = ure_config.get_rules();
     HandleSeq hs;
 

--- a/opencog/rule-engine/UREConfig.cc
+++ b/opencog/rule-engine/UREConfig.cc
@@ -1,5 +1,5 @@
 /*
- * UREConfigReader.cc
+ * UREConfig.cc
  *
  * Copyright (C) 2015 OpenCog Foundation
  *
@@ -21,7 +21,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include "UREConfigReader.h"
+#include "UREConfig.h"
 
 #include <opencog/atoms/core/NumberNode.h>
 #include <opencog/atomspaceutils/AtomSpaceUtils.h>
@@ -30,93 +30,93 @@
 using namespace std;
 using namespace opencog;
 
-const std::string UREConfigReader::top_rbs_name = "URE";
+const std::string UREConfig::top_rbs_name = "URE";
 
 // Parameters
-const std::string UREConfigReader::attention_alloc_name = "URE:attention-allocation";
-const std::string UREConfigReader::max_iter_name = "URE:maximum-iterations";
-const std::string UREConfigReader::bc_complexity_penalty_name = "URE:BC:complexity-penalty";
-const std::string UREConfigReader::bc_max_bit_size_name = "URE:BC:maximum-bit-size";
-const std::string UREConfigReader::bc_mm_complexity_penalty_name = "URE:BC:MM:complexity-penalty";
-const std::string UREConfigReader::bc_mm_compressiveness_name = "URE:BC:MM:compressiveness";
+const std::string UREConfig::attention_alloc_name = "URE:attention-allocation";
+const std::string UREConfig::max_iter_name = "URE:maximum-iterations";
+const std::string UREConfig::bc_complexity_penalty_name = "URE:BC:complexity-penalty";
+const std::string UREConfig::bc_max_bit_size_name = "URE:BC:maximum-bit-size";
+const std::string UREConfig::bc_mm_complexity_penalty_name = "URE:BC:MM:complexity-penalty";
+const std::string UREConfig::bc_mm_compressiveness_name = "URE:BC:MM:compressiveness";
 
-UREConfigReader::UREConfigReader(AtomSpace& as, const Handle& rbs) : _as(as)
+UREConfig::UREConfig(AtomSpace& as, const Handle& rbs) : _as(as)
 {
 	if (Handle::UNDEFINED == rbs)
 		throw RuntimeException(TRACE_INFO,
-			"UREConfigReader - invalid rulebase specified!");
+			"UREConfig - invalid rulebase specified!");
 
 	fetch_common_parameters(rbs);
 	fetch_fc_parameters(rbs);
 	fetch_bc_parameters(rbs);
 }
 
-const RuleSet& UREConfigReader::get_rules() const
+const RuleSet& UREConfig::get_rules() const
 {
 	return _common_params.rules;
 }
 
-RuleSet& UREConfigReader::get_rules()
+RuleSet& UREConfig::get_rules()
 {
 	return _common_params.rules;
 }
 
-bool UREConfigReader::get_attention_allocation() const
+bool UREConfig::get_attention_allocation() const
 {
 	return _common_params.attention_alloc;
 }
 
-int UREConfigReader::get_maximum_iterations() const
+int UREConfig::get_maximum_iterations() const
 {
 	return _common_params.max_iter;
 }
 
-double UREConfigReader::get_complexity_penalty() const
+double UREConfig::get_complexity_penalty() const
 {
 	return _bc_params.complexity_penalty;
 }
 
-double UREConfigReader::get_max_bit_size() const
+double UREConfig::get_max_bit_size() const
 {
 	return _bc_params.max_bit_size;
 }
 
-double UREConfigReader::get_mm_complexity_penalty() const
+double UREConfig::get_mm_complexity_penalty() const
 {
 	return _bc_params.mm_complexity_penalty;
 }
 
-double UREConfigReader::get_mm_compressiveness() const
+double UREConfig::get_mm_compressiveness() const
 {
 	return _bc_params.mm_compressiveness;
 }
 
-void UREConfigReader::set_attention_allocation(bool aa)
+void UREConfig::set_attention_allocation(bool aa)
 {
 	_common_params.attention_alloc = aa;
 }
 
-void UREConfigReader::set_maximum_iterations(int mi)
+void UREConfig::set_maximum_iterations(int mi)
 {
 	_common_params.max_iter = mi;
 }
 
-void UREConfigReader::set_complexity_penalty(double cp)
+void UREConfig::set_complexity_penalty(double cp)
 {
 	_bc_params.complexity_penalty = cp;
 }
 
-void UREConfigReader::set_mm_complexity_penalty(double mm_cp)
+void UREConfig::set_mm_complexity_penalty(double mm_cp)
 {
 	_bc_params.mm_complexity_penalty = mm_cp;
 }
 
-void UREConfigReader::set_mm_compressiveness(double mm_cpr)
+void UREConfig::set_mm_compressiveness(double mm_cpr)
 {
 	_bc_params.mm_complexity_penalty = mm_cpr;
 }
 
-HandleSeq UREConfigReader::fetch_rule_names(const Handle& rbs)
+HandleSeq UREConfig::fetch_rule_names(const Handle& rbs)
 {
 	// Retrieve rules
 	Handle rule_var = _as.add_node(VARIABLE_NODE, "__URE_RULE__"),
@@ -133,7 +133,7 @@ HandleSeq UREConfigReader::fetch_rule_names(const Handle& rbs)
 	return rule_names;
 }
 
-void UREConfigReader::fetch_common_parameters(const Handle& rbs)
+void UREConfig::fetch_common_parameters(const Handle& rbs)
 {
 	// Retrieve the rules (MemberLinks) and instantiate them
 	for (const Handle& rule_name : fetch_rule_names(rbs))
@@ -146,12 +146,12 @@ void UREConfigReader::fetch_common_parameters(const Handle& rbs)
 	_common_params.attention_alloc = fetch_bool_param(attention_alloc_name, rbs);
 }
 
-void UREConfigReader::fetch_fc_parameters(const Handle& rbs)
+void UREConfig::fetch_fc_parameters(const Handle& rbs)
 {
 	// None yet
 }
 
-void UREConfigReader::fetch_bc_parameters(const Handle& rbs)
+void UREConfig::fetch_bc_parameters(const Handle& rbs)
 {
 	// Fetch BC complexity penalty parameter
 	_bc_params.complexity_penalty =
@@ -169,9 +169,9 @@ void UREConfigReader::fetch_bc_parameters(const Handle& rbs)
 		fetch_num_param(bc_mm_compressiveness_name, rbs, 1);
 }
 
-HandleSeq UREConfigReader::fetch_execution_outputs(const Handle& schema,
-                                                   const Handle& input,
-                                                   Type type)
+HandleSeq UREConfig::fetch_execution_outputs(const Handle& schema,
+                                             const Handle& input,
+                                             Type type)
 {
 	// Retrieve rules
 	Handle var_node = _as.add_node(VARIABLE_NODE, "__EXECUTION_OUTPUT_VAR__"),
@@ -201,9 +201,9 @@ HandleSeq UREConfigReader::fetch_execution_outputs(const Handle& schema,
 	return outputs;
 }
 
-double UREConfigReader::fetch_num_param(const string& schema_name,
-                                        const Handle& input,
-                                        double default_value)
+double UREConfig::fetch_num_param(const string& schema_name,
+                                  const Handle& input,
+                                  double default_value)
 {
 	Handle param_schema = _as.add_node(SCHEMA_NODE, schema_name);
 	HandleSeq outputs = fetch_execution_outputs(param_schema, input, NUMBER_NODE);
@@ -234,8 +234,8 @@ double UREConfigReader::fetch_num_param(const string& schema_name,
 	}
 }
 
-bool UREConfigReader::fetch_bool_param(const string& pred_name,
-                                       const Handle& input)
+bool UREConfig::fetch_bool_param(const string& pred_name,
+                                 const Handle& input)
 {
 	Handle pred = _as.add_node(PREDICATE_NODE, pred_name);
 	TruthValuePtr tv =

--- a/opencog/rule-engine/UREConfig.h
+++ b/opencog/rule-engine/UREConfig.h
@@ -1,5 +1,5 @@
 /*
- * UREConfigReader.h
+ * UREConfig.h
  *
  * Copyright (C) 2015 OpenCog Foundation
  *
@@ -21,8 +21,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef _URE_CONFIG_READER_H
-#define _URE_CONFIG_READER_H
+#ifndef _URE_CONFIG_H
+#define _URE_CONFIG_H
 
 #include "Rule.h"
 
@@ -31,7 +31,7 @@
 namespace opencog {
 
 /**
- * Read the URE configuration in the AtomSpace as described in
+ * Read the URE configuration from the AtomSpace as described in
  * http://wiki.opencog.org/w/URE_Configuration_Format, and provide
  * parameter accessors for all rule-based systems.
  *
@@ -41,7 +41,7 @@ namespace opencog {
  * instead it assumes all parameters are duplicated for all systems
  * and subsystems, for now.
  */
-class UREConfigReader
+class UREConfig
 {
 public:
 	/////////////
@@ -49,7 +49,7 @@ public:
 	/////////////
 
 	// rbs is a Handle pointing to a rule-based system is as
-	UREConfigReader(AtomSpace& as, const Handle& rbs);
+	UREConfig(AtomSpace& as, const Handle& rbs);
 
 	///////////////
 	// Accessors //
@@ -68,7 +68,7 @@ public:
 
 	///////////////////////////////////////////////////////////////////
 	// Modifiers. WARNING: Those changes are not reflected in the    //
-	// AtomSpace, only in the UREConfigReader object.                //
+	// AtomSpace, only in the UREConfig object.                      //
 	///////////////////////////////////////////////////////////////////
 
 	// Common
@@ -218,4 +218,4 @@ private:
 } // ~namespace opencog
 
 
-#endif /* _URE_CONFIG_READER_H_ */
+#endif /* _URE_CONFIG_H_ */

--- a/opencog/rule-engine/UREConfigReader.cc
+++ b/opencog/rule-engine/UREConfigReader.cc
@@ -162,11 +162,11 @@ void UREConfigReader::fetch_bc_parameters(const Handle& rbs)
 
 	// Fetch BC Mixture Model complexity penalty parameter
 	_bc_params.mm_complexity_penalty =
-		fetch_num_param(bc_mm_complexity_penalty_name, rbs);
+		fetch_num_param(bc_mm_complexity_penalty_name, rbs, 0);
 
 	// Fetch BC Mixture Model complexity penalty parameter
 	_bc_params.mm_compressiveness =
-		fetch_num_param(bc_mm_compressiveness_name, rbs);
+		fetch_num_param(bc_mm_compressiveness_name, rbs, 1);
 }
 
 HandleSeq UREConfigReader::fetch_execution_outputs(const Handle& schema,

--- a/opencog/rule-engine/UREConfigReader.cc
+++ b/opencog/rule-engine/UREConfigReader.cc
@@ -37,40 +37,18 @@ const std::string UREConfigReader::attention_alloc_name = "URE:attention-allocat
 const std::string UREConfigReader::max_iter_name = "URE:maximum-iterations";
 const std::string UREConfigReader::bc_complexity_penalty_name = "URE:BC:complexity-penalty";
 const std::string UREConfigReader::bc_max_bit_size_name = "URE:BC:maximum-bit-size";
+const std::string UREConfigReader::bc_mm_complexity_penalty_name = "URE:BC:MM:complexity-penalty";
+const std::string UREConfigReader::bc_mm_compressiveness_name = "URE:BC:MM:compressiveness";
 
 UREConfigReader::UREConfigReader(AtomSpace& as, const Handle& rbs) : _as(as)
 {
-	//////////////////////////
-	// Common parameters    //
-	//////////////////////////
-
 	if (Handle::UNDEFINED == rbs)
 		throw RuntimeException(TRACE_INFO,
 			"UREConfigReader - invalid rulebase specified!");
 
-	// Retrieve the rules (MemberLinks) and instantiate them
-	for (const Handle& rule_name : fetch_rule_names(rbs))
-		_common_params.rules.emplace(rule_name, rbs);
-
-	// Fetch maximum number of iterations
-	_common_params.max_iter = fetch_num_param(max_iter_name, rbs);
-
-	// Fetch attention allocation parameter
-	_common_params.attention_alloc = fetch_bool_param(attention_alloc_name, rbs);
-
-	//////////////////////
-	// FC parameters    //
-	//////////////////////
-
-	//////////////////////
-	// BC parameters    //
-	//////////////////////
-
-	// Fetch BC complexity penalty parameter
-	_bc_params.complexity_penalty = fetch_num_param(bc_complexity_penalty_name, rbs);
-
-	// Fetch BC BIT maximum size parameter
-	_bc_params.max_bit_size = fetch_num_param(bc_max_bit_size_name, rbs, -1);
+	fetch_common_parameters(rbs);
+	fetch_fc_parameters(rbs);
+	fetch_bc_parameters(rbs);
 }
 
 const RuleSet& UREConfigReader::get_rules() const
@@ -103,6 +81,16 @@ double UREConfigReader::get_max_bit_size() const
 	return _bc_params.max_bit_size;
 }
 
+double UREConfigReader::get_mm_complexity_penalty() const
+{
+	return _bc_params.mm_complexity_penalty;
+}
+
+double UREConfigReader::get_mm_compressiveness() const
+{
+	return _bc_params.mm_compressiveness;
+}
+
 void UREConfigReader::set_attention_allocation(bool aa)
 {
 	_common_params.attention_alloc = aa;
@@ -116,6 +104,16 @@ void UREConfigReader::set_maximum_iterations(int mi)
 void UREConfigReader::set_complexity_penalty(double cp)
 {
 	_bc_params.complexity_penalty = cp;
+}
+
+void UREConfigReader::set_mm_complexity_penalty(double mm_cp)
+{
+	_bc_params.mm_complexity_penalty = mm_cp;
+}
+
+void UREConfigReader::set_mm_compressiveness(double mm_cpr)
+{
+	_bc_params.mm_complexity_penalty = mm_cpr;
 }
 
 HandleSeq UREConfigReader::fetch_rule_names(const Handle& rbs)
@@ -133,6 +131,42 @@ HandleSeq UREConfigReader::fetch_rule_names(const Handle& rbs)
 	_as.extract_atom(results);
 
 	return rule_names;
+}
+
+void UREConfigReader::fetch_common_parameters(const Handle& rbs)
+{
+	// Retrieve the rules (MemberLinks) and instantiate them
+	for (const Handle& rule_name : fetch_rule_names(rbs))
+		_common_params.rules.emplace(rule_name, rbs);
+
+	// Fetch maximum number of iterations
+	_common_params.max_iter = fetch_num_param(max_iter_name, rbs);
+
+	// Fetch attention allocation parameter
+	_common_params.attention_alloc = fetch_bool_param(attention_alloc_name, rbs);
+}
+
+void UREConfigReader::fetch_fc_parameters(const Handle& rbs)
+{
+	// None yet
+}
+
+void UREConfigReader::fetch_bc_parameters(const Handle& rbs)
+{
+	// Fetch BC complexity penalty parameter
+	_bc_params.complexity_penalty =
+		fetch_num_param(bc_complexity_penalty_name, rbs);
+
+	// Fetch BC BIT maximum size parameter
+	_bc_params.max_bit_size = fetch_num_param(bc_max_bit_size_name, rbs, -1);
+
+	// Fetch BC Mixture Model complexity penalty parameter
+	_bc_params.mm_complexity_penalty =
+		fetch_num_param(bc_mm_complexity_penalty_name, rbs);
+
+	// Fetch BC Mixture Model complexity penalty parameter
+	_bc_params.mm_compressiveness =
+		fetch_num_param(bc_mm_compressiveness_name, rbs);
 }
 
 HandleSeq UREConfigReader::fetch_execution_outputs(const Handle& schema,

--- a/opencog/rule-engine/UREConfigReader.h
+++ b/opencog/rule-engine/UREConfigReader.h
@@ -63,6 +63,8 @@ public:
 	// BC
 	double get_complexity_penalty() const;
 	double get_max_bit_size() const;
+	double get_mm_complexity_penalty() const;
+	double get_mm_compressiveness() const;
 
 	///////////////////////////////////////////////////////////////////
 	// Modifiers. WARNING: Those changes are not reflected in the    //
@@ -74,6 +76,8 @@ public:
 	void set_maximum_iterations(int);
 	// BC
 	void set_complexity_penalty(double);
+	void set_mm_complexity_penalty(double);
+	void set_mm_compressiveness(double);
 
 	//////////////////
 	// Constants    //
@@ -98,16 +102,16 @@ public:
 
 	// Name of the maximum number of and-BITs in the BIT parameter
 	static const std::string bc_max_bit_size_name;
+
+	// Name of the parameter of the Mixture Model controlling how
+	// complexity affects model prior.
+	static const std::string bc_mm_complexity_penalty_name;
+
+	// Name of the parameter of the Mixture Model controlling how
+	// much unexplained data are compressed
+	static const std::string bc_mm_compressiveness_name;
+
 private:
-
-	// Fetch from the AtomSpace all rules of a given rube-based
-	// system. Specifically fetches patterns
-	//
-	// MemberLink <TV>
-	//    <rule name>
-	//    <rbs>
-	HandleSeq fetch_rule_names(const Handle& rbs);
-
 	AtomSpace& _as;
 
 	// Parameter common to the forward and backward chainer.
@@ -133,8 +137,38 @@ private:
 		// This put an upper boundary on the maximum number of
 		// and-BITs the BIT can hold. Negative means unlimited.
 		int max_bit_size;
+
+		// Parameter of the Mixture Model controlling how complexity
+		// affects model prior. The prior exponentially decreases
+		// w.r.t. to the complexity. Specifically
+		//
+		// prior = exp(-mm_complexity_penalty * complexity)
+		double mm_complexity_penalty;
+
+		// Parameter of the Mixture Model controlling how much
+		// unexplained data are compressed. The compressed unexplained
+		// data are added to the model complexity.
+		double mm_compressiveness;
 	};
 	BCParameters _bc_params;
+
+	// Fetch from the AtomSpace all rules of a given rube-based
+	// system. Specifically fetches patterns
+	//
+	// MemberLink <TV>
+	//    <rule name>
+	//    <rbs>
+	HandleSeq fetch_rule_names(const Handle& rbs);
+
+	// Fetch from the atomspace all parameters common to the forward
+	// and backward chainer
+	void fetch_common_parameters(const Handle& rbs);
+
+	// Fetch from the atomspace all forward chainer parameters
+	void fetch_fc_parameters(const Handle& rbs);
+
+	// Fetch from the atomspace all backward chainer parameters
+	void fetch_bc_parameters(const Handle& rbs);
 
 	// Given <schema>, an <input> and optionally an output <type> (or
 	// subtype), return the <output>s in

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.cc
@@ -58,7 +58,7 @@ BackwardChainer::BackwardChainer(AtomSpace& as, const Handle& rbs,
 	  _bit(as, target, vardecl, bitnode_fitness),
 	  _andbit_fitness(andbit_fitness),
 	  _trace_recorder(trace_as),
-	  _control(_configReader.get_rules(), _bit, control_as),
+	  _control(_configReader, _bit, control_as),
 	  _rules(_control.rules),
 	  _iteration(0), _last_expansion_andbit(nullptr)
 {

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.cc
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.cc
@@ -66,12 +66,12 @@ BackwardChainer::BackwardChainer(AtomSpace& as, const Handle& rbs,
 	_trace_recorder.target(target);
 }
 
-UREConfigReader& BackwardChainer::get_config()
+UREConfig& BackwardChainer::get_config()
 {
 	return _configReader;
 }
 
-const UREConfigReader& BackwardChainer::get_config() const
+const UREConfig& BackwardChainer::get_config() const
 {
 	return _configReader;
 }

--- a/opencog/rule-engine/backwardchainer/BackwardChainer.h
+++ b/opencog/rule-engine/backwardchainer/BackwardChainer.h
@@ -26,7 +26,7 @@
 #define OPENCOG_BACKWARDCHAINER_H_
 
 #include <opencog/rule-engine/Rule.h>
-#include <opencog/rule-engine/UREConfigReader.h>
+#include <opencog/rule-engine/UREConfig.h>
 
 #include "BIT.h"
 #include "TraceRecorder.h"
@@ -109,8 +109,8 @@ public:
 	/**
 	 * URE configuration accessors
 	 */
-	UREConfigReader& get_config();
-	const UREConfigReader& get_config() const;
+	UREConfig& get_config();
+	const UREConfig& get_config() const;
 
 	/**
 	 * Perform backward chaining inference till the termination
@@ -183,7 +183,7 @@ private:
 	AtomSpace& _as;
 
 	// Contain the configuration
-	UREConfigReader _configReader;
+	UREConfig _configReader;
 
 	// Structure holding the Back Inference Tree
 	BIT _bit;

--- a/opencog/rule-engine/backwardchainer/BetaDistribution.cc
+++ b/opencog/rule-engine/backwardchainer/BetaDistribution.cc
@@ -22,6 +22,7 @@
  */
 
 #include "BetaDistribution.h"
+#include "../URELogger.h"
 
 #include <opencog/truthvalue/SimpleTruthValue.h>
 
@@ -90,6 +91,15 @@ TruthValuePtr mk_stv(double mean, double variance,
 
 	if (beta < 1 and 1 <= alpha)
 		mode = 1;
+
+	// This is mathematically wrong, but for now we don't try to have
+	// a bimodal TV, rather a unimodal one with very low confidence.
+	if (alpha < 1 and beta < 1)
+		mode = mean;
+
+	LAZY_URE_LOG_FINE << "mk_stv alpha alpha = " << alpha
+	                  << ", beta = " << beta << ", count = " << count
+	                  << ", confidence = " << confidence << ", mode = " << mode;
 
 	// The strength is in fact the mode, this should be corrected once
 	// TruthValue is reworked

--- a/opencog/rule-engine/backwardchainer/BetaDistribution.cc
+++ b/opencog/rule-engine/backwardchainer/BetaDistribution.cc
@@ -38,6 +38,16 @@ BetaDistribution::BetaDistribution(double pos_count, double count,
                                    double p_alpha, double p_beta)
 	: _beta_distribution(p_alpha + pos_count, p_beta + count - pos_count) {}
 
+double BetaDistribution::alpha() const
+{
+	return _beta_distribution.alpha();
+}
+
+double BetaDistribution::beta() const
+{
+	return _beta_distribution.beta();
+}
+
 double BetaDistribution::mean() const
 {
 	return boost::math::mean(_beta_distribution);

--- a/opencog/rule-engine/backwardchainer/BetaDistribution.cc
+++ b/opencog/rule-engine/backwardchainer/BetaDistribution.cc
@@ -78,7 +78,7 @@ TruthValuePtr mk_stv(double mean, double variance,
 	// alpha == prior_alpha + pos_count
 	// beta == prior_beta + count - pos_count
 	double count = alpha + beta - prior_alpha - prior_beta;
-	count = std::max(0.1, count); // Hack to avoid having too non-sensical TV
+	count = std::max(0.1, count); // Hack to avoid non-sensical TV
 	double confidence = count / (count + SimpleTruthValue::DEFAULT_K),
 		mode = 1;               // default strength if confidence is null
 

--- a/opencog/rule-engine/backwardchainer/BetaDistribution.cc
+++ b/opencog/rule-engine/backwardchainer/BetaDistribution.cc
@@ -77,8 +77,9 @@ TruthValuePtr mk_stv(double mean, double variance,
 	// Inferred from
 	// alpha == prior_alpha + pos_count
 	// beta == prior_beta + count - pos_count
-	double count = alpha + beta - prior_alpha - prior_beta,
-		confidence = count / (count + SimpleTruthValue::DEFAULT_K),
+	double count = alpha + beta - prior_alpha - prior_beta;
+	count = std::max(0.1, count); // Hack to avoid having too non-sensical TV
+	double confidence = count / (count + SimpleTruthValue::DEFAULT_K),
 		mode = 1;               // default strength if confidence is null
 
 	if (1 < alpha and 1 < beta)

--- a/opencog/rule-engine/backwardchainer/BetaDistribution.cc
+++ b/opencog/rule-engine/backwardchainer/BetaDistribution.cc
@@ -29,6 +29,7 @@ namespace opencog {
 
 BetaDistribution::BetaDistribution(const TruthValuePtr& tv,
                                    double p_alpha, double p_beta)
+	// TODO should be replaced by tv->get_mode() once implemented
 	: BetaDistribution(tv->get_mean() * tv->get_count(),
 	                   tv->get_count(), p_alpha, p_beta) {}
 
@@ -77,9 +78,21 @@ TruthValuePtr mk_stv(double mean, double variance,
 	// alpha == prior_alpha + pos_count
 	// beta == prior_beta + count - pos_count
 	double count = alpha + beta - prior_alpha - prior_beta,
-		confidence = count / (count + SimpleTruthValue::DEFAULT_K);
+		confidence = count / (count + SimpleTruthValue::DEFAULT_K),
+		mode = 1;               // default strength if confidence is null
 
-	return SimpleTruthValue::createTV(mean, confidence);
+	if (1 < alpha and 1 < beta)
+		mode = boost::math::mode(beta_distribution<double>(alpha, beta));
+
+	if (alpha < 1 and 1 <= beta)
+		mode = 0;
+
+	if (beta < 1 and 1 <= alpha)
+		mode = 1;
+
+	// The strength is in fact the mode, this should be corrected once
+	// TruthValue is reworked
+	return SimpleTruthValue::createTV(mode, confidence);
 }
 
 } // ~namespace opencog

--- a/opencog/rule-engine/backwardchainer/BetaDistribution.h
+++ b/opencog/rule-engine/backwardchainer/BetaDistribution.h
@@ -48,12 +48,22 @@ public:
 	                 double prior_alpha=1.0, double prior_beta=1.0);
 
 	/**
-	 * Return the mean of the beta distribution
+	 * Return the alpha parameter of the distribution
+	 */
+	double alpha() const;
+
+	/**
+	 * Return the beta of the beta parameter of the distribution
+	 */
+	double beta() const;
+
+	/**
+	 * Return the mean of the distribution
 	 */
 	double mean() const;
 
 	/**
-	 * Return the variance of the beta distribution
+	 * Return the variance of the distribution
 	 */
 	double variance() const;
 
@@ -74,8 +84,9 @@ private:
 
 // Helpers
 BetaDistribution mk_beta_distribution(const TruthValuePtr& tv);
-	TruthValuePtr mk_stv(double mean, double variance,
-	                     double prior_alpha=1.0, double prior_beta=1.0);
+
+TruthValuePtr mk_stv(double mean, double variance,
+                     double prior_alpha=1.0, double prior_beta=1.0);
 
 } // namespace opencog
 

--- a/opencog/rule-engine/backwardchainer/BetaDistribution.h
+++ b/opencog/rule-engine/backwardchainer/BetaDistribution.h
@@ -42,13 +42,20 @@ public:
 	 * Construct a BetaDistribution given a TV and a beta-distribution
 	 * prior with parameters (alpha, beta).
 	 */
-	BetaDistribution(const TruthValuePtr& tv, double alpha=1.0, double beta=1.0);
-	BetaDistribution(double pos_count, double count, double alpha=1.0, double beta=1.0);
+	BetaDistribution(const TruthValuePtr& tv,
+	                 double prior_alpha=1.0, double prior_beta=1.0);
+	BetaDistribution(double pos_count, double count,
+	                 double prior_alpha=1.0, double prior_beta=1.0);
 
 	/**
 	 * Return the mean of the beta distribution
 	 */
 	double mean() const;
+
+	/**
+	 * Return the variance of the beta distribution
+	 */
+	double variance() const;
 
 	/**
 	 * Calculate the cdf of a beta distribution, given the number of
@@ -64,6 +71,11 @@ public:
 private:
 	boost::math::beta_distribution<double> _beta_distribution;
 };
+
+// Helpers
+BetaDistribution mk_beta_distribution(const TruthValuePtr& tv);
+	TruthValuePtr mk_stv(double mean, double variance,
+	                     double prior_alpha=1.0, double prior_beta=1.0);
 
 } // namespace opencog
 

--- a/opencog/rule-engine/backwardchainer/ControlPolicy.cc
+++ b/opencog/rule-engine/backwardchainer/ControlPolicy.cc
@@ -173,8 +173,8 @@ HandleTVMap ControlPolicy::expansion_success_tvs(
 			// model.
 			//
 			// TODO add cpx_penalty and compressiveness as parameters.
-			double cpx_penalty = 0.1,
-				compressiveness = 0.1;
+			double cpx_penalty = 0.01,
+				compressiveness = 0.99;
 			success_tvs[rule] = MixtureModel(active_ctrl_rules,
 			                                 cpx_penalty,
 			                                 compressiveness)();

--- a/opencog/rule-engine/backwardchainer/ControlPolicy.cc
+++ b/opencog/rule-engine/backwardchainer/ControlPolicy.cc
@@ -171,15 +171,20 @@ HandleTVMap ControlPolicy::expansion_success_tvs(
 		} else {
 			// Otherwise calculate the truth value of its mixture
 			// model.
-			// TODO: set cpx_penalty and compressiveness.
-			success_tvs[rule] = MixtureModel(active_ctrl_rules)();
+			//
+			// TODO add cpx_penalty and compressiveness as parameters.
+			double cpx_penalty = 0.1,
+				compressiveness = 0.1;
+			success_tvs[rule] = MixtureModel(active_ctrl_rules,
+			                                 cpx_penalty,
+			                                 compressiveness)();
 		}
 	}
 
 	// Log TVs of representing probability of success (expanding into
 	// a preproof) for each action
 	std::stringstream ss;
-	ss << "Rule TVs expanding a supposed preproof into another preproof:" << std::endl;
+	ss << "Rule TVs of expanding a preproof into another preproof:" << std::endl;
 	for (const auto& rtv : success_tvs)
 		ss << rtv.second->to_string() << " " << oc_to_string(rtv.first);
 	ure_logger().debug() << ss.str();

--- a/opencog/rule-engine/backwardchainer/ControlPolicy.cc
+++ b/opencog/rule-engine/backwardchainer/ControlPolicy.cc
@@ -279,12 +279,12 @@ bool ControlPolicy::is_control_rule_active(const AndBIT& andbit,
                                            const Handle& ctrl_rule) const
 {
 	Handle ctrl_vardecl = ScopeLinkCast(ctrl_rule)->get_vardecl(),
-		expansion = retrieve_expansion(ctrl_rule),
-		input = expansion->getOutgoingAtom(1),
-		ctrl_andbit = input->getOutgoingAtom(0),
-		ctrl_bitleaf = input->getOutgoingAtom(1),
+		ctrl_expansion = retrieve_expansion(ctrl_rule),
+		ctrl_input = ctrl_expansion->getOutgoingAtom(1),
+		ctrl_andbit = ctrl_input->getOutgoingAtom(0),
+		ctrl_bitleaf = ctrl_input->getOutgoingAtom(1),
 		actual_andbit = andbit.fcs,
-		actual_andbit_vardecl = ScopeLinkCast(ctrl_rule)->get_vardecl();
+		actual_andbit_vardecl = ScopeLinkCast(actual_andbit)->get_vardecl();
 
 	// Make sure that the variables in the control rule and the actual
 	// andbit are disjoint
@@ -292,8 +292,15 @@ bool ControlPolicy::is_control_rule_active(const AndBIT& andbit,
 	// TODO: should be alpha-converted to have no variable in common.
 	Variables ctrl_vars = VariableList(ctrl_vardecl).get_variables(),
 		actual_andbit_vars = VariableList(actual_andbit_vardecl).get_variables();
-	OC_ASSERT(is_disjoint(ctrl_vars.varset, actual_andbit_vars.varset),
-	          "Not implemented yet");
+	if (not is_disjoint(ctrl_vars.varset, actual_andbit_vars.varset)) {
+		std::stringstream ss;
+		ss << "Not implemented yet. "
+		   << "ctrl_vars and actual_andbit_vars ctrl_vars should be disjoint, "
+		   << "but ctrl_vars = " << oc_to_string(ctrl_vars) << std::endl
+		   << "actual_andbit_vars = "
+		   << oc_to_string(actual_andbit_vars) << std::endl;
+		OC_ASSERT(false, ss.str());
+	}
 
 	// Check that the current andbit (resp. current bitleaf) and the
 	// andbit (resp. bitleaf) on the control rule are unifiable.

--- a/opencog/rule-engine/backwardchainer/ControlPolicy.cc
+++ b/opencog/rule-engine/backwardchainer/ControlPolicy.cc
@@ -40,9 +40,10 @@ using namespace opencog;
 #define al _query_as->add_link
 #define an _query_as->add_node
 
-ControlPolicy::ControlPolicy(const RuleSet& rs, const BIT& bit,
+ControlPolicy::ControlPolicy(const UREConfig& ure_config, const BIT& bit,
                              AtomSpace* control_as) :
-	rules(rs), _bit(bit), _control_as(control_as), _query_as(nullptr)
+	rules(ure_config.get_rules()), _ure_config(ure_config),
+	_bit(bit), _control_as(control_as), _query_as(nullptr)
 {
 	// Fetch default TVs for each inference rule (the TV on the member
 	// link connecting the rule to the rule base
@@ -171,13 +172,10 @@ HandleTVMap ControlPolicy::expansion_success_tvs(
 		} else {
 			// Otherwise calculate the truth value of its mixture
 			// model.
-			//
-			// TODO add cpx_penalty and compressiveness as parameters.
-			double cpx_penalty = 0.01,
-				compressiveness = 0.99;
+			double cpx_penalty = _ure_config.get_mm_complexity_penalty(),
+				compressiveness = _ure_config.get_mm_compressiveness();
 			success_tvs[rule] = MixtureModel(active_ctrl_rules,
-			                                 cpx_penalty,
-			                                 compressiveness)();
+			                                 cpx_penalty, compressiveness)();
 		}
 	}
 

--- a/opencog/rule-engine/backwardchainer/ControlPolicy.h
+++ b/opencog/rule-engine/backwardchainer/ControlPolicy.h
@@ -182,47 +182,43 @@ private:
 
 	/**
 	 * Given an inference rule, fetch both pattern and pattern free
-	 * expansion control rules. See comments of
-	 * fetch_pattern_free_expansion_control_rules and
-	 * fetch_pattern_expansion_control_rules
+	 * expansion control rules. See comments below.
 	 */
 	HandleSet fetch_expansion_control_rules(const Handle& inf_rule);
 
 	/**
 	 * Fetch control rules from _control_as involved in BIT
-	 * expansion. Informally that if and-BIT, A, expands into B from L
-	 * with the given rule, and follow some pattern, then B has a
-	 * probability TV of being a preproof of T. Formally
+	 * expansion. Informally that if and-BIT, A, is a preproof and
+	 * expands into B from L with the given rule, and follow some
+	 * pattern, then B has a probability TV of being a preproof of
+	 * T. Formally
 	 *
 	 * ImplicationScope <TV>
-	 *  VariableList
-	 *    Variable "$T"  ;; Theorem/target to prove
-	 *    TypedVariable  ;; and-BIT to expand
-	 *      Variable "$A"
-	 *      Type "BindLink"
-	 *    Variable "$L"  ;; Leaf from A to expand
-	 *    TypedVariable  ;; Resulting and-BIT from the expansion of L from A with rule R
-	 *      Variable "$B"
-	 *      Type "BindLink"
+	 *  <vardecl>
 	 *  And
+	 *    Evaluation
+	 *      Predicate "preproof-of"
+	 *      List
+	 *        <A>
+	 *        <T>
 	 *    Execution
 	 *      Schema "expand-and-BIT"
 	 *      List
-	 *        BontExec Variable "$A"
-	 *        Variable "$L"
-	 *        DontExec <inf_rule>
-	 *      DontExec Variable "$B"
+	 *        <A>
+	 *        <L>
+	 *        <inf_rule>
+	 *      <B>
 	 *    <pattern-1>
 	 *    ...
 	 *    <pattern-n>
 	 *  Evaluation
 	 *    Predicate "preproof"
 	 *    List
-	 *      DontExec Variable "$B"
-	 *      Variable "$T"
+	 *      <B>
+	 *      <T>
 	 *
-	 * n is the number of patterns in addition to the expansion itself
-	 * (the Execution link).
+	 * n >=0 is the number of patterns in addition to preproof and
+	 * expansion.
 	 */
 	HandleSet fetch_expansion_control_rules(const Handle& inf_rule, int n);
 

--- a/opencog/rule-engine/backwardchainer/ControlPolicy.h
+++ b/opencog/rule-engine/backwardchainer/ControlPolicy.h
@@ -26,6 +26,7 @@
 #include <opencog/atomspace/AtomSpace.h>
 
 #include "BIT.h"
+#include "../UREConfig.h"
 #include "../Rule.h"
 
 class ControlPolicyUTest;
@@ -45,7 +46,7 @@ class ControlPolicy
 {
     friend class ::ControlPolicyUTest;
 public:
-	ControlPolicy(const RuleSet& rules, const BIT& bit,
+	ControlPolicy(const UREConfig& ure_config, const BIT& bit,
 	              AtomSpace* control_as=nullptr);
 	~ControlPolicy();
 
@@ -73,6 +74,9 @@ public:
 	RuleSelection select_rule(AndBIT& andbit, BITNode& bitleaf);
 
 private:
+	// Reference to URE configuration
+	const UREConfig& _ure_config;
+
 	// Reference to the BackwardChainer BIT
 	const BIT& _bit;
 

--- a/opencog/rule-engine/backwardchainer/ControlPolicy.h
+++ b/opencog/rule-engine/backwardchainer/ControlPolicy.h
@@ -274,8 +274,8 @@ private:
 	Handle mk_pattern_var(int i);
 
 	/**
-	 * Calculate the actual mean of a TV. which is to be constracted
-	 * by the mean in the TruthValue class which doesn't correspond to
+	 * Calculate the actual mean of a TV. which is to be contrasted by
+	 * the mean in the TruthValue class which doesn't correspond to
 	 * the actual mean of the second order distribution.
 	 *
 	 * TODO: replace this by the mean method of the TruthValue once

--- a/opencog/rule-engine/backwardchainer/ControlPolicy.h
+++ b/opencog/rule-engine/backwardchainer/ControlPolicy.h
@@ -100,14 +100,15 @@ private:
 	std::map<Handle, HandleSet> _expansion_control_rules;
 
 	/**
-	 * Return all valid rules, in the sense that they may possibly be
-	 * used to infer the target.
+	 * Return all valid inference rules, in the sense that they may
+	 * possibly be used to infer the target.
 	 */
 	RuleTypedSubstitutionMap get_valid_rules(const AndBIT& andbit,
 	                                         const BITNode& bitleaf);
 
 	/**
-	 * Select a rule for expansion amongst a set of valid ones.
+	 * Select an inference rule for expansion amongst a set of valid
+	 * ones.
 	 */
 	RuleSelection select_rule(const AndBIT& andbit,
 	                          const BITNode& bitleaf,
@@ -160,19 +161,51 @@ private:
 	 * Get all active expansion control rules concerning the given
 	 * inference rule.
 	 */
-	HandleSet active_expansion_control_rules(const Handle& inf_rule_alias);
+	HandleSet active_expansion_control_rules(const AndBIT& andbit,
+	                                         const BITNode& bitleaf,
+	                                         const Handle& inf_rule_alias);
 
 	/**
-	 * Return true iff the given control is current active, that is
-	 * the case of an expansion control rule whether the pattern is
-	 * true.
+	 * Return true iff the given control is current active, that is,
+	 * in the case of an expansion control rule, whether the pattern
+	 * is true.
+	 *
+	 * For now it just tries to unify andbit with the input and-BIT of
+	 * the expansion, and bitleaf with the BIT-leaf of the expansion.
 	 *
 	 * Ultimately this should be replace by a TV because most patterns
 	 * will have a certain probability of being true, or some degree
 	 * of truth. To do well it should rely on a conditional
 	 * instantiation PLN rule.
 	 */
-	bool control_rule_active(const Handle& ctrl_rule) const;
+	bool is_control_rule_active(const AndBIT& andbit,
+	                            const BITNode& bitleaf,
+	                            const Handle& ctrl_rule) const;
+
+	/**
+	 * Given a control rule, retrieve the antecedent part concerning
+	 * the expansion. That is given
+	 *
+	 * ImplicationScope
+	 *   <variables>
+	 *   And
+	 *     <preproof-of-A>
+	 *     Execution
+	 *       Schema "URE:BC:expand"
+	 *       List <A> <L> <ctrl_rule>
+	 *       <B>
+	 *     <patterns>
+	 *   <preproof-of-B>
+	 *
+	 * return
+	 *
+	 *     Execution
+	 *       Schema "URE:BC:expand"
+	 *       List <A> <L> <ctrl_rule>
+	 *       <B>
+	 */
+	Handle retrieve_expansion(const Handle& ctrl_rule) const;
+	bool is_expansion(const Handle& h) const;
 
 	/**
 	 * Return the pattern in a given expansion control rule, if it has
@@ -217,7 +250,7 @@ private:
 	 *      <B>
 	 *      <T>
 	 *
-	 * n >=0 is the number of patterns in addition to preproof and
+	 * n >= 0 is the number of patterns in addition to preproof and
 	 * expansion.
 	 */
 	HandleSet fetch_expansion_control_rules(const Handle& inf_rule, int n);
@@ -246,7 +279,6 @@ private:
 	 */
 	double get_actual_mean(TruthValuePtr tv) const;
 };
-
 
 } // namespace opencog
 

--- a/opencog/rule-engine/backwardchainer/MixtureModel.cc
+++ b/opencog/rule-engine/backwardchainer/MixtureModel.cc
@@ -78,6 +78,10 @@ TruthValuePtr MixtureModel::operator()()
 TruthValuePtr MixtureModel::weighted_average(const std::vector<TruthValuePtr>& tvs,
                                              const std::vector<double>& weights) const
 {
+	// Don't bother mixing if there's only one TV
+	if (tvs.size () == 1)
+		return tvs[0];
+
 	// Normalize the weights
 	double total = boost::accumulate(weights, 0.0);
 	std::vector<double> norm_weights;

--- a/opencog/rule-engine/backwardchainer/MixtureModel.cc
+++ b/opencog/rule-engine/backwardchainer/MixtureModel.cc
@@ -97,10 +97,11 @@ double MixtureModel::prior_estimate(const Handle& model)
 		remain_data_size = data_set_size - model->getTruthValue()->get_count(),
 		kestimate = kolmogorov_estimate(remain_data_size);
 
-	ure_logger().fine() << "MixtureModel::prior_estimate "
-	                    << "partial_length = " << partial_length
-	                    << ", remain_data_size = " << remain_data_size
-	                    << ", kestimate = " << kestimate;
+	LAZY_URE_LOG_FINE << "MixtureModel::prior_estimate "
+	                  << "model = " << oc_to_string(model)
+	                  << "partial_length = " << partial_length
+	                  << ", remain_data_size = " << remain_data_size
+	                  << ", kestimate = " << kestimate;
 
 	return prior(partial_length + kestimate);
 }
@@ -112,8 +113,8 @@ double MixtureModel::kolmogorov_estimate(double remain_count)
 
 double MixtureModel::prior(double length)
 {
-	ure_logger().fine() << "MixtureModel::prior length = " << length
-	                    << ", prior = " << exp(-cpx_penalty*length);
+	LAZY_URE_LOG_FINE << "MixtureModel::prior length = " << length
+	                  << ", prior = " << exp(-cpx_penalty*length);
 	return exp(-cpx_penalty*length);
 }
 

--- a/opencog/rule-engine/backwardchainer/MixtureModel.cc
+++ b/opencog/rule-engine/backwardchainer/MixtureModel.cc
@@ -49,28 +49,8 @@ TruthValuePtr MixtureModel::operator()()
 	std::vector<TruthValuePtr> tvs;
 	std::vector<double> weights;
 	for (const Handle model : models) {
-		ure_logger().fine() << "MixtureModel::operator() model = "
-		                    << oc_to_string(model);
-
-		// Get model's TV
-		TruthValuePtr tv = model->getTruthValue();
-		tvs.push_back(tv);
-
-		// Calculate model's weight
-		double count = tv->get_count(),
-			pos_count = tv->get_mean() * count, // TODO correct when mean is fixed
-			binom = binomial_coefficient<double>(count, pos_count),
-			prior = prior_estimate(model),
-			weight = prior * (count+1) * binom;
-
-		ure_logger().fine() << "MixtureModel::operator() count = " << count
-		                    << ", pos_count = " << pos_count
-		                    << ", binom = " << binom
-		                    << ", (count+1) * binom = " << (count+1) * binom
-		                    << ", prior_estimate = " << prior
-		                    << ", weight = " << weight;
-
-		weights.push_back(weight);
+		tvs.push_back(model->getTruthValue());
+		weights.push_back(prior_estimate(model));
 	}
 	return weighted_average(tvs, weights);
 }

--- a/opencog/rule-engine/backwardchainer/MixtureModel.cc
+++ b/opencog/rule-engine/backwardchainer/MixtureModel.cc
@@ -87,6 +87,9 @@ TruthValuePtr MixtureModel::weighted_average(const std::vector<TruthValuePtr>& t
 		relative_variances[i] += sq(means[i] - mean);
 	double variance = boost::inner_product(norm_weights, relative_variances, 0.0);
 
+	LAZY_URE_LOG_FINE << "MixtureModel::weighted_average mean = " << mean
+	                  << ", variance = " << variance;
+
 	return mk_stv(mean, variance);
 }
 
@@ -98,7 +101,6 @@ double MixtureModel::prior_estimate(const Handle& model)
 		kestimate = kolmogorov_estimate(remain_data_size);
 
 	LAZY_URE_LOG_FINE << "MixtureModel::prior_estimate "
-	                  << "model = " << oc_to_string(model)
 	                  << "partial_length = " << partial_length
 	                  << ", remain_data_size = " << remain_data_size
 	                  << ", kestimate = " << kestimate;

--- a/opencog/rule-engine/backwardchainer/MixtureModel.h
+++ b/opencog/rule-engine/backwardchainer/MixtureModel.h
@@ -71,9 +71,10 @@ public:
 	             double compressiveness=0.0);
 
 	/**
-	 * Calculate the TV of the mixture model. According to Universal
-	 * Operator Induction, assuming complete models, the equation
-	 * rewritten for TVs is
+	 * Calculate the TV of the mixture model.
+	 *
+	 * According to Universal Operator Induction, assuming complete
+	 * models, the equation rewritten for TVs is
 	 *
 	 * TV_MM(D') = Sum_i=0^n TV_Mi(D') * P(Mi) / Sum_i=0^n P(Mi)
 	 *

--- a/opencog/rule-engine/backwardchainer/MixtureModel.h
+++ b/opencog/rule-engine/backwardchainer/MixtureModel.h
@@ -71,69 +71,40 @@ public:
 	             double compressiveness=0.0);
 
 	/**
-	 * TODO: correct comment. Remove the choose shenanigan.
+	 * Calculate the TV of the mixture model. Assuming the ith model,
+	 * Mi, with prior Pi, has its TV represented by a probabilistic
+	 * density function pfd_i, a beta-distributions with parameters
+	 * alpha_i, beta_i, then, an optimal mixture, according to
+	 * Universal Operator Induction, may be approached with
 	 *
-	 * Calculate the TV of the mixture model.
+	 * Sum_i Pi * pdf_i * Beta(alpha_i, beta_i)
 	 *
-	 * According to Universal Operator Induction, assuming complete
-	 * models, the equation rewritten for TVs is
+	 * up to a normalizing factor so that the resulting pdf integrates
+	 * to 1. The reason for that is lengthly explained in Subsection
+	 * Combining Inference Control Rules of
+	 * <OPENCOG_ROOT>/examples/pln/inference-control-learning/README.md
 	 *
-	 * TV_MM(D') = Sum_i=0^n TV_Mi(D') * P(Mi) / Sum_i=0^n P(Mi)
-	 *
-	 * where
-	 * - D' is the new data to explain
-	 * - TV_MM(D') is the TV of the mixture model explaining D'
-	 * - TV_Mi(D') is the TV of model Mi explaining D'
-	 * - P(Mi) is the prior probability of model Mi
-	 *
-	 * TVs already captures the likelihood of the training data (the
-	 * binomial part of the beta-binomial distribution underlying a
-	 * TV, see Section 4.5.1 of the PLN book) which is why it doesn't
-	 * appear in the equation.
-	 *
-	 * However, most of the time the models are partial, they are only
-	 * active on a subset of observations. Ignoring the unexplained
-	 * data would give an unfair advantage to partial models. Indeed
-	 * the multiplicative factor to have the TV exactly equal to the
-	 * likelihood of explaining the historical data could be ignored
-	 * in the equation above because it is constant for all complete
-	 * models, but it can no longer be ignored for partial
-	 * models. Assuming Ni and Xi are respectively the number of total
-	 * and positive observations defined in model Mi, this factor is
-	 *
-	 * 1 / (Ni+1)*(choose Ni Xi)
-	 *
-	 * which grows quadratically to exponentially as N goes down.
-	 *
-	 * In principle a way to deal with that would be to complete these
-	 * partial models with as many models as possible. As it is
-	 * costly, if not impractical, we will attempt to avoid that
-	 * entirely and assume instead a fictive completion that perfectly
-	 * explains the remaining data, leading to a likelihood of 1. It
-	 * seems acceptable as such a fictive completion dominates all
-	 * others in terms of fitness (pior*likelihood). However to do
-	 * well we need to estimate its size, the Kolmogorov complexity of
-	 * the unexplained data. Which almost brings us back to square
-	 * one. For now we will use the following simplistic heuristic to
-	 * estimate its Kolmogorov complexity
+	 * Since Mi may be based on a subet of observations, Pi must
+	 * account for the complexity of the missing observations. We use
+	 * the simplistic heuristic to estimate the Kolmogorov complexity
+	 * of the missing observations D
 	 *
 	 * K(D) = |D|^(1-c)
 	 *
 	 * where c is a compressiveness parameter, that ranges from 0, no
 	 * compression, to 1, full compression.
 	 *
-	 * So for partial models the TV of the mixture model can be
+	 * So for partial models the pdf of the mixture model can be
 	 * defined as followed
 	 *
-	 * TV_MM(D') = Sum_i=0^n TV_Mi(D') * P(Li + K(Di)) * ((Ni+1)*(choose Ni Xi))
-	 *           / Sum_i=0^n P(Li + K(Di)) * ((Ni+1)*(choose Ni Xi))
+	 * Sum_i P(Li + K(Di)) * pdf_i * Beta(alpha_i, beta_i)
 	 *
 	 * where
 	 * - Li is the length of model Mi
-	 * - Di are the unexplained data by model Mi
+	 * - Di are the missing data of model Mi
 	 * - P(Li + K(Di)) is the prior of model Mi + perfect fictive completion
 	 */
-	TruthValuePtr operator()();
+	TruthValuePtr operator()() const;
 
 	/**
 	 * Given a list of TVs and a list of associated weights, that do
@@ -148,10 +119,16 @@ public:
 	                               const std::vector<double>& weights) const;
 
 	/**
+	 * Calculate the alpha and beta parameters of the model's TV, and
+	 * return Beta(alpha, beta), where Beta is the beta function.
+	 */
+	double beta_factor(const Handle& model) const;
+
+	/**
 	 * Given a model, calculate it's prior estimate. In the case of a
 	 * partial model, the length is estimated
 	 */
-	double prior_estimate(const Handle& model);
+	double prior_estimate(const Handle& model) const;
 
 	/**
 	 * Given the size of the data set that isn't explained by a model,
@@ -165,7 +142,7 @@ public:
 	 * it return 1, which is the maximum compression, all data can be
 	 * explained with just one bit.
 	 */
-	double kolmogorov_estimate(double remain_data_size);
+	double kolmogorov_estimate(double remain_data_size) const;
 
 	/**
 	 * Given the length of a model, calculate its prior
@@ -180,14 +157,14 @@ public:
 	 * The prior doesn't have to sum up to 1 because the probability
 	 * estimates are normalized.
 	 */
-	double prior(double length);
+	double prior(double length) const;
 
 private:
 	/**
 	 * Infer the data set size by taking the max count of all models
 	 * (it works assuming that one of them is complete).
 	 */
-	double infer_data_set_size();
+	double infer_data_set_size() const;
 
 };
 

--- a/opencog/rule-engine/backwardchainer/MixtureModel.h
+++ b/opencog/rule-engine/backwardchainer/MixtureModel.h
@@ -71,6 +71,8 @@ public:
 	             double compressiveness=0.0);
 
 	/**
+	 * TODO: correct comment. Remove the choose shenanigan.
+	 *
 	 * Calculate the TV of the mixture model.
 	 *
 	 * According to Universal Operator Induction, assuming complete

--- a/opencog/rule-engine/forwardchainer/ForwardChainer.cc
+++ b/opencog/rule-engine/forwardchainer/ForwardChainer.cc
@@ -100,12 +100,12 @@ void ForwardChainer::init(const Handle& source,
 	_iteration = 0;
 }
 
-UREConfigReader& ForwardChainer::get_config()
+UREConfig& ForwardChainer::get_config()
 {
 	return _configReader;
 }
 
-const UREConfigReader& ForwardChainer::get_config() const
+const UREConfig& ForwardChainer::get_config() const
 {
 	return _configReader;
 }

--- a/opencog/rule-engine/forwardchainer/ForwardChainer.h
+++ b/opencog/rule-engine/forwardchainer/ForwardChainer.h
@@ -25,7 +25,7 @@
 #define FORWARDCHAINERX_H_
 
 #include <opencog/rule-engine/URECommons.h>
-#include <opencog/rule-engine/UREConfigReader.h>
+#include <opencog/rule-engine/UREConfig.h>
 
 #include "FCStat.h"
 
@@ -57,7 +57,7 @@ private:
 
 	URECommons _rec;            // utility class
 	Handle _rbs;                // rule-based system
-	UREConfigReader _configReader;
+	UREConfig _configReader;
 
 	int _iteration;
 	source_selection_mode _ts_mode;
@@ -137,8 +137,8 @@ public:
 	/**
 	 * URE configuration accessors
 	 */
-	UREConfigReader& get_config();
-	const UREConfigReader& get_config() const;
+	UREConfig& get_config();
+	const UREConfig& get_config() const;
 
 	/**
 	 * Perform forward chaining inference till the termination

--- a/opencog/scm/opencog/rule-engine/rule-engine-utils.scm
+++ b/opencog/scm/opencog/rule-engine/rule-engine-utils.scm
@@ -91,7 +91,7 @@
   tv (head): Optional TV representing the probability (uncertainty included) that the rule produces a desire outcome.
 "
     ; Didn't add type checking here b/c the ure-configuration format isn't
-    ; set in stone yet. And the best place to do that is in c++ UREConfigReader
+    ; set in stone yet. And the best place to do that is in c++ UREConfig
     (let ((alias (DefinedSchemaNode rule-name)))
         (DefineLink alias rule)
 

--- a/tests/rule-engine/CMakeLists.txt
+++ b/tests/rule-engine/CMakeLists.txt
@@ -10,5 +10,5 @@ LINK_LIBRARIES(
 # Run the tests in logical order, not alphabetical order:
 # The URE reader has to work, else the chainers will fail
 ADD_CXXTEST(ChainerUtilsUTest)
-ADD_CXXTEST(UREConfigReaderUTest)
+ADD_CXXTEST(UREConfigUTest)
 ADD_CXXTEST(RuleUTest)

--- a/tests/rule-engine/UREConfigUTest.cxxtest
+++ b/tests/rule-engine/UREConfigUTest.cxxtest
@@ -1,17 +1,17 @@
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/guile/SchemeEval.h>
 
-#include <opencog/rule-engine/UREConfigReader.h>
+#include <opencog/rule-engine/UREConfig.h>
 
 using namespace opencog;
 
-class UREConfigReaderUTest : public CxxTest::TestSuite {
+class UREConfigUTest : public CxxTest::TestSuite {
 private:
 	AtomSpace _as;
 	SchemeEval _eval;
 
 public:
-	UREConfigReaderUTest() : _eval(&_as)
+	UREConfigUTest() : _eval(&_as)
 	{
 		// Module loading is borked from the C++ environment, so
 		// add the following paths so that utilities.scm is found.
@@ -32,7 +32,7 @@ public:
 		std::cout << "AtomSpace = " << _as << std::endl;
 	}
 
-	~UREConfigReaderUTest()
+	~UREConfigUTest()
 	{
 		// Erase the log file if no assertions failed.
 		if (!CxxTest::TestTracker::tracker().suiteFailed())
@@ -47,7 +47,7 @@ _exit(rc); // XXX hack to avoid double-free in __run_exit_handlers
 		// to test
 		Handle rbs = _as.get_node(CONCEPT_NODE, "fc-rule-base");
 
-		UREConfigReader cr(_as, rbs);
+		UREConfig cr(_as, rbs);
 
 		TS_ASSERT_EQUALS(cr.get_rules().size(), 2);
 		TS_ASSERT_EQUALS(cr.get_attention_allocation(), false);

--- a/tests/rule-engine/backwardchainer/BackwardChainerUTest.cxxtest
+++ b/tests/rule-engine/backwardchainer/BackwardChainerUTest.cxxtest
@@ -106,7 +106,7 @@ void BackwardChainerUTest::reset_bc()
 
 	// std::cout << "eval_result = " << eval_result << std::endl;
 
-	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfigReader::top_rbs_name);
+	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfig::top_rbs_name);
 
 	_bc = new BackwardChainer(_as, top_rbs, Handle::UNDEFINED);
 }
@@ -179,7 +179,7 @@ void BackwardChainerUTest::test_deduction()
 	load_from_path("bc-transitive-closure.scm");
 	randGen().seed(0);
 
-	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfigReader::top_rbs_name);
+	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfig::top_rbs_name);
 	Handle X = an(VARIABLE_NODE, "$X"),
 		D = an(CONCEPT_NODE, "D"),
 		target = al(INHERITANCE_LINK, X, D);
@@ -213,7 +213,7 @@ void BackwardChainerUTest::test_deduction_tv_query()
 	load_from_path("bc-transitive-closure.scm");
 	randGen().seed(0);
 
-	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfigReader::top_rbs_name);
+	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfig::top_rbs_name);
 	Handle target = _eval.eval_h("(Inheritance"
 	                             "   (Concept \"A\")"
 	                             "   (Concept \"D\"))");
@@ -236,7 +236,7 @@ void BackwardChainerUTest::test_modus_ponens_tv_query()
 	load_from_path("modus-ponens-example.scm");
 	randGen().seed(0);
 
-	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfigReader::top_rbs_name);
+	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfig::top_rbs_name);
 	Handle target = an(PREDICATE_NODE, "T");
 
 	BackwardChainer bc(_as, top_rbs, target);
@@ -258,7 +258,7 @@ void BackwardChainerUTest::test_conjunction_fuzzy_evaluation_tv_query()
 	result = load_from_path("simple-conjunction.scm");
 	randGen().seed(0);
 
-	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfigReader::top_rbs_name);
+	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfig::top_rbs_name);
 
 	Handle P = an(PREDICATE_NODE, "P"),
 		Q = an(PREDICATE_NODE, "Q"),
@@ -289,7 +289,7 @@ void BackwardChainerUTest::test_conditional_instantiation_1()
 	result = load_from_path("friends.scm");
 	randGen().seed(0);
 
-	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfigReader::top_rbs_name);
+	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfig::top_rbs_name);
 
 	Handle are_friends = an(PREDICATE_NODE, "are-friends"),
 		john = an(CONCEPT_NODE, "John"),
@@ -332,7 +332,7 @@ void BackwardChainerUTest::test_conditional_instantiation_2()
 	load_from_path("animals.scm");
 	randGen().seed(0);
 
-	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfigReader::top_rbs_name);
+	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfig::top_rbs_name);
 
 	Handle green = an(CONCEPT_NODE, "green"),
 		Fritz = an(CONCEPT_NODE, "Fritz"),
@@ -364,7 +364,7 @@ void BackwardChainerUTest::test_conditional_instantiation_tv_query()
 	load_from_path("animals.scm");
 	randGen().seed(500);
 
-	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfigReader::top_rbs_name);
+	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfig::top_rbs_name);
 
 	Handle target =
 	    _eval.eval_h("(InheritanceLink"
@@ -429,7 +429,7 @@ void BackwardChainerUTest::test_conditional_partial_instantiation()
 	result = load_from_path("friends.scm");
 	randGen().seed(0);
 
-	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfigReader::top_rbs_name);
+	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfig::top_rbs_name);
 
 	Handle target = _eval.eval_h("(ImplicationScope"
 	                             "   (TypedVariable"
@@ -479,7 +479,7 @@ void BackwardChainerUTest::test_impossible_criminal()
 	load_from_path("criminal.scm");
 	randGen().seed(0);
 
-	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfigReader::top_rbs_name);
+	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfig::top_rbs_name);
 
 	Handle target =
 	    _eval.eval_h("(InheritanceLink"
@@ -516,7 +516,7 @@ void BackwardChainerUTest::test_criminal()
 	load_from_path("criminal.scm");
 	randGen().seed(0);
 
-	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfigReader::top_rbs_name);
+	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfig::top_rbs_name);
 
 	Handle target_var = _eval.eval_h("(VariableNode \"$who\")");
 	Handle target =
@@ -621,7 +621,7 @@ void BackwardChainerUTest::test_induction()
 
 	randGen().seed(500);
 
-	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfigReader::top_rbs_name);
+	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfig::top_rbs_name);
 
 	Handle target = _eval.eval_h("bc-induction-target");
 
@@ -647,7 +647,7 @@ void BackwardChainerUTest::test_focus_set()
 	load_from_path("animals.scm");
 	randGen().seed(500);
 
-	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfigReader::top_rbs_name);
+	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfig::top_rbs_name);
 
 	Handle green = an(CONCEPT_NODE, "green"),
 		Fritz = an(CONCEPT_NODE, "Fritz"),

--- a/tests/rule-engine/backwardchainer/ControlPolicyUTest.cxxtest
+++ b/tests/rule-engine/backwardchainer/ControlPolicyUTest.cxxtest
@@ -77,7 +77,9 @@ void ControlPolicyUTest::test_fetch_control_rules()
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
 	_eval.eval("(load-from-path \"control-rules.scm\")");
-	_cp = new ControlPolicy(RuleSet(), BIT(), &_control_as);
+	AtomSpace rbs_as;
+	Handle rbs = rbs_as.add_node(CONCEPT_NODE, "dummy");
+	_cp = new ControlPolicy(UREConfig(rbs_as, rbs), BIT(), &_control_as);
 
 	Handle rule_1_alias = _eval.eval_h("(DefinedSchemaNode \"rule-1\")");
 	HandleSet control_1_rules = _cp->fetch_expansion_control_rules(rule_1_alias);

--- a/tests/rule-engine/backwardchainer/ControlPolicyUTest.cxxtest
+++ b/tests/rule-engine/backwardchainer/ControlPolicyUTest.cxxtest
@@ -35,7 +35,7 @@ public:
 	void setUp();
 	void tearDown();
 
-	void test_fetch_control_rule();
+	void test_fetch_control_rules();
 };
 
 ControlPolicyUTest::ControlPolicyUTest() : _eval(&_control_as)
@@ -72,19 +72,22 @@ void ControlPolicyUTest::tearDown()
 	delete(_cp);
 }
 
-void ControlPolicyUTest::test_fetch_control_rule()
+void ControlPolicyUTest::test_fetch_control_rules()
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	_eval.eval("(load-from-path \"tests/rule-engine/backwardchainer/control-rules.scm\")");
-	Handle rule_alias = _eval.eval_h("(DefinedSchemaNode \"rule-1\")");
-
+	_eval.eval("(load-from-path \"control-rules.scm\")");
 	_cp = new ControlPolicy(RuleSet(), BIT(), &_control_as);
-	HandleSet control_rules = _cp->fetch_expansion_control_rules(rule_alias);
 
-	logger().debug() << "control_rules = " << oc_to_string(control_rules);
+	Handle rule_1_alias = _eval.eval_h("(DefinedSchemaNode \"rule-1\")");
+	HandleSet control_1_rules = _cp->fetch_expansion_control_rules(rule_1_alias);
+	logger().debug() << "control_1_rules = " << oc_to_string(control_1_rules);
+	TS_ASSERT_EQUALS(control_1_rules.size(), 1);
 
-	TS_ASSERT_EQUALS(control_rules.size(), 1);
+	Handle rule_2_alias = _eval.eval_h("(DefinedSchemaNode \"rule-2\")");
+	HandleSet control_2_rules = _cp->fetch_expansion_control_rules(rule_2_alias);
+	logger().debug() << "control_2_rules = " << oc_to_string(control_2_rules);
+	TS_ASSERT_EQUALS(control_2_rules.size(), 1);
 
 	logger().debug("END TEST: %s", __FUNCTION__);
 }

--- a/tests/rule-engine/backwardchainer/control-rules.scm
+++ b/tests/rule-engine/backwardchainer/control-rules.scm
@@ -1,3 +1,4 @@
+;; Context-free control rules for inference rule-1
 (ImplicationScopeLink (stv 0.5 0.0025)
    (VariableList
       (VariableNode "$T")
@@ -19,6 +20,51 @@
             (VariableNode "$L")
             (DontExecLink
                (DefinedSchemaNode "rule-1")
+            )
+         )
+         (VariableNode "$B")
+      )
+      (EvaluationLink
+         (PredicateNode "URE:BC:preproof-of")
+         (ListLink
+            (VariableNode "$A")
+            (VariableNode "$T")
+         )
+      )
+   )
+   (EvaluationLink
+      (PredicateNode "URE:BC:preproof-of")
+      (ListLink
+         (VariableNode "$B")
+         (VariableNode "$T")
+      )
+   )
+)
+
+;; Context-sensitive control rules for inference rule-2
+(ImplicationScopeLink (stv 1 0.001)
+   (VariableList
+      (VariableNode "$T")
+      (TypedVariableLink
+         (VariableNode "$A")
+         (TypeNode "DontExecLink")
+      )
+      (VariableNode "$X")
+      (TypedVariableLink
+         (VariableNode "$B")
+         (TypeNode "DontExecLink")
+      )
+   )
+   (AndLink
+      (ExecutionLink
+         (SchemaNode "URE:BC:expand-and-BIT")
+         (ListLink
+            (VariableNode "$A")
+            (InheritanceLink
+              (ConceptNode "a")
+              (VariableNode "$X")
+            (DontExecLink
+               (DefinedSchemaNode "rule-2")
             )
          )
          (VariableNode "$B")

--- a/tests/rule-engine/backwardchainer/control-rules.scm
+++ b/tests/rule-engine/backwardchainer/control-rules.scm
@@ -4,42 +4,29 @@
       (VariableNode "$T")
       (TypedVariableLink
          (VariableNode "$A")
-         (TypeNode "DontExecLink")
-      )
+         (TypeNode "DontExecLink"))
       (VariableNode "$L")
       (TypedVariableLink
          (VariableNode "$B")
-         (TypeNode "DontExecLink")
-      )
-   )
+         (TypeNode "DontExecLink")))
    (AndLink
       (ExecutionLink
          (SchemaNode "URE:BC:expand-and-BIT")
          (ListLink
             (VariableNode "$A")
             (VariableNode "$L")
-            (DontExecLink
-               (DefinedSchemaNode "rule-1")
-            )
-         )
-         (VariableNode "$B")
-      )
+            (DontExecLink (DefinedSchemaNode "rule-1")))
+         (VariableNode "$B"))
       (EvaluationLink
          (PredicateNode "URE:BC:preproof-of")
          (ListLink
             (VariableNode "$A")
-            (VariableNode "$T")
-         )
-      )
-   )
+            (VariableNode "$T"))))
    (EvaluationLink
       (PredicateNode "URE:BC:preproof-of")
       (ListLink
          (VariableNode "$B")
-         (VariableNode "$T")
-      )
-   )
-)
+         (VariableNode "$T"))))
 
 ;; Context-sensitive control rules for inference rule-2
 (ImplicationScopeLink (stv 1 0.001)
@@ -47,14 +34,11 @@
       (VariableNode "$T")
       (TypedVariableLink
          (VariableNode "$A")
-         (TypeNode "DontExecLink")
-      )
+         (TypeNode "DontExecLink"))
       (VariableNode "$X")
       (TypedVariableLink
          (VariableNode "$B")
-         (TypeNode "DontExecLink")
-      )
-   )
+         (TypeNode "DontExecLink")))
    (AndLink
       (ExecutionLink
          (SchemaNode "URE:BC:expand-and-BIT")
@@ -62,26 +46,16 @@
             (VariableNode "$A")
             (InheritanceLink
               (ConceptNode "a")
-              (VariableNode "$X")
-            (DontExecLink
-               (DefinedSchemaNode "rule-2")
-            )
-         )
-         (VariableNode "$B")
-      )
+              (VariableNode "$X"))
+            (DontExecLink (DefinedSchemaNode "rule-2")))
+         (VariableNode "$B"))
       (EvaluationLink
          (PredicateNode "URE:BC:preproof-of")
          (ListLink
             (VariableNode "$A")
-            (VariableNode "$T")
-         )
-      )
-   )
+            (VariableNode "$T"))))
    (EvaluationLink
       (PredicateNode "URE:BC:preproof-of")
       (ListLink
          (VariableNode "$B")
-         (VariableNode "$T")
-      )
-   )
-)
+         (VariableNode "$T"))))

--- a/tests/rule-engine/forwardchainer/ForwardChainerUTest.cxxtest
+++ b/tests/rule-engine/forwardchainer/ForwardChainerUTest.cxxtest
@@ -115,7 +115,7 @@ void ForwardChainerUTest::test_do_chain_animals()
 	_eval.eval("(load-from-path \"animals.scm\")");
 	randGen().seed(0);
 
-	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfigReader::top_rbs_name);
+	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfig::top_rbs_name);
 
 	Handle Fritz = an(CONCEPT_NODE, "Fritz"),
 		croaks = an(PREDICATE_NODE, "croaks"),


### PR DESCRIPTION
The Backward Chainer now partially supports context sensitive control rule, as long as it is solely expressed in the form of non-evaluatable patterns. Full support will come as soon as I happen to need it.

On top of that the `MixtureModel` class has been substantially improved. I thing it would make sense to wrap this code in a `MixtureModelLink` or something that can be easily used by other components. In a nutshell, it enables a form of Solomonoff induction while leveraging the expressiveness of OpenCog's truth values.