### PR TITLE
cog-af get top N atoms

### DIFF
--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -368,6 +368,7 @@ void SchemeSmob::register_procs()
 
 	// AttentionalFocus
 	register_proc("cog-af",                0, 0, 0, C(ss_af));
+	register_proc("cog-af-topn",           1, 0, 0, C(ss_af_topn));
 	register_proc("cog-af-size",           0, 0, 0, C(ss_af_size));
 	register_proc("cog-set-af-size!",      1, 0, 0, C(ss_set_af_size));
 

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -190,6 +190,7 @@ private:
 	// AttentionalFocus and AttentionalFocus Boundary
 	// XXX FIXME these should move to the attention bank!
 	static SCM ss_af(void);
+	static SCM ss_af_topn(SCM);
 	static SCM ss_af_size(void);
 	static SCM ss_set_af_size(SCM);
 	static SCM ss_stimulate(SCM, SCM);

--- a/opencog/guile/SchemeSmobAF.cc
+++ b/opencog/guile/SchemeSmobAF.cc
@@ -76,6 +76,31 @@ SCM SchemeSmob::ss_af (void)
 }
 
 /**
+ * Return the top N atoms from the AF based on their STI value.
+ * Setting N to a value larger than the AF size will be equivalent
+ * to calling ss_af or cog-af from scheme.
+ */
+SCM SchemeSmob::ss_af_topn (SCM n)
+{
+	AtomSpace* atomspace = ss_get_env_as("cog-af-topn");
+	HandleSeq attentionalFocus;
+	attentionbank(atomspace).get_handle_set_in_attentional_focus(back_inserter(attentionalFocus));
+	size_t isz = attentionalFocus.size();
+	if (0 == isz) return SCM_EOL;
+
+	SCM head = SCM_EOL;
+	int N = scm_to_int(n);
+	if( N > isz)  N = isz;
+	for (size_t i = isz - N; i < isz ; i++) {
+		Handle hi = attentionalFocus[i];
+		SCM smob = handle_to_scm(hi);
+		head = scm_cons(smob, head);
+	}
+
+	return head;
+}
+
+/**
  *  Stimulate an atom with given stimulus amount.
  */
 SCM SchemeSmob::ss_stimulate (SCM satom, SCM sstimulus)


### PR DESCRIPTION
A function that returns top N (based on STI value) atoms subset of the AF; a feature requested by the ghost-script team. 