### PR TITLE
fix minor cython c string compile error

### DIFF
--- a/opencog/cython/opencog/nameserver.pyx
+++ b/opencog/cython/opencog/nameserver.pyx
@@ -15,7 +15,7 @@ cdef c_get_type_name(Type t):
     s = nameserver().getTypeName(t)
 
     if 0 == strcmp(s.c_str(), "*** Unknown Type! ***") :
-        s = string("")
+        s = string(b"")
     return s.c_str()
 
 # Given the string name, look up the numeric type.


### PR DESCRIPTION
according to [the cython doc](http://docs.cython.org/en/latest/src/tutorial/strings.html) one needs to either specify the encoding or use a python string. 