### PR TITLE
Zermelo and Von Neumann set-theory number constructions

### DIFF
--- a/examples/atomspace/set-numbers.scm
+++ b/examples/atomspace/set-numbers.scm
@@ -1,0 +1,66 @@
+;; Construct Zermelo and Von Neumann numbers
+
+(define (zermelo n)
+"
+  Construct the first n+1 Zermelo numbers
+
+  (zermelo 0) -> (Set)
+  (zermelo n) -> (Set (zermelo n-1))
+"
+  (if (= n 0)
+      (Set)
+      (Set (zermelo (+ n -1)))))
+
+(define (von-neumann n)
+"
+  Construct the first n+1 Von Neumann numbers
+
+  (von-neumann 0) -> (Set)
+  (von-neumann n) -> (Set (von-neumann n-1)) union (von-neumann n-1)
+"
+  (if (= n 0)
+      (Set)
+      (let* ((dec-n (+ n -1))
+             (dec-vn (von-neumann dec-n))
+             (dec-vn-mbrs (cog-outgoing-set dec-vn)))
+        (Set dec-vn dec-vn-mbrs))))
+
+;; Examples
+
+;; The following
+;;
+;; (zermelo 3)
+;;
+;; is expected to return
+;;
+;; (SetLink
+;;    (SetLink
+;;       (SetLink
+;;          (SetLink
+;;          )
+;;       )
+;;    )
+;; )
+
+;; The following
+;;
+;; (von-neumann 3)
+;;
+;; is expected to return
+;;
+;; (SetLink
+;;    (SetLink
+;;    )
+;;    (SetLink
+;;       (SetLink
+;;       )
+;;    )
+;;    (SetLink
+;;       (SetLink
+;;       )
+;;       (SetLink
+;;          (SetLink
+;;          )
+;;       )
+;;    )
+;; )


### PR DESCRIPTION
I actually added these for some quick memory benchmark as they kinda represent 2 extreme constructions.

Zermelo's numbers are just a linear chain where each link has an arity of 1 (or initially zero), while Von Neumann numbers have ever increasing link arities.

The results are rather interesting
```
(von-neumann 10000) ;; 10K
```
takes 4GB of RAM. While
```
(zermelo 10000000) ;; 10M
```
takes 5.5GB of RAM.

I think they could be added to the benchmark repo, (which I'm probably gonna do soon), but I added them here because I think they can be of interest beyond benchmarking.
