### PR TITLE
Provide a thread-safe star-getter

### DIFF
--- a/opencog/matrix/object-api.scm
+++ b/opencog/matrix/object-api.scm
@@ -198,6 +198,7 @@
 (use-modules (srfi srfi-1))
 (use-modules (ice-9 optargs)) ; for define*-public
 (use-modules (ice-9 atomic))  ; for atomic-box
+(use-modules (ice-9 threads)) ; for mutex locks
 (use-modules (opencog) (opencog exec))
 
 ; ---------------------------------------------------------------------
@@ -254,9 +255,11 @@
 			(r-hit (make-atomic-box '()))
 			(r-miss (make-atomic-box '()))
 
+#! ============ Alternate variant, not currently used.
 			; Temporary atomspaces
 			(l-asp (make-fluid))
 			(r-asp (make-fluid))
+=============== !#
 
 			; Temporary atomspaces, non-fluid style.
 			(l-mtx (make-mutex))
@@ -348,6 +351,8 @@
 				(unlock-mutex r-mtx)
 				stars))
 
+#! ============ Alternate variant, not currently used.
+Yes, this actually works -- its just not being used.
 		; Use a temporary atomspace for performing the query.
 		; This is thread-safe, but quite slow when threads are
 		; being constantly created/destroyed, as it results in
@@ -391,7 +396,7 @@
 				(cog-atomspace-clear tmp-asp)
 				(cog-set-atomspace! oldas)
 				stars))
-
+============= !#
 
 		; Cache the most recent two values.  This should offer a
 		; significant performance enhancement for computing cosines

--- a/opencog/matrix/object-api.scm
+++ b/opencog/matrix/object-api.scm
@@ -357,9 +357,9 @@
 						; Else compute a value and cache it.
 						(if (and (not (null? miss)) (equal? ITEM (car miss)))
 							(begin
-								(atomic-box-set! A-HIT (list ITEM miss))
+								(atomic-box-set! A-HIT miss)
 								(atomic-box-set! A-MISS '())
-								miss)
+								(cadr miss))
 							(let ((stars (GETTER ITEM)))
 								(atomic-box-set! A-MISS (list ITEM stars))
 								stars))))))

--- a/opencog/query/README.md
+++ b/opencog/query/README.md
@@ -801,6 +801,14 @@ TODO
    then there is no point in instantiating `term` a second time - just
    repeat what is there.
 
+ * API enhancement: A not-uncommon search is to create a temporary
+   BindLink, perform the search, get the results, and then trash the
+   BindLink and the SetLink that the results came in. This is ...
+   annoyingly inefficient. Also not inherently thread-safe.  It can
+   be worked around by placing the BindLink, and the search results
+   in a temporary atomspace, but this is ... kind-of-ish icky?
+   Can we do something nicer, here?
+
  * Atomspaces are done wrong. Grounding whould always be performed
    in the same atomspace that the bindlink is in.  Thus should be fetched
    directly from the bind-link, and not passed as a third-party parameter.


### PR DESCRIPTION
The getter routine for for wild-cards was not thread-safe.  Make it thread-safe.
Also provide caching -- the most recent two values cached, which should be
enough for most common usages.