### PR TITLE
Fix execution output pattern

### DIFF
--- a/opencog/atoms/execution/ExecutionOutputLink.cc
+++ b/opencog/atoms/execution/ExecutionOutputLink.cc
@@ -46,7 +46,9 @@ public:
 void ExecutionOutputLink::check_schema(const Handle& schema) const
 {
 	if (not classserver().isA(schema->get_type(), SCHEMA_NODE) and
-	    LAMBDA_LINK != schema->get_type())
+	    LAMBDA_LINK != schema->get_type() and
+	    // In case it is a pattern matcher query
+	    UNQUOTE_LINK != schema->get_type())
 	{
 		throw SyntaxException(TRACE_INFO,
 		                      "ExecutionOutputLink must have schema! Got %s",

--- a/opencog/atoms/execution/ExecutionOutputLink.cc
+++ b/opencog/atoms/execution/ExecutionOutputLink.cc
@@ -83,6 +83,8 @@ ExecutionOutputLink::ExecutionOutputLink(const Link& l)
 	if (EXECUTION_OUTPUT_LINK != tscope)
 		throw SyntaxException(TRACE_INFO,
 			"Expection an ExecutionOutputLink!");
+
+	check_schema(l.getOutgoingAtom(0));
 }
 
 /// execute -- execute the function defined in an ExecutionOutputLink

--- a/tests/query/ExecutionOutputUTest.cxxtest
+++ b/tests/query/ExecutionOutputUTest.cxxtest
@@ -31,29 +31,29 @@ using namespace opencog;
 
 class ExecutionOutputUTest :  public CxxTest::TestSuite
 {
-	private:
-		AtomSpace *as;
+private:
+	AtomSpace *as;
 
-	public:
+public:
 
-		ExecutionOutputUTest(void)
-		{
-			logger().set_level(Logger::DEBUG);
-			logger().set_print_to_stdout_flag(true);
-		}
+	ExecutionOutputUTest(void)
+	{
+		logger().set_level(Logger::DEBUG);
+		logger().set_print_to_stdout_flag(true);
+	}
 
-		~ExecutionOutputUTest()
-		{
-			// erase the log file if no assertions failed
-			if (!CxxTest::TestTracker::tracker().suiteFailed())
-				std::remove(logger().get_filename().c_str());
-		}
+	~ExecutionOutputUTest()
+	{
+		// erase the log file if no assertions failed
+		if (!CxxTest::TestTracker::tracker().suiteFailed())
+			std::remove(logger().get_filename().c_str());
+	}
 
-		void setUp(void);
-		void tearDown(void);
+	void setUp(void);
+	void tearDown(void);
 
-		void test_exec(void);
-		void test_varsub(void);
+	void test_exec(void);
+	void test_varsub(void);
 };
 
 #define an as->add_node
@@ -81,7 +81,6 @@ void ExecutionOutputUTest::setUp(void)
  *          WordNode "capital"
  *          DefinedLinguisticRelationshipNode "of"
  */
-
 void ExecutionOutputUTest::test_exec(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);

--- a/tests/query/ExecutionOutputUTest.cxxtest
+++ b/tests/query/ExecutionOutputUTest.cxxtest
@@ -20,10 +20,11 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <opencog/util/Logger.h>
 #include <opencog/atoms/base/Link.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/guile/SchemeEval.h>
-#include <opencog/util/Logger.h>
+#include <opencog/query/BindLinkAPI.h>
 
 #include "imply.h"
 
@@ -41,6 +42,9 @@ public:
 	{
 		logger().set_level(Logger::DEBUG);
 		logger().set_print_to_stdout_flag(true);
+
+		eval.eval("(add-to-load-path \"..\")");
+		eval.eval("(add-to-load-path \"../../..\")");
 	}
 
 	~ExecutionOutputUTest()
@@ -263,8 +267,11 @@ void ExecutionOutputUTest::test_query_exec(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	// TODO
-	TS_ASSERT(true);
-	
+	eval.eval("(load-from-path \"tests/query/exec.scm\")");
+
+	Handle exec_query = eval.eval_h("exec-query");
+	Handle results = satisfying_set(&as, exec_query);
+	TS_ASSERT_EQUALS(results->get_arity(), 3);
+
 	logger().debug("END TEST: %s", __FUNCTION__);
 }

--- a/tests/query/ExecutionOutputUTest.cxxtest
+++ b/tests/query/ExecutionOutputUTest.cxxtest
@@ -32,11 +32,12 @@ using namespace opencog;
 class ExecutionOutputUTest :  public CxxTest::TestSuite
 {
 private:
-	AtomSpace *as;
+	AtomSpace as;
+	SchemeEval eval;
 
 public:
 
-	ExecutionOutputUTest(void)
+	ExecutionOutputUTest(void) : eval(&as)
 	{
 		logger().set_level(Logger::DEBUG);
 		logger().set_print_to_stdout_flag(true);
@@ -54,20 +55,20 @@ public:
 
 	void test_exec(void);
 	void test_varsub(void);
+	void test_query_exec(void);
 };
 
-#define an as->add_node
-#define al as->add_link
+#define an as.add_node
+#define al as.add_link
 #define getarity(hand) hand->get_arity()
 #define getlink(hand,pos) hand->getOutgoingAtom(pos)
 
 void ExecutionOutputUTest::tearDown(void)
 {
-	delete as;
+	as.clear();
 }
 void ExecutionOutputUTest::setUp(void)
 {
-	as = new AtomSpace();
 }
 
 /*
@@ -149,12 +150,10 @@ void ExecutionOutputUTest::test_exec(void)
 	"		) \n"
 	"	) \n"
 	")";
-	SchemeEval* ev = new SchemeEval(as);
-	ev->eval(str);
-	delete ev;
+	eval.eval(str);
 
 	// Result should be a ListLink
-	Handle result = imply(as, clauses, implicand);
+	Handle result = imply(&as, clauses, implicand);
 
 	// There should be only one solution: the Berlin one.
 	// The Madrid graph should be rejected because of the
@@ -188,11 +187,8 @@ void ExecutionOutputUTest::test_varsub(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	const char * str =
-	"(define (retarg x) x)\n";
-	SchemeEval* ev = new SchemeEval(as);
-	ev->eval(str);
-	delete ev;
+	const char * str = "(define (retarg x) x)\n";
+	eval.eval(str);
 
 	Handle resolution;
 	// Raw data
@@ -217,7 +213,6 @@ void ExecutionOutputUTest::test_varsub(void)
 		)
 	);
 
-
 	Handle situ =
 	al(BIND_LINK,
 	   al(CONTEXT_LINK,
@@ -238,25 +233,38 @@ void ExecutionOutputUTest::test_varsub(void)
 	);
 	BindLinkPtr predicament(createBindLink(*LinkCast(pred)));
 
-   // Now perform the search.
-   DefaultImplicator simpl(as);
-   simpl.implicand = situation->get_implicand();
-   situation->imply(simpl);
+	// Now perform the search.
+	DefaultImplicator simpl(&as);
+	simpl.implicand = situation->get_implicand();
+	situation->imply(simpl);
 
-   // The result_list contains a list of the grounded expressions.
-   Handle res = simpl.get_result_list()[0];
+	// The result_list contains a list of the grounded expressions.
+	Handle res = simpl.get_result_list()[0];
 	printf("res is %s\n", res->to_short_string().c_str());
 	TSM_ASSERT_EQUALS("incorrect resolution", res, resolution);
 
-   // Now perform the search.
-   DefaultImplicator pimpl(as);
-   pimpl.implicand = predicament->get_implicand();
-   predicament->imply(pimpl);
+	// Now perform the search.
+	DefaultImplicator pimpl(&as);
+	pimpl.implicand = predicament->get_implicand();
+	predicament->imply(pimpl);
 
-   // The result_list contains a list of the grounded expressions.
-   Handle del = pimpl.get_result_list()[0];
+	// The result_list contains a list of the grounded expressions.
+	Handle del = pimpl.get_result_list()[0];
 	printf("del is %s\n", del->to_short_string().c_str());
 	TSM_ASSERT_EQUALS("incorrect delivarance", del, deliverance);
 
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+/*
+ * Query ExecutionOutputLink atoms, with varying schemas.
+ */
+void ExecutionOutputUTest::test_query_exec(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	// TODO
+	TS_ASSERT(true);
+	
 	logger().debug("END TEST: %s", __FUNCTION__);
 }

--- a/tests/query/exec.scm
+++ b/tests/query/exec.scm
@@ -1,0 +1,24 @@
+;; Used by ExecutionOutputUTest::test_query_exec
+
+;; Grounds
+
+(ExecutionOutput
+  (Schema "sc-1")
+  (Concept "a"))
+
+(ExecutionOutput
+  (Schema "sc-2")
+  (Concept "b"))
+
+(ExecutionOutput
+  (Schema "sc-3")
+  (Concept "c"))
+
+;; Query
+
+(define exec-query
+  (Get
+    (Quote
+      (ExecutionOutput
+        (Unquote (Variable "$schema"))
+        (Unquote (Variable "$arg"))))))


### PR DESCRIPTION
Relax https://github.com/opencog/atomspace/blob/master/opencog/atoms/execution/ExecutionOutputLink.cc#L46 to allows `ExecutionOutputLink` in patterns like
```
(Get (Quote (ExecutionOutput (Unquote (Variable "$schema")) (Unquote (Variable "$arg")))))
```
