### PR TITLE
speedup hashing function by doing less mixing

### DIFF
--- a/opencog/atoms/base/hash.h
+++ b/opencog/atoms/base/hash.h
@@ -1,0 +1,55 @@
+#ifndef _OPENCOG_HASH_H
+#define _OPENCOG_HASH_H
+
+#include <opencog/atoms/base/Handle.h>
+
+namespace opencog {
+
+/* ================================================================= */
+
+// Fowler–Noll–Vo hash function
+// Parameters are taken from author's page
+// http://www.isthe.com/chongo/tech/comp/fnv/index.html#FNV-1a
+const size_t FNV_32_PRIME = 0x01000193;
+const size_t FNV_32_OFFSET = 0x811c9dc5;
+const size_t FNV_64_PRIME = 0x100000001b3;
+const size_t FNV_64_OFFSET = 0xcbf29ce484222325;
+
+template <unsigned n>
+constexpr size_t get_fvna_prime(){
+	return FNV_32_PRIME;
+}
+
+template <>
+constexpr size_t get_fvna_prime<8>(){
+	return FNV_64_PRIME;
+}
+
+template <unsigned n>
+constexpr size_t get_fvna_offset(){
+	return FNV_32_OFFSET;
+}
+
+template <>
+constexpr size_t get_fvna_offset<8>(){
+	return FNV_64_OFFSET;
+}
+
+template<typename T>
+ContentHash fnv1a_hash (ContentHash & hval, T buf_t)
+{
+	size_t size = sizeof(buf_t);
+	const char * buf = (const char *)&buf_t;
+	size_t count = 0;
+	while (count < size)
+	{
+		hval ^= (ContentHash) (*(buf+count));
+		hval *= (ContentHash) get_fvna_prime<sizeof(ContentHash)>();
+		count ++;
+	}
+	return hval;
+}
+
+} // namespace opencog
+
+#endif // _OPENCOG_HASH_H

--- a/opencog/atoms/core/ScopeLink.cc
+++ b/opencog/atoms/core/ScopeLink.cc
@@ -27,6 +27,7 @@
 #include <opencog/util/random.h>
 #include <opencog/util/Logger.h>
 #include <opencog/atoms/base/ClassServer.h>
+#include <opencog/atoms/base/hash.h>
 #include <opencog/atoms/core/LambdaLink.h>
 #include <opencog/atoms/core/TypeNode.h>
 #include <opencog/atomutils/TypeUtils.h>
@@ -231,50 +232,6 @@ bool ScopeLink::is_equal(const Handle& other, bool silent) const
 // is needed to deal with unordered links and alpha-conversion.
 // Addition is "abelian": A+B = B+A while most functions that mix are
 // non-abalian -- the result depends on the order of the operations.
-
-
-// Fowler–Noll–Vo hash function
-// Parameters are taken from author's page
-// http://www.isthe.com/chongo/tech/comp/fnv/index.html#FNV-1a
-const size_t FNV_32_PRIME = 0x01000193;
-const size_t FNV_32_OFFSET = 0x811c9dc5;
-const size_t FNV_64_PRIME = 0x100000001b3;
-const size_t FNV_64_OFFSET = 0xcbf29ce484222325;
-
-template <unsigned n>
-constexpr size_t get_fvna_prime(){
-	return FNV_32_PRIME;
-}
-
-template <>
-constexpr size_t get_fvna_prime<8>(){
-	return FNV_64_PRIME;
-}
-
-template <unsigned n>
-constexpr size_t get_fvna_offset(){
-	return FNV_32_OFFSET;
-}
-
-template <>
-constexpr size_t get_fvna_offset<8>(){
-	return FNV_64_OFFSET;
-}
-
-template<typename T>
-ContentHash fnv1a_hash (ContentHash & hval, T buf_t)
-{
-	size_t size = sizeof(buf_t);
-	const char * buf = (const char *)&buf_t;
-	size_t count = 0;
-	while (count < size)
-	{
-		hval ^= (ContentHash) (*(buf+count));
-		hval *= (ContentHash) get_fvna_prime<sizeof(ContentHash)>();
-		count ++;
-	}
-	return hval;
-}
 
 ContentHash ScopeLink::compute_hash() const
 {


### PR DESCRIPTION
I tested with ./benchmark  --benchmark_repetitions=100 --benchmark_report_aggregates_only=true

old code

BM_CreateScopeLinkWithVariableList_mean            1558 ns       1558 ns     452391
BM_CreateScopeLinkWithVariableList_median          1551 ns       1551 ns     452391
BM_CreateScopeLinkWithVariableList_stddev            29 ns         29 ns     452391
BM_CreateScopeLinkWithoutVariableList_mean         1169 ns       1169 ns     603959
BM_CreateScopeLinkWithoutVariableList_median       1163 ns       1163 ns     603959
BM_CreateScopeLinkWithoutVariableList_stddev         24 ns         24 ns     603959
BM_CreateScopeLinkWithLambdaLink_mean              1065 ns       1065 ns     638571
BM_CreateScopeLinkWithLambdaLink_median            1059 ns       1059 ns     638571
BM_CreateScopeLinkWithLambdaLink_stddev              23 ns         23 ns     638571


new

BM_CreateScopeLinkWithVariableList_mean            1548 ns       1547 ns     452378
BM_CreateScopeLinkWithVariableList_median          1531 ns       1531 ns     452378
BM_CreateScopeLinkWithVariableList_stddev            36 ns         36 ns     452378
BM_CreateScopeLinkWithoutVariableList_mean         1158 ns       1158 ns     605659
BM_CreateScopeLinkWithoutVariableList_median       1152 ns       1152 ns     605659
BM_CreateScopeLinkWithoutVariableList_stddev         20 ns         20 ns     605659
BM_CreateScopeLinkWithLambdaLink_mean              1054 ns       1054 ns     615944
BM_CreateScopeLinkWithLambdaLink_median            1049 ns       1049 ns     615944
BM_CreateScopeLinkWithLambdaLink_stddev              21 ns         21 ns     615944