### PR TITLE
URE: remove constant clauses

### DIFF
--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -948,11 +948,11 @@ void PatternLink::remove_constant_clauses(const AtomSpace& queried_as)
 	if (bogus)
 	{
 		logger().warn("%s: Constant clauses removed from pattern %s",
-		              __FUNCTION__, to_short_string().c_str());
+		              __FUNCTION__, to_string().c_str());
 		for (const Handle& h: _pat.constants)
 		{
 			logger().warn("%s: Removed %s",
-			              __FUNCTION__, h->to_short_string().c_str());
+			              __FUNCTION__, h->to_string().c_str());
 		}
 
 		_num_comps = _components.size();

--- a/opencog/atoms/pattern/PatternUtils.cc
+++ b/opencog/atoms/pattern/PatternUtils.cc
@@ -120,7 +120,7 @@ bool is_in_atomspace(const Handle& handle, const AtomSpace& atomspace)
 }
 
 bool is_constant(const HandleSet& vars, const Handle& clause,
-                 const AtomSpace* as)
+                 const AtomSpace* queried_as)
 {
 	Type ct = clause->get_type();
 	bool constant =
@@ -142,8 +142,8 @@ bool is_constant(const HandleSet& vars, const Handle& clause,
 		              or
 		              clause->getOutgoingAtom(0)->get_type() != PREDICATE_NODE)));
 
-	if (as)
-		return constant and is_in_atomspace(clause, *as);
+	if (queried_as)
+		return constant and is_in_atomspace(clause, *queried_as);
 	return constant;
 }
 

--- a/opencog/atoms/pattern/PatternUtils.h
+++ b/opencog/atoms/pattern/PatternUtils.h
@@ -51,7 +51,7 @@ bool is_in_atomspace(const Handle& clause, const AtomSpace& atomspace);
 // Return true iff the clause is constant. If an atomspace is provided
 // it also check that it is present in it.
 bool is_constant(const HandleSet& vars, const Handle& clause,
-                 const AtomSpace* as=nullptr);
+                 const AtomSpace* queried_as=nullptr);
 
 // See C file for description
 void get_connected_components(const HandleSet& vars,

--- a/opencog/atoms/pattern/PatternUtils.h
+++ b/opencog/atoms/pattern/PatternUtils.h
@@ -48,8 +48,10 @@ bool remove_constants(const HandleSet& vars,
 // check whether an Atom exists in a given atomspace.
 bool is_in_atomspace(const Handle& clause, const AtomSpace& atomspace);
 
-// Return true if the clause is constant
-bool is_constant(const HandleSet& vars, const Handle& clause);
+// Return true iff the clause is constant. If an atomspace is provided
+// it also check that it is present in it.
+bool is_constant(const HandleSet& vars, const Handle& clause,
+                 const AtomSpace* as=nullptr);
 
 // See C file for description
 void get_connected_components(const HandleSet& vars,

--- a/opencog/query/InitiateSearchCB.cc
+++ b/opencog/query/InitiateSearchCB.cc
@@ -750,7 +750,7 @@ bool InitiateSearchCB::variable_search(PatternMatchEngine *pme)
 
 		if (not _variables->_deep_typemap.empty())
 		{
-			logger().warn("Warning: Full deep-type support not implemented!");
+			logger().warn("Full deep-type support not implemented!");
 		}
 		else
 		{
@@ -759,7 +759,7 @@ bool InitiateSearchCB::variable_search(PatternMatchEngine *pme)
 			throw SyntaxException(TRACE_INFO,
 				"Error: There were no type restrictions! That's infinite-recursive!");
 #else
-			logger().warn("Warning: No type restrictions! Your code has a bug in it!");
+			logger().warn("No type restrictions! Your code has a bug in it!");
 			for (const Handle& var: _variables->varset)
 				logger().warn("Offending variable=%s\n", var->to_string().c_str());
 			for (const Handle& cl : clauses)

--- a/opencog/rule-engine/Rule.cc
+++ b/opencog/rule-engine/Rule.cc
@@ -366,7 +366,8 @@ Rule Rule::gen_standardize_apart(AtomSpace* as)
 }
 
 RuleTypedSubstitutionMap Rule::unify_source(const Handle& source,
-                                            const Handle& vardecl) const
+                                            const Handle& vardecl,
+                                            const AtomSpace* queried_as) const
 {
 	// If the rule's handle has not been set yet
 	if (not is_valid())
@@ -391,7 +392,7 @@ RuleTypedSubstitutionMap Rule::unify_source(const Handle& source,
 			// substituting all variables by their associated
 			// values.
 			for (const auto& ts : tss)
-				unified_rules.insert({alpha_rule.substituted(ts), ts});
+				unified_rules.insert({alpha_rule.substituted(ts, queried_as), ts});
 		}
 	}
 
@@ -399,7 +400,8 @@ RuleTypedSubstitutionMap Rule::unify_source(const Handle& source,
 }
 
 RuleTypedSubstitutionMap Rule::unify_target(const Handle& target,
-                                            const Handle& vardecl) const
+                                            const Handle& vardecl,
+                                            const AtomSpace* queried_as) const
 {
 	// If the rule's handle has not been set yet
 	if (not is_valid())
@@ -424,7 +426,7 @@ RuleTypedSubstitutionMap Rule::unify_target(const Handle& target,
 			// substituting all variables by their associated
 			// values.
 			for (const auto& ts : tss) {
-				unified_rules.insert({alpha_rule.substituted(ts), ts});
+				unified_rules.insert({alpha_rule.substituted(ts, queried_as), ts});
 			}
 		}
 	}
@@ -556,10 +558,11 @@ Handle Rule::get_execution_output_first_argument(const Handle& h) const
 		return args;
 }
 
-Rule Rule::substituted(const Unify::TypedSubstitution& ts) const
+Rule Rule::substituted(const Unify::TypedSubstitution& ts,
+                       const AtomSpace* queried_as) const
 {
 	Rule new_rule(*this);
-	new_rule.set_rule(Unify::substitute(_rule, ts));
+	new_rule.set_rule(Unify::substitute(_rule, ts, queried_as));
 	return new_rule;
 }
 

--- a/opencog/rule-engine/Rule.h
+++ b/opencog/rule-engine/Rule.h
@@ -226,7 +226,8 @@ public:
 	 * now we return both.
 	 */
 	RuleTypedSubstitutionMap unify_source(const Handle& source,
-	                                      const Handle& vardecl=Handle::UNDEFINED) const;
+	                                      const Handle& vardecl=Handle::UNDEFINED,
+	                                      const AtomSpace* queried_as=nullptr) const;
 
 	/**
 	 * Used by the backward chainer. Given a target, generate all rule
@@ -240,7 +241,8 @@ public:
 	 * typed substitutions.
 	 */
 	 RuleTypedSubstitutionMap unify_target(const Handle& target,
-	                                       const Handle& vardecl=Handle::UNDEFINED) const;
+	                                       const Handle& vardecl=Handle::UNDEFINED,
+	                                       const AtomSpace* queried_as=nullptr) const;
 
 	/**
 	 * Remove the typed substitutions from the rule typed substitution map.
@@ -300,7 +302,8 @@ private:
 
 	// Given a typed substitution obtained from typed_substitutions
 	// unify function, generate a new partially substituted rule.
-	Rule substituted(const Unify::TypedSubstitution& ts) const;
+	Rule substituted(const Unify::TypedSubstitution& ts,
+	                 const AtomSpace* queried_as=nullptr) const;
 };
 
 // Debugging helpers see

--- a/opencog/rule-engine/backwardchainer/BIT.cc
+++ b/opencog/rule-engine/backwardchainer/BIT.cc
@@ -102,8 +102,8 @@ AndBIT::AndBIT(AtomSpace& bit_as, const Handle& target, Handle vardecl,
 	complexity = it->second.complexity;
 }
 
-	AndBIT::AndBIT(const Handle& f, double cpx, const AtomSpace* qas)
-		: fcs(f), complexity(cpx), exhausted(false), queried_as(qas)
+AndBIT::AndBIT(const Handle& f, double cpx, const AtomSpace* qas)
+	: fcs(f), complexity(cpx), exhausted(false), queried_as(qas)
 {
 	set_leaf2bitnode();         // TODO: might differ till needed to optimize
 }

--- a/opencog/rule-engine/backwardchainer/BIT.cc
+++ b/opencog/rule-engine/backwardchainer/BIT.cc
@@ -83,25 +83,27 @@ std::string	BITNode::to_string(const std::string& indent) const
 
 AndBIT::AndBIT() : exhausted(false) {}
 
-AndBIT::AndBIT(AtomSpace& as, const Handle& target, Handle vardecl,
-               const BITNodeFitness& fitness) : exhausted(false)
+AndBIT::AndBIT(AtomSpace& bit_as, const Handle& target, Handle vardecl,
+               const BITNodeFitness& fitness, const AtomSpace* qas)
+	: exhausted(false), queried_as(qas)
 {
 	// Create initial FCS
 	vardecl = gen_vardecl(target, vardecl); // in case it is undefined
-	Handle body = Unify::remove_constant_clauses(vardecl, target);
+	Handle body =
+		Unify::remove_constant_clauses(vardecl, target, queried_as);
 	HandleSeq bl{body, target};
 	vardecl = filter_vardecl(vardecl, body); // remove useless vardecl
 	if (vardecl)
 		bl.insert(bl.begin(), vardecl);
-	fcs = as.add_link(BIND_LINK, bl);
+	fcs = bit_as.add_link(BIND_LINK, bl);
 
 	// Insert the initial BITNode and initialize the AndBIT complexity
 	auto it = insert_bitnode(target, fitness);
 	complexity = it->second.complexity;
 }
 
-AndBIT::AndBIT(const Handle& f, double cpx)	:
-	fcs(f), complexity(cpx), exhausted(false)
+	AndBIT::AndBIT(const Handle& f, double cpx, const AtomSpace* qas)
+		: fcs(f), complexity(cpx), exhausted(false), queried_as(qas)
 {
 	set_leaf2bitnode();         // TODO: might differ till needed to optimize
 }
@@ -131,7 +133,7 @@ AndBIT AndBIT::expand(const Handle& leaf,
 		return AndBIT();
 	}
 
-	return AndBIT(new_fcs, new_cpx);
+	return AndBIT(new_fcs, new_cpx, queried_as);
 }
 
 BITNode* AndBIT::select_leaf()
@@ -408,7 +410,7 @@ Handle AndBIT::substitute_unified_variables(const Handle& leaf,
                                             const Unify::TypedSubstitution& ts) const
 {
 	BindLinkPtr fcs_bl(BindLinkCast(fcs));
-	return Handle(Unify::substitute(fcs_bl, ts));
+	return Handle(Unify::substitute(fcs_bl, ts, queried_as));
 }
 
 Handle AndBIT::expand_fcs_pattern(const Handle& fcs_pattern,
@@ -657,15 +659,15 @@ std::string AndBIT::line_separator(const std::string& up_aa,
 // BIT //
 /////////
 
-BIT::BIT() {}
+BIT::BIT() : _as(nullptr) {}
 
 BIT::BIT(AtomSpace& as,
          const Handle& target,
          const Handle& vardecl,
          const BITNodeFitness& fitness)
-	: bit_as(&as),
-	  _init_target(target), _init_vardecl(vardecl), _init_fitness(fitness)
-{}
+	: bit_as(&as), // child atomspace of as
+	  _as(&as), _init_target(target), _init_vardecl(vardecl),
+	  _init_fitness(fitness) {}
 
 BIT::~BIT() {}
 
@@ -681,7 +683,8 @@ size_t BIT::size() const
 
 AndBIT* BIT::init()
 {
-	andbits.emplace_back(bit_as, _init_target, _init_vardecl, _init_fitness);
+	andbits.emplace_back(bit_as, _init_target,
+	                     _init_vardecl, _init_fitness, _as);
 
 	LAZY_URE_LOG_DEBUG << "Initialize BIT with:" << std::endl
 	                   << andbits.begin()->to_string();

--- a/opencog/rule-engine/backwardchainer/BIT.h
+++ b/opencog/rule-engine/backwardchainer/BIT.h
@@ -93,17 +93,25 @@ public:
 	// True iff all leaves are exhausted (see BITNode::exhausted)
 	bool exhausted;
 
+	// Queried atomspace
+	const AtomSpace* queried_as;
+
 	/**
 	 * @brief Initialize an and-BIT with a certain target, vardecl and
-	 * fitness and add it in as.
+	 * fitness and add it in bit_as. If an extra atomspace queried_as
+	 * is provided, then subsequent and-BITs produced from it will
+	 * have their constants removed if present in the queried
+	 * atomspace.
 	 */
 	AndBIT();
-	AndBIT(AtomSpace& as, const Handle& target, Handle vardecl,
-	       const BITNodeFitness& fitness=BITNodeFitness());
+	AndBIT(AtomSpace& bit_as, const Handle& target, Handle vardecl,
+	       const BITNodeFitness& fitness=BITNodeFitness(),
+	       const AtomSpace* queried_as=nullptr);
 	/**
 	 * @brief construct a and-BIT given its FCS and complexity.
 	 */
-	AndBIT(const Handle& fcs, double complexity=0.0);
+	AndBIT(const Handle& fcs, double complexity=0.0,
+	       const AtomSpace* queried_as=nullptr);
 	~AndBIT();
 
 	/**
@@ -371,7 +379,7 @@ private:
 class BIT
 {
 public:
-	// Atomspace for storing the BIT
+	// Child atomspace of the queried atomspace for storing the BIT
 	AtomSpace bit_as;
 
 	// Collection of and-BITs. We use a sorted vector instead of a set
@@ -448,6 +456,9 @@ public:
 	           const BITNode& bitnode) const;
 
 private:
+    // Queried atomspace
+	AtomSpace* _as;
+
 	Handle _init_target;
 	Handle _init_vardecl;
 	BITNodeFitness _init_fitness;

--- a/opencog/unify/Unify.cc
+++ b/opencog/unify/Unify.cc
@@ -405,12 +405,7 @@ Handle Unify::remove_constant_clauses(const Handle& vardecl,
 	HandleSeq hs;
 	if (t == AND_LINK) {
 		for (const Handle& clause : clauses->getOutgoingSet()) {
-			if (clause->get_hash() == 241327676611018844UL)
-				logger().debug() << "Unify::remove_constant_clauses clause = " << oc_to_string(clause);
-			bool constant = is_constant(vars, clause, as);
-			if (clause->get_hash() == 241327676611018844UL)
-				logger().debug() << "Unify::remove_constant_clauses constant = " << constant;
-			if (not constant) {
+			if (not is_constant(vars, clause, as)) {
 				hs.push_back(clause);
 			}
 		}

--- a/opencog/unify/Unify.h
+++ b/opencog/unify/Unify.h
@@ -246,8 +246,13 @@ public:
 	/**
 	 * Given a typed substitution, perform the substitution over a scope
 	 * link (for now only BindLinks are supported).
+	 *
+	 * If an atomspace is provided then remove constant clauses
+	 * present in the atomspace.
 	 */
-	static Handle substitute(BindLinkPtr bl, const TypedSubstitution& ts);
+	static Handle substitute(BindLinkPtr bl,
+	                         const TypedSubstitution& ts,
+	                         const AtomSpace* queried_as=nullptr);
 
 	/**
 	 * Given a mapping from variables to values, return a copy of
@@ -259,9 +264,8 @@ public:
 	 * removed from the BindLink. If no clause remains then the
 	 * pattern body is left with an empty AndLink.
 	 *
-	 * TODO: removing constant clauses might be a problem as the
-	 * clauses might not necessarily be in the queried atomspace, so
-	 * they might not be trivially true.
+	 * If an atomspace is provided then remove constant clauses
+	 * present in the atomspace.
 	 *
 	 * Examples:
 	 *
@@ -316,7 +320,8 @@ public:
 	 * TODO: replace by RewriteLink methods!
 	 */
 	static Handle substitute(BindLinkPtr bl, const HandleMap& var2val,
-	                         Handle vardecl=Handle::UNDEFINED);
+	                         Handle vardecl=Handle::UNDEFINED,
+	                         const AtomSpace* queried_as=nullptr);
 
 	/**
 	 * Substitute the variable declaration of a BindLink. Remove
@@ -333,6 +338,9 @@ public:
 	 * declaration, remove the constant clauses. If all clauses are
 	 * constants then return an empty AndLink.
 	 *
+	 * If an atomspace is provided then check that the constant is in
+	 * the atomspace as well, otherwise do not remove it.
+	 *
 	 * The variable declaration is assumed defined. That is if there
 	 * are no variable, rather than Handle::UNDEFINED the vardecl will
 	 * have to be a empty VariableList. That is because an undefined
@@ -340,7 +348,8 @@ public:
 	 * it means empty or containing all free variables.
 	 */
 	static Handle remove_constant_clauses(const Handle& vardecl,
-	                                      const Handle& clauses);
+	                                      const Handle& clauses,
+	                                      const AtomSpace* queried_as=nullptr);
 
 	/**
 	 * Perform unification by recursively


### PR DESCRIPTION
For some reason the warning message of the pattern matcher slows down the URE 3x (in my test case). To counteract this the URE now preemptively remove constant clauses from unified rules and inference trees.

This, I believe, doesn't change the fact that constant checking on the pattern matcher end should still be at run time.