### PR TITLE
Fix PutLink

### DIFF
--- a/opencog/atoms/core/PrenexLink.cc
+++ b/opencog/atoms/core/PrenexLink.cc
@@ -75,7 +75,26 @@ Handle PrenexLink::reassemble(const HandleMap& vm,
 
 	// Reassemble if necessary
 	if (not final_varlist.empty())
-		return Handle(createLink(get_type(), vdecl, newbod));
+	{
+		Type ntype = get_type();
+		// Due to the fact that
+		//
+		// PutLink
+		//   <vardecl>
+		//   <body>
+		//   <values>
+		//
+		// is equivalent to
+		//
+		// PutLink
+		//   Lambda
+		//     <vardecl>
+		//     <body>
+		//   <values>
+		if (ntype == PUT_LINK)
+			ntype = LAMBDA_LINK;
+		return Handle(createLink(ntype, vdecl, newbod));
+	}
 
 	return newbod;
 }

--- a/tests/atoms/PutLinkUTest.cxxtest
+++ b/tests/atoms/PutLinkUTest.cxxtest
@@ -1214,7 +1214,7 @@ void PutLinkUTest::test_nested_1()
 }
 
 /**
- * Test that the following raise an exception
+ * Test that the following
  *
  * (PutLink
  *   (PutLink
@@ -1253,8 +1253,11 @@ void PutLinkUTest::test_nested_2()
 	logger().debug() << "rs = " << rs;
 
 	Instantiator inst(&_as);
-	Handle nested_put = _eval.eval_h("nested-put-2");
-	TS_ASSERT_THROWS_ANYTHING(inst.execute(nested_put));
+	Handle nested_put = _eval.eval_h("nested-put-2"),
+		result = inst.execute(nested_put),
+		expected = _eval.eval_h("expected-2");
+
+	TS_ASSERT_EQUALS(result, expected);
 
 	logger().info("END TEST: %s", __FUNCTION__);
 }
@@ -1559,12 +1562,29 @@ void PutLinkUTest::test_ill_put()
 	                              "        (VariableNode \"$g\")"
 	                              "        (VariableNode \"$texts\")"
 	                              "        (VariableNode \"$ms\")))"
-	                              "    (VariableNode \"$f\")))");
-	Handle result = inst.execute(ill_put);
+	                              "    (VariableNode \"$f\")))"),
+		result = inst.execute(ill_put),
+		expected = _eval.eval_h("(ListLink"
+		                        "  (EvaluationLink"
+		                        "    (PredicateNode \"minsup\")"
+		                        "    (ListLink"
+		                        "      (LambdaLink"
+		                        "        (VariableNode \"$x\")"
+		                        "        (VariableNode \"$x\"))"
+		                        "      (VariableNode \"$texts\")"
+		                        "      (VariableNode \"$ms\")))"
+		                        "  (EvaluationLink"
+		                        "    (PredicateNode \"minsup\")"
+		                        "    (ListLink"
+		                        "      (VariableNode \"$g\")"
+		                        "      (VariableNode \"$texts\")"
+		                        "      (VariableNode \"$ms\")))"
+		                        "  (VariableNode \"$f\"))");
 
 	logger().debug() << "result = " << oc_to_string(result);
+	logger().debug() << "expected = " << oc_to_string(expected);
 
-	TS_ASSERT_EQUALS(result, nullptr);
+	TS_ASSERT_EQUALS(result, expected);
 
 	logger().info("END TEST: %s", __FUNCTION__);
 }

--- a/tests/atoms/tricky-put.scm
+++ b/tests/atoms/tricky-put.scm
@@ -40,9 +40,10 @@
   (List (Variable "$Z") (Variable "$W"))))
 
 (define expected-4
-(InheritanceLink
-  (VariableNode "$X")
-  (VariableNode "$Y")))
+(LambdaLink
+  (InheritanceLink
+    (VariableNode "$X")
+    (VariableNode "$Y"))))
 
 (define put-5
 (Put


### PR DESCRIPTION
It's the same attempt to fix #1585 with the same fix, the only difference is that it only contains the fix, not any new unit tests. Also the unit tests have been modified to reflect the assumption that
```
PutLink
  <vardecl>
  <body>
  <values>
```
is equivalent to
```
PutLink
  Lambda
    <vardecl>
    <body>
  <values>
```