### PR TITLE
Fix execute malformed putlink

### DIFF
--- a/opencog/atoms/core/PrenexLink.cc
+++ b/opencog/atoms/core/PrenexLink.cc
@@ -237,6 +237,17 @@ Handle PrenexLink::beta_reduce(const HandleMap& vmap) const
 			ScopeLinkPtr sc = ScopeLinkCast(pare->second);
 			Variables bound = sc->get_variables();
 			Handle body = sc->get_body();
+
+			// The body might not exist, if there's an unmantched
+			// UnquoteLink in it. In such a case the beta-reduction is
+			// aborted.
+			if (nullptr == body)
+			{
+				throw SyntaxException(TRACE_INFO,
+				                      "PrenexLink given a malformed value=%s",
+				                      sc->to_string().c_str());
+			}
+
 			HandleMap scopissued;
 			for (const Handle& bv : bound.varseq)
 			{

--- a/opencog/atoms/core/PutLink.cc
+++ b/opencog/atoms/core/PutLink.cc
@@ -387,6 +387,10 @@ Handle PutLink::do_reduce(void) const
 			{
 				return Handle::UNDEFINED;
 			}
+			catch (const SyntaxException& ex)
+			{
+				return Handle::UNDEFINED;
+			}
 		}
 
 		// If the values are given in a set, then iterate over the set...

--- a/opencog/atoms/execution/Instantiator.cc
+++ b/opencog/atoms/execution/Instantiator.cc
@@ -207,6 +207,9 @@ Handle Instantiator::walk_tree(const Handle& expr, bool silent)
 		// Step one: beta-reduce.
 		Handle red(ppp->reduce());
 
+		if (nullptr == red)
+			return red;
+
 		// Step two: execute the resulting body.
 		// (unless its not executable)
 		if (DONT_EXEC_LINK == red->get_type())

--- a/tests/atoms/PutLinkUTest.cxxtest
+++ b/tests/atoms/PutLinkUTest.cxxtest
@@ -42,6 +42,7 @@ public:
 	PutLinkUTest()
 	{
 		logger().set_print_to_stdout_flag(true);
+		logger().set_level(Logger::DEBUG);
 		logger().set_sync_flag(true); // interleave with printf correctly
 	}
 
@@ -67,7 +68,7 @@ public:
 	void test_eval_inheritance();
 	void test_eval_implication_1();
 	void test_eval_implication_2();
-	void xtest_ill_unquote();
+	void test_ill_unquote();
 };
 
 #define N _as.add_node
@@ -1122,7 +1123,7 @@ void PutLinkUTest::test_eval_implication_2()
  *   )
  * )
  */
-void PutLinkUTest::xtest_ill_unquote()
+void PutLinkUTest::test_ill_unquote()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
@@ -1139,7 +1140,7 @@ void PutLinkUTest::xtest_ill_unquote()
 		          L(UNQUOTE_LINK, g)));
 
 	Instantiator inst(&_as);
-	TS_ASSERT_THROWS_ANYTHING(inst.execute(put));
+	TS_ASSERT_EQUALS(inst.execute(put), nullptr);
 
 	logger().info("END TEST: %s", __FUNCTION__);
 }


### PR DESCRIPTION
Address the bug about `PutLink::reduce()` eluded in https://github.com/opencog/atomspace/issues/1511#issue-285959632 (not the check whether outgoing is defined in `Link::Link`).