### PR TITLE
#1640 - some atoms might not be printed by cog-prt-atomspace

### DIFF
--- a/opencog/guile/SchemeSmobAS.cc
+++ b/opencog/guile/SchemeSmobAS.cc
@@ -232,7 +232,7 @@ SCM SchemeSmob::ss_as_uuid(SCM sas)
 
 /* ============================================================== */
 /**
- * Return parent of the atomspace
+ * Return parent of the atomspace, or an empty list if there is no parent
  */
 SCM SchemeSmob::ss_as_env(SCM sas)
 {
@@ -247,7 +247,7 @@ SCM SchemeSmob::ss_as_env(SCM sas)
 
 	AtomSpace* env = as->get_environ();
 	scm_remember_upto_here_1(sas);
-	return make_as(env);
+	return env ? make_as(env) : SCM_EOL;
 }
 
 /* ============================================================== */

--- a/opencog/scm/opencog/base/utilities.scm
+++ b/opencog/scm/opencog/base/utilities.scm
@@ -324,10 +324,6 @@
   those atoms that have no incoming set in the atomspace or its ancestors,
   and thus are at the top of a tree.  All other atoms (those which do
   have an incoming set) will appear somewhere underneath these top-most atoms.
-
-  N.B. That means, if the atomspace contains a link, refering an atom in a
-  child or independent atomspace, the printed result will include this
-  alien atom too.
 "
 	(traverse-roots display)
 )

--- a/opencog/scm/opencog/base/utilities.scm
+++ b/opencog/scm/opencog/base/utilities.scm
@@ -288,22 +288,48 @@
 )
 
 ; -----------------------------------------------------------------------
+(define (traverse-roots func)
+"
+  traverse-roots -- Applies func to every root atom in the atomspace.
+
+  The root atoms are those, which have no incoming atoms,
+  located in the atomspace or its ancestors (i.e. visible from the atomspace).
+"
+	(define (is-visible? atom)
+		(member
+			(cog-as atom)
+			(get-atomspace-and-parents
+				(cog-atomspace)
+				`())))
+	(define (get-atomspace-and-parents atomspace res)
+		(if (null? atomspace)
+			res
+			(get-atomspace-and-parents
+				(cog-atomspace-env atomspace)
+				(cons atomspace res))))
+
+	(define (apply-if-root h)
+		(if (null? (filter is-visible? (cog-incoming-set h)))
+			(func h))
+		#f)
+
+	(for-each (lambda (ty) (cog-map-type apply-if-root ty)) (cog-get-types))
+)
+; -----------------------------------------------------------------------
 (define-public (cog-prt-atomspace)
 "
   cog-prt-atomspace -- Prints all atoms in the atomspace
 
   This will print all of the atoms in the atomspace: specifically, only
-  those atoms that have no incoming set, and thus are at the top of a
-  tree.  All other atoms (those which do have an incoming set) will
-  appear somewhere underneath these top-most atoms.
-"
-	(define (prt-atom h)
-		; Print only the top-level atoms.
-		(if (null? (cog-incoming-set h))
-			(display h))
-		#f)
+  those atoms that have no incoming set in the atomspace or its ancestors,
+  and thus are at the top of a tree.  All other atoms (those which do
+  have an incoming set) will appear somewhere underneath these top-most atoms.
 
-	(for-each (lambda (ty) (cog-map-type prt-atom ty)) (cog-get-types))
+  N.B. That means, if the atomspace contains a link, refering an atom in a
+  child or independent atomspace, the printed result will include this
+  alien atom too.
+"
+	(traverse-roots display)
 )
 
 ; -----------------------------------------------------------------------


### PR DESCRIPTION
This fix addresses the symptoms of the problem only.
But it seems like the root cause lies deeper - the nested atomspaces are not enough isolated from each other.

I suppose that the right behavior is that children atomspaces must see all atoms from its parents, but not vice-versa. Otherwise the idea of using children atomspaces for temporary computations is compromised, as in fact they might pollute scopes of their parents.

Even if it is so, I do not think that fixing this behavior is a top priority task. @linas, @ngeiswei, what is your opinion?