### PR TITLE
Fix oc_to_string

### DIFF
--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -33,6 +33,7 @@
 #include <string>
 #include <unordered_set>
 
+#include <opencog/util/empty_string.h>
 #include <opencog/util/sigslot.h>
 #include <opencog/atoms/base/Handle.h>
 #include <opencog/atoms/proto/ProtoAtom.h>
@@ -415,8 +416,8 @@ static inline Handle HandleCast(const ProtoAtomPtr& pa)
 // The reason indent is not an optional argument with default is
 // because gdb doesn't support that, see
 // http://stackoverflow.com/questions/16734783 for more explanation.
-std::string oc_to_string(const IncomingSet& iset, const std::string& indent);
-std::string oc_to_string(const IncomingSet& iset);
+std::string oc_to_string(const IncomingSet& iset,
+                         const std::string& indent=empty_string);
 
 /** @}*/
 } // namespace opencog

--- a/opencog/atoms/base/Handle.cc
+++ b/opencog/atoms/base/Handle.cc
@@ -136,10 +136,7 @@ std::string oc_to_string(const Handle& h, const std::string& indent)
 	else
 		return h->to_string(indent);
 }
-std::string oc_to_string(const Handle& h)
-{
-	return oc_to_string(h, "");
-}
+
 std::string oc_to_string(const HandlePair& hp, const std::string& indent)
 {
 	std::stringstream ss;
@@ -149,10 +146,7 @@ std::string oc_to_string(const HandlePair& hp, const std::string& indent)
 	   << oc_to_string(hp.second, indent + OC_TO_STRING_INDENT);
 	return ss.str();
 }
-std::string oc_to_string(const HandlePair& hp)
-{
-	return oc_to_string(hp, "");
-}
+
 // Hack around the lack template use in Handle.h due to circular dependencies
 #define GEN_ATOM_CONTAINER_OC_TO_STRING(T) \
 std::string oc_to_string(const T& hs, const std::string& indent) { \
@@ -167,10 +161,7 @@ std::string oc_to_string(const T& hs, const std::string& indent) { \
 	return ss.str(); \
 }
 GEN_ATOM_CONTAINER_OC_TO_STRING(opencog::HandleSeq)
-std::string oc_to_string(const HandleSeq& hs)
-{
-	return oc_to_string(hs, "");
-}
+
 std::string oc_to_string(const HandleSeqSeq& hss, const std::string& indent)
 {
 	std::stringstream ss;
@@ -183,15 +174,9 @@ std::string oc_to_string(const HandleSeqSeq& hss, const std::string& indent)
 	}
 	return ss.str();
 }
-std::string oc_to_string(const HandleSeqSeq& hss)
-{
-	return oc_to_string(hss, "");
-}
+
 GEN_ATOM_CONTAINER_OC_TO_STRING(opencog::HandleSet)
-std::string oc_to_string(const HandleSet& ohs)
-{
-	return oc_to_string(ohs, "");
-}
+
 std::string oc_to_string(const HandleSetSeq& hss, const std::string& indent)
 {
 	std::stringstream ss;
@@ -204,15 +189,9 @@ std::string oc_to_string(const HandleSetSeq& hss, const std::string& indent)
 	}
 	return ss.str();
 }
-std::string oc_to_string(const HandleSetSeq& hss)
-{
-	return oc_to_string(hss, "");
-}
+
 GEN_ATOM_CONTAINER_OC_TO_STRING(opencog::UnorderedHandleSet)
-std::string oc_to_string(const UnorderedHandleSet& uhs)
-{
-	return oc_to_string(uhs, "");
-}
+
 std::string oc_to_string(const HandleMap& hmap, const std::string& indent)
 {
 	std::stringstream ss;
@@ -227,10 +206,7 @@ std::string oc_to_string(const HandleMap& hmap, const std::string& indent)
 	}
 	return ss.str();
 }
-std::string oc_to_string(const HandleMap& hmap)
-{
-	return oc_to_string(hmap, "");
-}
+
 std::string oc_to_string(const HandleMultimap& hmultimap, const std::string& indent)
 {
 	std::stringstream ss;
@@ -246,10 +222,7 @@ std::string oc_to_string(const HandleMultimap& hmultimap, const std::string& ind
 	}
 	return ss.str();
 }
-std::string oc_to_string(const HandleMultimap& hmultimap)
-{
-	return oc_to_string(hmultimap, "");
-}
+
 std::string oc_to_string(const HandleMapSeq& hms, const std::string& indent)
 {
 	std::stringstream ss;
@@ -259,10 +232,7 @@ std::string oc_to_string(const HandleMapSeq& hms, const std::string& indent)
 		   << oc_to_string(hms[i], indent + OC_TO_STRING_INDENT);
 	return ss.str();
 }
-std::string oc_to_string(const HandleMapSeq& hms)
-{
-	return oc_to_string(hms, "");
-}
+
 std::string oc_to_string(const HandleMapSet& hms, const std::string& indent)
 {
 	std::stringstream ss;
@@ -275,10 +245,7 @@ std::string oc_to_string(const HandleMapSet& hms, const std::string& indent)
 	}
 	return ss.str();
 }
-std::string oc_to_string(const HandleMapSet& hms)
-{
-	return oc_to_string(hms, "");
-}
+
 std::string oc_to_string(const HandlePairSeq& hps, const std::string& indent)
 {
 	std::stringstream ss;
@@ -293,10 +260,7 @@ std::string oc_to_string(const HandlePairSeq& hps, const std::string& indent)
 	}
 	return ss.str();
 }
-std::string oc_to_string(const HandlePairSeq& hps)
-{
-	return oc_to_string(hps, "");
-}
+
 std::string oc_to_string(const HandleCounter& hc, const std::string& indent)
 {
 	std::stringstream ss;
@@ -310,10 +274,7 @@ std::string oc_to_string(const HandleCounter& hc, const std::string& indent)
 	}
 	return ss.str();
 }
-std::string oc_to_string(const HandleCounter& hc)
-{
-	return oc_to_string(hc, "");
-}
+
 std::string oc_to_string(const HandleUCounter& huc, const std::string& indent)
 {
 	std::stringstream ss;
@@ -327,20 +288,14 @@ std::string oc_to_string(const HandleUCounter& huc, const std::string& indent)
 	}
 	return ss.str();
 }
-std::string oc_to_string(const HandleUCounter& huc)
-{
-	return oc_to_string(huc, "");
-}
+
 std::string oc_to_string(Type type, const std::string& indent)
 {
 	std::stringstream ss;
 	ss << indent << nameserver().getTypeName(type) << std::endl;
 	return ss.str();
 }
-std::string oc_to_string(Type type)
-{
-	return oc_to_string(type, "");
-}
+
 std::string oc_to_string(const TypeSet& types, const std::string& indent)
 {
 	std::stringstream ss;
@@ -354,25 +309,15 @@ std::string oc_to_string(const TypeSet& types, const std::string& indent)
 	ss << std::endl;
 	return ss.str();
 }
-std::string oc_to_string(const TypeSet& types)
-{
-	return oc_to_string(types, "");
-}
+
 std::string oc_to_string(const AtomPtr& aptr, const std::string& indent)
 {
 	return oc_to_string(aptr->get_handle(), indent);
 }
-std::string oc_to_string(const AtomPtr& aptr)
-{
-	return oc_to_string(aptr, "");
-}
+
 std::string oc_to_string(const LinkPtr& lptr, const std::string& indent)
 {
 	return oc_to_string(lptr->get_handle(), indent);
-}
-std::string oc_to_string(const LinkPtr& lptr)
-{
-	return oc_to_string(lptr, "");
 }
 
 } // ~namespace opencog

--- a/opencog/atoms/base/Handle.h
+++ b/opencog/atoms/base/Handle.h
@@ -38,6 +38,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include <opencog/util/empty_string.h>
 #include <opencog/util/Counter.h>
 #include <opencog/atoms/proto/types.h>
 
@@ -275,40 +276,40 @@ static inline std::string operator+ (const std::string &lhs, Handle h)
 // because gdb doesn't support that, see
 // http://stackoverflow.com/questions/16734783 for more explanation.
 #define OC_TO_STRING_INDENT "  "
-std::string oc_to_string(const Handle& h, const std::string& indent);
-std::string oc_to_string(const Handle& h);
-std::string oc_to_string(const HandlePair& hp, const std::string& indent);
-std::string oc_to_string(const HandlePair& hp);
-std::string oc_to_string(const HandleSeq& hs, const std::string& indent);
-std::string oc_to_string(const HandleSeq& hs);
-std::string oc_to_string(const HandleSeqSeq& hss, const std::string& indent);
-std::string oc_to_string(const HandleSeqSeq& hss);
-std::string oc_to_string(const HandleSet& ohs, const std::string& indent);
-std::string oc_to_string(const HandleSet& ohs);
-std::string oc_to_string(const HandleSetSeq& ohss, const std::string& indent);
-std::string oc_to_string(const HandleSetSeq& ohss);
-std::string oc_to_string(const UnorderedHandleSet& uhs, const std::string& indent);
-std::string oc_to_string(const UnorderedHandleSet& uhs);
-std::string oc_to_string(const HandleMap& hm, const std::string& indent);
-std::string oc_to_string(const HandleMap& hm);
-std::string oc_to_string(const HandleMultimap& hmm, const std::string& indent);
-std::string oc_to_string(const HandleMultimap& hmm);
-std::string oc_to_string(const HandleMapSeq& hms, const std::string& indent);
-std::string oc_to_string(const HandleMapSeq& hms);
-std::string oc_to_string(const HandleMapSet& hms, const std::string& indent);
-std::string oc_to_string(const HandleMapSet& hms);
-std::string oc_to_string(const HandlePairSeq& hps, const std::string& indent);
-std::string oc_to_string(const HandlePairSeq& hps);
-std::string oc_to_string(const HandleCounter& hc, const std::string& indent);
-std::string oc_to_string(const HandleCounter& hc);
-std::string oc_to_string(const HandleUCounter& huc, const std::string& indent);
-std::string oc_to_string(const HandleUCounter& huc);
-std::string oc_to_string(Type type, const std::string& indent);
-std::string oc_to_string(Type type);
-std::string oc_to_string(const TypeSet& types, const std::string& indent);
-std::string oc_to_string(const TypeSet& types);
-std::string oc_to_string(const AtomPtr& aptr, const std::string& indent);
-std::string oc_to_string(const AtomPtr& aptr);
+std::string oc_to_string(const Handle& h,
+                         const std::string& indent=empty_string);
+std::string oc_to_string(const HandlePair& hp,
+                         const std::string& indent=empty_string);
+std::string oc_to_string(const HandleSeq& hs,
+                         const std::string& indent=empty_string);
+std::string oc_to_string(const HandleSeqSeq& hss,
+                         const std::string& indent=empty_string);
+std::string oc_to_string(const HandleSet& ohs,
+                         const std::string& indent=empty_string);
+std::string oc_to_string(const HandleSetSeq& ohss,
+                         const std::string& indent=empty_string);
+std::string oc_to_string(const UnorderedHandleSet& uhs,
+                         const std::string& indent=empty_string);
+std::string oc_to_string(const HandleMap& hm,
+                         const std::string& indent=empty_string);
+std::string oc_to_string(const HandleMultimap& hmm,
+                         const std::string& indent=empty_string);
+std::string oc_to_string(const HandleMapSeq& hms,
+                         const std::string& indent=empty_string);
+std::string oc_to_string(const HandleMapSet& hms,
+                         const std::string& indent=empty_string);
+std::string oc_to_string(const HandlePairSeq& hps,
+                         const std::string& indent=empty_string);
+std::string oc_to_string(const HandleCounter& hc,
+                         const std::string& indent=empty_string);
+std::string oc_to_string(const HandleUCounter& huc,
+                         const std::string& indent=empty_string);
+std::string oc_to_string(Type type,
+                         const std::string& indent=empty_string);
+std::string oc_to_string(const TypeSet& types,
+                         const std::string& indent=empty_string);
+std::string oc_to_string(const AtomPtr& aptr,
+                         const std::string& indent=empty_string);
 
 } // namespace opencog
 

--- a/opencog/atoms/core/Context.cc
+++ b/opencog/atoms/core/Context.cc
@@ -128,10 +128,7 @@ std::string oc_to_string(const Context::VariablesStack& scope_variables,
 	}
 	return ss.str();
 }
-std::string oc_to_string(const Context::VariablesStack& scope_variables)
-{
-	return oc_to_string(scope_variables, "");
-}
+
 std::string oc_to_string(const Context& c, const std::string& indent)
 {
 	std::stringstream ss;
@@ -149,10 +146,6 @@ std::string oc_to_string(const Context& c, const std::string& indent)
 			ss << indent + OC_TO_STRING_INDENT << "ignored" << std::endl;
 	}
 	return ss.str();
-}
-std::string oc_to_string(const Context& c)
-{
-	return oc_to_string(c, "");
 }
 
 } // namespace opencog

--- a/opencog/atoms/core/Context.h
+++ b/opencog/atoms/core/Context.h
@@ -30,6 +30,7 @@
 
 #include <boost/operators.hpp>
 
+#include <opencog/util/empty_string.h>
 #include <opencog/atoms/proto/atom_types.h>
 #include <opencog/atoms/base/Handle.h>
 #include <opencog/atoms/core/Quotation.h>
@@ -116,8 +117,8 @@ bool ohs_content_eq(const HandleSet& lhs, const HandleSet& rhs);
 // The reason indent is not an optional argument with default is
 // because gdb doesn't support that, see
 // http://stackoverflow.com/questions/16734783 for more explanation.
-std::string oc_to_string(const Context& c, const std::string& indent);
-std::string oc_to_string(const Context& c);
+std::string oc_to_string(const Context& c,
+                         const std::string& indent=empty_string);
 	
 /** @}*/
 } // namespace opencog

--- a/opencog/atoms/core/Quotation.cc
+++ b/opencog/atoms/core/Quotation.cc
@@ -101,9 +101,5 @@ std::string oc_to_string(const Quotation& quotation, const std::string& indent)
 {
 	return quotation.to_string(indent);
 }
-std::string oc_to_string(const Quotation& quotation)
-{
-	return oc_to_string(quotation, "");
-}
-	
+
 } // namespace opencog

--- a/opencog/atoms/core/Quotation.h
+++ b/opencog/atoms/core/Quotation.h
@@ -28,6 +28,7 @@
 #include <string>
 #include <boost/operators.hpp>
 
+#include <opencog/util/empty_string.h>
 #include <opencog/atoms/proto/atom_types.h>
 
 namespace opencog
@@ -97,8 +98,8 @@ public:
 // The reason indent is not an optional argument with default is
 // because gdb doesn't support that, see
 // http://stackoverflow.com/questions/16734783 for more explanation.
-std::string oc_to_string(const Quotation& quotation, const std::string& indent);
-std::string oc_to_string(const Quotation& quotation);
+std::string oc_to_string(const Quotation& quotation,
+                         const std::string& indent=empty_string);
 	
 /** @}*/
 } // namespace opencog

--- a/opencog/atoms/core/VariableList.cc
+++ b/opencog/atoms/core/VariableList.cc
@@ -430,10 +430,6 @@ std::string opencog::oc_to_string(const VariableListPtr& vlp,
 	else
 		return oc_to_string(vlp->get_handle(), indent);
 }
-std::string opencog::oc_to_string(const VariableListPtr& vlp)
-{
-	return oc_to_string(vlp, "");
-}
 
 DEFINE_LINK_FACTORY(VariableList, VARIABLE_LIST)
 

--- a/opencog/atoms/core/VariableList.h
+++ b/opencog/atoms/core/VariableList.h
@@ -23,6 +23,7 @@
 #ifndef _OPENCOG_VARIABLE_LIST_H
 #define _OPENCOG_VARIABLE_LIST_H
 
+#include <opencog/util/empty_string.h>
 #include <opencog/atoms/base/Handle.h>
 #include <opencog/atoms/base/Link.h>
 #include <opencog/atoms/core/Variables.h>
@@ -105,8 +106,8 @@ static inline VariableListPtr VariableListCast(const AtomPtr& a)
 // The reason indent is not an optional argument with default is
 // because gdb doesn't support that, see
 // http://stackoverflow.com/questions/16734783 for more explanation.
-std::string oc_to_string(const VariableListPtr& vlp, const std::string& indent);
-std::string oc_to_string(const VariableListPtr& vlp);
+std::string oc_to_string(const VariableListPtr& vlp,
+                         const std::string& indent=empty_string);
 
 /** @}*/
 }

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -805,9 +805,5 @@ std::string oc_to_string(const Variables& var, const std::string& indent)
 {
 	return var.to_string(indent);
 }
-std::string oc_to_string(const Variables& var)
-{
-	return oc_to_string(var, "");
-}
 
 } // ~namespace opencog

--- a/opencog/atoms/core/Variables.h
+++ b/opencog/atoms/core/Variables.h
@@ -28,6 +28,7 @@
 
 #include <boost/operators.hpp>
 
+#include <opencog/util/empty_string.h>
 #include <opencog/atoms/base/Handle.h>
 #include <opencog/atoms/core/Quotation.h>
 
@@ -277,8 +278,8 @@ struct Variables : public FreeVariables,
 // The reason indent is not an optional argument with default is
 // because gdb doesn't support that, see
 // http://stackoverflow.com/questions/16734783 for more explanation.
-std::string oc_to_string(const Variables& var, const std::string& indent);
-std::string oc_to_string(const Variables& var);
+std::string oc_to_string(const Variables& var,
+                         const std::string& indent=empty_string);
 
 /** @}*/
 }

--- a/opencog/atoms/pattern/Pattern.cc
+++ b/opencog/atoms/pattern/Pattern.cc
@@ -66,9 +66,5 @@ std::string oc_to_string(const Pattern& pattern, const std::string& indent)
 {
 	return pattern.to_string(indent);
 }
-std::string oc_to_string(const Pattern& pattern)
-{
-	return oc_to_string(pattern, "");
-}
 
 } // ~namespace opencog

--- a/opencog/atoms/pattern/Pattern.h
+++ b/opencog/atoms/pattern/Pattern.h
@@ -30,6 +30,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include <opencog/util/empty_string.h>
 #include <opencog/atoms/base/Handle.h>
 #include <opencog/atoms/proto/types.h>  // for typedef Type
 #include <opencog/atoms/pattern/PatternTerm.h>
@@ -142,8 +143,8 @@ struct Pattern
 
 // For gdb, see
 // http://wiki.opencog.org/w/Development_standards#Print_OpenCog_Objects
-std::string oc_to_string(const Pattern& pattern, const std::string& indent);
-std::string oc_to_string(const Pattern& pattern);
+std::string oc_to_string(const Pattern& pattern,
+                         const std::string& indent=empty_string);
 
 /** @}*/
 } // namespace opencog

--- a/opencog/atoms/pattern/PatternTerm.cc
+++ b/opencog/atoms/pattern/PatternTerm.cc
@@ -144,17 +144,10 @@ std::string oc_to_string(const PatternTerm& pt, const std::string& indent)
 {
 	return pt.to_string(indent);
 }
-std::string oc_to_string(const PatternTerm& pt)
-{
-	return oc_to_string(pt, "");
-}
+
 std::string oc_to_string(const PatternTermPtr& pt_ptr, const std::string& indent)
 {
 	return pt_ptr->to_string();
-}
-std::string oc_to_string(const PatternTermPtr& pt_ptr)
-{
-	return oc_to_string(pt_ptr, "");
 }
 
 } // ~namespace opencog

--- a/opencog/atoms/pattern/PatternTerm.h
+++ b/opencog/atoms/pattern/PatternTerm.h
@@ -29,6 +29,7 @@
 
 #include <opencog/util/Logger.h>
 
+#include <opencog/util/empty_string.h>
 #include <opencog/atoms/base/Handle.h>
 #include <opencog/atoms/base/Link.h>
 #include <opencog/atoms/core/Quotation.h>
@@ -135,10 +136,10 @@ public:
 
 // For gdb, see
 // http://wiki.opencog.org/w/Development_standards#Print_OpenCog_Objects
-std::string oc_to_string(const PatternTerm& pt, const std::string& indent);
-std::string oc_to_string(const PatternTerm& pt);
-std::string oc_to_string(const PatternTermPtr& pt, const std::string& indent);
-std::string oc_to_string(const PatternTermPtr& pt_ptr);
+std::string oc_to_string(const PatternTerm& pt,
+                         const std::string& indent=empty_string);
+std::string oc_to_string(const PatternTermPtr& pt,
+                         const std::string& indent=empty_string);
 
 } // namespace opencog
 

--- a/opencog/rule-engine/Rule.cc
+++ b/opencog/rule-engine/Rule.cc
@@ -597,10 +597,6 @@ std::string oc_to_string(const Rule& rule, const std::string& indent)
 {
 	return rule.to_string(indent);
 }
-std::string oc_to_string(const Rule& rule)
-{
-	return oc_to_string(rule, "");
-}
 std::string oc_to_string(const RuleSet& rules, const std::string& indent)
 {
 	std::stringstream ss;
@@ -610,10 +606,6 @@ std::string oc_to_string(const RuleSet& rules, const std::string& indent)
 		ss << indent << "rule[" << i++ << "]:" << std::endl
 		   << oc_to_string(rule, indent + OC_TO_STRING_INDENT) << std::endl;
 	return ss.str();
-}
-std::string oc_to_string(const RuleSet& rules)
-{
-	return oc_to_string(rules, "");
 }
 std::string oc_to_string(const RuleTypedSubstitutionPair& rule_ts,
                          const std::string& indent)
@@ -627,10 +619,6 @@ std::string oc_to_string(const RuleTypedSubstitutionPair& rule_ts,
 	   << std::endl;
 	return ss.str();
 }
-std::string oc_to_string(const RuleTypedSubstitutionPair& rule_ts)
-{
-	return oc_to_string(rule_ts, "");
-}
 std::string oc_to_string(const RuleTypedSubstitutionMap& rules,
                          const std::string& indent)
 {
@@ -642,10 +630,6 @@ std::string oc_to_string(const RuleTypedSubstitutionMap& rules,
 		   << oc_to_string(rule, indent + OC_TO_STRING_INDENT)
 		   << std::endl;
 	return ss.str();
-}
-std::string oc_to_string(const RuleTypedSubstitutionMap& rules)
-{
-	return oc_to_string(rules, "");
 }
 
 } // ~namespace opencog

--- a/opencog/rule-engine/Rule.h
+++ b/opencog/rule-engine/Rule.h
@@ -32,6 +32,7 @@
 #include <opencog/atoms/core/VariableList.h>
 #include <opencog/atoms/pattern/BindLink.h>
 #include <opencog/unify/Unify.h>
+#include <opencog/util/empty_string.h>
 
 namespace opencog {
 
@@ -322,14 +323,14 @@ private:
 // The reason indent is not an optional argument with default is
 // because gdb doesn't support that, see
 // http://stackoverflow.com/questions/16734783 for more explanation.
-std::string oc_to_string(const Rule& rule, const std::string& indent);
-std::string oc_to_string(const Rule& rule);
-std::string oc_to_string(const RuleSet& rules, const std::string& indent);
-std::string oc_to_string(const RuleSet& rules);
-std::string oc_to_string(const RuleTypedSubstitutionPair& rule_ts_pair, const std::string& indent);
-std::string oc_to_string(const RuleTypedSubstitutionPair& rule_ts_pair);
-std::string oc_to_string(const RuleTypedSubstitutionMap& rule_ts_map, const std::string& indent);
-std::string oc_to_string(const RuleTypedSubstitutionMap& rule_ts_map);
+std::string oc_to_string(const Rule& rule,
+                         const std::string& indent=empty_string);
+std::string oc_to_string(const RuleSet& rules,
+                         const std::string& indent=empty_string);
+std::string oc_to_string(const RuleTypedSubstitutionPair& rule_ts_pair,
+                         const std::string& indent=empty_string);
+std::string oc_to_string(const RuleTypedSubstitutionMap& rule_ts_map,
+                         const std::string& indent=empty_string);
 
 } // ~namespace opencog
 

--- a/opencog/rule-engine/backwardchainer/ActionSelection.cc
+++ b/opencog/rule-engine/backwardchainer/ActionSelection.cc
@@ -91,10 +91,7 @@ std::string oc_to_string(const ActionSelection& asel, const std::string& indent)
 	   << oc_to_string(asel.action2tv, indent + OC_TO_STRING_INDENT);
 	return ss.str();
 }
-std::string oc_to_string(const ActionSelection& asel)
-{
-	return oc_to_string(asel, "");
-}
+
 std::string oc_to_string(const HandleTVMap& h2tv, const std::string& indent)
 {
 	std::stringstream ss;
@@ -107,10 +104,6 @@ std::string oc_to_string(const HandleTVMap& h2tv, const std::string& indent)
 		   << oc_to_string(htv.second) << std::endl;
 	}
 	return ss.str();
-}
-std::string oc_to_string(const HandleTVMap& h2tv)
-{
-	return oc_to_string(h2tv, "");
 }
 
 } // ~namespace opencog

--- a/opencog/rule-engine/backwardchainer/ActionSelection.h
+++ b/opencog/rule-engine/backwardchainer/ActionSelection.h
@@ -23,6 +23,7 @@
 #ifndef _OPENCOG_ACTIONSELECTION_H_
 #define _OPENCOG_ACTIONSELECTION_H_
 
+#include <opencog/util/empty_string.h>
 #include <opencog/atoms/base/Handle.h>
 #include <opencog/truthvalue/TruthValue.h>
 
@@ -87,10 +88,10 @@ private:
 // The reason indent is not an optional argument with default is
 // because gdb doesn't support that, see
 // http://stackoverflow.com/questions/16734783 for more explanation.
-std::string	oc_to_string(const ActionSelection& asel, const std::string& indent);
-std::string	oc_to_string(const ActionSelection& asel);
-std::string	oc_to_string(const HandleTVMap& h2tv, const std::string& indent);
-std::string	oc_to_string(const HandleTVMap& h2tv);
+std::string	oc_to_string(const ActionSelection& asel,
+                         const std::string& indent=empty_string);
+std::string	oc_to_string(const HandleTVMap& h2tv,
+                         const std::string& indent=empty_string);
 
 } // namespace opencog
 

--- a/opencog/rule-engine/backwardchainer/BIT.cc
+++ b/opencog/rule-engine/backwardchainer/BIT.cc
@@ -752,18 +752,10 @@ std::string oc_to_string(const BITNode& bitnode, const std::string& indent)
 {
 	return bitnode.to_string(indent);
 }
-std::string oc_to_string(const BITNode& bitnode)
-{
-	return oc_to_string(bitnode, "");
-}
 
 std::string oc_to_string(const AndBIT& andbit, const std::string& indent)
 {
 	return andbit.to_string(indent);
-}
-std::string oc_to_string(const AndBIT& andbit)
-{
-	return oc_to_string(andbit, "");
 }
 
 // std::string oc_to_string(const BIT& bit)

--- a/opencog/rule-engine/backwardchainer/BIT.h
+++ b/opencog/rule-engine/backwardchainer/BIT.h
@@ -24,6 +24,8 @@
 #define _OPENCOG_BIT_H
 
 #include <boost/operators.hpp>
+
+#include <opencog/util/empty_string.h>
 #include <opencog/rule-engine/Rule.h>
 #include <opencog/atoms/base/Handle.h>
 #include <opencog/atomspaceutils/AtomSpaceUtils.h>
@@ -473,11 +475,10 @@ BIT::AndBITs::iterator BIT::erase(It pos)
 
 // Gdb debugging, see
 // http://wiki.opencog.org/w/Development_standards#Print_OpenCog_Objects
-std::string oc_to_string(const BITNode& bitnode, const std::string& indent);
-std::string oc_to_string(const BITNode& bitnode);
-std::string oc_to_string(const AndBIT& andbit, const std::string& indent);
-std::string oc_to_string(const AndBIT& andbit);
-// std::string oc_to_string(const BIT& bit);
+std::string oc_to_string(const BITNode& bitnode,
+                         const std::string& indent=empty_string);
+std::string oc_to_string(const AndBIT& andbit,
+                         const std::string& indent=empty_string);
 
 } // ~namespace opencog
 

--- a/opencog/rule-engine/backwardchainer/BetaDistribution.cc
+++ b/opencog/rule-engine/backwardchainer/BetaDistribution.cc
@@ -130,9 +130,5 @@ std::string oc_to_string(const BetaDistribution& bd, const std::string& indent)
 {
 	return bd.to_string(indent);
 }
-std::string oc_to_string(const BetaDistribution& bd)
-{
-	return oc_to_string(bd, "");
-}
 
 } // ~namespace opencog

--- a/opencog/rule-engine/backwardchainer/BetaDistribution.h
+++ b/opencog/rule-engine/backwardchainer/BetaDistribution.h
@@ -25,6 +25,7 @@
 
 #include <boost/math/distributions/beta.hpp>
 
+#include <opencog/util/empty_string.h>
 #include <opencog/truthvalue/TruthValue.h>
 
 namespace opencog
@@ -103,8 +104,8 @@ TruthValuePtr mk_stv(double mean, double variance,
 // The reason indent is not an optional argument with default is
 // because gdb doesn't support that, see
 // http://stackoverflow.com/questions/16734783 for more explanation.
-std::string oc_to_string(const BetaDistribution& bd, const std::string& indent);
-std::string oc_to_string(const BetaDistribution& bd);
+std::string oc_to_string(const BetaDistribution& bd,
+                         const std::string& indent=empty_string);
 
 } // namespace opencog
 

--- a/opencog/truthvalue/TruthValue.cc
+++ b/opencog/truthvalue/TruthValue.cc
@@ -188,9 +188,5 @@ std::string oc_to_string(TruthValuePtr tv, const std::string& indent)
 		return tv->to_string();
 	return "none";
 }
-std::string oc_to_string(TruthValuePtr tv)
-{
-	return oc_to_string(tv, "");
-}
 
 } // ~namespace opencog

--- a/opencog/truthvalue/TruthValue.h
+++ b/opencog/truthvalue/TruthValue.h
@@ -30,6 +30,7 @@
 #include <string>
 #include <vector>
 
+#include <opencog/util/empty_string.h>
 #include <opencog/util/exceptions.h>
 #include <opencog/atoms/proto/FloatValue.h>
 
@@ -186,8 +187,8 @@ static inline ProtoAtomPtr ProtoAtomCast(const TruthValuePtr& tv)
 // The reason indent is not an optional argument with default is
 // because gdb doesn't support that, see
 // http://stackoverflow.com/questions/16734783 for more explanation.
-std::string oc_to_string(TruthValuePtr tv, const std::string& indent);
-std::string oc_to_string(TruthValuePtr tv);
+std::string oc_to_string(TruthValuePtr tv,
+                         const std::string& indent=empty_string);
 
 } // namespace opencog
 

--- a/opencog/unify/Unify.cc
+++ b/opencog/unify/Unify.cc
@@ -1026,10 +1026,6 @@ std::string oc_to_string(const Unify::CHandle& ch, const std::string& indent)
 	   << oc_to_string(ch.handle, indent + OC_TO_STRING_INDENT);
 	return ss.str();
 }
-std::string oc_to_string(const Unify::CHandle& ch)
-{
-	return oc_to_string(ch, "");
-}
 
 std::string oc_to_string(const Unify::Block& pb, const std::string& indent)
 {
@@ -1041,10 +1037,6 @@ std::string oc_to_string(const Unify::Block& pb, const std::string& indent)
 		   << oc_to_string(el, indent + OC_TO_STRING_INDENT);
 	return ss.str();
 }
-std::string oc_to_string(const Unify::Block& pb)
-{
-	return oc_to_string(pb, "");
-}
 
 std::string oc_to_string(const Unify::TypedBlock& tb, const std::string& indent)
 {
@@ -1055,10 +1047,6 @@ std::string oc_to_string(const Unify::TypedBlock& tb, const std::string& indent)
 	   << oc_to_string(tb.second, indent + OC_TO_STRING_INDENT);
 	return ss.str();
 }
-std::string oc_to_string(const Unify::TypedBlock& tb)
-{
-	return oc_to_string(tb, "");
-}
 
 std::string oc_to_string(const Unify::TypedBlockSeq& tbs, const std::string& indent)
 {
@@ -1068,10 +1056,6 @@ std::string oc_to_string(const Unify::TypedBlockSeq& tbs, const std::string& ind
 		ss << indent << "typed block[" << i << "]:" << std::endl
 		   << oc_to_string(tbs[i], indent + OC_TO_STRING_INDENT);
 	return ss.str();
-}
-std::string oc_to_string(const Unify::TypedBlockSeq& tbs)
-{
-	return oc_to_string(tbs, "");
 }
 
 std::string oc_to_string(const Unify::Partition& up, const std::string& indent)
@@ -1088,10 +1072,6 @@ std::string oc_to_string(const Unify::Partition& up, const std::string& indent)
 	}
 	return ss.str();
 }
-std::string oc_to_string(const Unify::Partition& up)
-{
-	return oc_to_string(up, "");
-}
 
 std::string oc_to_string(const Unify::Partitions& par, const std::string& indent)
 {
@@ -1104,10 +1084,6 @@ std::string oc_to_string(const Unify::Partitions& par, const std::string& indent
 		i++;
 	}
 	return ss.str();
-}
-std::string oc_to_string(const Unify::Partitions& par)
-{
-	return oc_to_string(par, "");
 }
 
 std::string oc_to_string(const Unify::HandleCHandleMap& hchm, const std::string& indent)
@@ -1124,10 +1100,6 @@ std::string oc_to_string(const Unify::HandleCHandleMap& hchm, const std::string&
 	}
 	return ss.str();
 }
-std::string oc_to_string(const Unify::HandleCHandleMap& hchm)
-{
-	return oc_to_string(hchm, "");
-}
 
 std::string oc_to_string(const Unify::TypedSubstitution& ts, const std::string& indent)
 {
@@ -1137,10 +1109,6 @@ std::string oc_to_string(const Unify::TypedSubstitution& ts, const std::string& 
 	   << indent << "vardecl:" << std::endl
 	   << oc_to_string(ts.second, indent + OC_TO_STRING_INDENT);
 	return ss.str();
-}
-std::string oc_to_string(const Unify::TypedSubstitution& ts)
-{
-	return oc_to_string(ts, "");
 }
 
 std::string oc_to_string(const Unify::TypedSubstitutions& tss, const std::string& indent)
@@ -1154,10 +1122,6 @@ std::string oc_to_string(const Unify::TypedSubstitutions& tss, const std::string
 		i++;
 	}
 	return ss.str();
-}
-std::string oc_to_string(const Unify::TypedSubstitutions& tss)
-{
-	return oc_to_string(tss, "");
 }
 
 } // namespace opencog

--- a/opencog/unify/Unify.h
+++ b/opencog/unify/Unify.h
@@ -28,6 +28,7 @@
 
 #include <boost/operators.hpp>
 
+#include <opencog/util/empty_string.h>
 #include <opencog/atoms/base/Handle.h>
 #include <opencog/atoms/proto/atom_types.h>
 #include <opencog/atoms/core/Quotation.h>
@@ -731,24 +732,24 @@ Handle merge_vardecl(const Handle& l_vardecl, const Handle& r_vardecl);
 // The reason indent is not an optional argument with default is
 // because gdb doesn't support that, see
 // http://stackoverflow.com/questions/16734783 for more explanation.
-std::string oc_to_string(const Unify::CHandle& ch, const std::string& indent);
-std::string oc_to_string(const Unify::CHandle& ch);
-std::string oc_to_string(const Unify::Block& pb, const std::string& indent);
-std::string oc_to_string(const Unify::Block& pb);
-std::string oc_to_string(const Unify::Partition& hshm, const std::string& indent);
-std::string oc_to_string(const Unify::Partition& hshm);
-std::string oc_to_string(const Unify::TypedBlock& tb, const std::string& indent);
-std::string oc_to_string(const Unify::TypedBlock& tb);
-std::string oc_to_string(const Unify::TypedBlockSeq& tbs, const std::string& indent);
-std::string oc_to_string(const Unify::TypedBlockSeq& tbs);
-std::string oc_to_string(const Unify::Partitions& par, const std::string& indent);
-std::string oc_to_string(const Unify::Partitions& par);
-std::string oc_to_string(const Unify::HandleCHandleMap& hchm, const std::string& indent);
-std::string oc_to_string(const Unify::HandleCHandleMap& hchm);
-std::string oc_to_string(const Unify::TypedSubstitution& ts, const std::string& indent);
-std::string oc_to_string(const Unify::TypedSubstitution& ts);
-std::string oc_to_string(const Unify::TypedSubstitutions& tss, const std::string& indent);
-std::string oc_to_string(const Unify::TypedSubstitutions& tss);
+std::string oc_to_string(const Unify::CHandle& ch,
+                         const std::string& indent=empty_string);
+std::string oc_to_string(const Unify::Block& pb,
+                         const std::string& indent=empty_string);
+std::string oc_to_string(const Unify::Partition& hshm,
+                         const std::string& indent=empty_string);
+std::string oc_to_string(const Unify::TypedBlock& tb,
+                         const std::string& indent=empty_string);
+std::string oc_to_string(const Unify::TypedBlockSeq& tbs,
+                         const std::string& indent=empty_string);
+std::string oc_to_string(const Unify::Partitions& par,
+                         const std::string& indent=empty_string);
+std::string oc_to_string(const Unify::HandleCHandleMap& hchm,
+                         const std::string& indent=empty_string);
+std::string oc_to_string(const Unify::TypedSubstitution& ts,
+                         const std::string& indent=empty_string);
+std::string oc_to_string(const Unify::TypedSubstitutions& tss,
+                         const std::string& indent=empty_string);
 	
 } // namespace opencog
 


### PR DESCRIPTION
Fixes #1740 

We can now move away from gdb-4.9 and still be able to pretty print opencog objects in gdb with `poc`, see http://wiki.opencog.org/w/Development_standards#Pretty_Print_OpenCog_Objects
