### PR TITLE
ChoiceLink fixes.

### DIFF
--- a/opencog/query/InitiateSearchCB.cc
+++ b/opencog/query/InitiateSearchCB.cc
@@ -195,7 +195,6 @@ InitiateSearchCB::find_starter_recursive(const Handle& h, size_t& depth,
 	// the search there.  If there are two at the same depth,
 	// then start with the skinnier one.
 	size_t deepest = depth;
-	startrm = Handle::UNDEFINED;
 	Handle hdeepest(Handle::UNDEFINED);
 	size_t thinnest = SIZE_MAX;
 
@@ -203,7 +202,12 @@ InitiateSearchCB::find_starter_recursive(const Handle& h, size_t& depth,
 	{
 		size_t brdepth = depth + 1;
 		size_t brwid = SIZE_MAX;
-		Handle sbr(h);
+
+		// The start-term is a term that contains the starting atom...
+		// but it cannot be a ChoiceLink; it must be above or below
+		// any choice link.
+		Handle sbr(startrm);
+		if (CHOICE_LINK != t) sbr = h;
 
 		// Blow past the QuoteLinks, since they just screw up the search start.
 		if (Quotation::is_quotation_type(hunt->get_type()))

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1077,6 +1077,15 @@ bool PatternMatchEngine::tree_compare(const PatternTermPtr& ptm,
 	if (hp->is_node() and hg->is_node())
 		return node_compare(hp, hg);
 
+	// CHOICE_LINK's are multiple-choice links. As long as we can
+	// can match one of the sub-expressions of the ChoiceLink, then
+	// the ChoiceLink as a whole can be considered to be grounded.
+	// Note, we must do this before the fuzzy_match below, because
+	// hg might be a node (i.e. we compare a choice of nodes to one
+	// node).
+	if (CHOICE_LINK == tp)
+		return choice_compare(ptm, hg);
+
 	// If they're not both links, then it is clearly a mismatch.
 	if (not (hp->is_link() and hg->is_link())) return _pmc.fuzzy_match(hp, hg);
 
@@ -1087,13 +1096,6 @@ bool PatternMatchEngine::tree_compare(const PatternTermPtr& ptm,
 	DO_LOG({LAZY_LOG_FINE << "depth=" << depth;})
 	logmsg("tree_compare:", hp);
 	logmsg("to:", hg);
-
-	// CHOICE_LINK's are multiple-choice links. As long as we can
-	// can match one of the sub-expressions of the ChoiceLink, then
-	// the ChoiceLink as a whole can be considered to be grounded.
-	//
-	if (CHOICE_LINK == tp)
-		return choice_compare(ptm, hg);
 
 	// If the two links are both ordered, its enough to compare
 	// them "side-by-side".

--- a/tests/query/ChoiceLinkUTest.cxxtest
+++ b/tests/query/ChoiceLinkUTest.cxxtest
@@ -67,6 +67,7 @@ public:
 	void test_double_or(void);
 	void test_unary(void);
 	void test_typed(void);
+	void test_nodes(void);
 };
 
 void ChoiceLinkUTest::tearDown(void)
@@ -259,4 +260,22 @@ void ChoiceLinkUTest::test_typed(void)
 
 	printf("typed get-nodes found:\n%s\n", rules->to_string().c_str());
 	TS_ASSERT_EQUALS(2, getarity(rules));
+}
+
+/*
+ * ChoiceLink with nodes in it
+ */
+void ChoiceLinkUTest::test_nodes(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	eval->eval("(load-from-path \"tests/query/choice-nodes.scm\")");
+
+	// Needed to define cog-execute!
+	eval->eval("(use-modules (opencog exec))");
+
+	Handle result = eval->eval_h("(cog-execute! query)");
+
+	printf("typed get-nodes found:\n%s\n", result->to_string().c_str());
+	TS_ASSERT_EQUALS(1, getarity(result));
 }

--- a/tests/query/choice-nodes.scm
+++ b/tests/query/choice-nodes.scm
@@ -1,0 +1,25 @@
+;
+; Basic unit testing for ChoiceLinks in the pattern matcher.
+;
+(use-modules (opencog))
+(use-modules (opencog exec))
+
+;;; Populate the atomspace with four small trees.
+(ListLink
+	(ConceptNode "A")
+	(ConceptNode "B")
+)
+
+;;; Two clauses; they both connected with a common variable.
+(define query
+	(GetLink
+		(TypedVariableLink (VariableNode "$x") (TypeNode "ConceptNode"))
+		(ListLink
+			(ChoiceLink
+				(ConceptNode "A")
+				(ConceptNode "C")
+			)
+			(VariableNode "$x")
+		)
+	)
+)


### PR DESCRIPTION
Fix for issue #474 

There were two distinct bugs that lead to the failure in #474 
* The pattern match engine incorrectly handled the comparison of Node to a choice of Nodes.
* The search-start code incorrectly suggested a ChoiceLink as a reasonable place to start the search. Its not.