### PR TITLE
Add ScopeLink::partial_subtitute

### DIFF
--- a/opencog/atoms/base/Handle.cc
+++ b/opencog/atoms/base/Handle.cc
@@ -100,6 +100,19 @@ bool Handle::operator<(const Handle& h) const noexcept
 	return get()->operator<(*h);
 }
 
+bool content_eq(const HandleSeq& lhs, const HandleSeq& rhs)
+{
+	if (lhs.size() != rhs.size())
+		return false;
+
+	auto lit = lhs.begin(), rit = rhs.begin();
+	for (; rit != rhs.end(); ++lit, ++rit)
+		if (not content_eq(*lit, *rit))
+			return false;
+	return true;
+
+}
+
 bool content_eq(const HandleSet& lhs, const HandleSet& rhs)
 {
 	if (lhs.size() != rhs.size())

--- a/opencog/atoms/base/Handle.h
+++ b/opencog/atoms/base/Handle.h
@@ -203,6 +203,9 @@ typedef Counter<Handle, unsigned> HandleUCounter;
 //! a handle iterator
 typedef std::iterator<std::forward_iterator_tag, Handle> HandleIterator;
 
+bool content_eq(const opencog::HandleSeq& lhs,
+                const opencog::HandleSeq& rhs);
+
 bool content_eq(const opencog::HandleSet& lhs,
                 const opencog::HandleSet& rhs);
 

--- a/opencog/atomutils/TypeUtils.cc
+++ b/opencog/atomutils/TypeUtils.cc
@@ -311,10 +311,13 @@ Handle filter_vardecl(const Handle& vardecl, const HandleSeq& hs)
 	else if (VARIABLE_LIST == t)
 	{
 		HandleSeq subvardecls;
+		HandleSet subvars;      // avoid duplicating variables
 		for (const Handle& v : vardecl->getOutgoingSet())
 		{
-			if (filter_vardecl(v, hs))
+			if (filter_vardecl(v, hs) and subvars.find(v) == subvars.end()) {
 				subvardecls.push_back(v);
+				subvars.insert(v);
+			}
 		}
 		if (subvardecls.empty() and get_free_variables(hs).empty())
 			return Handle::UNDEFINED;

--- a/opencog/atomutils/Unify.h
+++ b/opencog/atomutils/Unify.h
@@ -240,6 +240,8 @@ public:
 	 *    grounded scope links.
 	 *
 	 * No other use of quotation is assumed besides the 2 above.
+	 *
+	 * TODO: replace by ScopeLink methods!
 	 */
 	static BindLinkPtr consume_ill_quotations(BindLinkPtr bl);
 	static Handle consume_ill_quotations(const Handle& vardecl, const Handle& h);
@@ -252,6 +254,8 @@ public:
 	/**
 	 * Return true iff the variable declaration of local_scope is a
 	 * variable of variables wrapped in a UnquoteLink.
+	 *
+	 * TODO: user ScopeLink method instead!
 	 */
 	static bool is_bound_to_ancestor(const Variables& variables,
 	                                 const Handle& local_scope);
@@ -332,6 +336,8 @@ public:
 	 *   (ExecutionOutputLink
 	 *     (GroundedSchemaNode "gsn")
 	 *     (Inheritance (Concept "$A") (Concept "B"))))
+	 *
+	 * TODO: replace by ScopeLink methods!
 	 */
 	static Handle substitute(BindLinkPtr bl, const HandleMap& var2val,
 	                         Handle vardecl=Handle::UNDEFINED);
@@ -340,6 +346,8 @@ public:
 	 * Substitute the variable declaration of a BindLink. Remove
 	 * variables that are substituted by values. If all variables are
 	 * removed it returns Handle::UNDEFINED.
+	 *
+	 * TODO: replace by ScopeLink methods!
 	 */
 	static Handle substitute_vardecl(const Handle& vardecl,
 	                                 const HandleMap& var2val);

--- a/tests/atoms/ScopeLinkUTest.cxxtest
+++ b/tests/atoms/ScopeLinkUTest.cxxtest
@@ -68,6 +68,8 @@ public:
 	void test_compute_hash_1();
 	void test_compute_hash_2();
 	void test_content_less();
+	void test_partial_substitute_1();
+	void test_partial_substitute_2();
 };
 
 void ScopeLinkUTest::test_get_variables_1()
@@ -186,6 +188,53 @@ void ScopeLinkUTest::test_content_less()
 	TS_ASSERT(content_eq(scX, scY));
 	TS_ASSERT(not lt(scX, scY));
 	TS_ASSERT(not lt(scY, scX));
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// Test ScopeLink::partial_substitute with duplicated variable names
+void ScopeLinkUTest::test_partial_substitute_1()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Test simple ScopeLink
+	Handle X = createNode(VARIABLE_NODE, "$X"),
+		Y = createNode(VARIABLE_NODE, "$Y"),
+		Z = createNode(VARIABLE_NODE, "$Z"),
+		hsc = createLink(SCOPE_LINK,
+		                 createLink(VARIABLE_LIST, X, Y),
+		                 createLink(INHERITANCE_LINK, X, Y));
+
+	ScopeLinkPtr sc(ScopeLinkCast(hsc));
+	Handle result = sc->partial_substitute(HandleMap{{X, Z}, {Y, Z}}),
+		expected = createLink(SCOPE_LINK, Z, createLink(INHERITANCE_LINK, Z, Z));
+
+	std::cout << "result = " << oc_to_string(result);
+	std::cout << "expected = " << oc_to_string(expected);
+
+	TS_ASSERT(content_eq(result, expected));
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// Test ScopeLink::partial_substitute with no variable
+void ScopeLinkUTest::test_partial_substitute_2()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Test simple ScopeLink
+	Handle hsc = createLink(SCOPE_LINK,
+	                        createLink(VARIABLE_LIST, X, Y),
+	                        createLink(INHERITANCE_LINK, X, Y));
+
+	ScopeLinkPtr sc(ScopeLinkCast(hsc));
+	Handle result = sc->partial_substitute(HandleMap{}),
+		expected = hsc;
+
+	std::cout << "result = " << oc_to_string(result);
+	std::cout << "expected = " << oc_to_string(expected);
+
+	TS_ASSERT(content_eq(result, expected));
 
 	logger().info("END TEST: %s", __FUNCTION__);
 }

--- a/tests/query/ScopeUTest.cxxtest
+++ b/tests/query/ScopeUTest.cxxtest
@@ -56,8 +56,8 @@ public:
 		// Erase the log file if no assertions failed.
 		if (!CxxTest::TestTracker::tracker().suiteFailed())
 			std::remove(logger().get_filename().c_str());
-int rc = CxxTest::TestTracker::tracker().suiteFailed();
-_exit(rc); // XXX hack to avoid double-free in __run_exit_handlers
+		int rc = CxxTest::TestTracker::tracker().suiteFailed();
+		_exit(rc); // XXX hack to avoid double-free in __run_exit_handlers
 	}
 
 	void setUp();


### PR DESCRIPTION
Similar to `LambdaLink::substitute` but produce a partially substituted scope link instead of a fully substited body.

I have decided to have this method in `ScopeLink` instead of `LambdaLink` because not all scope links inherits `LambdaLink`.