### PR TITLE
Fix build for unusual protobuf environments

### DIFF
--- a/opencog/persist/zmq/atomspace/CMakeLists.txt
+++ b/opencog/persist/zmq/atomspace/CMakeLists.txt
@@ -1,12 +1,13 @@
 # The atom_types.h file is written to the build directory
 INCLUDE_DIRECTORIES (
 	${CMAKE_BINARY_DIR}
+	${PROTOBUF_INCLUDE_DIR}
 )
 
 # Generate the .pb.h and .pb.cc files dynamically.
 ADD_CUSTOM_COMMAND(
 	OUTPUT ZMQMessages.pb.h ZMQMessages.pb.cc
-	COMMAND protoc
+	COMMAND ${PROTOBUF_PROTOC_EXECUTABLE}
 	ARGS --cpp_out=. -I ${CMAKE_CURRENT_SOURCE_DIR}
 		${CMAKE_CURRENT_SOURCE_DIR}/ZMQMessages.proto
 	DEPENDS ZMQMessages.proto


### PR DESCRIPTION
Use ```protoc``` executable and Protobuf include path found by Protobuf
cmake module instead of relying that they are located in standard places.