### PR TITLE
Avoid hard crash of cogserver

### DIFF
--- a/opencog/cython/PythonEval.cc
+++ b/opencog/cython/PythonEval.cc
@@ -516,8 +516,14 @@ void PythonEval::initialize_python_objects_and_imports(void)
     // Add ATOMSPACE to __main__ module.
     PyObject* pyRootDictionary = PyModule_GetDict(_pyRootModule);
     PyObject* pyAtomSpaceObject = this->atomspace_py_object(_atomspace);
-    PyDict_SetItemString(pyRootDictionary, "ATOMSPACE", pyAtomSpaceObject);
-    Py_DECREF(pyAtomSpaceObject);
+
+    // Sometimes the atomspace cannot be found, viz null pointer.
+    // I don't know why.
+    if (pyAtomSpaceObject)
+    {
+        PyDict_SetItemString(pyRootDictionary, "ATOMSPACE", pyAtomSpaceObject);
+        Py_DECREF(pyAtomSpaceObject);
+    }
 
     // PyModule_GetDict returns a borrowed reference, so don't do this:
     // Py_DECREF(pyRootDictionary);


### PR DESCRIPTION
Python has a null-pointer deref due to issue opencog/opencog#3226 

This works around the hard-crash.