### PR TITLE
Implement prenex-form function composition.

### DIFF
--- a/opencog/atoms/base/atom_types.script
+++ b/opencog/atoms/base/atom_types.script
@@ -251,23 +251,29 @@ SCOPE_LINK <- ORDERED_LINK
 // like LambdaLink ... it isn't.  Not everything is a Lambda.
 REWRITE_LINK <- SCOPE_LINK
 
-// The LambdaLink is supposed to closely model the traditional concept
+// The PrenexLink is a RewriteLink that maintains prenex normal form.
+// It serves as a base class for the various pattern-matching links,
+// since pattern matching only makes sense when the patterns are written
+// in prenex normal form.  It also serves as the base class for Lambda,
+// since function composition in atomese only seems to make sense if
+// the result is in prenex form. (I can't figure out the meaning,
+// semantics of the non-prenex forms).
+PRENEX_LINK <- REWRITE_LINK
+
+// The LambdaLink is supposed to roughly model the traditional concept
 // of a lambda from lambda calculus (or functional programming). It
-// is meant to behave just like a combinator, and supports the standard
-// operations of beta-reduction and alpha-conversion (modulo that the
-// atomspace enforces alpha-equivalence).
-LAMBDA_LINK <- REWRITE_LINK
+// is meant to behave just like a lambda-abstraction, and supports the
+// standard operations of beta-reduction and alpha-conversion (modulo
+// that the atomspace enforces alpha-equivalence).  Non-prenex lambdas
+// in atomese don't seem to "make any sense", at least to me, so
+// lambda's are forced to be prenex. This is a departure from classical
+// lambda calculus.
+LAMBDA_LINK <- PRENEX_LINK
 
 // PutLinks perform a beta-reduction when executed; i.e. they get
 // beta-reduced when they are executed. PutLinks are the same thing as
 // beta-redexes.
-PUT_LINK <- REWRITE_LINK
-
-// The PrenexLink is a ScopeLink that is in prenex normal form.  It
-// serves as a base class for the various pattern-matching links, since
-// pattern matching only makes sense when the patterns are written in
-// prenex normal form.
-PRENEX_LINK <- REWRITE_LINK
+PUT_LINK <- PRENEX_LINK
 
 // Pattern definition, pattern grounding/satisfaction.
 // The PatternLink implements the base class holding a pattern that

--- a/opencog/atoms/core/LambdaLink.cc
+++ b/opencog/atoms/core/LambdaLink.cc
@@ -28,12 +28,12 @@
 using namespace opencog;
 
 LambdaLink::LambdaLink(const Handle& vars, const Handle& body)
-	: RewriteLink(HandleSeq({vars, body}), LAMBDA_LINK)
+	: PrenexLink(HandleSeq({vars, body}), LAMBDA_LINK)
 {
 }
 
 LambdaLink::LambdaLink(const HandleSeq& oset, Type t)
-	: RewriteLink(oset, t)
+	: PrenexLink(oset, t)
 {
 	if (not classserver().isA(t, LAMBDA_LINK))
 	{
@@ -44,7 +44,7 @@ LambdaLink::LambdaLink(const HandleSeq& oset, Type t)
 }
 
 LambdaLink::LambdaLink(const Link &l)
-	: RewriteLink(l)
+	: PrenexLink(l)
 {
 	// Type must be as expected
 	Type tscope = l.get_type();

--- a/opencog/atoms/core/LambdaLink.h
+++ b/opencog/atoms/core/LambdaLink.h
@@ -23,7 +23,7 @@
 #ifndef _OPENCOG_LAMBDA_LINK_H
 #define _OPENCOG_LAMBDA_LINK_H
 
-#include <opencog/atoms/core/RewriteLink.h>
+#include <opencog/atoms/core/PrenexLink.h>
 
 namespace opencog
 {
@@ -38,19 +38,19 @@ namespace opencog
 /// atomspace enforces alpha-equivalence).
 ///
 /// The actual implementation of the alpha and beta reduction sits on
-/// the RewriteLink, so this class is effectively a no-op, from the
+/// the PrenexLink, so this class is effectively a no-op, from the
 /// C++ point of view. However...
 ///
 /// However, we want to have this to minimize confusion in other,
 /// distant parts of the code base.  The issue is that there are many
-/// other classes derived from RewriteLink, and they are NOT lambdas!
+/// other classes derived from PrenexLink, and they are NOT lambdas!
 /// The most prominent example are the various PatternLinks; a simpler
 /// example is the PutLink, which is a beta-redex and therefore cannot
-/// ever be an actual lambda, elthough it derives from RewriteLink
+/// ever be an actual lambda, elthough it derives from PrenexLink
 /// to do it's beta-reduction.  And so that's why we have a no-op C++
 /// class, here.
 ///
-class LambdaLink : public RewriteLink
+class LambdaLink : public PrenexLink
 {
 public:
 	LambdaLink(const HandleSeq&, Type=LAMBDA_LINK);

--- a/opencog/atoms/core/PrenexLink.cc
+++ b/opencog/atoms/core/PrenexLink.cc
@@ -146,8 +146,11 @@ Handle PrenexLink::beta_reduce(const HandleMap& vmap) const
 				Handle alt = collect(bv, final_varlist, used_vars);
 				if (alt)
 				{
-OC_ASSERT(false, "Not Implemented!");
-					// body = substitute_nocheck(...); XXX TODO
+					// In the body of the scope link, rename
+					// the bond variable to its new name.
+					HandleMap alpha;
+					alpha[bv] = alt;
+					body = bound.substitute_nocheck(body, alpha);
 				}
 			}
 			vm[pare->first] = body;

--- a/opencog/atoms/core/PrenexLink.cc
+++ b/opencog/atoms/core/PrenexLink.cc
@@ -92,6 +92,7 @@ static Handle collect(const Handle& var,
 		std::string altname = randstr(var->get_name() + "-");
 		alt = createNode(VARIABLE_NODE, altname);
 	} while (used_vars.find(alt) != used_vars.end());
+	final_varlist.push_back(alt);
 	used_vars.insert(alt);
 	return alt;
 }

--- a/opencog/atoms/core/PrenexLink.cc
+++ b/opencog/atoms/core/PrenexLink.cc
@@ -135,7 +135,7 @@ Handle PrenexLink::beta_reduce(const HandleMap& vmap) const
 	}
 
 	// Now get the new body...
-	Handle newbod = vars.substitute(_body, vm);
+	Handle newbod = vars.substitute(_body, vm, _silent);
 
 	if (0 < final_varlist.size())
 	{

--- a/opencog/atoms/core/PrenexLink.cc
+++ b/opencog/atoms/core/PrenexLink.cc
@@ -134,8 +134,8 @@ Handle PrenexLink::beta_reduce(const HandleMap& vmap) const
 		}
 	}
 
-	// Now get the new body... XXX should check... not nocheck
-	Handle newbod = vars.substitute_nocheck(_body, vm);
+	// Now get the new body...
+	Handle newbod = vars.substitute(_body, vm);
 
 	if (0 < final_varlist.size())
 	{

--- a/opencog/atoms/core/PrenexLink.cc
+++ b/opencog/atoms/core/PrenexLink.cc
@@ -67,6 +67,13 @@ PrenexLink::PrenexLink(const Link &l)
 
 /* ================================================================= */
 
+Handle PrenexLink::beta_reduce(const HandleSeq& seq) const
+{
+	return RewriteLink::beta_reduce(seq);
+}
+
+/* ================================================================= */
+
 static Handle collect(const Handle& var,
                       HandleSeq& final_varlist, HandleSet& used_vars)
 {

--- a/opencog/atoms/core/PrenexLink.cc
+++ b/opencog/atoms/core/PrenexLink.cc
@@ -121,10 +121,22 @@ Handle PrenexLink::beta_reduce(const HandleMap& vmap) const
 			continue;
 		}
 
-		// If we are here, then var is in to be beta-reduced.
+		Type valuetype = pare->second->get_type();
+
+		// If we are here, then var will be beta-reduced.
+		// But if the value is another variable, then alpha-convert,
+		// instead.
+		if (VARIABLE_NODE == valuetype)
+		{
+			Handle alt = collect(pare->second, final_varlist, used_vars);
+			if (alt)
+				vm[var] = alt;
+			continue;
+		}
+
+		// If we are here, then var will be beta-reduced.
 		// Is the value a ScopeLink? If so, handle it.
-		Type vtype = pare->second->get_type();
-		if (classserver().isA(vtype, SCOPE_LINK))
+		if (classserver().isA(valuetype, SCOPE_LINK))
 		{
 			ScopeLinkPtr sc = ScopeLinkCast(pare->second);
 			Variables bound = sc->get_variables();
@@ -134,6 +146,7 @@ Handle PrenexLink::beta_reduce(const HandleMap& vmap) const
 				Handle alt = collect(bv, final_varlist, used_vars);
 				if (alt)
 				{
+OC_ASSERT(false, "Not Implemented!");
 					// body = substitute_nocheck(...); XXX TODO
 				}
 			}

--- a/opencog/atoms/core/PrenexLink.h
+++ b/opencog/atoms/core/PrenexLink.h
@@ -52,7 +52,11 @@ public:
 	PrenexLink(const Handle& varcdecls, const Handle& body);
 	PrenexLink(const Link &l);
 
-	virtual Handle beta_reduce(const HandleSeq& values) const;
+	virtual Handle beta_reduce(const HandleSeq& seq) const {
+		// call the base class, trivially.
+		return RewriteLink::beta_reduce(seq);
+	}
+	virtual Handle beta_reduce(const HandleMap& vm) const;
 
 	static Handle factory(const Handle&);
 };

--- a/opencog/atoms/core/PrenexLink.h
+++ b/opencog/atoms/core/PrenexLink.h
@@ -52,10 +52,7 @@ public:
 	PrenexLink(const Handle& varcdecls, const Handle& body);
 	PrenexLink(const Link &l);
 
-	virtual Handle beta_reduce(const HandleSeq& seq) const {
-		// call the base class, trivially.
-		return RewriteLink::beta_reduce(seq);
-	}
+	virtual Handle beta_reduce(const HandleSeq& seq) const;
 	virtual Handle beta_reduce(const HandleMap& vm) const;
 
 	static Handle factory(const Handle&);

--- a/opencog/atoms/core/PutLink.cc
+++ b/opencog/atoms/core/PutLink.cc
@@ -30,13 +30,13 @@
 using namespace opencog;
 
 PutLink::PutLink(const HandleSeq& oset, Type t)
-    : RewriteLink(oset, t)
+    : PrenexLink(oset, t)
 {
 	init();
 }
 
 PutLink::PutLink(const Link& l)
-    : RewriteLink(l)
+    : PrenexLink(l)
 {
 	init();
 }
@@ -219,7 +219,7 @@ void PutLink::static_typecheck_values(void)
 
 /* ================================================================= */
 
-static inline Handle reddy(RewriteLinkPtr subs, const HandleSeq& oset)
+static inline Handle reddy(PrenexLinkPtr subs, const HandleSeq& oset)
 {
 	subs->make_silent(true);
 	return subs->beta_reduce(oset);
@@ -267,7 +267,7 @@ Handle PutLink::do_reduce(void) const
 {
 	Handle bods(_body);
 	Variables vars(_varlist);
-	RewriteLinkPtr subs(RewriteLinkCast(get_handle()));
+	PrenexLinkPtr subs(PrenexLinkCast(get_handle()));
 
 	// Resolve the body, if needed. That is, if the body is
 	// given in a defintion, get that defintion.

--- a/opencog/atoms/core/PutLink.h
+++ b/opencog/atoms/core/PutLink.h
@@ -23,7 +23,7 @@
 #ifndef _OPENCOG_PUT_LINK_H
 #define _OPENCOG_PUT_LINK_H
 
-#include <opencog/atoms/core/RewriteLink.h>
+#include <opencog/atoms/core/PrenexLink.h>
 
 namespace opencog
 {
@@ -70,7 +70,7 @@ namespace opencog
  * values must be wrapped in a ListLink, to be consistent with other
  * parts of atomese. However, for N=1, the ListLink is optional.
  */
-class PutLink : public RewriteLink
+class PutLink : public PrenexLink
 {
 protected:
 	/// The values that are to be placed into the body.

--- a/opencog/atoms/core/RewriteLink.cc
+++ b/opencog/atoms/core/RewriteLink.cc
@@ -132,7 +132,7 @@ Handle RewriteLink::beta_reduce(const HandleMap& vm) const
 		// form of a redex, i.e. doesn't have variable declarations
 		// in it. So we must not call createLink(), below.
 		Type t = get_type();
-		if (PUT_LINK == t)
+		if (PUT_LINK == t or LAMBDA_LINK == t)
 			return hs[0];
 	}
 

--- a/opencog/atoms/core/RewriteLink.cc
+++ b/opencog/atoms/core/RewriteLink.cc
@@ -170,7 +170,9 @@ Handle RewriteLink::beta_reduce(const HandleSeq& vals) const
 
 	}
 
-	if (1 == vals.size() and LAMBDA_LINK == vals[0]->get_type())
+	if (vals.size() != vars.size() and
+	    1 == vals.size() and
+       LAMBDA_LINK == vals[0]->get_type())
 	{
 		// Perform a very simple-minded eta reduction.
 		LambdaLinkPtr lam(LambdaLinkCast(vals[0]));

--- a/opencog/atoms/core/RewriteLink.cc
+++ b/opencog/atoms/core/RewriteLink.cc
@@ -132,7 +132,7 @@ Handle RewriteLink::beta_reduce(const HandleMap& vm) const
 		// form of a redex, i.e. doesn't have variable declarations
 		// in it. So we must not call createLink(), below.
 		Type t = get_type();
-		if (PUT_LINK == t or LAMBDA_LINK == t)
+		if (PUT_LINK == t)
 			return hs[0];
 	}
 
@@ -172,9 +172,7 @@ Handle RewriteLink::beta_reduce(const HandleSeq& vals) const
 
 	if (1 == vals.size() and LAMBDA_LINK == vals[0]->get_type())
 	{
-		// Attempt a cheesy form of eta reduction.
-		// XXX this is not really correct, because we are accidentally
-		// converting bound variables into free variables.
+		// Perform a very simple-minded eta reduction.
 		LambdaLinkPtr lam(LambdaLinkCast(vals[0]));
 		const Handle& body = lam->get_body();
 		const HandleSeq& eta = body->getOutgoingSet();

--- a/opencog/atoms/core/RewriteLink.h
+++ b/opencog/atoms/core/RewriteLink.h
@@ -31,9 +31,15 @@ namespace opencog
  *  @{
  */
 
-/// The RewriteLink extends the ScopeLink class to add a large variety
-/// of methods to rewrite various parts of the ScopeLink in various
-/// ways.  These are used by the backward and foreward chainers to
+/// The RewriteLink extends the ScopeLink class to add several
+/// methods to perform alpha-conversion and beta-reduction on the
+/// ScopeLink.  Note that the beta-reduction being performed is
+/// NOT compatible with classical Lambda Calculus: it mixes together,
+/// in one place, both alpha and beta conversions. That's OK -
+/// Atomese is not Lambda Calculus; its more natural to do it this
+/// way in Atomese.
+///
+/// The methods here are used by the backward and foreward chainers to
 /// edit and create PatternLinks on the fly, thus allowing different
 /// kinds of queries to be generated and run as chaining proceeds.
 ///
@@ -128,7 +134,10 @@ public:
 	 * from the returned RewriteLink.
 	 *
 	 * If the map specifies a variable->new-variable, then an
-	 * alpha-conversion is performed.
+	 * alpha-conversion is performed, replacing the old variable
+	 * with the new one.  The variable continues to be bound,
+	 * instead of becoming free. Note that this is NOT how
+	 * classical lambda calculus works!!
 	 *
 	 * If the original RewriteLink contains bound variables that
 	 * are not mentioned in the map, these are untouched.
@@ -141,7 +150,10 @@ public:
 
 	/**
 	 * Like the above, but uses a sequence of values, presumed to be
-	 * in the same order as the variable declarations.
+	 * in the same order as the variable declarations. The number of
+	 * values must match the number of variables, or there must be
+	 * a single value that is eta-convertible and gives the right
+	 * number of values.
 	 */
 	virtual Handle beta_reduce(const HandleSeq& values) const;
 

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -627,6 +627,13 @@ Handle Variables::substitute(const Handle& func,
 	return substitute_nocheck(func, args);
 }
 
+Handle Variables::substitute(const Handle& func,
+                             const HandleMap& map,
+                             bool silent) const
+{
+	return substitute(func, make_sequence(map), silent);
+}
+
 /* ================================================================= */
 /**
  * Extend a set of variables.

--- a/opencog/atoms/core/Variables.h
+++ b/opencog/atoms/core/Variables.h
@@ -222,6 +222,11 @@ struct Variables : public FreeVariables,
 	                  const HandleSeq& vals,
 	                  bool silent=false) const;
 
+	// Like the above, but using a partial map.
+	Handle substitute(const Handle& tree,
+	                  const HandleMap& map,
+	                  bool silent=false) const;
+
 	// Extend this variable set by adding in the given variable set.
 	void extend(const Variables&);
 

--- a/opencog/atomutils/TypeUtils.cc
+++ b/opencog/atomutils/TypeUtils.cc
@@ -327,7 +327,7 @@ Handle filter_vardecl(const Handle& vardecl, const HandleSeq& hs)
 	}
 
 	// If we're here we have failed to recognize vardecl as a useful
-	// and well formed variable declaration, so Handle::UNDEFINED is
+	// and well-formed variable declaration, so Handle::UNDEFINED is
 	// returned.
 	return Handle::UNDEFINED;
 }

--- a/tests/atoms/PutLinkUTest.cxxtest
+++ b/tests/atoms/PutLinkUTest.cxxtest
@@ -52,6 +52,7 @@ public:
 	void test_lambda();
 	void test_lambda_partial_substitution();
 	void test_eta();
+	void test_alpha();
 	void test_eval_inheritance();
 	void test_eval_implication_1();
 	void test_eval_implication_2();
@@ -355,6 +356,54 @@ void PutLinkUTest::test_eta()
 	logger().info("END TEST: %s", __FUNCTION__);
 }
 
+// Test alpha-renaming, where values are variables. Similar to
+// the test_eta, except the result has free variables, not bound.
+void PutLinkUTest::test_alpha()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Test that alpha-renaming can be performed on the values.
+	// (define lam (Lambda
+	//      (VariableList (Variable "$x")(Variable "$y")(Variable "$z"))
+	//      (Inheritance (Variable "$z") (Variable "$x"))))
+	//
+	// (define put (Put lam
+	//      (List (Concept "animal") (Concept "foobar") (Variable "$w"))))
+	// expect
+	//
+	// (Inheritance (Variable "$w") (Concept "animal"))
+	//
+	Handle lam =
+		L(LAMBDA_LINK,
+			L(VARIABLE_LIST,
+				N(VARIABLE_NODE, "$x"),
+				N(VARIABLE_NODE, "$y"),
+				N(VARIABLE_NODE, "$z")),
+			L(INHERITANCE_LINK,
+				N(VARIABLE_NODE, "$z"),
+				N(VARIABLE_NODE, "$x")));
+	Handle put =
+		L(PUT_LINK,
+			lam,
+			L(LIST_LINK,
+				N(CONCEPT_NODE, "animal"),
+				N(CONCEPT_NODE, "foobar"),
+				N(VARIABLE_NODE, "$w")));
+
+	Instantiator inst(&_as);
+	Handle putted = inst.execute(put);
+
+	Handle expected_putted =
+			L(INHERITANCE_LINK,
+				N(VARIABLE_NODE, "$w"),
+				N(CONCEPT_NODE, "animal"));
+
+	printf("Expecting %s\n", expected_putted->to_string().c_str());
+	printf("Got %s\n", putted->to_string().c_str());
+	TS_ASSERT_EQUALS(putted, expected_putted);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
 
 /**
  * This test is for the case where PutLink has to evaluate the beta

--- a/tests/atoms/PutLinkUTest.cxxtest
+++ b/tests/atoms/PutLinkUTest.cxxtest
@@ -316,7 +316,11 @@ void PutLinkUTest::test_eta()
 	// (define put (Put lam
 	//      (Lambda (Variable "$w")
 	//          (List (Concept "animal") (Concept "foobar") (Variable "$w")))))
-	// expect
+	//
+	// We expect the below, with $w bound, because this is how beta
+	// reduction is defined in atomese. Note that it is NOT compatible
+	// with beta-reduction is classical lambda calculus! In lmbda calc,
+	// the result would leave $w free, not bound.
 	//
 	// (Lambda (Variable "$w") (Inheritance (Variable "$w") (Concept "animal")))
 	//
@@ -357,7 +361,7 @@ void PutLinkUTest::test_eta()
 }
 
 // Test alpha-renaming, where values are variables. Similar to
-// the test_eta, except the result has free variables, not bound.
+// the test_eta, except the input is pointless (aka tacit).
 void PutLinkUTest::test_alpha()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
@@ -369,9 +373,13 @@ void PutLinkUTest::test_alpha()
 	//
 	// (define put (Put lam
 	//      (List (Concept "animal") (Concept "foobar") (Variable "$w"))))
-	// expect
 	//
-	// (Inheritance (Variable "$w") (Concept "animal"))
+	// We expect the below, with $w bound, because this is how beta
+	// reduction is defined in atomese. Note that it is NOT compatible
+	// with beta-reduction is classical lambda calculus! In lmbda calc,
+	// the result would leave $w free, not bound.
+	//
+	// (Lambda (Variable "$w") (Inheritance (Variable "$w") (Concept "animal")))
 	//
 	Handle lam =
 		L(LAMBDA_LINK,
@@ -394,9 +402,11 @@ void PutLinkUTest::test_alpha()
 	Handle putted = inst.execute(put);
 
 	Handle expected_putted =
+		L(LAMBDA_LINK,
+			N(VARIABLE_NODE, "$w"),
 			L(INHERITANCE_LINK,
 				N(VARIABLE_NODE, "$w"),
-				N(CONCEPT_NODE, "animal"));
+				N(CONCEPT_NODE, "animal")));
 
 	printf("Expecting %s\n", expected_putted->to_string().c_str());
 	printf("Got %s\n", putted->to_string().c_str());

--- a/tests/atoms/PutLinkUTest.cxxtest
+++ b/tests/atoms/PutLinkUTest.cxxtest
@@ -56,6 +56,7 @@ public:
 	void test_alpha();
 	void test_compose();
 	void test_ident_compose();
+	void test_recursive_compose();
 	void test_eval_inheritance();
 	void test_eval_implication_1();
 	void test_eval_implication_2();
@@ -470,7 +471,7 @@ void PutLinkUTest::test_ident_compose()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
-	// Test that simple function compostion can be performed.
+	// Test function compostion with a cartesian product
 	//
 	// (define g (Lambda (Evaluation (Variable "X") (Variable "Y"))))
 	// (define f2 (Lambda
@@ -518,6 +519,76 @@ void PutLinkUTest::test_ident_compose()
 				L(INHERITANCE_LINK,
 					N(VARIABLE_NODE, "$y"),
 					N(VARIABLE_NODE, "$z"))));
+
+	printf("Expecting %s\n", expected_putted->to_string().c_str());
+	printf("Got %s\n", putted->to_string().c_str());
+	TS_ASSERT_EQUALS(putted, expected_putted);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// Test recursive function composition
+void PutLinkUTest::test_recursive_compose()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Test recursive function compostion can be performed.
+	//
+	// (define g (Lambda (Evaluation (Variable "X") (Variable "Y"))))
+	// (define f2 (Lambda
+	//    (VariableList (Variable "X") (Variable "Y") (Variable "Z"))
+	//    (Inheritance (Variable "Y")(Variable "Z")) ))
+	//
+	// (define inject ;; knock out first argument
+	//    (List (Concept "junk") (Variable "S")(Variable "T")))
+	//
+	// (define ident (Lambda (Variable "W") (Variable "W")))
+	// (cog-execute! (Put g (List ident (Put f2 inject))))
+	//
+	// We expect the result to be in prenex form.
+	//
+	Handle gee =
+		L(LAMBDA_LINK,
+			L(EVALUATION_LINK,
+				N(VARIABLE_NODE, "$x"),
+				N(VARIABLE_NODE, "$y")));
+	Handle eff =
+		L(LAMBDA_LINK,
+			L(VARIABLE_LIST,
+				N(VARIABLE_NODE, "$x"),
+				N(VARIABLE_NODE, "$y"),
+				N(VARIABLE_NODE, "$z")),
+			L(INHERITANCE_LINK,
+				N(VARIABLE_NODE, "$y"),
+				N(VARIABLE_NODE, "$z")));
+	Handle inject =
+		L(LIST_LINK,
+			N(CONCEPT_NODE, "junk"),
+			N(VARIABLE_NODE, "$x"),
+			N(VARIABLE_NODE, "$y"));
+
+	Handle ident =
+		L(LAMBDA_LINK,
+			N(VARIABLE_NODE, "$x"), N(VARIABLE_NODE, "$x"));
+
+	Handle put =
+		L(PUT_LINK, gee,
+			L(LIST_LINK, ident, L(PUT_LINK, eff, inject)));
+
+	Instantiator inst(&_as);
+	Handle putted = inst.execute(put);
+
+	Handle expected_putted =
+		L(LAMBDA_LINK,
+			L(VARIABLE_LIST,
+				N(VARIABLE_NODE, "A"),
+				N(VARIABLE_NODE, "B"),
+				N(VARIABLE_NODE, "C")),
+			L(EVALUATION_LINK,
+				N(VARIABLE_NODE, "A"),
+				L(INHERITANCE_LINK,
+					N(VARIABLE_NODE, "B"),
+					N(VARIABLE_NODE, "C"))));
 
 	printf("Expecting %s\n", expected_putted->to_string().c_str());
 	printf("Got %s\n", putted->to_string().c_str());

--- a/tests/atoms/PutLinkUTest.cxxtest
+++ b/tests/atoms/PutLinkUTest.cxxtest
@@ -308,6 +308,17 @@ void PutLinkUTest::test_eta()
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
 	// Test that eta-reduction can be performed on the values.
+	// (define lam (Lambda
+	//      (VariableList (Variable "$x")(Variable "$y")(Variable "$z"))
+	//      (Inheritance (Variable "$z") (Variable "$x"))))
+	//
+	// (define put (Put lam
+	//      (Lambda (Variable "$w")
+	//          (List (Concept "animal") (Concept "foobar") (Variable "$w")))))
+	// expect
+	//
+	// (Lambda (Variable "$w") (Inheritance (Variable "$w") (Concept "animal")))
+	//
 	Handle lam =
 		L(LAMBDA_LINK,
 			L(VARIABLE_LIST,

--- a/tests/atoms/PutLinkUTest.cxxtest
+++ b/tests/atoms/PutLinkUTest.cxxtest
@@ -1,7 +1,8 @@
 /*
  * tests/atoms/PutUTest.cxxtest
  *
- * Copyright (C) 2015 Linas Vepstas
+ * Copyright (C) 2015,2017 Linas Vepstas
+ * Copyright (C) 2016 Nil Geiswieller
  * All Rights Reserved
  *
  * This program is free software; you can redistribute it and/or modify
@@ -54,6 +55,7 @@ public:
 	void test_eta();
 	void test_alpha();
 	void test_compose();
+	void test_ident_compose();
 	void test_eval_inheritance();
 	void test_eval_implication_1();
 	void test_eval_implication_2();
@@ -455,6 +457,67 @@ void PutLinkUTest::test_compose()
 				L(INHERITANCE_LINK,
 					N(VARIABLE_NODE, "$x"),
 					N(VARIABLE_NODE, "$y"))));
+
+	printf("Expecting %s\n", expected_putted->to_string().c_str());
+	printf("Got %s\n", putted->to_string().c_str());
+	TS_ASSERT_EQUALS(putted, expected_putted);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// Test function composition with identity function
+void PutLinkUTest::test_ident_compose()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Test that simple function compostion can be performed.
+	//
+	// (define g (Lambda (Evaluation (Variable "X") (Variable "Y"))))
+	// (define f2 (Lambda
+	//    (VariableList (Variable "X") (Variable "Y") (Variable "Z"))
+	//    (Inheritance (Variable "Y")(Variable "Z")) ))
+	//
+	// (define ident (Lambda (Variable "W") (Variable "W")))
+	// (cog-execute! (Put g (List ident f2)))
+	//
+	// We expect the result to be in prenex form.
+	//
+	Handle gee =
+		L(LAMBDA_LINK,
+			L(EVALUATION_LINK,
+				N(VARIABLE_NODE, "$x"),
+				N(VARIABLE_NODE, "$y")));
+	Handle eff =
+		L(LAMBDA_LINK,
+			L(VARIABLE_LIST,
+				N(VARIABLE_NODE, "$x"),
+				N(VARIABLE_NODE, "$y"),
+				N(VARIABLE_NODE, "$z")),
+			L(INHERITANCE_LINK,
+				N(VARIABLE_NODE, "$y"),
+				N(VARIABLE_NODE, "$z")));
+	Handle ident =
+		L(LAMBDA_LINK,
+			N(VARIABLE_NODE, "$x"), N(VARIABLE_NODE, "$x"));
+
+	Handle put =
+		L(PUT_LINK, gee, L(LIST_LINK, ident, eff));
+
+	Instantiator inst(&_as);
+	Handle putted = inst.execute(put);
+
+	Handle expected_putted =
+		L(LAMBDA_LINK,
+			L(VARIABLE_LIST,
+				N(VARIABLE_NODE, "$w"),
+				N(VARIABLE_NODE, "$x"),
+				N(VARIABLE_NODE, "$y"),
+				N(VARIABLE_NODE, "$z")),
+			L(EVALUATION_LINK,
+				N(VARIABLE_NODE, "$w"),
+				L(INHERITANCE_LINK,
+					N(VARIABLE_NODE, "$y"),
+					N(VARIABLE_NODE, "$z"))));
 
 	printf("Expecting %s\n", expected_putted->to_string().c_str());
 	printf("Got %s\n", putted->to_string().c_str());

--- a/tests/atoms/PutLinkUTest.cxxtest
+++ b/tests/atoms/PutLinkUTest.cxxtest
@@ -53,6 +53,7 @@ public:
 	void test_lambda_partial_substitution();
 	void test_eta();
 	void test_alpha();
+	void test_compose();
 	void test_eval_inheritance();
 	void test_eval_implication_1();
 	void test_eval_implication_2();
@@ -407,6 +408,53 @@ void PutLinkUTest::test_alpha()
 			L(INHERITANCE_LINK,
 				N(VARIABLE_NODE, "$w"),
 				N(CONCEPT_NODE, "animal")));
+
+	printf("Expecting %s\n", expected_putted->to_string().c_str());
+	printf("Got %s\n", putted->to_string().c_str());
+	TS_ASSERT_EQUALS(putted, expected_putted);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// Test simple function composition.
+void PutLinkUTest::test_compose()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Test that simple function compostion can be performed.
+	//
+	// (define g (Lambda (Evaluation (Predicate "P") (Variable "X"))))
+	// (define f (Lambda (Inheritance (Variable "X") (Variable "Y"))))
+	// (cog-execute! (Put g f))
+	//
+	// We expect the result to be in prenex form.
+	//
+	Handle gee =
+		L(LAMBDA_LINK,
+			L(EVALUATION_LINK,
+				N(PREDICATE_NODE, "P"),
+				N(VARIABLE_NODE, "$x")));
+	Handle eff =
+		L(LAMBDA_LINK,
+			L(INHERITANCE_LINK,
+				N(VARIABLE_NODE, "$x"),
+				N(VARIABLE_NODE, "$y")));
+	Handle put =
+		L(PUT_LINK, gee, eff);
+
+	Instantiator inst(&_as);
+	Handle putted = inst.execute(put);
+
+	Handle expected_putted =
+		L(LAMBDA_LINK,
+			L(VARIABLE_LIST,
+				N(VARIABLE_NODE, "$x"),
+				N(VARIABLE_NODE, "$y")),
+			L(EVALUATION_LINK,
+				N(PREDICATE_NODE, "P"),
+				L(INHERITANCE_LINK,
+					N(VARIABLE_NODE, "$x"),
+					N(VARIABLE_NODE, "$y"))));
 
 	printf("Expecting %s\n", expected_putted->to_string().c_str());
 	printf("Got %s\n", putted->to_string().c_str());


### PR DESCRIPTION
This implements the observation that, when two patterns are composed, their product should be in prenex form.

I think that this captures much of the intent of the ComposeLink, and probably some of what the URE forward chainer is trying to do.

This passes basic unit tests, including thopse reported in #1490 but is likely to fail if used with complex variable declarations and/or with patternlinks (its untested for those cases, thus likely buggy).