### PR TITLE
#1161 Add scheme_eval_v which returns value to python

### DIFF
--- a/examples/python/values.py
+++ b/examples/python/values.py
@@ -8,9 +8,10 @@ An example of using values via Python API
 
 from opencog.atomspace import AtomSpace, TruthValue
 from opencog.type_constructors import *
+from opencog.scheme_wrapper import scheme_eval_v
 
-a = AtomSpace()
-set_type_ctor_atomspace(a)
+atomspace = AtomSpace()
+set_type_ctor_atomspace(atomspace)
 
 a = FloatValue([1.0, 2.0, 3.0])
 b = FloatValue([1.0, 2.0, 3.0])
@@ -28,3 +29,8 @@ boundingBox.set_value(featureKey, featureValue)
 print('set value to atom: {}'.format(boundingBox))
 
 print('get value from atom: {}'.format(boundingBox.get_value(featureKey)))
+
+value = scheme_eval_v(atomspace, '(ValueOf (ConceptNode "boundingBox") '
+                      '(PredicateNode "features"))')
+value = boundingBox.get_value(featureKey)
+print('get value from atom using Scheme program: {}'.format(value))

--- a/opencog/cython/opencog/PyScheme.cc
+++ b/opencog/cython/opencog/PyScheme.cc
@@ -73,6 +73,26 @@ std::string opencog::eval_scheme(AtomSpace* as, const std::string &s)
 }
 
 // Convenience wrapper, for stand-alone usage.
+ProtoAtomPtr opencog::eval_scheme_v(AtomSpace* as, const std::string &s)
+{
+#ifdef HAVE_GUILE
+	do_init();
+	OC_ASSERT(nullptr != as, "Cython failed to specify an atomspace!");
+
+	SchemeEval* evaluator = SchemeEval::get_evaluator(as);
+	ProtoAtomPtr scheme_return_value = evaluator->eval_v(s);
+
+	if (evaluator->eval_error())
+		throw RuntimeException(TRACE_INFO,
+		       "Python-Scheme Wrapper: Failed to execute '%s'", s.c_str());
+
+	return scheme_return_value;
+#else // HAVE_GUILE
+	return "Error: Compiled without Guile support";
+#endif // HAVE_GUILE
+}
+
+// Convenience wrapper, for stand-alone usage.
 Handle opencog::eval_scheme_h(AtomSpace* as, const std::string &s)
 {
 #ifdef HAVE_GUILE

--- a/opencog/cython/opencog/PyScheme.h
+++ b/opencog/cython/opencog/PyScheme.h
@@ -10,6 +10,7 @@ namespace opencog
 
 /** For easier wrapping by Cython */
 std::string eval_scheme(AtomSpace*, const std::string &);
+ProtoAtomPtr eval_scheme_v(AtomSpace*, const std::string &);
 Handle eval_scheme_h(AtomSpace*, const std::string &);
 AtomSpace* eval_scheme_as(const std::string &);
 

--- a/opencog/cython/opencog/scheme_wrapper.pyx
+++ b/opencog/cython/opencog/scheme_wrapper.pyx
@@ -11,7 +11,10 @@ Also refer to the list of .scm type definition files in opencog.conf
 """
 
 from cython.operator cimport dereference as deref
-from opencog.atomspace cimport cProtoAtomPtr, ProtoAtom, cAtomSpace, Atom, AtomSpace, cAtom, cHandle, AtomSpace_factory, void_from_candle
+from opencog.atomspace cimport (cProtoAtomPtr, ProtoAtom, cAtomSpace, 
+                                Atom, AtomSpace, cAtom, cHandle, 
+                                AtomSpace_factory, void_from_candle,
+                                createProtoAtom)
 
 
 # basic wrapping for std::string conversion
@@ -53,7 +56,7 @@ def scheme_eval_v(AtomSpace a, str pys):
     cdef string expr
     expr = pys.encode('UTF-8')
     ret = eval_scheme_v(a.atomspace, expr)
-    return ProtoAtom.from_cProtoAtomPtr(ret)
+    return createProtoAtom(ret)
 
 cdef extern from "opencog/cython/opencog/PyScheme.h" namespace "opencog":
     cHandle eval_scheme_h(cAtomSpace* as, const string& s) except +

--- a/opencog/cython/opencog/scheme_wrapper.pyx
+++ b/opencog/cython/opencog/scheme_wrapper.pyx
@@ -40,8 +40,14 @@ cdef extern from "opencog/cython/opencog/PyScheme.h" namespace "opencog":
     cProtoAtomPtr eval_scheme_v(cAtomSpace* as, const string& s) except +
 
 def scheme_eval_v(AtomSpace a, str pys):
-    """
-    Returns a ProtoAtom
+    """Evaluate Scheme program when expected result is Value.
+    Args:
+        a (AtomSpace): atomspace to work on
+        pys (str): Scheme program to evaluate
+    Returns:
+        ProtoAtom: result of a evaluation
+    Raises:
+        RuntimeError: in case of evaluation error
     """
     cdef cProtoAtomPtr ret
     cdef string expr

--- a/opencog/cython/opencog/scheme_wrapper.pyx
+++ b/opencog/cython/opencog/scheme_wrapper.pyx
@@ -11,7 +11,7 @@ Also refer to the list of .scm type definition files in opencog.conf
 """
 
 from cython.operator cimport dereference as deref
-from opencog.atomspace cimport cAtomSpace, Atom, AtomSpace, cAtom, cHandle, AtomSpace_factory, void_from_candle
+from opencog.atomspace cimport cProtoAtomPtr, ProtoAtom, cAtomSpace, Atom, AtomSpace, cAtom, cHandle, AtomSpace_factory, void_from_candle
 
 
 # basic wrapping for std::string conversion
@@ -35,6 +35,19 @@ def scheme_eval(AtomSpace a, str pys):
     # print "Debug: called scheme eval with atomspace {0:x}".format(<unsigned long int>a.atomspace)
     ret = eval_scheme(a.atomspace, expr)
     return ret.c_str()
+
+cdef extern from "opencog/cython/opencog/PyScheme.h" namespace "opencog":
+    cProtoAtomPtr eval_scheme_v(cAtomSpace* as, const string& s) except +
+
+def scheme_eval_v(AtomSpace a, str pys):
+    """
+    Returns a ProtoAtom
+    """
+    cdef cProtoAtomPtr ret
+    cdef string expr
+    expr = pys.encode('UTF-8')
+    ret = eval_scheme_v(a.atomspace, expr)
+    return ProtoAtom.from_cProtoAtomPtr(ret)
 
 cdef extern from "opencog/cython/opencog/PyScheme.h" namespace "opencog":
     cHandle eval_scheme_h(cAtomSpace* as, const string& s) except +


### PR DESCRIPTION
Issue https://github.com/opencog/atomspace/issues/1161. Add scheme_eval_v method which is analog of SchemeEval::eval_v() to evaluate Scheme code which returns values from Python.