### PR TITLE
Bugfix -- reset the atomspace after a ctrl-C

### DIFF
--- a/opencog/matrix/object-api.scm
+++ b/opencog/matrix/object-api.scm
@@ -322,32 +322,30 @@
 		; ITEM should be an atom of (LLOBJ 'right-type); if it isn't,
 		; the the behavior is undefined.
 		;
+		(define (do-get-stars VAR TYPE TERM ASPACE)
+			(let* ((old-as (cog-set-atomspace! ASPACE))
+					(setlnk (cog-execute! (Bind (TypedVariable
+						VAR (Type (symbol->string TYPE)))
+						TERM TERM)))
+					(stars (cog-outgoing-set setlnk)))
+				(cog-atomspace-clear ASPACE)
+				(cog-set-atomspace! old-as)
+				stars))
+
 		(define (do-get-left-stars ITEM)
 			(let* ((lock (lock-mutex l-mtx))
-					(old-as (cog-set-atomspace! l-ase))
 					(uniqvar (VariableNode "$obj-api-left-star"))
 					(term (LLOBJ 'make-pair uniqvar ITEM))
-					(setlnk (cog-execute! (Bind (TypedVariable
-						uniqvar (Type (symbol->string left-type)))
-						term term)))
-					(stars (cog-outgoing-set setlnk)))
-				(cog-atomspace-clear l-ase)
-				(cog-set-atomspace! old-as)
+					(stars (do-get-stars uniqvar left-type term l-ase)))
 				(unlock-mutex l-mtx)
 				stars))
 
 		; Same as above, but on the right.
 		(define (do-get-right-stars ITEM)
 			(let* ((lock (lock-mutex r-mtx))
-					(old-as (cog-set-atomspace! r-ase))
 					(uniqvar (VariableNode "$obj-api-right-star"))
 					(term (LLOBJ 'make-pair ITEM uniqvar))
-					(setlnk (cog-execute! (Bind (TypedVariable
-						uniqvar (Type (symbol->string right-type)))
-						term term)))
-					(stars (cog-outgoing-set setlnk)))
-				(cog-atomspace-clear r-ase)
-				(cog-set-atomspace! old-as)
+					(stars (do-get-stars uniqvar right-type term r-ase)))
 				(unlock-mutex r-mtx)
 				stars))
 

--- a/opencog/matrix/object-api.scm
+++ b/opencog/matrix/object-api.scm
@@ -342,22 +342,22 @@
 					(cog-set-atomspace! old-as)
 				'())))
 
-		(define (do-get-left-stars ITEM)
-			(let* ((lock (lock-mutex l-mtx))
-					(uniqvar (VariableNode "$obj-api-left-star"))
-					(term (LLOBJ 'make-pair uniqvar ITEM))
-					(stars (raii-get-stars uniqvar left-type term l-ase)))
-				(unlock-mutex l-mtx)
+		(define (lock-get-stars LOCK VAR TYPE TERM ASPACE)
+			(let* ((lock (lock-mutex LOCK))
+					(stars (raii-get-stars VAR TYPE TERM ASPACE)))
+				(unlock-mutex LOCK)
 				stars))
+
+		(define (do-get-left-stars ITEM)
+			(let* ((uniqvar (VariableNode "$obj-api-left-star"))
+					(term (LLOBJ 'make-pair uniqvar ITEM)))
+				(lock-get-stars l-mtx uniqvar left-type term l-ase)))
 
 		; Same as above, but on the right.
 		(define (do-get-right-stars ITEM)
-			(let* ((lock (lock-mutex r-mtx))
-					(uniqvar (VariableNode "$obj-api-right-star"))
-					(term (LLOBJ 'make-pair ITEM uniqvar))
-					(stars (raii-get-stars uniqvar right-type term r-ase)))
-				(unlock-mutex r-mtx)
-				stars))
+			(let* ((uniqvar (VariableNode "$obj-api-right-star"))
+					(term (LLOBJ 'make-pair ITEM uniqvar)))
+				(lock-get-stars r-mtx uniqvar right-type term r-ase)))
 
 #! ============ Alternate variant, not currently used.
 Yes, this actually works -- its just not being used.


### PR DESCRIPTION
Use RAII style to reset the atomspace back to normal (instead of the temp atomspace)
if the user hits ctrl-C during processing.