### PR TITLE
Fixed segmentation fault when running cython test

### DIFF
--- a/tests/cython/guile/basic_unify.scm
+++ b/tests/cython/guile/basic_unify.scm
@@ -5,6 +5,7 @@
 
 (add-to-load-path "./opencog/scm")
 (use-modules (opencog))
+(use-modules (opencog exec))
 
 (define (stv mean conf) (cog-new-stv mean conf))
 


### PR DESCRIPTION
Seems the unit test was failing cause the cogutil exec module was not loaded.
The segmentation fault was thrown by cog-execute! not been defined