### PR TITLE
Add quotation support in MapLink

### DIFF
--- a/opencog/atoms/execution/ExecSCM.cc
+++ b/opencog/atoms/execution/ExecSCM.cc
@@ -26,7 +26,7 @@ using namespace opencog;
  */
 static Handle ss_execute(AtomSpace* atomspace, const Handle& h)
 {
-	Instantiator inst(atomspace, false);
+	Instantiator inst(atomspace);
 	Handle rh(inst.execute(h));
 	if (NULL != rh)
 		rh = atomspace->add_atom(rh);

--- a/opencog/atoms/execution/Force.cc
+++ b/opencog/atoms/execution/Force.cc
@@ -50,7 +50,7 @@ using namespace opencog;
 ///
 Handle opencog::force_execute(AtomSpace* as, const Handle& cargs, bool silent)
 {
-	Instantiator inst(as, false);
+	Instantiator inst(as);
 
 	if (LIST_LINK != cargs->get_type())
 	{

--- a/opencog/atoms/execution/Instantiator.cc
+++ b/opencog/atoms/execution/Instantiator.cc
@@ -34,9 +34,9 @@
 
 using namespace opencog;
 
-Instantiator::Instantiator(AtomSpace* as, bool consume_quotations)
+Instantiator::Instantiator(AtomSpace* as)
 	: _as(as), _vmap(nullptr), _halt(false),
-	  _consume_quotations(consume_quotations),
+	  _consume_quotations(true),
 	  _needless_quotation(true),
 	  _eager(true) {}
 

--- a/opencog/atoms/execution/Instantiator.h
+++ b/opencog/atoms/execution/Instantiator.h
@@ -114,7 +114,7 @@ private:
 	static bool not_self_match(Type t);
 
 public:
-	Instantiator(AtomSpace* as, bool consume_quotations=false);
+	Instantiator(AtomSpace* as);
 
 	void ready(AtomSpace* as)
 	{
@@ -126,6 +126,7 @@ public:
 	{
 		_as = nullptr;
 		_vmap = nullptr;
+		_consume_quotations = true;
 	}
 
 	void reset_halt()
@@ -133,10 +134,15 @@ public:
 		_halt = false;
 	}
 
+	// TODO: set consume_quotations to false when executing, set it to
+	// true when instantiating
 	Handle instantiate(const Handle& expr, const HandleMap &vars,
 	                   bool silent=false);
 	Handle execute(const Handle& expr, bool silent=false)
 	{
+		// If no actual instantiation is involved then do not consume
+		// quotations as it might change the semantics.
+		_consume_quotations = false;
 		return instantiate(expr, HandleMap(), silent);
 	}
 };

--- a/opencog/atoms/execution/MapLink.cc
+++ b/opencog/atoms/execution/MapLink.cc
@@ -322,7 +322,7 @@ bool MapLink::extract(const Handle& termpat,
 
 Handle MapLink::rewrite_one(const Handle& cterm, AtomSpace* scratch) const
 {
-	Instantiator inst(scratch, true);
+	Instantiator inst(scratch);
 	Handle term(inst.execute(cterm));
 
 	// Extract values for variables.

--- a/opencog/atoms/execution/MapLink.cc
+++ b/opencog/atoms/execution/MapLink.cc
@@ -160,7 +160,8 @@ MapLink::MapLink(const Link &l)
 ///
 bool MapLink::extract(const Handle& termpat,
                       const Handle& ground,
-                      HandleMap& valmap) const
+                      HandleMap& valmap,
+                      Quotation quotation) const
 {
 	if (termpat == ground) return true;
 
@@ -184,6 +185,16 @@ bool MapLink::extract(const Handle& termpat,
 		return true;
 	}
 
+	// Save quotation state before updating it
+	Quotation quotation_cp;
+	quotation.update(t);
+
+	// Consume quotation
+	if (quotation_cp.consumable(t))
+	{
+		return extract(termpat->getOutgoingAtom(0), ground, valmap, quotation);
+	}
+
 	if (GLOB_NODE == t and 0 < _varset->count(termpat))
 	{
 		// Check the type of the value.
@@ -199,7 +210,7 @@ bool MapLink::extract(const Handle& termpat,
 	{
 		for (const Handle& choice : termpat->getOutgoingSet())
 		{
-			if (extract(choice, ground, valmap))
+			if (extract(choice, ground, valmap, quotation))
 				return true;
 		}
 		return false;
@@ -224,7 +235,7 @@ bool MapLink::extract(const Handle& termpat,
 		if (gsz != tsz) return false;
 		for (size_t i=0; i<tsz; i++)
 		{
-			if (not extract(tlo[i], glo[i], valmap))
+			if (not extract(tlo[i], glo[i], valmap, quotation))
 				return false;
 		}
 
@@ -254,7 +265,7 @@ bool MapLink::extract(const Handle& termpat,
 			}
 
 			// Match at least one.
-			bool tc = extract(glob, glo[jg], valmap);
+			bool tc = extract(glob, glo[jg], valmap, quotation);
 			if (not tc) return false;
 
 			glob_seq.push_back(glo[jg]);
@@ -266,10 +277,10 @@ bool MapLink::extract(const Handle& termpat,
 				if (have_post)
 				{
 					// If the atom after the glob matches, then we are done.
-					tc = extract(post_glob, glo[jg], valmap);
+					tc = extract(post_glob, glo[jg], valmap, quotation);
 					if (tc) break;
 				}
-				tc = extract(glob, glo[jg], valmap);
+				tc = extract(glob, glo[jg], valmap, quotation);
 				if (tc) glob_seq.push_back(glo[jg]);
 				jg ++;
 			}
@@ -302,7 +313,7 @@ bool MapLink::extract(const Handle& termpat,
 		else
 		{
 			// If we are here, we are not comparing to a glob.
-			if (not extract(tlo[ip], glo[jg], valmap))
+			if (not extract(tlo[ip], glo[jg], valmap, quotation))
 				return false;
 		}
 	}

--- a/opencog/atoms/execution/MapLink.h
+++ b/opencog/atoms/execution/MapLink.h
@@ -25,6 +25,7 @@
 
 #include <opencog/atoms/core/FunctionLink.h>
 #include <opencog/atoms/core/ScopeLink.h>
+#include <opencog/atoms/core/Quotation.h>
 
 namespace opencog
 {
@@ -56,7 +57,8 @@ protected:
 
 	MapLink(Type, const Handle&);
 
-	bool extract(const Handle&, const Handle&, HandleMap&) const;
+	bool extract(const Handle&, const Handle&, HandleMap&,
+	             Quotation quotation=Quotation()) const;
 
 	Handle rewrite_one(const Handle&, AtomSpace*) const;
 

--- a/opencog/haskell/Exec_CWrapper.cpp
+++ b/opencog/haskell/Exec_CWrapper.cpp
@@ -10,7 +10,7 @@
 int Exec_execute(AtomSpace* atomspace, Handle* handle,Handle* out)
 {
     Handle h = *handle;
-    Instantiator inst(atomspace, false);
+    Instantiator inst(atomspace);
 	Handle rh(inst.execute(h));
 	if (nullptr != rh) {
 		rh = atomspace->add_atom(rh);

--- a/opencog/query/DefaultPatternMatchCB.cc
+++ b/opencog/query/DefaultPatternMatchCB.cc
@@ -122,7 +122,7 @@ DefaultPatternMatchCB::DefaultPatternMatchCB(AtomSpace* as) :
 	_classserver(classserver())
 {
 	_temp_aspace = grab_transient_atomspace(as);
-	_instor = new Instantiator(_temp_aspace, true);
+	_instor = new Instantiator(_temp_aspace);
 
 	_connectives.insert(SEQUENTIAL_AND_LINK);
 	_connectives.insert(SEQUENTIAL_OR_LINK);

--- a/opencog/query/Implicator.h
+++ b/opencog/query/Implicator.h
@@ -59,7 +59,7 @@ class Implicator :
 		HandleSeq _result_list;
 
 	public:
-		Implicator(AtomSpace* as) : inst(as, true), max_results(SIZE_MAX) {}
+		Implicator(AtomSpace* as) : inst(as), max_results(SIZE_MAX) {}
 		Instantiator inst;
 		Handle implicand;
 		size_t max_results;

--- a/tests/atoms/MapLinkUTest.cxxtest
+++ b/tests/atoms/MapLinkUTest.cxxtest
@@ -22,6 +22,7 @@
 
 #include <opencog/guile/SchemeEval.h>
 #include <opencog/atomspace/AtomSpace.h>
+#include <opencog/atoms/execution/Instantiator.h>
 #include <opencog/util/Logger.h>
 
 using namespace opencog;
@@ -63,6 +64,7 @@ public:
     void test_implication(void);
     void test_glob(void);
     void test_implication_nodecl(void);
+	void test_local_quote_map(void);
 };
 
 void MapLinkUTest::tearDown(void)
@@ -295,5 +297,24 @@ void MapLinkUTest::test_implication_nodecl(void)
     printf("expected %s\n", sete->to_string().c_str());
 
     TS_ASSERT(result == sete);
+    logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+void MapLinkUTest::test_local_quote_map(void)
+{
+    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+    eval->eval("(load-from-path \"tests/atoms/maplink.scm\")");
+
+    Instantiator inst(as);
+    Handle local_quote_map = eval->eval_h("local-quote-map"),
+	    result = inst.execute(local_quote_map),
+	    expected = eval->eval_h("local-quote-map-result");
+
+    printf("result %s", result->to_string().c_str());
+    printf("expected %s\n", expected->to_string().c_str());
+
+    TS_ASSERT(result == expected);
+
     logger().debug("END TEST: %s", __FUNCTION__);
 }

--- a/tests/atoms/maplink.scm
+++ b/tests/atoms/maplink.scm
@@ -456,3 +456,28 @@
 		(ListLink
 			(Concept "baz") (Concept "ni") (Concept "goh"))
 	))
+
+(define local-quote-map
+(MapLink
+  (LambdaLink
+    (VariableList
+      (VariableNode "$X")
+      (VariableNode "$Y")
+    )
+    (LocalQuoteLink
+      (AndLink
+        (VariableNode "$X")
+        (VariableNode "$Y")
+      )
+    )
+  )
+  (AndLink
+    (ConceptNode "A")
+    (ConceptNode "B")
+  )
+)
+)
+
+(define local-quote-map-result
+  (ListLink
+    (ConceptNode "A") (ConceptNode "B")))


### PR DESCRIPTION
Also, better manage when `Instantiator` consumes quotes or not. When `Instantiator::execute` called `Instantiator::_consume_quote` is set to false (as opposed to initialized with `Instantiator`).