### PR TITLE
Revert "Revert "Change param types""

### DIFF
--- a/opencog/attentionbank/AttentionBank.cc
+++ b/opencog/attentionbank/AttentionBank.cc
@@ -34,14 +34,14 @@ using namespace opencog;
 
 AttentionBank::AttentionBank(AtomSpace* asp)
 {
-    startingFundsSTI = fundsSTI = config().get_int("STARTING_STI_FUNDS", 100000);
-    startingFundsLTI = fundsLTI = config().get_int("STARTING_LTI_FUNDS", 100000);
-    stiFundsBuffer = config().get_int("STI_FUNDS_BUFFER", 10000);
-    ltiFundsBuffer = config().get_int("LTI_FUNDS_BUFFER", 10000);
-    targetLTI = config().get_int("TARGET_LTI_FUNDS", 10000);
-    targetSTI = config().get_int("TARGET_STI_FUNDS", 10000);
-    STIAtomWage = config().get_int("ECAN_STARTING_ATOM_STI_WAGE", 10);
-    LTIAtomWage = config().get_int("ECAN_STARTING_ATOM_LTI_WAGE", 10);
+    startingFundsSTI = fundsSTI = config().get_double("STARTING_STI_FUNDS", 100000);
+    startingFundsLTI = fundsLTI = config().get_double("STARTING_LTI_FUNDS", 100000);
+    stiFundsBuffer = config().get_double("STI_FUNDS_BUFFER", 10000);
+    ltiFundsBuffer = config().get_double("LTI_FUNDS_BUFFER", 10000);
+    targetLTI = config().get_double("TARGET_LTI_FUNDS", 10000);
+    targetSTI = config().get_double("TARGET_STI_FUNDS", 10000);
+    STIAtomWage = config().get_double("ECAN_STARTING_ATOM_STI_WAGE", 10);
+    LTIAtomWage = config().get_double("ECAN_STARTING_ATOM_LTI_WAGE", 10);
     maxAFSize = config().get_int("ECAN_MAX_AF_SIZE", 100);
 
     _remove_signal = &asp->atomRemovedSignal();

--- a/opencog/attentionbank/AttentionBank.h
+++ b/opencog/attentionbank/AttentionBank.h
@@ -88,8 +88,8 @@ class AttentionBank
     std::atomic_long fundsSTI;
     std::atomic_long fundsLTI;
 
-    long startingFundsSTI;
-    long startingFundsLTI;
+    AttentionValue::sti_t startingFundsSTI;
+    AttentionValue::lti_t startingFundsLTI;
 
     AttentionValue::sti_t stiFundsBuffer;
     AttentionValue::lti_t ltiFundsBuffer;
@@ -168,8 +168,8 @@ public:
      *
      * @return total STI in the AttentionBank
      */
-    long getTotalSTI() const {
-        return startingFundsSTI - fundsSTI;
+    AttentionValue::sti_t getTotalSTI() const {
+        return startingFundsSTI - (AttentionValue::sti_t)fundsSTI;
     }
 
     /**
@@ -178,8 +178,8 @@ public:
      *
      * @return total LTI in the AttentionBank
      */
-    long getTotalLTI() const {
-        return startingFundsLTI - fundsLTI;
+    AttentionValue::lti_t getTotalLTI() const {
+        return startingFundsLTI - (AttentionValue::lti_t)fundsLTI;
     }
 
     /**


### PR DESCRIPTION
Reverts opencog/atomspace#1564

Apparently, this is NOT the cause of the unit test breakage.  WTF. 