### PR TITLE
Make Python loading from Scheme compatible with Python3

### DIFF
--- a/examples/atomspace/execute.scm
+++ b/examples/atomspace/execute.scm
@@ -14,7 +14,7 @@
 
 ; The below demonstrates the use of python code in an execution link.
 ; Begin by loading the python code. (See `python.scm` for more details).
-(python-eval "execfile('my_py_func.py')")
+(python-eval "exec(open('my_py_func.py'))")
 
 ; Execute the python function `my_py_func`. The python function shhould
 ; return an atom, which is then printed.

--- a/examples/atomspace/python.scm
+++ b/examples/atomspace/python.scm
@@ -10,8 +10,8 @@
 ; The below should print "hello! 4"
 (python-eval "print ('hello! ' + str(2+2))")
 
-; Use execfile to load python files:
-(python-eval "execfile('my_py_func.py')")
+; Use exec(open()) to load python files:
+(python-eval "exec(open('my_py_func.py'))")
 
 ; -------------------------------------------------------------------
 ; It is possible to communicate an AtomSpace from guile to python.


### PR DESCRIPTION
Python3 doesn't have execfile anymore so scripts should be loaded using
exec(open('<script>')) call.