### PR TITLE
Catch and rethrow asynchronous database exceptions

### DIFF
--- a/opencog/persist/sql/multi-driver/SQLAtomLoad.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomLoad.cc
@@ -157,6 +157,7 @@ Handle SQLAtomStorage::doGetNode(Type t, const char * str)
 
 Handle SQLAtomStorage::getNode(Type t, const char * str)
 {
+	rethrow();
 	Handle h(doGetNode(t, str));
 	if (h) get_atom_values(h);
 	return h;
@@ -210,6 +211,7 @@ Handle SQLAtomStorage::doGetLink(Type t, const HandleSeq& hseq)
 
 Handle SQLAtomStorage::getLink(Type t, const HandleSeq& hs)
 {
+	rethrow();
 	Handle hg(doGetLink(t, hs));
 	if (hg) get_atom_values(hg);
 	return hg;

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
@@ -190,6 +190,15 @@ bool SQLAtomStorage::connected(void)
 	return have_connection;
 }
 
+/// Rethrow asynchronous exceptions caught during atom storage.
+///
+/// Atoms are stored asynchronously, from a write queue, from some
+/// other thread. If that thread has an exception, e.g. due to some
+/// SQL error, and the exception is uncaught, then the process will
+/// die. So we have to catch that exception.  Once caught, what do
+/// we do with it? Well, we culd ignore it, but then the user would
+/// not know that the SQL backend was damaged. So, instead, we throw
+/// it at the first user, any user that is doing soem other SQL stuff.
 void SQLAtomStorage::rethrow(void)
 {
 	if (_async_write_queue_exception)

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
@@ -220,7 +220,9 @@ void SQLAtomStorage::rethrow(void)
 ///
 void SQLAtomStorage::flushStoreQueue()
 {
+	rethrow();
 	_write_queue.barrier();
+	rethrow();
 }
 
 /* ================================================================ */
@@ -290,6 +292,7 @@ void SQLAtomStorage::create_tables(void)
  */
 void SQLAtomStorage::kill_data(void)
 {
+	rethrow();
 	Response rp(conn_pool);
 
 	// See the file "atom.sql" for detailed documentation as to the

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.h
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.h
@@ -234,6 +234,8 @@ class SQLAtomStorage : public AtomStorage
 		// Provider of asynchronous store of atoms.
 		// async_caller<SQLAtomStorage, Handle> _write_queue;
 		async_buffer<SQLAtomStorage, Handle> _write_queue;
+		std::exception_ptr _async_write_queue_exception;
+		void rethrow(void);
 
 	public:
 		SQLAtomStorage(std::string uri);

--- a/opencog/persist/sql/multi-driver/SQLAtomStore.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStore.cc
@@ -110,8 +110,15 @@ int SQLAtomStorage::do_store_atom(const Handle& h)
 
 void SQLAtomStorage::vdo_store_atom(const Handle& h)
 {
-	if (not_yet_stored(h)) do_store_atom(h);
-	store_atom_values(h);
+	try
+	{
+		if (not_yet_stored(h)) do_store_atom(h);
+		store_atom_values(h);
+	}
+	catch (...)
+	{
+		_async_write_queue_exception = std::current_exception();
+	}
 }
 
 /* ================================================================ */

--- a/opencog/persist/sql/multi-driver/SQLAtomStore.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStore.cc
@@ -67,6 +67,8 @@ using namespace opencog;
  */
 void SQLAtomStorage::storeAtom(const Handle& h, bool synchronous)
 {
+	rethrow();
+
 	// If a synchronous store, avoid the queues entirely.
 	if (synchronous)
 	{

--- a/opencog/persist/sql/multi-driver/SQLBulk.cc
+++ b/opencog/persist/sql/multi-driver/SQLBulk.cc
@@ -87,6 +87,8 @@ void SQLAtomStorage::getIncoming(AtomTable& table, const char *buff)
  */
 void SQLAtomStorage::getIncomingSet(AtomTable& table, const Handle& h)
 {
+	rethrow();
+
 	// If the uuid is not known, then the atom is not in storage,
 	// and therefore, cannot have an incoming set.  Just return.
 	UUID uuid = check_uuid(h);
@@ -113,6 +115,8 @@ void SQLAtomStorage::getIncomingSet(AtomTable& table, const Handle& h)
  */
 void SQLAtomStorage::getIncomingByType(AtomTable& table, const Handle& h, Type t)
 {
+	rethrow();
+
 	// If the uuid is not known, then the atom is not in storage,
 	// and therefore, cannot have an incoming set.  Just return.
 	UUID uuid = check_uuid(h);
@@ -141,6 +145,7 @@ int SQLAtomStorage::getMaxObservedHeight(void)
 
 void SQLAtomStorage::load(AtomTable &table)
 {
+	rethrow();
 	UUID max_nrec = getMaxObservedUUID();
 	_load_count = 0;
 	max_height = getMaxObservedHeight();
@@ -198,6 +203,8 @@ void SQLAtomStorage::load(AtomTable &table)
 
 void SQLAtomStorage::loadType(AtomTable &table, Type atom_type)
 {
+	rethrow();
+
 	UUID max_nrec = getMaxObservedUUID();
 	_load_count = 0;
 
@@ -257,6 +264,8 @@ void SQLAtomStorage::loadType(AtomTable &table, Type atom_type)
 /// Store all of the atoms in the atom table.
 void SQLAtomStorage::store(const AtomTable &table)
 {
+	rethrow();
+
 	max_height = 0;
 	_store_count = 0;
 

--- a/opencog/persist/sql/multi-driver/SQLValues.cc
+++ b/opencog/persist/sql/multi-driver/SQLValues.cc
@@ -495,6 +495,8 @@ void SQLAtomStorage::get_atom_values(Handle& atom)
 void SQLAtomStorage::getValuations(AtomTable& table,
                                    const Handle& key, bool get_all_values)
 {
+	rethrow();
+
 	// If the uuid of the key is not known, the key does not exist
 	// in the database; therefore, there are no values. Just return.
 	UUID kuid = check_uuid(key);

--- a/opencog/persist/sql/multi-driver/ll-pg-cxx.cc
+++ b/opencog/persist/sql/multi-driver/ll-pg-cxx.cc
@@ -111,10 +111,18 @@ LLPGConnection::exec(const char * buff, bool trial_run)
 			throw opencog::SilentException();
 		}
 
-		std::string msg = "PQresult message: ";
-		msg += PQresultErrorMessage(rs->_result);
-		msg += "\nPQ query was: ";
-		msg += buff;
+		std::string msg;
+		if (PQstatus(_pgconn) != CONNECTION_OK)
+		{
+			msg = "No connection to the database!";
+		}
+		else
+		{
+			msg = "PQresult message: ";
+			msg += PQresultErrorMessage(rs->_result);
+			msg += "\nPQ query was: ";
+			msg += buff;
+		}
 		rs->release();
 
 		opencog::logger().warn("%s", msg.c_str());

--- a/opencog/persist/sql/multi-driver/llapi.cc
+++ b/opencog/persist/sql/multi-driver/llapi.cc
@@ -45,9 +45,6 @@
 
 #include "llapi.h"
 
-#define PERR(...) \
-    throw opencog::RuntimeException(TRACE_INFO, __VA_ARGS__);
-
 /* =========================================================== */
 
 LLConnection::LLConnection(void)


### PR DESCRIPTION
Prior to this, any asynchronous exception thrown by the write queues caused the process to exit.

After this, the exception will be rethrown to someone who can deal with it.