### PR TITLE
Use PROJECT_SOURCE_DIR in unit tests.

### DIFF
--- a/tests/atoms/MapLinkUTest.cxxtest
+++ b/tests/atoms/MapLinkUTest.cxxtest
@@ -41,8 +41,7 @@ public:
 
         as = new AtomSpace();
         eval = new SchemeEval(as);
-        eval->eval("(add-to-load-path \"..\")");
-        eval->eval("(add-to-load-path \"../../..\")");
+        eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
         eval->eval("(use-modules (opencog exec))");
     }
 

--- a/tests/atoms/ParallelUTest.cxxtest
+++ b/tests/atoms/ParallelUTest.cxxtest
@@ -51,8 +51,8 @@ public:
 
         as = new AtomSpace();
         eval = new SchemeEval(as);
-        eval->eval("(add-to-load-path \"..\")");
-        eval->eval("(add-to-load-path \"../../..\")");
+        eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
     }
 
     ~ParallelUTest()

--- a/tests/atoms/PutLinkUTest.cxxtest
+++ b/tests/atoms/PutLinkUTest.cxxtest
@@ -48,8 +48,8 @@ public:
 		logger().set_timestamp_flag(false);
 		logger().set_sync_flag(true); // interleave with printf correctly
 
-		_eval.eval("(add-to-load-path \"..\")");
-		_eval.eval("(add-to-load-path \"../../..\")");
+		_eval.eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
 	}
 
 	void setUp() {}

--- a/tests/atoms/QuotationUTest.cxxtest
+++ b/tests/atoms/QuotationUTest.cxxtest
@@ -46,8 +46,8 @@ public:
 		logger().set_level(Logger::DEBUG);
 		logger().set_print_to_stdout_flag(true);
 
-		_eval.eval("(add-to-load-path \"..\")");
-		_eval.eval("(add-to-load-path \"../../..\")");
+		_eval.eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
 	}
 
 	void setUp() {}

--- a/tests/atoms/RandomUTest.cxxtest
+++ b/tests/atoms/RandomUTest.cxxtest
@@ -40,8 +40,8 @@ public:
 
         as = new AtomSpace();
         eval = new SchemeEval(as);
-        eval->eval("(add-to-load-path \"..\")");
-        eval->eval("(add-to-load-path \"../../..\")");
+        eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
     }
 
     ~RandomUTest()

--- a/tests/atoms/RewriteLinkUTest.cxxtest
+++ b/tests/atoms/RewriteLinkUTest.cxxtest
@@ -60,8 +60,8 @@ public:
 		Q = an(PREDICATE_NODE, "Q");
 		CT = an(TYPE_NODE, "ConceptNode");
 
-		_eval.eval("(add-to-load-path \"..\")");
-		_eval.eval("(add-to-load-path \"../../..\")");
+		_eval.eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
 	}
 
 	void setUp() {}

--- a/tests/atoms/ScopeLinkUTest.cxxtest
+++ b/tests/atoms/ScopeLinkUTest.cxxtest
@@ -54,8 +54,8 @@ public:
 		Q = an(PREDICATE_NODE, "Q");
 		CT = an(TYPE_NODE, "ConceptNode");
 
-		_eval.eval("(add-to-load-path \"..\")");
-		_eval.eval("(add-to-load-path \"../../..\")");
+		_eval.eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
 	}
 
 	void setUp() {}

--- a/tests/query/AbsentUTest.cxxtest
+++ b/tests/query/AbsentUTest.cxxtest
@@ -40,8 +40,8 @@ public:
 
 		as = new AtomSpace();
 		eval = new SchemeEval(as);
-		eval->eval("(add-to-load-path \"..\")");
-		eval->eval("(add-to-load-path \"../../..\")");
+		eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
 		eval->eval("(use-modules (opencog exec))");
 	}
 

--- a/tests/query/ArcanaUTest.cxxtest
+++ b/tests/query/ArcanaUTest.cxxtest
@@ -41,8 +41,8 @@ public:
 
 		as = new AtomSpace();
 		eval = new SchemeEval(as);
-		eval->eval("(add-to-load-path \"..\")");
-		eval->eval("(add-to-load-path \"../../..\")");
+		eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
 		eval->eval("(use-modules (opencog exec))");
 		eval->eval("(load-from-path \"tests/query/test_types.scm\")");
 	}

--- a/tests/query/AttentionalFocusCBUTest.cxxtest
+++ b/tests/query/AttentionalFocusCBUTest.cxxtest
@@ -40,8 +40,8 @@ public:
 
 		as = new AtomSpace();
 		eval = new SchemeEval(as);
-		eval->eval("(add-to-load-path \"..\")");
-		eval->eval("(add-to-load-path \"../../..\")");
+		eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
 	}
 
 	~AttentionalFocusCBUTest()

--- a/tests/query/BuggyBindLinkUTest.cxxtest
+++ b/tests/query/BuggyBindLinkUTest.cxxtest
@@ -39,8 +39,8 @@ public:
         logger().set_level(Logger::DEBUG);
         logger().set_print_to_stdout_flag(true);
 
-        eval.eval("(add-to-load-path \"..\")");
-        eval.eval("(add-to-load-path \"../../..\")");
+        eval.eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
     }
 
     ~BuggyBindLinkUTest()

--- a/tests/query/BuggyEqualUTest.cxxtest
+++ b/tests/query/BuggyEqualUTest.cxxtest
@@ -43,8 +43,8 @@ class BuggyEqual :  public CxxTest::TestSuite
 			as = new AtomSpace();
 			eval = new SchemeEval(as);
 			eval->eval("(use-modules (opencog exec))");
-			eval->eval("(add-to-load-path \"..\")");
-			eval->eval("(add-to-load-path \"../../..\")");
+			eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
 		}
 
 		~BuggyEqual()

--- a/tests/query/BuggyLinkUTest.cxxtest
+++ b/tests/query/BuggyLinkUTest.cxxtest
@@ -41,8 +41,8 @@ public:
 
         as = new AtomSpace();
         eval = new SchemeEval(as);
-        eval->eval("(add-to-load-path \"..\")");
-        eval->eval("(add-to-load-path \"../../..\")");
+        eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
     }
 
     ~BuggyLinkUTest()

--- a/tests/query/BuggyNotUTest.cxxtest
+++ b/tests/query/BuggyNotUTest.cxxtest
@@ -46,8 +46,8 @@ class BuggyNot :  public CxxTest::TestSuite
 
 			as = new AtomSpace();
 			eval = new SchemeEval(as);
-			eval->eval("(add-to-load-path \"..\")");
-			eval->eval("(add-to-load-path \"../../..\")");
+			eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
 		}
 
 		~BuggyNot()

--- a/tests/query/BuggyQuoteUTest.cxxtest
+++ b/tests/query/BuggyQuoteUTest.cxxtest
@@ -41,8 +41,8 @@ public:
 
         as = new AtomSpace();
         eval = new SchemeEval(as);
-        eval->eval("(add-to-load-path \"..\")");
-        eval->eval("(add-to-load-path \"../../..\")");
+        eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
     }
 
     ~BuggyQuoteUTest()

--- a/tests/query/BuggySelfGroundUTest.cxxtest
+++ b/tests/query/BuggySelfGroundUTest.cxxtest
@@ -43,8 +43,8 @@ public:
 
         as = new AtomSpace();
         eval = new SchemeEval(as);
-        eval->eval("(add-to-load-path \"..\")");
-        eval->eval("(add-to-load-path \"../../..\")");
+        eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
     }
 
     ~BuggySelfGroundUTest()

--- a/tests/query/BuggyStackUTest.cxxtest
+++ b/tests/query/BuggyStackUTest.cxxtest
@@ -72,8 +72,8 @@ void BuggyStackUTest::setUp(void)
 {
 	as = new AtomSpace();
 	SchemeEval* eval = new SchemeEval(as);
-	eval->eval("(add-to-load-path \"..\")");
-	eval->eval("(add-to-load-path \"../../..\")");
+	eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
 	eval->eval("(load-from-path \"tests/query/test_types.scm\")");
 	eval->eval("(load-from-path \"tests/query/buggy-stack.scm\")");
 

--- a/tests/query/ChoiceLinkUTest.cxxtest
+++ b/tests/query/ChoiceLinkUTest.cxxtest
@@ -40,8 +40,8 @@ public:
 
 		as = new AtomSpace();
 		eval = new SchemeEval(as);
-		eval->eval("(add-to-load-path \"..\")");
-		eval->eval("(add-to-load-path \"../../..\")");
+		eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
 	}
 
 	~ChoiceLinkUTest()

--- a/tests/query/DeepTypeUTest.cxxtest
+++ b/tests/query/DeepTypeUTest.cxxtest
@@ -43,8 +43,8 @@ public:
 		as = new AtomSpace();
 		eval = new SchemeEval(as);
 		eval->eval("(use-modules (opencog exec) (opencog query))");
-		eval->eval("(add-to-load-path \"..\")");
-		eval->eval("(add-to-load-path \"../../..\")");
+		eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
 	}
 
 	~DeepTypeUTest()

--- a/tests/query/DefineUTest.cxxtest
+++ b/tests/query/DefineUTest.cxxtest
@@ -41,8 +41,8 @@ public:
 
 		as = new AtomSpace();
 		eval = new SchemeEval(as);
-		eval->eval("(add-to-load-path \"..\")");
-		eval->eval("(add-to-load-path \"../../..\")");
+		eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
 		eval->eval("(use-modules (opencog exec))");
 	}
 

--- a/tests/query/DisconnectedUTest.cxxtest
+++ b/tests/query/DisconnectedUTest.cxxtest
@@ -71,8 +71,8 @@ void DisconnectedUTest::setUp(void)
 	as = new AtomSpace();
 	eval = new SchemeEval(as);
 
-	eval->eval("(add-to-load-path \"..\")");
-	eval->eval("(add-to-load-path \"../../..\")");
+	eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
 	eval->eval("(load-from-path \"tests/query/test_types.scm\")");
 }
 

--- a/tests/query/DontExecUTest.cxxtest
+++ b/tests/query/DontExecUTest.cxxtest
@@ -46,8 +46,8 @@ public:
 		logger().set_sync_flag(true);
 		logger().set_print_to_stdout_flag(true);
 
-		eval.eval("(add-to-load-path \"..\")");
-		eval.eval("(add-to-load-path \"../../..\")");
+		eval.eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
 	}
 
 	~DontExecUTest()

--- a/tests/query/EinsteinUTest.cxxtest
+++ b/tests/query/EinsteinUTest.cxxtest
@@ -47,8 +47,8 @@ class EinsteinPuzzle :  public CxxTest::TestSuite
 
 			as = new AtomSpace();
 			eval = new SchemeEval(as);
-			eval->eval("(add-to-load-path \"..\")");
-			eval->eval("(add-to-load-path \"../../..\")");
+			eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
 			eval->eval("(load-from-path \"tests/query/test_types.scm\")");
 		}
 

--- a/tests/query/EvaluationUTest.cxxtest
+++ b/tests/query/EvaluationUTest.cxxtest
@@ -69,8 +69,8 @@ void EvaluationUTest::setUp(void)
 {
 	as->clear();
 	eval->eval("(use-modules (opencog exec))");
-	eval->eval("(add-to-load-path \"..\")");
-	eval->eval("(add-to-load-path \"../../..\")");
+	eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
 }
 
 #define getarity(hand) hand->get_arity()

--- a/tests/query/ExecutionOutputUTest.cxxtest
+++ b/tests/query/ExecutionOutputUTest.cxxtest
@@ -43,8 +43,8 @@ public:
 		logger().set_level(Logger::DEBUG);
 		logger().set_print_to_stdout_flag(true);
 
-		eval.eval("(add-to-load-path \"..\")");
-		eval.eval("(add-to-load-path \"../../..\")");
+		eval.eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
 	}
 
 	~ExecutionOutputUTest()

--- a/tests/query/FiniteStateMachineUTest.cxxtest
+++ b/tests/query/FiniteStateMachineUTest.cxxtest
@@ -41,8 +41,8 @@ public:
 		as = new AtomSpace();
 		eval = new SchemeEval(as);
 		eval->eval("(use-modules (opencog exec))");
-		eval->eval("(add-to-load-path \"..\")");
-		eval->eval("(add-to-load-path \"../../..\")");
+		eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
 	}
 
 	~FiniteStateMachineUTest()

--- a/tests/query/FirstNUTest.cxxtest
+++ b/tests/query/FirstNUTest.cxxtest
@@ -42,8 +42,8 @@ public:
 
         as = new AtomSpace();
         eval = new SchemeEval(as);
-        eval->eval("(add-to-load-path \"..\")");
-        eval->eval("(add-to-load-path \"../../..\")");
+        eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
     }
 
     ~FirstNUTest()

--- a/tests/query/GetLinkUTest.cxxtest
+++ b/tests/query/GetLinkUTest.cxxtest
@@ -48,8 +48,8 @@ public:
 		as = new AtomSpace();
 		eval = new SchemeEval(as);
 		eval->eval("(use-modules (opencog exec) (opencog query))");
-		eval->eval("(add-to-load-path \"..\")");
-		eval->eval("(add-to-load-path \"../../..\")");
+		eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
 	}
 
 	~GetLinkUTest()

--- a/tests/query/GetStateUTest.cxxtest
+++ b/tests/query/GetStateUTest.cxxtest
@@ -52,8 +52,8 @@ public:
 		as = new AtomSpace();
 		SchemeEval* eval = SchemeEval::get_evaluator(as);
 		eval->eval("(use-modules (opencog exec))");
-		eval->eval("(add-to-load-path \"..\")");
-		eval->eval("(add-to-load-path \"../../..\")");
+		eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
 	}
 
 	~GetStateUTest()

--- a/tests/query/GlobUTest.cxxtest
+++ b/tests/query/GlobUTest.cxxtest
@@ -40,8 +40,8 @@ public:
 
 		as = new AtomSpace();
 		eval = new SchemeEval(as);
-		eval->eval("(add-to-load-path \"..\")");
-		eval->eval("(add-to-load-path \"../../..\")");
+		eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
 		eval->eval("(use-modules (opencog exec))");
 	}
 

--- a/tests/query/GreaterComputeUTest.cxxtest
+++ b/tests/query/GreaterComputeUTest.cxxtest
@@ -42,8 +42,8 @@ public:
         as = new AtomSpace();
         eval = new SchemeEval(as);
         eval->eval("(use-modules (opencog exec))");
-        eval->eval("(add-to-load-path \"..\")");
-        eval->eval("(add-to-load-path \"../../..\")");
+        eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
     }
 
     ~GreaterComputeUTest()

--- a/tests/query/GreaterThanUTest.cxxtest
+++ b/tests/query/GreaterThanUTest.cxxtest
@@ -41,8 +41,8 @@ public:
 
 		as = new AtomSpace();
 		eval = new SchemeEval(as);
-		eval->eval("(add-to-load-path \"..\")");
-		eval->eval("(add-to-load-path \"../../..\")");
+		eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
 	}
 
 	~GreaterThanUTest()

--- a/tests/query/MatchLinkUTest.cxxtest
+++ b/tests/query/MatchLinkUTest.cxxtest
@@ -72,8 +72,8 @@ void MatchLink::setUp(void)
 	as = new AtomSpace();
 
 	SchemeEval* eval = new SchemeEval(as);
-	eval->eval("(add-to-load-path \"..\")");
-	eval->eval("(add-to-load-path \"../../..\")");
+	eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
 	eval->eval("(load-from-path \"tests/query/test_types.scm\")");
 	eval->eval("(load-from-path \"tests/query/match-link.scm\")");
 

--- a/tests/query/NestedPutUTest.cxxtest
+++ b/tests/query/NestedPutUTest.cxxtest
@@ -42,8 +42,8 @@ public:
 		logger().set_level(Logger::DEBUG);
 		logger().set_print_to_stdout_flag(true);
 
-		_eval.eval("(add-to-load-path \"..\")");
-		_eval.eval("(add-to-load-path \"../../..\")");
+		_eval.eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
 		_eval.eval("(use-modules (opencog query))");
 	}
 

--- a/tests/query/NoExceptionUTest.cxxtest
+++ b/tests/query/NoExceptionUTest.cxxtest
@@ -47,8 +47,8 @@ public:
 		as = new AtomSpace();
 		eval = new SchemeEval(as);
 
-		eval->eval("(add-to-load-path \"..\")");
-		eval->eval("(add-to-load-path \"../../..\")");
+		eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
 		eval->eval("(use-modules (opencog exec))");
 	}
 

--- a/tests/query/NotLinkUTest.cxxtest
+++ b/tests/query/NotLinkUTest.cxxtest
@@ -48,8 +48,8 @@ public:
 		as = new AtomSpace();
 		eval = new SchemeEval(as);
 		eval->eval("(use-modules (opencog exec) (opencog query))");
-		eval->eval("(add-to-load-path \"..\")");
-		eval->eval("(add-to-load-path \"../../..\")");
+		eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
 	}
 
 	~NotLinkUTest()

--- a/tests/query/QuoteUTest.cxxtest
+++ b/tests/query/QuoteUTest.cxxtest
@@ -45,8 +45,8 @@ public:
 
         as = new AtomSpace();
         eval = new SchemeEval(as);
-        eval->eval("(add-to-load-path \"..\")");
-        eval->eval("(add-to-load-path \"../../..\")");
+        eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
     }
 
     ~QuoteUTest()

--- a/tests/query/RecognizerUTest.cxxtest
+++ b/tests/query/RecognizerUTest.cxxtest
@@ -69,8 +69,8 @@ void RecognizerUTest::tearDown(void)
 void RecognizerUTest::setUp(void)
 {
 	as->clear();
-	eval->eval("(add-to-load-path \"..\")");
-	eval->eval("(add-to-load-path \"../../..\")");
+	eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
 	eval->eval("(load-from-path \"tests/query/test_types.scm\")");
 }
 

--- a/tests/query/ScopeUTest.cxxtest
+++ b/tests/query/ScopeUTest.cxxtest
@@ -44,8 +44,8 @@ public:
 
 		as = new AtomSpace();
 		eval = new SchemeEval(as);
-		eval->eval("(add-to-load-path \"..\")");
-		eval->eval("(add-to-load-path \"../../..\")");
+		eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
 		eval->eval("(use-modules (opencog query))");
 	}
 

--- a/tests/query/SequenceUTest.cxxtest
+++ b/tests/query/SequenceUTest.cxxtest
@@ -41,8 +41,8 @@ public:
 
 		as = new AtomSpace();
 		eval = new SchemeEval(as);
-		eval->eval("(add-to-load-path \"..\")");
-		eval->eval("(add-to-load-path \"../../..\")");
+		eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
 		eval->eval("(use-modules (opencog query))");
 	}
 

--- a/tests/query/SingleUTest.cxxtest
+++ b/tests/query/SingleUTest.cxxtest
@@ -42,8 +42,8 @@ public:
         as = new AtomSpace();
         eval = new SchemeEval(as);
         eval->eval("(use-modules (opencog exec) (opencog query))");
-        eval->eval("(add-to-load-path \"..\")");
-        eval->eval("(add-to-load-path \"../../..\")");
+        eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
     }
 
     ~SingleUTest()

--- a/tests/query/StackMoreUTest.cxxtest
+++ b/tests/query/StackMoreUTest.cxxtest
@@ -75,8 +75,8 @@ void StackMoreUTest::setUp(void)
 	as = new AtomSpace();
 	SchemeEval* eval = new SchemeEval(as);
 
-	eval->eval("(add-to-load-path \"..\")");
-	eval->eval("(add-to-load-path \"../../..\")");
+	eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
 	eval->eval("(load-from-path \"tests/query/test_types.scm\")");
 	eval->eval("(load-from-path \"tests/query/stackmore-o-o.scm\")");
 	eval->eval("(load-from-path \"tests/query/stackmore-o-u.scm\")");

--- a/tests/query/SubstitutionUTest.cxxtest
+++ b/tests/query/SubstitutionUTest.cxxtest
@@ -42,8 +42,8 @@ public:
 
 		as = new AtomSpace();
 		eval = new SchemeEval(as);
-		eval->eval("(add-to-load-path \"..\")");
-		eval->eval("(add-to-load-path \"../../..\")");
+		eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
 		eval->eval("(load-from-path \"tests/query/substitution.scm\")");
 	}
 

--- a/tests/query/SudokuUTest.cxxtest
+++ b/tests/query/SudokuUTest.cxxtest
@@ -45,8 +45,8 @@ class SudokuPuzzle :  public CxxTest::TestSuite
 
 			as = new AtomSpace();
 			eval = new SchemeEval(as);
-			eval->eval("(add-to-load-path \"..\")");
-			eval->eval("(add-to-load-path \"../../..\")");
+			eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
 			eval->eval("(use-modules (opencog exec))");
 		}
 

--- a/tests/query/UnorderedUTest.cxxtest
+++ b/tests/query/UnorderedUTest.cxxtest
@@ -80,8 +80,8 @@ void UnorderedUTest::setUp(void)
 {
 	as = new AtomSpace();
 	SchemeEval* eval = new SchemeEval(as);
-	eval->eval("(add-to-load-path \"..\")");
-	eval->eval("(add-to-load-path \"../../..\")");
+	eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
 	eval->eval("(load-from-path \"tests/query/test_types.scm\")");
 	eval->eval("(load-from-path \"tests/query/unordered.scm\")");
 	eval->eval("(load-from-path \"tests/query/unordered-more.scm\")");

--- a/tests/query/VarTypeNotUTest.cxxtest
+++ b/tests/query/VarTypeNotUTest.cxxtest
@@ -67,8 +67,8 @@ void VarTypeNot::setUp(void)
 {
 	as = new AtomSpace();
 	eval = new SchemeEval(as);
-	eval->eval("(add-to-load-path \"..\")");
-	eval->eval("(add-to-load-path \"../../..\")");
+	eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
 	eval->eval("(load-from-path \"tests/query/test_types.scm\")");
 	eval->eval("(load-from-path \"tests/query/var-type-not.scm\")");
 }

--- a/tests/rule-engine/UREConfigUTest.cxxtest
+++ b/tests/rule-engine/UREConfigUTest.cxxtest
@@ -19,8 +19,8 @@ public:
 		_eval.eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "/opencog/scm/opencog\")");
 		_eval.eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "/opencog/scm/opencog/rule-engine\")");
 
-		_eval.eval("(add-to-load-path \"..\")");
-		_eval.eval("(add-to-load-path \"../../..\")");
+		_eval.eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
 		_eval.eval("(use-modules (opencog) (opencog query))");
 
 		// Load the simple crisp system example to test it

--- a/tests/scm/BasicSCMUTest.cxxtest
+++ b/tests/scm/BasicSCMUTest.cxxtest
@@ -212,9 +212,9 @@ void BasicSCMUTest::test_single_atom(void)
 	TSM_ASSERT("Failed to find handle for first atom", h != nullptr);
 
 	// Load the utility definitions
-	eval->eval("(add-to-load-path \"..\")");
+	eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
 	eval->eval("(add-to-load-path \"../..\")");
-	eval->eval("(add-to-load-path \"../../..\")");
+
 	std::string rs = eval->eval("(load-from-path \"tests/scm/typedefs.scm\")");
 	eval_err = eval->eval_error();
 	if (eval_err)

--- a/tests/scm/MultiAtomSpaceUTest.cxxtest
+++ b/tests/scm/MultiAtomSpaceUTest.cxxtest
@@ -73,7 +73,7 @@ void MultiAtomSpace::setUp(void)
 {
 	main_as = new AtomSpace();
 	evaluator = new SchemeEval(main_as);
-	evaluator->eval("(add-to-load-path \"..\")");
+	evaluator->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
 	evaluator->eval("(add-to-load-path \"../../..\")");
 }
 

--- a/tests/scm/SCMUtilsUTest.cxxtest
+++ b/tests/scm/SCMUtilsUTest.cxxtest
@@ -68,7 +68,7 @@ void SCMUtilsUTest::setUp(void)
 {
 	as = new AtomSpace();
 	evaluator = new SchemeEval(as);
-	evaluator->eval("(add-to-load-path \"..\")");
+	evaluator->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
 	evaluator->eval("(add-to-load-path \"../../..\")");
 	evaluator->eval("(load-from-path \"tests/query/test_types.scm\")");
 	evaluator->eval("(load-from-path \"tests/scm/utils-test.scm\")");


### PR DESCRIPTION
Unit tests use relative paths to load scheme definitions. It makes
impossible running unit tests in any folder except subfolder of source
root.