### PR TITLE
Revert "resolve #1630"

### DIFF
--- a/opencog/rule-engine/Rule.cc
+++ b/opencog/rule-engine/Rule.cc
@@ -39,7 +39,6 @@
 #include <opencog/unify/Unify.h>
 
 #include <opencog/query/BindLinkAPI.h>
-#include <opencog/util/algorithm.h>
 
 #include "URELogger.h"
 
@@ -402,8 +401,10 @@ RuleTypedSubstitutionMap Rule::unify_source(const Handle& source,
 		return {};
 
 	// To guarantee that the rule variable does not have the same name
-	// as any variable in the source.
-	Rule alpha_rule = rand_alpha_converted(source, vardecl);
+	// as any variable in the source. XXX This is only a stochastic
+	// guarantee, there is a small chance that the new random name
+	// will still collide.
+	Rule alpha_rule = rand_alpha_converted();
 
 	RuleTypedSubstitutionMap unified_rules;
 	Handle rule_vardecl = alpha_rule.get_vardecl();
@@ -434,8 +435,10 @@ RuleTypedSubstitutionMap Rule::unify_target(const Handle& target,
 		return {};
 
 	// To guarantee that the rule variable does not have the same name
-	// as any variable in the target.
-	Rule alpha_rule = rand_alpha_converted(target, vardecl);
+	// as any variable in the target. XXX This is only a stochastic
+	// guarantee, there is a small chance that the new random name
+	// will still collide.
+	Rule alpha_rule = rand_alpha_converted();
 
 	RuleTypedSubstitutionMap unified_rules;
 	Handle alpha_vardecl = alpha_rule.get_vardecl();
@@ -481,19 +484,13 @@ std::string Rule::to_string(const std::string& indent) const
 	return ss.str();
 }
 
-Rule Rule::rand_alpha_converted(const Handle& term, const Handle& vardecl)
-const
+Rule Rule::rand_alpha_converted() const
 {
 	// Clone the rule
 	Rule result = *this;
-	const HandleSet& term_vars = gen_variables(term, vardecl).varset;
-	const HandleSet& result_vars = result._rule->get_variables().varset;
 
-	do {
-		// Alpha convert the rule
-		result.set_rule(_rule->alpha_convert());
-	}
-	while(!is_disjoint(target_vars, result_vars));
+	// Alpha convert the rule
+	result.set_rule(_rule->alpha_convert());
 
 	return result;
 }

--- a/opencog/rule-engine/Rule.h
+++ b/opencog/rule-engine/Rule.h
@@ -295,15 +295,9 @@ private:
 	// URE will always choose the one with the highest confidence.
 	TruthValuePtr _tv;
 
-	/**
-	*
-	* @param vardecl: declarations of variables
-	* @param target: source term used by the foward chainer or target term used
-	* by the backward chainer; only used to get the variables out of the term in case
-	* there are no variable declarations
-	* @return alpha converted rule that has no collisions with the given term
-	*/
-	Rule rand_alpha_converted(const Handle& term, const Handle& vardecl) const;
+	// Return a copy of the rule with the variables alpha-converted
+	// into random variable names.
+	Rule rand_alpha_converted() const;
 
 	Handle standardize_helper(AtomSpace*, const Handle&, HandleMap&);
 


### PR DESCRIPTION
Reverts opencog/atomspace#1715

Code does not compile. Please make sure your code compiles and passes unit tests before requesting a merge.
```
[ 79%] Building CXX object opencog/rule-engine/CMakeFiles/ruleengine.dir/Rule.cc.o
/src/atomspace-git/opencog/rule-engine/Rule.cc: In member function ‘opencog::Rule opencog::Rule::rand_alpha_converted(const opencog::Handle&, const opencog::Handle&) const’:
/src/atomspace-git/opencog/rule-engine/Rule.cc:496:21: error: ‘target_vars’ was not declared in this scope
  while(!is_disjoint(target_vars, result_vars));
                     ^~~~~~~~~~~
/src/atomspace-git/opencog/rule-engine/Rule.cc:489:19: warning: unused variable ‘term_vars’ [-Wunused-variable]
  const HandleSet& term_vars = gen_variables(term, vardecl).varset;
                   ^~~~~~~~~
opencog/rule-engine/CMakeFiles/ruleengine.dir/build.make:398: recipe for target 'opencog/rule-engine/CMakeFiles/ruleengine.dir/Rule.cc.o' failed
make[2]: *** [opencog/rule-engine/CMakeFiles/ruleengine.dir/Rule.cc.o] Error 1
CMakeFiles/Makefile2:1747: recipe for target 'opencog/rule-engine/CMakeFiles/ruleengine.dir/all' failed
make[1]: *** [opencog/rule-engine/CMakeFiles/ruleengine.dir/all] Error 2
Makefile:149: recipe for target 'all' failed
make: *** [all] Error 2
```