### PR TITLE
Re-implement RewriteLink::consume_quotations

### DIFF
--- a/opencog/atoms/core/RewriteLink.cc
+++ b/opencog/atoms/core/RewriteLink.cc
@@ -335,17 +335,21 @@ Handle RewriteLink::consume_ill_quotations(const Variables& variables, Handle h,
 			}
 		} else if (t == UNQUOTE_LINK) {
 			Handle uh = h->getOutgoingAtom(0);
-			// Either remove subsequent unquote associated by a
+			// Either remove subsequent unquote associated to a
 			// removed quote, or useless unquote because there are no
 			// free variables to unquote
 			if (not escape or get_free_variables(uh).empty()) {
 				quotation.update(t);
-				return consume_ill_quotations(variables, h->getOutgoingAtom(0),
-				                              quotation);
+				return consume_ill_quotations(variables, uh, quotation);
+			}
+			// The other possibility is that a Quote follows an
+			// Unquote, in which case we can consume both of them
+			// without altering semantics.
+			if (escape and uh->get_type() == QUOTE_LINK) {
+				Handle uqh = uh->getOutgoingAtom(0); // (Unquote (Quote ...))
+				return consume_ill_quotations(variables, uqh, quotation);
 			}
 		}
-		// Ignore LocalQuotes as they supposedly used only to quote
-		// pattern matcher connectors.
 	}
 
 	quotation.update(t);

--- a/opencog/atoms/core/RewriteLink.h
+++ b/opencog/atoms/core/RewriteLink.h
@@ -97,6 +97,11 @@ protected:
 	 */
 	static bool is_bound_to_ancestor(const Variables& variables,
 	                                 const Handle& local_scope);
+	/**
+	 * Like is_bound_to_ancestor but doesn't assume that the handle is
+	 * a scope, and test for it as well, returning false if it isn't.
+	 */
+	static bool is_scope_bound_to_ancestor(const Variables& variables, const Handle& h);
 
 public:
 	RewriteLink(const HandleSeq&, Type=REWRITE_LINK);
@@ -212,11 +217,16 @@ public:
 	 */
 	Handle consume_ill_quotations() const;
 	static Handle consume_ill_quotations(const Handle& vardecl, const Handle& h);
-	static Handle consume_ill_quotations(const Variables& variables, Handle h,
-	                                     Quotation quotation=Quotation(),
-	                                     bool escape=false /* ignore the next
-	                                                        * quotation
-	                                                        * consumption */);
+	static Handle consume_ill_quotations(const Variables& variables, const Handle& h);
+	static Handle consume_ill_quotations(const Variables& variables, const Handle& h,
+	                                     Quotation quotation);
+	static Handle consume_ill_quotations(const Variables& variables, const Handle& h,
+	                                     Quotation quotation,
+	                                     bool& needless_quotation);
+	static HandleSeq consume_ill_quotations(const Variables& variables,
+	                                        const HandleSeq& hs,
+	                                        Quotation quotation,
+	                                        bool& needless_quotation);
 
 	static Handle factory(const Handle&);
 };

--- a/opencog/atoms/core/RewriteLink.h
+++ b/opencog/atoms/core/RewriteLink.h
@@ -257,6 +257,11 @@ public:
 	                                    Quotation quotation,
 	                                    bool& needless_quotation,
 	                                    bool clause_root);
+	static Handle consume_quotations_mere_rec(const Variables& variables,
+	                                          const Handle& h,
+	                                          Quotation quotation,
+	                                          bool& needless_quotation,
+	                                          bool clause_root);
 
 	static Handle factory(const Handle&);
 };

--- a/opencog/atoms/core/RewriteLink.h
+++ b/opencog/atoms/core/RewriteLink.h
@@ -216,17 +216,30 @@ public:
 	 *       Unquote Variable "$X"
 	 */
 	Handle consume_ill_quotations() const;
-	static Handle consume_ill_quotations(const Handle& vardecl, const Handle& h);
-	static Handle consume_ill_quotations(const Variables& variables, const Handle& h);
+	static Handle consume_ill_quotations(const Handle& vardecl, const Handle& h,
+	                                     /* Remember if some atom
+	                                      * is the clause root of a
+	                                      * pattern */
+	                                     bool clause_root);
 	static Handle consume_ill_quotations(const Variables& variables, const Handle& h,
-	                                     Quotation quotation);
+	                                     bool clause_root);
 	static Handle consume_ill_quotations(const Variables& variables, const Handle& h,
 	                                     Quotation quotation,
-	                                     bool& needless_quotation);
+	                                     bool clause_root);
+	static Handle consume_ill_quotations(const Variables& variables, const Handle& h,
+	                                     // TODO: we probably want to
+	                                     // move quotation,
+	                                     // needless_quotation,
+	                                     // clause_root and more in
+	                                     // its own class
+	                                     Quotation quotation,
+	                                     bool& needless_quotation,
+	                                     bool clause_root);
 	static HandleSeq consume_ill_quotations(const Variables& variables,
 	                                        const HandleSeq& hs,
 	                                        Quotation quotation,
-	                                        bool& needless_quotation);
+	                                        bool& needless_quotation,
+	                                        bool clause_root);
 
 	static Handle factory(const Handle&);
 };

--- a/opencog/atoms/core/RewriteLink.h
+++ b/opencog/atoms/core/RewriteLink.h
@@ -232,31 +232,31 @@ public:
 	 *   (TypedVariable (Variable "$X") (Type "ConceptNode"))
 	 *   (And (Concept "A") (Variable "$X")))
 	 */
-	Handle consume_ill_quotations() const;
-	static Handle consume_ill_quotations(const Handle& vardecl, const Handle& h,
-	                                     /* Remember if some atom
-	                                      * is the clause root of a
-	                                      * pattern */
-	                                     bool clause_root);
-	static Handle consume_ill_quotations(const Variables& variables, const Handle& h,
-	                                     bool clause_root);
-	static Handle consume_ill_quotations(const Variables& variables, const Handle& h,
-	                                     Quotation quotation,
-	                                     bool clause_root);
-	static Handle consume_ill_quotations(const Variables& variables, const Handle& h,
-	                                     // TODO: we probably want to
-	                                     // move quotation,
-	                                     // needless_quotation,
-	                                     // clause_root and more in
-	                                     // its own class
-	                                     Quotation quotation,
-	                                     bool& needless_quotation,
-	                                     bool clause_root);
-	static HandleSeq consume_ill_quotations(const Variables& variables,
-	                                        const HandleSeq& hs,
-	                                        Quotation quotation,
-	                                        bool& needless_quotation,
-	                                        bool clause_root);
+	Handle consume_quotations() const;
+	static Handle consume_quotations(const Handle& vardecl, const Handle& h,
+	                                 /* Remember if some atom
+	                                  * is the clause root of a
+	                                  * pattern */
+	                                 bool clause_root);
+	static Handle consume_quotations(const Variables& variables, const Handle& h,
+	                                 bool clause_root);
+	static Handle consume_quotations(const Variables& variables, const Handle& h,
+	                                 Quotation quotation,
+	                                 bool clause_root);
+	static Handle consume_quotations(const Variables& variables, const Handle& h,
+	                                 // TODO: we probably want to
+	                                 // move quotation,
+	                                 // needless_quotation,
+	                                 // clause_root and more in
+	                                 // its own class
+	                                 Quotation quotation,
+	                                 bool& needless_quotation,
+	                                 bool clause_root);
+	static HandleSeq consume_quotations(const Variables& variables,
+	                                    const HandleSeq& hs,
+	                                    Quotation quotation,
+	                                    bool& needless_quotation,
+	                                    bool clause_root);
 
 	static Handle factory(const Handle&);
 };

--- a/opencog/atoms/execution/Instantiator.cc
+++ b/opencog/atoms/execution/Instantiator.cc
@@ -311,6 +311,7 @@ Handle Instantiator::walk_tree(const Handle& expr, bool silent)
 			HandleSeq oset{body};
 			if (vardecl)
 				oset.insert(oset.begin(), vardecl);
+			// TODO: copy values
 			return createLink(oset, LAMBDA_LINK);
 		}
 		return expr;

--- a/opencog/unify/Unify.cc
+++ b/opencog/unify/Unify.cc
@@ -192,7 +192,7 @@ Unify::TypedSubstitution Unify::typed_substitution(const Partition& partition,
 	for (auto& vcv : var2cval) {
 		Handle consumed =
 			RewriteLink::consume_ill_quotations(_variables, vcv.second.handle,
-			                                    vcv.second.context.quotation);
+			                                    vcv.second.context.quotation, false);
 		vcv.second = CHandle(consumed, vcv.second.context);
 	}
 
@@ -317,13 +317,13 @@ Handle Unify::substitute(BindLinkPtr bl, const HandleMap& var2val,
 	// Perform substitution over the pattern term, then remove
 	// constant clauses
 	Handle clauses = variables.substitute_nocheck(bl->get_body(), values);
-	clauses = RewriteLink::consume_ill_quotations(vardecl, clauses);
+	clauses = RewriteLink::consume_ill_quotations(vardecl, clauses, true);
 //	clauses = remove_constant_clauses(vardecl, clauses);
 	hs.push_back(clauses);
 
 	// Perform substitution over the rewrite term
 	Handle rewrite = variables.substitute_nocheck(bl->get_implicand(), values);
-	rewrite = RewriteLink::consume_ill_quotations(vardecl, rewrite);
+	rewrite = RewriteLink::consume_ill_quotations(vardecl, rewrite, false);
 	hs.push_back(rewrite);
 
 	// Filter vardecl

--- a/opencog/unify/Unify.cc
+++ b/opencog/unify/Unify.cc
@@ -191,8 +191,8 @@ Unify::TypedSubstitution Unify::typed_substitution(const Partition& partition,
 	// Remove ill quotations
 	for (auto& vcv : var2cval) {
 		Handle consumed =
-			RewriteLink::consume_ill_quotations(_variables, vcv.second.handle,
-			                                    vcv.second.context.quotation, false);
+			RewriteLink::consume_quotations(_variables, vcv.second.handle,
+			                                vcv.second.context.quotation, false);
 		vcv.second = CHandle(consumed, vcv.second.context);
 	}
 
@@ -317,13 +317,13 @@ Handle Unify::substitute(BindLinkPtr bl, const HandleMap& var2val,
 	// Perform substitution over the pattern term, then remove
 	// constant clauses
 	Handle clauses = variables.substitute_nocheck(bl->get_body(), values);
-	clauses = RewriteLink::consume_ill_quotations(vardecl, clauses, true);
+	clauses = RewriteLink::consume_quotations(vardecl, clauses, true);
 //	clauses = remove_constant_clauses(vardecl, clauses);
 	hs.push_back(clauses);
 
 	// Perform substitution over the rewrite term
 	Handle rewrite = variables.substitute_nocheck(bl->get_implicand(), values);
-	rewrite = RewriteLink::consume_ill_quotations(vardecl, rewrite, false);
+	rewrite = RewriteLink::consume_quotations(vardecl, rewrite, false);
 	hs.push_back(rewrite);
 
 	// Filter vardecl

--- a/opencog/unify/Unify.h
+++ b/opencog/unify/Unify.h
@@ -231,25 +231,10 @@ public:
 	/**
 	 * If the quotations are useless or harmful, which might be the
 	 * case if they deprive a ScopeLink from hiding supposedly hidden
-	 * variables, consume them.
-	 *
-	 * Specifically this code makes 2 assumptions
-	 *
-	 * 1. LocalQuotes in front root level And, Or or Not links on the
-	 *    pattern body are not consumed because they are supposedly
-	 *    used to avoid interpreting them as pattern matcher
-	 *    connectors.
-	 *
-	 * 2. Quote/Unquote are used to wrap scope links so that their
-	 *    variable declaration can pattern match grounded or partially
-	 *    grounded scope links.
-	 *
-	 * No other use of quotation is assumed besides the 2 above.
-	 *
-	 * TODO: apparently not used. And if it is used it should be moved
-	 * to RewriteLink.
+	 * variables, consume them. See RewriteLink::consume_quotations
+	 * comment for more details.
 	 */
-	static BindLinkPtr consume_ill_quotations(BindLinkPtr bl);
+	static BindLinkPtr consume_quotations(BindLinkPtr bl);
 
 	/**
 	 * Return true iff the handle or type correspond to a pattern

--- a/tests/atoms/RewriteLinkUTest.cxxtest
+++ b/tests/atoms/RewriteLinkUTest.cxxtest
@@ -131,6 +131,7 @@ void RewriteLinkUTest::test_names_alpha_conversion()
 
 // Like test_vardecl_bindlink_alpha_conversion but using a BindLink
 // instead of a RewriteLink
+// TODO: re-enable?
 void RewriteLinkUTest::xtest_vardecl_bindlink_alpha_conversion()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);

--- a/tests/atoms/RewriteLinkUTest.cxxtest
+++ b/tests/atoms/RewriteLinkUTest.cxxtest
@@ -255,7 +255,7 @@ void RewriteLinkUTest::test_remove_ill_quotations_1()
 	// harmful to the pattern matcher as it makes it believe that the
 	// gpn is evaluatable
 	RewriteLinkPtr sc(RewriteLinkCast(gl));
-	Handle result = sc->consume_ill_quotations(),
+	Handle result = sc->consume_quotations(),
 		expected = createLink(GET_LINK, X,
 		                      createLink(QUOTE_LINK,
 		                                 createLink(EVALUATION_LINK, gpn,
@@ -281,7 +281,7 @@ void RewriteLinkUTest::test_remove_ill_quotations_2()
 	// Remove the UnquoteLink wrapping gpn as it is useless, and even
 	// harmful to the pattern matcher as it makes it believe that the
 	// gpn is evaluatable
-	Handle result = RewriteLink::consume_ill_quotations(vardecl, ill_quoted, false),
+	Handle result = RewriteLink::consume_quotations(vardecl, ill_quoted, false),
 		expected = _eval.eval_h("well-quoted");
 
 	std::cout << "result = " << oc_to_string(result);

--- a/tests/atoms/RewriteLinkUTest.cxxtest
+++ b/tests/atoms/RewriteLinkUTest.cxxtest
@@ -74,8 +74,9 @@ public:
 	void test_unordered();
 	void test_beta_reduce_1();
 	void test_beta_reduce_2();
-	void test_remove_ill_quotations_1();
-	void test_remove_ill_quotations_2();
+	void test_consume_quotations_1();
+	void test_consume_quotations_2();
+	void test_consume_quotations_3();
 };
 
 #define NA _asa.add_node
@@ -238,7 +239,7 @@ void RewriteLinkUTest::test_beta_reduce_2()
 	logger().info("END TEST: %s", __FUNCTION__);
 }
 
-void RewriteLinkUTest::test_remove_ill_quotations_1()
+void RewriteLinkUTest::test_consume_quotations_1()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
@@ -267,7 +268,7 @@ void RewriteLinkUTest::test_remove_ill_quotations_1()
 	TS_ASSERT(content_eq(result, expected));
 }
 
-void RewriteLinkUTest::test_remove_ill_quotations_2()
+void RewriteLinkUTest::test_consume_quotations_2()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
@@ -283,6 +284,29 @@ void RewriteLinkUTest::test_remove_ill_quotations_2()
 	// gpn is evaluatable
 	Handle result = RewriteLink::consume_quotations(vardecl, ill_quoted, false),
 		expected = _eval.eval_h("well-quoted");
+
+	std::cout << "result = " << oc_to_string(result);
+	std::cout << "expected = " << oc_to_string(expected);
+
+	TS_ASSERT(content_eq(result, expected));
+}
+
+void RewriteLinkUTest::test_consume_quotations_3()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	std::string rs = _eval.eval("(load-from-path \"tests/atoms/quotations.scm\")");
+	logger().debug() << "rs = " << rs;
+
+	// Test simple RewriteLink
+	Handle vardecl = al(VARIABLE_LIST),
+		quoted_clauses = _eval.eval_h("quoted-clauses");
+
+	// Remove the UnquoteLink wrapping gpn as it is useless, and even
+	// harmful to the pattern matcher as it makes it believe that the
+	// gpn is evaluatable
+	Handle result = RewriteLink::consume_quotations(vardecl, quoted_clauses, true),
+		expected = _eval.eval_h("consumed-quoted-clauses");
 
 	std::cout << "result = " << oc_to_string(result);
 	std::cout << "expected = " << oc_to_string(expected);

--- a/tests/atoms/RewriteLinkUTest.cxxtest
+++ b/tests/atoms/RewriteLinkUTest.cxxtest
@@ -52,6 +52,7 @@ public:
 	{
 		logger().set_level(Logger::INFO);
 		logger().set_print_to_stdout_flag(true);
+		logger().set_timestamp_flag(false);
 
 		X = an(VARIABLE_NODE, "$X");
 		Y = an(VARIABLE_NODE, "$Y");
@@ -280,7 +281,7 @@ void RewriteLinkUTest::test_remove_ill_quotations_2()
 	// Remove the UnquoteLink wrapping gpn as it is useless, and even
 	// harmful to the pattern matcher as it makes it believe that the
 	// gpn is evaluatable
-	Handle result = RewriteLink::consume_ill_quotations(vardecl, ill_quoted),
+	Handle result = RewriteLink::consume_ill_quotations(vardecl, ill_quoted, false),
 		expected = _eval.eval_h("well-quoted");
 
 	std::cout << "result = " << oc_to_string(result);

--- a/tests/atoms/quotations.scm
+++ b/tests/atoms/quotations.scm
@@ -51,3 +51,81 @@
       (VariableNode "$vardecl"))
     (UnquoteLink
       (VariableNode "$body")))))
+
+(define quoted-clauses
+(LocalQuoteLink
+  (AndLink
+    (QuoteLink
+      (LambdaLink
+        (UnquoteLink
+          (TypedVariableLink
+            (VariableNode "$X")
+            (TypeNode "ConceptNode")
+          )
+        )
+        (UnquoteLink
+          (EvaluationLink
+            (PredicateNode "contain")
+            (ListLink
+              (ConceptNode "treatment-1")
+              (ConceptNode "compound-A")
+            )
+          )
+        )
+      )
+    )
+    (QuoteLink
+      (LambdaLink
+        (UnquoteLink
+          (TypedVariableLink
+            (VariableNode "$X")
+            (TypeNode "ConceptNode")
+          )
+        )
+        (UnquoteLink
+          (EvaluationLink
+            (PredicateNode "take")
+            (ListLink
+              (VariableNode "$X")
+              (ConceptNode "treatment-1")
+            )
+          )
+        )
+      )
+    )
+  )
+)
+)
+
+(define consumed-quoted-clauses
+(LocalQuoteLink
+  (AndLink
+    (LambdaLink
+      (TypedVariableLink
+        (VariableNode "$X")
+        (TypeNode "ConceptNode")
+      )
+      (EvaluationLink
+        (PredicateNode "contain")
+        (ListLink
+          (ConceptNode "treatment-1")
+          (ConceptNode "compound-A")
+        )
+      )
+    )
+    (LambdaLink
+      (TypedVariableLink
+        (VariableNode "$X")
+        (TypeNode "ConceptNode")
+      )
+      (EvaluationLink
+        (PredicateNode "take")
+        (ListLink
+          (VariableNode "$X")
+          (ConceptNode "treatment-1")
+        )
+      )
+    )
+  )
+)
+)

--- a/tests/rule-engine/backwardchainer/BITUTest.cxxtest
+++ b/tests/rule-engine/backwardchainer/BITUTest.cxxtest
@@ -27,6 +27,7 @@ private:
 
 	Handle closed_lambda_introduction_rule_h;
 	Handle implication_and_lambda_factorization_rule_h;
+	Handle unary_specialization_rule_h;
 
 public:
 	BITUTest() : _eval(&_as)
@@ -65,6 +66,13 @@ public:
 			             "   implication-and-lambda-factorization-rule-name"
 			             "   (ConceptNode \"URE\"))");
 
+		// Load implication-and-lambda-factorization-rule
+		eval_result = _eval.eval("(load-from-path \"unary-specialization-rule.scm\")");
+		unary_specialization_rule_h =
+			_eval.eval_h("(MemberLink (stv 1 1)"
+			             "   unary-specialization-rule-name"
+			             "   (ConceptNode \"URE\"))");
+
 		// Load bit.scm
 		eval_result = _eval.eval("(load-from-path \"bit.scm\")");
 	}
@@ -80,6 +88,7 @@ public:
 	void test_get_leaves();
 	void test_expand_1();
 	void test_expand_2();
+	void test_expand_3();
 	void test_has_cycle();
 };
 
@@ -843,6 +852,176 @@ void BITUTest::test_expand_2()
 		             "          )"
 		             "        )"
 		             "      )"
+		             "    )"
+		             "  )"
+		             ")"));
+
+	logger().debug() << "result = " << oc_to_string(result);
+	logger().debug() << "expected = " << oc_to_string(expected);
+
+	TS_ASSERT_EQUALS(result, expected);
+}
+
+void BITUTest::test_expand_3()
+{
+	AndBIT andbit(_eval.eval_h("fcs-5"));
+
+	Handle leaf = _eval.eval_h("(EvaluationLink"
+	                           "  (PredicateNode \"minsup\")"
+	                           "  (ListLink"
+	                           "    (VariableNode \"$g-2101505b\")"
+	                           "    (ConceptNode \"texts\")"
+	                           "    (NumberNode \"2.000000\")))");
+	Handle vardecl =
+		_eval.eval_h("(VariableList"
+		             "  (TypedVariableLink"
+		             "    (VariableNode \"$g-2101505b\")"
+		             "    (TypeChoice"
+		             "      (TypeNode \"LambdaLink\")"
+		             "      (TypeNode \"PutLink\")))"
+		             "  (TypedVariableLink"
+		             "    (VariableNode \"$f-53364b8c\")"
+		             "    (TypeChoice"
+		             "      (TypeNode \"ConceptNode\")"
+		             "      (TypeNode \"LambdaLink\"))))");
+
+	Rule unary_specialization_rule(unary_specialization_rule_h);
+	RuleTypedSubstitutionMap rules =
+        unary_specialization_rule.unify_target(leaf, vardecl);
+	RuleTypedSubstitutionPair rule = *rules.begin();
+
+	AndBIT result = andbit.expand(leaf, rule);
+	AndBIT expected(
+		_eval.eval_h("(BindLink"
+		             "  (VariableList"
+		             "    (TypedVariableLink"
+		             "      (VariableNode \"$f-53364b8c\")"
+		             "      (TypeChoice"
+		             "        (TypeNode \"ConceptNode\")"
+		             "        (TypeNode \"LambdaLink\")"
+		             "      )"
+		             "    )"
+		             "    (TypedVariableLink"
+		             "      (VariableNode \"$g-6566b25f\")"
+		             "      (TypeChoice"
+		             "        (TypeNode \"LambdaLink\")"
+		             "        (TypeNode \"PutLink\")"
+		             "      )"
+		             "    )"
+		             "    (TypedVariableLink"
+		             "      (VariableNode \"$f-72fe9f60\")"
+		             "      (TypeChoice"
+		             "        (TypeNode \"ConceptNode\")"
+		             "        (TypeNode \"LambdaLink\")"
+		             "      )"
+		             "    )"
+		             "  )"
+		             "  (AndLink"
+		             "    (VariableNode \"$f-72fe9f60\")"
+		             "    (VariableNode \"$f-53364b8c\")"
+		             "    (EvaluationLink"
+		             "      (GroundedPredicateNode \"scm: has-arity\")"
+		             "      (ListLink"
+		             "        (VariableNode \"$g-6566b25f\")"
+		             "        (NumberNode \"1.000000\")"
+		             "      )"
+		             "    )"
+		             "    (EvaluationLink"
+		             "      (PredicateNode \"minsup\")"
+		             "      (ListLink"
+		             "        (VariableNode \"$g-6566b25f\")"
+		             "        (ConceptNode \"texts\")"
+		             "        (NumberNode \"2.000000\")"
+		             "      )"
+		             "    )"
+		             "    (EvaluationLink"
+		             "      (GroundedPredicateNode \"scm: absolutely-true\")"
+		             "      (EvaluationLink"
+		             "        (PredicateNode \"minsup\")"
+		             "        (ListLink"
+		             "          (VariableNode \"$g-6566b25f\")"
+		             "          (ConceptNode \"texts\")"
+		             "          (NumberNode \"2.000000\")"
+		             "        )"
+		             "      )"
+		             "    )"
+		             "    (EvaluationLink"
+		             "      (GroundedPredicateNode \"scm: has-arity\")"
+		             "      (ListLink"
+		             "        (QuoteLink"
+		             "          (PutLink"
+		             "            (UnquoteLink"
+		             "              (VariableNode \"$g-6566b25f\")"
+		             "            )"
+		             "            (UnquoteLink"
+		             "              (VariableNode \"$f-72fe9f60\")"
+		             "            )"
+		             "          )"
+		             "        )"
+		             "        (NumberNode \"2.000000\")"
+		             "      )"
+		             "    )"
+		             "  )"
+		             "  (ExecutionOutputLink"
+		             "    (GroundedSchemaNode \"scm: specialization-formula\")"
+		             "    (ListLink"
+		             "      (EvaluationLink"
+		             "        (PredicateNode \"minsup\")"
+		             "        (ListLink"
+		             "          (QuoteLink"
+		             "            (PutLink"
+		             "              (PutLink"
+		             "                (UnquoteLink"
+		             "                  (VariableNode \"$g-6566b25f\")"
+		             "                )"
+		             "                (UnquoteLink"
+		             "                  (VariableNode \"$f-72fe9f60\")"
+		             "                )"
+		             "              )"
+		             "              (UnquoteLink"
+		             "                (ListLink"
+		             "                  (VariableNode \"$f-53364b8c\")"
+		             "                  (VariableNode \"$spe-arg-1\")"
+		             "                )"
+		             "              )"
+		             "            )"
+		             "          )"
+		             "          (ConceptNode \"texts\")"
+		             "          (NumberNode \"2.000000\")"
+		             "        )"
+		             "      )"
+		             "      (ExecutionOutputLink"
+		             "        (GroundedSchemaNode \"scm: specialization-formula\")"
+		             "        (ListLink"
+		             "          (EvaluationLink"
+		             "            (PredicateNode \"minsup\")"
+		             "            (ListLink"
+		             "              (QuoteLink"
+		             "                (PutLink"
+		             "                  (UnquoteLink"
+		             "                    (VariableNode \"$g-6566b25f\")"
+		             "                  )"
+		             "                  (UnquoteLink"
+		             "                    (VariableNode \"$f-72fe9f60\")"
+		             "                  )"
+		             "                )"
+		             "              )"
+		             "              (ConceptNode \"texts\")"
+		             "              (NumberNode \"2.000000\")"
+		             "            )"
+		             "          )"
+		             "          (EvaluationLink"
+		             "            (PredicateNode \"minsup\")"
+		             "            (ListLink"
+		             "              (VariableNode \"$g-6566b25f\")"
+		             "              (ConceptNode \"texts\")"
+		             "              (NumberNode \"2.000000\")"
+		             "            )"
+		             "          )"
+		             "          (VariableNode \"$f-72fe9f60\")"
+		             "        )"
+		             "      )"
+		             "      (VariableNode \"$f-53364b8c\")"
 		             "    )"
 		             "  )"
 		             ")"));

--- a/tests/rule-engine/backwardchainer/bit.scm
+++ b/tests/rule-engine/backwardchainer/bit.scm
@@ -1091,3 +1091,87 @@
   )
 )
 )
+
+(define fcs-5
+(BindLink
+  (VariableList
+    (TypedVariableLink
+      (VariableNode "$g-2101505b")
+      (TypeChoice
+        (TypeNode "LambdaLink")
+        (TypeNode "PutLink")
+      )
+    )
+    (TypedVariableLink
+      (VariableNode "$f-53364b8c")
+      (TypeChoice
+        (TypeNode "ConceptNode")
+        (TypeNode "LambdaLink")
+      )
+    )
+  )
+  (AndLink
+    (VariableNode "$f-53364b8c")
+    (EvaluationLink
+      (PredicateNode "minsup")
+      (ListLink
+        (VariableNode "$g-2101505b")
+        (ConceptNode "texts")
+        (NumberNode "2.000000")
+      )
+    )
+    (EvaluationLink
+      (GroundedPredicateNode "scm: has-arity")
+      (ListLink
+        (VariableNode "$g-2101505b")
+        (NumberNode "2.000000")
+      )
+    )
+    (EvaluationLink
+      (GroundedPredicateNode "scm: absolutely-true")
+      (EvaluationLink
+        (PredicateNode "minsup")
+        (ListLink
+          (VariableNode "$g-2101505b")
+          (ConceptNode "texts")
+          (NumberNode "2.000000")
+        )
+      )
+    )
+  )
+  (ExecutionOutputLink
+    (GroundedSchemaNode "scm: specialization-formula")
+    (ListLink
+      (EvaluationLink
+        (PredicateNode "minsup")
+        (ListLink
+          (QuoteLink
+            (PutLink
+              (UnquoteLink
+                (VariableNode "$g-2101505b")
+              )
+              (UnquoteLink
+                (ListLink
+                  (VariableNode "$f-53364b8c")
+                  (VariableNode "$spe-arg-1")
+                )
+              )
+            )
+          )
+          (ConceptNode "texts")
+          (NumberNode "2.000000")
+        )
+      )
+      (EvaluationLink
+        (PredicateNode "minsup")
+        (ListLink
+          (VariableNode "$g-2101505b")
+          (ConceptNode "texts")
+          (NumberNode "2.000000")
+        )
+      )
+      (VariableNode "$f-53364b8c")
+    )
+  )
+)
+)

--- a/tests/rule-engine/rules/unary-specialization-rule.scm
+++ b/tests/rule-engine/rules/unary-specialization-rule.scm
@@ -1,0 +1,64 @@
+(define unary-specialization-rule
+(BindLink
+  (VariableList
+    (TypedVariableLink
+      (VariableNode "$g")
+      (TypeChoice
+        (TypeNode "LambdaLink")
+        (TypeNode "PutLink")))
+    (TypedVariableLink
+      (VariableNode "$texts")
+      (TypeNode "ConceptNode"))
+    (TypedVariableLink
+      (VariableNode "$ms")
+      (TypeNode "NumberNode"))
+    (TypedVariableLink
+      (VariableNode "$f")
+      (TypeChoice
+        (TypeNode "LambdaLink")
+        (TypeNode "ConceptNode"))))
+  (AndLink
+    (VariableNode "$f")
+    (EvaluationLink
+      (GroundedPredicateNode "scm: has-arity")
+      (ListLink
+        (VariableNode "$g")
+        (NumberNode "1.000000")))
+    (EvaluationLink
+      (PredicateNode "minsup")
+      (ListLink
+        (VariableNode "$g")
+        (VariableNode "$texts")
+        (VariableNode "$ms")))
+    (EvaluationLink
+      (GroundedPredicateNode "scm: absolutely-true")
+      (EvaluationLink
+        (PredicateNode "minsup")
+        (ListLink
+          (VariableNode "$g")
+          (VariableNode "$texts")
+          (VariableNode "$ms")))))
+  (ExecutionOutputLink
+    (GroundedSchemaNode "scm: specialization-formula")
+    (ListLink
+      (EvaluationLink
+        (PredicateNode "minsup")
+        (ListLink
+          (QuoteLink
+            (PutLink
+              (UnquoteLink
+                (VariableNode "$g"))
+              (UnquoteLink
+                (VariableNode "$f"))))
+          (VariableNode "$texts")
+          (VariableNode "$ms")))
+      (EvaluationLink
+        (PredicateNode "minsup")
+        (ListLink
+          (VariableNode "$g")
+          (VariableNode "$texts")
+          (VariableNode "$ms")))
+      (VariableNode "$f")))))
+
+(define unary-specialization-rule-name (DefinedSchemaNode "unary-specialization-rule"))
+(DefineLink unary-specialization-rule-name unary-specialization-rule)


### PR DESCRIPTION
Re-implement `RewriteLink::consume_quotations` (formerly called `consume_ill_quotations`), not only remove harmful quotations but also eliminate most needless ones, thus the renaming.