### PR TITLE
Fix nested put links

### DIFF
--- a/opencog/atoms/core/PrenexLink.h
+++ b/opencog/atoms/core/PrenexLink.h
@@ -38,7 +38,7 @@ namespace opencog
 ///
 /// This is used primarily to ensure that PatternLinks remain in
 /// prenex form, even when being rewritten. PatternLinks must have
-/// all avraible declarations out in front, in order to work.
+/// all available declarations out in front, in order to work.
 ///
 class PrenexLink;
 typedef std::shared_ptr<PrenexLink> PrenexLinkPtr;

--- a/opencog/atoms/core/PutLink.cc
+++ b/opencog/atoms/core/PutLink.cc
@@ -117,6 +117,8 @@ void PutLink::static_typecheck_values(void)
 		return;
 	if (DEFINED_PREDICATE_NODE == btype)
 		return;
+	if (PUT_LINK == btype)
+		return;
 
 	// If its part of a signature, there is nothing to do.
 	if (classserver().isA(btype, TYPE_NODE) or TYPE_CHOICE == btype)
@@ -222,7 +224,7 @@ void PutLink::static_typecheck_values(void)
 		for (const Handle& h : valley->getOutgoingSet())
 		{
 			// If the arity is greater than one, then the values must be in a list.
-		   if (h->get_type() != LIST_LINK)
+			if (h->get_type() != LIST_LINK)
 				throw InvalidParamException(TRACE_INFO,
 					"PutLink expected value list!");
 
@@ -307,6 +309,14 @@ Handle PutLink::do_reduce(void) const
 			throw InvalidParamException(TRACE_INFO,
 					"Expecting a LambdaLink, got %s",
 			      bods->to_string().c_str());
+	}
+
+	// If the body is itself a PutLink, then reduce it first
+	if (PUT_LINK == btype)
+	{
+		PutLinkPtr nested_put = PutLinkCast(bods);
+		bods = nested_put->reduce();
+		btype = bods->get_type();
 	}
 
 	// If the body is a lambda, work with that.

--- a/opencog/atoms/core/PutLink.cc
+++ b/opencog/atoms/core/PutLink.cc
@@ -257,7 +257,7 @@ static inline Handle reddy(PrenexLinkPtr subs, const HandleSeq& oset)
  * This is a lot like applying the function fun to the argument list
  * args, except that no actual evaluation is performed; only
  * substitution.  The resulting tree is NOT placed into any atomspace,
- * either. If you want that, you must do it youself.  If you want
+ * either. If you want that, you must do it yourself.  If you want
  * evaluation or execution to happen during or after sustitution, use
  * either the EvaluationLink, the ExecutionOutputLink, or the Instantiator.
  *

--- a/opencog/atoms/execution/Instantiator.cc
+++ b/opencog/atoms/execution/Instantiator.cc
@@ -184,7 +184,7 @@ Handle Instantiator::walk_tree(const Handle& expr, bool silent)
 		{
 			ppp = PutLinkCast(expr);
 			// Execute the values in the PutLink before doing the
-			// beta-reduction. Execute the body only after the
+			// beta-reduction. Execute the PutLink only after the
 			// beta-reduction has been done.
 			Handle pvals = ppp->get_values();
 			Handle gargs = walk_tree(pvals, silent);

--- a/tests/atoms/CMakeLists.txt
+++ b/tests/atoms/CMakeLists.txt
@@ -14,6 +14,8 @@ IF(HAVE_GUILE)
 	TARGET_LINK_LIBRARIES(RewriteLinkUTest smob atomspace)
 	ADD_CXXTEST(ScopeLinkUTest)
 	TARGET_LINK_LIBRARIES(ScopeLinkUTest smob atomspace)
+	ADD_CXXTEST(PutLinkUTest)
+	TARGET_LINK_LIBRARIES(PutLinkUTest execution smob atomspace)
 ENDIF(HAVE_GUILE)
 
 ADD_CXXTEST(AlphaConvertUTest)
@@ -30,9 +32,6 @@ TARGET_LINK_LIBRARIES(DeleteLinkUTest execution atomspace)
 
 ADD_CXXTEST(EqualLinkUTest)
 TARGET_LINK_LIBRARIES(EqualLinkUTest execution atomspace)
-
-ADD_CXXTEST(PutLinkUTest)
-TARGET_LINK_LIBRARIES(PutLinkUTest execution atomspace)
 
 ADD_CXXTEST(StateLinkUTest)
 TARGET_LINK_LIBRARIES(StateLinkUTest execution atomspace)

--- a/tests/atoms/PutLinkUTest.cxxtest
+++ b/tests/atoms/PutLinkUTest.cxxtest
@@ -22,6 +22,7 @@
  */
 
 #include <opencog/util/exceptions.h>
+#include <opencog/guile/SchemeEval.h>
 #include <opencog/atoms/base/Atom.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/atoms/core/PutLink.h>
@@ -37,13 +38,17 @@ class PutLinkUTest: public CxxTest::TestSuite
 {
 private:
 	AtomSpace _as;
+	SchemeEval _eval;
 
 public:
-	PutLinkUTest()
+	PutLinkUTest() : _eval(&_as)
 	{
 		logger().set_print_to_stdout_flag(true);
 		logger().set_level(Logger::DEBUG);
 		logger().set_sync_flag(true); // interleave with printf correctly
+
+		_eval.eval("(add-to-load-path \"..\")");
+        _eval.eval("(add-to-load-path \"../../..\")");
 	}
 
 	void setUp() {}
@@ -69,6 +74,7 @@ public:
 	void test_eval_implication_1();
 	void test_eval_implication_2();
 	void test_ill_unquote();
+	void test_nested();
 };
 
 #define N _as.add_node
@@ -1141,6 +1147,55 @@ void PutLinkUTest::test_ill_unquote()
 
 	Instantiator inst(&_as);
 	TS_ASSERT_EQUALS(inst.execute(put), nullptr);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+/**
+ * Test that the nested PutLinks is supported, for instance that
+ * executing
+ *
+ * (Put
+ *   (Put
+ *     (Lambda
+ *       (Variable "$X")
+ *       (Variable "$X"))
+ *     (Lambda
+ *       (VariableList
+ *         (Variable "$Y")
+ *         (Variable "$Z"))
+ *       (Inheritance
+ *         (Variable "$Y")
+ *         (Variable "$Z"))))
+ *   (List
+ *     (Concept "A")
+ *     (Variable "$X")))
+ *
+ * outputs
+ *
+ * (Lambda
+ *   (Variable "X")
+ *   (Inheritance
+ *     (Concept "A")
+ *     (Variable "$X")))
+ *
+ */
+void PutLinkUTest::test_nested()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	std::string rs = _eval.eval("(load-from-path \"tests/atoms/nested-put.scm\")");
+	logger().debug() << "rs = " << rs;
+
+	Instantiator inst(&_as);
+	Handle nested_put = _eval.eval_h("nested-put"),
+		result = inst.execute(nested_put),
+		expected = _eval.eval_h("expected");
+
+	logger().debug() << "result = " << oc_to_string(result);
+	logger().debug() << "expected = " << oc_to_string(expected);
+
+	TS_ASSERT_EQUALS(result, expected);
 
 	logger().info("END TEST: %s", __FUNCTION__);
 }

--- a/tests/atoms/nested-put.scm
+++ b/tests/atoms/nested-put.scm
@@ -1,0 +1,25 @@
+(define nested-put
+(Put
+  (Put
+    (Lambda
+      (Variable "$X")
+      (Variable "$X"))
+    (Lambda
+      (VariableList
+        (Variable "$Y")
+        (Variable "$Z"))
+      (Inheritance
+        (Variable "$Y")
+        (Variable "$Z"))))
+  (List
+    (Concept "A")
+    (Variable "$X")))
+)
+
+(define expected
+(Lambda
+  (Variable "$X")
+  (Inheritance
+    (Concept "A")
+    (Variable "$X")))
+)


### PR DESCRIPTION
Fix beta-reducing nested put links like
```
(Put
  (Put
    (Lambda
      (Variable "$X")
      (Variable "$X"))
    (Lambda
      (VariableList
        (Variable "$Y")
        (Variable "$Z"))
      (Inheritance
        (Variable "$Y")
        (Variable "$Z"))))
  (List
    (Concept "A")
    (Variable "$X")))
```
that should output
```
(Lambda
  (Variable "X")
  (Inheritance
    (Concept "A")
    (Variable "$X")))
```
instead of crashing.