### PR TITLE
A DontExecLink fix

### DIFF
--- a/tests/query/DontExecUTest.cxxtest
+++ b/tests/query/DontExecUTest.cxxtest
@@ -63,6 +63,7 @@ public:
 	void tearDown();
 
 	void test_DontExecLink_simple();
+	void test_DontExecLink_multi();
 	void test_DontExecLink_consumption();
 };
 
@@ -101,6 +102,26 @@ void DontExecUTest::test_DontExecLink_simple()
 	logger().debug() << "put expected = " << oc_to_string(band);
 
 	TS_ASSERT_EQUALS(put_band, band);
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+/**
+ * Test that DontExecLink are properly consumed, even when
+ * wrapped in a set.
+ */
+void DontExecUTest::test_DontExecLink_multi()
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+	eval.eval("(load-from-path \"tests/query/dont-exec-simple.scm\")");
+
+	Handle got = eval.eval_h("(cog-execute! put-eval)");
+	Handle want = eval.eval_h("eval-expected");
+
+	TS_ASSERT_EQUALS(got, want);
+
+	logger().debug() << "put-multi result = " << oc_to_string(got);
+	logger().debug() << "put-multi expected = " << oc_to_string(want);
+
 	logger().debug("END TEST: %s", __FUNCTION__);
 }
 

--- a/tests/query/dont-exec-simple.scm
+++ b/tests/query/dont-exec-simple.scm
@@ -10,3 +10,23 @@
 (define put-and
 	(Put (DontExec (AndLink (Variable "$x")(Variable "$y")))
 		(ListLink (Concept "a") (Concept "b"))))
+
+; A multi-argument put whose EvaluationLink should not evaluate
+(define put-eval
+	(Put (DontExec (EvaluationLink
+			(PredicateNode "foo")
+			(Variable "$x")
+			(Variable "$y")
+			(Variable "$z")))
+		(SetLink
+			(ListLink (Concept "a") (Concept "b") (Concept "c"))
+			(ListLink (Concept "d") (Concept "e") (Concept "f"))
+			(ListLink (Concept "g") (Concept "h") (Concept "i"))
+			(ListLink (Concept "j") (Concept "k") (Concept "l")))))
+
+; The result we expect from the above
+(define eval-expected (SetLink
+	(Evaluation (Predicate "foo") (Concept "a") (Concept "b") (Concept "c"))
+	(Evaluation (Predicate "foo") (Concept "d") (Concept "e") (Concept "f"))
+	(Evaluation (Predicate "foo") (Concept "g") (Concept "h") (Concept "i"))
+	(Evaluation (Predicate "foo") (Concept "j") (Concept "k") (Concept "l"))))


### PR DESCRIPTION
The simple case worked fine. The variant that was encountered inside a SetLink was not.