### PR TITLE
Add unit test pathological hash collision

### DIFF
--- a/tests/atoms/CMakeLists.txt
+++ b/tests/atoms/CMakeLists.txt
@@ -18,6 +18,8 @@ IF(HAVE_GUILE)
 	TARGET_LINK_LIBRARIES(PutLinkUTest execution smob atomspace)
 	ADD_CXXTEST(QuotationUTest)
 	TARGET_LINK_LIBRARIES(QuotationUTest execution smob atomspace)
+	ADD_CXXTEST(HashUTest)
+	TARGET_LINK_LIBRARIES(HashUTest smob atomspace)
 ENDIF(HAVE_GUILE)
 
 ADD_CXXTEST(AlphaConvertUTest)

--- a/tests/atoms/HashUTest.cxxtest
+++ b/tests/atoms/HashUTest.cxxtest
@@ -1,0 +1,108 @@
+/*
+ * tests/atoms/HashUTest.cxxtest
+ *
+ * Copyright (C) 2018 OpenCog Foundation
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/guile/SchemeEval.h>
+#include <opencog/atoms/base/Atom.h>
+#include <opencog/atoms/base/Node.h>
+#include <opencog/atoms/base/Link.h>
+#include <opencog/atomspace/AtomSpace.h>
+#include <opencog/atoms/core/ScopeLink.h>
+
+#include <cxxtest/TestSuite.h>
+
+using namespace opencog;
+
+// Test Atom::compute_hash()
+//
+class HashUTest :  public CxxTest::TestSuite
+{
+private:
+	AtomSpace _as;
+	SchemeEval _eval;
+
+public:
+	HashUTest() : _eval(&_as)
+	{
+		logger().set_print_to_stdout_flag(true);
+
+		_eval.eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+	}
+
+	void setUp() {}
+
+	void tearDown() {}
+
+	void test_scope_compute_hash_1();
+	void test_scope_compute_hash_2();
+	void test_scope_compute_hash_3();
+};
+
+void HashUTest::test_scope_compute_hash_1()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	std::string result =
+		_eval.eval("(load-from-path \"tests/atoms/hash.scm\")");
+
+	Handle bl1 = _eval.eval_h("bl-1"),
+		bl2 = _eval.eval_h("bl-2");
+
+	TS_ASSERT_DIFFERS(bl1.value(), bl2.value());
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void HashUTest::test_scope_compute_hash_2()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	std::string result =
+		_eval.eval("(load-from-path \"tests/atoms/hash.scm\")");
+
+	Handle gl1 = _eval.eval_h("gl-1"),
+		gl2 = _eval.eval_h("gl-2");
+
+	TS_ASSERT_DIFFERS(gl1.value(), gl2.value());
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void HashUTest::test_scope_compute_hash_3(){
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	std::string result =
+		_eval.eval("(load-from-path \"tests/atoms/hash.scm\")");
+
+	Handle h1 = _eval.eval_h("ll-1");
+	Handle h2 = _eval.eval_h("ll-2");
+	TS_ASSERT_DIFFERS(h1.value(), h2.value());
+
+	h1 = _eval.eval_h("ll-3");
+	h2 = _eval.eval_h("ll-4");
+	TS_ASSERT_DIFFERS(h1.value(), h2.value());
+
+	h1 = _eval.eval_h("ll-5");
+	h2 = _eval.eval_h("ll-6");
+	TS_ASSERT_DIFFERS(h1.value(), h2.value());
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}

--- a/tests/atoms/HashUTest.cxxtest
+++ b/tests/atoms/HashUTest.cxxtest
@@ -44,6 +44,7 @@ private:
 public:
 	HashUTest() : _eval(&_as)
 	{
+		logger().set_timestamp_flag(false);
 		logger().set_print_to_stdout_flag(true);
 
 		_eval.eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
@@ -58,6 +59,10 @@ public:
 	void test_scope_compute_hash_2();
 	void test_scope_compute_hash_3();
 	void test_scope_compute_hash_4();
+
+	// Test hash collisions of non-scope links
+	void test_sequential_compute_hash();
+	void test_times_plus_compute_hash();
 };
 
 void HashUTest::test_scope_compute_hash_1()
@@ -122,6 +127,36 @@ void HashUTest::test_scope_compute_hash_4()
 		bl4 = _eval.eval_h("bl-4");
 
 	TS_ASSERT_DIFFERS(bl3.value(), bl4.value());
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void HashUTest::test_sequential_compute_hash()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	std::string result =
+		_eval.eval("(load-from-path \"tests/atoms/hash.scm\")");
+
+	Handle sal = _eval.eval_h("sal"),
+		sol = _eval.eval_h("sol");
+
+	TS_ASSERT_DIFFERS(sal.value(), sol.value());
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void HashUTest::test_times_plus_compute_hash()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	std::string result =
+		_eval.eval("(load-from-path \"tests/atoms/hash.scm\")");
+
+	Handle tl = _eval.eval_h("tl"),
+		pl = _eval.eval_h("pl");
+
+	TS_ASSERT_DIFFERS(tl.value(), pl.value());
 
 	logger().info("END TEST: %s", __FUNCTION__);
 }

--- a/tests/atoms/HashUTest.cxxtest
+++ b/tests/atoms/HashUTest.cxxtest
@@ -31,7 +31,9 @@
 
 using namespace opencog;
 
-// Test Atom::compute_hash()
+// Test Atom::compute_hash(), in particular whether 2 different atoms
+// have different hashes. Atom hash collisions are impossible to
+// completely eliminate, but we can avoid obviously pathological ones.
 //
 class HashUTest :  public CxxTest::TestSuite
 {
@@ -51,9 +53,11 @@ public:
 
 	void tearDown() {}
 
+	// Test hash collisions of scope links
 	void test_scope_compute_hash_1();
 	void test_scope_compute_hash_2();
 	void test_scope_compute_hash_3();
+	void test_scope_compute_hash_4();
 };
 
 void HashUTest::test_scope_compute_hash_1()
@@ -103,6 +107,21 @@ void HashUTest::test_scope_compute_hash_3(){
 	h1 = _eval.eval_h("ll-5");
 	h2 = _eval.eval_h("ll-6");
 	TS_ASSERT_DIFFERS(h1.value(), h2.value());
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void HashUTest::test_scope_compute_hash_4()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	std::string result =
+		_eval.eval("(load-from-path \"tests/atoms/hash.scm\")");
+
+	Handle bl3 = _eval.eval_h("bl-3"),
+		bl4 = _eval.eval_h("bl-4");
+
+	TS_ASSERT_DIFFERS(bl3.value(), bl4.value());
 
 	logger().info("END TEST: %s", __FUNCTION__);
 }

--- a/tests/atoms/ScopeLinkUTest.cxxtest
+++ b/tests/atoms/ScopeLinkUTest.cxxtest
@@ -57,7 +57,6 @@ public:
 		CT = an(TYPE_NODE, "ConceptNode");
 
 		_eval.eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
-
 	}
 
 	void setUp() {}
@@ -73,9 +72,6 @@ public:
 	void test_get_variables_1();
 	void test_get_variables_2();
 	void test_get_variables_3();
-	void test_compute_hash_1();
-	void test_compute_hash_2();
-	void test_compute_hash_3();
 };
 
 void ScopeLinkUTest::test_content_less()
@@ -296,57 +292,6 @@ void ScopeLinkUTest::test_get_variables_3()
 	TS_ASSERT_EQUALS(got, exp);
 
 	logger().info("END TEST: %s", __FUNCTION__);
-}
-
-void ScopeLinkUTest::test_compute_hash_1()
-{
-	logger().info("BEGIN TEST: %s", __FUNCTION__);
-
-	std::string result =
-		_eval.eval("(load-from-path \"tests/atoms/scopelinks.scm\")");
-
-	Handle bl1 = _eval.eval_h("bl-1"),
-		bl2 = _eval.eval_h("bl-2");
-
-	TS_ASSERT_DIFFERS(bl1.value(), bl2.value());
-
-	logger().info("END TEST: %s", __FUNCTION__);
-}
-
-void ScopeLinkUTest::test_compute_hash_2()
-{
-	logger().info("BEGIN TEST: %s", __FUNCTION__);
-
-	std::string result =
-		_eval.eval("(load-from-path \"tests/atoms/scopelinks.scm\")");
-
-	Handle gl1 = _eval.eval_h("gl-1"),
-		gl2 = _eval.eval_h("gl-2");
-
-	TS_ASSERT_DIFFERS(gl1.value(), gl2.value());
-
-	logger().info("END TEST: %s", __FUNCTION__);
-}
-
-void ScopeLinkUTest::test_compute_hash_3(){
-    logger().info("BEGIN TEST: %s", __FUNCTION__);
-
-    std::string result =
-        _eval.eval("(load-from-path \"tests/atoms/scopelinks.scm\")");
-
-    Handle hash1 = _eval.eval_h("hash-test1");
-    Handle hash2 = _eval.eval_h("hash-test2");
-    TS_ASSERT_DIFFERS(hash1.value(), hash2.value());
-
-    hash1 = _eval.eval_h("hash-test3");
-    hash2 = _eval.eval_h("hash-test4");
-    TS_ASSERT_DIFFERS(hash1.value(), hash2.value());
-
-    hash1 = _eval.eval_h("hash-test5");
-    hash2 = _eval.eval_h("hash-test6");
-    TS_ASSERT_DIFFERS(hash1.value(), hash2.value());
-
-    logger().info("END TEST: %s", __FUNCTION__);
 }
 
 #undef al

--- a/tests/atoms/hash.scm
+++ b/tests/atoms/hash.scm
@@ -1,5 +1,7 @@
 ;; Atoms for testing hash collisions
 
+;; Scope links
+
 ;; These 2 bind links are not alpha-equivalent and should ideally have
 ;; different hash values.
 
@@ -888,5 +890,69 @@
             (VariableNode "$PM-61bb02a1-5779870f")
         )
     )
+)
+)
+
+;; Non scope links
+
+(define sal
+(SequentialAndLink
+  (AbsentLink
+    (EvaluationLink
+      (PredicateNode "visible")
+      (ListLink
+        (VariableNode "$x")
+      )
+    )
+  )
+  (EvaluationLink
+    (GroundedPredicateNode "scm: incr-trig")
+    (ListLink
+    )
+  )
+)
+)
+
+(define sol
+(SequentialOrLink
+  (PresentLink
+    (EvaluationLink
+      (PredicateNode "visible")
+      (ListLink
+        (VariableNode "$x")
+      )
+    )
+  )
+  (EvaluationLink
+    (GroundedPredicateNode "scm: incr-trig")
+    (ListLink
+    )
+  )
+)
+)
+
+(define tl
+(TimesLink
+  (NumberNode "5.000000")
+  (PlusLink
+    (NumberNode "3.000000")
+    (ValueOfLink
+      (ConceptNode "some atom")
+      (PredicateNode "my key")
+    )
+  )
+)
+)
+
+(define pl
+(PlusLink
+  (NumberNode "5.000000")
+  (TimesLink
+    (NumberNode "3.000000")
+    (ValueOfLink
+      (ConceptNode "some atom")
+      (PredicateNode "my key")
+    )
+  )
 )
 )

--- a/tests/atoms/hash.scm
+++ b/tests/atoms/hash.scm
@@ -1,3 +1,5 @@
+;; Atoms for testing hash collisions
+
 ;; These 2 bind links are not alpha-equivalent and should ideally have
 ;; different hash values.
 
@@ -471,6 +473,47 @@
         )
       )
     )
+  )
+)
+)
+
+(define bl-3
+(BindLink
+  (TypedVariableLink
+    (GlobNode "$star")
+    (IntervalLink
+      (NumberNode "0.000000")
+      (NumberNode "1.000000")
+    )
+  )
+  (ListLink
+    (ConceptNode "I")
+    (ConceptNode "love")
+    (GlobNode "$star")
+  )
+  (ListLink
+    (ConceptNode "Hey!")
+    (ConceptNode "I")
+    (ConceptNode "like")
+    (GlobNode "$star")
+    (ConceptNode "also")
+  )
+)
+)
+
+(define bl-4
+(BindLink
+  (ListLink
+    (ConceptNode "I")
+    (ConceptNode "love")
+    (GlobNode "$star")
+  )
+  (ListLink
+    (ConceptNode "Hey!")
+    (ConceptNode "I")
+    (ConceptNode "like")
+    (GlobNode "$star")
+    (ConceptNode "also")
   )
 )
 )

--- a/tests/atoms/hash.scm
+++ b/tests/atoms/hash.scm
@@ -732,7 +732,7 @@
 )
 )
 
-(define hash-test1
+(define ll-1
 (LambdaLink
     (VariableList
         (VariableNode "$PM-565f9848")
@@ -751,7 +751,7 @@
 )
 )
 
-(define hash-test2
+(define ll-2
 (LambdaLink
     (VariableList
         (VariableNode "$PM-164e1b09")
@@ -770,7 +770,7 @@
 )
 )
 
-(define hash-test3
+(define ll-3
 (LambdaLink
     (VariableList
         (VariableNode "$PM-41da0db7-3475e0e1")
@@ -790,7 +790,7 @@
 )
 )
 
-(define hash-test4
+(define ll-4
 (LambdaLink
     (VariableList
         (VariableNode "$PM-61bb02a1-5779870f")
@@ -810,7 +810,7 @@
 )
 )
 
-(define hash-test5
+(define ll-5
 (LambdaLink
     (VariableList
         (VariableNode "$PM-61bb02a1-5779870f")
@@ -829,7 +829,7 @@
 )
 )
 
-(define hash-test6
+(define ll-6
 (LambdaLink
     (VariableList
         (VariableNode "$PM-61bb02a1")


### PR DESCRIPTION
Add all examples in #1739 (with the exclusion of the SimilarityLinks because they use atom types not in the core).

The BindLink still fails.