### PR TITLE
#1673 An approach to more reliable linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,7 @@ IF (CMAKE_COMPILER_IS_GNUCXX)
 
 		# The Apple linker does not support the --no-as-needed flag.
 		SET(NO_AS_NEEDED "")
+		SET(DUMMY_CC "${PROJECT_SOURCE_DIR}/lib/dummy.cc")
 
 	ELSE (APPLE)
 		SET(CMAKE_C_FLAGS "-Wall -fPIC")
@@ -96,6 +97,7 @@ IF (CMAKE_COMPILER_IS_GNUCXX)
 		# SET(CMAKE_C_FLAGS_RELEASE "-O3 -g -fstack-protector -flto=8")
 
 		SET(NO_AS_NEEDED "-Wl,--no-as-needed")
+		SET(DUMMY_CC "${PROJECT_SOURCE_DIR}/lib/dummy.cc")
 		LINK_LIBRARIES(pthread)
 
 		# Workaround for circular dependencies problem. This causes

--- a/lib/dummy.cc
+++ b/lib/dummy.cc
@@ -1,0 +1,7 @@
+// This file is used for generation of proxy libraries,
+// which use --no-as-needed flag to link with the actual implementations.
+// The client code needs to be linked with the proxy libraries.
+// That ensures, that the constructors, which register Atoms within ClassServer
+// are executed properly. Otherwise the execution
+// of the client code might fail in the unpredictable manner.
+

--- a/opencog/atoms/pattern/CMakeLists.txt
+++ b/opencog/atoms/pattern/CMakeLists.txt
@@ -2,7 +2,7 @@
 # The atom_types.h file is written to the build directory
 INCLUDE_DIRECTORIES( ${CMAKE_CURRENT_BINARY_DIR})
 
-ADD_LIBRARY (lambda
+ADD_LIBRARY (lambda_
 	BindLink.cc
 	DualLink.cc
 	PatternLink.cc
@@ -11,26 +11,36 @@ ADD_LIBRARY (lambda
 	Pattern.cc
 )
 
-# Without this, parallel make will race and crap up the generated files.
-ADD_DEPENDENCIES(lambda opencog_atom_types)
+ADD_LIBRARY (lambda
+	${DUMMY_CC}
+)
 
-TARGET_LINK_LIBRARIES(lambda
+# Without this, parallel make will race and crap up the generated files.
+ADD_DEPENDENCIES(lambda_ opencog_atom_types)
+ADD_DEPENDENCIES(lambda lambda_)
+
+
+TARGET_LINK_LIBRARIES(lambda_
 	atomspace
 	atomutils
 	atomcore
 	atombase
 	${COGUTIL_LIBRARY}
 )
+TARGET_LINK_LIBRARIES(lambda
+	# The library contains constructors. If the linker omits this library
+	# because it does not contain explicitly referenced symbols,
+	# then the target execution might break in runtime in unpredictable manner.
+	${NO_AS_NEEDED}
+	lambda_
+)
 
-IF (CYGWIN)
-	INSTALL (TARGETS lambda
-		DESTINATION "lib${LIB_DIR_SUFFIX}/opencog"
-	)
-ELSE (CYGWIN)
-	INSTALL (TARGETS lambda
-		DESTINATION "lib${LIB_DIR_SUFFIX}/opencog"
-	)
-ENDIF (CYGWIN)
+INSTALL (TARGETS lambda_
+  DESTINATION "lib${LIB_DIR_SUFFIX}/opencog"
+)
+INSTALL (TARGETS lambda
+  DESTINATION "lib${LIB_DIR_SUFFIX}/opencog"
+)
 
 INSTALL (FILES
 	BindLink.h

--- a/tests/atoms/CMakeLists.txt
+++ b/tests/atoms/CMakeLists.txt
@@ -21,7 +21,7 @@ IF(HAVE_GUILE)
 ENDIF(HAVE_GUILE)
 
 ADD_CXXTEST(AlphaConvertUTest)
-TARGET_LINK_LIBRARIES(AlphaConvertUTest query execution lambda atomspace)
+TARGET_LINK_LIBRARIES(AlphaConvertUTest lambda atomspace)
 
 ADD_CXXTEST(BetaReduceUTest)
 TARGET_LINK_LIBRARIES(BetaReduceUTest atomspace)


### PR DESCRIPTION
The idea is to link libraries via proxies. These proxies enforce linkage with the use of ${NO_AS_NEEDED}.
This pull requests concerns ```lambda``` library only.

If everything is fine with such approach, I can apply it to other libraries which rely on constructors.

N.B. I could not check, that it works on Macs.