### PR TITLE
has_name_collisions to avoid name collisions between soruce and target rule in variable declarations

### DIFF
--- a/opencog/rule-engine/Rule.cc
+++ b/opencog/rule-engine/Rule.cc
@@ -484,6 +484,30 @@ std::string Rule::to_string(const std::string& indent) const
 	return ss.str();
 }
 
+bool Rule::has_name_capture() const
+{
+    HandleSeq vardecls = VariableListCast((this->get_vardecl()))
+            ->get_variables().varseq;
+    HandleSeq boundvars = BindLinkCast(this->get_rule())->get_variables()
+            .varseq;
+    size_t sb = boundvars.size();
+    size_t sd = boundvars.size();
+
+    for (size_t i = 0; i < sb; i++)
+    {
+        for (size_t j = i+1; j < sb; j++)
+        {
+            if(content_eq(boundvars[i], boundvars[j])) return true;
+        }
+        for (size_t k = 0; k < sd; k++)
+        {
+            if(content_eq(boundvars[i], vardecls[k])) return true;
+        }
+
+    }
+    return false;
+}
+
 Rule Rule::rand_alpha_converted() const
 {
 	// Clone the rule

--- a/opencog/rule-engine/Rule.cc
+++ b/opencog/rule-engine/Rule.cc
@@ -486,9 +486,10 @@ std::string Rule::to_string(const std::string& indent) const
 
 bool Rule::has_name_capture() const
 {
-	HandleSeq boundvars = BindLinkCast(this->get_rule())->get_variables()
+	HandleSeq boundvars = (BindLinkCast(this->get_rule())->get_variables())
 			.varseq;
-	FreeVariables fv = VariableListCast((this->get_vardecl()))->get_variables();
+	FreeVariables fv = (VariableListCast(this->get_vardecl()))
+			->get_variables();
 
 	for (const auto& v : boundvars)
 	{

--- a/opencog/rule-engine/Rule.cc
+++ b/opencog/rule-engine/Rule.cc
@@ -435,10 +435,10 @@ RuleTypedSubstitutionMap Rule::unify_target(const Handle& target,
 		return {};
 
 	// To guarantee that the rule variable does not have the same name
-	// as any variable in the target. XXX This is only a stochastic
-	// guarantee, there is a small chance that the new random name
-	// will still collide.
+	// as any variable in the target.
 	Rule alpha_rule = rand_alpha_converted();
+	// Check for the small chance of still having name collisions
+	alpha_rule.has_name_collision(vardecl);
 
 	RuleTypedSubstitutionMap unified_rules;
 	Handle alpha_vardecl = alpha_rule.get_vardecl();
@@ -484,12 +484,11 @@ std::string Rule::to_string(const std::string& indent) const
 	return ss.str();
 }
 
-bool Rule::has_name_capture() const
+bool Rule::has_name_collision(const Handle& vardecl) const
 {
 	HandleSeq boundvars = (BindLinkCast(this->get_rule())->get_variables())
 			.varseq;
-	FreeVariables fv = (VariableListCast(this->get_vardecl()))
-			->get_variables();
+	Variables fv = (VariableListCast(vardecl))->get_variables();
 
 	for (const auto& v : boundvars)
 	{
@@ -505,7 +504,6 @@ Rule Rule::rand_alpha_converted() const
 
 	// Alpha convert the rule
 	result.set_rule(_rule->alpha_convert());
-	if(result.has_name_capture()) result.rand_alpha_converted();
 
 	return result;
 }

--- a/opencog/rule-engine/Rule.cc
+++ b/opencog/rule-engine/Rule.cc
@@ -486,23 +486,13 @@ std::string Rule::to_string(const std::string& indent) const
 
 bool Rule::has_name_capture() const
 {
-	HandleSeq vardecls = VariableListCast((this->get_vardecl()))
-			->get_variables().varseq;
 	HandleSeq boundvars = BindLinkCast(this->get_rule())->get_variables()
 			.varseq;
-	size_t sb = boundvars.size();
-	size_t sd = vardecls.size();
+	FreeVariables fv = VariableListCast((this->get_vardecl()))->get_variables();
 
-	for (size_t i = 0; i < sb; i++)
+	for (const auto& v : boundvars)
 	{
-		for (size_t j = i+1; j < sb; j++)
-		{
-			if(content_eq(boundvars[i], boundvars[j])) return true;
-		}
-		for (size_t k = 0; k < sd; k++)
-		{
-			if(content_eq(boundvars[i], vardecls[k])) return true;
-		}
+		if(fv.is_in_varset(v)) return true;
 	}
 	return false;
 }

--- a/opencog/rule-engine/Rule.cc
+++ b/opencog/rule-engine/Rule.cc
@@ -484,8 +484,7 @@ std::string Rule::to_string(const std::string& indent) const
 
 bool Rule::has_name_collision(const Handle& vardecl) const
 {
-	HandleSet boundvars = BindLinkCast(this->get_rule())->get_variables()
-			.varset;
+	const HandleSet& boundvars = _rule->get_variables().varset;
 	Variables fv = (VariableListCast(vardecl))->get_variables();
 
 	for (const auto& v : boundvars)

--- a/opencog/rule-engine/Rule.cc
+++ b/opencog/rule-engine/Rule.cc
@@ -486,26 +486,25 @@ std::string Rule::to_string(const std::string& indent) const
 
 bool Rule::has_name_capture() const
 {
-    HandleSeq vardecls = VariableListCast((this->get_vardecl()))
-            ->get_variables().varseq;
-    HandleSeq boundvars = BindLinkCast(this->get_rule())->get_variables()
-            .varseq;
-    size_t sb = boundvars.size();
-    size_t sd = boundvars.size();
+	HandleSeq vardecls = VariableListCast((this->get_vardecl()))
+			->get_variables().varseq;
+	HandleSeq boundvars = BindLinkCast(this->get_rule())->get_variables()
+			.varseq;
+	size_t sb = boundvars.size();
+	size_t sd = vardecls.size();
 
-    for (size_t i = 0; i < sb; i++)
-    {
-        for (size_t j = i+1; j < sb; j++)
-        {
-            if(content_eq(boundvars[i], boundvars[j])) return true;
-        }
-        for (size_t k = 0; k < sd; k++)
-        {
-            if(content_eq(boundvars[i], vardecls[k])) return true;
-        }
-
-    }
-    return false;
+	for (size_t i = 0; i < sb; i++)
+	{
+		for (size_t j = i+1; j < sb; j++)
+		{
+			if(content_eq(boundvars[i], boundvars[j])) return true;
+		}
+		for (size_t k = 0; k < sd; k++)
+		{
+			if(content_eq(boundvars[i], vardecls[k])) return true;
+		}
+	}
+	return false;
 }
 
 Rule Rule::rand_alpha_converted() const
@@ -515,6 +514,7 @@ Rule Rule::rand_alpha_converted() const
 
 	// Alpha convert the rule
 	result.set_rule(_rule->alpha_convert());
+	if(result.has_name_capture()) result.rand_alpha_converted();
 
 	return result;
 }

--- a/opencog/rule-engine/Rule.cc
+++ b/opencog/rule-engine/Rule.cc
@@ -39,6 +39,7 @@
 #include <opencog/unify/Unify.h>
 
 #include <opencog/query/BindLinkAPI.h>
+#include <opencog/util/algorithm.h>
 
 #include "URELogger.h"
 
@@ -482,18 +483,6 @@ std::string Rule::to_string(const std::string& indent) const
 	return ss.str();
 }
 
-bool Rule::has_name_collision(const Handle& vardecl) const
-{
-	const HandleSet& boundvars = _rule->get_variables().varset;
-	Variables fv = (VariableListCast(vardecl))->get_variables();
-
-	for (const auto& v : boundvars)
-	{
-		if (fv.is_in_varset(v)) return true;
-	}
-	return false;
-}
-
 Rule Rule::rand_alpha_converted(const Handle& vardecl) const
 {
 	// Clone the rule
@@ -503,7 +492,11 @@ Rule Rule::rand_alpha_converted(const Handle& vardecl) const
 	result.set_rule(_rule->alpha_convert());
 
 	// Check for the small chance of still having name collisions
-	while(result.has_name_collision(vardecl))
+	const HandleSet& boundvars = _rule->get_variables().varset;
+	const HandleSet& vardecls = (VariableListCast(vardecl))->get_variables()
+			.varset;
+
+	while(is_disjoint(boundvars, vardecls))
 	{
 		result.set_rule(_rule->alpha_convert());
 	}

--- a/opencog/rule-engine/Rule.h
+++ b/opencog/rule-engine/Rule.h
@@ -299,7 +299,7 @@ private:
 
 	// Return a copy of the rule with the variables alpha-converted
 	// into random variable names.
-	Rule rand_alpha_converted() const;
+	Rule rand_alpha_converted(const Handle& vardecls) const;
 
 	Handle standardize_helper(AtomSpace*, const Handle&, HandleMap&);
 

--- a/opencog/rule-engine/Rule.h
+++ b/opencog/rule-engine/Rule.h
@@ -295,11 +295,11 @@ private:
 	// URE will always choose the one with the highest confidence.
 	TruthValuePtr _tv;
 
-	bool has_name_collision(const Handle& vardecls) const;
+	bool has_name_collision(const Handle& vardecl) const;
 
 	// Return a copy of the rule with the variables alpha-converted
 	// into random variable names.
-	Rule rand_alpha_converted(const Handle& vardecls) const;
+	Rule rand_alpha_converted(const Handle& vardecl) const;
 
 	Handle standardize_helper(AtomSpace*, const Handle&, HandleMap&);
 

--- a/opencog/rule-engine/Rule.h
+++ b/opencog/rule-engine/Rule.h
@@ -295,7 +295,7 @@ private:
 	// URE will always choose the one with the highest confidence.
 	TruthValuePtr _tv;
 
-	bool has_name_capture() const;
+	bool has_name_collision(const Handle& vardecls) const;
 
 	// Return a copy of the rule with the variables alpha-converted
 	// into random variable names.

--- a/opencog/rule-engine/Rule.h
+++ b/opencog/rule-engine/Rule.h
@@ -295,6 +295,8 @@ private:
 	// URE will always choose the one with the highest confidence.
 	TruthValuePtr _tv;
 
+	bool has_name_capture() const;
+
 	// Return a copy of the rule with the variables alpha-converted
 	// into random variable names.
 	Rule rand_alpha_converted() const;

--- a/opencog/rule-engine/Rule.h
+++ b/opencog/rule-engine/Rule.h
@@ -295,8 +295,6 @@ private:
 	// URE will always choose the one with the highest confidence.
 	TruthValuePtr _tv;
 
-	bool has_name_collision(const Handle& vardecl) const;
-
 	// Return a copy of the rule with the variables alpha-converted
 	// into random variable names.
 	Rule rand_alpha_converted(const Handle& vardecl) const;


### PR DESCRIPTION
Last but not least #1630 should be fine now