### PR TITLE
More put fixes

### DIFF
--- a/opencog/atoms/core/PutLink.cc
+++ b/opencog/atoms/core/PutLink.cc
@@ -20,6 +20,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <opencog/util/Logger.h>
 #include <opencog/atoms/base/atom_types.h>
 #include <opencog/atoms/base/ClassServer.h>
 #include "DefineLink.h"
@@ -389,19 +390,7 @@ Handle PutLink::do_reduce(void) const
 		{
 			HandleSeq oset;
 			oset.emplace_back(_values);
-			try
-			{
-				// return vars.substitute(bods, oset, /* silent */ true);
-				return reddy(subs, oset);
-			}
-			catch (const TypeCheckException& ex)
-			{
-				return Handle::UNDEFINED;
-			}
-			catch (const SyntaxException& ex)
-			{
-				return Handle::UNDEFINED;
-			}
+			return reddy(subs, oset);
 		}
 
 		// If the values are given in a set, then iterate over the set...
@@ -412,7 +401,6 @@ Handle PutLink::do_reduce(void) const
 			oset.emplace_back(h);
 			try
 			{
-				// bset.emplace_back(vars.substitute(bods, oset, /* silent */ true));
 				bset.emplace_back(reddy(subs, oset));
 			}
 			catch (const TypeCheckException& ex) {}
@@ -426,15 +414,7 @@ Handle PutLink::do_reduce(void) const
 	if (LIST_LINK == vtype)
 	{
 		const HandleSeq& oset = _values->getOutgoingSet();
-		try
-		{
-			// return vars.substitute(bods, oset, /* silent */ true);
-			return reddy(subs, oset);
-		}
-		catch (const TypeCheckException& ex)
-		{
-			return Handle::UNDEFINED;
-		}
+		return reddy(subs, oset);
 	}
 
 	// If the value is a LambdaLink, it will eta-reducible.
@@ -444,14 +424,7 @@ Handle PutLink::do_reduce(void) const
 	{
 		HandleSeq oset;
 		oset.emplace_back(_values);
-		try
-		{
-			return reddy(subs, oset);
-		}
-		catch (const TypeCheckException& ex)
-		{
-			return Handle::UNDEFINED;
-		}
+		return reddy(subs, oset);
 	}
 
 	// If we are here, then there are multiple values.
@@ -459,7 +432,7 @@ Handle PutLink::do_reduce(void) const
 	if (SET_LINK != vtype)
 	{
 		if (_silent)
-			throw NotEvaluatableException();
+			throw TypeCheckException();
 
 		throw RuntimeException(TRACE_INFO,
 		                       "Should have caught this earlier, in the ctor");
@@ -471,7 +444,6 @@ Handle PutLink::do_reduce(void) const
 		const HandleSeq& oset = h->getOutgoingSet();
 		try
 		{
-			// bset.emplace_back(vars.substitute(bods, oset, /* silent */ true));
 			bset.emplace_back(reddy(subs, oset));
 		}
 		catch (const TypeCheckException& ex) {}

--- a/opencog/query/DefaultPatternMatchCB.cc
+++ b/opencog/query/DefaultPatternMatchCB.cc
@@ -581,7 +581,7 @@ bool DefaultPatternMatchCB::eval_term(const Handle& virt,
 	{
 		gvirt = _instor->instantiate(virt, gnds, true);
 	}
-	catch (const NotEvaluatableException& ex)
+	catch (...)
 	{
 		// The evaluation above can throw an exception if the
 		// instantiation turns out to be ill-formed. If so assume it

--- a/opencog/query/Implicator.cc
+++ b/opencog/query/Implicator.cc
@@ -55,9 +55,6 @@ bool Implicator::grounding(const HandleMap &var_soln,
 	// to prevent them from producing nothing.  In practice it is
 	// difficult to insure so meanwhile this try-catch is used. See
 	// issue #950 and pull req #962. XXX FIXME later.
-	//
-	// TODO: maybe instead it should be set to silent and only catch
-	// the exceptions dedicated to silent throwing.
 	try {
 		Handle h = inst.instantiate(implicand, var_soln, true);
 		insert_result(h);

--- a/tests/atoms/PutLinkUTest.cxxtest
+++ b/tests/atoms/PutLinkUTest.cxxtest
@@ -77,6 +77,7 @@ public:
 	void test_nested_1();
 	void test_nested_2();
 	void test_nested_3();
+	void test_nested_4();
 };
 
 #define N _as.add_node
@@ -1148,7 +1149,7 @@ void PutLinkUTest::test_ill_unquote()
 		          L(UNQUOTE_LINK, g)));
 
 	Instantiator inst(&_as);
-	TS_ASSERT_EQUALS(inst.execute(put), nullptr);
+	TS_ASSERT_THROWS_ANYTHING(inst.execute(put));
 
 	logger().info("END TEST: %s", __FUNCTION__);
 }
@@ -1202,7 +1203,7 @@ void PutLinkUTest::test_nested_1()
 }
 
 /**
- * Test that nested PutLinks is supported, specifically that executing
+ * Test that the following raise an exception
  *
  * (PutLink
  *   (PutLink
@@ -1241,14 +1242,8 @@ void PutLinkUTest::test_nested_2()
 	logger().debug() << "rs = " << rs;
 
 	Instantiator inst(&_as);
-	Handle nested_put = _eval.eval_h("nested-put-2"),
-		result = inst.execute(nested_put),
-		expected = _eval.eval_h("expected-2");
-
-	logger().debug() << "result = " << oc_to_string(result);
-	logger().debug() << "expected = " << oc_to_string(expected);
-
-	TS_ASSERT_EQUALS(result, expected);
+	Handle nested_put = _eval.eval_h("nested-put-2");
+	TS_ASSERT_THROWS_ANYTHING(inst.execute(nested_put));
 
 	logger().info("END TEST: %s", __FUNCTION__);
 }
@@ -1278,7 +1273,37 @@ void PutLinkUTest::test_nested_3()
 	Instantiator inst(&_as);
 	Handle nested_put = _eval.eval_h("nested-put-3");
 
-	TS_ASSERT_THROWS(inst.execute(nested_put, true), NotEvaluatableException);
+	TS_ASSERT_THROWS_ANYTHING(inst.execute(nested_put, true));
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+/**
+ * Test that the following PutLinks raise an exception when executed
+ *
+ * (PutLink
+ *   (PutLink
+ *     (PutLink
+ *       (LambdaLink
+ *         (VariableNode "$X")
+ *         (VariableNode "$X"))
+ *       (ConceptNode "texts"))
+ *     (ListLink
+ *       (ConceptNode "texts")
+ *       (VariableNode "$x-1")))
+ *   (ConceptNode "texts"))
+ */
+void PutLinkUTest::test_nested_4()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	std::string rs = _eval.eval("(load-from-path \"tests/atoms/nested-put.scm\")");
+	logger().debug() << "rs = " << rs;
+
+	Instantiator inst(&_as);
+	Handle nested_put = _eval.eval_h("nested-put-4");
+
+	TS_ASSERT_THROWS_ANYTHING(inst.execute(nested_put, true));
 
 	logger().info("END TEST: %s", __FUNCTION__);
 }

--- a/tests/atoms/PutLinkUTest.cxxtest
+++ b/tests/atoms/PutLinkUTest.cxxtest
@@ -1,5 +1,5 @@
 /*
- * tests/atoms/PutUTest.cxxtest
+ * tests/atoms/PutLinkUTest.cxxtest
  *
  * Copyright (C) 2015,2017 Linas Vepstas
  * Copyright (C) 2016 Nil Geiswieller
@@ -74,7 +74,9 @@ public:
 	void test_eval_implication_1();
 	void test_eval_implication_2();
 	void test_ill_unquote();
-	void test_nested();
+	void test_nested_1();
+	void test_nested_2();
+	void test_nested_3();
 };
 
 #define N _as.add_node
@@ -1152,8 +1154,7 @@ void PutLinkUTest::test_ill_unquote()
 }
 
 /**
- * Test that the nested PutLinks is supported, for instance that
- * executing
+ * Test that nested PutLinks is supported, specifically that executing
  *
  * (Put
  *   (Put
@@ -1180,7 +1181,7 @@ void PutLinkUTest::test_ill_unquote()
  *     (Variable "$X")))
  *
  */
-void PutLinkUTest::test_nested()
+void PutLinkUTest::test_nested_1()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
@@ -1188,12 +1189,97 @@ void PutLinkUTest::test_nested()
 	logger().debug() << "rs = " << rs;
 
 	Instantiator inst(&_as);
-	Handle nested_put = _eval.eval_h("nested-put"),
+	Handle nested_put = _eval.eval_h("nested-put-1"),
 		result = inst.execute(nested_put),
-		expected = _eval.eval_h("expected");
+		expected = _eval.eval_h("expected-1");
 
 	logger().debug() << "result = " << oc_to_string(result);
 	logger().debug() << "expected = " << oc_to_string(expected);
+
+	TS_ASSERT_EQUALS(result, expected);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+/**
+ * Test that nested PutLinks is supported, specifically that executing
+ *
+ * (PutLink
+ *   (PutLink
+ *     (LambdaLink
+ *       (VariableNode "$X")
+ *       (VariableNode "$X"))
+ *     (ListLink
+ *       (ConceptNode "texts")
+ *       (VariableNode "$W")))
+ *   (LambdaLink
+ *     (VariableList
+ *       (VariableNode "$Y")
+ *       (VariableNode "$Z"))
+ *     (InheritanceLink
+ *       (VariableNode "$Y")
+ *       (VariableNode "$Z"))))
+ *
+ * outputs
+ *
+ * (Lambda
+ *   (VariableList
+ *     (VariableNode "$Y")
+ *     (VariableNode "$Z"))
+ *   (ListLink
+ *     (ConceptNode "texts")
+ *     (Inheritance
+ *       (VariableNode "$Y")
+ *       (VariableNode "$Z"))))
+ *
+ */
+void PutLinkUTest::test_nested_2()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	std::string rs = _eval.eval("(load-from-path \"tests/atoms/nested-put.scm\")");
+	logger().debug() << "rs = " << rs;
+
+	Instantiator inst(&_as);
+	Handle nested_put = _eval.eval_h("nested-put-2"),
+		result = inst.execute(nested_put),
+		expected = _eval.eval_h("expected-2");
+
+	logger().debug() << "result = " << oc_to_string(result);
+	logger().debug() << "expected = " << oc_to_string(expected);
+
+	TS_ASSERT_EQUALS(result, expected);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+/**
+ * Test that nested PutLinks is supported, specifically that executing
+ *
+ * (PutLink
+ *   (PutLink
+ *     (PutLink
+ *       (LambdaLink
+ *         (VariableNode "$X")
+ *         (VariableNode "$X"))
+ *       (ConceptNode "A"))
+ *     (Concept "B"))
+ *   (Concept "C"))
+ *
+ * outputs an undefined atom, assuming that silent is enabled.
+ */
+void PutLinkUTest::test_nested_3()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	std::string rs = _eval.eval("(load-from-path \"tests/atoms/nested-put.scm\")");
+	logger().debug() << "rs = " << rs;
+
+	Instantiator inst(&_as);
+	Handle nested_put = _eval.eval_h("nested-put-3");
+
+	// TODO wrap that in NotEvaluatableException exception test assert
+	result = inst.execute(nested_put, true);
 
 	TS_ASSERT_EQUALS(result, expected);
 

--- a/tests/atoms/PutLinkUTest.cxxtest
+++ b/tests/atoms/PutLinkUTest.cxxtest
@@ -1266,7 +1266,7 @@ void PutLinkUTest::test_nested_2()
  *     (Concept "B"))
  *   (Concept "C"))
  *
- * outputs an undefined atom, assuming that silent is enabled.
+ * raise an exception
  */
 void PutLinkUTest::test_nested_3()
 {
@@ -1278,10 +1278,7 @@ void PutLinkUTest::test_nested_3()
 	Instantiator inst(&_as);
 	Handle nested_put = _eval.eval_h("nested-put-3");
 
-	// TODO wrap that in NotEvaluatableException exception test assert
-	result = inst.execute(nested_put, true);
-
-	TS_ASSERT_EQUALS(result, expected);
+	TS_ASSERT_THROWS(inst.execute(nested_put, true), NotEvaluatableException);
 
 	logger().info("END TEST: %s", __FUNCTION__);
 }

--- a/tests/atoms/nested-put.scm
+++ b/tests/atoms/nested-put.scm
@@ -1,4 +1,4 @@
-(define nested-put
+(define nested-put-1
 (Put
   (Put
     (Lambda
@@ -16,10 +16,64 @@
     (Variable "$X")))
 )
 
-(define expected
+(define expected-1
 (Lambda
   (Variable "$X")
   (Inheritance
     (Concept "A")
     (Variable "$X")))
+)
+
+(define nested-put-2
+(PutLink
+  (PutLink
+    (LambdaLink
+      (VariableNode "$X")
+      (VariableNode "$X")
+    )
+    (ListLink
+      (ConceptNode "texts")
+      (VariableNode "$W")
+    )
+  )
+  (LambdaLink
+    (VariableList
+      (VariableNode "$Y")
+      (VariableNode "$Z")
+    )
+    (InheritanceLink
+      (VariableNode "$Y")
+      (VariableNode "$Z")
+    )
+  )
+)
+)
+
+(define expected-2
+(Lambda
+  (VariableList
+    (VariableNode "$Y")
+    (VariableNode "$Z")
+  )
+  (ListLink
+    (ConceptNode "texts")
+    (Inheritance
+      (VariableNode "$Y")
+      (VariableNode "$Z"))))
+)
+
+(define nested-put-3
+(PutLink
+  (PutLink
+    (PutLink
+      (LambdaLink
+        (VariableNode "$X")
+        (VariableNode "$X")
+      )
+      (ConceptNode "A")
+    )
+    (Concept "B")
+  )
+  (Concept "C")
+)
 )

--- a/tests/atoms/nested-put.scm
+++ b/tests/atoms/nested-put.scm
@@ -29,24 +29,17 @@
   (PutLink
     (LambdaLink
       (VariableNode "$X")
-      (VariableNode "$X")
-    )
+      (VariableNode "$X"))
     (ListLink
       (ConceptNode "texts")
-      (VariableNode "$W")
-    )
-  )
+      (VariableNode "$W")))
   (LambdaLink
     (VariableList
       (VariableNode "$Y")
-      (VariableNode "$Z")
-    )
+      (VariableNode "$Z"))
     (InheritanceLink
       (VariableNode "$Y")
-      (VariableNode "$Z")
-    )
-  )
-)
+      (VariableNode "$Z"))))
 )
 
 (define expected-2
@@ -68,12 +61,22 @@
     (PutLink
       (LambdaLink
         (VariableNode "$X")
-        (VariableNode "$X")
-      )
-      (ConceptNode "A")
-    )
-    (Concept "B")
-  )
-  (Concept "C")
+        (VariableNode "$X"))
+      (ConceptNode "A"))
+    (Concept "B"))
+  (Concept "C"))
 )
+
+(define nested-put-4
+(PutLink
+  (PutLink
+    (PutLink
+      (LambdaLink
+        (VariableNode "$X")
+        (VariableNode "$X"))
+      (ConceptNode "texts"))
+    (ListLink
+      (ConceptNode "texts")
+      (VariableNode "$x-1")))
+  (ConceptNode "texts"))
 )


### PR DESCRIPTION
Raise exceptions instead of returning `Handle::UNDEFINED` in some places in PutLink. Some exceptions should be probably be silenced but that can be done later.