### PR TITLE
Fix link error for examples

### DIFF
--- a/examples/c++-api/CMakeLists.txt
+++ b/examples/c++-api/CMakeLists.txt
@@ -6,6 +6,7 @@ ADD_EXECUTABLE(crudexample
 	)
 TARGET_LINK_LIBRARIES(crudexample
 	atomspace
+	attentionbank
 	)
 
 ADD_EXECUTABLE(ureexample
@@ -22,4 +23,5 @@ ADD_EXECUTABLE(aseventsexample
     )
 TARGET_LINK_LIBRARIES(aseventsexample
     atomspace
+    attentionbank
     )

--- a/opencog/attentionbank/CMakeLists.txt
+++ b/opencog/attentionbank/CMakeLists.txt
@@ -13,6 +13,7 @@ ADD_LIBRARY (attentionbank
 TARGET_LINK_LIBRARIES(attentionbank
 #	${NO_AS_NEEDED}
 	query
+	execution
 	smob
 	atombase
 	truthvalue

--- a/opencog/query/CMakeLists.txt
+++ b/opencog/query/CMakeLists.txt
@@ -20,7 +20,7 @@ TARGET_LINK_LIBRARIES(query
 	atomutils
 	lambda
 	atomspace
-#	execution
+#	execution # disabled to avoid cyclic dependency
 )
 
 IF (HAVE_GUILE)


### PR DESCRIPTION
This PR addresses linking errors when compiling examples `make examples`.
