### PR TITLE
Uplift guile min version requirement to 2.2.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,8 +238,8 @@ FIND_LIBRARY(GMP_LIBRARY gmp)
 FIND_PATH(GMP_INCLUDE_DIR gmp.h)
 
 # Gnu Guile scheme interpreter
-# Version 2.0.9 is needed for mrs io ports, compilation, etc.
-FIND_PACKAGE(Guile 2.0.9)
+# Version 2.2.0 is needed for mrs io ports, compilation, atomics, etc.
+FIND_PACKAGE(Guile 2.2.0)
 IF (GUILE_FOUND AND GMP_LIBRARY AND GMP_INCLUDE_DIR)
 	ADD_DEFINITIONS(-DHAVE_GUILE)
 	SET(HAVE_GUILE 1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,8 +238,8 @@ FIND_LIBRARY(GMP_LIBRARY gmp)
 FIND_PATH(GMP_INCLUDE_DIR gmp.h)
 
 # Gnu Guile scheme interpreter
-# Version 2.2.0 is needed for mrs io ports, compilation, atomics, etc.
-FIND_PACKAGE(Guile 2.2.0)
+# Version 2.2.2 is needed for mrs io ports, compilation, atomics, nlp
+FIND_PACKAGE(Guile 2.2.2)
 IF (GUILE_FOUND AND GMP_LIBRARY AND GMP_INCLUDE_DIR)
 	ADD_DEFINITIONS(-DHAVE_GUILE)
 	SET(HAVE_GUILE 1)


### PR DESCRIPTION
Because opencog/matrix/object-api.scm requires ice-9 atomic that has
only been introduced in guile 2.2.0.

To address #1751 