### PR TITLE
fix BasicSCMUTest by setting en_US.utf8

### DIFF
--- a/tests/scm/BasicSCMUTest.cxxtest
+++ b/tests/scm/BasicSCMUTest.cxxtest
@@ -118,7 +118,7 @@ void BasicSCMUTest::setUp(void)
 	// in the majority of European locales. Unfortunately, guile number
 	// parsing is not locale dependent...
 	// eval->eval("(setlocale LC_ALL \"\")");
-	eval->eval("(setlocale LC_CTYPE \"\")");
+	eval->eval("(setlocale LC_CTYPE \"en_US.utf8\")");
 	eval->clear_pending();
 }
 


### PR DESCRIPTION
BasicSCMUTest requires a UTF-8 character set to complete its tests. 
This change explicitly changes locale to the en_US.utf8 LC_CTYPE within the test code.
This approach requires that en_US.utf8 be installed on the machine. 
( Test was failing on Ubuntu 16.04 and 17.04) 

There are various alternatives to approaching this fix and it seems reasonable to require a given character set for unit tests.   ( NB. I am essentially monolingual, so those of you that live beyond EBCDIC may have a better way to solve this problem.  - I will have a pull request for ocpkg to compliment this approach. ) 