### PR TITLE
Overload oc_to_string for HandleMap::value_type

### DIFF
--- a/opencog/atoms/base/Handle.cc
+++ b/opencog/atoms/base/Handle.cc
@@ -207,6 +207,16 @@ std::string oc_to_string(const HandleMap& hmap, const std::string& indent)
 	return ss.str();
 }
 
+std::string oc_to_string(const HandleMap::value_type& hmv, const std::string& indent)
+{
+	std::stringstream ss;
+	ss << indent << "key:" << std::endl
+	   << oc_to_string(hmv.first, indent + OC_TO_STRING_INDENT)
+	   << indent << "value:" << std::endl
+	   << oc_to_string(hmv.second, indent + OC_TO_STRING_INDENT);
+	return ss.str();
+}
+
 std::string oc_to_string(const HandleMultimap& hmultimap, const std::string& indent)
 {
 	std::stringstream ss;

--- a/opencog/atoms/base/Handle.h
+++ b/opencog/atoms/base/Handle.h
@@ -183,11 +183,11 @@ typedef std::vector<HandleSet> HandleSetSeq;
 //! a hash table. Usually has faster insertion.
 typedef std::unordered_set<Handle> UnorderedHandleSet;
 
-//! an ordered map from Handle to Handle set
-typedef std::map<Handle, HandleSet> HandleMultimap;
-
 //! an ordered map from Handle to Handle
 typedef std::map<Handle, Handle> HandleMap;
+
+//! an ordered map from Handle to Handle set
+typedef std::map<Handle, HandleSet> HandleMultimap;
 
 //! a sequence of ordered handle maps
 typedef std::vector<HandleMap> HandleMapSeq;
@@ -291,6 +291,8 @@ std::string oc_to_string(const HandleSetSeq& ohss,
 std::string oc_to_string(const UnorderedHandleSet& uhs,
                          const std::string& indent=empty_string);
 std::string oc_to_string(const HandleMap& hm,
+                         const std::string& indent=empty_string);
+std::string oc_to_string(const HandleMap::value_type& hmv,
                          const std::string& indent=empty_string);
 std::string oc_to_string(const HandleMultimap& hmm,
                          const std::string& indent=empty_string);


### PR DESCRIPTION
`HandleMap::value_type` is different than `HandlePair` because the first
element of `HandleMap::value_type` is const, thus an overloading is
needed.