### PR TITLE
Increment Cython version to 0.23

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -340,7 +340,7 @@ ENDIF()
 
 # Cython is used to generate python bindings.
 IF(HAVE_PY_INTERP)
-	FIND_PACKAGE(Cython 0.19.0)
+	FIND_PACKAGE(Cython 0.23.0)
 
 	IF (CYTHON_FOUND AND HAVE_PY_LIBS)
 		# Find python destination dir for python bindings because it may


### PR DESCRIPTION
This is to address https://github.com/opencog/atomspace/pull/1777#issuecomment-400386859. Adding of cProtoAtomPtr into Python API requires Cython version with support of std::shared_ptr. This support was added since Cython version 0.23 (see https://github.com/cython/cython/commits/master/Cython/Includes/libcpp/memory.pxd)