### PR TITLE
fix for cython build error on ubuntu 14.04 as described in issue #1523

### DIFF
--- a/opencog/cython/opencog/scheme_wrapper.pyx
+++ b/opencog/cython/opencog/scheme_wrapper.pyx
@@ -66,5 +66,6 @@ cdef extern from "opencog/cython/load-file.h" namespace "opencog":
     int load_scm_file_relative (cAtomSpace& as, char* filename) except +
 
 def load_scm(AtomSpace a, str fname):
-    status = load_scm_file_relative(deref(a.atomspace), fname.encode('UTF-8'))
+    fname_tmp = fname.encode('UTF-8')
+    status = load_scm_file_relative(deref(a.atomspace), fname_tmp)
     return status == 0


### PR DESCRIPTION
Assigning filename to temporary value allows it to compile on Ubuntu 14.04 using Cython version 0.20.1post0. Does not compile otherwise.   Confirmed on  Ubuntu 16.04 as well.  No impact on unit tests. 