### PR TITLE
Remove printing empty line at the end of Python eval.

### DIFF
--- a/opencog/cython/PythonEval.cc
+++ b/opencog/cython/PythonEval.cc
@@ -24,6 +24,7 @@
  */
 
 #include <dlfcn.h>
+#include <unistd.h>
 
 #include <boost/filesystem/operations.hpp>
 

--- a/opencog/cython/PythonEval.cc
+++ b/opencog/cython/PythonEval.cc
@@ -675,7 +675,7 @@ void PythonEval::execute_string(const char* command)
         Py_DECREF(pyResult);
 
     PyObject *f = PySys_GetObject((char *) "stdout");
-    if (f) PyFile_WriteString("\n", f);  // Force a flush
+    if (f) fsync(PyObject_AsFileDescriptor(f));  // Force a flush
 }
 
 int PythonEval::argument_count(PyObject* pyFunction)


### PR DESCRIPTION
Use fsync call instead to flush stdout. Printing empty line pollutes output. For instance in Python benchmarks one call is repeating many times and benchmark output cannot be seen because of empty lines.