### PR TITLE
#1812 Fix cython compilation issue.

### DIFF
--- a/opencog/cython/opencog/protoatom.pyx
+++ b/opencog/cython/opencog/protoatom.pyx
@@ -20,7 +20,7 @@ cdef list vector_of_strings_to_list(const vector[string]* cpp_vector):
     list = []
     it = cpp_vector.const_begin()
     while it != cpp_vector.const_end():
-        list.append(deref(it).decode('UTF-8'))
+        list.append((<bytes>deref(it).c_str()).decode('UTF-8'))
         inc(it)
     return list
 


### PR DESCRIPTION
Convert std::string to bytes explicitly before calling decode().
Fix for https://github.com/opencog/atomspace/pull/1808#issuecomment-401922293 and https://github.com/opencog/atomspace/issues/1812