### PR TITLE
Add support for indentation in oc_to_string

### DIFF
--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -440,9 +440,10 @@ std::string Atom::id_to_string() const
 std::string oc_to_string(const IncomingSet& iset, const std::string& indent)
 {
 	std::stringstream ss;
-	ss << "size = " << iset.size() << std::endl;
+	ss << indent << "size = " << iset.size() << std::endl;
 	for (unsigned i = 0; i < iset.size(); i++)
-		ss << "link[" << i << "]:" << std::endl << iset[i]->to_string();
+		ss << indent << "link[" << i << "]:" << std::endl
+		   << iset[i]->to_string(indent + OC_TO_STRING_INDENT);
 	return ss.str();
 }
 

--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -437,7 +437,7 @@ std::string Atom::id_to_string() const
         std::string("[") + (_atom_space? std::to_string(_atom_space->_atom_table.get_uuid()) : std::string("-1")) + "]";
 }
 
-std::string oc_to_string(const IncomingSet& iset)
+std::string oc_to_string(const IncomingSet& iset, const std::string& indent)
 {
 	std::stringstream ss;
 	ss << "size = " << iset.size() << std::endl;

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -410,8 +410,12 @@ static inline AtomPtr AtomCast(const Handle& h)
 static inline Handle HandleCast(const ProtoAtomPtr& pa)
     { return Handle(AtomCast(pa)); }
 
-// gdb helper, see
+// Debugging helpers see
 // http://wiki.opencog.org/w/Development_standards#Print_OpenCog_Objects
+// The reason indent is not an optional argument with default is
+// because gdb doesn't support that, see
+// http://stackoverflow.com/questions/16734783 for more explanation.
+std::string oc_to_string(const IncomingSet& iset, const std::string& indent);
 std::string oc_to_string(const IncomingSet& iset);
 
 /** @}*/

--- a/opencog/atoms/base/Handle.cc
+++ b/opencog/atoms/base/Handle.cc
@@ -126,109 +126,150 @@ bool content_eq(const HandleSet& lhs, const HandleSet& rhs)
 }
 
 // The rest of this file is devoted to printing utilities used only
-// during GDB debugging.  Thus, you won't find these anywhere in the
-// code base. You may call that directly from gdb
-// (opencog::h_to_string, etc), but very likely your version of GDB
-// supports overloading and in this case you can simply configure GDB
-// as follows
+// during GDB debugging. You can configure GDB as follows
 // http://wiki.opencog.org/w/Development_standards#Print_OpenCog_Objects
-std::string h_to_string(const Handle& h)
+
+std::string oc_to_string(const Handle& h, const std::string& indent)
 {
 	if (h == nullptr)
-		return "nullatom\n";
+		return indent + "nullatom\n";
 	else
-		return h->to_string();
+		return indent + h->to_string();
 }
-std::string hp_to_string(const HandlePair& hp)
+std::string oc_to_string(const Handle& h)
+{
+	return oc_to_string(h, "");
+}
+std::string oc_to_string(const HandlePair& hp, const std::string& indent)
 {
 	std::stringstream ss;
-	ss << "first:" << std::endl << h_to_string(hp.first);
-	ss << "second:" << std::endl << h_to_string(hp.second);
+	ss << "first:" << std::endl << oc_to_string(hp.first);
+	ss << "second:" << std::endl << oc_to_string(hp.second);
 	return ss.str();
 }
-std::string hs_to_string(const HandleSeq& hs)
+std::string oc_to_string(const HandlePair& hp)
+{
+	return oc_to_string(hp, "");
+}
+std::string oc_to_string(const HandleSeq& hs, const std::string& indent)
 {
 	std::stringstream ss; std::operator<<(ss, hs); return ss.str();
 }
-std::string hss_to_string(const HandleSeqSeq& hss)
+std::string oc_to_string(const HandleSeq& hs)
+{
+	return oc_to_string(hs, "");
+}
+std::string oc_to_string(const HandleSeqSeq& hss, const std::string& indent)
 {
 	std::stringstream ss;
 	ss << "size = " << hss.size() << std::endl;
 	size_t i = 0;
 	for (const HandleSeq& hs : hss) {
-		ss << "atoms[" << i << "]:" << std::endl << hs_to_string(hs);
+		ss << "atoms[" << i << "]:" << std::endl << oc_to_string(hs);
 		i++;
 	}
 	return ss.str();
 }
-std::string ohs_to_string(const HandleSet& ohs)
+std::string oc_to_string(const HandleSeqSeq& hss)
+{
+	return oc_to_string(hss, "");
+}
+std::string oc_to_string(const HandleSet& ohs, const std::string& indent)
 {
 	std::stringstream ss; std::operator<<(ss, ohs); return ss.str();
 }
-std::string uhs_to_string(const UnorderedHandleSet& uhs)
+std::string oc_to_string(const HandleSet& ohs)
+{
+	return oc_to_string(ohs, "");
+}
+std::string oc_to_string(const UnorderedHandleSet& uhs, const std::string& indent)
 {
 	std::stringstream ss; std::operator<<(ss, uhs); return ss.str();
 }
-std::string hmap_to_string(const HandleMap& hmap)
+std::string oc_to_string(const UnorderedHandleSet& uhs)
+{
+	return oc_to_string(uhs, "");
+}
+std::string oc_to_string(const HandleMap& hmap, const std::string& indent)
 {
 	std::stringstream ss;
 	ss << "size = " << hmap.size() << std::endl;
 	int i = 0;
 	for (const auto& p : hmap) {
-		ss << "key[" << i << "]:" << std::endl << h_to_string(p.first)
-		   << "value[" << i << "]:" << std::endl << h_to_string(p.second);
+		ss << "key[" << i << "]:" << std::endl << oc_to_string(p.first)
+		   << "value[" << i << "]:" << std::endl << oc_to_string(p.second);
 		i++;
 	}
 	return ss.str();
 }
-std::string hmultimap_to_string(const HandleMultimap& hmultimap)
+std::string oc_to_string(const HandleMap& hmap)
+{
+	return oc_to_string(hmap, "");
+}
+std::string oc_to_string(const HandleMultimap& hmultimap, const std::string& indent)
 {
 	std::stringstream ss;
 	ss << "size = " << hmultimap.size() << std::endl;
 	int i = 0;
 	for (const auto& p : hmultimap) {
-		ss << "key[" << i << "]:" << std::endl << h_to_string(p.first)
+		ss << "key[" << i << "]:" << std::endl << oc_to_string(p.first)
 		   << "value[" << i << "]:" << std::endl;
 		for (const auto s : p.second)
-			ss << h_to_string(s);
+			ss << oc_to_string(s);
 		i++;
 	}
 	return ss.str();
 }
-std::string hmaps_to_string(const HandleMapSeq& hms)
+std::string oc_to_string(const HandleMultimap& hmultimap)
+{
+	return oc_to_string(hmultimap, "");
+}
+std::string oc_to_string(const HandleMapSeq& hms, const std::string& indent)
 {
 	std::stringstream ss;
 	ss << "size = " << hms.size() << std::endl;
 	for (unsigned i = 0; i < hms.size(); i++)
 		ss << "--- map[" << i << "] ---" << std::endl
-		   << hmap_to_string(hms[i]);
+		   << oc_to_string(hms[i]);
 	return ss.str();
 }
-std::string hmapset_to_string(const HandleMapSet& hms)
+std::string oc_to_string(const HandleMapSeq& hms)
+{
+	return oc_to_string(hms, "");
+}
+std::string oc_to_string(const HandleMapSet& hms, const std::string& indent)
 {
 	std::stringstream ss;
 	ss << "size = " << hms.size() << std::endl;
 	unsigned i = 0;
 	for (const HandleMap& hm : hms) {
 		ss << "--- map[" << i << "] ---" << std::endl
-		   << hmap_to_string(hm);
+		   << oc_to_string(hm);
 		++i;
 	}
 	return ss.str();
 }
-std::string hps_to_string(const HandlePairSeq& hps)
+std::string oc_to_string(const HandleMapSet& hms)
+{
+	return oc_to_string(hms, "");
+}
+std::string oc_to_string(const HandlePairSeq& hps, const std::string& indent)
 {
 	std::stringstream ss;
 	ss << "size = " << hps.size() << std::endl;
 	size_t i = 0;
 	for (const HandlePair& hp : hps) {
-		ss << "atom.first[" << i << "]:" << std::endl << h_to_string(hp.first);
-		ss << "atom.second[" << i << "]:" << std::endl << h_to_string(hp.second);
+		ss << "atom.first[" << i << "]:" << std::endl << oc_to_string(hp.first);
+		ss << "atom.second[" << i << "]:" << std::endl << oc_to_string(hp.second);
 		i++;
 	}
 	return ss.str();
 }
-std::string hc_to_string(const HandleCounter& hc)
+std::string oc_to_string(const HandlePairSeq& hps)
+{
+	return oc_to_string(hps, "");
+}
+std::string oc_to_string(const HandleCounter& hc, const std::string& indent)
 {
 	std::stringstream ss;
 	ss << "size = " << hc.size() << std::endl;
@@ -240,7 +281,11 @@ std::string hc_to_string(const HandleCounter& hc)
 	}
 	return ss.str();
 }
-std::string huc_to_string(const HandleUCounter& huc)
+std::string oc_to_string(const HandleCounter& hc)
+{
+	return oc_to_string(hc, "");
+}
+std::string oc_to_string(const HandleUCounter& huc, const std::string& indent)
 {
 	std::stringstream ss;
 	ss << "size = " << huc.size() << std::endl;
@@ -252,80 +297,35 @@ std::string huc_to_string(const HandleUCounter& huc)
 	}
 	return ss.str();
 }
-std::string atomtype_to_string(Type type)
+std::string oc_to_string(const HandleUCounter& huc)
+{
+	return oc_to_string(huc, "");
+}
+std::string oc_to_string(Type type, const std::string& indent)
 {
 	std::stringstream ss;
 	ss << classserver().getTypeName(type) << std::endl;
 	return ss.str();
 }
-std::string aptr_to_string(const AtomPtr& aptr)
-{
-	return h_to_string(aptr->get_handle());
-}
-std::string lptr_to_string(const LinkPtr& lptr)
-{
-	return h_to_string(lptr->get_handle());
-}
-
-std::string oc_to_string(const Handle& h)
-{
-	return h_to_string(h);
-}
-std::string oc_to_string(const HandlePair& hp)
-{
-	return hp_to_string(hp);
-}
-std::string oc_to_string(const HandleSeq& hs)
-{
-	return hs_to_string(hs);
-}
-std::string oc_to_string(const HandleSeqSeq& hss)
-{
-	return hss_to_string(hss);
-}
-std::string oc_to_string(const HandleSet& ohs)
-{
-	return ohs_to_string(ohs);
-}
-std::string oc_to_string(const UnorderedHandleSet& uhs)
-{
-	return uhs_to_string(uhs);
-}
-std::string oc_to_string(const HandleMap& hm)
-{
-	return hmap_to_string(hm);
-}
-std::string oc_to_string(const HandleMultimap& hmm)
-{
-	return hmultimap_to_string(hmm);
-}
-std::string oc_to_string(const HandleMapSeq& hms)
-{
-	return hmaps_to_string(hms);
-}
-std::string oc_to_string(const HandleMapSet& hms)
-{
-	return hmapset_to_string(hms);
-}
-std::string oc_to_string(const HandlePairSeq& hps)
-{
-	return hps_to_string(hps);
-}
-std::string oc_to_string(const HandleCounter& hc)
-{
-	return hc_to_string(hc);
-}
-std::string oc_to_string(const HandleUCounter& huc)
-{
-	return huc_to_string(huc);
-}
 std::string oc_to_string(Type type)
 {
-	return atomtype_to_string(type);
+	return oc_to_string(type, "");
+}
+std::string oc_to_string(const AtomPtr& aptr, const std::string& indent)
+{
+	return oc_to_string(aptr->get_handle());
 }
 std::string oc_to_string(const AtomPtr& aptr)
 {
-	return aptr_to_string(aptr);
+	return oc_to_string(aptr, "");
+}
+std::string oc_to_string(const LinkPtr& lptr, const std::string& indent)
+{
+	return oc_to_string(lptr->get_handle());
+}
+std::string oc_to_string(const LinkPtr& lptr)
+{
+	return oc_to_string(lptr, "");
 }
 
 } // ~namespace opencog
@@ -338,7 +338,7 @@ ostream& operator<<(ostream& out, const T& hs) { \
 	out << "size = " << hs.size() << endl; \
 	size_t i = 0; \
 	for (const opencog::Handle& h : hs) { \
-		out << "atom[" << i << "]:" << endl << h_to_string(h); \
+		out << "atom[" << i << "]:" << endl << oc_to_string(h); \
 		i++; \
 	} \
 	return out; \

--- a/opencog/atoms/base/Handle.h
+++ b/opencog/atoms/base/Handle.h
@@ -266,40 +266,40 @@ static inline std::string operator+ (const std::string &lhs, Handle h)
     return lhs + buff;
 }
 
-// Debugging helpers, very convenient to print Handle sets in gdb
-std::string h_to_string(const Handle& h);
-std::string hp_to_string(const HandlePair& hp);
-std::string hs_to_string(const HandleSeq& hs);
-std::string hss_to_string(const HandleSeqSeq& hss);
-std::string ohs_to_string(const HandleSet& ohs);
-std::string uhs_to_string(const UnorderedHandleSet& uhs);
-std::string hmap_to_string(const HandleMap& hm);
-std::string hmultimap_to_string(const HandleMultimap& hmm);
-std::string hmaps_to_string(const HandleMapSeq& hms);
-std::string hmapset_to_string(const HandleMapSet& hms);
-std::string hps_to_string(const HandlePairSeq& hps);
-std::string atomtype_to_string(Type type);
-std::string aptr_to_string(const AtomPtr& aptr);
-class Link;
-typedef std::shared_ptr<Link> LinkPtr;
-std::string lptr_to_string(const LinkPtr& lptr);
-
-// In case your gdb supports overloading, see
+// Debugging helpers see
 // http://wiki.opencog.org/w/Development_standards#Print_OpenCog_Objects
+// The reason indent is not an optional argument with default is
+// because gdb doesn't support that, see
+// http://stackoverflow.com/questions/16734783 for more explanation.
+std::string oc_to_string(const Handle& h, const std::string& indent);
 std::string oc_to_string(const Handle& h);
+std::string oc_to_string(const HandlePair& hp, const std::string& indent);
 std::string oc_to_string(const HandlePair& hp);
+std::string oc_to_string(const HandleSeq& hs, const std::string& indent);
 std::string oc_to_string(const HandleSeq& hs);
+std::string oc_to_string(const HandleSeqSeq& hss, const std::string& indent);
 std::string oc_to_string(const HandleSeqSeq& hss);
+std::string oc_to_string(const HandleSet& ohs, const std::string& indent);
 std::string oc_to_string(const HandleSet& ohs);
+std::string oc_to_string(const UnorderedHandleSet& uhs, const std::string& indent);
 std::string oc_to_string(const UnorderedHandleSet& uhs);
+std::string oc_to_string(const HandleMap& hm, const std::string& indent);
 std::string oc_to_string(const HandleMap& hm);
+std::string oc_to_string(const HandleMultimap& hmm, const std::string& indent);
 std::string oc_to_string(const HandleMultimap& hmm);
+std::string oc_to_string(const HandleMapSeq& hms, const std::string& indent);
 std::string oc_to_string(const HandleMapSeq& hms);
+std::string oc_to_string(const HandleMapSet& hms, const std::string& indent);
 std::string oc_to_string(const HandleMapSet& hms);
+std::string oc_to_string(const HandlePairSeq& hps, const std::string& indent);
 std::string oc_to_string(const HandlePairSeq& hps);
+std::string oc_to_string(const HandleCounter& hc, const std::string& indent);
 std::string oc_to_string(const HandleCounter& hc);
+std::string oc_to_string(const HandleUCounter& huc, const std::string& indent);
 std::string oc_to_string(const HandleUCounter& huc);
+std::string oc_to_string(Type type, const std::string& indent);
 std::string oc_to_string(Type type);
+std::string oc_to_string(const AtomPtr& aptr, const std::string& indent);
 std::string oc_to_string(const AtomPtr& aptr);
 
 } // namespace opencog

--- a/opencog/atoms/base/Handle.h
+++ b/opencog/atoms/base/Handle.h
@@ -271,6 +271,7 @@ static inline std::string operator+ (const std::string &lhs, Handle h)
 // The reason indent is not an optional argument with default is
 // because gdb doesn't support that, see
 // http://stackoverflow.com/questions/16734783 for more explanation.
+#define OC_TO_STRING_INDENT "  "
 std::string oc_to_string(const Handle& h, const std::string& indent);
 std::string oc_to_string(const Handle& h);
 std::string oc_to_string(const HandlePair& hp, const std::string& indent);

--- a/opencog/atoms/core/Context.cc
+++ b/opencog/atoms/core/Context.cc
@@ -116,33 +116,43 @@ bool ohs_content_eq(const HandleSet& lhs, const HandleSet& rhs)
 	return true;
 }
 
-std::string oc_to_string(const Context::VariablesStack& scope_variables)
+std::string oc_to_string(const Context::VariablesStack& scope_variables,
+                         const std::string& indent)
 {
 	std::stringstream ss;
-	ss << "size = " << scope_variables.size() << std::endl;
+	ss << indent << "size = " << scope_variables.size() << std::endl;
 	int i = 0;
 	for (const Variables& variables : scope_variables) {
-		ss << "variables[" << i++ << "]:" << std::endl
-		   << variables.to_string();
+		ss << indent << "variables[" << i++ << "]:" << std::endl
+		   << variables.to_string(indent + OC_TO_STRING_INDENT);
 	}
 	return ss.str();
 }
-
-std::string oc_to_string(const Context& c)
+std::string oc_to_string(const Context::VariablesStack& scope_variables)
+{
+	return oc_to_string(scope_variables, "");
+}
+std::string oc_to_string(const Context& c, const std::string& indent)
 {
 	std::stringstream ss;
 	if (c == Context()) {
-		ss << "none" << std::endl;
+		ss << indent << "none" << std::endl;
 	} else {
-		ss << "quotation: " << oc_to_string(c.quotation) << std::endl
-		   << "shadow:" << std::endl << oc_to_string(c.shadow);
-		ss << "scope_variables:" << std::endl;
+		ss << indent << "quotation: " << oc_to_string(c.quotation)
+		   << indent << "shadow:" << std::endl
+		   << oc_to_string(c.shadow, indent + OC_TO_STRING_INDENT);
+		ss << indent << "scope_variables:" << std::endl;
 		if (c.store_scope_variables)
-			ss << oc_to_string(c.scope_variables);
+			ss << oc_to_string(c.scope_variables,
+			                   indent + OC_TO_STRING_INDENT);
 		else
-			ss << "ignored" << std::endl;
+			ss << indent + OC_TO_STRING_INDENT << "ignored" << std::endl;
 	}
 	return ss.str();
+}
+std::string oc_to_string(const Context& c)
+{
+	return oc_to_string(c, "");
 }
 
 } // namespace opencog

--- a/opencog/atoms/core/Context.h
+++ b/opencog/atoms/core/Context.h
@@ -111,8 +111,12 @@ struct Context : public boost::totally_ordered<Context>
 // the default, until then this function is here for that.
 bool ohs_content_eq(const HandleSet& lhs, const HandleSet& rhs);
 
-// For gdb, see
+// Debugging helpers see
 // http://wiki.opencog.org/w/Development_standards#Print_OpenCog_Objects
+// The reason indent is not an optional argument with default is
+// because gdb doesn't support that, see
+// http://stackoverflow.com/questions/16734783 for more explanation.
+std::string oc_to_string(const Context& c, const std::string& indent);
 std::string oc_to_string(const Context& c);
 	
 /** @}*/

--- a/opencog/atoms/core/Quotation.cc
+++ b/opencog/atoms/core/Quotation.cc
@@ -96,9 +96,13 @@ std::string Quotation::to_string() const
 	return ss.str();
 }
 
-std::string oc_to_string(const Quotation& quotation)
+std::string oc_to_string(const Quotation& quotation, const std::string& indent)
 {
 	return quotation.to_string();
+}
+std::string oc_to_string(const Quotation& quotation)
+{
+	return oc_to_string(quotation, "");
 }
 	
 } // namespace opencog

--- a/opencog/atoms/core/Quotation.cc
+++ b/opencog/atoms/core/Quotation.cc
@@ -89,16 +89,17 @@ bool Quotation::operator==(const Quotation& quotation) const
 		and (_local_quote == quotation._local_quote);
 }
 
-std::string Quotation::to_string() const
+std::string Quotation::to_string(const std::string& indent) const
 {
 	std::stringstream ss;
-	ss << "{level = " << _quotation_level << ", local = " << _local_quote << "}";
+	ss << indent << "{level = " << _quotation_level
+	   << ", local = " << _local_quote << "}" << std::endl;
 	return ss.str();
 }
 
 std::string oc_to_string(const Quotation& quotation, const std::string& indent)
 {
-	return quotation.to_string();
+	return quotation.to_string(indent);
 }
 std::string oc_to_string(const Quotation& quotation)
 {

--- a/opencog/atoms/core/Quotation.h
+++ b/opencog/atoms/core/Quotation.h
@@ -89,7 +89,7 @@ public:
 	bool operator<(const Quotation& quotation) const;
 	bool operator==(const Quotation& quotation) const;
 
-	std::string to_string() const;
+	std::string to_string(const std::string& indent) const;
 };
 
 // Debugging helpers see

--- a/opencog/atoms/core/Quotation.h
+++ b/opencog/atoms/core/Quotation.h
@@ -92,8 +92,12 @@ public:
 	std::string to_string() const;
 };
 
-// For gdb, see
+// Debugging helpers see
 // http://wiki.opencog.org/w/Development_standards#Print_OpenCog_Objects
+// The reason indent is not an optional argument with default is
+// because gdb doesn't support that, see
+// http://stackoverflow.com/questions/16734783 for more explanation.
+std::string oc_to_string(const Quotation& quotation, const std::string& indent);
 std::string oc_to_string(const Quotation& quotation);
 	
 /** @}*/

--- a/opencog/atoms/core/VariableList.cc
+++ b/opencog/atoms/core/VariableList.cc
@@ -422,12 +422,17 @@ void VariableList::build_index(void)
 	}
 }
 
-std::string opencog::oc_to_string(const VariableListPtr& vlp)
+std::string opencog::oc_to_string(const VariableListPtr& vlp,
+                                  const std::string& indent)
 {
 	if (vlp == nullptr)
-		return "nullvariablelist\n";
+		return indent + "nullvariablelist\n";
 	else
-		return oc_to_string(vlp->get_handle());
+		return oc_to_string(vlp->get_handle(), indent);
+}
+std::string opencog::oc_to_string(const VariableListPtr& vlp)
+{
+	return oc_to_string(vlp, "");
 }
 
 DEFINE_LINK_FACTORY(VariableList, VARIABLE_LIST)

--- a/opencog/atoms/core/VariableList.h
+++ b/opencog/atoms/core/VariableList.h
@@ -100,8 +100,12 @@ static inline VariableListPtr VariableListCast(const AtomPtr& a)
 
 #define createVariableList std::make_shared<VariableList>
 
-// For gdb, see
+// Debugging helpers see
 // http://wiki.opencog.org/w/Development_standards#Print_OpenCog_Objects
+// The reason indent is not an optional argument with default is
+// because gdb doesn't support that, see
+// http://stackoverflow.com/questions/16734783 for more explanation.
+std::string oc_to_string(const VariableListPtr& vlp, const std::string& indent);
 std::string oc_to_string(const VariableListPtr& vlp);
 
 /** @}*/

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -776,22 +776,23 @@ Handle Variables::get_vardecl() const
 	return Handle(createVariableList(vars));
 }
 
-std::string Variables::to_string() const
+std::string Variables::to_string(const std::string& indent) const
 {
 	std::stringstream ss;
 
 	// Varseq
-	ss << "varseq:" << std::endl << oc_to_string(varseq);
+	ss << indent << "varseq:" << std::endl
+	   << oc_to_string(varseq, indent + OC_TO_STRING_INDENT);
 
 	// Simple typemap
-	ss << "_simple_typemap:" << std::endl;
-	ss << "size = " << _simple_typemap.size() << std::endl;
+	ss << indent << "_simple_typemap:" << std::endl;
+	ss << indent << "size = " << _simple_typemap.size() << std::endl;
 	unsigned i = 0;
 	for (const auto& v : _simple_typemap)
 	{
-		ss << "variable[" << i << "]:" << std::endl
-			<< oc_to_string(v.first)
-		   << "types[" << i << "]:";
+		ss << indent << "variable[" << i << "]:" << std::endl
+		   << oc_to_string(v.first, indent + OC_TO_STRING_INDENT)
+		   << indent << "types[" << i << "]:";
 		for (auto& t : v.second)
 			ss << " " << classserver().getTypeName(t);
 		ss << std::endl;
@@ -802,7 +803,7 @@ std::string Variables::to_string() const
 
 std::string oc_to_string(const Variables& var, const std::string& indent)
 {
-	return var.to_string();
+	return var.to_string(indent);
 }
 std::string oc_to_string(const Variables& var)
 {

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -790,7 +790,7 @@ std::string Variables::to_string() const
 	for (const auto& v : _simple_typemap)
 	{
 		ss << "variable[" << i << "]:" << std::endl
-			<< h_to_string(v.first)
+			<< oc_to_string(v.first)
 		   << "types[" << i << "]:";
 		for (auto& t : v.second)
 			ss << " " << classserver().getTypeName(t);
@@ -800,9 +800,13 @@ std::string Variables::to_string() const
 	return ss.str();
 }
 
-std::string oc_to_string(const Variables& var)
+std::string oc_to_string(const Variables& var, const std::string& indent)
 {
 	return var.to_string();
+}
+std::string oc_to_string(const Variables& var)
+{
+	return oc_to_string(var, "");
 }
 
 } // ~namespace opencog

--- a/opencog/atoms/core/Variables.h
+++ b/opencog/atoms/core/Variables.h
@@ -272,8 +272,12 @@ struct Variables : public FreeVariables,
 	std::string to_string() const;
 };
 
-// For gdb, see
+// Debugging helpers see
 // http://wiki.opencog.org/w/Development_standards#Print_OpenCog_Objects
+// The reason indent is not an optional argument with default is
+// because gdb doesn't support that, see
+// http://stackoverflow.com/questions/16734783 for more explanation.
+std::string oc_to_string(const Variables& var, const std::string& indent);
 std::string oc_to_string(const Variables& var);
 
 /** @}*/

--- a/opencog/atoms/core/Variables.h
+++ b/opencog/atoms/core/Variables.h
@@ -269,7 +269,7 @@ struct Variables : public FreeVariables,
 	Handle get_vardecl() const;
 
 	// Useful for debugging
-	std::string to_string() const;
+	std::string to_string(const std::string& indent="") const;
 };
 
 // Debugging helpers see

--- a/opencog/atoms/pattern/CMakeLists.txt
+++ b/opencog/atoms/pattern/CMakeLists.txt
@@ -8,6 +8,7 @@ ADD_LIBRARY (lambda
 	PatternLink.cc
 	PatternTerm.cc
 	PatternUtils.cc
+    Pattern.cc
 )
 
 # Without this, parallel make will race and crap up the generated files.

--- a/opencog/atoms/pattern/Pattern.cc
+++ b/opencog/atoms/pattern/Pattern.cc
@@ -1,0 +1,74 @@
+/*
+ * Pattern.cc
+ *
+ * Copyright (C) 2018 OpenCog Foundation
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "Pattern.h"
+
+namespace opencog {
+
+std::string Pattern::to_string(const std::string& indent) const
+{
+	std::stringstream ss;
+	if (not clauses.empty())
+		ss << indent << "clauses:" << std::endl
+		   << oc_to_string(clauses, indent + OC_TO_STRING_INDENT);
+	if (not constants.empty())
+		ss << indent << "constants:" << std::endl
+		   << oc_to_string(constants, indent + OC_TO_STRING_INDENT);
+	if (not mandatory.empty())
+		ss << indent << "mandatory:" << std::endl
+		   << oc_to_string(mandatory, indent + OC_TO_STRING_INDENT);
+	if (not optionals.empty())
+		ss << indent << "optionals:" << std::endl
+		   << oc_to_string(optionals, indent + OC_TO_STRING_INDENT);
+	if (not black.empty())
+		ss << indent << "black:" << std::endl
+		   << oc_to_string(black, indent + OC_TO_STRING_INDENT);
+	if (not evaluatable_terms.empty())
+		ss << indent << "evaluatable_terms:" << std::endl
+		   << oc_to_string(evaluatable_terms,
+		                   indent + OC_TO_STRING_INDENT);
+	if (not evaluatable_holders.empty())
+		ss << indent << "evaluatable_holders:" << std::endl
+		   << oc_to_string(evaluatable_holders,
+		                   indent + OC_TO_STRING_INDENT);
+	if (not executable_terms.empty())
+		ss << indent << "executable_terms:" << std::endl
+		   << oc_to_string(executable_terms,
+		                   indent + OC_TO_STRING_INDENT);
+	if (not executable_holders.empty())
+		ss << indent << "executable_holders:" << std::endl
+		   << oc_to_string(executable_holders,
+		                   indent + OC_TO_STRING_INDENT);
+	return ss.str();
+}
+
+// For gdb, see
+// http://wiki.opencog.org/w/Development_standards#Print_OpenCog_Objects
+std::string oc_to_string(const Pattern& pattern, const std::string& indent)
+{
+	return pattern.to_string(indent);
+}
+std::string oc_to_string(const Pattern& pattern)
+{
+	return oc_to_string(pattern, "");
+}
+
+} // ~namespace opencog

--- a/opencog/atoms/pattern/Pattern.h
+++ b/opencog/atoms/pattern/Pattern.h
@@ -141,33 +141,34 @@ struct Pattern
 	{
 		std::stringstream ss;
 		if (not clauses.empty())
-			ss << "clauses:" << std::endl << hs_to_string(clauses);
+			ss << "clauses:" << std::endl << oc_to_string(clauses);
 		if (not constants.empty())
-			ss << "constants:" << std::endl << hs_to_string(constants);
+			ss << "constants:" << std::endl << oc_to_string(constants);
 		if (not mandatory.empty())
-			ss << "mandatory:" << std::endl << hs_to_string(mandatory);
+			ss << "mandatory:" << std::endl << oc_to_string(mandatory);
 		if (not optionals.empty())
-			ss << "optionals:" << std::endl << ohs_to_string(optionals);
+			ss << "optionals:" << std::endl << oc_to_string(optionals);
 		if (not black.empty())
-			ss << "black:" << std::endl << ohs_to_string(black);
+			ss << "black:" << std::endl << oc_to_string(black);
 		if (not evaluatable_terms.empty())
 			ss << "evaluatable_terms:" << std::endl
-			   << ohs_to_string(evaluatable_terms);
+			   << oc_to_string(evaluatable_terms);
 		if (not evaluatable_holders.empty())
 			ss << "evaluatable_holders:" << std::endl
-			   << ohs_to_string(evaluatable_holders);
+			   << oc_to_string(evaluatable_holders);
 		if (not executable_terms.empty())
 			ss << "executable_terms:" << std::endl
-			   << ohs_to_string(executable_terms);
+			   << oc_to_string(executable_terms);
 		if (not executable_holders.empty())
 			ss << "executable_holders:" << std::endl
-			   << ohs_to_string(executable_holders);
+			   << oc_to_string(executable_holders);
 		return ss.str();
 	}
 };
 
 // For gdb, see
 // http://wiki.opencog.org/w/Development_standards#Print_OpenCog_Objects
+std::string oc_to_string(const Pattern&, const std::string& indent);
 std::string oc_to_string(const Pattern&);
 
 /** @}*/

--- a/opencog/atoms/pattern/Pattern.h
+++ b/opencog/atoms/pattern/Pattern.h
@@ -137,39 +137,13 @@ struct Pattern
 
 	ConnectTermMap   connected_terms_map;  // setup by make_term_trees()
 
-	std::string to_string() const
-	{
-		std::stringstream ss;
-		if (not clauses.empty())
-			ss << "clauses:" << std::endl << oc_to_string(clauses);
-		if (not constants.empty())
-			ss << "constants:" << std::endl << oc_to_string(constants);
-		if (not mandatory.empty())
-			ss << "mandatory:" << std::endl << oc_to_string(mandatory);
-		if (not optionals.empty())
-			ss << "optionals:" << std::endl << oc_to_string(optionals);
-		if (not black.empty())
-			ss << "black:" << std::endl << oc_to_string(black);
-		if (not evaluatable_terms.empty())
-			ss << "evaluatable_terms:" << std::endl
-			   << oc_to_string(evaluatable_terms);
-		if (not evaluatable_holders.empty())
-			ss << "evaluatable_holders:" << std::endl
-			   << oc_to_string(evaluatable_holders);
-		if (not executable_terms.empty())
-			ss << "executable_terms:" << std::endl
-			   << oc_to_string(executable_terms);
-		if (not executable_holders.empty())
-			ss << "executable_holders:" << std::endl
-			   << oc_to_string(executable_holders);
-		return ss.str();
-	}
+	std::string to_string(const std::string& indent) const;
 };
 
 // For gdb, see
 // http://wiki.opencog.org/w/Development_standards#Print_OpenCog_Objects
-std::string oc_to_string(const Pattern&, const std::string& indent);
-std::string oc_to_string(const Pattern&);
+std::string oc_to_string(const Pattern& pattern, const std::string& indent);
+std::string oc_to_string(const Pattern& pattern);
 
 /** @}*/
 } // namespace opencog

--- a/opencog/atoms/pattern/PatternTerm.cc
+++ b/opencog/atoms/pattern/PatternTerm.cc
@@ -140,13 +140,21 @@ std::string PatternTerm::to_string(std::string indent) const
 	return str;
 }
 
+std::string oc_to_string(const PatternTerm& pt, const std::string& indent)
+{
+	return pt.to_string(indent);
+}
 std::string oc_to_string(const PatternTerm& pt)
 {
-	return pt.to_string();
+	return oc_to_string(pt, "");
+}
+std::string oc_to_string(const PatternTermPtr& pt_ptr, const std::string& indent)
+{
+	return pt_ptr->to_string();
 }
 std::string oc_to_string(const PatternTermPtr& pt_ptr)
 {
-	return pt_ptr->to_string();
+	return oc_to_string(pt_ptr, "");
 }
 
 } // ~namespace opencog

--- a/opencog/atoms/pattern/PatternTerm.h
+++ b/opencog/atoms/pattern/PatternTerm.h
@@ -135,7 +135,9 @@ public:
 
 // For gdb, see
 // http://wiki.opencog.org/w/Development_standards#Print_OpenCog_Objects
+std::string oc_to_string(const PatternTerm& pt, const std::string& indent);
 std::string oc_to_string(const PatternTerm& pt);
+std::string oc_to_string(const PatternTermPtr& pt, const std::string& indent);
 std::string oc_to_string(const PatternTermPtr& pt_ptr);
 
 } // namespace opencog

--- a/opencog/query/PatternMatch.cc
+++ b/opencog/query/PatternMatch.cc
@@ -474,11 +474,4 @@ bool PatternLink::satisfy(PatternMatchCallback& pmcb) const
 	                                       comp_var_gnds, comp_term_gnds);
 }
 
-// For gdb, see
-// http://wiki.opencog.org/w/Development_standards#Print_OpenCog_Objects
-std::string oc_to_string(const Pattern& pattern)
-{
-	return pattern.to_string();
-}
-
 /* ===================== END OF FILE ===================== */

--- a/opencog/rule-engine/Rule.cc
+++ b/opencog/rule-engine/Rule.cc
@@ -562,12 +562,15 @@ Rule Rule::substituted(const Unify::TypedSubstitution& ts) const
 	return new_rule;
 }
 
-std::string oc_to_string(const Rule& rule)
+std::string oc_to_string(const Rule& rule, const std::string& indent)
 {
 	return rule.to_string();
 }
-
-std::string oc_to_string(const RuleSet& rules)
+std::string oc_to_string(const Rule& rule)
+{
+	return oc_to_string(rule, "");
+}
+std::string oc_to_string(const RuleSet& rules, const std::string& indent)
 {
 	std::stringstream ss;
 	ss << "size = " << rules.size() << std::endl;
@@ -577,8 +580,12 @@ std::string oc_to_string(const RuleSet& rules)
 		   << oc_to_string(rule) << std::endl;
 	return ss.str();
 }
-
-std::string oc_to_string(const RuleTypedSubstitutionPair& rule_ts)
+std::string oc_to_string(const RuleSet& rules)
+{
+	return oc_to_string(rules, "");
+}
+std::string oc_to_string(const RuleTypedSubstitutionPair& rule_ts,
+                         const std::string& indent)
 {
 	std::stringstream ss;
 	ss << "rule:" << std::endl << oc_to_string(rule_ts.first) << std::endl;
@@ -586,8 +593,12 @@ std::string oc_to_string(const RuleTypedSubstitutionPair& rule_ts)
 	   << oc_to_string(rule_ts.second) << std::endl;
 	return ss.str();
 }
-
-std::string oc_to_string(const RuleTypedSubstitutionMap& rules)
+std::string oc_to_string(const RuleTypedSubstitutionPair& rule_ts)
+{
+	return oc_to_string(rule_ts, "");
+}
+std::string oc_to_string(const RuleTypedSubstitutionMap& rules,
+                         const std::string& indent)
 {
 	std::stringstream ss;
 	ss << "size = " << rules.size() << std::endl;
@@ -596,6 +607,10 @@ std::string oc_to_string(const RuleTypedSubstitutionMap& rules)
 		ss << "rule[" << i++ << "]:" << std::endl
 		   << oc_to_string(rule) << std::endl;
 	return ss.str();
+}
+std::string oc_to_string(const RuleTypedSubstitutionMap& rules)
+{
+	return oc_to_string(rules, "");
 }
 
 } // ~namespace opencog

--- a/opencog/rule-engine/Rule.cc
+++ b/opencog/rule-engine/Rule.cc
@@ -446,11 +446,12 @@ Handle Rule::apply(AtomSpace& as) const
 	return bindlink(&as, Handle(_rule));
 }
 
-std::string Rule::to_string() const
+std::string Rule::to_string(const std::string& indent) const
 {
 	std::stringstream ss;
-	ss << "name: " << _name << std::endl
-	   << "rule:" << std::endl << _rule->to_string();
+	ss << indent << "name: " << _name << std::endl
+	   << indent << "rule:" << std::endl
+	   << _rule->to_string(indent + OC_TO_STRING_INDENT);
 	return ss.str();
 }
 
@@ -564,7 +565,7 @@ Rule Rule::substituted(const Unify::TypedSubstitution& ts) const
 
 std::string oc_to_string(const Rule& rule, const std::string& indent)
 {
-	return rule.to_string();
+	return rule.to_string(indent);
 }
 std::string oc_to_string(const Rule& rule)
 {
@@ -573,11 +574,11 @@ std::string oc_to_string(const Rule& rule)
 std::string oc_to_string(const RuleSet& rules, const std::string& indent)
 {
 	std::stringstream ss;
-	ss << "size = " << rules.size() << std::endl;
+	ss << indent << "size = " << rules.size() << std::endl;
 	size_t i = 0;
 	for (const Rule& rule : rules)
-		ss << "rule[" << i++ << "]:" << std::endl
-		   << oc_to_string(rule) << std::endl;
+		ss << indent << "rule[" << i++ << "]:" << std::endl
+		   << oc_to_string(rule, indent + OC_TO_STRING_INDENT) << std::endl;
 	return ss.str();
 }
 std::string oc_to_string(const RuleSet& rules)
@@ -588,9 +589,12 @@ std::string oc_to_string(const RuleTypedSubstitutionPair& rule_ts,
                          const std::string& indent)
 {
 	std::stringstream ss;
-	ss << "rule:" << std::endl << oc_to_string(rule_ts.first) << std::endl;
-	ss << "typed substitutions:" << std::endl
-	   << oc_to_string(rule_ts.second) << std::endl;
+	ss << indent << "rule:" << std::endl
+	   << oc_to_string(rule_ts.first, indent + OC_TO_STRING_INDENT)
+	   << std::endl;
+	ss << indent << "typed substitutions:" << std::endl
+	   << oc_to_string(rule_ts.second, indent + OC_TO_STRING_INDENT)
+	   << std::endl;
 	return ss.str();
 }
 std::string oc_to_string(const RuleTypedSubstitutionPair& rule_ts)
@@ -601,11 +605,12 @@ std::string oc_to_string(const RuleTypedSubstitutionMap& rules,
                          const std::string& indent)
 {
 	std::stringstream ss;
-	ss << "size = " << rules.size() << std::endl;
+	ss << indent << "size = " << rules.size() << std::endl;
 	size_t i = 0;
 	for (const RuleTypedSubstitutionPair& rule : rules)
-		ss << "rule[" << i++ << "]:" << std::endl
-		   << oc_to_string(rule) << std::endl;
+		ss << indent << "rule[" << i++ << "]:" << std::endl
+		   << oc_to_string(rule, indent + OC_TO_STRING_INDENT)
+		   << std::endl;
 	return ss.str();
 }
 std::string oc_to_string(const RuleTypedSubstitutionMap& rules)

--- a/opencog/rule-engine/Rule.h
+++ b/opencog/rule-engine/Rule.h
@@ -252,7 +252,7 @@ public:
 	 */
 	Handle apply(AtomSpace& as) const;
 
-	std::string to_string() const;
+	std::string to_string(const std::string& indent="") const;
 
 	// This flag allows to only sonsider the Rule clauses as
 	// premises. This is for backward compatibility with some rule

--- a/opencog/rule-engine/Rule.h
+++ b/opencog/rule-engine/Rule.h
@@ -303,11 +303,18 @@ private:
 	Rule substituted(const Unify::TypedSubstitution& ts) const;
 };
 
-// For Gdb debugging, see
+// Debugging helpers see
 // http://wiki.opencog.org/w/Development_standards#Print_OpenCog_Objects
+// The reason indent is not an optional argument with default is
+// because gdb doesn't support that, see
+// http://stackoverflow.com/questions/16734783 for more explanation.
+std::string oc_to_string(const Rule& rule, const std::string& indent);
 std::string oc_to_string(const Rule& rule);
+std::string oc_to_string(const RuleSet& rules, const std::string& indent);
 std::string oc_to_string(const RuleSet& rules);
+std::string oc_to_string(const RuleTypedSubstitutionPair& rule_ts_pair, const std::string& indent);
 std::string oc_to_string(const RuleTypedSubstitutionPair& rule_ts_pair);
+std::string oc_to_string(const RuleTypedSubstitutionMap& rule_ts_map, const std::string& indent);
 std::string oc_to_string(const RuleTypedSubstitutionMap& rule_ts_map);
 
 } // ~namespace opencog

--- a/opencog/rule-engine/backwardchainer/ActionSelection.cc
+++ b/opencog/rule-engine/backwardchainer/ActionSelection.cc
@@ -84,14 +84,17 @@ double ActionSelection::Pi(size_t i,
 	return result;
 }
 
-std::string oc_to_string(const ActionSelection& asel)
+std::string oc_to_string(const ActionSelection& asel, const std::string& indent)
 {
 	std::stringstream ss;
 	ss << "action2tv:" << std::endl << oc_to_string(asel.action2tv);
 	return ss.str();
 }
-
-std::string oc_to_string(const HandleTVMap& h2tv)
+std::string oc_to_string(const ActionSelection& asel)
+{
+	return oc_to_string(asel, "");
+}
+std::string oc_to_string(const HandleTVMap& h2tv, const std::string& indent)
 {
 	std::stringstream ss;
 	ss << "size = " << h2tv.size() << std::endl;
@@ -101,6 +104,10 @@ std::string oc_to_string(const HandleTVMap& h2tv)
 		ss << "tv[" << i << "]:" << oc_to_string(htv.second) << std::endl;
 	}
 	return ss.str();
+}
+std::string oc_to_string(const HandleTVMap& h2tv)
+{
+	return oc_to_string(h2tv, "");
 }
 
 } // ~namespace opencog

--- a/opencog/rule-engine/backwardchainer/ActionSelection.cc
+++ b/opencog/rule-engine/backwardchainer/ActionSelection.cc
@@ -87,7 +87,8 @@ double ActionSelection::Pi(size_t i,
 std::string oc_to_string(const ActionSelection& asel, const std::string& indent)
 {
 	std::stringstream ss;
-	ss << "action2tv:" << std::endl << oc_to_string(asel.action2tv);
+	ss << indent << "action2tv:" << std::endl
+	   << oc_to_string(asel.action2tv, indent + OC_TO_STRING_INDENT);
 	return ss.str();
 }
 std::string oc_to_string(const ActionSelection& asel)
@@ -97,11 +98,13 @@ std::string oc_to_string(const ActionSelection& asel)
 std::string oc_to_string(const HandleTVMap& h2tv, const std::string& indent)
 {
 	std::stringstream ss;
-	ss << "size = " << h2tv.size() << std::endl;
+	ss << indent << "size = " << h2tv.size() << std::endl;
 	int i = 0;
 	for (const auto& htv : h2tv) {
-		ss << "atom[" << i << "]:" << std::endl << oc_to_string(htv.first);
-		ss << "tv[" << i << "]:" << oc_to_string(htv.second) << std::endl;
+		ss << indent << "atom[" << i << "]:" << std::endl
+		   << oc_to_string(htv.first, indent + OC_TO_STRING_INDENT);
+		ss << indent << "tv[" << i << "]:"
+		   << oc_to_string(htv.second) << std::endl;
 	}
 	return ss.str();
 }

--- a/opencog/rule-engine/backwardchainer/ActionSelection.h
+++ b/opencog/rule-engine/backwardchainer/ActionSelection.h
@@ -82,7 +82,14 @@ private:
 	double Pi(size_t i, const std::vector<std::vector<double>>& cdfs) const;
 };
 
+// Debugging helpers see
+// http://wiki.opencog.org/w/Development_standards#Print_OpenCog_Objects
+// The reason indent is not an optional argument with default is
+// because gdb doesn't support that, see
+// http://stackoverflow.com/questions/16734783 for more explanation.
+std::string	oc_to_string(const ActionSelection& asel, const std::string& indent);
 std::string	oc_to_string(const ActionSelection& asel);
+std::string	oc_to_string(const HandleTVMap& h2tv, const std::string& indent);
 std::string	oc_to_string(const HandleTVMap& h2tv);
 
 } // namespace opencog

--- a/opencog/rule-engine/backwardchainer/BIT.cc
+++ b/opencog/rule-engine/backwardchainer/BIT.cc
@@ -64,14 +64,15 @@ double BITNode::operator()() const
 		(fitness.upper - fitness(*this)) / (fitness.upper - fitness.lower);
 }
 
-std::string	BITNode::to_string() const
+std::string	BITNode::to_string(const std::string& indent) const
 {
 	std::stringstream ss;
-	ss << "body:" << std::endl << oc_to_string(body)
-	   << "exhausted: " << exhausted << std::endl
-	   << "rules: size = " << rules.size();
+	ss << indent << "body:" << std::endl
+	   << oc_to_string(body, indent + OC_TO_STRING_INDENT)
+	   << indent << "exhausted: " << exhausted << std::endl
+	   << indent << "rules: size = " << rules.size();
 	for (const auto& rule : rules)
-		ss << std::endl << rule.first.get_name()
+		ss << std::endl << indent << rule.first.get_name()
 		   << " " << rule.first.get_rule()->id_to_string();
 	return ss.str();
 }
@@ -222,9 +223,9 @@ bool AndBIT::operator<(const AndBIT& andbit) const
 		    and content_based_handle_less()(fcs, andbit.fcs));
 }
 
-std::string AndBIT::to_string() const
+std::string AndBIT::to_string(const std::string& indent) const
 {
-	return oc_to_string(fcs);
+	return oc_to_string(fcs, indent);
 }
 
 std::string AndBIT::fcs_to_ascii_art(const Handle& nfcs) const
@@ -737,14 +738,22 @@ bool BIT::is_in(const RuleTypedSubstitutionPair& rule,
 	return false;
 }
 
+std::string oc_to_string(const BITNode& bitnode, const std::string& indent)
+{
+	return bitnode.to_string(indent);
+}
 std::string oc_to_string(const BITNode& bitnode)
 {
-	return bitnode.to_string();
+	return oc_to_string(bitnode, "");
 }
 
+std::string oc_to_string(const AndBIT& andbit, const std::string& indent)
+{
+	return andbit.to_string(indent);
+}
 std::string oc_to_string(const AndBIT& andbit)
 {
-	return andbit.to_string();
+	return oc_to_string(andbit, "");
 }
 
 // std::string oc_to_string(const BIT& bit)

--- a/opencog/rule-engine/backwardchainer/BIT.h
+++ b/opencog/rule-engine/backwardchainer/BIT.h
@@ -69,7 +69,7 @@ public:
 	// TODO: Maybe this should be moved to BackwardChainer
 	double operator()() const;
 
-	std::string to_string() const;
+	std::string to_string(const std::string& indent="") const;
 };
 
 /**
@@ -166,7 +166,7 @@ public:
 	bool operator==(const AndBIT& andbit) const;
 	bool operator<(const AndBIT& andbit) const;
 
-	std::string to_string() const;
+	std::string to_string(const std::string& indent="") const;
 
 	/**
 	 * Print the inference tree of a given FCS in ascii art.
@@ -459,7 +459,9 @@ BIT::AndBITs::iterator BIT::erase(It pos)
 
 // Gdb debugging, see
 // http://wiki.opencog.org/w/Development_standards#Print_OpenCog_Objects
+std::string oc_to_string(const BITNode& bitnode, const std::string& indent);
 std::string oc_to_string(const BITNode& bitnode);
+std::string oc_to_string(const AndBIT& andbit, const std::string& indent);
 std::string oc_to_string(const AndBIT& andbit);
 // std::string oc_to_string(const BIT& bit);
 

--- a/opencog/rule-engine/backwardchainer/BetaDistribution.cc
+++ b/opencog/rule-engine/backwardchainer/BetaDistribution.cc
@@ -126,9 +126,13 @@ TruthValuePtr mk_stv(double mean, double variance,
 	return SimpleTruthValue::createTV(mode, confidence);
 }
 
-std::string oc_to_string(const BetaDistribution& bd)
+std::string oc_to_string(const BetaDistribution& bd, const std::string& indent)
 {
 	return bd.to_string();
+}
+std::string oc_to_string(const BetaDistribution& bd)
+{
+	return oc_to_string(bd, "");
 }
 
 } // ~namespace opencog

--- a/opencog/rule-engine/backwardchainer/BetaDistribution.cc
+++ b/opencog/rule-engine/backwardchainer/BetaDistribution.cc
@@ -74,10 +74,10 @@ double BetaDistribution::pd(double x) const
 	return boost::math::pdf(_beta_distribution, x);
 }
 
-std::string BetaDistribution::to_string() const
+std::string BetaDistribution::to_string(const std::string& indent) const
 {
 	std::stringstream ss;
-	ss << "alpha = " << alpha()
+	ss << indent << "alpha = " << alpha()
 	   << ", beta = " << beta()
 	   << ", mean = " << mean()
 	   << ", variance = " << variance() << std::endl;
@@ -128,7 +128,7 @@ TruthValuePtr mk_stv(double mean, double variance,
 
 std::string oc_to_string(const BetaDistribution& bd, const std::string& indent)
 {
-	return bd.to_string();
+	return bd.to_string(indent);
 }
 std::string oc_to_string(const BetaDistribution& bd)
 {

--- a/opencog/rule-engine/backwardchainer/BetaDistribution.h
+++ b/opencog/rule-engine/backwardchainer/BetaDistribution.h
@@ -98,6 +98,12 @@ BetaDistribution mk_beta_distribution(const TruthValuePtr& tv);
 TruthValuePtr mk_stv(double mean, double variance,
                      double prior_alpha=1.0, double prior_beta=1.0);
 
+// Debugging helpers see
+// http://wiki.opencog.org/w/Development_standards#Print_OpenCog_Objects
+// The reason indent is not an optional argument with default is
+// because gdb doesn't support that, see
+// http://stackoverflow.com/questions/16734783 for more explanation.
+std::string oc_to_string(const BetaDistribution& bd, const std::string& indent);
 std::string oc_to_string(const BetaDistribution& bd);
 
 } // namespace opencog

--- a/opencog/rule-engine/backwardchainer/BetaDistribution.h
+++ b/opencog/rule-engine/backwardchainer/BetaDistribution.h
@@ -86,7 +86,7 @@ public:
 	 */
 	double pd(double x) const;
 
-	std::string to_string() const;
+	std::string to_string(const std::string& indent) const;
 
 private:
 	boost::math::beta_distribution<double> _beta_distribution;

--- a/opencog/truthvalue/TruthValue.cc
+++ b/opencog/truthvalue/TruthValue.cc
@@ -182,11 +182,15 @@ TruthValuePtr TruthValue::factory(const ProtoAtomPtr& pap)
 	return nullptr;
 }
 
-std::string oc_to_string(TruthValuePtr tv)
+std::string oc_to_string(TruthValuePtr tv, const std::string& indent)
 {
 	if (tv)
 		return tv->to_string();
 	return "none";
+}
+std::string oc_to_string(TruthValuePtr tv)
+{
+	return oc_to_string(tv, "");
 }
 
 } // ~namespace opencog

--- a/opencog/truthvalue/TruthValue.h
+++ b/opencog/truthvalue/TruthValue.h
@@ -180,8 +180,12 @@ static inline ProtoAtomPtr ProtoAtomCast(const TruthValuePtr& tv)
     return std::shared_ptr<ProtoAtom>(tv, (ProtoAtom*) tv.get());
 }
 
-// Convenient for gdb debugging, see
-// https://wiki.opencog.org/w/Development_standards#Print_OpenCog_Objects
+// Debugging helpers see
+// http://wiki.opencog.org/w/Development_standards#Print_OpenCog_Objects
+// The reason indent is not an optional argument with default is
+// because gdb doesn't support that, see
+// http://stackoverflow.com/questions/16734783 for more explanation.
+std::string oc_to_string(TruthValuePtr tv, const std::string& indent);
 std::string oc_to_string(TruthValuePtr tv);
 
 } // namespace opencog

--- a/opencog/unify/Unify.cc
+++ b/opencog/unify/Unify.cc
@@ -997,135 +997,145 @@ Handle merge_vardecl(const Handle& lhs_vardecl, const Handle& rhs_vardecl)
 	return new_vars.get_vardecl();
 }
 
-std::string oc_to_string(const Unify::CHandle& ch)
+std::string oc_to_string(const Unify::CHandle& ch, const std::string& indent)
 {
 	std::stringstream ss;
-	ss << "context:" << std::endl << oc_to_string(ch.context)
-	   << "atom:" << std::endl << oc_to_string(ch.handle);
+	ss << indent << "context:" << std::endl
+	   << oc_to_string(ch.context, indent + OC_TO_STRING_INDENT)
+	   << indent << "atom:" << std::endl
+	   << oc_to_string(ch.handle, indent + OC_TO_STRING_INDENT);
 	return ss.str();
 }
-std::string oc_to_string(const Unify::CHandle& ch, const std::string& indent)
+std::string oc_to_string(const Unify::CHandle& ch)
 {
 	return oc_to_string(ch, "");
 }
 
-std::string oc_to_string(const Unify::Block& pb)
+std::string oc_to_string(const Unify::Block& pb, const std::string& indent)
 {
 	std::stringstream ss;
-	ss << "size = " << pb.size() << std::endl;
+	ss << indent << "size = " << pb.size() << std::endl;
 	int i = 0;
 	for (const auto& el : pb)
-		ss << "catom[" << i++ << "]:" << std::endl << oc_to_string(el);
+		ss << indent << "catom[" << i++ << "]:" << std::endl
+		   << oc_to_string(el, indent + OC_TO_STRING_INDENT);
 	return ss.str();
 }
-std::string oc_to_string(const Unify::Block& pb, const std::string& indent)
+std::string oc_to_string(const Unify::Block& pb)
 {
 	return oc_to_string(pb, "");
 }
 
-std::string oc_to_string(const Unify::TypedBlock& tb)
+std::string oc_to_string(const Unify::TypedBlock& tb, const std::string& indent)
 {
 	std::stringstream ss;
-	ss << "block:" << std::endl << oc_to_string(tb.first)
-	   << "type:" << std::endl << oc_to_string(tb.second);
+	ss << indent << "block:" << std::endl
+	   << oc_to_string(tb.first, indent + OC_TO_STRING_INDENT)
+	   << indent << "type:" << std::endl
+	   << oc_to_string(tb.second, indent + OC_TO_STRING_INDENT);
 	return ss.str();
 }
-std::string oc_to_string(const Unify::TypedBlock& tb, const std::string& indent)
+std::string oc_to_string(const Unify::TypedBlock& tb)
 {
 	return oc_to_string(tb, "");
 }
 
-std::string oc_to_string(const Unify::TypedBlockSeq& tbs)
+std::string oc_to_string(const Unify::TypedBlockSeq& tbs, const std::string& indent)
 {
 	std::stringstream ss;
-	ss << "size = " << tbs.size() << std::endl;
+	ss << indent << "size = " << tbs.size() << std::endl;
 	for (size_t i = 0; i < tbs.size(); i++)
-		ss << "typed block[" << i << "]:" << std::endl
-		   << oc_to_string(tbs[i]);
+		ss << indent << "typed block[" << i << "]:" << std::endl
+		   << oc_to_string(tbs[i], indent + OC_TO_STRING_INDENT);
 	return ss.str();
 }
-std::string oc_to_string(const Unify::TypedBlockSeq& tbs, const std::string& indent)
+std::string oc_to_string(const Unify::TypedBlockSeq& tbs)
 {
 	return oc_to_string(tbs, "");
 }
 
-std::string oc_to_string(const Unify::Partition& up)
+std::string oc_to_string(const Unify::Partition& up, const std::string& indent)
 {
 	std::stringstream ss;
-	ss << "size = " << up.size() << std::endl;
+	ss << indent << "size = " << up.size() << std::endl;
 	int i = 0;
 	for (const auto& p : up) {
-		ss << "block[" << i << "]:" << std::endl << oc_to_string(p.first)
-		   << "type[" << i << "]:" << std::endl << oc_to_string(p.second);
+		ss << indent << "block[" << i << "]:" << std::endl
+		   << oc_to_string(p.first, indent + OC_TO_STRING_INDENT)
+		   << indent << "type[" << i << "]:" << std::endl
+		   << oc_to_string(p.second, indent + OC_TO_STRING_INDENT);
 		i++;
 	}
 	return ss.str();
 }
-std::string oc_to_string(const Unify::Partition& up, const std::string& indent)
+std::string oc_to_string(const Unify::Partition& up)
 {
 	return oc_to_string(up, "");
 }
 
-std::string oc_to_string(const Unify::Partitions& par)
+std::string oc_to_string(const Unify::Partitions& par, const std::string& indent)
 {
 	std::stringstream ss;
-	ss << "size = " << par.size() << std::endl;
+	ss << indent << "size = " << par.size() << std::endl;
 	int i = 0;
 	for (const auto& el : par) {
-		ss << "typed partition[" << i << "]:" << std::endl << oc_to_string(el);
+		ss << indent << "typed partition[" << i << "]:"
+		   << std::endl << oc_to_string(el, indent + OC_TO_STRING_INDENT);
 		i++;
 	}
 	return ss.str();
 }
-std::string oc_to_string(const Unify::Partitions& par, const std::string& indent)
+std::string oc_to_string(const Unify::Partitions& par)
 {
 	return oc_to_string(par, "");
 }
 
-std::string oc_to_string(const Unify::HandleCHandleMap& hchm)
+std::string oc_to_string(const Unify::HandleCHandleMap& hchm, const std::string& indent)
 {
 	std::stringstream ss;
-	ss << "size = " << hchm.size() << std::endl;
+	ss << indent << "size = " << hchm.size() << std::endl;
 	int i = 0;
 	for (const auto& hch : hchm) {
-		ss << "atom[" << i << "]:" << std::endl
-		   << oc_to_string(hch.first);
-		ss << "catom[" << i << "]:" << std::endl
-		   << oc_to_string(hch.second);
+		ss << indent << "atom[" << i << "]:" << std::endl
+		   << oc_to_string(hch.first, indent + OC_TO_STRING_INDENT);
+		ss << indent << "catom[" << i << "]:" << std::endl
+		   << oc_to_string(hch.second, indent + OC_TO_STRING_INDENT);
 		i++;
 	}
 	return ss.str();
 }
-std::string oc_to_string(const Unify::HandleCHandleMap& hchm, const std::string& indent)
+std::string oc_to_string(const Unify::HandleCHandleMap& hchm)
 {
 	return oc_to_string(hchm, "");
 }
 
-std::string oc_to_string(const Unify::TypedSubstitution& ts)
+std::string oc_to_string(const Unify::TypedSubstitution& ts, const std::string& indent)
 {
 	std::stringstream ss;
-	ss << "substitution:" << std::endl << oc_to_string(ts.first)
-	   << "vardecl:" << std::endl << oc_to_string(ts.second);
+	ss << indent << "substitution:" << std::endl
+	   << oc_to_string(ts.first, indent + OC_TO_STRING_INDENT)
+	   << indent << "vardecl:" << std::endl
+	   << oc_to_string(ts.second, indent + OC_TO_STRING_INDENT);
 	return ss.str();
 }
-std::string oc_to_string(const Unify::TypedSubstitution& ts, const std::string& indent)
+std::string oc_to_string(const Unify::TypedSubstitution& ts)
 {
 	return oc_to_string(ts, "");
 }
 
-std::string oc_to_string(const Unify::TypedSubstitutions& tss)
+std::string oc_to_string(const Unify::TypedSubstitutions& tss, const std::string& indent)
 {
 	std::stringstream ss;
-	ss << "size = " << tss.size() << std::endl;
+	ss << indent << "size = " << tss.size() << std::endl;
 	int i = 0;
 	for (const auto& ts : tss) {
-		ss << "typed substitution[" << i << "]:" << std::endl
-		   << oc_to_string(ts);
+		ss << indent << "typed substitution[" << i << "]:" << std::endl
+		   << oc_to_string(ts, indent + OC_TO_STRING_INDENT);
 		i++;
 	}
 	return ss.str();
 }
-std::string oc_to_string(const Unify::TypedSubstitutions& tss, const std::string& indent)
+std::string oc_to_string(const Unify::TypedSubstitutions& tss)
 {
 	return oc_to_string(tss, "");
 }

--- a/opencog/unify/Unify.cc
+++ b/opencog/unify/Unify.cc
@@ -1004,6 +1004,10 @@ std::string oc_to_string(const Unify::CHandle& ch)
 	   << "atom:" << std::endl << oc_to_string(ch.handle);
 	return ss.str();
 }
+std::string oc_to_string(const Unify::CHandle& ch, const std::string& indent)
+{
+	return oc_to_string(ch, "");
+}
 
 std::string oc_to_string(const Unify::Block& pb)
 {
@@ -1014,6 +1018,10 @@ std::string oc_to_string(const Unify::Block& pb)
 		ss << "catom[" << i++ << "]:" << std::endl << oc_to_string(el);
 	return ss.str();
 }
+std::string oc_to_string(const Unify::Block& pb, const std::string& indent)
+{
+	return oc_to_string(pb, "");
+}
 
 std::string oc_to_string(const Unify::TypedBlock& tb)
 {
@@ -1021,6 +1029,10 @@ std::string oc_to_string(const Unify::TypedBlock& tb)
 	ss << "block:" << std::endl << oc_to_string(tb.first)
 	   << "type:" << std::endl << oc_to_string(tb.second);
 	return ss.str();
+}
+std::string oc_to_string(const Unify::TypedBlock& tb, const std::string& indent)
+{
+	return oc_to_string(tb, "");
 }
 
 std::string oc_to_string(const Unify::TypedBlockSeq& tbs)
@@ -1031,6 +1043,10 @@ std::string oc_to_string(const Unify::TypedBlockSeq& tbs)
 		ss << "typed block[" << i << "]:" << std::endl
 		   << oc_to_string(tbs[i]);
 	return ss.str();
+}
+std::string oc_to_string(const Unify::TypedBlockSeq& tbs, const std::string& indent)
+{
+	return oc_to_string(tbs, "");
 }
 
 std::string oc_to_string(const Unify::Partition& up)
@@ -1045,6 +1061,10 @@ std::string oc_to_string(const Unify::Partition& up)
 	}
 	return ss.str();
 }
+std::string oc_to_string(const Unify::Partition& up, const std::string& indent)
+{
+	return oc_to_string(up, "");
+}
 
 std::string oc_to_string(const Unify::Partitions& par)
 {
@@ -1056,6 +1076,10 @@ std::string oc_to_string(const Unify::Partitions& par)
 		i++;
 	}
 	return ss.str();
+}
+std::string oc_to_string(const Unify::Partitions& par, const std::string& indent)
+{
+	return oc_to_string(par, "");
 }
 
 std::string oc_to_string(const Unify::HandleCHandleMap& hchm)
@@ -1072,6 +1096,10 @@ std::string oc_to_string(const Unify::HandleCHandleMap& hchm)
 	}
 	return ss.str();
 }
+std::string oc_to_string(const Unify::HandleCHandleMap& hchm, const std::string& indent)
+{
+	return oc_to_string(hchm, "");
+}
 
 std::string oc_to_string(const Unify::TypedSubstitution& ts)
 {
@@ -1079,6 +1107,10 @@ std::string oc_to_string(const Unify::TypedSubstitution& ts)
 	ss << "substitution:" << std::endl << oc_to_string(ts.first)
 	   << "vardecl:" << std::endl << oc_to_string(ts.second);
 	return ss.str();
+}
+std::string oc_to_string(const Unify::TypedSubstitution& ts, const std::string& indent)
+{
+	return oc_to_string(ts, "");
 }
 
 std::string oc_to_string(const Unify::TypedSubstitutions& tss)
@@ -1092,6 +1124,10 @@ std::string oc_to_string(const Unify::TypedSubstitutions& tss)
 		i++;
 	}
 	return ss.str();
+}
+std::string oc_to_string(const Unify::TypedSubstitutions& tss, const std::string& indent)
+{
+	return oc_to_string(tss, "");
 }
 
 } // namespace opencog

--- a/opencog/unify/Unify.h
+++ b/opencog/unify/Unify.h
@@ -732,14 +732,28 @@ VariableListPtr gen_varlist(const Unify::CHandle& ch);
 Variables merge_variables(const Variables& lv, const Variables& rv);
 Handle merge_vardecl(const Handle& l_vardecl, const Handle& r_vardecl);
 
+// Debugging helpers see
+// http://wiki.opencog.org/w/Development_standards#Print_OpenCog_Objects
+// The reason indent is not an optional argument with default is
+// because gdb doesn't support that, see
+// http://stackoverflow.com/questions/16734783 for more explanation.
+std::string oc_to_string(const Unify::CHandle& ch, const std::string& indent);
 std::string oc_to_string(const Unify::CHandle& ch);
+std::string oc_to_string(const Unify::Block& pb, const std::string& indent);
 std::string oc_to_string(const Unify::Block& pb);
+std::string oc_to_string(const Unify::Partition& hshm, const std::string& indent);
 std::string oc_to_string(const Unify::Partition& hshm);
+std::string oc_to_string(const Unify::TypedBlock& tb, const std::string& indent);
 std::string oc_to_string(const Unify::TypedBlock& tb);
+std::string oc_to_string(const Unify::TypedBlockSeq& tbs, const std::string& indent);
 std::string oc_to_string(const Unify::TypedBlockSeq& tbs);
+std::string oc_to_string(const Unify::Partitions& par, const std::string& indent);
 std::string oc_to_string(const Unify::Partitions& par);
+std::string oc_to_string(const Unify::HandleCHandleMap& hchm, const std::string& indent);
 std::string oc_to_string(const Unify::HandleCHandleMap& hchm);
+std::string oc_to_string(const Unify::TypedSubstitution& ts, const std::string& indent);
 std::string oc_to_string(const Unify::TypedSubstitution& ts);
+std::string oc_to_string(const Unify::TypedSubstitutions& tss, const std::string& indent);
 std::string oc_to_string(const Unify::TypedSubstitutions& tss);
 	
 } // namespace opencog

--- a/tests/atoms/ScopeLinkUTest.cxxtest
+++ b/tests/atoms/ScopeLinkUTest.cxxtest
@@ -85,8 +85,8 @@ void ScopeLinkUTest::test_get_variables_1()
 	auto got = sc->get_variables().varset;
 	auto exp = HandleSet{X};
 
-	printf("Got %s\n", ohs_to_string(got).c_str());
-	printf("Excepted %s\n", ohs_to_string(exp).c_str());
+	printf("Got %s\n", oc_to_string(got).c_str());
+	printf("Excepted %s\n", oc_to_string(exp).c_str());
 
 	TS_ASSERT_EQUALS(got, exp);
 
@@ -109,8 +109,8 @@ void ScopeLinkUTest::test_get_variables_2()
 	auto got = sc->get_variables().varset;
 	auto exp = HandleSet{X};
 
-	printf("Got %s\n", ohs_to_string(got).c_str());
-	printf("Excepted %s\n", ohs_to_string(exp).c_str());
+	printf("Got %s\n", oc_to_string(got).c_str());
+	printf("Excepted %s\n", oc_to_string(exp).c_str());
 
 	TS_ASSERT_EQUALS(got, exp);
 
@@ -133,8 +133,8 @@ void ScopeLinkUTest::test_get_variables_3()
 	auto got = sc->get_variables().varset;
 	auto exp = HandleSet{X};
 
-	printf("Got %s\n", ohs_to_string(got).c_str());
-	printf("Excepted %s\n", ohs_to_string(exp).c_str());
+	printf("Got %s\n", oc_to_string(got).c_str());
+	printf("Excepted %s\n", oc_to_string(exp).c_str());
 
 	TS_ASSERT_EQUALS(got, exp);
 


### PR DESCRIPTION
Make printing opencog objects more intelligible.