### PR TITLE
Fix some BindLink crash

### DIFF
--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -159,7 +159,7 @@ static TruthValuePtr identical(const Handle& h)
 }
 
 /// Check for semantic equality
-static TruthValuePtr equal(AtomSpace* as, const Handle& h)
+static TruthValuePtr equal(AtomSpace* as, const Handle& h, bool silent)
 {
 	const HandleSeq& oset = h->getOutgoingSet();
 	if (2 != oset.size())
@@ -167,8 +167,8 @@ static TruthValuePtr equal(AtomSpace* as, const Handle& h)
 		     "EqualLink expects two arguments");
 
 	Instantiator inst(as);
-	Handle h0(inst.execute(oset[0]));
-	Handle h1(inst.execute(oset[1]));
+	Handle h0(inst.execute(oset[0], silent));
+	Handle h1(inst.execute(oset[1], silent));
 
 	if (h0 == h1)
 		return TruthValue::TRUE_TV();
@@ -284,7 +284,7 @@ TruthValuePtr EvaluationLink::do_eval_scratch(AtomSpace* as,
 	}
 	else if (EQUAL_LINK == t)
 	{
-		return equal(scratch, evelnk);
+		return equal(scratch, evelnk, silent);
 	}
 	else if (GREATER_THAN_LINK == t)
 	{

--- a/tests/query/BuggyBindLinkUTest.cxxtest
+++ b/tests/query/BuggyBindLinkUTest.cxxtest
@@ -1,0 +1,85 @@
+/*
+ * tests/query/BuggyBindLinkUTest.cxxtest
+ *
+ * Copyright (C) 2018 OpenCog Foundation
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/atomspace/AtomSpace.h>
+#include <opencog/guile/SchemeEval.h>
+#include <opencog/query/BindLinkAPI.h>
+#include <opencog/util/Logger.h>
+
+using namespace opencog;
+
+class BuggyBindLinkUTest: public CxxTest::TestSuite
+{
+private:
+        AtomSpace as;
+        SchemeEval eval;
+
+public:
+	BuggyBindLinkUTest(void) : eval(&as)
+    {
+        logger().set_level(Logger::DEBUG);
+        logger().set_print_to_stdout_flag(true);
+
+        eval.eval("(add-to-load-path \"..\")");
+        eval.eval("(add-to-load-path \"../../..\")");
+    }
+
+    ~BuggyBindLinkUTest()
+    {
+        // Erase the log file if no assertions failed.
+        if (!CxxTest::TestTracker::tracker().suiteFailed())
+                std::remove(logger().get_filename().c_str());
+    }
+
+    void setUp(void);
+    void tearDown(void);
+
+    void test_implication_introduction(void);
+};
+
+void BuggyBindLinkUTest::tearDown(void)
+{
+    as.clear();
+}
+
+void BuggyBindLinkUTest::setUp(void)
+{
+}
+
+/*
+ * Test some unexplained body is ill-formed exception. It should
+ * return nothing as opposed to crashing.
+ */
+void BuggyBindLinkUTest::test_implication_introduction(void)
+{
+    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+    eval.eval("(load-from-path \"tests/query/implication-introduction.scm\")");
+
+    Handle implication_introduction_rule =
+	    eval.eval_h("implication-introduction-rule");
+
+    Handle result = bindlink(&as, implication_introduction_rule);
+    logger().debug() << "Result is this:\n" << result->to_string();
+
+    TS_ASSERT_EQUALS(0, result->get_arity());
+}

--- a/tests/query/CMakeLists.txt
+++ b/tests/query/CMakeLists.txt
@@ -66,6 +66,7 @@ IF (HAVE_GUILE)
 	ADD_CXXTEST(BuggyQuoteUTest)
 	ADD_CXXTEST(BuggyEqualUTest)
 	ADD_CXXTEST(BuggySelfGroundUTest)
+    ADD_CXXTEST(BuggyBindLinkUTest)
 	ADD_CXXTEST(ChoiceLinkUTest)
 	ADD_CXXTEST(DefineUTest)
 	ADD_CXXTEST(FiniteStateMachineUTest)
@@ -178,3 +179,5 @@ CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/tests/query/friends.scm
     ${PROJECT_BINARY_DIR}/tests/query/friends.scm)
 CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/tests/query/ill-put.scm
     ${PROJECT_BINARY_DIR}/tests/query/ill-put.scm)
+CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/tests/query/implication-introduction.scm
+    ${PROJECT_BINARY_DIR}/tests/query/implication-introduction.scm)

--- a/tests/query/implication-introduction.scm
+++ b/tests/query/implication-introduction.scm
@@ -1,0 +1,87 @@
+(define and-lambda-distribution-rule
+   (BindLink
+      (VariableList
+         (TypedVariableLink
+            (VariableNode "$TyVs")
+            (TypeChoice
+               (TypeNode "TypedVariableLink")
+               (TypeNode "VariableNode")
+               (TypeNode "VariableList")
+            )
+         )
+         (TypedVariableLink
+            (VariableNode "$And")
+            (TypeNode "AndLink")
+         )
+      )
+      (QuoteLink
+         (LambdaLink
+            (UnquoteLink
+               (VariableNode "$TyVs")
+            )
+            (UnquoteLink
+               (VariableNode "$And")
+            )
+         )
+      )
+      (ExecutionOutputLink
+         (GroundedSchemaNode "scm: dummy")
+         (ListLink
+            (QuoteLink
+               (LambdaLink
+                  (UnquoteLink
+                     (VariableNode "$TyVs")
+                  )
+                  (UnquoteLink
+                     (VariableNode "$And")
+                  )
+               )
+            )
+         )
+      )
+   )
+)
+
+(define implication-introduction-rule
+   (BindLink
+      (VariableList
+         (TypedVariableLink
+            (VariableNode "$P")
+            (TypeChoice
+               (TypeNode "PredicateNode")
+               (TypeNode "LambdaLink")
+            )
+         )
+         (TypedVariableLink
+            (VariableNode "$Q")
+            (TypeChoice
+               (TypeNode "PredicateNode")
+               (TypeNode "LambdaLink")
+            )
+         )
+      )
+      (AndLink
+         (VariableNode "$P")
+         (VariableNode "$Q")
+         (NotLink
+            (EqualLink
+               (VariableNode "$P")
+               (VariableNode "$Q")
+            )
+         )
+      )
+      (ExecutionOutputLink
+         (GroundedSchemaNode "scm: dummy")
+         (ListLink
+            (ImplicationLink
+               (VariableNode "$P")
+               (VariableNode "$Q")
+            )
+            (VariableNode "$P")
+            (VariableNode "$Q")
+         )
+      )
+   )
+)
+
+(define (dummy . args) (Concept "dummy"))


### PR DESCRIPTION
Have `equal` support silent in `EvaluationLink`.