### PR TITLE
Make AttentionBank::getRandomAtomNotInAF(void) stable

### DIFF
--- a/opencog/attentionbank/AttentionBank.cc
+++ b/opencog/attentionbank/AttentionBank.cc
@@ -333,11 +333,7 @@ Handle AttentionBank::getRandomAtomNotInAF(void)
     if (atoms_not_in_af.empty())
         return Handle::UNDEFINED;
 
-    auto seed = std::chrono::duration_cast<std::chrono::microseconds>(
-            std::chrono::system_clock::now().time_since_epoch());
-    MT19937RandGen rng(seed.count());
-
     auto it = atoms_not_in_af.cbegin();
-    std::advance(it, rng.randint(atoms_not_in_af.size()));
+    std::advance(it, randGen().randint(atoms_not_in_af.size()));
     return *it;
 }

--- a/opencog/attentionbank/AttentionBank.cc
+++ b/opencog/attentionbank/AttentionBank.cc
@@ -24,6 +24,7 @@
 
 #include <functional>
 #include <opencog/util/Config.h>
+#include <opencog/util/mt19937ar.h>
 
 #include <opencog/atoms/base/Handle.h>
 #include <opencog/atomspace/AtomSpace.h>
@@ -320,21 +321,21 @@ void AttentionBank::updateAttentionalFocus(const Handle& h,
 
 Handle AttentionBank::getRandomAtomNotInAF(void)
 {
-    std::lock_guard<std::mutex> lock(AFMutex);
-    auto find_in_af = [this](const Handle& h){
-       auto it = std::find_if(attentionalFocus.begin(), attentionalFocus.end(),
-                [h](const std::pair<Handle, AttentionValuePtr>& hsp) { return hsp.first == h; });
-       return it;
-    };
+    UnorderedHandleSet atoms_not_in_af = _importanceIndex.getHandleSet(0);
 
-    int count = 50; // We might get stuck in the while loop if there are no atoms outside the AF
-    Handle h = Handle::UNDEFINED;
-    do {
-        h = _importanceIndex.getRandomAtom();
-    } while(find_in_af(h) != attentionalFocus.end() and --count > 0);
-    // Make sure the last selection did not select from the AF.
-    if(find_in_af(h) != attentionalFocus.end())
+    std::lock_guard<std::mutex> lock(AFMutex);
+    for (const auto& hsp : attentionalFocus) {
+        atoms_not_in_af.erase(hsp.first);
+    }
+
+    if (atoms_not_in_af.empty())
         return Handle::UNDEFINED;
 
-    return h;
+    auto seed = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch());
+    MT19937RandGen rng(seed.count());
+
+    auto it = atoms_not_in_af.cbegin();
+    std::advance(it, rng.randint(atoms_not_in_af.size()));
+    return *it;
 }

--- a/opencog/attentionbank/AttentionBank.cc
+++ b/opencog/attentionbank/AttentionBank.cc
@@ -323,9 +323,11 @@ Handle AttentionBank::getRandomAtomNotInAF(void)
 {
     UnorderedHandleSet atoms_not_in_af = _importanceIndex.getHandleSet(0);
 
-    std::lock_guard<std::mutex> lock(AFMutex);
-    for (const auto& hsp : attentionalFocus) {
-        atoms_not_in_af.erase(hsp.first);
+    {
+        std::lock_guard<std::mutex> lock(AFMutex);
+        for (const auto& hsp : attentionalFocus) {
+            atoms_not_in_af.erase(hsp.first);
+        }
     }
 
     if (atoms_not_in_af.empty())

--- a/tests/attentionbank/AttentionUTest.cxxtest
+++ b/tests/attentionbank/AttentionUTest.cxxtest
@@ -70,4 +70,21 @@ class AttentionUTest :  public CxxTest::TestSuite
                 TS_ASSERT_DIFFERS(h, Handle::UNDEFINED);
             }
         }
+
+        void testGetRandomAtomsBigAF()
+        {
+            AttentionBank _ab(&_as);
+            _ab.set_af_size(999);
+
+            // Check Valid atoms are selected.
+            for(int i = 0; i < 1000; i++) {
+                Handle h = _as.add_node(CONCEPT_NODE, "cnode-"+ std::to_string(i));
+                _ab.set_sti(h, 1 + i*10);
+            }
+
+            for( int i = 0; i < 50; i++) {
+                Handle h = _ab.getRandomAtomNotInAF();
+                TS_ASSERT_DIFFERS(h, Handle::UNDEFINED);
+            }
+        }
 };


### PR DESCRIPTION
Previous AttentionBank::getRandomAtomNotInAF() implementation expects that it can get some random atom from _importanceIndex which is out of attentionalFocus collection in 50 attempts, which is not always true. Add unit test to demonstrate it and fix implementation.

Looks like https://github.com/opencog/atomspace/blob/49b8eaa5d28c26549241c2f5cb7d3a7770ae8aac/opencog/attentionbank/ImportanceIndex.h#L123 can be removed as well as it is called from getRandomAtomNotInAF() only.

Other random method was entered prior getRandomAtomNotInAF() adding: https://github.com/opencog/atomspace/blob/0031878db70fa978fb55a18773f7f0f098418c51/opencog/attentionbank/AtomBins.h#L72