### PR TITLE
Unit test for EvaluationLink retaining default TV in pattern matcher

### DIFF
--- a/tests/query/CMakeLists.txt
+++ b/tests/query/CMakeLists.txt
@@ -42,6 +42,7 @@ IF (HAVE_GUILE)
 	ADD_CXXTEST(ImplicationUTest)
 	ADD_CXXTEST(ExecutionOutputUTest)
 	ADD_CXXTEST(BindTVUTest)
+	ADD_CXXTEST(EvalLinkDefaultTVUTest)
 	ADD_CXXTEST(BuggyStackUTest)
 	ADD_CXXTEST(VarTypeNotUTest)
 	ADD_CXXTEST(BuggyNotUTest)
@@ -185,3 +186,5 @@ CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/tests/query/ill-put.scm
     ${PROJECT_BINARY_DIR}/tests/query/ill-put.scm)
 CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/tests/query/implication-introduction.scm
     ${PROJECT_BINARY_DIR}/tests/query/implication-introduction.scm)
+CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/tests/query/eval-default-tv.scm
+    ${PROJECT_BINARY_DIR}/tests/query/eval-default-tv.scm)

--- a/tests/query/EvalLinkDefaultTVUTest.cxxtest
+++ b/tests/query/EvalLinkDefaultTVUTest.cxxtest
@@ -30,6 +30,16 @@
 using namespace opencog;
 
 
+/*
+ * Test that it is possible to modify truth value
+ * of virtual EvaluationLink from with the grounded predicate.
+ * Also test that pattern matcher does not override the value set in
+ * the grounded predicate with the value returned.
+ * This behavior is necessary if one wants to process EvaluationLinks with
+ * truth values < 0.5 in URE since pattern matcher would dismiss such evaluation link.
+ * See the discurssion at https://github.com/opencog/atomspace/issues/1868
+ */
+
 class EvalLinkDefaultTVUTest: public CxxTest::TestSuite
 {
 private:

--- a/tests/query/EvalLinkDefaultTVUTest.cxxtest
+++ b/tests/query/EvalLinkDefaultTVUTest.cxxtest
@@ -1,0 +1,74 @@
+/*
+ * tests/query/EvalLinkDefaultTVUTest.cxxtest
+ *
+ * Copyright (C) 2018 SingularityNet Foundation
+ * All Rights Reserved
+ *
+ * Authors: Anatoly Belikov
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/guile/SchemeEval.h>
+#include <opencog/atomspace/AtomSpace.h>
+#include <opencog/query/BindLinkAPI.h>
+#include <opencog/util/Logger.h>
+
+using namespace opencog;
+
+
+class EvalLinkDefaultTVUTest: public CxxTest::TestSuite
+{
+private:
+	AtomSpace * as;
+	SchemeEval * eval;
+public:
+	EvalLinkDefaultTVUTest(){
+		logger().set_level(Logger::DEBUG);
+		logger().set_print_to_stdout_flag(true);
+		this->as = new AtomSpace();
+		this->eval = new SchemeEval(as);
+		this->eval->eval("(use-modules (opencog query))");
+		this->eval->eval("(use-modules (opencog exec))");
+		eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+	}
+
+	~EvalLinkDefaultTVUTest(){
+		delete this->eval;
+		delete this->as;
+
+		// Erase the log file if no assertions failed.
+		if (!CxxTest::TestTracker::tracker().suiteFailed())
+			std::remove(logger().get_filename().c_str());
+		int rc = CxxTest::TestTracker::tracker().suiteFailed();
+		_exit(rc); // XXX hack to avoid double-free in __run_exit_handlers
+	}
+
+	void test_query_evallink(){
+		logger().debug("BEGIN TEST: %s", __FUNCTION__);
+		this->eval->eval("(load-from-path \"tests/query/eval-default-tv.scm\")");	
+		Handle query = eval->eval_h("query");
+		Handle answers = bindlink(as, query); 
+		Handle answer = answers->getOutgoingAtom(0);
+		TruthValuePtr stv = answer->getTruthValue();
+		float strengh = stv->get_mean();
+		float confidence = stv->get_confidence();
+		float expected_strength = 1;
+		float expected_confidence = 0;
+		TS_ASSERT_EQUALS(strengh, expected_strength);
+		TS_ASSERT_EQUALS(confidence, expected_confidence);
+	}
+};

--- a/tests/query/EvalLinkDefaultTVUTest.cxxtest
+++ b/tests/query/EvalLinkDefaultTVUTest.cxxtest
@@ -63,6 +63,8 @@ public:
 		Handle query = eval->eval_h("query");
 		Handle answers = bindlink(as, query); 
 		Handle answer = answers->getOutgoingAtom(0);
+		int num_results = answers->getOutgoingSet().size();
+		TS_ASSERT_EQUALS(num_results, 1);
 		TruthValuePtr stv = answer->getTruthValue();
 		float strengh = stv->get_mean();
 		float confidence = stv->get_confidence();

--- a/tests/query/eval-default-tv.scm
+++ b/tests/query/eval-default-tv.scm
@@ -1,4 +1,5 @@
-
+;see comment section in EvalLinkDefaultTVUTest.cxxtest 
+;see the discurssion at https://github.com/opencog/atomspace/issues/1868
 
 (define (check-color object color)
     (if (string=? (cog-name object) "RedItem")

--- a/tests/query/eval-default-tv.scm
+++ b/tests/query/eval-default-tv.scm
@@ -1,25 +1,33 @@
 
 
-(define (redness node)
-    (stv 0.55 0.55)
+(define (check-color object color)
+    (if (string=? (cog-name object) "RedItem")
+        (stv 0.55 0.55)
+        (stv 0.45 0.45))
 )
 
 (define red-thing (ConceptNode "RedItem"))
+(define tr-thing (ConceptNode "TransparentItem"))
 
 (Inheritance (stv 1.0 0.999) red-thing (ConceptNode "colored"))
+(Inheritance (stv 1.0 0.999) tr-thing (ConceptNode "colored"))
+(Inheritance (stv 1.0 0.999) (ConceptNode "Red") (ConceptNode "Color"))
 
-(define is-red 
+(define has-color
         (EvaluationLink
-            (GroundedPredicateNode "scm:redness")
-            (VariableNode "$X")
+            (GroundedPredicateNode "scm:check-color")
+            (ListLink (VariableNode "$X")
+                      (VariableNode "$C"))
         )
 )
+
 
 (define query
     (BindLink
         (AndLink
-           (InheritanceLink (VariableNode "$X") (ConceptNode "colored"))
-           is-red
+          (InheritanceLink (VariableNode "$X") (ConceptNode "colored"))
+          (InheritanceLink (VariableNode "$C") (ConceptNode "Color"))
+          has-color
         )
-    is-red)
-) 
+    has-color)
+)

--- a/tests/query/eval-default-tv.scm
+++ b/tests/query/eval-default-tv.scm
@@ -1,0 +1,25 @@
+
+
+(define (redness node)
+    (stv 0.55 0.55)
+)
+
+(define red-thing (ConceptNode "RedItem"))
+
+(Inheritance (stv 1.0 0.999) red-thing (ConceptNode "colored"))
+
+(define is-red 
+        (EvaluationLink
+            (GroundedPredicateNode "scm:redness")
+            (VariableNode "$X")
+        )
+)
+
+(define query
+    (BindLink
+        (AndLink
+           (InheritanceLink (VariableNode "$X") (ConceptNode "colored"))
+           is-red
+        )
+    is-red)
+) 


### PR DESCRIPTION
Run cog-execute! with BindLink returning virtual evaluation link, check that returned evaluation link retains default truth value. See the discussion in issue #1868