### PR TITLE
Fix for running VectorAPIUTest before 'make install'

### DIFF
--- a/tests/matrix/VectorAPIUTest.cxxtest
+++ b/tests/matrix/VectorAPIUTest.cxxtest
@@ -106,7 +106,11 @@ void VectorAPIUTest::setUp(void)
 	eval->clear_pending();
 
 	eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+	CHKERR;
 	eval->eval("(add-to-load-path \"../../..\")");
+	CHKERR;
+	eval->eval("(add-to-load-path \"" PROJECT_BINARY_DIR "/opencog/scm\")");
+	CHKERR;
 
 	eval->eval("(load-from-path \"tests/query/test_types.scm\")");
 	CHKERR;


### PR DESCRIPTION
Depends on opencog/cogutil#123 which handles copying scm files instead of making symlinks.

Fixes #1834.