### PR TITLE
#1726 Check hash collision between atoms at run-time

### DIFF
--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -48,6 +48,7 @@
 
 //#define DPRINTF printf
 #define DPRINTF(...)
+#define DEBUG 1
 
 using namespace opencog;
 
@@ -460,6 +461,17 @@ Handle AtomTable::add(AtomPtr atom, bool async)
 
     Handle h(atom->get_handle());
     _atom_store.insert({atom->get_hash(), h});
+
+#ifdef DEBUG
+    auto its = _atom_store.equal_range(atom->get_hash());
+    for (auto it = its.first; it != its.second; ++it) {
+        AtomPtr a = it->second;
+        if (atom != a) {
+            LAZY_LOG_FINE << "hash collision between different atoms: " << std::endl
+                          << atom->to_string() << a->to_string();
+        }
+    }
+#endif
 
     if (not _transient and not async)
         put_atom_into_index(atom);


### PR DESCRIPTION
It is a proposal to print different atoms from the  _atom_store with the same hash.

What is not clear for me is it good to print it to the logger with the fine level or may be it is better to do in different way?

I also saw the code '#define DEBUG 1' in the PatternMatch.cc. Was it done by purpose and should I use it in the hash collisions logging? 