### PR TITLE
Add opencog test runner that works with ctest

### DIFF
--- a/opencog/scm/CMakeLists.txt
+++ b/opencog/scm/CMakeLists.txt
@@ -41,6 +41,7 @@ INSTALL (FILES
 	opencog/persist.scm
 	opencog/query.scm
 	opencog/rule-engine.scm
+	opencog/test-runner.scm
 	DESTINATION "${DATADIR}/scm/opencog"
 )
 

--- a/opencog/scm/opencog/base/utilities.scm
+++ b/opencog/scm/opencog/base/utilities.scm
@@ -62,7 +62,6 @@
 ;
 
 (use-modules (srfi srfi-1))
-(use-modules (srfi srfi-64))  ; For opencog-test-runner
 (use-modules (ice-9 threads))  ; needed for par-map par-for-each
 
 ; See below; the compiler step is not needed for guile-2.1
@@ -1277,49 +1276,6 @@
   (let* ((subtypes (cog-get-subtypes atom-type))
          (rec-subtypes (map cog-get-all-subtypes subtypes)))
     (delete-duplicates (append subtypes (apply append rec-subtypes)))))
-
-; -----------------------------------------------------------------------
-; NOTE This is not exported because it is only used for testing and
-; is not part of the opencog api.
-(define (opencog-test-runner)
-"
-  opencog-test-runner
-
-  Sets a new test-runner that is based on test-runner-simple, by wrapping
-  test-on-final-simple so as to return non-zero exit codes when
-  there are test failures. This allows cmake's ctest to report the failures
-  properly, provided (test-end) is called.
-
-  Since it is not exported for using the runner follow the follwing pattern
-  in test-scripts
-
-    ((@@ (opencog) opencog-test-runner))
-
-    (test-begin \"Name of the test suite\")
-    (test-assert ...)
-    ...
-    ...
-    (test-end \"Name of the test suite\")
-    ; Any code written after 'test-end' is called will not be run as
-    ; 'test-end calls 'exit'.
-
-  For details on the apis for writing srfi-64 test-suites see
-  https://srfi.schemers.org/srfi-64/srfi-64.html
-"
-  (define (new-final)
-    (lambda (runner)
-      ((test-runner-on-final (test-runner-simple)) runner)
-      (display "%%%% Exiting test suite\n")
-      (exit (+ (test-runner-fail-count runner)
-               (test-runner-xfail-count runner)))))
-
-  (let ((runner (test-runner-simple)))
-    (test-runner-on-final! runner (new-final))
-
-    ; Set the new runner as the default factory
-    (test-runner-factory (lambda () runner))
-  )
-)
 
 ; -----------------------------------------------------------------------
 

--- a/opencog/scm/opencog/base/utilities.scm
+++ b/opencog/scm/opencog/base/utilities.scm
@@ -1303,13 +1303,13 @@
     ; Any code written after 'test-end' is called will not be run as
     ; 'test-end calls 'exit'.
 
-  For details on the apis for writing srfi-64 test-suite see
+  For details on the apis for writing srfi-64 test-suites see
   https://srfi.schemers.org/srfi-64/srfi-64.html
 "
   (define (new-final)
     (lambda (runner)
       ((test-runner-on-final (test-runner-simple)) runner)
-      (display "%%%% Exiting test suite \n")
+      (display "%%%% Exiting test suite\n")
       (exit (+ (test-runner-fail-count runner)
                (test-runner-xfail-count runner)))))
 

--- a/opencog/scm/opencog/base/utilities.scm
+++ b/opencog/scm/opencog/base/utilities.scm
@@ -62,6 +62,7 @@
 ;
 
 (use-modules (srfi srfi-1))
+(use-modules (srfi srfi-64))  ; For opencog-test-runner
 (use-modules (ice-9 threads))  ; needed for par-map par-for-each
 
 ; See below; the compiler step is not needed for guile-2.1
@@ -1276,6 +1277,49 @@
   (let* ((subtypes (cog-get-subtypes atom-type))
          (rec-subtypes (map cog-get-all-subtypes subtypes)))
     (delete-duplicates (append subtypes (apply append rec-subtypes)))))
+
+; -----------------------------------------------------------------------
+; NOTE This is not exported because it is only used for testing and
+; is not part of the opencog api.
+(define (opencog-test-runner)
+"
+  opencog-test-runner
+
+  Sets a new test-runner that is based on test-runner-simple, by wrapping
+  test-on-final-simple so as to return non-zero exit codes when
+  there are test failures. This allows cmake's ctest to report the failures
+  properly, provided (test-end) is called.
+
+  Since it is not exported for using the runner follow the follwing pattern
+  in test-scripts
+
+    ((@@ (opencog) opencog-test-runner))
+
+    (test-begin \"Name of the test suite\")
+    (test-assert ...)
+    ...
+    ...
+    (test-end \"Name of the test suite\")
+    ; Any code written after 'test-end' is called will not be run as
+    ; 'test-end calls 'exit'.
+
+  For details on the apis for writing srfi-64 test-suite see
+  https://srfi.schemers.org/srfi-64/srfi-64.html
+"
+  (define (new-final)
+    (lambda (runner)
+      ((test-runner-on-final (test-runner-simple)) runner)
+      (display "%%%% Exiting test suite \n")
+      (exit (+ (test-runner-fail-count runner)
+               (test-runner-xfail-count runner)))))
+
+  (let ((runner (test-runner-simple)))
+    (test-runner-on-final! runner (new-final))
+
+    ; Set the new runner as the default factory
+    (test-runner-factory (lambda () runner))
+  )
+)
 
 ; -----------------------------------------------------------------------
 

--- a/opencog/scm/opencog/test-runner.scm
+++ b/opencog/scm/opencog/test-runner.scm
@@ -1,0 +1,43 @@
+(define-module (opencog test-runner)
+  #:use-module (srfi srfi-64)
+  #:export (opencog-test-runner))
+
+(define (opencog-test-runner)
+"
+  opencog-test-runner
+
+  Sets a new test-runner that is based on test-runner-simple, by wrapping
+  test-on-final-simple so as to return non-zero exit codes when
+  there are test failures. This allows cmake's ctest to report the failures
+  properly, provided (test-end) is called.
+
+  For using the runner follow the following pattern in test-scripts
+
+    (opencog-test-runner)
+
+    (test-begin \"Name of the test suite\")
+    (test-assert ...)
+    ...
+    ...
+    (test-end \"Name of the test suite\")
+    ; Any code written after 'test-end' is called will not be run as
+    ; 'test-end calls 'exit'.
+
+  For details on the apis for writing srfi-64 test-suites see
+  https://srfi.schemers.org/srfi-64/srfi-64.html
+"
+  (define (new-final)
+    (lambda (runner)
+      ((test-runner-on-final (test-runner-simple)) runner)
+      (display "%%%% Exiting test suite\n")
+      (exit (+ (test-runner-fail-count runner)
+               (test-runner-xfail-count runner)))))
+
+  (let ((runner (test-runner-simple)))
+    (test-runner-on-final! runner (new-final))
+
+    ; Set the factory for the new runner.
+    (test-runner-factory (lambda () runner))
+  )
+)
+

--- a/tests/scm/CMakeLists.txt
+++ b/tests/scm/CMakeLists.txt
@@ -27,6 +27,7 @@ ADD_CXXTEST(SCMExecutionOutputUTest)
 
 ADD_GUILE_TEST(SCMOpenogTestRunnerPass scm-opencog-test-runner-pass.scm)
 ADD_GUILE_TEST(SCMOpenogTestRunnerFail scm-opencog-test-runner-fail.scm)
-# The SCMOpenogTestRunnerFail fails purposely as it is testing that the runner
-# exits properly and thus flipping the result by setting the properties below.
+# The SCMOpenogTestRunnerFail fails purposely, as it is testing that the
+# scheme opencog-test-runner exits properly; thus requiring the flipping
+# of the test result by setting its properties.
 SET_TESTS_PROPERTIES(SCMOpenogTestRunnerFail PROPERTIES WILL_FAIL TRUE)

--- a/tests/scm/CMakeLists.txt
+++ b/tests/scm/CMakeLists.txt
@@ -24,3 +24,9 @@ ADD_CXXTEST(MultiAtomSpaceUTest)
 ADD_CXXTEST(MultiThreadUTest)
 ADD_CXXTEST(SCMUtilsUTest)
 ADD_CXXTEST(SCMExecutionOutputUTest)
+
+ADD_GUILE_TEST(SCMOpenogTestRunnerPass scm-opencog-test-runner-pass.scm)
+ADD_GUILE_TEST(SCMOpenogTestRunnerFail scm-opencog-test-runner-fail.scm)
+# The SCMOpenogTestRunnerFail fails purposely as it is testing that the runner
+# exits properly and thus flipping the result by setting the properties below.
+SET_TESTS_PROPERTIES(SCMOpenogTestRunnerFail PROPERTIES WILL_FAIL TRUE)

--- a/tests/scm/scm-opencog-test-runner-fail.scm
+++ b/tests/scm/scm-opencog-test-runner-fail.scm
@@ -1,0 +1,10 @@
+((@@ (opencog) opencog-test-runner))
+
+(define t "opencog-test-runner-fail")
+
+; Test that exit value is propageted correctly on fail.
+(test-begin t)
+
+(test-assert "Failing-test" #f)
+
+(test-end t)

--- a/tests/scm/scm-opencog-test-runner-fail.scm
+++ b/tests/scm/scm-opencog-test-runner-fail.scm
@@ -1,5 +1,6 @@
-((@@ (opencog) opencog-test-runner))
+(use-modules (opencog test-runner))
 
+(opencog-test-runner)
 (define t "opencog-test-runner-fail")
 
 ; Test that exit value is propageted correctly on fail.

--- a/tests/scm/scm-opencog-test-runner-pass.scm
+++ b/tests/scm/scm-opencog-test-runner-pass.scm
@@ -1,5 +1,6 @@
-((@@ (opencog) opencog-test-runner))
+(use-modules (opencog test-runner))
 
+(opencog-test-runner)
 (define t "opencog-test-runner-pass")
 
 ; Test that exit value is propageted correctly on pass.

--- a/tests/scm/scm-opencog-test-runner-pass.scm
+++ b/tests/scm/scm-opencog-test-runner-pass.scm
@@ -1,0 +1,10 @@
+((@@ (opencog) opencog-test-runner))
+
+(define t "opencog-test-runner-pass")
+
+; Test that exit value is propageted correctly on pass.
+(test-begin t)
+
+(test-assert "Passing-test" #t)
+
+(test-end t)


### PR DESCRIPTION
This makes it easy to write scheme tests without having to write c++ codes. See included unit tests for examples.

Depends on https://github.com/opencog/cogutil/pull/131