### PR TITLE
Replace the broken design with workable one.

### DIFF
--- a/opencog/matrix/filter.scm
+++ b/opencog/matrix/filter.scm
@@ -37,6 +37,10 @@
 (use-modules (ice-9 optargs)) ; for define*-public
 
 ; ---------------------------------------------------------------------
+; XXX TODO -- redesign this to use left-duals and right-duals instead
+; of left-stars and right-stars. The real goal here is to get rid of
+; the 'left-element and 'right-element methods, which some of the
+; objects are not able to support.
 
 (define-public (add-generic-filter LLOBJ
 	LEFT-BASIS-PRED RIGHT-BASIS-PRED

--- a/opencog/matrix/fold-api.scm
+++ b/opencog/matrix/fold-api.scm
@@ -151,15 +151,11 @@
 			; inserted repeatedly.
 			(define atom-set (make-atom-set))
 
-			; Add the left-side of the pair to the set.
-			(define (add-left-to-set LIST)
-				(for-each
-					(lambda (star-pair) (atom-set (LLOBJ 'left-element star-pair)))
-					LIST))
-
-			; loop over everything in the tuple.
+			; Loop over everything in the tuple.
 			(for-each
-				(lambda (item) (add-left-to-set (star-obj 'left-stars item)))
+				(lambda (item)
+					(for-each (lambda (dual) (atom-set dual))
+						(star-obj 'left-duals item)))
 				TUPLE)
 
 			; Return the union of all left-stars in the tuple.
@@ -167,13 +163,12 @@
 
 		(define (get-right-union TUPLE)
 			(define atom-set (make-atom-set))
-			(define (add-right-to-set LIST)
-				(for-each
-					(lambda (star-pair) (atom-set (LLOBJ 'right-element star-pair)))
-					LIST))
 			(for-each
-				(lambda (item) (add-right-to-set (star-obj 'right-stars item)))
+				(lambda (item)
+					(for-each (lambda (dual) (atom-set dual))
+						(star-obj 'right-duals item)))
 				TUPLE)
+
 			(atom-set #f))
 
 		; ---------------

--- a/opencog/matrix/object-api.scm
+++ b/opencog/matrix/object-api.scm
@@ -227,6 +227,15 @@
 
   'right-basis-size - Likewise.
 
+  'left-duals COL - Return the set of rows for which the pair
+      (row, COL) exists in the atomspace.  That is, return the set
+          { x | (x,COL) exists in the atomspace }
+      The returned rows will all be of type (LLOBJ 'left-type).
+      The input COL atom must be of type (LLOBJ 'right-type).
+      This does NOT verify that these pairs have a non-zero count.
+
+  'right-duals ROW - Likewise, but returns the columns for (ROW, *).
+
   'left-stars COL - Return the set of pairs (row, column) for
       which the column is COL, and the pair exists in the atomspace.
       That is, return the set

--- a/opencog/matrix/object-api.scm
+++ b/opencog/matrix/object-api.scm
@@ -371,15 +371,15 @@
 		; Define patterns, that, when executed, return the stars.
 		(define (left-star-pat ITEM)
 			(let* ((var (Variable "$api-left-star"))
-					(term (LLOBJ 'make-pair var ITEM))
+					(term (LLOBJ 'make-pair var ITEM)))
 				(Bind (TypedVariable var (Type left-type))
-					term term))))
+					term term)))
 
 		(define (right-star-pat ITEM)
 			(let* ((var (Variable "$api-right-star"))
-					(term (LLOBJ 'make-pair ITEM var))
+					(term (LLOBJ 'make-pair ITEM var)))
 				(Bind (TypedVariable var (Type right-type))
-					term term))))
+					term term)))
 
 		; Actually get the patterns
 		(define (do-get-left-stars ITEM)

--- a/opencog/matrix/object-api.scm
+++ b/opencog/matrix/object-api.scm
@@ -125,14 +125,6 @@
 ;     (define (make-pair L-ATOM R-ATOM)
 ;        (Evaluation (Predicate "foo") (List L-ATOM R-ATOM)))
 ;
-;     ; Return the left member of the pair. Given the pair-atom,
-;     ; locate the left-side atom.
-;     (define (get-left-element PAIR)
-;        (gadr PAIR))
-;
-;     (define (get-right-element PAIR)
-;        (gddr PAIR))
-;
 ;     ; Return an atom to which column subtotals can be attached,
 ;     ; such as, for example, the subtotal `N(*,y)`. Thus, `y`
 ;     ; denotes a column, and the star is on the left (the star
@@ -181,8 +173,6 @@
 ;              ((get-pair) get-pair)
 ;              ((get-count) get-count)
 ;              ((make-pair) make-pair)
-;              ((left-element) get-left-element)
-;              ((right-element) get-right-element)
 ;              ((left-wildcard) get-left-wildcard)
 ;              ((right-wildcard) get-right-wildcard)
 ;              ((wild-wild) get-wild-wild)

--- a/opencog/matrix/object-api.scm
+++ b/opencog/matrix/object-api.scm
@@ -259,10 +259,16 @@
 			(r-size 0)
 
 			; Caches for the left and right stars
-			(l-hit (make-atomic-box '()))
-			(l-miss (make-atomic-box '()))
-			(r-hit (make-atomic-box '()))
-			(r-miss (make-atomic-box '()))
+			(star-l-hit (make-atomic-box '()))
+			(star-l-miss (make-atomic-box '()))
+			(star-r-hit (make-atomic-box '()))
+			(star-r-miss (make-atomic-box '()))
+
+			; Caches for the left and right duals
+			(dual-l-hit (make-atomic-box '()))
+			(dual-l-miss (make-atomic-box '()))
+			(dual-r-hit (make-atomic-box '()))
+			(dual-r-miss (make-atomic-box '()))
 
 #! ============ Alternate variant, not currently used. See below.
 			; Temporary atomspaces
@@ -339,6 +345,28 @@
 			(overload 'left-star-pattern default-left-star-pat))
 		(define f-right-star-pat
 			(overload 'right-star-pattern default-right-star-pat))
+
+		; -------------------------------------------------------
+		; Same as above, but for the duals, not the stars.
+		; The pattern is almost the same, except that this time,
+		; we return basis elements.
+		;
+		; Define default patterns, that, when executed, return the duals.
+		; The LLOBJ can provide custom versions of this.
+		(define (default-left-dual-pat ITEM)
+			(let* ((var (Variable "$api-left-dual"))
+					(term (LLOBJ 'make-pair var ITEM)))
+				(Get (TypedVariable var (Type left-type)) term)))
+
+		(define (default-right-dual-pat ITEM)
+			(let* ((var (Variable "$api-right-dual"))
+					(term (LLOBJ 'make-pair ITEM var)))
+				(Get (TypedVariable var (Type right-type)) term)))
+
+		(define f-left-dual-pat
+			(overload 'left-dual-pattern default-left-dual-pat))
+		(define f-right-dual-pat
+			(overload 'right-dual-pattern default-right-dual-pat))
 
 		; -------------------------------------------------------
 		;
@@ -423,12 +451,12 @@
 
 		; Apply caching to the stars
 		(define (get-left-stars ITEM)
-			(do-get-stars l-hit l-miss
+			(do-get-stars star-l-hit star-l-miss
 				(lambda (itm) (get-stars f-left-star-pat itm)) ITEM))
 
 		; Same as above, but on the right.
 		(define (get-right-stars ITEM)
-			(do-get-stars r-hit r-miss
+			(do-get-stars star-r-hit star-r-miss
 				(lambda (itm) (get-stars f-right-star-pat itm)) ITEM))
 
 		; Invalidate the caches. This is needed, when atoms get deleted.

--- a/opencog/matrix/transpose.scm
+++ b/opencog/matrix/transpose.scm
@@ -233,7 +233,7 @@
 			(support-obj   (add-support-api LLOBJ))
 			(api-obj       (add-transpose-api LLOBJ))
 			(get-cnt       (lambda (x) (LLOBJ GET-COUNT x)))
-			(get-pr-cnt    (lambda (l r) (get-cnt (LLOBJ get-pair l r))))
+			(get-pr-cnt    (lambda (l r) (get-cnt (LLOBJ 'get-pair l r))))
 			(left-support  (lambda (x) (support-obj LEFT-SUPPORT x)))
 			(right-support (lambda (x) (support-obj RIGHT-SUPPORT x)))
 			(left-count    (lambda (x) (support-obj LEFT-COUNT x)))

--- a/opencog/matrix/transpose.scm
+++ b/opencog/matrix/transpose.scm
@@ -233,6 +233,7 @@
 			(support-obj   (add-support-api LLOBJ))
 			(api-obj       (add-transpose-api LLOBJ))
 			(get-cnt       (lambda (x) (LLOBJ GET-COUNT x)))
+			(get-pr-cnt    (lambda (l r) (get-cnt (LLOBJ get-pair l r))))
 			(left-support  (lambda (x) (support-obj LEFT-SUPPORT x)))
 			(right-support (lambda (x) (support-obj RIGHT-SUPPORT x)))
 			(left-count    (lambda (x) (support-obj LEFT-COUNT x)))
@@ -243,55 +244,42 @@
 		; Return a list of all pairs (x,y) for y == ITEM for which
 		; sum_x N(x,*) N(x,y) > 0.
 		(define (get-mtm-support-set ITEM)
-			(filter (lambda (star)
-				(< 0 (* (right-count (LLOBJ 'left-element star)) (get-cnt star))))
-			(star-obj 'left-stars ITEM)))
+			(filter (lambda (ldual)
+				(< 0 (* (right-count ldual) (get-pr-cnt ldual ITEM))))
+			(star-obj 'left-duals ITEM)))
 
 		; Same as above, but on the right.
 		(define (get-mmt-support-set ITEM)
-			(filter (lambda (star)
-				(< 0 (* (left-count (LLOBJ 'right-element star)) (get-cnt star))))
-			(star-obj 'right-stars ITEM)))
+			(filter (lambda (rdual)
+				(< 0 (* (left-count rdual) (get-pr-cnt ITEM rdual))))
+			(star-obj 'right-duals ITEM)))
 
 		; -------------
 		; Return how many non-zero items are in the list.
 		; Identical to (length (get-mmt-support-set ITEM))
 		(define (sum-mmt-support ITEM)
-			(fold (lambda (star sum)
-				(if (< 0 (* (left-count (LLOBJ 'right-element star))
-						(get-cnt star))) (+ sum 1) sum)) 0
-				(star-obj 'right-stars ITEM)))
+			(fold (lambda (rdual sum)
+				(if (< 0 (* (left-count rdual)
+						(get-pr-cnt ITEM rdual))) (+ sum 1) sum)) 0
+				(star-obj 'right-duals ITEM)))
 
 		(define (sum-mtm-support ITEM)
-			(fold (lambda (star sum)
-				(if (< 0 (* (right-count (LLOBJ 'left-element star))
-						(get-cnt star))) (+ sum 1) sum)) 0
-				(star-obj 'left-stars ITEM)))
+			(fold (lambda (ldual sum)
+				(if (< 0 (* (right-count ldual)
+						(get-pr-cnt ldual ITEM))) (+ sum 1) sum)) 0
+				(star-obj 'left-duals ITEM)))
 
 		; -------------
-		; Both sum-mmt-count and sum-mmt-count-slow compute the same
-		; thing. The first is much faster, because it loops only over
-		; the stars, of which there are few. However, it depends on a
-		; non-broken, funcional 'right-element method. The second is
-		; much much slower, because it loops over the entire basis,
-		; which is going to have non-zero counts very sparsly.
-		(define (sum-mmt-count-slow ITEM)
-			(fold (lambda (wild sum)
-				(+ sum (* (left-count wild)
-						(get-cnt (LLOBJ 'get-pair ITEM wild))))) 0
-				(star-obj 'right-basis)))
-
+		; Sum counts
 		(define (sum-mmt-count ITEM)
-			(fold (lambda (star sum)
-				(+ sum (* (left-count (LLOBJ 'right-element star))
-						(get-cnt star)))) 0
-				(star-obj 'right-stars ITEM)))
+			(fold (lambda (rdual sum)
+				(+ sum (* (left-count rdual) (get-pr-cnt ITEM rdual)))) 0
+				(star-obj 'right-duals ITEM)))
 
 		(define (sum-mtm-count ITEM)
-			(fold (lambda (star sum)
-				(+ sum (* (right-count (LLOBJ 'left-element star))
-						(get-cnt star)))) 0
-				(star-obj 'left-stars ITEM)))
+			(fold (lambda (ldual sum)
+				(+ sum (* (right-count ldual) (get-pr-cnt ldual ITEM)))) 0
+				(star-obj 'left-duals ITEM)))
 
 		; -------------
 		; Compute grand-totals for the two matrix products.


### PR DESCRIPTION
Some objects cannot implement the 'left-element, 'right-element methods,
so this was a bad idea. But all objects can implement a dual element search,
so use that instead.