### PR TITLE
build tweak: missing hashbang

### DIFF
--- a/opencog/haskell/build.sh
+++ b/opencog/haskell/build.sh
@@ -1,8 +1,9 @@
+#!/bin/bash
 BIN_DIR=$1
 
 ghcver="$(stack --allow-different-user ghc -- --version)"
 
-if [[ $ghcver == *8.0.2* ]]
+if [[ "$ghcver" == *8.0.2* ]]
 then
     echo "Correct GHC version installed"
 else


### PR DESCRIPTION
I fixed the MapLink #include and a warning related to Debian running the Haskell build.sh script with the sh interpreter while the scrip expected bash (due to the use of the [[ program), but it seems like the include was fixed while I was preparing this PR.