### PR TITLE
changes required for OSX gcc7 build

### DIFF
--- a/opencog/attentionbank/ImportanceIndex.cc
+++ b/opencog/attentionbank/ImportanceIndex.cc
@@ -21,6 +21,9 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#ifdef __APPLE__
+  #include <cmath>
+#endif
 #include <algorithm>
 #include <boost/range/adaptor/reversed.hpp>
 

--- a/opencog/cython/PythonEval.cc
+++ b/opencog/cython/PythonEval.cc
@@ -48,6 +48,10 @@ using namespace opencog;
 //#define DPRINTF printf
 #define DPRINTF(...)
 
+#ifdef __APPLE__
+  #define secure_getenv getenv
+#endif
+
 PythonEval* PythonEval::singletonInstance = NULL;
 
 const int NO_SIGNAL_HANDLERS = 0;

--- a/tests/atoms/ParallelUTest.cxxtest
+++ b/tests/atoms/ParallelUTest.cxxtest
@@ -27,6 +27,12 @@
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/util/Logger.h>
 
+#ifndef __APPLE__
+  #define ATOM_SLEEP(x,y) clock_nanosleep(CLOCK_REALTIME, 0, x, y)
+#else
+  #define ATOM_SLEEP(x,y) nanosleep(x, y)
+#endif
+
 using namespace opencog;
 
 class ParallelUTest: public CxxTest::TestSuite
@@ -89,7 +95,7 @@ int ParallelUTest::robustSleep(int secs)
     gettimeofday(&tv, nullptr);
     double start = tv.tv_sec + 1.0e-6 * tv.tv_usec;
     
-    while ((e = clock_nanosleep(CLOCK_REALTIME, 0, &request, &remain)) != 0) {
+    while ((e = ATOM_SLEEP(&request, &remain)) != 0) {
         gettimeofday(&tv, nullptr);
         double now = tv.tv_sec + 1.0e-6 * tv.tv_usec;
         printf("Slept for %.4f secs so far\n", now - start);


### PR DESCRIPTION
On OSX with gcc7:
- secure_getenv is not defined, 
- cmath inclusion is required for using std::ceil and std::pow 
- clock_nanosleep does not exist 

/ed
