### PR TITLE
Fix atom content less

### DIFF
--- a/opencog/atoms/base/Link.cc
+++ b/opencog/atoms/base/Link.cc
@@ -143,6 +143,12 @@ bool Link::operator<(const Atom& other) const
     if (arity != other_arity)
         return arity < other_arity;
 
+    // Before comparing their outgoings, make sure that they are not
+    // equal. Indeed, in some cases, such as alpha-equivalence,
+    // comparing their outgoings won't work
+    if (operator==(other))
+	    return false;
+
     for (Arity i=0; i < arity; i++)
     {
         const Handle& ll(outgoing[i]);

--- a/opencog/atoms/core/ScopeLink.cc
+++ b/opencog/atoms/core/ScopeLink.cc
@@ -175,7 +175,7 @@ bool ScopeLink::is_equal(const Handle& other, bool silent) const
 
 	// Some derived classes (such as BindLink) have multiple body parts,
 	// so it is not enough to compare this->_body to other->_body.
-	// They tricky bit, below, is skipping over variable decls correctly,
+	// The tricky bit, below, is skipping over variable decls correctly,
 	// to find the remaining body parts. Start by counting to make sure
 	// that this and other have the same number of body parts.
 	Arity vardecl_offset = _vardecl != Handle::UNDEFINED;


### PR DESCRIPTION
Possible fix for #1446 

@linas I don't know if that the best way to fix it, it certainly seems like the simplest, but instead I could have overloaded operator< for ScopeLink. I think this fix is more generic but might have some unwanted performance overhead. Let me know what you think.