### PR TITLE
Verifying rule format.

### DIFF
--- a/opencog/rule-engine/Rule.cc
+++ b/opencog/rule-engine/Rule.cc
@@ -5,6 +5,7 @@
  *
  * Authors: Misgana Bayetta <misgana.bayetta@gmail.com> 2015
  *          Nil Geisweiller 2015-2016
+ *          Shujing Ke 2018
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License v3 as
@@ -113,6 +114,32 @@ void Rule::init(const Handle& rule_alias, const Handle& rule, const Handle& rbs)
 	AtomSpace& as = *rule_alias->getAtomSpace();
 	Handle ml = as.get_link(MEMBER_LINK, rule_alias, rbs);
 	_tv = ml->getTruthValue();
+
+    verify_rule();
+}
+
+bool Rule::verify_rule()
+{
+    // currently do not verify meta rules
+    if (is_meta())
+        return true;
+
+    Handle rewrite = _rule->get_implicand();
+    Type rewrite_type = rewrite->get_type();
+
+    // check 1: If there are multiple conclusions
+    if ((rewrite_type == AND_LINK) || (rewrite_type == LIST_LINK))
+    {
+        logger().warn() << "\nRule::verify_rule: " << _rule_alias->get_name()
+                        << " contains multiple conclusions.\n"
+                        << "This rule will not work in backwardchainer.\n"
+                        << "All the conclusions should be wrapped with an ExecutionOutPutLink.\n"
+                        << "Please check /atomspace/examples/rule-engine/DummyExecutionOutput.scm for example."
+                        << std::endl;
+        return false;
+    }
+
+    return true;
 }
 
 bool Rule::operator==(const Rule& r) const

--- a/opencog/rule-engine/Rule.h
+++ b/opencog/rule-engine/Rule.h
@@ -5,6 +5,7 @@
  *
  * Authors: Misgana Bayetta <misgana.bayetta@gmail.com>  2015
  *          Nil Geisweiller 2015-2016
+ *          Shujing Ke 2018
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License v3 as
@@ -106,6 +107,16 @@ public:
 	void init(const Handle& rule_member);
 	void init(const Handle& rule_alias, const Handle& rbs);
 	void init(const Handle& rule_alias, const Handle& rule, const Handle& rbs);
+
+    /**
+     * Verify if this rule is defined in the required format.
+     * The main purpose is to give user the corresponding warnings and info.
+     * Only verify a normal rule, do not use this function to verify a meta rule.
+     * Current verify items:
+     * 1.If there are multiple conslusions, they also need to be wrapped with one
+     *   single ExecutionOutPutLink, otherwise it won't work for bc.
+     */
+    bool verify_rule();
 	
 	// Comparison
 	bool operator==(const Rule& r) const;

--- a/opencog/rule-engine/UREConfig.cc
+++ b/opencog/rule-engine/UREConfig.cc
@@ -137,7 +137,15 @@ void UREConfig::fetch_common_parameters(const Handle& rbs)
 {
 	// Retrieve the rules (MemberLinks) and instantiate them
 	for (const Handle& rule_name : fetch_rule_names(rbs))
+    {
+        OC_ASSERT((rule_name->get_type() == DEFINED_SCHEMA_NODE),
+              "The rule: \n%s \n is not a DefinedSchemaNode."
+              "A rule needs an alias and to be defined a DefinedSchemaNode.\n"
+              "Please check rules in /atomspace/examples/rule-engine for example.\n\n",
+              rule_name->to_short_string().c_str());
+
 		_common_params.rules.emplace(rule_name, rbs);
+    }
 
 	// Fetch maximum number of iterations
 	_common_params.max_iter = fetch_num_param(max_iter_name, rbs);


### PR DESCRIPTION
First, assert if a user defined rule is defined as a DefinedSchemaNode with an alias in UREConfig::fetch_common_parameters. Otherwise it will crash (or Assert fail) later when fetching the BindLink of the rule and user has no idea that it is because the rule is not defined as a DefinedSchemaNode with an alias.
Then a verify_rule function is added to Rule class and is called during init(), currently check if the conclusions are wrapped with an ExecutionOutputLink when there are multiple conclusions and give warnings. This function should not be added into Rule::is_valid(), because is_valid() check if the rule has been assigned a valid Handle, which has been used in many places. verify_rule() give warning, should only be used when init a rule.
