### PR TITLE
Handy utility for getting the number of a NumberNode

### DIFF
--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -313,6 +313,7 @@ void SchemeSmob::register_procs()
 
 	// property getters on atoms
 	register_proc("cog-name",              1, 0, 0, C(ss_name));
+	register_proc("cog-number",            1, 0, 0, C(ss_number));
 	register_proc("cog-type",              1, 0, 0, C(ss_type));
 	register_proc("cog-arity",             1, 0, 0, C(ss_arity));
 	register_proc("cog-incoming-set",      1, 0, 0, C(ss_incoming_set));

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -118,6 +118,7 @@ private:
 
 	// Atom properties
 	static SCM ss_name(SCM);
+	static SCM ss_number(SCM);
 	static SCM ss_type(SCM);
 	static SCM ss_arity(SCM);
 	static SCM ss_as(SCM);

--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -13,6 +13,7 @@
 
 #include <opencog/atoms/proto/NameServer.h>
 #include <opencog/atoms/proto/ProtoAtom.h>
+#include <opencog/atoms/core/NumberNode.h>
 #include <opencog/truthvalue/AttentionValue.h>
 #include <opencog/truthvalue/CountTruthValue.h>
 #include <opencog/truthvalue/TruthValue.h>
@@ -73,6 +74,21 @@ SCM SchemeSmob::ss_name (SCM satom)
 	if (h->is_node()) name = h->get_name();
 	SCM str = scm_from_utf8_string(name.c_str());
 	return str;
+}
+
+/**
+ * Return the number of the NumberNode
+ */
+SCM SchemeSmob::ss_number (SCM satom)
+{
+	Handle h = verify_handle(satom, "cog-number");
+
+	NumberNodePtr nn(NumberNodeCast(h));
+	// Faster than saying if (not nameserver().isA(h->get_type(), NUMBER_NODE))
+	if (nullptr == nn)
+		scm_wrong_type_arg_msg("cog-number", 0, satom, "NumberNode");
+	SCM num = scm_from_double(nn->get_value());
+	return num;
 }
 
 SCM SchemeSmob::ss_type (SCM satom)

--- a/opencog/scm/opencog/base/core-docs.scm
+++ b/opencog/scm/opencog/base/core-docs.scm
@@ -317,6 +317,21 @@
        \"abc\"
 ")
 
+(set-procedure-property! cog-number 'documentation
+"
+ cog-number NUMBER-NODE
+    Return the floating point value of the NumberNode NUMBER-NODE.
+    If it is a NumberNode, then this is the same as saying
+        (string->number (cog-name NUMBER-NODE))
+    If it is not a NumberNode, then this will throw an exception.
+
+    Example:
+       ; Define a node
+       guile> (define x (cog-new-node 'NumberNode 42))
+       guile> (cog-number x)
+       42.0
+")
+
 (set-procedure-property! cog-type 'documentation
 "
  cog-type ATOM

--- a/opencog/scm/opencog/rule-engine/rule-engine-utils.scm
+++ b/opencog/scm/opencog/rule-engine/rule-engine-utils.scm
@@ -406,7 +406,7 @@
 "
   Convert (NumberNode <number>) to number.
 "
-  (string->number (cog-name A)))
+  (cog-number A))
 
 ;; Very handy and frequent rule precondition.
 (define-public (gt-zero-confidence A)

--- a/tests/query/define-schema.scm
+++ b/tests/query/define-schema.scm
@@ -2,7 +2,7 @@
 ; Demonstrate the used of DefinedSchemaNodes
 ;
 (define (get-timestamp)
-   (NumberNode (number->string (current-time))))
+   (NumberNode (current-time)))
 
 (DefineLink
    (DefinedSchemaNode "set timestamp")

--- a/tests/query/greater-compute.scm
+++ b/tests/query/greater-compute.scm
@@ -47,7 +47,7 @@
 
 ; Function that takes the square root of a numeric values
 (define (eff x)
-	(NumberNode (sqrt (string->number (cog-name x))))
+	(NumberNode (sqrt (cog-number x)))
 )
 
 ; Function that does some computation

--- a/tests/query/greater_than.scm
+++ b/tests/query/greater_than.scm
@@ -132,7 +132,7 @@
 ;; -----------------------------------------------------
 ;; This variant uses a hand-rolled scm compare function
 (define (richer a b)
-	(if (> (string->number (cog-name a)) (string->number (cog-name b)))
+	(if (> (cog-number a) (cog-number b))
 		(stv 1 1)  ;; true
 		(stv 0 1)  ;; false
 	)

--- a/tests/scm/SCMExecutionOutputUTest.cxxtest
+++ b/tests/scm/SCMExecutionOutputUTest.cxxtest
@@ -339,13 +339,9 @@ void SCMExecutionOutputUTest::test_nested(void)
 	// Define various generic utilities
 	eval->eval(
 		"(define (oc-plus x y)"
-		"   (NumberNode (number->string (+ "
-		"      (string->number (cog-name x)) "
-		"      (string->number (cog-name y))))))"
+		"   (NumberNode (+ (cog-number x) (cog-number y))))"
 		"(define (oc-times x y)"
-		"   (NumberNode (number->string (* "
-		"      (string->number (cog-name x)) "
-		"      (string->number (cog-name y))))))"
+		"   (NumberNode (* (cog-number x) (cog-number y))))"
 	);
 	CHKEV(eval);
 
@@ -357,9 +353,9 @@ void SCMExecutionOutputUTest::test_nested(void)
 		"         (ExecutionOutputLink "
 		"            (GroundedSchemaNode \"scm: oc-plus\")"
 		"            (ListLink "
-		"               (NumberNode \"1\")"
-		"               (NumberNode \"2\")))"
-		"         (NumberNode \"3\"))))"
+		"               (NumberNode 1)"
+		"               (NumberNode 2)))"
+		"         (NumberNode 3))))"
 	);
 	CHKEV(eval);
 


### PR DESCRIPTION
This is a short-cut for having to say `(string->number (cog-name ATOM))` and nothing more.