### PR TITLE
Fix issue #1528

### DIFF
--- a/opencog/atoms/pattern/PatternUtils.cc
+++ b/opencog/atoms/pattern/PatternUtils.cc
@@ -63,7 +63,8 @@ namespace opencog {
  */
 bool remove_constants(const HandleSet &vars,
                       Pattern &pat,
-                      HandleSeqSeq &components,
+                      HandleSeqSeq& components,
+                      HandleSeq& component_patterns,
                       const AtomSpace &queried_as)
 {
 	bool modified = false;
@@ -79,10 +80,18 @@ bool remove_constants(const HandleSet &vars,
 			pat.constants.emplace_back(clause);
 			i = pat.clauses.erase(i);
 
-			// remove the clause from _components.
+			// remove the clause from components and component_patterns
 			auto j = boost::find(components, HandleSeq{clause});
 			if (j != components.end())
+			{
 				components.erase(j);
+				if (not component_patterns.empty())
+				{
+					auto cpj = std::next(component_patterns.begin(),
+					                     std::distance(components.begin(), j));
+					component_patterns.erase(cpj);
+				}
+			}
 
 			// remove the clause from _pattern_mandatory.
 			auto m = boost::find(pat.mandatory, clause);

--- a/opencog/atoms/pattern/PatternUtils.h
+++ b/opencog/atoms/pattern/PatternUtils.h
@@ -41,7 +41,8 @@ namespace opencog {
 // See C file for description
 bool remove_constants(const HandleSet& vars,
                       Pattern& pat,
-                      HandleSeqSeq &components,
+                      HandleSeqSeq& components,
+                      HandleSeq& component_patterns,
                       const AtomSpace &queried_as);
 
 // check whether an Atom exists in a given atomspace.

--- a/opencog/query/PatternMatch.cc
+++ b/opencog/query/PatternMatch.cc
@@ -339,7 +339,8 @@ bool BindLink::imply(PatternMatchCallback& pmc, AtomSpace* as, bool check_conn)
 	// The presence of constant clauses will mess up the current
 	// pattern matcher.  Constant clauses are "trivial" to match,
 	// and so its pointless to even send them through the system.
-	bool bogus = remove_constants(_varlist.varset, _pat, _components, as);
+	bool bogus = remove_constants(_varlist.varset, _pat, _components,
+	                              _component_patterns, as);
 	if (bogus)
 	{
 		logger().warn("%s: Constant clauses removed from pattern %s",

--- a/opencog/query/PatternMatch.cc
+++ b/opencog/query/PatternMatch.cc
@@ -328,10 +328,10 @@ bool PatternMatch::recursive_virtual(PatternMatchCallback& cb,
  */
 bool BindLink::imply(PatternMatchCallback& pmc, AtomSpace* as, bool check_conn)
 {
-   if (check_conn and 0 == _virtual.size() and 1 < _components.size())
+	if (check_conn and 0 == _virtual.size() and 1 < _components.size())
 		throw InvalidParamException(TRACE_INFO,
-			"BindLink consists of multiple disconnected components!");
-			// PatternLink::check_connectivity(_comps);
+		                            "BindLink consists of multiple "
+		                            "disconnected components!");
 
 	// Make sure that the user did not pass in bogus clauses
 	// in the queried atomspace.

--- a/tests/query/blair-witch.scm
+++ b/tests/query/blair-witch.scm
@@ -4,23 +4,11 @@
 ;;
 ;; blair-witch is here to emphasize the weirdness of the bug.
 
-;; Data
-(LambdaLink
-  (VariableList
-    (VariableNode "$X")
-    (VariableNode "$Y")
-  )
-  (InheritanceLink
-    (VariableNode "$X")
-    (VariableNode "$Y")
-  )
-)
-
 ;; Query
 (define query
 (BindLink
   (AndLink
-    ;; (VariableNode "$f-lamb-e84bdd8")
+    (VariableNode "$f-lamb-e84bdd8")
     (NumberNode "2.000000")
     (EvaluationLink
       (GroundedPredicateNode "scm: dummy")


### PR DESCRIPTION
There was a discrepancy between `PatternLink::_components` and `PatternLink::_component_patterns`. Fix it by removing constant component patterns from `PatternLink::_component_patterns` as well.