### PR TITLE
use bash shell instead of bourne on haskell target build issue #1525

### DIFF
--- a/opencog/haskell/CMakeLists.txt
+++ b/opencog/haskell/CMakeLists.txt
@@ -21,7 +21,7 @@ INSTALL (TARGETS atomspace-cwrapper
 IF (HAVE_STACK)
     ADD_CUSTOM_TARGET(haskell-atomspace-lib ALL
         DEPENDS atomspace-cwrapper
-        COMMAND sh build.sh ${CMAKE_CURRENT_BINARY_DIR}
+        COMMAND bash build.sh ${CMAKE_CURRENT_BINARY_DIR}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         COMMENT "Building Haskell bindings."
     )


### PR DESCRIPTION
Corrects issue checking haskell target where a shell script 
that requires bash is invoked with sh 

