### PR TITLE
Wrap evaluation of virtual clause in try/catch

### DIFF
--- a/opencog/atoms/core/PutLink.cc
+++ b/opencog/atoms/core/PutLink.cc
@@ -315,9 +315,8 @@ Handle PutLink::do_reduce(void) const
 	if (PUT_LINK == btype)
 	{
 		PutLinkPtr nested_put = PutLinkCast(bods);
+		nested_put->make_silent(_silent);
 		bods = nested_put->reduce();
-		if (not bods)
-			return Handle::UNDEFINED;
 		btype = bods->get_type();
 	}
 

--- a/opencog/atoms/execution/Instantiator.h
+++ b/opencog/atoms/execution/Instantiator.h
@@ -97,6 +97,11 @@ public:
 		_vmap = nullptr;
 	}
 
+	void reset_halt()
+	{
+		_halt = false;
+	}
+
 	Handle instantiate(const Handle& expr, const HandleMap &vars,
 	                   bool silent=false);
 	Handle execute(const Handle& expr, bool silent=false)

--- a/opencog/query/Implicator.cc
+++ b/opencog/query/Implicator.cc
@@ -55,6 +55,9 @@ bool Implicator::grounding(const HandleMap &var_soln,
 	// to prevent them from producing nothing.  In practice it is
 	// difficult to insure so meanwhile this try-catch is used. See
 	// issue #950 and pull req #962. XXX FIXME later.
+	//
+	// TODO: maybe instead it should be set to silent and only catch
+	// the exceptions dedicated to silent throwing.
 	try {
 		Handle h = inst.instantiate(implicand, var_soln, true);
 		insert_result(h);

--- a/tests/query/CMakeLists.txt
+++ b/tests/query/CMakeLists.txt
@@ -72,6 +72,7 @@ IF (HAVE_GUILE)
 	ADD_CXXTEST(AbsentUTest)
 	ADD_CXXTEST(SingleUTest)
 	ADD_CXXTEST(ScopeUTest)
+    ADD_CXXTEST(PutUTest)
 
 	ADD_CXXTEST(FirstNUTest)
 	ADD_CXXTEST(AttentionalFocusCBUTest)
@@ -175,3 +176,5 @@ CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/tests/query/no-exception.scm
     ${PROJECT_BINARY_DIR}/tests/query/no-exception.scm)
 CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/tests/query/friends.scm
 		${PROJECT_BINARY_DIR}/tests/query/friends.scm)
+CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/tests/query/ill-put.scm
+		${PROJECT_BINARY_DIR}/tests/query/ill-put.scm)

--- a/tests/query/PutUTest.cxxtest
+++ b/tests/query/PutUTest.cxxtest
@@ -1,0 +1,97 @@
+/*
+ * tests/query/PutUTest.cxxtest
+ *
+ * Copyright (C) 2018 OpenCog Foundation
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/guile/SchemeEval.h>
+#include <opencog/atomspace/AtomSpace.h>
+#include <opencog/query/BindLinkAPI.h>
+#include <opencog/util/Logger.h>
+
+using namespace opencog;
+
+#define an _as.add_node
+#define al _as.add_link
+
+class PutUTest: public CxxTest::TestSuite
+{
+private:
+	AtomSpace _as;
+	SchemeEval _eval;
+
+public:
+	PutUTest() : _eval(&_as)
+	{
+		logger().set_level(Logger::DEBUG);
+		logger().set_print_to_stdout_flag(true);
+
+		_eval.eval("(add-to-load-path \"..\")");
+		_eval.eval("(add-to-load-path \"../../..\")");
+		_eval.eval("(use-modules (opencog query))");
+	}
+
+	~PutUTest()
+	{
+		// Erase the log file if no assertions failed.
+		if (!CxxTest::TestTracker::tracker().suiteFailed())
+			std::remove(logger().get_filename().c_str());
+		int rc = CxxTest::TestTracker::tracker().suiteFailed();
+		_exit(rc); // XXX hack to avoid double-free in __run_exit_handlers
+	}
+
+	void setUp();
+	void tearDown();
+
+	void test_ill_put();
+};
+
+void PutUTest::tearDown()
+{
+	_as.clear();
+}
+
+void PutUTest::setUp()
+{
+}
+
+/**
+ * Run a query evaluating PutLinks, including some ill-formed ones
+ * (only detectable at run-time).
+ */
+void PutUTest::test_ill_put()
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	_eval.eval("(load-from-path \"tests/query/ill-put.scm\")");
+
+	Handle get_put = _eval.eval_h("get-put"),
+		results = satisfying_set(&_as, get_put),
+		expected = al(SET_LINK, _eval.eval_h("put-1"));
+
+	logger().debug() << "results = " << oc_to_string(results);
+	logger().debug() << "expected = " << oc_to_string(expected);
+
+	TS_ASSERT_EQUALS(results, expected);
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+#undef an
+#undef al

--- a/tests/query/ill-put.scm
+++ b/tests/query/ill-put.scm
@@ -1,0 +1,38 @@
+(use-modules (opencog logger))
+
+;; Well formed PutLink
+(define put-1
+(PutLink
+  (LambdaLink
+    (VariableNode "$X")
+    (VariableNode "$X"))
+  (ConceptNode "A"))
+)
+
+;; Ill formed PutLinks (only detectable at run-time)
+(define put-2
+(PutLink
+  put-1
+  (Concept "B"))
+)
+(define put-3
+(PutLink
+  put-2
+  (Concept "C"))
+)
+
+(define get-put
+(Get
+  (TypedVariable
+    (Variable "$P")
+    (Type "PutLink"))
+  (And
+    (Variable "$P")
+    (Evaluation
+      (GroundedPredicate "scm: well-formed?")
+      (Variable "$P"))))
+)
+
+(define (well-formed? P)
+  (cog-logger-debug "well-formed? P = ~a" P)
+  (stv 1 1))


### PR DESCRIPTION
and add a unit test for it.

The Instantiator::reset_halt() method is used not to falsely detect
infinit recursion when an exception aborts an evaluation before
Instantiator::_halt gets switched back to false.