### PR TITLE
modify return value on timepair_t AtomSpaceBenchmark::bm_getHandlesBy

### DIFF
--- a/opencog/benchmark/AtomSpaceBenchmark.cc
+++ b/opencog/benchmark/AtomSpaceBenchmark.cc
@@ -1370,7 +1370,7 @@ timepair_t AtomSpaceBenchmark::bm_getHandlesByType()
         std::string ps = dss.str();
         clock_t t_begin = clock();
         pyev->eval(ps);
-        return Nclock*(clock() - t_begin);
+        return timepair_t(Nclock*clock(), Nclock*t_begin);
     }
 #endif /* HAVE_CYTHON */
 #if HAVE_GUILE


### PR DESCRIPTION
Was returning a clock_t when a timepair_t is needed. 

While has no impact on my unit tests, this PR requires a bit of review to ensure
this is the proper fix. 

/ed
