### PR TITLE
Replace create...Value macroses by functions

### DIFF
--- a/opencog/atoms/proto/FloatValue.h
+++ b/opencog/atoms/proto/FloatValue.h
@@ -69,7 +69,10 @@ typedef std::shared_ptr<const FloatValue> FloatValuePtr;
 static inline FloatValuePtr FloatValueCast(const ProtoAtomPtr& a)
 	{ return std::dynamic_pointer_cast<const FloatValue>(a); }
 
-#define createFloatValue std::make_shared<FloatValue>
+template<typename ... Type>
+static inline std::shared_ptr<FloatValue> createFloatValue(Type&&... args) {
+	return std::make_shared<FloatValue>(std::forward<Type>(args)...);
+}
 
 // Scalar multiplication and addition
 ProtoAtomPtr times(double, const FloatValuePtr&);

--- a/opencog/atoms/proto/LinkValue.h
+++ b/opencog/atoms/proto/LinkValue.h
@@ -63,7 +63,10 @@ typedef std::shared_ptr<LinkValue> LinkValuePtr;
 static inline LinkValuePtr LinkValueCast(const ProtoAtomPtr& a)
 	{ return std::dynamic_pointer_cast<LinkValue>(a); }
 
-#define createLinkValue std::make_shared<LinkValue>
+template<typename ... Type>
+static inline std::shared_ptr<LinkValue> createLinkValue(Type&&... args) {
+	return std::make_shared<LinkValue>(std::forward<Type>(args)...);
+}
 
 
 /** @}*/

--- a/opencog/atoms/proto/RandomStream.h
+++ b/opencog/atoms/proto/RandomStream.h
@@ -59,7 +59,10 @@ typedef std::shared_ptr<RandomStream> RandomStreamPtr;
 static inline RandomStreamPtr RandomStreamCast(ProtoAtomPtr& a)
 	{ return std::dynamic_pointer_cast<RandomStream>(a); }
 
-#define createRandomStream std::make_shared<RandomStream>
+template<typename ... Type>
+static inline std::shared_ptr<RandomStream> createRandomStream(Type&&... args) {
+	return std::make_shared<RandomStream>(std::forward<Type>(args)...);
+}
 
 
 /** @}*/

--- a/opencog/atoms/proto/StreamValue.h
+++ b/opencog/atoms/proto/StreamValue.h
@@ -54,7 +54,6 @@ typedef std::shared_ptr<StreamValue> StreamValuePtr;
 static inline StreamValuePtr StreamValueCast(ProtoAtomPtr& a)
 	{ return std::dynamic_pointer_cast<StreamValue>(a); }
 
-#define createStreamValue std::make_shared<StreamValue>
 
 
 /** @}*/

--- a/opencog/atoms/proto/StringValue.h
+++ b/opencog/atoms/proto/StringValue.h
@@ -65,7 +65,10 @@ typedef std::shared_ptr<const StringValue> StringValuePtr;
 static inline StringValuePtr StringValueCast(const ProtoAtomPtr& a)
 	{ return std::dynamic_pointer_cast<const StringValue>(a); }
 
-#define createStringValue std::make_shared<StringValue>
+template<typename ... Type>
+static inline std::shared_ptr<StringValue> createStringValue(Type&&... args) {
+	return std::make_shared<StringValue>(std::forward<Type>(args)...);
+}
 
 
 /** @}*/


### PR DESCRIPTION
Cython cannot import C macroses as functions so I replace create...Value
macroses by functions to import them in cython.
Delete createStreamValue as StreamValue doesn't have public
constructors.