### PR TITLE
Add typedef std::vector<HandleSet> HandleSetSeq

### DIFF
--- a/opencog/atoms/base/Handle.cc
+++ b/opencog/atoms/base/Handle.cc
@@ -192,6 +192,22 @@ std::string oc_to_string(const HandleSet& ohs)
 {
 	return oc_to_string(ohs, "");
 }
+std::string oc_to_string(const HandleSetSeq& hss, const std::string& indent)
+{
+	std::stringstream ss;
+	ss << indent << "size = " << hss.size() << std::endl;
+	size_t i = 0;
+	for (const HandleSet& hs : hss) {
+		ss << indent << "atoms[" << i << "]:" << std::endl
+		   << oc_to_string(hs, indent + OC_TO_STRING_INDENT);
+		i++;
+	}
+	return ss.str();
+}
+std::string oc_to_string(const HandleSetSeq& hss)
+{
+	return oc_to_string(hss, "");
+}
 GEN_ATOM_CONTAINER_OC_TO_STRING(opencog::UnorderedHandleSet)
 std::string oc_to_string(const UnorderedHandleSet& uhs)
 {

--- a/opencog/atoms/base/Handle.h
+++ b/opencog/atoms/base/Handle.h
@@ -176,6 +176,9 @@ typedef std::vector<HandleSeq> HandleSeqSeq;
 //! RAM and has faster iteration.
 typedef std::set<Handle> HandleSet;
 
+//! a sequence of sets of handles.
+typedef std::vector<HandleSet> HandleSetSeq;
+
 //! a hash table. Usually has faster insertion.
 typedef std::unordered_set<Handle> UnorderedHandleSet;
 
@@ -282,6 +285,8 @@ std::string oc_to_string(const HandleSeqSeq& hss, const std::string& indent);
 std::string oc_to_string(const HandleSeqSeq& hss);
 std::string oc_to_string(const HandleSet& ohs, const std::string& indent);
 std::string oc_to_string(const HandleSet& ohs);
+std::string oc_to_string(const HandleSetSeq& ohss, const std::string& indent);
+std::string oc_to_string(const HandleSetSeq& ohss);
 std::string oc_to_string(const UnorderedHandleSet& uhs, const std::string& indent);
 std::string oc_to_string(const UnorderedHandleSet& uhs);
 std::string oc_to_string(const HandleMap& hm, const std::string& indent);

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -833,7 +833,7 @@ void PatternLink::make_map_recursive(const Handle& root, const Handle& h)
 /// leading to an undefined condition.  So, explicitly check and throw
 /// an error if a pattern is ill-formed.
 void PatternLink::check_satisfiability(const HandleSet& vars,
-                                       const std::vector<HandleSet>& compvars)
+                                       const HandleSetSeq& compvars)
 {
 	// Compute the set-union of all component vars.
 	HandleSet vunion;

--- a/opencog/atoms/pattern/PatternLink.h
+++ b/opencog/atoms/pattern/PatternLink.h
@@ -92,7 +92,7 @@ protected:
 
 	size_t _num_comps;
 	HandleSeqSeq _components;
-	std::vector<HandleSet> _component_vars;
+	HandleSetSeq _component_vars;
 	HandleSeq _component_patterns;
 
 	void unbundle_clauses(const Handle& body);
@@ -124,7 +124,7 @@ protected:
 	void make_map_recursive(const Handle&, const Handle&);
 	void check_connectivity(const HandleSeqSeq&);
 	void check_satisfiability(const HandleSet&,
-	                          const std::vector<HandleSet>&);
+	                          const HandleSetSeq&);
 
 	void make_term_trees();
 	void make_term_tree_recursive(const Handle&, Handle,

--- a/opencog/atoms/pattern/PatternUtils.cc
+++ b/opencog/atoms/pattern/PatternUtils.cc
@@ -179,7 +179,7 @@ bool is_constant(const HandleSet& vars, const Handle& clause)
 void get_connected_components(const HandleSet& vars,
                               const HandleSeq& clauses,
                               HandleSeqSeq& components,
-                              std::vector<HandleSet>& component_vars)
+                              HandleSetSeq& component_vars)
 {
 	HandleSeq todo(clauses);
 

--- a/opencog/atoms/pattern/PatternUtils.h
+++ b/opencog/atoms/pattern/PatternUtils.h
@@ -55,7 +55,7 @@ bool is_constant(const HandleSet& vars, const Handle& clause);
 void get_connected_components(const HandleSet& vars,
                               const HandleSeq& clauses,
                               HandleSeqSeq& compset,
-                              std::vector<HandleSet>& compvars);
+                              HandleSetSeq& compvars);
 
 } // namespace opencog
 

--- a/opencog/attentionbank/AtomBins.h
+++ b/opencog/attentionbank/AtomBins.h
@@ -43,7 +43,7 @@ class AtomBins
 {
     private:
         mutable std::mutex _mtx;
-        std::vector<HandleSet> _idx;
+        HandleSetSeq _idx;
 
     public:
         AtomBins(size_t sz)


### PR DESCRIPTION
I know what you think, `HandleSetSeq` looks a lot like `HandleSeqSeq`, but C++ is no Python, the compiler watches your back...