### PR TITLE
Use const auto& in loops to prevent copying

### DIFF
--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -363,7 +363,7 @@ size_t Atom::getIncomingSetSize() const
     std::lock_guard<std::mutex> lck (_mtx);
 
     size_t cnt = 0;
-    for (const auto pr : _incoming_set->_iset)
+    for (const auto& pr : _incoming_set->_iset)
         cnt += pr.second.size();
     return cnt;
 }
@@ -382,7 +382,7 @@ IncomingSet Atom::getIncomingSet(AtomSpace* as) const
         // Prevent update of set while a copy is being made.
         std::lock_guard<std::mutex> lck (_mtx);
         IncomingSet iset;
-        for (const auto bucket : _incoming_set->_iset)
+        for (const auto& bucket : _incoming_set->_iset)
         {
             for (const WinkPtr& w : bucket.second)
             {
@@ -397,7 +397,7 @@ IncomingSet Atom::getIncomingSet(AtomSpace* as) const
     // Prevent update of set while a copy is being made.
     std::lock_guard<std::mutex> lck (_mtx);
     IncomingSet iset;
-    for (const auto bucket : _incoming_set->_iset)
+    for (const auto& bucket : _incoming_set->_iset)
     {
         for (const WinkPtr& w : bucket.second)
         {

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -307,7 +307,7 @@ public:
     {
         if (nullptr == _incoming_set) return result;
         std::lock_guard<std::mutex> lck(_mtx);
-        for (const auto bucket : _incoming_set->_iset)
+        for (const auto& bucket : _incoming_set->_iset)
         {
             for (const WinkPtr& w : bucket.second)
             {

--- a/opencog/atoms/base/Handle.cc
+++ b/opencog/atoms/base/Handle.cc
@@ -240,7 +240,7 @@ std::string oc_to_string(const HandleMultimap& hmultimap, const std::string& ind
 		ss << indent << "key[" << i << "]:" << std::endl
 		   << oc_to_string(p.first, indent + OC_TO_STRING_INDENT)
 		   << indent << "value[" << i << "]:" << std::endl;
-		for (const auto s : p.second)
+		for (const auto& s : p.second)
 			ss << oc_to_string(s, indent + OC_TO_STRING_INDENT);
 		i++;
 	}
@@ -302,7 +302,7 @@ std::string oc_to_string(const HandleCounter& hc, const std::string& indent)
 	std::stringstream ss;
 	ss << indent << "size = " << hc.size() << std::endl;
 	size_t i = 0;
-	for (const auto el : hc) {
+	for (const auto& el : hc) {
 		ss << indent << "atom[" << i << "]:" << std::endl
 		   << oc_to_string(el.first, indent + OC_TO_STRING_INDENT)
 		   << indent << "num[" << i << "]:" << el.second << std::endl;

--- a/opencog/attentionbank/AttentionBank.h
+++ b/opencog/attentionbank/AttentionBank.h
@@ -68,7 +68,7 @@ class AttentionBank
 
     void updateAttentionalFocus(const Handle&, const AttentionValuePtr&,
                                 const AttentionValuePtr&);
-    
+
     /** AV changes */
     void AVChanged(const Handle&, const AttentionValuePtr&, const AttentionValuePtr&);
 
@@ -248,7 +248,7 @@ public:
     get_handle_set_in_attentional_focus(OutputIterator result)
     {
          std::lock_guard<std::mutex> lock(AFMutex);
-         for (const auto p : attentionalFocus) {
+         for (const auto& p : attentionalFocus) {
              *result++ = p.first;
          }
          return result;


### PR DESCRIPTION
Originally it was introduced to improve performance of
getIncomingSetSize() method. I have visited all such places in code
then.

Benchmark results:
$ ./atomspace/atomspace/atomspace_bm -m getIncomingSetSize -n 10000000

Before optimization:
Benchmarking AtomSpace's getIncomingSetSize method 10000000 times ..........
Sum clock() time for all requests: 1873069 (1.87307 seconds, 5.33883e+06 requests per second)

After optimization:
Benchmarking AtomSpace's getIncomingSetSize method 10000000 times ..........
Sum clock() time for all requests: 1062651 (1.06265 seconds, 9.41043e+06 requests per second)