### PR TITLE
Allow matching of quoted arithmetic link with unquoted args

### DIFF
--- a/opencog/atoms/core/Checkers.cc
+++ b/opencog/atoms/core/Checkers.cc
@@ -90,6 +90,9 @@ bool check_numeric(const Handle& bool_atom)
 		// Oddly enough, sets of numbers are allowed.
 		if (SET_LINK == t and check_numeric(h)) continue;
 
+		if (QUOTE_LINK == t) continue;
+		if (UNQUOTE_LINK == t) continue;
+
 		if (not h->is_type(NUMERIC_OUTPUT_LINK)) return false;
 	}
 	return true;

--- a/tests/query/QuoteUTest.cxxtest
+++ b/tests/query/QuoteUTest.cxxtest
@@ -203,7 +203,7 @@ void QuoteUTest::test_gpn_bindy(void)
 }
 
 /*
- * QuoteLink unit test.  Test proper search scope
+ * Test matching quoted TimesLink
  */
 void QuoteUTest::test_gpn_get_times_link(void)
 {

--- a/tests/query/QuoteUTest.cxxtest
+++ b/tests/query/QuoteUTest.cxxtest
@@ -64,7 +64,8 @@ public:
     void test_quoted_variable(void);
     void test_nest(void);
     void test_throw(void);
-    void test_gpn(void);
+    void test_gpn_bindy(void);
+    void test_gpn_get_times_link(void);
     void test_double_quote(void);
     void test_impossible(void);
     void test_numeric_greater(void);
@@ -183,7 +184,7 @@ void QuoteUTest::test_throw(void)
 /*
  * QuoteLink unit test.  Test proper search scope
  */
-void QuoteUTest::test_gpn(void)
+void QuoteUTest::test_gpn_bindy(void)
 {
     logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
@@ -197,6 +198,27 @@ void QuoteUTest::test_gpn(void)
     allstar = getlink(allstar, 0);
     TS_ASSERT_EQUALS(LIST_LINK, allstar->get_type());
     TS_ASSERT_EQUALS(2, getarity(allstar));
+
+    logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+/*
+ * QuoteLink unit test.  Test proper search scope
+ */
+void QuoteUTest::test_gpn_get_times_link(void)
+{
+    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+    eval->eval("(load-from-path \"tests/query/quote-gpn.scm\")");
+
+    Handle get_times_link = eval->eval_h("get-times-link");
+
+    Handle result = satisfying_set(as, get_times_link);
+    TS_ASSERT_EQUALS(1, getarity(result));
+
+    Handle times_link = getlink(result, 0);
+    TS_ASSERT_EQUALS(LIST_LINK, times_link->get_type());
+    TS_ASSERT_EQUALS(2, getarity(times_link));
 
     logger().debug("END TEST: %s", __FUNCTION__);
 }

--- a/tests/query/quote-gpn.scm
+++ b/tests/query/quote-gpn.scm
@@ -33,9 +33,8 @@
 	(NumberNode 5)
 	)
 
-; The pattern below can confuse the search start, becuase
-; the first constant link in the clause is the quote ... 
-; and that's won't provide the desired start ...
+; Pattern uses QuoteLink to match TimesLink without
+; making actual calculations
 (define get-times-link
 	(GetLink
 		(VariableList

--- a/tests/query/quote-gpn.scm
+++ b/tests/query/quote-gpn.scm
@@ -26,3 +26,27 @@
 		(VariableNode "$stuff")
 	)
 )
+
+; data to check Times matching
+(TimesLink
+	(NumberNode 3)
+	(NumberNode 5)
+	)
+
+; The pattern below can confuse the search start, becuase
+; the first constant link in the clause is the quote ... 
+; and that's won't provide the desired start ...
+(define get-times-link
+	(GetLink
+		(VariableList
+			(VariableNode "$a")
+			(VariableNode "$b")
+			)
+		(QuoteLink
+			(TimesLink
+				(UnquoteLink (VariableNode "$a"))
+				(UnquoteLink (VariableNode "$b"))
+				)
+			)
+		)
+	)


### PR DESCRIPTION
To match for example Times link without executing it one should write something like (GetLink (Variable "$A") (Quoted (Times (Unquoted (Variable "$A")) (Number 3)))). It doesn't work because arithmetic link arguments are checked to be numeric. Fixing it using check_evaluatable() as example.