### PR TITLE
Define logger in StreamUTest and ValueOfUTest

### DIFF
--- a/tests/atoms/StreamUTest.cxxtest
+++ b/tests/atoms/StreamUTest.cxxtest
@@ -27,6 +27,7 @@
 #include <opencog/guile/SchemeEval.h>
 #include <opencog/atoms/proto/RandomStream.h>
 #include <opencog/atomspace/AtomSpace.h>
+#include <opencog/util/Logger.h>
 
 #include <cxxtest/TestSuite.h>
 
@@ -44,6 +45,8 @@ private:
 	Handle atom;
 
 public:
+	StreamUTest(void);
+
 	void setUp(void);
 
 	void check(void);
@@ -61,6 +64,12 @@ public:
 
 	void test_guile();
 };
+
+StreamUTest::StreamUTest(void)
+{
+	logger().set_level(Logger::INFO);
+	logger().set_print_to_stdout_flag(true);
+}
 
 // This unit test is a stand-in test for the concept of a streaming API
 // on Values. For lack of anything better to test, the RandomStream is

--- a/tests/atoms/ValueOfUTest.cxxtest
+++ b/tests/atoms/ValueOfUTest.cxxtest
@@ -26,6 +26,7 @@
 #include <opencog/atoms/execution/Instantiator.h>
 #include <opencog/atoms/proto/FloatValue.h>
 #include <opencog/atomspace/AtomSpace.h>
+#include <opencog/util/Logger.h>
 
 #include <cxxtest/TestSuite.h>
 
@@ -43,6 +44,8 @@ private:
 	Handle atom;
 	
 public:
+	ValueOfUTest(void);
+
 	void setUp(void);
 	void check(void);
 
@@ -56,6 +59,12 @@ public:
 	void test_divide();
 	void test_number();
 };
+
+ValueOfUTest::ValueOfUTest(void)
+{
+	logger().set_level(Logger::INFO);
+	logger().set_print_to_stdout_flag(true);
+}
 
 void ValueOfUTest::setUp(void)
 {


### PR DESCRIPTION
Convenient for debugging (in that instance about hash collision but
not only).