### PR TITLE
Add FloatValue unit tests for Python API.

### DIFF
--- a/opencog/atoms/proto/FloatValue.cc
+++ b/opencog/atoms/proto/FloatValue.cc
@@ -39,7 +39,7 @@ bool FloatValue::operator==(const ProtoAtom& other) const
 		// http://www.cygnus-software.com/papers/comparingfloats/Comparing%20floating%20point%20numbers.htm
 		// if (1.0e-15 < fabs(1.0 - fov->_value[i]/_value[i])) return false;
 #define MAX_ULPS 24
-		if (MAX_ULPS < abs(*(int64_t*) &(_value[i]) - *(int64_t*)&(fov->_value[i])))
+		if (MAX_ULPS < llabs(*(int64_t*) &(_value[i]) - *(int64_t*)&(fov->_value[i])))
 			return false;
 	return true;
 }

--- a/tests/atoms/StreamUTest.cxxtest
+++ b/tests/atoms/StreamUTest.cxxtest
@@ -59,6 +59,7 @@ public:
 	void test_minus();
 	void test_divide();
 	void test_number();
+	void test_equals();
 
 	void test_chaining();
 
@@ -343,6 +344,19 @@ void StreamUTest::test_number()
 }
 
 // ====================================================================
+// Test FloatValue::operator==()
+void StreamUTest::test_equals()
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+	FloatValuePtr a = createFloatValue(1.0);
+	FloatValuePtr b = createFloatValue(2.0);
+	
+	TS_ASSERT(*a != *b);
+	
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+// ====================================================================
 // ====================================================================
 // ====================================================================
 // And now for something completely different....
@@ -410,3 +424,4 @@ void StreamUTest::test_guile()
 
 	logger().debug("END TEST: %s", __FUNCTION__);
 }
+

--- a/tests/cython/atomspace/test_floatvalue.py
+++ b/tests/cython/atomspace/test_floatvalue.py
@@ -1,0 +1,56 @@
+import unittest
+
+from opencog.atomspace import AtomSpace, TruthValue, Atom
+from opencog.type_constructors import *
+from opencog.utilities import initialize_opencog, finalize_opencog
+
+class FloatValueTest(unittest.TestCase):
+    
+    def setUp(self):
+        self.space = AtomSpace()
+        initialize_opencog(self.space)
+
+    def tearDown(self):
+        finalize_opencog()
+        del self.space
+
+    def test_create_single_float_value(self):
+        value = FloatValue(1.234)
+        self.assertTrue(value is not None)
+
+    def test_create_list_float_value(self):
+        value = FloatValue([3.21, 2.1, 1])
+        self.assertTrue(value is not None)
+    
+    def test_float_value_equals(self):
+        self.assertEqual(FloatValue(1.234), FloatValue([1.234]))
+        self.assertEqual(FloatValue([1.0, 2.0, 3.0]),
+                         FloatValue([1.0, 2.0 ,3.0]))
+        self.assertNotEqual(FloatValue(1.0), FloatValue(2.0))
+        self.assertNotEqual(FloatValue(1), FloatValue(2))
+        self.assertNotEqual(FloatValue([1.0, 2.0, 3.0]), 
+                            FloatValue([3.0, 2.0, 1.0]))
+
+    def test_add_value_to_atom(self):
+        atom = ConceptNode('foo')
+        key = PredicateNode('bar')
+        value = FloatValue([1.0, 2.0, 3.0])
+        atom.set_value(key, value)
+        self.assertEqual(FloatValue([1.0, 2.0, 3.0]), atom.get_value(key))
+
+    def test_get_list_of_items_from_value(self):
+        value = FloatValue([1.0, 2.0, 3.0])        
+        self.assertEqual([1.0, 2.0, 3.0], value.to_list())
+
+    def test_str(self):
+        value = FloatValue(1.234)
+        self.assertEqual('(FloatValue 1.234)\n', str(value))
+
+    def test_is_a(self):
+        value = FloatValue(1.234)
+        self.assertEqual(types.FloatValue, value.type)
+        self.assertEqual('FloatValue', value.type_name)
+        self.assertFalse(value.is_node())
+        self.assertFalse(value.is_atom())
+        self.assertFalse(value.is_link())
+        self.assertTrue(value.is_a(types.Value))


### PR DESCRIPTION
Continue working on issue https://github.com/opencog/atomspace/issues/1161. Add FloatValue unit tests for Python API. Fix FloatValue::operator==() issue.