### PR TITLE
Bug-fix nested Glob searches

### DIFF
--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1219,11 +1219,16 @@ bool PatternMatchEngine::explore_up_branches(const PatternTermPtr& ptm,
 		// their state will be recorded in _glob_state, so that one can,
 		// if needed, resume and try to ground those globs again in a
 		// different way (e.g. backtracking from another branchpoint).
-		// If there is no more possible ways to ground them, they
+		// If there are no more possible ways to ground them, they
 		// will be removed from glob_state. So simply by comparing the
 		// _glob_state size before and after seems to be an OK way to
 		// quickly check if we can move on to the next one or not.
-		if (has_glob) gstate_size = _glob_state.size();
+		std::map<GlobPair, GlobState> saved_glob_state;
+		if (has_glob)
+		{
+			saved_glob_state = _glob_state;
+			gstate_size = _glob_state.size();
+		}
 
 		found = explore_link_branches(ptm, Handle(iset[i]), clause_root);
 
@@ -1233,6 +1238,10 @@ bool PatternMatchEngine::explore_up_branches(const PatternTermPtr& ptm,
 		{
 			found = explore_link_branches(ptm, Handle(iset[i]), clause_root);
 		}
+
+		// Restore the saved state, for the next go-around.
+		if (has_glob)
+			_glob_state = saved_glob_state;
 
 		if (found) break;
 	}

--- a/tests/query/GlobUTest.cxxtest
+++ b/tests/query/GlobUTest.cxxtest
@@ -73,6 +73,7 @@ _exit(rc); // XXX hack to avoid double-free in __run_exit_handlers
 	void test_glob_backtoo(void);
 	void test_glob_backmore(void);
 	void test_glob_multiple(void);
+	void test_nest(void);
 };
 
 void GlobUTest::tearDown(void)
@@ -513,6 +514,28 @@ void GlobUTest::test_glob_multiple(void)
 		"    (ConceptNode \"FOO\")))"
 	);
 	TS_ASSERT_EQUALS(ma, response);
+
+	// ----
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+/*
+ * Test nested expressions.
+ */
+void GlobUTest::test_nest(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	eval->eval("(load-from-path \"tests/query/glob-nest.scm\")");
+
+	Handle five = eval->eval_h("(cog-execute! get-five)");
+	printf("nested %s\n", five->to_string().c_str());
+	TS_ASSERT_EQUALS(5, five->get_arity());
+
+	Handle response = eval->eval_h(
+		"(SetLink one two three four five)"
+	);
+	TS_ASSERT_EQUALS(five, response);
 
 	// ----
 	logger().debug("END TEST: %s", __FUNCTION__);

--- a/tests/query/glob-nest.scm
+++ b/tests/query/glob-nest.scm
@@ -1,0 +1,77 @@
+;
+; glob-nest.scm
+;
+; Test nested glob expressions.
+;
+
+; The use of the MemberLink here messes it up.
+; Current code incorrectly finds only one instance.
+(define (body WORD)
+	(List
+		(Variable "$point")
+		(OrderedLink
+			(Glob "$begin")
+			(Member WORD (Variable "$set"))
+			(Glob "$end"))))
+
+(define (locate WORD)
+	(Bind (VariableList
+		(TypedVariable (Variable "$point") (Type 'ConceptNode))
+		(TypedVariable (Variable "$set") (Type 'ConceptNode))
+		(TypedVariable (Glob "$begin") (Interval (Number 0) (Number -1)))
+		(TypedVariable (Glob "$end") (Interval (Number 0) (Number -1))))
+		(body WORD)(body WORD)))
+
+(define get-five (locate (Concept "special")))
+
+(define one
+(List
+	(Concept "first")
+	(OrderedLink
+		(Member (Concept "special") (Concept "stuff"))
+		(Concept "A")
+		(Concept "B")
+		(Concept "C")
+		(Concept "D"))))
+
+(define two
+(List
+	(Concept "second")
+	(OrderedLink
+		(Concept "A")
+		(Member (Concept "special") (Concept "things"))
+		(Concept "B")
+		(Concept "C")
+		(Concept "D"))))
+
+(define three
+(List
+	(Concept "third")
+	(OrderedLink
+		(Concept "A")
+		(Concept "B")
+		(Member (Concept "special") (Concept "stuff"))
+		(Concept "C")
+		(Concept "D"))))
+
+(define four
+(List
+	(Concept "fourth")
+	(OrderedLink
+		(Concept "A")
+		(Concept "B")
+		(Concept "C")
+		(Member (Concept "special") (Concept "stuff"))
+		(Concept "D"))))
+
+(define five
+(List
+	(Concept "fifth")
+	(OrderedLink
+		(Concept "A")
+		(Concept "B")
+		(Concept "C")
+		(Concept "D")
+		(Member (Concept "special") (Concept "stuff")))))
+
+*unspecified*


### PR DESCRIPTION
Add a failing unit test, and a fix for it.  The glob-matching state was not being
pushed/popped so not all possibilities were being explored.