### PR TITLE
Bugfix exploration of possible glob groundings (#1825)

### DIFF
--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1607,13 +1607,6 @@ bool PatternMatchEngine::do_next_clause(void)
 		found = _pmc.grounding(var_grounding, clause_grounding);
 		DO_LOG(logger().fine("==================== FINITO! accepted=%d", found);)
 		DO_LOG(log_solution(var_grounding, clause_grounding);)
-
-		// Since the PM may move on and try to search for more solutions,
-		// clear the _glob_state here to prevent it from comparing the
-		// exact same term to the exact same candidate again.
-		// Otherwise, all possible ways to ground the globs in the term
-		// will be explored before moving to the next candidate.
-		_glob_state.clear();
 	}
 	else
 	{

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -540,7 +540,12 @@ bool PatternMatchEngine::unorder_compare(const PatternTermPtr& ptm,
 
 		if (has_glob)
 		{
+			// Each glob comparision steps the glob state forwards.
+			// Each different permutation has to start with the
+			// same glob state as before. So save and restore state.
+			std::map<GlobPair, GlobState> saved_glob_state = _glob_state;
 			match = glob_compare(mutation, osg);
+			_glob_state = saved_glob_state;
 		}
 		else
 		{

--- a/tests/query/GlobUTest.cxxtest
+++ b/tests/query/GlobUTest.cxxtest
@@ -75,6 +75,7 @@ _exit(rc); // XXX hack to avoid double-free in __run_exit_handlers
 	void test_glob_multiple(void);
 	void test_nest(void);
 	void test_gnest(void);
+	void test_partition(void);
 };
 
 void GlobUTest::tearDown(void)
@@ -552,7 +553,7 @@ void GlobUTest::test_gnest(void)
 	eval->eval("(load-from-path \"tests/query/glob-nest.scm\")");
 
 	Handle four = eval->eval_h("(cog-execute! get-four)");
-	printf("nested %s\n", four->to_string().c_str());
+	printf("g-nested got %s\n", four->to_string().c_str());
 	TS_ASSERT_EQUALS(4, four->get_arity());
 
 	// "two" should not be found.
@@ -561,6 +562,86 @@ void GlobUTest::test_gnest(void)
 	);
 	TS_ASSERT_EQUALS(four, response);
 
+	// ----
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+/*
+ * Test partitioning of list of like items.
+ * Issue #1825
+ */
+void GlobUTest::test_partition(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	eval->eval("(load-from-path \"tests/query/glob-partition.scm\")");
+
+	Handle parts = eval->eval_h("(cog-execute! partition)");
+	printf("party got %s\n", parts->to_string().c_str());
+	TS_ASSERT_EQUALS(4, parts->get_arity());
+
+	Handle response = eval->eval_h(
+		"(SetLink"
+		"	(OrderedLink"
+		"		(ConceptNode \"begin\")"
+		"		(ConceptNode \"foo\")"
+		"		(ConceptNode \"foo\")"
+		"		(ConceptNode \"foo\")"
+		"		(ConceptNode \"end\"))"
+		"	(OrderedLink"
+		"		(ConceptNode \"begin\")"
+		"		(ConceptNode \"foo\")"
+		"		(ConceptNode \"foo\")"
+		"		(ConceptNode \"end\")"
+		"		(ConceptNode \"foo\"))"
+		"	(OrderedLink"
+		"		(ConceptNode \"begin\")"
+		"		(ConceptNode \"foo\")"
+		"		(ConceptNode \"end\")"
+		"		(ConceptNode \"foo\")"
+		"		(ConceptNode \"foo\"))"
+		"	(OrderedLink"
+		"		(ConceptNode \"begin\")"
+		"		(ConceptNode \"end\")"
+		"		(ConceptNode \"foo\")"
+		"		(ConceptNode \"foo\")"
+		"		(ConceptNode \"foo\")))"
+	);
+	TS_ASSERT_EQUALS(parts, response);
+
+	// -----------
+	parts = eval->eval_h("(cog-execute! part-deeper)");
+	printf("party got %s\n", parts->to_string().c_str());
+	TS_ASSERT_EQUALS(4, parts->get_arity());
+
+	response = eval->eval_h(
+		"(SetLink"
+		"	(OrderedLink"
+		"		(ConceptNode \"begin\")"
+		"		(ConceptNode \"bar\")"
+		"		(ConceptNode \"bar\")"
+		"		(ConceptNode \"bar\")"
+		"		(ConceptNode \"end\"))"
+		"	(OrderedLink"
+		"		(ConceptNode \"begin\")"
+		"		(ConceptNode \"bar\")"
+		"		(ConceptNode \"bar\")"
+		"		(ConceptNode \"end\")"
+		"		(ConceptNode \"bar\"))"
+		"	(OrderedLink"
+		"		(ConceptNode \"begin\")"
+		"		(ConceptNode \"bar\")"
+		"		(ConceptNode \"end\")"
+		"		(ConceptNode \"bar\")"
+		"		(ConceptNode \"bar\"))"
+		"	(OrderedLink"
+		"		(ConceptNode \"begin\")"
+		"		(ConceptNode \"end\")"
+		"		(ConceptNode \"bar\")"
+		"		(ConceptNode \"bar\")"
+		"		(ConceptNode \"bar\")))"
+	);
+	TS_ASSERT_EQUALS(parts, response);
 	// ----
 	logger().debug("END TEST: %s", __FUNCTION__);
 }

--- a/tests/query/glob-partition.scm
+++ b/tests/query/glob-partition.scm
@@ -1,0 +1,55 @@
+;
+; Reported in issue #1825
+;
+(define partition
+
+(BindLink
+	(VariableList
+		(TypedVariableLink
+			(GlobNode "$begin")
+			(IntervalLink (NumberNode 0) (NumberNode -1)))
+		(TypedVariableLink
+			(GlobNode "$end")
+			(IntervalLink (NumberNode 0) (NumberNode -1))))
+
+	; The Concept foo should be found in four different locations.
+	(List
+		(GlobNode "$begin")
+		(Concept "foo")
+		(GlobNode "$end"))
+	(OrderedLink
+		(Concept "begin")
+		(GlobNode "$begin")
+		(Concept "end")
+		(GlobNode "$end")))
+)
+
+; Data
+(List (Concept "foo")(Concept "foo")(Concept "foo")(Concept "foo"))
+
+; ----------------------------------------------------
+(define part-deeper
+
+(BindLink
+	(VariableList
+		(TypedVariableLink
+			(GlobNode "$begin")
+			(IntervalLink (NumberNode 0) (NumberNode -1)))
+		(TypedVariableLink
+			(GlobNode "$end")
+			(IntervalLink (NumberNode 0) (NumberNode -1))))
+
+	; The Concept foo should be found in four different locations.
+	(List (List
+		(GlobNode "$begin")
+		(Concept "bar")
+		(GlobNode "$end")))
+	(OrderedLink
+		(Concept "begin")
+		(GlobNode "$begin")
+		(Concept "end")
+		(GlobNode "$end")))
+)
+
+; Data
+(List (List (Concept "bar")(Concept "bar")(Concept "bar")(Concept "bar")))


### PR DESCRIPTION
This fixes #1825 -- its a three-line fix; the glob state needs to be saved on stack, and restored.