### PR TITLE
automatic eta reduction in PutLink

### DIFF
--- a/opencog/atoms/core/PutLink.cc
+++ b/opencog/atoms/core/PutLink.cc
@@ -315,8 +315,8 @@ Handle PutLink::do_reduce(void) const
 
 	size_t nvars = vars.varseq.size();
 
-	// FunctionLinks behave like combinators; that is, one can create
-	// valid beta-redexes with them. We handle that here.
+	// FunctionLinks behave like pointless lambdas; that is, one can
+	// create valid beta-redexes with them. We handle that here.
 	//
 	// XXX At this time, we don't know the number of arguments any
 	// given FunctionLink might take.  Atomese does have the mechanisms

--- a/tests/atoms/PutLinkUTest.cxxtest
+++ b/tests/atoms/PutLinkUTest.cxxtest
@@ -51,6 +51,7 @@ public:
 	void test_function();
 	void test_lambda();
 	void test_lambda_partial_substitution();
+	void test_eta();
 	void test_eval_inheritance();
 	void test_eval_implication_1();
 	void test_eval_implication_2();
@@ -270,6 +271,10 @@ void PutLinkUTest::test_lambda_partial_substitution()
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
 	// Test partial substitution
+	// (Put
+	//     (Lambda (Variable "$x")
+	//         (Inheritance (Variable "$x") (Variable "$y")))
+	//     (Concept "animal"))
 	Handle lam =
 		L(LAMBDA_LINK,
 			N(VARIABLE_NODE, "$x"),
@@ -284,6 +289,7 @@ void PutLinkUTest::test_lambda_partial_substitution()
 	Instantiator inst(&_as);
 	Handle putted = inst.execute(put);
 
+	// (Inheritance (Concept "animal") (Variable "$y"))
 	Handle expected_putted =
 		L(INHERITANCE_LINK,
 			N(VARIABLE_NODE, "$y"),
@@ -295,6 +301,49 @@ void PutLinkUTest::test_lambda_partial_substitution()
 
 	logger().info("END TEST: %s", __FUNCTION__);
 }
+
+// Test eta-reduction of the values
+void PutLinkUTest::test_eta()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Test that eta-reduction can be performed on the values.
+	Handle lam =
+		L(LAMBDA_LINK,
+			L(VARIABLE_LIST,
+				N(VARIABLE_NODE, "$x"),
+				N(VARIABLE_NODE, "$y"),
+				N(VARIABLE_NODE, "$z")),
+			L(INHERITANCE_LINK,
+				N(VARIABLE_NODE, "$z"),
+				N(VARIABLE_NODE, "$x")));
+	Handle put =
+		L(PUT_LINK,
+			lam,
+			L(LAMBDA_LINK,
+				N(VARIABLE_NODE, "$w"),
+				L(LIST_LINK,
+					N(CONCEPT_NODE, "animal"),
+					N(CONCEPT_NODE, "foobar"),
+					N(VARIABLE_NODE, "$w"))));
+
+	Instantiator inst(&_as);
+	Handle putted = inst.execute(put);
+
+	Handle expected_putted =
+		L(LAMBDA_LINK,
+			N(VARIABLE_NODE, "$w"),
+			L(INHERITANCE_LINK,
+				N(VARIABLE_NODE, "$w"),
+				N(CONCEPT_NODE, "animal")));
+
+	printf("Expecting %s\n", expected_putted->to_string().c_str());
+	printf("Got %s\n", putted->to_string().c_str());
+	TS_ASSERT_EQUALS(putted, expected_putted);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
 
 /**
  * This test is for the case where PutLink has to evaluate the beta


### PR DESCRIPTION
Automate the eta reduction. This makes PutLink a little more usabel for function composition.