### PR TITLE
Move ProtoAtom factory method out of class.

### DIFF
--- a/opencog/cython/opencog/atom.pyx
+++ b/opencog/cython/opencog/atom.pyx
@@ -172,7 +172,7 @@ cdef class Atom(object):
         cdef cProtoAtomPtr value = self.get_ptr().getValue(
             deref((<Atom>key).handle))
         if (value != NULL):
-            return ProtoAtom.from_cProtoAtomPtr(value)
+            return createProtoAtom(value)
         else:
             return None
 

--- a/opencog/cython/opencog/atomspace.pxd
+++ b/opencog/cython/opencog/atomspace.pxd
@@ -102,9 +102,9 @@ cdef extern from "opencog/atoms/proto/ProtoAtom.h" namespace "opencog":
 
 cdef class ProtoAtom:
     cdef cProtoAtomPtr shared_ptr
-    @staticmethod
-    cdef ProtoAtom from_cProtoAtomPtr(cProtoAtomPtr shared_ptr)
     cdef cProtoAtom* get_ptr(ProtoAtom self)
+
+cdef ProtoAtom createProtoAtom(cProtoAtomPtr shared_ptr)
 
 # Atom
 ctypedef public short av_type

--- a/opencog/cython/opencog/protoatom.pyx
+++ b/opencog/cython/opencog/protoatom.pyx
@@ -1,16 +1,15 @@
 from cpython.object cimport Py_EQ, Py_NE
 
+cdef ProtoAtom createProtoAtom(cProtoAtomPtr shared_ptr):
+    """Factory method to construct ProtoAtom from C++ ProtoAtomPtr (see
+    http://docs.cython.org/en/latest/src/userguide/extension_types.html#instantiation-from-existing-c-c-pointers
+    for example)"""
+    cdef ProtoAtom proto_atom = ProtoAtom.__new__(ProtoAtom)
+    proto_atom.shared_ptr = shared_ptr
+    return proto_atom
+
 cdef class ProtoAtom:
     """C++ ProtoAtom object wrapper for Python clients"""
-
-    @staticmethod
-    cdef ProtoAtom from_cProtoAtomPtr(cProtoAtomPtr shared_ptr):
-        """Factory method to construct ProtoAtom from C++ ProtoAtomPtr (see
-        http://docs.cython.org/en/latest/src/userguide/extension_types.html#instantiation-from-existing-c-c-pointers
-        for example)"""
-        cdef ProtoAtom proto_atom = ProtoAtom.__new__(ProtoAtom)
-        proto_atom.shared_ptr = shared_ptr
-        return proto_atom
 
     cdef cProtoAtom* get_ptr(self):
         """Return plain C++ ProtoAtom pointer, raise AttributeError if

--- a/opencog/cython/opencog/type_constructors.pyx
+++ b/opencog/cython/opencog/type_constructors.pyx
@@ -8,7 +8,8 @@
 #
 
 from opencog.atomspace import AtomSpace, TruthValue, types
-from atomspace cimport cProtoAtomPtr, createFloatValue, ProtoAtom
+from atomspace cimport (cProtoAtomPtr, createFloatValue, 
+                        ProtoAtom, createProtoAtom)
 from libcpp.vector cimport vector
 
 atomspace = None
@@ -32,6 +33,6 @@ cdef createValue(type, arg):
             result = createFloatValue(<double>arg)
     else:
         raise TypeError('Unexpected value type {}'.format(type))
-    return ProtoAtom.from_cProtoAtomPtr(result)
+    return createProtoAtom(result)
 
 include "opencog/atoms/proto/core_types.pyx"


### PR DESCRIPTION
Addressing https://github.com/opencog/atomspace/pull/1768#issuecomment-400109533
To make code compatible with older versions of Cython/Python, move
static methon into separate function and rename it accordingly.