### PR TITLE
Fix Atomspace Python README.md

### DIFF
--- a/tests/cython/README.md
+++ b/tests/cython/README.md
@@ -1,8 +1,20 @@
 
-HOWTO run these tests by hand:
-------------------------------
+## Preconditions
 
-You need to set up the PYTHON path:
+```nose``` Python testing framework is required.
+
+Installation using ```pip``` package manager :
+```
+pip install nose
+```
+or install it using ```conda``` package manager:
+```
+conda install nose
+```
+
+## Running tests
+
+You may need to set up the PYTHON path:
 export PYTHONPATH=${PROJECT_BINARY_DIR}/opencog/cython
 or, if installed:
 export PYTHONPATH=/usr/local/lib/python3.5/dist-packages/opencog:${PYTHON}
@@ -10,18 +22,12 @@ export PYTHONPATH=/usr/local/lib/python3.5/dist-packages/opencog:${PYTHON}
 For example:
 export PYTHONPATH=build/opencog/cython
 
-Then:
+Then from atomspace root source dir execute:
 
+```
 nosetests -vs ./tests/cython/
 nosetests -vs ./tests/cython/atomspace/
 nosetests -vs ./tests/cython/bindlink/
 nosetests -vs ./tests/cython/guile/
 nosetests -vs ./tests/cython/utilities/
-
-
-If you modify the cython bindings, you may need to manually remove
-some build files to get a clean rebuild.  Basically, the CMakefiles
-for cython/python are buggy, and fail to rebuild when changes are made.
-So:
-
-rm build/opencog/cython/opencog/pymoses.cpp
+```


### PR DESCRIPTION
Add required packages description, remove old commend about moses.cpp which is copy of https://github.com/opencog/moses/tree/master/tests/cython.