### PR TITLE
Fix broken search-path for the core atom types.

### DIFF
--- a/opencog/atoms/proto/CMakeLists.txt
+++ b/opencog/atoms/proto/CMakeLists.txt
@@ -48,5 +48,5 @@ INSTALL (FILES
 # Install the auto-generated atom types as well
 INSTALL (FILES
 	${CMAKE_CURRENT_BINARY_DIR}/core_types.scm
-	DESTINATION "${DATADIR}/scm/opencog/proto"
+	DESTINATION "${DATADIR}/scm/opencog/base"
 )

--- a/opencog/scm/opencog.scm
+++ b/opencog/scm/opencog.scm
@@ -93,8 +93,7 @@
 		(cog-set-atomspace! cog-initial-as)))
 
 ; Load core atom types.
-; The remaining atom types from the cogserver are in (opencog atom-types)
-(load-from-path "opencog/atoms/proto/core_types.scm")
+(load-from-path "opencog/base/core_types.scm")
 
 ; Load other grunge too.
 ; Some of these things could possibly be modules ...?


### PR DESCRIPTION
The core-types were placed in the wrong directory.
Then they are looked for in a third directory which does not exist.
This should fix issue #1742