### PR TITLE
Make the matrix (atom-pair) API more flexible

### DIFF
--- a/opencog/matrix/compute-mi.scm
+++ b/opencog/matrix/compute-mi.scm
@@ -171,7 +171,7 @@
 		; This returns the count, or zero, if the pair was never observed.
 		(define (compute-left-count ITEM)
 			(fold
-				(lambda (pr sum) (+ sum (llobj 'pair-count pr)))
+				(lambda (pr sum) (+ sum (llobj 'get-count pr)))
 				0
 				(star-obj 'left-stars ITEM)))
 
@@ -188,7 +188,7 @@
 		; Compute the right-side wild-card count N(x,*).
 		(define (compute-right-count ITEM)
 			(fold
-				(lambda (pr sum) (+ sum (llobj 'pair-count pr)))
+				(lambda (pr sum) (+ sum (llobj 'get-count pr)))
 				0
 				(star-obj 'right-stars ITEM)))
 
@@ -309,7 +309,7 @@
 		; the frequency with which the pair (x,y) is observed. Return
 		; the frequency, or zero, if the pair was never observed.
 		(define (compute-pair-freq PAIR)
-			(/ (cntobj 'pair-count PAIR) tot-cnt))
+			(/ (cntobj 'get-count PAIR) tot-cnt))
 
 		; Compute the left-side wild-card frequency. This is the ratio
 		; P(*,y) = N(*,y) / N(*,*) = sum_x P(x,y)

--- a/opencog/matrix/compute-mi.scm
+++ b/opencog/matrix/compute-mi.scm
@@ -465,7 +465,7 @@
 							(define pr-freq (frqobj 'pair-freq lipr))
 							(define pr-logli (frqobj 'pair-logli lipr))
 
-							(define right-item (gdr lipr))
+							(define right-item (llobj 'right-element lipr))
 							(if (< 0 (cntobj 'left-wild-count right-item))
 								(let* ((l-logli (frqobj 'left-wild-logli right-item))
 										(fmi (- (+ r-logli l-logli) pr-logli))

--- a/opencog/matrix/compute-mi.scm
+++ b/opencog/matrix/compute-mi.scm
@@ -30,7 +30,7 @@
 ; on the "low-level API". These include:
 ;   'left-type and 'right-type, both of which should return 'WordNode
 ;         for the above.
-;   'item-pair, which should return the EvaluationLink, given the
+;   'get-pair, which should return the EvaluationLink, given the
 ;        ListLink
 ;   'left-wildcard and 'right-wildcard, indicating where the partial
 ;        sums, such as N(x,*) and N(*,y) should be stored.

--- a/opencog/matrix/cosine.scm
+++ b/opencog/matrix/cosine.scm
@@ -19,7 +19,7 @@
 ; ---------------------------------------------------------------------
 
 (define*-public (add-pair-cosine-compute LLOBJ
-	#:optional (GET-CNT 'pair-count))
+	#:optional (GET-CNT 'get-count))
 "
   add-pair-cosine-compute LLOBJ - Extend LLOBJ with methods to compute
   vector dot-products, cosine angles and jaccard distances between two

--- a/opencog/matrix/filter.scm
+++ b/opencog/matrix/filter.scm
@@ -55,7 +55,7 @@
   be kept.
 
   The PAIR-PRED should be a function to that accepts individual matrix
-  entries. It is applied whenever the 'item-pair or 'pair-count methods
+  entries. It is applied whenever the 'get-pair or 'pair-count methods
   are invoked.  Like the others, it should return #t to keep the pair.
 
   The ID-STR should be a string; it is appended to the dataset name and
@@ -121,7 +121,7 @@
 		; ---------------
 		; Apply the pair-cut to each pair.
 		(define (get-item-pair PAIR)
-			(if (PAIR-PRED PAIR) (LLOBJ 'item-pair PAIR) '()))
+			(if (PAIR-PRED PAIR) (LLOBJ 'get-pair PAIR) '()))
 
 		(define (get-pair-count PAIR)
 			(if (PAIR-PRED PAIR) (LLOBJ 'pair-count PAIR) 0))
@@ -156,7 +156,7 @@
 				((right-basis)      (get-right-basis))
 				((left-basis-size)  (get-left-size))
 				((right-basis-size) (get-right-size))
-				((item-pair)        (apply get-item-pair args))
+				((get-pair)         (apply get-item-pair args))
 				((pair-count)       (apply get-pair-count args))
 				((provides)         (apply provides args))
 				((filters?)         RENAME)

--- a/opencog/matrix/filter.scm
+++ b/opencog/matrix/filter.scm
@@ -55,7 +55,7 @@
   be kept.
 
   The PAIR-PRED should be a function to that accepts individual matrix
-  entries. It is applied whenever the 'get-pair or 'pair-count methods
+  entries. It is applied whenever the 'get-pair or 'get-count methods
   are invoked.  Like the others, it should return #t to keep the pair.
 
   The ID-STR should be a string; it is appended to the dataset name and
@@ -120,11 +120,12 @@
 
 		; ---------------
 		; Apply the pair-cut to each pair.
-		(define (get-item-pair PAIR)
-			(if (PAIR-PRED PAIR) (LLOBJ 'get-pair PAIR) '()))
+;xxx this is broken.
+		(define (get-item-pair L-ATOM R-ATOM)
+			(if (PAIR-PRED PAIR) (LLOBJ 'get-pair L-ATOM R-ATOM) '()))
 
 		(define (get-pair-count PAIR)
-			(if (PAIR-PRED PAIR) (LLOBJ 'pair-count PAIR) 0))
+			(if (PAIR-PRED PAIR) (LLOBJ 'get-count PAIR) 0))
 
 		; ---------------
 		(define (get-name)
@@ -157,7 +158,7 @@
 				((left-basis-size)  (get-left-size))
 				((right-basis-size) (get-right-size))
 				((get-pair)         (apply get-item-pair args))
-				((pair-count)       (apply get-pair-count args))
+				((get-count)        (apply get-pair-count args))
 				((provides)         (apply provides args))
 				((filters?)         RENAME)
 				; Pass through some selected methods
@@ -244,7 +245,7 @@
 			(< RIGHT-CUT (cnt-obj 'left-wild-count (gdr PAIR))))
 
 		(define (pair-pred PAIR)
-			(< PAIR-CUT (LLOBJ 'pair-count PAIR)))
+			(< PAIR-CUT (LLOBJ 'get-count PAIR)))
 
 		(define id-str
 			(format #f "cut-~D-~D-~D"

--- a/opencog/matrix/filter.scm
+++ b/opencog/matrix/filter.scm
@@ -120,7 +120,7 @@
 
 		; ---------------
 		; Apply the pair-cut to each pair.
-;xxx this is broken.
+;xxxxxx this is broken.
 		(define (get-item-pair L-ATOM R-ATOM)
 			(if (PAIR-PRED PAIR) (LLOBJ 'get-pair L-ATOM R-ATOM) '()))
 
@@ -239,10 +239,10 @@
 		;
 		; See comments above: LEFT-CUT < right-wild-count is correct.
 		(define (left-stars-pred PAIR)
-			(< LEFT-CUT (cnt-obj 'right-wild-count (gar PAIR))))
+			(< LEFT-CUT (cnt-obj 'right-wild-count (LLOBJ 'left-element PAIR))))
 
 		(define (right-stars-pred PAIR)
-			(< RIGHT-CUT (cnt-obj 'left-wild-count (gdr PAIR))))
+			(< RIGHT-CUT (cnt-obj 'left-wild-count (LLOBJ 'right-element PAIR))))
 
 		(define (pair-pred PAIR)
 			(< PAIR-CUT (LLOBJ 'get-count PAIR)))
@@ -286,10 +286,10 @@
 	; ---------------
 	; Return only those stars that pass the cutoff.
 	(define (left-stars-pred PAIR)
-		(left-basis-pred (gar PAIR)))
+		(left-basis-pred (LLOBJ 'left-element PAIR)))
 
 	(define (right-stars-pred PAIR)
-		(right-basis-pred (gdr PAIR)))
+		(right-basis-pred (LLOBJ 'right-element PAIR)))
 
 	(define (pair-pred PAIR)
 		(and (left-stars-pred PAIR) (right-stars-pred PAIR)))

--- a/opencog/matrix/fold-api.scm
+++ b/opencog/matrix/fold-api.scm
@@ -85,7 +85,7 @@
 ; ---------------------------------------------------------------------
 ;
 (define*-public (add-tuple-math LLOBJ FUNC #:optional
-	(GET-CNT 'pair-count))
+	(GET-CNT 'get-count))
 "
   add-tuple-math LLOBJ FUNC - Extend LLOBJ with ability to take tuples
   of rows or columns, and then call FUNC on that tuple, in the place of
@@ -178,19 +178,18 @@
 
 		; ---------------
 		; Given a TUPLE of items of 'right-type, this returns
-		; a tuple of low-level pairs of LEFTY and each righty
-		; in the TUPLE.  If such a pair does not exist, the
-		; returned tuple will contain an empty list at that locus.
-		(define (get-left-lopr-tuple LEFTY TUPLE)
-			(define prty (LLOBJ 'pair-type))
+		; a tuple of pairs of LEFTY and each righty in the TUPLE.
+		; If such a pair does not exist, the returned tuple will
+		; contain an empty list at that locus.
+		(define (get-left-tuple LEFTY TUPLE)
 			(map
-				(lambda (rght) (cog-link prty LEFTY rght))
+				(lambda (rght) (LLOBJ 'get-pair LEFTY rght))
 				TUPLE))
 
-		(define (get-right-lopr-tuple RIGHTY TUPLE)
+		(define (get-right-tuple RIGHTY TUPLE)
 			(define prty (LLOBJ 'pair-type))
 			(map
-				(lambda (left) (cog-link prty left RIGHTY))
+				(lambda (left) (LLOBJ 'get-pair left RIGHTY))
 				TUPLE))
 
 		; ---------------
@@ -224,22 +223,17 @@
 
 		(define (left-star-union TUPLE)
 			(map
-				(lambda (lefty) (get-left-lopr-tuple lefty TUPLE))
+				(lambda (lefty) (get-left-tuple lefty TUPLE))
 				(get-left-union TUPLE)))
 
 		; Same as above, but for the right
 		(define (right-star-union TUPLE)
 			(map
-				(lambda (righty) (get-right-lopr-tuple righty TUPLE))
+				(lambda (righty) (get-right-tuple righty TUPLE))
 				(get-right-union TUPLE)))
 
 		; ---------------
-		; Given a TUPLE of low-level pairs, return a tuple of high-level
-		; pairs.
-		(define (get-pair TUPLE)
-			(map (lambda (lopr) (LLOBJ 'get-pair lopr)) TUPLE))
-
-		; Given a TUPLE of high-level pairs, return a single number.
+		; Given a TUPLE of pairs, return a single number.
 		; The FUNC is applied to reduce the counts on each pair
 		; in the tuple down to just one number.
 		(define (get-func-count TUPLE)
@@ -254,7 +248,6 @@
 			(case meth
 				((left-stars)  left-star-union)
 				((right-stars) right-star-union)
-				((get-pair)    get-pair)
 				((pair-count)  get-func-count)
 				(else          (LLOBJ 'provides meth))))
 

--- a/opencog/matrix/fold-api.scm
+++ b/opencog/matrix/fold-api.scm
@@ -119,9 +119,9 @@
   then the returned triple would be [(), (x,z), (x,w)].  At least one
   of the entries in the tuple is non-nil.
 
-  The 'item-pair method just distributes over the tuples. In the
-  above example, 'item-pair [(x,y), (x,z), (x,w)] will return the
-  triple ['item-pair (x,y), 'item-pair (x,z), 'item-pair (x,w)]
+  The 'get-pair method just distributes over the tuples. In the
+  above example, 'get-pair [(x,y), (x,z), (x,w)] will return the
+  triple ['get-pair (x,y), 'get-pair (x,z), 'get-pair (x,w)]
 
   The 'pair-count method will apply FUNC to the tuple. In the above
   example, the 'pair-count method will return a number, specifically,
@@ -237,7 +237,7 @@
 		; Given a TUPLE of low-level pairs, return a tuple of high-level
 		; pairs.
 		(define (get-pair TUPLE)
-			(map (lambda (lopr) (LLOBJ 'item-pair lopr)) TUPLE))
+			(map (lambda (lopr) (LLOBJ 'get-pair lopr)) TUPLE))
 
 		; Given a TUPLE of high-level pairs, return a single number.
 		; The FUNC is applied to reduce the counts on each pair
@@ -254,7 +254,7 @@
 			(case meth
 				((left-stars)  left-star-union)
 				((right-stars) right-star-union)
-				((item-pair)   get-pair)
+				((get-pair)    get-pair)
 				((pair-count)  get-func-count)
 				(else          (LLOBJ 'provides meth))))
 
@@ -265,7 +265,7 @@
 			(case message
 				((left-stars)      (apply left-star-union args))
 				((right-stars)     (apply right-star-union args))
-				((item-pair)       (apply get-pair args))
+				((get-pair)        (apply get-pair args))
 				((pair-count)      (apply get-func-count args))
 				((provides)        (apply provides args))
 				(else              (apply LLOBJ (cons message args))))

--- a/opencog/matrix/fold-api.scm
+++ b/opencog/matrix/fold-api.scm
@@ -248,7 +248,7 @@
 			(case meth
 				((left-stars)  left-star-union)
 				((right-stars) right-star-union)
-				((pair-count)  get-func-count)
+				((get-count)   get-func-count)
 				(else          (LLOBJ 'provides meth))))
 
 		; ---------------
@@ -258,8 +258,7 @@
 			(case message
 				((left-stars)      (apply left-star-union args))
 				((right-stars)     (apply right-star-union args))
-				((get-pair)        (apply get-pair args))
-				((pair-count)      (apply get-func-count args))
+				((get-count)       (apply get-func-count args))
 				((provides)        (apply provides args))
 				(else              (apply LLOBJ (cons message args))))
 			)))

--- a/opencog/matrix/fold-api.scm
+++ b/opencog/matrix/fold-api.scm
@@ -154,7 +154,7 @@
 			; Add the left-side of the pair to the set.
 			(define (add-left-to-set LIST)
 				(for-each
-					(lambda (star-pair) (atom-set (gar star-pair)))
+					(lambda (star-pair) (atom-set (LLOBJ 'left-element star-pair)))
 					LIST))
 
 			; loop over everything in the tuple.
@@ -169,7 +169,7 @@
 			(define atom-set (make-atom-set))
 			(define (add-right-to-set LIST)
 				(for-each
-					(lambda (star-pair) (atom-set (gdr star-pair)))
+					(lambda (star-pair) (atom-set (LLOBJ 'right-element star-pair)))
 					LIST))
 			(for-each
 				(lambda (item) (add-right-to-set (star-obj 'right-stars item)))
@@ -187,7 +187,6 @@
 				TUPLE))
 
 		(define (get-right-tuple RIGHTY TUPLE)
-			(define prty (LLOBJ 'pair-type))
 			(map
 				(lambda (left) (LLOBJ 'get-pair left RIGHTY))
 				TUPLE))

--- a/opencog/matrix/loop-api.scm
+++ b/opencog/matrix/loop-api.scm
@@ -15,7 +15,7 @@
 ;
 ; The matrix is accessed using the wild-card stars object, and
 ; specifically uses these methods:
-;   'item-pair, which should return high-level pair, given the
+;   'get-pair, which should return high-level pair, given the
 ;        low-level pair.
 ;   'left-basis and 'right-basis, providing a list of all rows and columns
 ;   'left-stars and 'right-stars, providing a list of all non-zero

--- a/opencog/matrix/object-api.scm
+++ b/opencog/matrix/object-api.scm
@@ -634,17 +634,17 @@
 	; Return the MI value on the pair.
 	; The MI is defined as
 	; + P(x,y) log_2 P(x,y) / P(x,*) P(*,y)
-	(define (get-pair-mi L-ATOM R-ATOM)
-		(get-total-mi (LLOBJ 'get-pair L-ATOM R-ATOM)))
+	(define (get-pair-mi PAIR)
+		(get-total-mi PAIR))
 
 	; Return the fractional MI (lexical attraction) on the pair.
 	; + log_2 P(x,y) / P(x,*) P(*,y)
 	; It differs from the MI above only by the leading probability.
-	(define (get-pair-fmi L-ATOM R-ATOM)
-		(get-fractional-mi (LLOBJ 'get-pair L-ATOM R-ATOM)))
+	(define (get-pair-fmi PAIR)
+		(get-fractional-mi PAIR))
 
-	(define (set-pair-mi L-ATOM R-ATOM MI FMI)
-		(set-mi (LLOBJ 'get-pair L-ATOM R-ATOM) MI FMI))
+	(define (set-pair-mi PAIR MI FMI)
+		(set-mi PAIR MI FMI))
 
 	; ----------------------------------------------------
 	; Get the left wildcard frequency

--- a/opencog/matrix/object-api.scm
+++ b/opencog/matrix/object-api.scm
@@ -109,13 +109,15 @@
 ;        (if (null? maybe-list) '()
 ;           (cog-link 'EvaluationLink (Predicate "foo") maybe-list)))
 ;
+;     ; Return the observed count for the pair PAIR.
+;     (define (get-count PAIR)
+;        (cog-value-ref (cog-value PAIR (Predicate "counter")) 42))
+;
 ;     ; Return the observed count for the pair (L-ATOM, R-ATOM), if it
 ;     ; exists, else return zero.
-;     (define (get-pair-count L-ATOM R-ATOM))
+;     (define (get-pair-count L-ATOM R-ATOM)
 ;        (define stats-atom (get-pair L-ATOM R-ATOM))
-;        (if (null? stats-atom) 0
-;           (cog-value-ref
-;               (cog-value stats-atom (Predicate "counter")) 42)))
+;        (if (null? stats-atom) 0 (get-count stats-atom)))
 ;
 ;     ; Return the atom holding the count, creating it if it does
 ;     ; not yet exist.  Returns the same structure as the 'item-pair
@@ -168,7 +170,8 @@
 ;              ((right-type) get-right-type)
 ;              ((pair-type) get-pair-type)
 ;              ((pair-count) get-pair-count)
-;              ((item-pair) get-pair)
+;              ((get-pair) get-pair)
+;              ((get-count) get-count)
 ;              ((make-pair) make-pair)
 ;              ((left-wildcard) get-left-wildcard)
 ;              ((right-wildcard) get-right-wildcard)

--- a/opencog/matrix/object-api.scm
+++ b/opencog/matrix/object-api.scm
@@ -90,9 +90,10 @@
 ;     ; the right side of the (row, column) pairs.
 ;     (define (get-right-type) 'WordNode)
 ;
-;     ; Return the type of the pair itself.  In this example, each pair
-;     ; will be of the form (ListLink (Word "row") (Word "col"))
-;     (define (get-pair-type) 'ListLink)
+;     ; Return the type of the link that holds the pair.  In this
+;     ; example, each pair will be held in the form
+;     ;  (Evaluation (Predicate "foo") (List (Word "row") (Word "col")))
+;     (define (get-pair-type) 'EvaluationLink)
 ;
 ;     ; Return the atom for a matrix (row,column) pair, if it exists,
 ;     ; else return nil. In this example, the matrix is defined by an
@@ -103,17 +104,15 @@
 ;     ; so on. Users are free to (are encouraged to) use this atom to
 ;     ; attach additional information and statistics.
 ;     ;
-;     ; The PAIR atom must be of 'pair-type, that is, a ListLink in this
-;     ; example.  Note: the cog-link function does NOT create the atom,
-;     ; if it does not already exist!
-;     (define (get-pair PAIR)
-;        (cog-link 'EvaluationLink (Predicate "foo") PAIR))
+;     (define (get-pair L-ATOM R-ATOM)
+;        (define maybe-list (cog-link 'ListLink L-ATOM R-ATOM))
+;        (if (null? maybe-list) '()
+;           (cog-link 'EvaluationLink (Predicate "foo") maybe-list)))
 ;
-;     ; Return the observed count for PAIR, if it exists, else
-;     ; return zero. The PAIR atom must be of type 'pair-type;
-;     ; that is, a ListLink in this example.
-;     (define (get-pair-count PAIR)
-;        (define stats-atom (get-pair PAIR))
+;     ; Return the observed count for the pair (L-ATOM, R-ATOM), if it
+;     ; exists, else return zero.
+;     (define (get-pair-count L-ATOM R-ATOM))
+;        (define stats-atom (get-pair L-ATOM R-ATOM))
 ;        (if (null? stats-atom) 0
 ;           (cog-value-ref
 ;               (cog-value stats-atom (Predicate "counter")) 42)))
@@ -121,8 +120,8 @@
 ;     ; Return the atom holding the count, creating it if it does
 ;     ; not yet exist.  Returns the same structure as the 'item-pair
 ;     ; method (the get-pair function, above).
-;     (define (make-pair PAIR)
-;        (EvaluationLink (Predicate "foo") PAIR))
+;     (define (make-pair L-ATOM R-ATOM)
+;        (Evaluation (Predicate "foo") (List L-ATOM R-ATOM)))
 ;
 ;     ; Return an atom to which column subtotals can be attached,
 ;     ; such as, for example, the subtotal `N(*,y)`. Thus, `y`

--- a/opencog/matrix/object-api.scm
+++ b/opencog/matrix/object-api.scm
@@ -120,7 +120,7 @@
 ;        (if (null? stats-atom) 0 (get-count stats-atom)))
 ;
 ;     ; Return the atom holding the count, creating it if it does
-;     ; not yet exist.  Returns the same structure as the 'item-pair
+;     ; not yet exist.  Returns the same structure as the 'get-pair
 ;     ; method (the get-pair function, above).
 ;     (define (make-pair L-ATOM R-ATOM)
 ;        (Evaluation (Predicate "foo") (List L-ATOM R-ATOM)))
@@ -284,7 +284,7 @@
 		; The point of this function is to find and return the complete
 		; wild-card set (*,y) = {(x,y) | there-exists pair (x,y) for some x}
 		; The pairs are Links of type 'pair-type, as would be returned by
-		; 'item-pair. That is, this returns a list of atoms of the form
+		; 'get-pair. That is, this returns a list of atoms of the form
 		;
 		;    (LLOBJ 'make-pair $variable ITEM)
 		;
@@ -397,7 +397,7 @@
   atomspace.  A method is provided to set the value, as well.
 
   Here, the LLOBJ is expected to be an object, with methods for
-  'item-pair 'make-pair 'left-wildcard 'right-wildcard and 'wild-wild
+  'get-pair 'make-pair 'left-wildcard 'right-wildcard and 'wild-wild
   on it, in the form documented above for the \"low-level API class\".
 "
 	; ----------------------------------------------------
@@ -477,7 +477,7 @@
   provide a reasonable default.
 
   Here, the LLOBJ is expected to be an object, with methods for
-  'item-pair 'make-pair 'left-wildcard and 'right-wildcard on it,
+  'get-pair 'make-pair 'left-wildcard and 'right-wildcard on it,
   in the form documented above for the \"low-level API class\".
 
   The optional ID argument should be #f or a string, used to construct
@@ -606,18 +606,18 @@
 	; Return the observational frequency on PAIR.
 	; If the PAIR does not exist (was not observed) return 0.
 	(define (get-pair-freq L-ATOM R-ATOM)
-		(get-freq (LLOBJ 'item-pair L-ATOM R-ATOM)))
+		(get-freq (LLOBJ 'get-pair L-ATOM R-ATOM)))
 
 	(define (get-pair-logli L-ATOM R-ATOM)
-		(get-logli (LLOBJ 'item-pair L-ATOM R-ATOM)))
+		(get-logli (LLOBJ 'get-pair L-ATOM R-ATOM)))
 
 	(define (get-pair-entropy L-ATOM R-ATOM)
-		(get-entropy (LLOBJ 'item-pair L-ATOM R-ATOM)))
+		(get-entropy (LLOBJ 'get-pair L-ATOM R-ATOM)))
 
 	; Set the frequency and log-frequency on PAIR
 	; Return the atom that holds this count.
-	(define (set-pair-freq L-ATOM R-ATOM FREQ)
-		(set-freq (LLOBJ 'make-pair L-ATOM R-ATOM) FREQ))
+	(define (set-pair-freq PAIR FREQ)
+		(set-freq PAIR FREQ))
 
 	; ----------------------------------------------------
 
@@ -625,16 +625,16 @@
 	; The MI is defined as
 	; + P(x,y) log_2 P(x,y) / P(x,*) P(*,y)
 	(define (get-pair-mi L-ATOM R-ATOM)
-		(get-total-mi (LLOBJ 'item-pair L-ATOM R-ATOM)))
+		(get-total-mi (LLOBJ 'get-pair L-ATOM R-ATOM)))
 
 	; Return the fractional MI (lexical attraction) on the pair.
 	; + log_2 P(x,y) / P(x,*) P(*,y)
 	; It differs from the MI above only by the leading probability.
 	(define (get-pair-fmi L-ATOM R-ATOM)
-		(get-fractional-mi (LLOBJ 'item-pair L-ATOM R-ATOM)))
+		(get-fractional-mi (LLOBJ 'get-pair L-ATOM R-ATOM)))
 
 	(define (set-pair-mi L-ATOM R-ATOM MI FMI)
-		(set-mi (LLOBJ 'item-pair L-ATOM R-ATOM) MI FMI))
+		(set-mi (LLOBJ 'get-pair L-ATOM R-ATOM) MI FMI))
 
 	; ----------------------------------------------------
 	; Get the left wildcard frequency

--- a/opencog/matrix/object-api.scm
+++ b/opencog/matrix/object-api.scm
@@ -602,36 +602,36 @@
 	; ----------------------------------------------------
 	; Return the observational frequency on PAIR.
 	; If the PAIR does not exist (was not observed) return 0.
-	(define (get-pair-freq PAIR)
-		(get-freq (LLOBJ 'item-pair PAIR)))
+	(define (get-pair-freq L-ATOM R-ATOM)
+		(get-freq (LLOBJ 'item-pair L-ATOM R-ATOM)))
 
-	(define (get-pair-logli PAIR)
-		(get-logli (LLOBJ 'item-pair PAIR)))
+	(define (get-pair-logli L-ATOM R-ATOM)
+		(get-logli (LLOBJ 'item-pair L-ATOM R-ATOM)))
 
-	(define (get-pair-entropy PAIR)
-		(get-entropy (LLOBJ 'item-pair PAIR)))
+	(define (get-pair-entropy L-ATOM R-ATOM)
+		(get-entropy (LLOBJ 'item-pair L-ATOM R-ATOM)))
 
 	; Set the frequency and log-frequency on PAIR
 	; Return the atom that holds this count.
-	(define (set-pair-freq PAIR FREQ)
-		(set-freq (LLOBJ 'make-pair PAIR) FREQ))
+	(define (set-pair-freq L-ATOM R-ATOM FREQ)
+		(set-freq (LLOBJ 'make-pair L-ATOM R-ATOM) FREQ))
 
 	; ----------------------------------------------------
 
 	; Return the MI value on the pair.
 	; The MI is defined as
 	; + P(x,y) log_2 P(x,y) / P(x,*) P(*,y)
-	(define (get-pair-mi PAIR)
-		(get-total-mi (LLOBJ 'item-pair PAIR)))
+	(define (get-pair-mi L-ATOM R-ATOM)
+		(get-total-mi (LLOBJ 'item-pair L-ATOM R-ATOM)))
 
 	; Return the fractional MI (lexical attraction) on the pair.
 	; + log_2 P(x,y) / P(x,*) P(*,y)
 	; It differs from the MI above only by the leading probability.
-	(define (get-pair-fmi PAIR)
-		(get-fractional-mi (LLOBJ 'item-pair PAIR)))
+	(define (get-pair-fmi L-ATOM R-ATOM)
+		(get-fractional-mi (LLOBJ 'item-pair L-ATOM R-ATOM)))
 
-	(define (set-pair-mi PAIR MI FMI)
-		(set-mi (LLOBJ 'item-pair PAIR) MI FMI))
+	(define (set-pair-mi L-ATOM R-ATOM MI FMI)
+		(set-mi (LLOBJ 'item-pair L-ATOM R-ATOM) MI FMI))
 
 	; ----------------------------------------------------
 	; Get the left wildcard frequency

--- a/opencog/matrix/object-api.scm
+++ b/opencog/matrix/object-api.scm
@@ -605,14 +605,14 @@
 	; ----------------------------------------------------
 	; Return the observational frequency on PAIR.
 	; If the PAIR does not exist (was not observed) return 0.
-	(define (get-pair-freq L-ATOM R-ATOM)
-		(get-freq (LLOBJ 'get-pair L-ATOM R-ATOM)))
+	(define (get-pair-freq PAIR)
+		(get-freq PAIR))
 
-	(define (get-pair-logli L-ATOM R-ATOM)
-		(get-logli (LLOBJ 'get-pair L-ATOM R-ATOM)))
+	(define (get-pair-logli PAIR)
+		(get-logli PAIR))
 
-	(define (get-pair-entropy L-ATOM R-ATOM)
-		(get-entropy (LLOBJ 'get-pair L-ATOM R-ATOM)))
+	(define (get-pair-entropy PAIR)
+		(get-entropy PAIR))
 
 	; Set the frequency and log-frequency on PAIR
 	; Return the atom that holds this count.

--- a/opencog/matrix/object-api.scm
+++ b/opencog/matrix/object-api.scm
@@ -314,7 +314,7 @@
 		; forced atom deletion to make up for the ineffiency.
 		;
 		(define (get-left-stars ITEM)
-			(define uniqvar (Variable "$X"))
+			(define uniqvar (uniquely-named-variable))
 			(define term (LLOBJ 'make-pair uniqvar ITEM))
 			(define setlnk (cog-execute! (Bind (TypedVariable
 					uniqvar (Type (symbol->string left-type)))
@@ -326,7 +326,7 @@
 
 		; Same as above, but on the right.
 		(define (get-right-stars ITEM)
-			(define uniqvar (Variable "$X"))
+			(define uniqvar (uniquely-named-variable))
 			(define term (LLOBJ 'make-pair ITEM uniqvar))
 			(define setlnk (cog-execute! (Bind (TypedVariable
 					uniqvar (Type (symbol->string right-type)))

--- a/opencog/matrix/object-api.scm
+++ b/opencog/matrix/object-api.scm
@@ -126,7 +126,7 @@
 ;        (Evaluation (Predicate "foo") (List L-ATOM R-ATOM)))
 ;
 ;     ; Return the left member of the pair. Given the pair-atom,
-;     ; extract the left-side atom.
+;     ; locate the left-side atom.
 ;     (define (get-left-element PAIR)
 ;        (gadr PAIR))
 ;

--- a/opencog/matrix/object-api.scm
+++ b/opencog/matrix/object-api.scm
@@ -125,6 +125,14 @@
 ;     (define (make-pair L-ATOM R-ATOM)
 ;        (Evaluation (Predicate "foo") (List L-ATOM R-ATOM)))
 ;
+;     ; Return the left member of the pair. Given the pair-atom,
+;     ; extract the left-side atom.
+;     (define (get-left-element PAIR)
+;        (gadr PAIR))
+;
+;     (define (get-right-element PAIR)
+;        (gddr PAIR))
+;
 ;     ; Return an atom to which column subtotals can be attached,
 ;     ; such as, for example, the subtotal `N(*,y)`. Thus, `y`
 ;     ; denotes a column, and the star is on the left (the star
@@ -173,6 +181,8 @@
 ;              ((get-pair) get-pair)
 ;              ((get-count) get-count)
 ;              ((make-pair) make-pair)
+;              ((left-element) get-left-element)
+;              ((right-element) get-right-element)
 ;              ((left-wildcard) get-left-wildcard)
 ;              ((right-wildcard) get-right-wildcard)
 ;              ((wild-wild) get-wild-wild)

--- a/opencog/matrix/support.scm
+++ b/opencog/matrix/support.scm
@@ -154,8 +154,8 @@
 		(define (non-zero-filter LIST)
 			(filter-map
 				(lambda (lopr)
-					; 'item-pair returns the atom holding the count
-					(define hipr (LLOBJ 'item-pair lopr))
+					; 'get-pair returns the atom holding the count
+					(define hipr (LLOBJ 'get-pair lopr))
 					(define cnt (get-cnt lopr))
 					(if (< 0 cnt) hipr #f))
 				LIST))
@@ -175,7 +175,7 @@
 		(define (get-support-size LIST)
 			(fold
 				(lambda (lopr sum)
-					; 'item-pair returns the atom holding the count
+					; 'get-pair returns the atom holding the count
 					(+ sum
 						(if (< 0 (get-cnt lopr))
 							1 0)))

--- a/opencog/matrix/support.scm
+++ b/opencog/matrix/support.scm
@@ -169,10 +169,7 @@
 		(define (get-support-size LIST)
 			(fold
 				(lambda (lopr sum)
-					; 'get-pair returns the atom holding the count
-					(+ sum
-						(if (< 0 (get-cnt lopr))
-							1 0)))
+					(if (< 0 (get-cnt lopr)) (+ sum 1) sum))
 				0
 				LIST))
 

--- a/opencog/matrix/support.scm
+++ b/opencog/matrix/support.scm
@@ -149,16 +149,10 @@
 		)
 
 		; -------------
-		; Given a list of low-level pairs, return list of high-level
-		; pairs for which the count is non-zero. Internal use only.
+		; Filter and return only pairs with non-zero count.
+		; Internal use only.
 		(define (non-zero-filter LIST)
-			(filter-map
-				(lambda (lopr)
-					; 'get-pair returns the atom holding the count
-					(define hipr (LLOBJ 'get-pair lopr))
-					(define cnt (get-cnt lopr))
-					(if (< 0 cnt) hipr #f))
-				LIST))
+			(filter (lambda (lopr) (< 0 (get-cnt lopr))) LIST))
 
 		; Return a list of all pairs (x, y) for y == ITEM for which
 		; N(x,y) > 0.  Specifically, this returns the pairs which

--- a/opencog/matrix/support.scm
+++ b/opencog/matrix/support.scm
@@ -100,7 +100,7 @@
 ; ---------------------------------------------------------------------
 
 (define*-public (add-support-compute LLOBJ
-	 #:optional (GET-CNT 'pair-count))
+	 #:optional (GET-CNT 'get-count))
 "
   add-support-compute LLOBJ - Extend LLOBJ with methods to
   compute wild-card sums, including the support (lp-norm for p=0),

--- a/opencog/matrix/thresh-pca.scm
+++ b/opencog/matrix/thresh-pca.scm
@@ -59,13 +59,13 @@
 ; ---------------------------------------------------------------------
 
 (define*-public (make-power-iter-pca LLOBJ #:optional
-	; Default is to use the pair-count method
-	(get-value 'pair-count))
+	; Default is to use the get-count method
+	(get-value 'get-count))
 "
   make-power-iter-pca LLOBJ - Implement a power-iteration form of PCA.
 
   Optionally, the name of a method can be supplied, from which the matrix
-  values will be fetched.  If not supplied, it defaults to 'pair-count.
+  values will be fetched.  If not supplied, it defaults to 'get-count.
   You can get fancier if you wish.  Using the MI could be interesting,
   for example: this would result in a MaxEnt style computation, instead
   of a PCA-style computation.
@@ -257,12 +257,12 @@
 ; ---------------------------------------------------------------------
 
 (define*-public (make-cosine-matrix LLOBJ #:optional
-	; Default is to use the pair-count method
-	(GET-CNT 'pair-count))
+	; Default is to use the get-count method
+	(GET-CNT 'get-count))
 "
   make-cosine-matrix LLOBJ - Provide a cosine-matrix form of LLOBJ.
 
-  Given an LLOBJ whose 'pair-count returns values N(x,y), one can define
+  Given an LLOBJ whose 'get-count returns values N(x,y), one can define
   another matrix such that the rows or columns are normalized to be unit
   vectors.  That is, one can define the left-unit
 
@@ -278,7 +278,7 @@
   We call it the 'left similarity' to emphasize that the summation is
   taking place over the left index.
 
-  The LLOBJ object needs to provide the 'pair-count method.
+  The LLOBJ object needs to provide the 'get-count method.
 "
 	(let* ((star-obj (add-pair-stars LLOBJ))
 			(supp-obj (add-support-compute star-obj GET-CNT))

--- a/opencog/matrix/thresh-pca.scm
+++ b/opencog/matrix/thresh-pca.scm
@@ -114,7 +114,7 @@
 			(lambda (ITEM)
 				(fold
 					(lambda (PAIR sum)
-						(define vecval (fvec (gar PAIR)))
+						(define vecval (fvec (LLOBJ 'left-element PAIR)))
 						; Avoid fetching the pair value if its
 						; multiply-by-zero
 						(if (eqv? 0 vecval)
@@ -130,7 +130,7 @@
 			(lambda (ITEM)
 				(fold
 					(lambda (PAIR sum)
-						(define vecval (fvec (gdr PAIR)))
+						(define vecval (fvec (LLOBJ 'right-element PAIR)))
 						(if (eqv? 0 vecval)
 							sum
 							(+ sum (* (llobj get-value PAIR) vecval))))
@@ -293,13 +293,13 @@
 		; --------------------
 		(define (do-left-unit PAIR)
 			(define cnt (LLOBJ GET-CNT PAIR))
-			(define len (get-left-length (gdr PAIR)))
+			(define len (get-left-length (LLOBJ 'right-element PAIR)))
 			(/ cnt len)
 		)
 
 		(define (do-right-unit PAIR)
 			(define cnt (LLOBJ GET-CNT PAIR))
-			(define len (get-right-length (gar PAIR)))
+			(define len (get-right-length (LLOBJ 'left-element PAIR)))
 			(/ cnt len)
 		)
 

--- a/opencog/scm/opencog/base/utilities.scm
+++ b/opencog/scm/opencog/base/utilities.scm
@@ -82,37 +82,41 @@
   Return the floating-point mean (strength) of a TruthValue.
   Deprecated; use cog-tv-mean instead.
 "
-	(cog-tv-mean TV))
+	(cog-tv-mean TV)
+)
 
 (define-public (tv-conf TV)
 "
   Return the floating-point confidence of a TruthValue.
   Deprecated; use cog-tv-confidence instead.
 "
-	(cog-tv-confidence TV))
+	(cog-tv-confidence TV)
+)
 
 (define-public (tv-non-null-conf? TV)
 "
   Return #t if the confidence of tv is positive, #f otherwise.
   Deprecated. Just say (< 0 (cog-tv-confidence TV)) instead.
 "
-	(< 0 (cog-tv-confidence TV)))
+	(< 0 (cog-tv-confidence TV))
+)
 
 ;
 ; Simple truth values won't have a count. Its faster to just check
 ; for #f than to call (cog-ctv? tv)
-(define-public (tv-count tv)
+(define-public (tv-count TV)
 "
   Return the floating-point count of a CountTruthValue.
   Deprecated; use cog-tv-count instead.
 "
-	(cog-tv-count TV))
+	(cog-tv-count TV)
+)
 
-(define-public (tv-positive-count tv)
+(define-public (tv-positive-count TV)
 "
   Return the floating-point positive count of a EvidenceCountTruthValue.
 "
-	(define pos-cnt (assoc-ref (cog-tv->alist tv) 'positive-count))
+	(define pos-cnt (assoc-ref (cog-tv->alist TV) 'positive-count))
 	(if (eq? pos-cnt #f) 0 pos-cnt)
 )
 
@@ -1086,9 +1090,13 @@
 
 (define-public (random-node-name node-type random-length prefix)
 "
-  Creates a random node name of type `node-type`, with name `prefix` followed by
-  a random string of length `random-length`. It Makes sure the resulting node
-  did not previously exist in the current atomspace.
+  random-node-name TYPE LENGTH PREFIX - create a unique node.
+
+  Create a random string, consisting of `PREFIX` followed by
+  a random string of length `LENGTH`.  The string is checked, so
+  that no node of type `TYPE` exists in the atomspace at the time
+  of this call. Thus, the name is almost unique -- there still is
+  a tiny window in which a race can occur.
 "
 	(define (check-name? node-name node-type)
 	"
@@ -1111,13 +1119,21 @@
 	node-name
 )
 
-;; TODO rename to random-variable-name
 (define-public (choose-var-name)
 "
- Creates a new random VariableNode.
+ DEPRECATED - use uniquely-named-variable instead.
 "
-    (random-node-name 'VariableNode 36 "$")
+    (random-node-name 'VariableNode 24 "$")
 )
+
+(define-public (uniquely-named-variable)
+"
+ uniquely-named-variable -- Creates a new uniquely-named VariableNode.
+"
+    (Variable (random-node-name 'VariableNode 24 "$"))
+)
+
+
 
 ; -----------------------------------------------------------------------
 

--- a/opencog/sheaf/mst-parser.scm
+++ b/opencog/sheaf/mst-parser.scm
@@ -43,7 +43,7 @@
   make-score-fn LLOBJ METHOD -- Create a function that returns a
   score for a pair of atoms, the score being given by invoking
   METHOD on LLOBJ.  The LLOBJ must provide the METHOD, of course,
-  and also the 'pair-type method, so that pairs can be assembled.
+  and also the 'get-pair method, so that pairs can be assembled.
 
   If either atom is nil, or if the atom-pair cannot be found, then a
   default value of -1e40 is returned.
@@ -54,11 +54,11 @@
 	(lambda (left-atom right-atom distance)
 
 		; We take care here to not actually create the atoms,
-		; if they aren't already in the atomspace. cog-link returns
+		; if they aren't already in the atomspace. 'get-pair returns
 		; nil if the atoms can't be found.
 		(define wpr
 			(if (and (not (null? left-atom)) (not (null? right-atom)))
-				(cog-link (LLOBJ 'pair-type) left-atom right-atom)
+				(LLOBJ 'get-pair left-atom right-atom)
 				'()))
 		(if (null? wpr) bad-mi (LLOBJ METHOD wpr))
 	)

--- a/tests/matrix/BasicAPIUTest.cxxtest
+++ b/tests/matrix/BasicAPIUTest.cxxtest
@@ -134,10 +134,12 @@ void BasicAPIUTest::test_basic(void)
 	tru = eval->eval("(equal? \"unit-test-demo\" (bapi 'id))");
 	CHKERR; TSM_ASSERT_EQUALS("Expecting #t", tru, "#t\n");
 
-	tru = eval->eval("(equal? chicken-legs (bapi 'item-pair (Word \"chicken\") (Word \"legs\")))");
+	tru = eval->eval(
+		"(equal? chicken-legs (bapi 'get-pair (Word \"chicken\") (Word \"legs\")))");
 	CHKERR; TSM_ASSERT_EQUALS("Expecting #t", tru, "#t\n");
 
-	tru = eval->eval("(equal? 3.0 (bapi 'pair-count (Word \"chicken\") (Word \"legs\")))");
+	tru = eval->eval(
+		"(equal? 3.0 (bapi 'pair-count (Word \"chicken\") (Word \"legs\")))");
 	printf ("Got >>>%s", tru.c_str());
 	CHKERR; TSM_ASSERT_EQUALS("Expecting #t", tru, "#t\n");
 

--- a/tests/matrix/BasicAPIUTest.cxxtest
+++ b/tests/matrix/BasicAPIUTest.cxxtest
@@ -134,10 +134,10 @@ void BasicAPIUTest::test_basic(void)
 	tru = eval->eval("(equal? \"unit-test-demo\" (bapi 'id))");
 	CHKERR; TSM_ASSERT_EQUALS("Expecting #t", tru, "#t\n");
 
-	tru = eval->eval("(equal? chicken-legs (bapi 'item-pair chicken-legs-pair))");
+	tru = eval->eval("(equal? chicken-legs (bapi 'item-pair (Word \"chicken\") (Word \"legs\")))");
 	CHKERR; TSM_ASSERT_EQUALS("Expecting #t", tru, "#t\n");
 
-	tru = eval->eval("(equal? 3.0 (bapi 'pair-count chicken-legs-pair))");
+	tru = eval->eval("(equal? 3.0 (bapi 'pair-count (Word \"chicken\") (Word \"legs\")))");
 	printf ("Got >>>%s", tru.c_str());
 	CHKERR; TSM_ASSERT_EQUALS("Expecting #t", tru, "#t\n");
 

--- a/tests/matrix/basic-api.scm
+++ b/tests/matrix/basic-api.scm
@@ -39,13 +39,15 @@
 		(if (null? maybe-list) '()
 			(cog-link 'EvaluationLink (Predicate "foo") maybe-list)))
 
+	; Return the observed count for the pair PAIR.
+	(define (get-count PAIR)
+		(cog-value-ref (cog-value PAIR (Predicate "counter")) 2))
+
 	; Return the observed count for the pair (L-ATOM, R-ATOM), if it
 	; exists, else return zero.
 	(define (get-pair-count L-ATOM R-ATOM)
 		(define stats-atom (get-pair L-ATOM R-ATOM))
-		(if (null? stats-atom) 0
-			(cog-value-ref
-				 (cog-value stats-atom (Predicate "counter")) 2)))
+		(if (null? stats-atom) 0 (get-count stats-atom)))
 
 	; Return the atom holding the count, creating it if it does
 	; not yet exist.  Returns the same structure as the 'item-pair
@@ -98,7 +100,8 @@
 				((right-type) get-right-type)
 				((pair-type) get-pair-type)
 				((pair-count) get-pair-count)
-				((item-pair) get-pair)
+				((get-pair) get-pair)
+				((get-count) get-count)
 				((make-pair) make-pair)
 				((left-wildcard) get-left-wildcard)
 				((right-wildcard) get-right-wildcard)

--- a/tests/matrix/basic-api.scm
+++ b/tests/matrix/basic-api.scm
@@ -30,7 +30,7 @@
 	; EvaluationLink holding the ListLink. This atom is where all
 	; values associated with this matrix are held.  This includes not
 	; only the count (the number of observations of the pair) but also
-	; any dervides values, such as frequency, mutual information, and
+	; any derived values, such as frequency, mutual information, and
 	; so on. Users are free to (are encouraged to) use this atom to
 	; attach additional information and statistics.
 	;

--- a/tests/matrix/basic-api.scm
+++ b/tests/matrix/basic-api.scm
@@ -55,6 +55,14 @@
 	(define (make-pair L-ATOM R-ATOM)
 		(EvaluationLink (Predicate "foo") (List L-ATOM R-ATOM)))
 
+	; Return the left member of the pair. Given the pair-atom,
+	; extract the left-side atom.
+	(define (get-left-element PAIR)
+		(gadr PAIR))
+
+	(define (get-right-element PAIR)
+		(gddr PAIR))
+
 	; Return an atom to which column subtotals can be attached,
 	; such as, for example, the subtotal `N(*,y)`. Thus, `y`
 	; denotes a column, and the star is on the left (the star
@@ -103,6 +111,8 @@
 				((get-pair) get-pair)
 				((get-count) get-count)
 				((make-pair) make-pair)
+				((left-element) get-left-element)
+				((right-element) get-right-element)
 				((left-wildcard) get-left-wildcard)
 				((right-wildcard) get-right-wildcard)
 				((wild-wild) get-wild-wild)

--- a/tests/matrix/basic-api.scm
+++ b/tests/matrix/basic-api.scm
@@ -56,7 +56,7 @@
 		(EvaluationLink (Predicate "foo") (List L-ATOM R-ATOM)))
 
 	; Return the left member of the pair. Given the pair-atom,
-	; extract the left-side atom.
+	; locate the left-side atom.
 	(define (get-left-element PAIR)
 		(gadr PAIR))
 

--- a/tests/matrix/basic-api.scm
+++ b/tests/matrix/basic-api.scm
@@ -20,9 +20,10 @@
 	; the right side of the (row, column) pairs.
 	(define (get-right-type) 'WordNode)
 
-	; Return the type of the pair itself.  In this example, each pair
-	; will be of the form (ListLink (Word "row") (Word "col"))
-	(define (get-pair-type) 'ListLink)
+	; Return the type of the link that holds the pair.  In this
+	; example, each pair will be held in the form
+	;  (Evaluation (Predicate "foo") (List (Word "row") (Word "col")))
+	(define (get-pair-type) 'EvaluationLink)
 
 	; Return the atom for a matrix (row,column) pair, if it exists,
 	; else return nil. In this example, the matrix is defined by an
@@ -33,17 +34,15 @@
 	; so on. Users are free to (are encouraged to) use this atom to
 	; attach additional information and statistics.
 	;
-	; The PAIR atom must be of 'pair-type, that is, a ListLink in this
-	; example.  Note: the cog-link function does NOT create the atom,
-	; if it does not already exist!
-	(define (get-pair PAIR)
-		(cog-link 'EvaluationLink (Predicate "foo") PAIR))
+	(define (get-pair L-ATOM R-ATOM)
+		(define maybe-list (cog-link 'ListLink L-ATOM R-ATOM))
+		(if (null? maybe-list) '()
+			(cog-link 'EvaluationLink (Predicate "foo") maybe-list)))
 
-	; Return the observed count for PAIR, if it exists, else
-	; return zero. The PAIR atom must be of type 'pair-type;
-	; that is, a ListLink in this example.
-	(define (get-pair-count PAIR)
-		(define stats-atom (get-pair PAIR))
+	; Return the observed count for the pair (L-ATOM, R-ATOM), if it
+	; exists, else return zero.
+	(define (get-pair-count L-ATOM R-ATOM)
+		(define stats-atom (get-pair L-ATOM R-ATOM))
 		(if (null? stats-atom) 0
 			(cog-value-ref
 				 (cog-value stats-atom (Predicate "counter")) 2)))
@@ -51,8 +50,8 @@
 	; Return the atom holding the count, creating it if it does
 	; not yet exist.  Returns the same structure as the 'item-pair
 	; method (the get-pair function, above).
-	(define (make-pair PAIR)
-		(EvaluationLink (Predicate "foo") PAIR))
+	(define (make-pair L-ATOM R-ATOM)
+		(EvaluationLink (Predicate "foo") (List L-ATOM R-ATOM)))
 
 	; Return an atom to which column subtotals can be attached,
 	; such as, for example, the subtotal `N(*,y)`. Thus, `y`

--- a/tests/matrix/basic-data.scm
+++ b/tests/matrix/basic-data.scm
@@ -2,22 +2,20 @@
 ; Data set which the basic API will yoke together.
 
 ; Create the high-level par, given the low-level one.
-(define (mkfoo PR) (Evaluation (Predicate "foo") PR))
-(define (mkfoob WA WB) (Evaluation (Predicate "foo") (List (Word WA) (Word WB))))
+(define (mkfoo WA WB) (Evaluation (Predicate "foo") (List (Word WA) (Word WB))))
 ; Set the count on the high-level pair
 (define (setcnt LK VAL) (cog-set-value! LK (Predicate "counter") (FloatValue 1 2 VAL)))
 
-(define chicken-legs-pair (List (Word "chicken") (Word "legs")))
-(define chicken-legs (mkfoo chicken-legs-pair))
+(define chicken-legs (mkfoo "chicken" "legs"))
 (setcnt chicken-legs 3)
 
 ; More data
-(setcnt (mkfoob "chicken" "wings") 6)
-(setcnt (mkfoob "chicken" "eyes") 2)
-(setcnt (mkfoob "dog" "legs") 4)
-(setcnt (mkfoob "dog" "snouts") 1)
-(setcnt (mkfoob "dog" "eyes") 2)
-(setcnt (mkfoob "table" "legs") 4)
+(setcnt (mkfoo "chicken" "wings") 6)
+(setcnt (mkfoo "chicken" "eyes") 2)
+(setcnt (mkfoo "dog" "legs") 4)
+(setcnt (mkfoo "dog" "snouts") 1)
+(setcnt (mkfoo "dog" "eyes") 2)
+(setcnt (mkfoo "table" "legs") 4)
 
 ; left-basis-size = 3 = chicken, dog, table
 ; right-basis-size = 4 = legs, wings, eyes, snouts


### PR DESCRIPTION
The atom-pair API was not sufficiently general to allow certain types of pairs to be explore certain types of relationships.  Make the API more general.   This requires a corresponding pull for the opencog repo; it affects the language-learning code.