### PR TITLE
Perform full scheme intialization in python

### DIFF
--- a/opencog/cython/opencog/PyScheme.cc
+++ b/opencog/cython/opencog/PyScheme.cc
@@ -30,11 +30,11 @@ using std::string;
 using namespace opencog;
 
 // Convenience wrapper, for stand-alone usage.
-std::string opencog::eval_scheme(AtomSpace& as, const std::string &s)
+std::string opencog::eval_scheme(AtomSpace* as, const std::string &s)
 {
 #ifdef HAVE_GUILE
-	OC_ASSERT(nullptr != (void *) &as, "Cython failed to specify an atomspace!");
-	SchemeEval* evaluator = SchemeEval::get_evaluator(&as);
+	OC_ASSERT(nullptr != as, "Cython failed to specify an atomspace!");
+	SchemeEval* evaluator = SchemeEval::get_evaluator(as);
 	std::string scheme_return_value = evaluator->eval(s);
 
 	// If there's an error, the scheme_return_value will contain
@@ -55,11 +55,12 @@ std::string opencog::eval_scheme(AtomSpace& as, const std::string &s)
 }
 
 // Convenience wrapper, for stand-alone usage.
-Handle opencog::eval_scheme_h(AtomSpace& as, const std::string &s)
+Handle opencog::eval_scheme_h(AtomSpace* as, const std::string &s)
 {
 #ifdef HAVE_GUILE
-	OC_ASSERT(nullptr != (void *) &as, "Cython failed to specify an atomspace!");
-	SchemeEval* evaluator = SchemeEval::get_evaluator(&as);
+	OC_ASSERT(nullptr != as, "Cython failed to specify an atomspace!");
+
+	SchemeEval* evaluator = SchemeEval::get_evaluator(as);
 	Handle scheme_return_value = evaluator->eval_h(s);
 
 	if (evaluator->eval_error())

--- a/opencog/cython/opencog/PyScheme.h
+++ b/opencog/cython/opencog/PyScheme.h
@@ -9,8 +9,8 @@ namespace opencog
 {
 
 /** For easier wrapping by Cython */
-std::string eval_scheme(AtomSpace&, const std::string &);
-Handle eval_scheme_h(AtomSpace&, const std::string &);
+std::string eval_scheme(AtomSpace*, const std::string &);
+Handle eval_scheme_h(AtomSpace*, const std::string &);
 AtomSpace* eval_scheme_as(const std::string &);
 
 } // namespace opencog

--- a/opencog/cython/opencog/atomspace_details.pyx
+++ b/opencog/cython/opencog/atomspace_details.pyx
@@ -26,6 +26,7 @@ cdef convert_handle_seq_to_python_list(vector[cHandle] handles, AtomSpace atomsp
 cdef AtomSpace_factory(cAtomSpace *to_wrap):
     cdef AtomSpace instance = AtomSpace.__new__(AtomSpace)
     instance.atomspace = to_wrap
+    # print "Debug: atomspace factory={0:x}".format(<long unsigned int>to_wrap)
     instance.owns_atomspace = False
     return instance
 

--- a/opencog/cython/opencog/scheme_wrapper.pyx
+++ b/opencog/cython/opencog/scheme_wrapper.pyx
@@ -23,7 +23,7 @@ cdef extern from "<string>" namespace "std":
         int size()
 
 cdef extern from "opencog/cython/opencog/PyScheme.h" namespace "opencog":
-    string eval_scheme(cAtomSpace& as, const string& s) except +
+    string eval_scheme(cAtomSpace* as, const string& s) except +
 
 def scheme_eval(AtomSpace a, char* s):
     """
@@ -32,11 +32,12 @@ def scheme_eval(AtomSpace a, char* s):
     cdef string ret
     cdef string expr
     expr = string(s)
-    ret = eval_scheme(deref(a.atomspace), expr)
+    # print "Debug: called scheme eval with atomspace {0:x}".format(<unsigned long int>a.atomspace)
+    ret = eval_scheme(a.atomspace, expr)
     return ret.c_str()
 
 cdef extern from "opencog/cython/opencog/PyScheme.h" namespace "opencog":
-    cHandle eval_scheme_h(cAtomSpace& as, const string& s) except +
+    cHandle eval_scheme_h(cAtomSpace* as, const string& s) except +
 
 def scheme_eval_h(AtomSpace a, char* s):
     """
@@ -45,7 +46,7 @@ def scheme_eval_h(AtomSpace a, char* s):
     cdef cHandle ret
     cdef string expr
     expr = string(s)
-    ret = eval_scheme_h(deref(a.atomspace), expr)
+    ret = eval_scheme_h(a.atomspace, expr)
     return Atom(void_from_candle(ret), a)
 
 cdef extern from "opencog/cython/opencog/PyScheme.h" namespace "opencog":


### PR DESCRIPTION
Scheme was not fully initialized in the python wrapper.  Apparently, this has been broken a long time, no one noticed.  This should hold water, for now.  Fixes bug https://github.com/opencog/opencog/issues/2972