### PR TITLE
Improve Unify

### DIFF
--- a/opencog/atoms/base/Handle.cc
+++ b/opencog/atoms/base/Handle.cc
@@ -325,6 +325,23 @@ std::string oc_to_string(Type type)
 {
 	return oc_to_string(type, "");
 }
+std::string oc_to_string(const TypeSet& types, const std::string& indent)
+{
+	std::stringstream ss;
+	ss << indent << "size = " << types.size();
+	if (not types.empty()) {
+		ss << ", types =";
+		for (Type t : types) {
+			ss << " " << oc_to_string(t);
+		}
+	}
+	ss << std::endl;
+	return ss.str();
+}
+std::string oc_to_string(const TypeSet& types)
+{
+	return oc_to_string(types, "");
+}
 std::string oc_to_string(const AtomPtr& aptr, const std::string& indent)
 {
 	return oc_to_string(aptr->get_handle(), indent);

--- a/opencog/atoms/base/Handle.h
+++ b/opencog/atoms/base/Handle.h
@@ -300,6 +300,8 @@ std::string oc_to_string(const HandleUCounter& huc, const std::string& indent);
 std::string oc_to_string(const HandleUCounter& huc);
 std::string oc_to_string(Type type, const std::string& indent);
 std::string oc_to_string(Type type);
+std::string oc_to_string(const TypeSet& types, const std::string& indent);
+std::string oc_to_string(const TypeSet& types);
 std::string oc_to_string(const AtomPtr& aptr, const std::string& indent);
 std::string oc_to_string(const AtomPtr& aptr);
 

--- a/opencog/atoms/base/types.h
+++ b/opencog/atoms/base/types.h
@@ -30,6 +30,8 @@
 #ifndef _OPENCOG_TYPES_H
 #define _OPENCOG_TYPES_H
 
+#include <set>
+
 namespace opencog
 {
 /** \addtogroup grp_atomspace
@@ -38,6 +40,9 @@ namespace opencog
 
 //! type of Atoms, represented as short integer (16 bits)
 typedef unsigned short Type;
+
+//! Set of atom types
+typedef std::set<Type> TypeSet;
 
 /** @}*/
 } // namespace opencog

--- a/opencog/atoms/core/VariableList.cc
+++ b/opencog/atoms/core/VariableList.cc
@@ -228,29 +228,29 @@ void VariableList::get_vartype(const Handle& htypelink)
 		Type vt = TypeNodeCast(vartype)->get_value();
 		if (vt != ATOM)  // Atom type is same as untyped.
 		{
-			std::set<Type> ts = {vt};
+			TypeSet ts = {vt};
 			_varlist._simple_typemap.insert({varname, ts});
 		}
 	}
 	else if (TYPE_INH_NODE == t)
 	{
 		Type vt = TypeNodeCast(vartype)->get_value();
-		std::set<Type> ts;
-		std::set<Type>::iterator it = ts.begin();
+		TypeSet ts;
+		TypeSet::iterator it = ts.begin();
 		classserver().getChildren(vt, std::inserter(ts, it));
 		_varlist._simple_typemap.insert({varname, ts});
 	}
 	else if (TYPE_CO_INH_NODE == t)
 	{
 		Type vt = TypeNodeCast(vartype)->get_value();
-		std::set<Type> ts;
-		std::set<Type>::iterator it = ts.begin();
+		TypeSet ts;
+		TypeSet::iterator it = ts.begin();
 		classserver().getChildren(vt, std::inserter(ts, it));
 		_varlist._simple_typemap.insert({varname, ts});
 	}
 	else if (TYPE_CHOICE == t)
 	{
-		std::set<Type> typeset;
+		TypeSet typeset;
 		HandleSet deepset;
 		HandleSet fuzzset;
 

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -435,9 +435,9 @@ bool Variables::is_type(const Handle& var, const Handle& val) const
 	VariableTypeMap::const_iterator tit = _simple_typemap.find(var);
 	if (_simple_typemap.end() != tit)
 	{
-		const std::set<Type> &tchoice = tit->second;
+		const TypeSet &tchoice = tit->second;
 		Type htype = val->get_type();
-		std::set<Type>::const_iterator allow = tchoice.find(htype);
+		TypeSet::const_iterator allow = tchoice.find(htype);
 
 		// If the value has the simple type, then we are good to go;
 		// we are done.  Else, fall through, and see if one of the
@@ -664,8 +664,8 @@ void Variables::extend(const Variables& vset)
 			// Merge the two typemaps, if needed.
 			try
 			{
-				const std::set<Type>& tms = vset._simple_typemap.at(h);
-				std::set<Type> mytypes =
+				const TypeSet& tms = vset._simple_typemap.at(h);
+				TypeSet mytypes =
 					type_intersection(_simple_typemap[h], tms);
 				_simple_typemap.erase(h);	 // is it safe to erase if
                                              // h not in already?

--- a/opencog/atoms/core/Variables.h
+++ b/opencog/atoms/core/Variables.h
@@ -148,7 +148,7 @@ protected:
 	                         Quotation quotation=Quotation()) const;
 };
 
-typedef std::map<Handle, const std::set<Type>> VariableTypeMap;
+typedef std::map<Handle, const TypeSet> VariableTypeMap;
 typedef std::map<Handle, const HandleSet> VariableDeepTypeMap;
 typedef std::map<Handle, const std::pair<double, double>> GlobIntervalMap;
 

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -74,7 +74,7 @@ void PatternLink::common_init(void)
 	// we are being run with the DefaultPatternMatchCB, and so we assume
 	// that the logical connectives are AndLink, OrLink and NotLink.
 	// Tweak the evaluatable_holders to reflect this.
-	std::set<Type> connectives({AND_LINK, SEQUENTIAL_AND_LINK,
+	TypeSet connectives({AND_LINK, SEQUENTIAL_AND_LINK,
 	                            OR_LINK, SEQUENTIAL_OR_LINK, NOT_LINK});
 	trace_connectives(connectives, _pat.clauses);
 
@@ -361,7 +361,7 @@ void PatternLink::unbundle_clauses(const Handle& hbody)
 	{
 		// XXX FIXME, Just like in trace_connectives, assume we are
 		// working with the DefaultPatternMatchCB, which uses these.
-		std::set<Type> connectives({AND_LINK, SEQUENTIAL_AND_LINK,
+		TypeSet connectives({AND_LINK, SEQUENTIAL_AND_LINK,
 		                            OR_LINK, SEQUENTIAL_OR_LINK, NOT_LINK});
 		const HandleSeq& oset = hbody->getOutgoingSet();
 		unbundle_clauses_rec(connectives, oset);
@@ -378,7 +378,7 @@ void PatternLink::unbundle_clauses(const Handle& hbody)
 /// Search for any PRESENT_LINK or ABSENT_LINK's that are
 /// recusively embedded inside some evaluatable clause.  Expose these
 /// as first-class, groundable clauses.
-void PatternLink::unbundle_clauses_rec(const std::set<Type>& connectives,
+void PatternLink::unbundle_clauses_rec(const TypeSet& connectives,
                                        const HandleSeq& nest)
 {
 	for (const Handle& ho : nest)
@@ -756,7 +756,7 @@ bool PatternLink::add_dummies()
 /// having the form (AndLink stuff (OrLink more-stuff (NotLink not-stuff)))
 /// we have to assume that stuff, more-stuff and not-stuff are all
 /// evaluatable.
-void PatternLink::trace_connectives(const std::set<Type>& connectives,
+void PatternLink::trace_connectives(const TypeSet& connectives,
                                     const HandleSeq& oset,
                                     Quotation quotation)
 {

--- a/opencog/atoms/pattern/PatternLink.h
+++ b/opencog/atoms/pattern/PatternLink.h
@@ -96,7 +96,7 @@ protected:
 	HandleSeq _component_patterns;
 
 	void unbundle_clauses(const Handle& body);
-	void unbundle_clauses_rec(const std::set<Type>&,
+	void unbundle_clauses_rec(const TypeSet&,
 	                          const HandleSeq&);
 
 	void locate_defines(HandleSeq& clauses);
@@ -116,7 +116,7 @@ protected:
 
 	bool add_dummies();
 
-	void trace_connectives(const std::set<Type>&,
+	void trace_connectives(const TypeSet&,
 	                       const HandleSeq& clauses,
 	                       Quotation quotation=Quotation());
 

--- a/opencog/atomspace/BackingStore.h
+++ b/opencog/atomspace/BackingStore.h
@@ -134,7 +134,7 @@ class BackingStore
 		/**
 		 * The set of ignored atom types.
 		 */
-		std::set<Type> _ignored_types;
+		TypeSet _ignored_types;
 
 		/**
 		 * Register this backing store with the atomspace.

--- a/opencog/atomutils/FindUtils.h
+++ b/opencog/atomutils/FindUtils.h
@@ -89,7 +89,7 @@ namespace opencog {
 class FindAtoms
 {
 public:
-	std::set<Type> stopset;
+	TypeSet stopset;
 	HandleSet varset;
 	HandleSet holders;
 	HandleSet least_holders;
@@ -117,7 +117,7 @@ private:
 	Loco find_rec(const Handle& h, Quotation quotation=Quotation());
 
 private:
-	std::set<Type> _target_types;
+	TypeSet _target_types;
 	HandleSet _target_atoms;
 };
 

--- a/opencog/atomutils/TypeUtils.cc
+++ b/opencog/atomutils/TypeUtils.cc
@@ -337,7 +337,7 @@ bool is_well_typed(Type t)
 	return t != NOTYPE;
 }
 
-bool is_well_typed(const std::set<Type>& ts)
+bool is_well_typed(const TypeSet& ts)
 {
 	for (Type t : ts)
 		if (not is_well_typed(t))
@@ -355,9 +355,9 @@ Type type_intersection(Type lhs, Type rhs)
 	return NOTYPE;              // represent the bottom type
 }
 
-std::set<Type> type_intersection(Type lhs, const std::set<Type>& rhs)
+TypeSet type_intersection(Type lhs, const TypeSet& rhs)
 {
-	std::set<Type> res;
+	TypeSet res;
 	// Distribute the intersection over the union type rhs
 	for (Type rhst : rhs) {
 		Type ty = type_intersection(lhs, rhst);
@@ -367,8 +367,8 @@ std::set<Type> type_intersection(Type lhs, const std::set<Type>& rhs)
 	return res;
 }
 
-std::set<Type> type_intersection(const std::set<Type>& lhs,
-                                 const std::set<Type>& rhs)
+TypeSet type_intersection(const TypeSet& lhs,
+                          const TypeSet& rhs)
 {
 	// Base cases
 	if (lhs.empty())
@@ -377,9 +377,9 @@ std::set<Type> type_intersection(const std::set<Type>& lhs,
 		return lhs;
 
 	// Recursive cases
-	std::set<Type> res;
+	TypeSet res;
 	for (Type ty : lhs) {
-		std::set<Type> itr = type_intersection(ty, rhs);
+		TypeSet itr = type_intersection(ty, rhs);
 		res.insert(itr.begin(), itr.end());
 	}
 	return res;

--- a/opencog/atomutils/TypeUtils.h
+++ b/opencog/atomutils/TypeUtils.h
@@ -169,16 +169,16 @@ bool is_well_typed(Type t);
  * amount to the valid type. We may want to relax that definition in
  * the future.
  */
-bool is_well_typed(const std::set<Type>& ts);
+bool is_well_typed(const TypeSet& ts);
 
 /**
  * Return shallow type intersection between lhs and rhs. Take into
  * account type inheritance as well.
  */
 Type type_intersection(Type lhs, Type rhs);
-std::set<Type> type_intersection(Type lhs, const std::set<Type>& rhs);
-std::set<Type> type_intersection(const std::set<Type>& lhs,
-                                 const std::set<Type>& rhs);
+TypeSet type_intersection(Type lhs, const TypeSet& rhs);
+TypeSet type_intersection(const TypeSet& lhs,
+                          const TypeSet& rhs);
 
 /**
  * Generate a VariableList of the free variables of a given atom h.

--- a/opencog/query/DefaultPatternMatchCB.h
+++ b/opencog/query/DefaultPatternMatchCB.h
@@ -85,7 +85,7 @@ class DefaultPatternMatchCB : public virtual PatternMatchCallback
 		virtual bool evaluate_sentence(const Handle& pat, const HandleMap& gnds)
 		{ return eval_sentence(pat, gnds); }
 
-		virtual const std::set<Type>& get_connectives(void)
+		virtual const TypeSet& get_connectives(void)
 		{
 			return _connectives;
 		}
@@ -131,7 +131,7 @@ class DefaultPatternMatchCB : public virtual PatternMatchCallback
 		virtual void clear();
 #endif
 		// Crisp-logic evaluation of evaluatable terms
-		std::set<Type> _connectives;
+		TypeSet _connectives;
 		bool eval_term(const Handle& pat, const HandleMap& gnds);
 		bool eval_sentence(const Handle& pat, const HandleMap& gnds);
 

--- a/opencog/query/InitiateSearchCB.cc
+++ b/opencog/query/InitiateSearchCB.cc
@@ -672,7 +672,7 @@ bool InitiateSearchCB::variable_search(PatternMatchEngine *pme)
 
 	// Find the rarest variable type;
 	size_t count = SIZE_MAX;
-	std::set<Type> ptypes;
+	TypeSet ptypes;
 
 	DO_LOG({LAZY_LOG_FINE << "_variables = " <<  _variables->to_string();})
 	_root = Handle::UNDEFINED;
@@ -693,7 +693,7 @@ bool InitiateSearchCB::variable_search(PatternMatchEngine *pme)
 
 		auto tit = _variables->_simple_typemap.find(var);
 		if (_variables->_simple_typemap.end() == tit) continue;
-		const std::set<Type>& typeset = tit->second;
+		const TypeSet& typeset = tit->second;
 		DO_LOG({LAZY_LOG_FINE << "Type-restriction set size = "
 		              << typeset.size();})
 

--- a/opencog/query/PatternMatchCallback.h
+++ b/opencog/query/PatternMatchCallback.h
@@ -300,8 +300,8 @@ class PatternMatchCallback
 		 */
 		virtual void pop(void) {}
 
-		virtual const std::set<Type>& get_connectives(void)
-		{ static const std::set<Type> _empty; return _empty; }
+		virtual const TypeSet& get_connectives(void)
+		{ static const TypeSet _empty; return _empty; }
 
 		/**
 		 * Called to initiate the search. This callback is responsible

--- a/opencog/unify/Unify.cc
+++ b/opencog/unify/Unify.cc
@@ -883,12 +883,12 @@ Unify::CHandle Unify::type_intersection(const CHandle& lch, const CHandle& rch) 
 	return Handle::UNDEFINED;
 }
 
-std::set<Type> Unify::simplify_type_union(std::set<Type>& type) const
+TypeSet Unify::simplify_type_union(TypeSet& type) const
 {
 	return {}; // TODO: do we really need that?
 }
 
-std::set<Type> Unify::get_union_type(const Handle& h) const
+TypeSet Unify::get_union_type(const Handle& h) const
 {
 	const VariableTypeMap& vtm = _variables._simple_typemap;
 	auto it = vtm.find(h);
@@ -962,7 +962,7 @@ bool Unify::inherit(Type lhs, Type rhs) const
 	return classserver().isA(lhs, rhs);
 }
 
-bool Unify::inherit(Type lhs, const std::set<Type>& rhs) const
+bool Unify::inherit(Type lhs, const TypeSet& rhs) const
 {
 	for (Type ty : rhs)
 		if (inherit(lhs, ty))
@@ -970,7 +970,7 @@ bool Unify::inherit(Type lhs, const std::set<Type>& rhs) const
 	return false;
 }
 
-bool Unify::inherit(const std::set<Type>& lhs, const std::set<Type>& rhs) const
+bool Unify::inherit(const TypeSet& lhs, const TypeSet& rhs) const
 {
 	for (Type ty : lhs)
 		if (not inherit(ty, rhs))

--- a/opencog/unify/Unify.cc
+++ b/opencog/unify/Unify.cc
@@ -215,17 +215,21 @@ void Unify::set_variables(const Handle& lhs, const Handle& rhs,
 Unify::CHandle Unify::find_least_abstract(const TypedBlock& block,
                                           const Handle& pre) const
 {
+	// Get the least abstract element of the block
 	static Handle top(Handle(createNode(VARIABLE_NODE, "__dummy_top__")));
 	CHandle least_abstract(top);
-	for (const CHandle& ch : block.first) {
-		if (inherit(ch, least_abstract) and
-		    // If h is a variable, consider it if it is in pre (stands
-		    // for precedence)
-		    (not ch.is_free_variable()
-		     or is_unquoted_unscoped_in_tree(pre, ch.handle))) {
+	for (const CHandle& ch : block.first)
+		if (inherit(ch, least_abstract))
 			least_abstract = ch;
-		}
-	}
+
+	// In case of ties pick up the one in pre (pre stands for
+	// precedence)
+	for (const CHandle& ch : block.first)
+		if (inherit(ch, least_abstract)
+		    and
+		    (not ch.is_free_variable()
+		     or is_unquoted_unscoped_in_tree(pre, ch.handle)))
+			least_abstract = ch;
 
 	OC_ASSERT(least_abstract.handle != top,
 	          "Finding the least abstract atom in the block has failed. "

--- a/opencog/unify/Unify.h
+++ b/opencog/unify/Unify.h
@@ -644,7 +644,7 @@ private:
 	 *
 	 * As ConceptNode inherits Node.
 	 */
-	std::set<Type> simplify_type_union(std::set<Type>& type) const;
+	TypeSet simplify_type_union(TypeSet& type) const;
 
 	/**
 	 * Return the union type of a variable. If the variable
@@ -653,7 +653,7 @@ private:
 	 * union type would instead mean the bottom type (that nothing can
 	 * inherit).
 	 */
-	std::set<Type> get_union_type(const Handle& h) const;
+	TypeSet get_union_type(const Handle& h) const;
 
 	/**
 	 * Return true if lhs inherit rhs. If lhs is not a variable then it
@@ -672,13 +672,13 @@ private:
 	/**
 	 * Return true if a type inherits a type union.
 	 */
-	bool inherit(Type lhs, const std::set<Type>& rhs) const;
+	bool inherit(Type lhs, const TypeSet& rhs) const;
 
 	/**
 	 * Return true if lhs inherits rhs. That is if all elements of lhs
 	 * inherits rhs.
 	 */
-	bool inherit(const std::set<Type>& lhs, const std::set<Type>& rhs) const;
+	bool inherit(const TypeSet& lhs, const TypeSet& rhs) const;
 };
 
 bool unifiable(const Handle& lhs, const Handle& rhs,

--- a/tests/rule-engine/RuleUTest.cxxtest
+++ b/tests/rule-engine/RuleUTest.cxxtest
@@ -118,7 +118,7 @@ void RuleUTest::setUp()
 		             "   (ConceptNode \"URE\"))");
 
 	X = an(VARIABLE_NODE, "$X");
-	A = an(CONCEPT_NODE, "$A");
+	A = an(CONCEPT_NODE, "A");
 	V = an(VARIABLE_NODE, "$V");
 	CT = an(TYPE_NODE, "ConceptNode");
 	Typed_X = al(TYPED_VARIABLE_LINK, X, CT);
@@ -145,11 +145,7 @@ void RuleUTest::test_unify_target_deduction_1()
 	Handle rule = rules.begin()->first.get_rule(),
 		// Expected up to an alpha conversion
 		vardecl = al(VARIABLE_LIST,
-		             // TODO: unify needs to be upgraded so it can
-		             // infer that X is in fact a ConceptNode
-		             //
-		             // al(TYPED_VARIABLE_LINK, X, CT),
-		             X,
+		             al(TYPED_VARIABLE_LINK, X, CT),
 		             al(TYPED_VARIABLE_LINK, V, CT)),
 		XV = al(INHERITANCE_LINK, X, V),
 		VA = al(INHERITANCE_LINK, V, A),

--- a/tests/unify/UnifyUTest.cxxtest
+++ b/tests/unify/UnifyUTest.cxxtest
@@ -1806,10 +1806,10 @@ void UnifyUTest::test_unify_complex_10()
 	TS_ASSERT_EQUALS(result, expected);
 
 	Handle ts_vardecl = _eval.eval_h("(TypedVariableLink"
-	                                 "  (VariableNode \"$patvar\")"
+	                                 "  (VariableNode \"$f\")"
 	                                 "  (TypeChoice"
+	                                 "    (TypeNode \"ConceptNode\")"
 	                                 "    (TypeNode \"LambdaLink\")"
-	                                 "    (TypeNode \"PutLink\")"
 	                                 "  )"
 	                                 ")");
 
@@ -1818,9 +1818,9 @@ void UnifyUTest::test_unify_complex_10()
 	Unify::TypedSubstitutions ts_expected =
 		Unify::TypedSubstitutions{{{{texts_var, texts},
 		                            {g_var, Ctop},
-		                            {f_var, pat_var},
+		                            {f_var, f_var},
 		                            {ms_var, ms},
-		                            {pat_var, pat_var}},
+		                            {pat_var, f_var}},
 		                           ts_vardecl}};
 
 	std::cout << "ts_result = " << oc_to_string(ts_result) << std::endl;

--- a/tests/unify/UnifyUTest.cxxtest
+++ b/tests/unify/UnifyUTest.cxxtest
@@ -163,6 +163,7 @@ public:
 	void test_unify_complex_7();
 	void test_unify_complex_8();
 	void test_unify_complex_9();
+	void test_unify_complex_10();
 };
 
 void UnifyUTest::setUp(void)
@@ -1708,6 +1709,124 @@ void UnifyUTest::test_unify_complex_9()
 	std::cout << "expected = " << oc_to_string(expected) << std::endl;
 
 	TS_ASSERT_EQUALS(result, expected);
+}
+
+void UnifyUTest::test_unify_complex_10()
+{
+	Handle target =
+		_eval.eval_h("(EvaluationLink"
+		             "  (PredicateNode \"minsup\")"
+		             "  (ListLink"
+		             "    (QuoteLink"
+		             "      (PutLink"
+		             "        (LambdaLink"
+		             "          (VariableNode \"$top-arg\")"
+		             "          (VariableNode \"$top-arg\")"
+		             "        )"
+		             "        (UnquoteLink"
+		             "          (VariableNode \"$patvar\")"
+		             "        )"
+		             "      )"
+		             "    )"
+		             "    (ConceptNode \"texts\")"
+		             "    (NumberNode \"2.000000\")"
+		             "  )"
+		             ")");
+
+	Handle alpha_pat =
+        _eval.eval_h("(EvaluationLink"
+                     "  (PredicateNode \"minsup\")"
+                     "  (ListLink"
+                     "    (QuoteLink"
+                     "      (PutLink"
+                     "        (UnquoteLink"
+                     "          (VariableNode \"$g\")"
+                     "        )"
+                     "        (UnquoteLink"
+                     "          (VariableNode \"$f\")"
+                     "        )"
+                     "      )"
+                     "    )"
+                     "    (VariableNode \"$texts\")"
+                     "    (VariableNode \"$ms\")"
+                     "  )"
+                     ")");
+
+	Handle vardecl =
+        _eval.eval_h("(VariableNode \"$patvar\")");
+
+	Handle alpha_vardecl =
+        _eval.eval_h("(VariableList"
+                     "  (TypedVariableLink"
+                     "    (VariableNode \"$g\")"
+                     "    (TypeChoice"
+                     "      (TypeNode \"LambdaLink\")"
+                     "      (TypeNode \"PutLink\")"
+                     "    )"
+                     "  )"
+                     "  (TypedVariableLink"
+                     "    (VariableNode \"$texts\")"
+                     "    (TypeNode \"ConceptNode\")"
+                     "  )"
+                     "  (TypedVariableLink"
+                     "    (VariableNode \"$ms\")"
+                     "    (TypeNode \"NumberNode\")"
+                     "  )"
+                     "  (TypedVariableLink"
+                     "    (VariableNode \"$f\")"
+                     "    (TypeChoice"
+                     "      (TypeNode \"LambdaLink\")"
+                     "      (TypeNode \"ConceptNode\")"
+                     "    )"
+                     "  )"
+                     ")");
+
+	Handle g_var = _eval.eval_h("(VariableNode \"$g\")");
+	Handle top = _eval.eval_h("(LambdaLink"
+	                          "  (VariableNode \"$top-arg\")"
+	                          "  (VariableNode \"$top-arg\"))");
+	Unify::CHandle Ctop(top, Quotation(1));
+	Handle pat_var = _eval.eval_h("(VariableNode \"$patvar\")");
+	Handle f_var = _eval.eval_h("(VariableNode \"$f\")");
+	Handle texts_var = _eval.eval_h("(VariableNode \"$texts\")");
+	Handle texts = _eval.eval_h("(ConceptNode \"texts\")");
+	Handle ms_var = _eval.eval_h("(VariableNode \"$ms\")");
+	Handle ms = _eval.eval_h("(NumberNode \"2.0\")");
+
+	Unify unify(target, alpha_pat, vardecl, alpha_vardecl);
+	Unify::SolutionSet result = unify(),
+		expected = Unify::SolutionSet({{{{g_var, Ctop}, Ctop},
+					                    {{pat_var, f_var}, f_var},
+					                    {{texts_var, texts}, texts},
+					                    {{ms_var, ms}, ms}}});
+
+	std::cout << "result = " << oc_to_string(result) << std::endl;
+	std::cout << "expected = " << oc_to_string(expected) << std::endl;
+
+	TS_ASSERT_EQUALS(result, expected);
+
+	Handle ts_vardecl = _eval.eval_h("(TypedVariableLink"
+	                                 "  (VariableNode \"$patvar\")"
+	                                 "  (TypeChoice"
+	                                 "    (TypeNode \"LambdaLink\")"
+	                                 "    (TypeNode \"PutLink\")"
+	                                 "  )"
+	                                 ")");
+
+	Unify::TypedSubstitutions ts_result =
+		unify.typed_substitutions(result, target);
+	Unify::TypedSubstitutions ts_expected =
+		Unify::TypedSubstitutions{{{{texts_var, texts},
+		                            {g_var, Ctop},
+		                            {f_var, pat_var},
+		                            {ms_var, ms},
+		                            {pat_var, pat_var}},
+		                           ts_vardecl}};
+
+	std::cout << "ts_result = " << oc_to_string(ts_result) << std::endl;
+	std::cout << "ts_expected = " << oc_to_string(ts_expected) << std::endl;
+
+	TS_ASSERT(tss_content_eq(ts_result, ts_expected));
 }
 
 #undef al


### PR DESCRIPTION
In particular reconstructed variable declarations capture more type restrictions when available.

Also include some minor code simplification, `std::vector<Type>` renamed into `TypeSet`.