### PR TITLE
Replace most uses of `cog-bind` by `cog-execute!`

### DIFF
--- a/opencog/scm/opencog/rule-engine/rule-engine-utils.scm
+++ b/opencog/scm/opencog/rule-engine/rule-engine-utils.scm
@@ -25,7 +25,7 @@
 ;
 
 (use-modules (opencog))
-(use-modules (opencog query))
+(use-modules (opencog exec))
 (use-modules (srfi srfi-1))
 
 (define* (cog-fc rbs source #:key (vardecl (List)) (focus-set (Set)))
@@ -179,7 +179,7 @@
                           (DeleteLink
                              (param-hypergraph (VariableNode "__VALUE__"))))))
        ; Delete any previous value for that parameter
-       (cog-bind del-prev-val)
+       (cog-execute! del-prev-val)
        ; Delete pattern to not create to much junk in the atomspace
        (extract-hypergraph del-prev-val)
   )
@@ -238,8 +238,8 @@
   applying the generated rules to the atomspace. Convenient for testing
   meta-rules.
 "
-  (let* ((rules (cog-bind bl))
-         (result-sets (map cog-bind (cog-outgoing-set rules)))
+  (let* ((rules (cog-execute! bl))
+         (result-sets (map cog-execute! (cog-outgoing-set rules)))
          (result-lists (map cog-outgoing-set result-sets))
          (equal-lset-union (lambda (x y) (lset-union equal? x y)))
          (results (fold equal-lset-union '() result-lists)))

--- a/tests/cython/guile/test_pattern.py
+++ b/tests/cython/guile/test_pattern.py
@@ -67,13 +67,13 @@ class SchemeTest(TestCase):
     # Run the pattern-matcher/unifier/query-engine.
     def test_unifier(self):
 
-        scheme_eval(self.space, "(use-modules (opencog query))")
+        scheme_eval(self.space, "(use-modules (opencog exec))")
         question = scheme_eval_h(self.space, "find-animals")
         self.assertTrue(question)
         print "\nThe question is:"
         print question
 
-        answer = scheme_eval_h(self.space, "(cog-bind find-animals)")
+        answer = scheme_eval_h(self.space, "(cog-execute! find-animals)")
         self.assertTrue(answer)
         print "\nThe answer is:"
         print answer

--- a/tests/query/AbsentUTest.cxxtest
+++ b/tests/query/AbsentUTest.cxxtest
@@ -42,7 +42,7 @@ public:
 		eval = new SchemeEval(as);
 		eval->eval("(add-to-load-path \"..\")");
 		eval->eval("(add-to-load-path \"../../..\")");
-		eval->eval("(use-modules (opencog exec) (opencog query))");
+		eval->eval("(use-modules (opencog exec))");
 	}
 
 	~AbsentUTest()
@@ -100,9 +100,9 @@ void AbsentUTest::test_single(void)
 	TS_ASSERT_EQUALS(state, empty);
 
 	// Make the golem come alive
-	eval->eval_h("(cog-bind create)");
-	eval->eval_h("(cog-bind is-visible)");
-	eval->eval_h("(cog-bind is-invisible)");
+	eval->eval_h("(cog-execute! create)");
+	eval->eval_h("(cog-execute! is-visible)");
+	eval->eval_h("(cog-execute! is-invisible)");
 
 	state = eval->eval_h("(show-room-state)");
 	printf("Expecting: %s\n", full->to_string().c_str());
@@ -110,24 +110,24 @@ void AbsentUTest::test_single(void)
 	TS_ASSERT_EQUALS(state, full);
 
 	// Kill the golem
-	eval->eval_h("(cog-bind destroy)");
-	eval->eval_h("(cog-bind is-visible)");
-	eval->eval_h("(cog-bind is-invisible)");
+	eval->eval_h("(cog-execute! destroy)");
+	eval->eval_h("(cog-execute! is-visible)");
+	eval->eval_h("(cog-execute! is-invisible)");
 
 	state = eval->eval_h("(show-room-state)");
 	TS_ASSERT_EQUALS(state, empty);
 
 	// Once more, for good luck.
-	eval->eval_h("(cog-bind create)");
-	eval->eval_h("(cog-bind is-visible)");
-	eval->eval_h("(cog-bind is-invisible)");
+	eval->eval_h("(cog-execute! create)");
+	eval->eval_h("(cog-execute! is-visible)");
+	eval->eval_h("(cog-execute! is-invisible)");
 
 	state = eval->eval_h("(show-room-state)");
 	TS_ASSERT_EQUALS(state, full);
 
-	eval->eval_h("(cog-bind destroy)");
-	eval->eval_h("(cog-bind is-visible)");
-	eval->eval_h("(cog-bind is-invisible)");
+	eval->eval_h("(cog-execute! destroy)");
+	eval->eval_h("(cog-execute! is-visible)");
+	eval->eval_h("(cog-execute! is-invisible)");
 
 	state = eval->eval_h("(show-room-state)");
 	TS_ASSERT_EQUALS(state, empty);
@@ -150,45 +150,45 @@ void AbsentUTest::test_double(void)
 	TS_ASSERT_EQUALS(state, exists);
 
 	// Mulder and Scully not around; UFO should be.
-	eval->eval_h("(cog-bind is-visible)");
-	eval->eval_h("(cog-bind is-invisible)");
-	eval->eval_h("(cog-bind is-proven)");
+	eval->eval_h("(cog-execute! is-visible)");
+	eval->eval_h("(cog-execute! is-invisible)");
+	eval->eval_h("(cog-execute! is-proven)");
 
 	state = eval->eval_h("(show-ufo-state)");
 	TS_ASSERT_EQUALS(state, exists);
 
 	// Get Mulder on the scene
 	eval->eval_h("(cog-execute! call-mulder)");
-	eval->eval_h("(cog-bind is-visible)");
-	eval->eval_h("(cog-bind is-invisible)");
-	eval->eval_h("(cog-bind is-proven)");
+	eval->eval_h("(cog-execute! is-visible)");
+	eval->eval_h("(cog-execute! is-invisible)");
+	eval->eval_h("(cog-execute! is-proven)");
 
 	state = eval->eval_h("(show-ufo-state)");
 	TS_ASSERT_EQUALS(state, denied);
 
 	// Discredit Mulder
-	eval->eval_h("(cog-bind discredit-mulder)");
-	eval->eval_h("(cog-bind is-visible)");
-	eval->eval_h("(cog-bind is-invisible)");
-	eval->eval_h("(cog-bind is-proven)");
+	eval->eval_h("(cog-execute! discredit-mulder)");
+	eval->eval_h("(cog-execute! is-visible)");
+	eval->eval_h("(cog-execute! is-invisible)");
+	eval->eval_h("(cog-execute! is-proven)");
 
 	state = eval->eval_h("(show-ufo-state)");
 	TS_ASSERT_EQUALS(state, exists);
 
 	// Get Scully on the scene
 	eval->eval_h("(cog-execute! call-scully)");
-	eval->eval_h("(cog-bind is-visible)");
-	eval->eval_h("(cog-bind is-invisible)");
-	eval->eval_h("(cog-bind is-proven)");
+	eval->eval_h("(cog-execute! is-visible)");
+	eval->eval_h("(cog-execute! is-invisible)");
+	eval->eval_h("(cog-execute! is-proven)");
 
 	state = eval->eval_h("(show-ufo-state)");
 	TS_ASSERT_EQUALS(state, denied);
 
 	// Discredit Scully
-	eval->eval_h("(cog-bind discredit-scully)");
-	eval->eval_h("(cog-bind is-visible)");
-	eval->eval_h("(cog-bind is-invisible)");
-	eval->eval_h("(cog-bind is-proven)");
+	eval->eval_h("(cog-execute! discredit-scully)");
+	eval->eval_h("(cog-execute! is-visible)");
+	eval->eval_h("(cog-execute! is-invisible)");
+	eval->eval_h("(cog-execute! is-proven)");
 
 	state = eval->eval_h("(show-ufo-state)");
 	TS_ASSERT_EQUALS(state, exists);
@@ -196,27 +196,27 @@ void AbsentUTest::test_double(void)
 	// Get both Mulder and Scully on the job
 	eval->eval_h("(cog-execute! call-mulder)");
 	eval->eval_h("(cog-execute! call-scully)");
-	eval->eval_h("(cog-bind is-visible)");
-	eval->eval_h("(cog-bind is-invisible)");
-	eval->eval_h("(cog-bind is-proven)");
+	eval->eval_h("(cog-execute! is-visible)");
+	eval->eval_h("(cog-execute! is-invisible)");
+	eval->eval_h("(cog-execute! is-proven)");
 
 	state = eval->eval_h("(show-ufo-state)");
 	TS_ASSERT_EQUALS(state, proven);
 
 	// Discredit Scully
-	eval->eval_h("(cog-bind discredit-scully)");
-	eval->eval_h("(cog-bind is-visible)");
-	eval->eval_h("(cog-bind is-invisible)");
-	eval->eval_h("(cog-bind is-proven)");
+	eval->eval_h("(cog-execute! discredit-scully)");
+	eval->eval_h("(cog-execute! is-visible)");
+	eval->eval_h("(cog-execute! is-invisible)");
+	eval->eval_h("(cog-execute! is-proven)");
 
 	state = eval->eval_h("(show-ufo-state)");
 	TS_ASSERT_EQUALS(state, denied);
 
 	// Discredit Mulder too
-	eval->eval_h("(cog-bind discredit-mulder)");
-	eval->eval_h("(cog-bind is-visible)");
-	eval->eval_h("(cog-bind is-invisible)");
-	eval->eval_h("(cog-bind is-proven)");
+	eval->eval_h("(cog-execute! discredit-mulder)");
+	eval->eval_h("(cog-execute! is-visible)");
+	eval->eval_h("(cog-execute! is-invisible)");
+	eval->eval_h("(cog-execute! is-proven)");
 
 	state = eval->eval_h("(show-ufo-state)");
 	TS_ASSERT_EQUALS(state, exists);
@@ -230,7 +230,7 @@ void AbsentUTest::test_connect_exist(void)
 
 	eval->eval("(load-from-path \"tests/query/absent-conn1.scm\")");
 
-	Handle rtn = eval->eval_h("(cog-bind test)");
+	Handle rtn = eval->eval_h("(cog-execute! test)");
 
 	Handle soln = eval->eval_h("soln");
 
@@ -246,7 +246,7 @@ void AbsentUTest::test_connect_not_exist(void)
 
 	eval->eval("(load-from-path \"tests/query/absent-conn2.scm\")");
 
-	Handle rtn = eval->eval_h("(cog-bind test)");
+	Handle rtn = eval->eval_h("(cog-execute! test)");
 
 	Handle soln = eval->eval_h("soln");
 
@@ -262,7 +262,7 @@ void AbsentUTest::test_discon_exist(void)
 
 	eval->eval("(load-from-path \"tests/query/absent-disconn1.scm\")");
 
-	Handle rtn = eval->eval_h("(cog-bind test)");
+	Handle rtn = eval->eval_h("(cog-execute! test)");
 
 	Handle soln = eval->eval_h("soln");
 
@@ -278,7 +278,7 @@ void AbsentUTest::test_discon_not_exist(void)
 
 	eval->eval("(load-from-path \"tests/query/absent-disconn2.scm\")");
 
-	Handle rtn = eval->eval_h("(cog-bind test)");
+	Handle rtn = eval->eval_h("(cog-execute! test)");
 
 	Handle soln = eval->eval_h("soln");
 

--- a/tests/query/ArcanaUTest.cxxtest
+++ b/tests/query/ArcanaUTest.cxxtest
@@ -43,7 +43,7 @@ public:
 		eval = new SchemeEval(as);
 		eval->eval("(add-to-load-path \"..\")");
 		eval->eval("(add-to-load-path \"../../..\")");
-		eval->eval("(use-modules (opencog query))");
+		eval->eval("(use-modules (opencog exec))");
 		eval->eval("(load-from-path \"tests/query/test_types.scm\")");
 	}
 
@@ -90,11 +90,11 @@ void ArcanaUTest::test_repeats(void)
 
 	eval->eval("(load-from-path \"tests/query/arcana-repeat.scm\")");
 
-	Handle same = eval->eval_h("(cog-bind (repeat-same))");
+	Handle same = eval->eval_h("(cog-execute! (repeat-same))");
 	printf("same, num solutions=%lu\n", getarity(same));
 	TS_ASSERT_EQUALS(1, getarity(same));
 
-	Handle diff = eval->eval_h("(cog-bind (repeat-different))");
+	Handle diff = eval->eval_h("(cog-execute! (repeat-different))");
 
 	// Either one or two solutions are acceptable, as long as the
 	// two are identical. One solution is prefered, but seems
@@ -111,16 +111,16 @@ void ArcanaUTest::test_repeats(void)
 		printf("Solution 2:\n%s\n", oset[0]->to_short_string().c_str());
 	TS_ASSERT_EQUALS(true, pass);
 
-	Handle d3d = eval->eval_h("(cog-bind (repeat-diff-thrice))");
+	Handle d3d = eval->eval_h("(cog-execute! (repeat-diff-thrice))");
 	printf("d3d, num solutions=%lu\n", getarity(d3d));
 	TS_ASSERT(1 <= getarity(d3d));
 	TS_ASSERT(getarity(d3d) <= 3);
 
-	Handle thrice = eval->eval_h("(cog-bind (repeat-thrice))");
+	Handle thrice = eval->eval_h("(cog-execute! (repeat-thrice))");
 	printf("thrice, num solutions=%lu\n", getarity(thrice));
 	TS_ASSERT_EQUALS(1, getarity(thrice));
 
-	Handle once = eval->eval_h("(cog-bind (repeat-once))");
+	Handle once = eval->eval_h("(cog-execute! (repeat-once))");
 	printf("once, num solutions=%lu\n", getarity(once));
 	TS_ASSERT_EQUALS(1, getarity(once));
 
@@ -141,7 +141,7 @@ void ArcanaUTest::test_const(void)
 	// ----
 	Handle marconi = eval->eval_h("marconi");
 
-	Handle answer = eval->eval_h("(cog-bind who)");
+	Handle answer = eval->eval_h("(cog-execute! who)");
 	printf("radio=%s\n", answer->to_string().c_str());
 
 	TS_ASSERT_EQUALS(1, getarity(answer));
@@ -151,7 +151,7 @@ void ArcanaUTest::test_const(void)
 
 	// ----
 	// Test DefinedSchemaNode as an answer.
-	Handle defans = eval->eval_h("(cog-bind whodfn)");
+	Handle defans = eval->eval_h("(cog-execute! whodfn)");
 	printf("defined radio=%s\n", defans->to_string().c_str());
 
 	TS_ASSERT_EQUALS(1, getarity(defans));

--- a/tests/query/BuggyEqualUTest.cxxtest
+++ b/tests/query/BuggyEqualUTest.cxxtest
@@ -42,7 +42,7 @@ class BuggyEqual :  public CxxTest::TestSuite
 
 			as = new AtomSpace();
 			eval = new SchemeEval(as);
-			eval->eval("(use-modules (opencog query))");
+			eval->eval("(use-modules (opencog exec))");
 			eval->eval("(add-to-load-path \"..\")");
 			eval->eval("(add-to-load-path \"../../..\")");
 		}
@@ -83,7 +83,7 @@ void BuggyEqual::test_bugeq(void)
 
 	eval->eval("(load-from-path \"tests/query/buggy-equal.scm\")");
 
-	Handle pln = eval->eval_h("(cog-bind pln-rule-deduction)");
+	Handle pln = eval->eval_h("(cog-execute! pln-rule-deduction)");
 	printf("Deduction results:\n%s\n", pln->to_short_string().c_str());
 	TSM_ASSERT_EQUALS("wrong number of solutions found", 4, getarity(pln));
 
@@ -98,7 +98,7 @@ void BuggyEqual::test_bugalt(void)
 
 	eval->eval("(load-from-path \"tests/query/buggy-equal.scm\")");
 
-	Handle alt = eval->eval_h("(cog-bind pln-alt)");
+	Handle alt = eval->eval_h("(cog-execute! pln-alt)");
 	printf("Alt results:\n%s\n", alt->to_short_string().c_str());
 	TSM_ASSERT_EQUALS("wrong number of solutions found", 4, getarity(alt));
 

--- a/tests/query/ChoiceLinkUTest.cxxtest
+++ b/tests/query/ChoiceLinkUTest.cxxtest
@@ -77,7 +77,7 @@ void ChoiceLinkUTest::tearDown(void)
 void ChoiceLinkUTest::setUp(void)
 {
 	as->clear();
-	eval->eval("(use-modules (opencog query))");
+	eval->eval("(use-modules (opencog exec))");
 }
 
 #define getarity(hand) hand->get_arity()
@@ -91,7 +91,7 @@ void ChoiceLinkUTest::test_basic_or(void)
 
 	eval->eval("(load-from-path \"tests/query/choice-link.scm\")");
 
-	Handle items = eval->eval_h("(cog-bind (basic))");
+	Handle items = eval->eval_h("(cog-execute! (basic))");
 
 	TS_ASSERT_EQUALS(2, getarity(items));
 }
@@ -105,7 +105,7 @@ void ChoiceLinkUTest::test_embed_or(void)
 
 	eval->eval("(load-from-path \"tests/query/choice-embed.scm\")");
 
-	Handle items = eval->eval_h("(cog-bind (embed))");
+	Handle items = eval->eval_h("(cog-execute! (embed))");
 
 	TS_ASSERT_EQUALS(2, getarity(items));
 }
@@ -119,7 +119,7 @@ void ChoiceLinkUTest::test_nest_or(void)
 
 	eval->eval("(load-from-path \"tests/query/choice-nest.scm\")");
 
-	Handle items = eval->eval_h("(cog-bind (nest))");
+	Handle items = eval->eval_h("(cog-execute! (nest))");
 
 	printf ("Nest found:\n%s\n", items->to_short_string().c_str());
 	TS_ASSERT_EQUALS(5, getarity(items));
@@ -134,7 +134,7 @@ void ChoiceLinkUTest::test_top_nest_or(void)
 
 	eval->eval("(load-from-path \"tests/query/choice-top-nest.scm\")");
 
-	Handle items = eval->eval_h("(cog-bind (top-nest))");
+	Handle items = eval->eval_h("(cog-execute! (top-nest))");
 
 	printf ("Top-nest found:\n%s\n", items->to_short_string().c_str());
 	TS_ASSERT_EQUALS(5, getarity(items));
@@ -149,7 +149,7 @@ void ChoiceLinkUTest::test_nest_bad_or(void)
 
 	eval->eval("(load-from-path \"tests/query/choice-nest.scm\")");
 
-	Handle items = eval->eval_h("(cog-bind (nest-bad))");
+	Handle items = eval->eval_h("(cog-execute! (nest-bad))");
 
 	printf ("Nest-bad found:\n%s\n", items->to_short_string().c_str());
 	TS_ASSERT_EQUALS(4, getarity(items));
@@ -164,7 +164,7 @@ void ChoiceLinkUTest::test_top_nest_bad_or(void)
 
 	eval->eval("(load-from-path \"tests/query/choice-top-nest.scm\")");
 
-	Handle items = eval->eval_h("(cog-bind (top-nest-bad))");
+	Handle items = eval->eval_h("(cog-execute! (top-nest-bad))");
 
 	printf ("Top-nest-bad found:\n%s\n", items->to_short_string().c_str());
 	TS_ASSERT_EQUALS(4, getarity(items));
@@ -179,12 +179,12 @@ void ChoiceLinkUTest::test_top_disco(void)
 
 	eval->eval("(load-from-path \"tests/query/choice-disconnected.scm\")");
 
-	Handle items = eval->eval_h("(cog-bind (top-disco))");
+	Handle items = eval->eval_h("(cog-execute! (top-disco))");
 
 	printf ("Top-disco found:\n%s\n", items->to_short_string().c_str());
 	TS_ASSERT_EQUALS(2, getarity(items));
 
-	Handle wrap = eval->eval_h("(cog-bind (wrapped-disco))");
+	Handle wrap = eval->eval_h("(cog-execute! (wrapped-disco))");
 
 	printf ("Top-wrapped-disco found:\n%s\n", wrap->to_short_string().c_str());
 	TS_ASSERT_EQUALS(2, getarity(wrap));
@@ -200,7 +200,7 @@ void ChoiceLinkUTest::test_embed_disco(void)
 
 	eval->eval("(load-from-path \"tests/query/choice-embed-disco.scm\")");
 
-	Handle items = eval->eval_h("(cog-bind (embed-disco))");
+	Handle items = eval->eval_h("(cog-execute! (embed-disco))");
 
 	printf ("Embed pseudo-disco found:\n%s\n", items->to_short_string().c_str());
 	TS_ASSERT_EQUALS(2, getarity(items));
@@ -215,7 +215,7 @@ void ChoiceLinkUTest::test_double_or(void)
 
 	eval->eval("(load-from-path \"tests/query/choice-double.scm\")");
 
-	Handle items = eval->eval_h("(cog-bind (double))");
+	Handle items = eval->eval_h("(cog-execute! (double))");
 
 	TS_ASSERT_EQUALS(3, getarity(items));
 }

--- a/tests/query/DefineUTest.cxxtest
+++ b/tests/query/DefineUTest.cxxtest
@@ -43,7 +43,7 @@ public:
 		eval = new SchemeEval(as);
 		eval->eval("(add-to-load-path \"..\")");
 		eval->eval("(add-to-load-path \"../../..\")");
-		eval->eval("(use-modules (opencog query))");
+		eval->eval("(use-modules (opencog exec))");
 	}
 
 	~DefineLinkUTest()

--- a/tests/query/EvaluationUTest.cxxtest
+++ b/tests/query/EvaluationUTest.cxxtest
@@ -69,7 +69,6 @@ void EvaluationUTest::setUp(void)
 {
 	as->clear();
 	eval->eval("(use-modules (opencog exec))");
-	eval->eval("(use-modules (opencog query))");
 	eval->eval("(add-to-load-path \"..\")");
 	eval->eval("(add-to-load-path \"../../..\")");
 }

--- a/tests/query/FiniteStateMachineUTest.cxxtest
+++ b/tests/query/FiniteStateMachineUTest.cxxtest
@@ -40,7 +40,7 @@ public:
 
 		as = new AtomSpace();
 		eval = new SchemeEval(as);
-		eval->eval("(use-modules (opencog query))");
+		eval->eval("(use-modules (opencog exec))");
 		eval->eval("(add-to-load-path \"..\")");
 		eval->eval("(add-to-load-path \"../../..\")");
 	}
@@ -108,7 +108,7 @@ void FiniteStateMachineUTest::test_basic(void)
 
 	// Take one step of the finite state machine.
 	printf("Going to take one step\n");
-	Handle first = eval->eval_h("(cog-bind take-one-step)");
+	Handle first = eval->eval_h("(cog-execute! take-one-step)");
 	printf("First state found:\n%s\n", first->to_short_string().c_str());
 	TS_ASSERT_EQUALS(1, getarity(first));
 
@@ -123,7 +123,7 @@ void FiniteStateMachineUTest::test_basic(void)
 	for (int i=1; i<21; i++)
 	{
 		printf("Going to take one step; %d\n", i);
-		Handle next = eval->eval_h("(cog-bind take-one-step)");
+		Handle next = eval->eval_h("(cog-execute! take-one-step)");
 		TS_ASSERT_EQUALS(1, getarity(next));
 		TS_ASSERT_EQUALS(states[i%3], get_state(next));
 	}

--- a/tests/query/GetStateUTest.cxxtest
+++ b/tests/query/GetStateUTest.cxxtest
@@ -51,7 +51,7 @@ public:
 
 		as = new AtomSpace();
 		SchemeEval* eval = SchemeEval::get_evaluator(as);
-		eval->eval("(use-modules (opencog exec) (opencog query))");
+		eval->eval("(use-modules (opencog exec))");
 		eval->eval("(add-to-load-path \"..\")");
 		eval->eval("(add-to-load-path \"../../..\")");
 	}

--- a/tests/query/GlobUTest.cxxtest
+++ b/tests/query/GlobUTest.cxxtest
@@ -42,7 +42,7 @@ public:
 		eval = new SchemeEval(as);
 		eval->eval("(add-to-load-path \"..\")");
 		eval->eval("(add-to-load-path \"../../..\")");
-		eval->eval("(use-modules (opencog query))");
+		eval->eval("(use-modules (opencog exec))");
 	}
 
 	~GlobUTest()

--- a/tests/query/NoExceptionUTest.cxxtest
+++ b/tests/query/NoExceptionUTest.cxxtest
@@ -49,7 +49,7 @@ public:
 
 		eval->eval("(add-to-load-path \"..\")");
 		eval->eval("(add-to-load-path \"../../..\")");
-		eval->eval("(use-modules (opencog exec) (opencog query))");
+		eval->eval("(use-modules (opencog exec))");
 	}
 
 	~NoExceptionUTest()

--- a/tests/query/QuoteUTest.cxxtest
+++ b/tests/query/QuoteUTest.cxxtest
@@ -277,7 +277,7 @@ void QuoteUTest::test_crash(void)
     eval->eval("(load-from-path \"tests/query/quote-crash.scm\")");
 
     // If we can execute this without crashing, the test is succesful.
-    Handle cr = eval->eval_h("(cog-bind crasher)");
+    Handle cr = eval->eval_h("(cog-execute! crasher)");
     TS_ASSERT_EQUALS(1, getarity(cr));
 
     // This blows out the stack in an infinite loop, if the pattern

--- a/tests/query/ScopeUTest.cxxtest
+++ b/tests/query/ScopeUTest.cxxtest
@@ -133,10 +133,10 @@ void ScopeUTest::test_search()
 	eval->eval("(load-from-path \"tests/query/scope-search.scm\")");
 
 	Handle c1 = eval->eval_h("(content-1)");
-	Handle r1 = eval->eval_h("(cog-bind (member-to-evaluation-2-1-rule))");
+	Handle r1 = eval->eval_h("(cog-execute! (member-to-evaluation-2-1-rule))");
 
 	Handle c2 = eval->eval_h("(content-2)");
-	Handle r2 = eval->eval_h("(cog-bind (member-to-evaluation-2-1-rule))");
+	Handle r2 = eval->eval_h("(cog-execute! (member-to-evaluation-2-1-rule))");
 
 	TS_ASSERT_EQUALS(c1, c2);
 	TS_ASSERT_EQUALS(r1, r2);
@@ -154,10 +154,10 @@ void ScopeUTest::test_search_reverse()
 	eval->eval("(load-from-path \"tests/query/scope-search.scm\")");
 
 	Handle c2 = eval->eval_h("(content-2)");
-	Handle r2 = eval->eval_h("(cog-bind (member-to-evaluation-2-1-rule))");
+	Handle r2 = eval->eval_h("(cog-execute! (member-to-evaluation-2-1-rule))");
 
 	Handle c1 = eval->eval_h("(content-1)");
-	Handle r1 = eval->eval_h("(cog-bind (member-to-evaluation-2-1-rule))");
+	Handle r1 = eval->eval_h("(cog-execute! (member-to-evaluation-2-1-rule))");
 
 	TS_ASSERT_EQUALS(c1, c2);
 	TS_ASSERT_EQUALS(r1, r2);
@@ -174,10 +174,10 @@ void ScopeUTest::test_search_alt()
 	eval->eval("(load-from-path \"tests/query/scope-search.scm\")");
 
 	Handle c1 = eval->eval_h("(content-1)");
-	Handle r1 = eval->eval_h("(cog-bind (member-to-evaluation-2-1-alt))");
+	Handle r1 = eval->eval_h("(cog-execute! (member-to-evaluation-2-1-alt))");
 
 	Handle c2 = eval->eval_h("(content-2)");
-	Handle r2 = eval->eval_h("(cog-bind (member-to-evaluation-2-1-rule))");
+	Handle r2 = eval->eval_h("(cog-execute! (member-to-evaluation-2-1-rule))");
 
 	TS_ASSERT_EQUALS(c1, c2);
 	TS_ASSERT_EQUALS(r1, r2);
@@ -199,9 +199,9 @@ void ScopeUTest::test_pushpop()
 	Handle c1 = eval->eval_h("(content-1)");
 	eval->eval_h("(evaluation-to-member-2-rule-loose)");
 	eval->eval_h("(evaluation-to-member-2-rule)");
-	eval->eval_h("(cog-bind (member-to-evaluation-2-1-rule))");
+	eval->eval_h("(cog-execute! (member-to-evaluation-2-1-rule))");
 
-	Handle em = eval->eval_h("(cog-bind (evaluation-to-member-2-rule))");
+	Handle em = eval->eval_h("(cog-execute! (evaluation-to-member-2-rule))");
 	TS_ASSERT_EQUALS(1, em->get_arity());
 	Handle c2 = em->getOutgoingAtom(0);
 
@@ -220,8 +220,8 @@ void ScopeUTest::test_quote()
 
 	eval->eval("(load-from-path \"tests/query/scope-quote.scm\")");
 
-	Handle list = eval->eval_h("(cog-bind blist)");
-	Handle andl = eval->eval_h("(cog-bind bland)");
+	Handle list = eval->eval_h("(cog-execute! blist)");
+	Handle andl = eval->eval_h("(cog-execute! bland)");
 
 	Handle elist = eval->eval_h("(SetLink (OrderedLink p-lamb q-lamb))");
 	Handle eandl = eval->eval_h("(SetLink (UnorderedLink p-lamb q-lamb))");

--- a/tests/query/SingleUTest.cxxtest
+++ b/tests/query/SingleUTest.cxxtest
@@ -87,7 +87,7 @@ void SingleUTest::test_single_bindlink(void)
 
     // First, get all the solutions. There should be 3 of them:
     // Socrates, Einstein and Peirce all inherit from man
-    Handle answersAll = eval->eval_h("(cog-bind find-man)");
+    Handle answersAll = eval->eval_h("(cog-execute! find-man)");
     TS_ASSERT_EQUALS(3, getarity(answersAll));
 
     // Test PatternMatch::single_bindlink, which should only return the

--- a/tests/query/SudokuUTest.cxxtest
+++ b/tests/query/SudokuUTest.cxxtest
@@ -47,7 +47,7 @@ class SudokuPuzzle :  public CxxTest::TestSuite
 			eval = new SchemeEval(as);
 			eval->eval("(add-to-load-path \"..\")");
 			eval->eval("(add-to-load-path \"../../..\")");
-			eval->eval("(use-modules (opencog query))");
+			eval->eval("(use-modules (opencog exec))");
 		}
 
 		~SudokuPuzzle()
@@ -103,7 +103,7 @@ void SudokuPuzzle::test_2x2_puzzle(void)
 
 	// Solve the puzzle
 	// Handle puzzle_solution = bindlink(as, puzzle);
-	Handle puzzle_solution = eval->eval_h("(cog-bind (x2-puzzle))");
+	Handle puzzle_solution = eval->eval_h("(cog-execute! (x2-puzzle))");
 	logger().debug("puzzle solution is %s\n", SchemeSmob::to_string(puzzle_solution).c_str());
 	TSM_ASSERT_EQUALS("wrong number of solutions found", 1, getarity(puzzle_solution));
 
@@ -155,7 +155,7 @@ void SudokuPuzzle::test_3x3_puzzle(void)
 
 	// Solve the puzzle
 	// Handle puzzle_solution = bindlink(as, puzzle);
-	Handle puzzle_solution = eval->eval_h("(cog-bind (x3-puzzle))");
+	Handle puzzle_solution = eval->eval_h("(cog-execute! (x3-puzzle))");
 	logger().debug("puzzle solution is %s\n", SchemeSmob::to_string(puzzle_solution).c_str());
 	TSM_ASSERT_EQUALS("wrong number of solutions found", 4, getarity(puzzle_solution));
 

--- a/tests/query/absent-multi.scm
+++ b/tests/query/absent-multi.scm
@@ -7,7 +7,6 @@
 ; proof.
 ;
 (use-modules (opencog))
-(use-modules (opencog query))
 (use-modules (opencog exec))
 
 ; Clause to match during query - are Agents Mulder and Scully around?

--- a/tests/query/absent.scm
+++ b/tests/query/absent.scm
@@ -18,7 +18,7 @@
 ; patterns, `create` or `destroy`.
 ;
 (use-modules (opencog))
-(use-modules (opencog query))
+(use-modules (opencog exec))
 
 ; Clause to match during query
 (define query 

--- a/tests/query/arcana-bigger-dummy.scm
+++ b/tests/query/arcana-bigger-dummy.scm
@@ -2,7 +2,7 @@
 ; Unit testing for addition of more complex dummy clauses
 ;
 (use-modules (opencog))
-(use-modules (opencog query) (opencog exec))
+(use-modules (opencog exec))
 
 ; Data  -- This is the answer we expect to get.
 (define stfu

--- a/tests/query/arcana-const.scm
+++ b/tests/query/arcana-const.scm
@@ -2,7 +2,7 @@
 ; Unit testing for a constant pattern
 ;
 (use-modules (opencog))
-(use-modules (opencog query))
+(use-modules (opencog exec))
 
 (define marconi
 	(ListLink

--- a/tests/query/arcana-dummy.scm
+++ b/tests/query/arcana-dummy.scm
@@ -2,7 +2,7 @@
 ; Unit testing for addition of "dummy" clauses into pattern.
 ;
 (use-modules (opencog))
-(use-modules (opencog query) (opencog exec))
+(use-modules (opencog exec))
 
 ; Data
 (Number 42)

--- a/tests/query/arcana-repeat.scm
+++ b/tests/query/arcana-repeat.scm
@@ -3,7 +3,7 @@
 ;
 ;;; Populate the atomspace with two things
 (use-modules (opencog))
-(use-modules (opencog query))
+(use-modules (opencog exec))
 
 ; Two parts, both identical
 (ListLink

--- a/tests/query/buggy-equal.scm
+++ b/tests/query/buggy-equal.scm
@@ -4,7 +4,7 @@
 ; Unit test for github bug report opencog/opencog#1520
 ;
 (use-modules (opencog))
-(use-modules (opencog query))
+(use-modules (opencog exec))
 
 ; --------------------------------------------------------------------
 ; First, some data to populate the atomspace

--- a/tests/query/buggy-stack.scm
+++ b/tests/query/buggy-stack.scm
@@ -142,5 +142,5 @@
 )
 
 ; Running the implication should return only one answer!
-; (cog-bind (impy))
+; (cog-execute! (impy))
 

--- a/tests/query/choice-disconnected.scm
+++ b/tests/query/choice-disconnected.scm
@@ -2,7 +2,7 @@
 ; Unit testing for disconnected patterns within ChoiceLinks.
 ;
 (use-modules (opencog))
-(use-modules (opencog query))
+(use-modules (opencog exec))
 
 ;;; Populate the atomspace with three small trees.
 (EvaluationLink

--- a/tests/query/choice-double.scm
+++ b/tests/query/choice-double.scm
@@ -3,7 +3,7 @@
 ; Much link choice-embed, except it ahs two choice links
 ;
 (use-modules (opencog))
-(use-modules (opencog query))
+(use-modules (opencog exec))
 
 ;;; Populate the atomspace with four small trees.
 (MemberLink

--- a/tests/query/choice-embed-disco.scm
+++ b/tests/query/choice-embed-disco.scm
@@ -6,7 +6,7 @@
 ; (where a connection is defined in terms of shared variables)
 ;
 (use-modules (opencog))
-(use-modules (opencog query))
+(use-modules (opencog exec))
 
 ;;; Populate the atomspace with three small trees.
 (MemberLink

--- a/tests/query/choice-embed.scm
+++ b/tests/query/choice-embed.scm
@@ -2,7 +2,7 @@
 ; Unit testing for ChoiceLinks in the pattern matcher.
 ;
 (use-modules (opencog))
-(use-modules (opencog query))
+(use-modules (opencog exec))
 
 ;;; Populate the atomspace with four small trees.
 (MemberLink

--- a/tests/query/choice-link.scm
+++ b/tests/query/choice-link.scm
@@ -2,7 +2,7 @@
 ; Basic unit testing for ChoiceLinks in the pattern matcher.
 ;
 (use-modules (opencog))
-(use-modules (opencog query))
+(use-modules (opencog exec))
 
 ;;; Populate the atomspace with four small trees.
 (MemberLink

--- a/tests/query/choice-nest.scm
+++ b/tests/query/choice-nest.scm
@@ -2,7 +2,7 @@
 ; Unit testing for nested ChoiceLinks in the pattern matcher.
 ;
 (use-modules (opencog))
-(use-modules (opencog query))
+(use-modules (opencog exec))
 
 
 ;;; Populate the atomspace with four small trees.

--- a/tests/query/choice-top-nest.scm
+++ b/tests/query/choice-top-nest.scm
@@ -2,7 +2,7 @@
 ; Unit testing for nested ChoiceLinks in the pattern matcher.
 ;
 (use-modules (opencog))
-(use-modules (opencog query))
+(use-modules (opencog exec))
 
 
 ;;; Populate the atomspace with four small trees.

--- a/tests/query/deep-types.scm
+++ b/tests/query/deep-types.scm
@@ -5,7 +5,7 @@
 ; a pattrn match: by default, types are checked during a search, and
 ; variable groundings must respect the variable type.
 ;
-(use-modules (opencog) (opencog query) (opencog exec))
+(use-modules (opencog) (opencog exec))
 
 ; Populate the atomspace with some nonsense atoms.
 (Inheritance (Concept "foo") (Concept "bingo"))

--- a/tests/query/define.scm
+++ b/tests/query/define.scm
@@ -4,7 +4,6 @@
 ; Demonstrate the use of DefineLink to give names to things.
 ;
 (use-modules (opencog))
-(use-modules (opencog query))
 (use-modules (opencog exec))
 
 ;; Some data to populate the atomspace.

--- a/tests/query/eval-var.scm
+++ b/tests/query/eval-var.scm
@@ -2,7 +2,7 @@
 ; Unit test for evaluation of variables
 ;
 (use-modules (opencog))
-(use-modules (opencog query))
+(use-modules (opencog exec))
 
 (define (truf x)
 	(cond

--- a/tests/query/evaluation.scm
+++ b/tests/query/evaluation.scm
@@ -2,7 +2,7 @@
 ; Basic unit testing for different ways of nesting evaluatable links.
 ;
 (use-modules (opencog))
-(use-modules (opencog query))
+(use-modules (opencog exec))
 
 ;;; Populate the atomspace with a cover of a directed bouquet of four circles
 ;;; All nodes are equivalent to one, and there are directed arrows

--- a/tests/query/finite-state-machine.scm
+++ b/tests/query/finite-state-machine.scm
@@ -2,7 +2,7 @@
 ; Basic unit test of the DeleteLink
 ;
 (use-modules (opencog))
-(use-modules (opencog query))
+(use-modules (opencog exec))
 
 ;; Set of possible states of the state machine
 (SetLink

--- a/tests/query/get-link-eval.scm
+++ b/tests/query/get-link-eval.scm
@@ -1,6 +1,6 @@
 ; https://github.com/opencog/atomspace/issues/211
 
-(use-modules ((opencog query)))
+(use-modules ((opencog exec)))
 
 (EvaluationLink
    (ConceptNode "arkle")

--- a/tests/query/get-link.scm
+++ b/tests/query/get-link.scm
@@ -2,7 +2,7 @@
 ; Data and tests for GetLink
 ;
 
-(use-modules ((opencog query)))
+(use-modules ((opencog exec)))
 
 (InheritanceLink (ConceptNode "Ben") (ConceptNode "human"))
 (InheritanceLink (ConceptNode "Linas") (ConceptNode "human"))

--- a/tests/query/quote-crash.scm
+++ b/tests/query/quote-crash.scm
@@ -1,6 +1,6 @@
 
 (use-modules (opencog))
-(use-modules (opencog query))
+(use-modules (opencog exec))
 
 ; This is an infinite loop, except that the QuoteLink is supposed
 ; to stop the recursion.

--- a/tests/query/quote-var.scm
+++ b/tests/query/quote-var.scm
@@ -5,7 +5,7 @@
 ; quoted variable.
 ;
 
-(use-modules (opencog) (opencog query))
+(use-modules (opencog) (opencog exec))
 
 (EvaluationLink
 	(PredicateNode "similar")

--- a/tests/query/scope-confound.scm
+++ b/tests/query/scope-confound.scm
@@ -3,7 +3,7 @@
 ;
 
 (use-modules (opencog))
-(use-modules (opencog query))
+(use-modules (opencog exec))
 
 ; -------------------------------------------------------------
 ; From "opencog/pln/rules/evaluation-to-member-rule.scm"

--- a/tests/query/scope-hide.scm
+++ b/tests/query/scope-hide.scm
@@ -3,7 +3,7 @@
 ;
 
 (use-modules (opencog))
-(use-modules (opencog query))
+(use-modules (opencog exec))
 
 ;; The ForAll link is a ScopeLink, and so (VariableNode "$X")
 ;; is a bound var.

--- a/tests/query/scope-quote.scm
+++ b/tests/query/scope-quote.scm
@@ -16,7 +16,7 @@
 ; to simplify debugging, in case there is a bug.
 
 (use-modules (opencog))
-(use-modules (opencog query))
+(use-modules (opencog exec))
 
 
 ; Sample data

--- a/tests/query/scope-search.scm
+++ b/tests/query/scope-search.scm
@@ -3,7 +3,7 @@
 ;
 
 (use-modules (opencog))
-(use-modules (opencog query))
+(use-modules (opencog exec))
 
 ; (use-modules (opencog logger))
 ; (cog-logger-set-level! "fine")

--- a/tests/query/sequence.scm
+++ b/tests/query/sequence.scm
@@ -6,7 +6,7 @@
 ; works.
 ;
 (use-modules (opencog))
-(use-modules (opencog query))
+(use-modules (opencog exec))
 
 (define green-light  (ConceptNode "green light"))
 (define red-light  (ConceptNode "red light"))

--- a/tests/query/sudoku-puzzle.scm
+++ b/tests/query/sudoku-puzzle.scm
@@ -1,5 +1,5 @@
 (use-modules (opencog))
-(use-modules (opencog query))
+(use-modules (opencog exec))
 
 ;
 ; Definition for a specific puzzle

--- a/tests/query/sudoku-rules.scm
+++ b/tests/query/sudoku-rules.scm
@@ -3,7 +3,7 @@
 ; can try to do a brute-force exploration.
 ;
 (use-modules (opencog))
-(use-modules (opencog query))
+(use-modules (opencog exec))
 
 
 ; Definition of a number.  Cells in the sudoku puzzle can only contain

--- a/tests/query/sudoku-simple.scm
+++ b/tests/query/sudoku-simple.scm
@@ -4,7 +4,7 @@
 ; can try to do a brute-force exploration.
 ;
 (use-modules (opencog))
-(use-modules (opencog query))
+(use-modules (opencog exec))
 
 
 ; Definition of a number.  Cells in the sudoku puzzle can only contain

--- a/tests/scm/pm.scm
+++ b/tests/scm/pm.scm
@@ -51,7 +51,7 @@
 ;; history-as.
 (define (run-bug i)
   (cog-logger-debug "run-bug ~a" i)
-  (cog-bind query)
+  (cog-execute! query)
   (gc)) ;; <--- precipitate the bug
 
 (for-each run-bug (iota 100))


### PR DESCRIPTION
Replace most uses of `cog-bind` by `cog-execute!`

There is no need for `cog-bind` any more. Try to avoid using it.