### PR TITLE
#1673 AlphaConvertUTest::test_bindlink failed

### DIFF
--- a/tests/atoms/CMakeLists.txt
+++ b/tests/atoms/CMakeLists.txt
@@ -21,7 +21,7 @@ IF(HAVE_GUILE)
 ENDIF(HAVE_GUILE)
 
 ADD_CXXTEST(AlphaConvertUTest)
-TARGET_LINK_LIBRARIES(AlphaConvertUTest query execution lambda atomspace)
+TARGET_LINK_LIBRARIES(AlphaConvertUTest -Wl,--no-as-needed lambda -Wl,--as-needed atomspace)
 
 ADD_CXXTEST(BetaReduceUTest)
 TARGET_LINK_LIBRARIES(BetaReduceUTest atomspace)


### PR DESCRIPTION
This is another approach to #1673. It looks more reliable than existing, but still ugly.