### PR TITLE
Read-only base AtomSpace, with a read-write overlay.

### DIFF
--- a/examples/atomspace/README.md
+++ b/examples/atomspace/README.md
@@ -9,6 +9,7 @@ underlying the AtomSpace. This includes:
 * A simple pattern-matching example.
 * Techniques to control state in the AtomSpace.
 * How to use Values to attach arbitrary data to specific Atoms.
+* How to user a read-only base AtomSpace, with a read-write overlay.
 * How to use time-varying (streaming) Values (experimental).
 
 All of the examples are written in scheme.
@@ -28,12 +29,12 @@ It is recommended that you go through the examples in the order given.
 * `values.scm`  -- Using Values and attaching them to Atoms.
 * `filter.scm`  -- Filtering sets of atoms.
 * `map.scm`     -- Applying a map function to a set or list.
-* `recursive-loop.scm` -- An example of a tail-recursive loop.
-* `random-choice.scm`  -- Numerical programming, including loops.
-* `logger-example.scm` -- Using the built-in logger.
-* `except.scm`  -- An example of exceptions being thrown and passed.
-* `persist-example.scm` -- An example of saving atomspace data in an SQL
-                   database.
+* `recursive-loop.scm`  -- An example of a tail-recursive loop.
+* `random-choice.scm`   -- Numerical programming, including loops.
+* `logger-example.scm`  -- Using the built-in logger.
+* `except.scm`          -- Throwing and catching exceptions.
+* `persist-example.scm` -- Saving atomspace data in an SQL database.
+* `copy-on-write.scm`   -- Read-only atomspaces, with r/w overlays.
 * `stream.scm`  -- Using a stream of time-varying Values.
 * `gperf.scm`   -- Some very crude performance measurements.
 
@@ -108,7 +109,7 @@ for additional documentation.
 
 List of the various OpenCog modules
 ===================================
-A reasonably up-to-datelist of modules provided by OpenCog:
+A reasonably up-to-date list of modules provided by OpenCog:
 ```
 (use-modules (opencog))
 (use-modules (opencog exec))

--- a/examples/atomspace/copy-on-write.scm
+++ b/examples/atomspace/copy-on-write.scm
@@ -1,0 +1,53 @@
+ ;
+ ; Example of copy-on-write into overlay AtomSpaces.
+ ;
+ ; This creates two atomspaces: the base atomspace, which
+ ; will be marked read-only (after adding atoms to it),
+ ; and an overlay atomspace, which will remain read-write.
+ ; Atoms and truth values can be manipulated in the overlay,
+ ; without damaging atoms in the base space.
+ ;
+ (use-modules (opencog))
+
+ ; Create atoms in the base atomspace.
+ (define a (Concept "a"))
+ (define b (Concept "b"))
+
+ (cog-set-tv! a (cog-new-stv 0.1 0.1))
+
+ ; Mark the current atomspace as read-only.
+ ; New atoms can no longer be created.
+ (cog-atomspace-ro!)
+ (define c (Concept "c"))
+ (cog-prt-atomspace)
+
+ ; Truth values can no longer be changed.
+ (cog-set-tv! a (cog-new-stv 0.2 0.2))
+ (cog-prt-atomspace)
+ ; Create an overlay (that will be read-write)
+ ;
+ (define base (cog-atomspace))
+ (define ovly (cog-new-atomspace base))
+ (cog-set-atomspace! ovly)
+
+ ; Alter the TV on atom a -- this causes a copy-on-write (COW)
+ ; into the overlay atomspace.
+ (cog-set-tv! a (cog-new-stv 0.3 0.3))
+ (cog-prt-atomspace)
+ (cog-set-tv! a (cog-new-stv 0.4 0.4))
+ (cog-prt-atomspace)
+
+ ; But in the base atomspace, we still have the original.
+ (cog-set-atomspace! base)
+ (cog-prt-atomspace)
+
+ ; And the overlay still contains the modified atom.
+ (cog-set-atomspace! ovly)
+ (cog-prt-atomspace)
+
+ ; Verify Links in the overlay
+ (OrderedLink a b)  ; note that a is in the base
+ (define averly (Concept "a")) ; get the overlay version
+ (ListLink averly b)
+ (cog-prt-atomspace)
+

--- a/examples/atomspace/copy-on-write.scm
+++ b/examples/atomspace/copy-on-write.scm
@@ -1,11 +1,20 @@
  ;
  ; Example of copy-on-write into overlay AtomSpaces.
  ;
+ ; The goal is to demonstrate how to use read-write atomspaces
+ ; layered on top of a read-only atomspace.
+ ;
  ; This creates two atomspaces: the base atomspace, which
  ; will be marked read-only (after adding atoms to it),
  ; and an overlay atomspace, which will remain read-write.
  ; Atoms and truth values can be manipulated in the overlay,
  ; without damaging atoms in the base space.
+ ;
+ ; The expected use case is a very-large read-only database
+ ; holding data that is shared by many people. Individual users
+ ; can then "mount" this database, and make local changes to it
+ ; (i.e. perform read-write operations) without corrupting the
+ ; shared read-only database.
  ;
  (use-modules (opencog))
 

--- a/opencog/atomspace/AtomSpace.cc
+++ b/opencog/atomspace/AtomSpace.cc
@@ -438,13 +438,15 @@ void AtomSpace::set_value(Handle& h,
     // is read-only) and this atomspace is read-write, then make
     // a copy of the atom, and then set the value.
     AtomSpace* has = h->getAtomSpace();
-    if (has != this and has->_read_only and not _read_only) {
-        // Copy the atom into this atomspace
-        Handle copy(_atom_table.add(h, false, true));
-        copy->setValue(key, value);
-        return;
+    if (has->_read_only) {
+        if (has != this and not _read_only) {
+            // Copy the atom into this atomspace
+            Handle copy(_atom_table.add(h, false, true));
+            copy->setValue(key, value);
+        }
+    } else {
+        h->setValue(key, value);
     }
-    if (not _read_only) h->setValue(key, value);
 }
 
 void AtomSpace::set_truthvalue(Handle& h, const TruthValuePtr& tvp)
@@ -453,13 +455,15 @@ void AtomSpace::set_truthvalue(Handle& h, const TruthValuePtr& tvp)
     // is read-only) and this atomspace is read-write, then make
     // a copy of the atom, and then set the value.
     AtomSpace* has = h->getAtomSpace();
-    if (has != this and has->_read_only and not _read_only) {
-        // Copy the atom into this atomspace
-        Handle copy(_atom_table.add(h, false, true));
-        copy->setTruthValue(tvp);
-        return;
+    if (has->_read_only) {
+        if (has != this and not _read_only) {
+            // Copy the atom into this atomspace
+            Handle copy(_atom_table.add(h, false, true));
+            copy->setTruthValue(tvp);
+        }
+    } else {
+        h->setTruthValue(tvp);
     }
-    if (not _read_only) h->setTruthValue(tvp);
 }
 
 std::string AtomSpace::to_string() const

--- a/opencog/atomspace/AtomSpace.cc
+++ b/opencog/atomspace/AtomSpace.cc
@@ -292,6 +292,10 @@ Handle AtomSpace::add_atom(const Handle& h, bool async)
 Handle AtomSpace::add_node(Type t, const string& name,
                            bool async)
 {
+    // Cannot add atoms to a read-only atomspce. But if it's already
+    // in the atomspace, return it.
+    if (_read_only) return _atom_table.getHandle(t, name);
+
     return _atom_table.add(createNode(t, name), async);
 }
 

--- a/opencog/atomspace/AtomSpace.cc
+++ b/opencog/atomspace/AtomSpace.cc
@@ -128,9 +128,9 @@ bool AtomSpace::compare_atomspaces(const AtomSpace& space_first,
     // If we get this far, we need to compare each individual atom.
 
     // Get the atoms in each atomspace.
-    HandleSeq atomsInFirstSpace, atomsInSecondSpace;
-    space_first.get_all_atoms(atomsInFirstSpace);
-    space_second.get_all_atoms(atomsInSecondSpace);
+    HandleSet atomsInFirstSpace, atomsInSecondSpace;
+    space_first.get_handleset_by_type(atomsInFirstSpace, ATOM, true);
+    space_second.get_handleset_by_type(atomsInSecondSpace, ATOM, true);
 
     // Uncheck each atom in the second atomspace.
     for (auto atom : atomsInSecondSpace)

--- a/opencog/atomspace/AtomSpace.cc
+++ b/opencog/atomspace/AtomSpace.cc
@@ -431,9 +431,9 @@ bool AtomSpace::remove_atom(Handle h, bool recursive)
 }
 
 // Copy-on-write for setting values.
-void AtomSpace::set_value(Handle& h,
-                          const Handle& key,
-                          const ProtoAtomPtr& value)
+Handle AtomSpace::set_value(Handle& h,
+                            const Handle& key,
+                            const ProtoAtomPtr& value)
 {
     // If the atom is in a read-only atomspace (i.e. if the parent
     // is read-only) and this atomspace is read-write, then make
@@ -444,14 +444,19 @@ void AtomSpace::set_value(Handle& h,
             // Copy the atom into this atomspace
             Handle copy(_atom_table.add(h, false, true));
             copy->setValue(key, value);
+            return copy;
         }
     } else {
         h->setValue(key, value);
+        return h;
     }
+    throw opencog::RuntimeException(TRACE_INFO,
+         "Value not changed; AtomSpace is readonly");
+    return Handle::UNDEFINED;
 }
 
 // Copy-on-write for setting truth values.
-void AtomSpace::set_truthvalue(Handle& h, const TruthValuePtr& tvp)
+Handle AtomSpace::set_truthvalue(Handle& h, const TruthValuePtr& tvp)
 {
     // If the atom is in a read-only atomspace (i.e. if the parent
     // is read-only) and this atomspace is read-write, then make
@@ -462,10 +467,15 @@ void AtomSpace::set_truthvalue(Handle& h, const TruthValuePtr& tvp)
             // Copy the atom into this atomspace
             Handle copy(_atom_table.add(h, false, true));
             copy->setTruthValue(tvp);
+            return copy;
         }
     } else {
         h->setTruthValue(tvp);
+        return h;
     }
+    throw opencog::RuntimeException(TRACE_INFO,
+         "TruthValue not changed; AtomSpace is readonly");
+    return Handle::UNDEFINED;
 }
 
 std::string AtomSpace::to_string() const

--- a/opencog/atomspace/AtomSpace.cc
+++ b/opencog/atomspace/AtomSpace.cc
@@ -434,12 +434,32 @@ void AtomSpace::set_value(Handle& h,
                           const Handle& key,
                           const ProtoAtomPtr& value)
 {
-    h->setValue(key, value);
+    // If the atom is in a read-only atomspace (i.e. if the parent
+    // is read-only) and this atomspace is read-write, then make
+    // a copy of the atom, and then set the value.
+    AtomSpace* has = h->getAtomSpace();
+    if (has != this and has->_read_only and not _read_only) {
+        // Copy the atom into this atomspace
+        Handle copy(_atom_table.add(h, false, true));
+        copy->setValue(key, value);
+        return;
+    }
+    if (not _read_only) h->setValue(key, value);
 }
 
 void AtomSpace::set_truthvalue(Handle& h, const TruthValuePtr& tvp)
 {
-    h->setTruthValue(tvp);
+    // If the atom is in a read-only atomspace (i.e. if the parent
+    // is read-only) and this atomspace is read-write, then make
+    // a copy of the atom, and then set the value.
+    AtomSpace* has = h->getAtomSpace();
+    if (has != this and has->_read_only and not _read_only) {
+        // Copy the atom into this atomspace
+        Handle copy(_atom_table.add(h, false, true));
+        copy->setTruthValue(tvp);
+        return;
+    }
+    if (not _read_only) h->setTruthValue(tvp);
 }
 
 std::string AtomSpace::to_string() const

--- a/opencog/atomspace/AtomSpace.cc
+++ b/opencog/atomspace/AtomSpace.cc
@@ -61,7 +61,7 @@ using namespace opencog;
 AtomSpace::AtomSpace(AtomSpace* parent, bool transient) :
     _atom_table(parent? &parent->_atom_table : nullptr, this, transient),
     _backing_store(nullptr),
-    _transient(transient)
+    _read_only(false)
 {
 }
 
@@ -77,6 +77,17 @@ void AtomSpace::ready_transient(AtomSpace* parent)
 void AtomSpace::clear_transient()
 {
     _atom_table.clear_transient();
+}
+
+// An extremely primitive permissions system.
+void AtomSpace::set_read_only(void)
+{
+    _read_only = true;
+}
+
+void AtomSpace::set_read_write(void)
+{
+    _read_only = false;
 }
 
 bool AtomSpace::compare_atomspaces(const AtomSpace& space_first,

--- a/opencog/atomspace/AtomSpace.cc
+++ b/opencog/atomspace/AtomSpace.cc
@@ -417,7 +417,11 @@ void AtomSpace::fetch_valuations(Handle key, bool get_all_values)
 
 bool AtomSpace::remove_atom(Handle h, bool recursive)
 {
-    if (_backing_store)
+    // Removal of atoms from read-only databases is not allowed.
+    // It is OK to remove atoms from a read-only atomspace, because
+    // it is acting as a cache for the database, and removal is used
+    // used to free up RAM storage.
+    if (_backing_store and not _read_only)
         _backing_store->removeAtom(h, recursive);
     return 0 < _atom_table.extract(h, recursive).size();
 }

--- a/opencog/atomspace/AtomSpace.cc
+++ b/opencog/atomspace/AtomSpace.cc
@@ -430,6 +430,7 @@ bool AtomSpace::remove_atom(Handle h, bool recursive)
     return 0 < _atom_table.extract(h, recursive).size();
 }
 
+// Copy-on-write for setting values.
 void AtomSpace::set_value(Handle& h,
                           const Handle& key,
                           const ProtoAtomPtr& value)
@@ -449,6 +450,7 @@ void AtomSpace::set_value(Handle& h,
     }
 }
 
+// Copy-on-write for setting truth values.
 void AtomSpace::set_truthvalue(Handle& h, const TruthValuePtr& tvp)
 {
     // If the atom is in a read-only atomspace (i.e. if the parent

--- a/opencog/atomspace/AtomSpace.cc
+++ b/opencog/atomspace/AtomSpace.cc
@@ -430,6 +430,18 @@ bool AtomSpace::remove_atom(Handle h, bool recursive)
     return 0 < _atom_table.extract(h, recursive).size();
 }
 
+void AtomSpace::set_value(Handle& h,
+                          const Handle& key,
+                          const ProtoAtomPtr& value)
+{
+    h->setValue(key, value);
+}
+
+void AtomSpace::set_truthvalue(Handle& h, const TruthValuePtr& tvp)
+{
+    h->setTruthValue(tvp);
+}
+
 std::string AtomSpace::to_string() const
 {
 	std::stringstream ss;

--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -345,6 +345,13 @@ public:
     bool remove_atom(Handle h, bool recursive=false);
 
     /**
+     * Set the Value on the atom, performing necessary permissions
+     * checking.
+     */
+    void set_value(Handle& h, const Handle& key, const ProtoAtomPtr& value);
+    void set_truthvalue(Handle& h, const TruthValuePtr&);
+
+    /**
      * Get a node from the AtomTable, if it's in there. If its not found
      * in the AtomTable, and there's a backing store, then the atom will
      * be fetched from the backingstore (and added to the AtomTable). If

--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -351,9 +351,11 @@ public:
      * permissions, but the atom is in a parent atomspace that is
      * read-only, then the atom is copied into this atomspace, before
      * the value is changed. (Copy-on-write (COW) semantics).
+     *
+     * If the atom is copied, then the copy is returned.
      */
-    void set_value(Handle& h, const Handle& key, const ProtoAtomPtr& value);
-    void set_truthvalue(Handle& h, const TruthValuePtr&);
+    Handle set_value(Handle& h, const Handle& key, const ProtoAtomPtr& value);
+    Handle set_truthvalue(Handle& h, const TruthValuePtr&);
 
     /**
      * Get a node from the AtomTable, if it's in there. If its not found

--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -76,7 +76,7 @@ class AtomSpace
 
     AtomTable& get_atomtable(void) { return _atom_table; }
 
-    bool _transient;
+    bool _read_only;
 protected:
 
     /**
@@ -92,8 +92,15 @@ public:
     AtomSpace(AtomSpace* parent=nullptr, bool transient=false);
     ~AtomSpace();
 
+    // Transient atomspaces are lighter-weight, faster, but are missing
+    // some features. They are used during pattern matching, to hold
+    // temporary results.
     void ready_transient(AtomSpace* parent);
     void clear_transient();
+
+    void set_read_only(void);
+    void set_read_write(void);
+    bool get_read_only(void) { return _read_only; }
 
     /// Get the environment that this atomspace was created in.
     AtomSpace* get_environ() const {

--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -346,7 +346,11 @@ public:
 
     /**
      * Set the Value on the atom, performing necessary permissions
-     * checking.
+     * checking. If this atomspace is read-only, then the setting
+     * of values is prohibited.  If this atomspace has read-write
+     * permissions, but the atom is in a parent atomspace that is
+     * read-only, then the atom is copied into this atomspace, before
+     * the value is changed. (Copy-on-write (COW) semantics).
      */
     void set_value(Handle& h, const Handle& key, const ProtoAtomPtr& value);
     void set_truthvalue(Handle& h, const TruthValuePtr&);

--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -411,45 +411,29 @@ public:
     }
 
     /**
-     * Gets all the atoms of any type and appends them to the HandleSeq.
-     * Caution: this is slower than using get_handleset_by_type() to
-     * get a set, as it forces the use of a copy to deduplicate atoms.
-     *
-     * @param appendToHandles the HandleSeq to which to append the handles.
-     *
-     * Example of call to this method:
-     * @code
-     *         HandleSeq atoms;
-     *         atomSpace.get_all_atoms(atoms);
-     * @endcode
-     */
-    void get_all_atoms(HandleSeq& appendToHandles) const
-    {
-        // Defer to handles by type for ATOMs and subclasses.
-        get_handles_by_type(appendToHandles, ATOM, true);
-    }
-
-    /**
-     * Gets all the nodes of any type and appends them to the HandleSeq.
-     * Caution: this is slower than using get_handleset_by_type() to
-     * get a set, as it forces the use of a copy to deduplicate atoms.
-     *
-     * @param appendToHandles the HandleSeq to which to append the handles.
-     *
-     * Example of call to this method:
-     * @code
-     *         HandleSeq nodes;
-     *         atomSpace.get_all_nodes(nodes);
-     * @endcode
-     */
-    void get_all_nodes(HandleSeq& appendToHandles) const
-    {
-        // Defer to handles by type for NODEs and subclasses.
-        get_handles_by_type(appendToHandles, NODE, true);
-    }
-
-    /**
      * Gets a set of handles that matches with the given type
+     * (subclasses optionally).
+     *
+     * @param hset the HandleSet into which to insert handles.
+     * @param type The desired type.
+     * @param subclass Whether type subclasses should be considered.
+     *
+     * Example of call to this method, which would return all ConceptNodes
+     * in the AtomSpace:
+     * @code
+     *         HandleSet atoms;
+     *         atomSpace.get_handlset_by_type(atoms, CONCEPT_NODE);
+     * @endcode
+     */
+    void get_handleset_by_type(HandleSet& hset,
+                               Type type,
+                               bool subclass=false) const
+    {
+        return _atom_table.getHandleSetByType(hset, type, subclass);
+    }
+
+    /**
+     * Gets a sequence of handles that matches with the given type
      * (subclasses optionally).
      * Caution: this is slower than using get_handleset_by_type() to
      * get a set, as it forces the use of a copy to deduplicate atoms.
@@ -458,14 +442,11 @@ public:
      * @param type The desired type.
      * @param subclass Whether type subclasses should be considered.
      *
-     * @note The matched entries are appended to a container whose
-     *        OutputIterator is passed as the first argument.
-     *
      * Example of call to this method, which would return all ConceptNodes
      * in the AtomSpace:
      * @code
-     *         std::list<Handle> atoms;
-     *         atomSpace.getHandlesByType(atoms, CONCEPT_NODE);
+     *         HandleSeq atoms;
+     *         atomSpace.get_handle_by_type(atoms, CONCEPT_NODE);
      * @endcode
      */
     void get_handles_by_type(HandleSeq& appendToHandles,
@@ -487,15 +468,8 @@ public:
         get_handles_by_type(back_inserter(appendToHandles), type, subclass);
     }
 
-    void get_handleset_by_type(HandleSet& hset,
-                               Type type,
-                               bool subclass=false) const
-    {
-        return _atom_table.getHandleSetByType(hset, type, subclass);
-    }
-
     /**
-     * Gets a set of handles that matches with the given type
+     * Gets a container of handles that matches with the given type
      * (subclasses optionally).
      * Caution: this is slower than using get_handleset_by_type() to
      * get a set, as it forces the use of a copy to deduplicate atoms.
@@ -513,7 +487,7 @@ public:
      * in AtomSpace:
      * @code
      *         std::list<Handle> ret;
-     *         atomSpace.getHandlesByType(back_inserter(ret), ATOM, true);
+     *         atomSpace.get_handles_by_type(back_inserter(ret), ATOM, true);
      * @endcode
      */
     template <typename OutputIterator> OutputIterator
@@ -540,8 +514,6 @@ public:
         // the lock for too long. (because we don't know how long
         // the callback will take.)
         HandleSet handle_set;
-        // The intended signatue is
-        // getHandleSet(OutputIterator result, Type type, bool subclass)
         get_handleset_by_type(handle_set, atype, subclass);
 
         // Loop over all handles in the handle set.

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -362,13 +362,13 @@ static void prt_diag(AtomPtr atom, size_t i, size_t arity, const HandleSeq& ogs)
 }
 #endif
 
-Handle AtomTable::add(AtomPtr atom, bool async)
+Handle AtomTable::add(AtomPtr atom, bool async, bool force)
 {
     // Can be null, if its a ProtoAtom
     if (nullptr == atom) return Handle::UNDEFINED;
 
     // Is the atom already in this table, or one of its environments?
-    if (in_environ(atom))
+    if (not force and in_environ(atom))
         return atom->get_handle();
 
     AtomPtr orig(atom);

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -230,10 +230,8 @@ Handle AtomTable::getHandle(Type t, const std::string& n) const
     return getNodeHandle(a);
 }
 
-Handle AtomTable::getNodeHandle(const AtomPtr& orig) const
+Handle AtomTable::getNodeHandle(const AtomPtr& a) const
 {
-    AtomPtr a(orig);
-
     ContentHash ch = a->get_hash();
     std::lock_guard<std::recursive_mutex> lck(_mtx);
 

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -255,25 +255,16 @@ Handle AtomTable::getHandle(Type t, const HandleSeq& seq) const
     return getLinkHandle(a);
 }
 
-Handle AtomTable::getLinkHandle(const AtomPtr& orig) const
+Handle AtomTable::getLinkHandle(const AtomPtr& a) const
 {
-    AtomPtr a(orig);
-    Type t = a->get_type();
     const HandleSeq &seq = a->getOutgoingSet();
 
     // Make sure all the atoms in the outgoing set are in the atomspace.
     // If any are not, then reject the whole mess.
-    HandleSeq resolved_seq;
-    // Reserving space improves emplace_back performance by 2x
-    resolved_seq.reserve(seq.size());
-    bool changed = false;
     for (const Handle& ho : seq) {
         Handle rh(getHandle(ho));
         if (not rh) return rh;
-        if (rh != ho) changed = true;
-        resolved_seq.emplace_back(rh);
     }
-    if (changed) a = createLink(resolved_seq, t);
 
     // Start searching to see if we have this atom.
     ContentHash ch = a->get_hash();

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -257,11 +257,12 @@ Handle AtomTable::getHandle(Type t, const HandleSeq& seq) const
 
 Handle AtomTable::getLinkHandle(const AtomPtr& a) const
 {
-    const HandleSeq &seq = a->getOutgoingSet();
-
     // Make sure all the atoms in the outgoing set are in the atomspace.
-    // If any are not, then reject the whole mess.
-    for (const Handle& ho : seq) {
+    // If any are not, then reject the whole mess. XXX Why? So what?
+    // If the hash-checking, below, is good, then everything should be
+    // just fine. XXX Except BackwardChainerUTest fails myseriously,
+    // when we skip this test. Not sure why. Strange. XXX FIXME.
+    for (const Handle& ho : a->getOutgoingSet()) {
         Handle rh(getHandle(ho));
         if (not rh) return rh;
     }

--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -300,10 +300,13 @@ public:
      * and also giving each index its own unique mutex, to avoid
      * collisions.  So the API is here, but more work is still needed.
      *
+     * The `force` flag forces the addtion of this atom into the
+     * atomtable, even if it is already in a parent atomspace.
+     *
      * @param The new atom to be added.
      * @return The handle of the newly added atom.
      */
-    Handle add(AtomPtr, bool async);
+    Handle add(AtomPtr, bool async, bool force=false);
 
     /**
      * Read-write synchronization barrier fence.  When called, this

--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -216,18 +216,48 @@ public:
      * @param Whether type subclasses should be considered.
      * @return The set of atoms of a given type (subclasses optionally).
      */
+    void
+    getHandleSetByType(HandleSet& hset,
+                       Type type,
+                       bool subclass=false,
+                       bool parent=true) const
+    {
+        std::lock_guard<std::recursive_mutex> lck(_mtx);
+        auto tit = typeIndex.begin(type, subclass);
+        auto tend = typeIndex.end();
+        while (tit != tend) { hset.insert(*tit); tit++; }
+        // If an atom is already in the set, it will hide any duplicate
+        // atom in the parent.
+        if (parent and _environ)
+            _environ->getHandleSetByType(hset, type, subclass, parent);
+    }
+
+    /**
+     * Returns the set of atoms of a given type (subclasses optionally).
+     *
+     * @param The desired type.
+     * @param Whether type subclasses should be considered.
+     * @return The set of atoms of a given type (subclasses optionally).
+     */
     template <typename OutputIterator> OutputIterator
     getHandlesByType(OutputIterator result,
                      Type type,
                      bool subclass=false,
                      bool parent=true) const
     {
+        // If parent wanted, and parent exists, then we must use the
+        // handleset to disabmbiguate results.  This causes an extra
+        // copy of the handles, unfortunately.
+        if (parent and _environ) {
+           HandleSet hset;
+           getHandleSetByType(hset, type, subclass, parent);
+           return std::copy(hset.begin(), hset.end(), result);
+        }
+
+        // No parent ... avoid the copy above.
         std::lock_guard<std::recursive_mutex> lck(_mtx);
-        if (parent && _environ)
-            _environ->getHandlesByType(result, type, subclass, parent);
         return std::copy(typeIndex.begin(type, subclass),
-                         typeIndex.end(),
-                         result);
+                         typeIndex.end(), result);
     }
 
     /** Calls function 'func' on all atoms */
@@ -238,7 +268,7 @@ public:
                         bool parent=true) const
     {
         std::lock_guard<std::recursive_mutex> lck(_mtx);
-        if (parent && _environ)
+        if (parent and _environ)
             _environ->foreachHandleByType(func, type, subclass);
         std::for_each(typeIndex.begin(type, subclass),
                       typeIndex.end(),
@@ -254,7 +284,7 @@ public:
                         bool parent=true) const
     {
         std::lock_guard<std::recursive_mutex> lck(_mtx);
-        if (parent && _environ)
+        if (parent and _environ)
             _environ->foreachParallelByType(func, type, subclass);
 
         // Parallelize, always, no matter what!

--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -358,6 +358,9 @@ void SchemeSmob::register_procs()
 	register_proc("cog-atomspace-env",     1, 0, 0, C(ss_as_env));
 	register_proc("cog-atomspace-uuid",    1, 0, 0, C(ss_as_uuid));
 	register_proc("cog-atomspace-clear",   1, 0, 0, C(ss_as_clear));
+	register_proc("cog-atomspace-readonly?", 0, 1, 0, C(ss_as_readonly_p));
+	register_proc("cog-atomspace-ro!",     0, 1, 0, C(ss_as_mark_readonly));
+	register_proc("cog-atomspace-rw!",     0, 1, 0, C(ss_as_mark_readwrite));
 
 	// Attention values
 	register_proc("cog-new-av",            3, 0, 0, C(ss_new_av));

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -175,6 +175,9 @@ private:
 	static SCM ss_as_env(SCM);
 	static SCM ss_as_uuid(SCM);
 	static SCM ss_as_clear(SCM);
+	static SCM ss_as_mark_readonly(SCM);
+	static SCM ss_as_mark_readwrite(SCM);
+	static SCM ss_as_readonly_p(SCM);
 	static SCM make_as(AtomSpace *);
 	static void release_as(AtomSpace *);
 	static AtomSpace* ss_to_atomspace(SCM);

--- a/opencog/guile/SchemeSmobAS.cc
+++ b/opencog/guile/SchemeSmobAS.cc
@@ -218,7 +218,9 @@ SCM SchemeSmob::ss_as_uuid(SCM sas)
 	AtomSpace* as = ss_to_atomspace(sas);
 	if (nullptr == as)
 	{
-		// Special care for atom whose atomspace was null
+		// Special case when asking for the UUID of an atomspace
+		// for an atom whose atomspace was null. (XXX Really? When,
+		// exactly, does this actually happen? Who calls this method?)
 		if (scm_is_null(sas))
 			return scm_from_ulong(ULONG_MAX);
 		scm_wrong_type_arg_msg("cog-atomspace-uuid", 1, sas, "atomspace");
@@ -248,6 +250,47 @@ SCM SchemeSmob::ss_as_env(SCM sas)
 	AtomSpace* env = as->get_environ();
 	scm_remember_upto_here_1(sas);
 	return env ? make_as(env) : SCM_EOL;
+}
+
+/* ============================================================== */
+/**
+ * Return readonly flag of the atomspace.  If no atomspace specified,
+ * then get the current atomspace.
+ */
+SCM SchemeSmob::ss_as_readonly_p(SCM sas)
+{
+	AtomSpace* as = ss_to_atomspace(sas);
+	scm_remember_upto_here_1(sas);
+	if (nullptr == as) as = ss_get_env_as("cog-atomspace-readonly?");
+
+	if (as->get_read_only()) return SCM_BOOL_T;
+	return SCM_BOOL_F;
+}
+
+/* ============================================================== */
+/**
+ * Set the readonly flag of the atomspace.  If no atomspace specified,
+ * then set it on the current atomspace.  XXX This is a temporary hack,
+ * until a better permission system is invented. XXX FIXME.
+ */
+SCM SchemeSmob::ss_as_mark_readonly(SCM sas)
+{
+	AtomSpace* as = ss_to_atomspace(sas);
+	scm_remember_upto_here_1(sas);
+	if (nullptr == as) as = ss_get_env_as("cog-atomspace-ro!");
+
+	as->set_read_only();
+	return SCM_BOOL_T;
+}
+
+SCM SchemeSmob::ss_as_mark_readwrite(SCM sas)
+{
+	AtomSpace* as = ss_to_atomspace(sas);
+	scm_remember_upto_here_1(sas);
+	if (nullptr == as) as = ss_get_env_as("cog-atomspace-rw!");
+
+	as->set_read_write();
+	return SCM_BOOL_T;
 }
 
 /* ============================================================== */

--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -155,9 +155,11 @@ SCM SchemeSmob::ss_set_tv (SCM satom, SCM stv)
 	TruthValuePtr tv = verify_tv(stv, "cog-set-tv!", 2);
 
 	AtomSpace* as = ss_get_env_as("cog-set-tv!");
-	as->set_truthvalue(h, tv);
+	Handle newh = as->set_truthvalue(h, tv);
 	scm_remember_upto_here_1(stv);
-	return satom;
+
+	if (h == newh) return satom;
+	return handle_to_scm(newh);
 }
 
 // Increment the count, keeping mean and confidence as-is.

--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -154,7 +154,8 @@ SCM SchemeSmob::ss_set_tv (SCM satom, SCM stv)
 	Handle h = verify_handle(satom, "cog-set-tv!");
 	TruthValuePtr tv = verify_tv(stv, "cog-set-tv!", 2);
 
-	h->setTruthValue(tv);
+	AtomSpace* as = ss_get_env_as("cog-set-tv!");
+	as->set_truthvalue(h, tv);
 	scm_remember_upto_here_1(stv);
 	return satom;
 }
@@ -174,7 +175,8 @@ SCM SchemeSmob::ss_inc_count (SCM satom, SCM scnt)
 	tv = CountTruthValue::createTV(
 		tv->get_mean(), tv->get_confidence(), cnt);
 
-	h->setTruthValue(tv);
+	AtomSpace* as = ss_get_env_as("cog-set-tv!");
+	as->set_truthvalue(h, tv);
 	return satom;
 }
 

--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -153,13 +153,20 @@ SCM SchemeSmob::ss_set_tv (SCM satom, SCM stv)
 {
 	Handle h = verify_handle(satom, "cog-set-tv!");
 	TruthValuePtr tv = verify_tv(stv, "cog-set-tv!", 2);
-
-	AtomSpace* as = ss_get_env_as("cog-set-tv!");
-	Handle newh = as->set_truthvalue(h, tv);
 	scm_remember_upto_here_1(stv);
 
-	if (h == newh) return satom;
-	return handle_to_scm(newh);
+	AtomSpace* as = ss_get_env_as("cog-set-tv!");
+	try
+	{
+		Handle newh = as->set_truthvalue(h, tv);
+
+		if (h == newh) return satom;
+		return handle_to_scm(newh);
+	}
+	catch (const std::exception& ex)
+	{
+		throw_exception(ex, "cog-set-tv!", satom);
+	}
 }
 
 // Increment the count, keeping mean and confidence as-is.

--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -298,13 +298,13 @@ SCM SchemeSmob::ss_map_type (SCM proc, SCM stype)
 	AtomSpace* atomspace = ss_get_env_as("cog-map-type");
 
 	// Get all of the handles of the indicated type
-	HandleSeq hseq;
-	atomspace->get_handles_by_type(hseq, t);
+	HandleSet hset;
+	atomspace->get_handleset_by_type(hset, t);
 
 	// Loop over all handles in the handle set.
 	// Call proc on each handle, in turn.
 	// Break out of the loop if proc returns anything other than #f
-	for (const Handle& h : hseq) {
+	for (const Handle& h : hset) {
 
 		// In case h got removed from the atomspace between
 		// get_handles_by_type call and now. This may happen either

--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -298,15 +298,13 @@ SCM SchemeSmob::ss_map_type (SCM proc, SCM stype)
 	AtomSpace* atomspace = ss_get_env_as("cog-map-type");
 
 	// Get all of the handles of the indicated type
-	std::list<Handle> handle_set;
-	atomspace->get_handles_by_type(back_inserter(handle_set), t, false);
+	HandleSeq hseq;
+	atomspace->get_handles_by_type(hseq, t);
 
 	// Loop over all handles in the handle set.
 	// Call proc on each handle, in turn.
 	// Break out of the loop if proc returns anything other than #f
-	std::list<Handle>::iterator i;
-	for (i = handle_set.begin(); i != handle_set.end(); ++i) {
-		Handle h = *i;
+	for (const Handle& h : hseq) {
 
 		// In case h got removed from the atomspace between
 		// get_handles_by_type call and now. This may happen either

--- a/opencog/guile/SchemeSmobNew.cc
+++ b/opencog/guile/SchemeSmobNew.cc
@@ -417,7 +417,7 @@ SCM SchemeSmob::ss_node (SCM stype, SCM sname, SCM kv_pairs)
 
 	// If there was a truth value, change it.
 	const TruthValuePtr tv(get_tv_from_list(kv_pairs));
-	if (tv) h->setTruthValue(tv);
+	if (tv) atomspace->set_truthvalue(h, tv);
 
 	scm_remember_upto_here_1(kv_pairs);
 	return handle_to_scm (h);
@@ -535,7 +535,7 @@ SCM SchemeSmob::ss_link (SCM stype, SCM satom_list)
 
 	// If there was a truth value, change it.
 	const TruthValuePtr tv(get_tv_from_list(satom_list));
-	if (tv) h->setTruthValue(tv);
+	if (tv) atomspace->set_truthvalue(h, tv);
 
 	scm_remember_upto_here_1(satom_list);
 	return handle_to_scm (h);

--- a/opencog/guile/SchemeSmobNew.cc
+++ b/opencog/guile/SchemeSmobNew.cc
@@ -372,15 +372,18 @@ SCM SchemeSmob::ss_new_node (SCM stype, SCM sname, SCM kv_pairs)
 		"string name for the node"));
 
 	AtomSpace* atomspace = get_as_from_list(kv_pairs);
-	if (NULL == atomspace) atomspace = ss_get_env_as("cog-new-node");
+	if (nullptr == atomspace) atomspace = ss_get_env_as("cog-new-node");
 
 	try
 	{
 		// Now, create the actual node... in the actual atom space.
 		Handle h(atomspace->add_node(t, name));
 
-		const TruthValuePtr tv(get_tv_from_list(kv_pairs));
-		if (tv) h->setTruthValue(tv);
+		if (h)
+		{
+			const TruthValuePtr tv(get_tv_from_list(kv_pairs));
+			if (tv) h->setTruthValue(tv);
+		}
 
 		return handle_to_scm(h);
 	}
@@ -406,11 +409,11 @@ SCM SchemeSmob::ss_node (SCM stype, SCM sname, SCM kv_pairs)
 									"string name for the node");
 
 	AtomSpace* atomspace = get_as_from_list(kv_pairs);
-	if (NULL == atomspace) atomspace = ss_get_env_as("cog-node");
+	if (nullptr == atomspace) atomspace = ss_get_env_as("cog-node");
 
 	// Now, look for the actual node... in the actual atom space.
 	Handle h(atomspace->get_handle(t, name));
-	if (NULL == h) return SCM_EOL;
+	if (nullptr == h) return SCM_EOL;
 
 	// If there was a truth value, change it.
 	const TruthValuePtr tv(get_tv_from_list(kv_pairs));
@@ -487,7 +490,7 @@ SCM SchemeSmob::ss_new_link (SCM stype, SCM satom_list)
 	outgoing_set = verify_handle_list(satom_list, "cog-new-link", 2);
 
 	AtomSpace* atomspace = get_as_from_list(satom_list);
-	if (NULL == atomspace) atomspace = ss_get_env_as("cog-new-link");
+	if (nullptr == atomspace) atomspace = ss_get_env_as("cog-new-link");
 
 	try
 	{
@@ -495,8 +498,11 @@ SCM SchemeSmob::ss_new_link (SCM stype, SCM satom_list)
 		Handle h(atomspace->add_link(t, outgoing_set));
 
 		// Fish out a truth value, if its there.
-		const TruthValuePtr tv(get_tv_from_list(satom_list));
-		if (tv) h->setTruthValue(tv);
+		if (h)
+		{
+			const TruthValuePtr tv(get_tv_from_list(satom_list));
+			if (tv) h->setTruthValue(tv);
+		}
 
 		return handle_to_scm (h);
 	}
@@ -521,7 +527,7 @@ SCM SchemeSmob::ss_link (SCM stype, SCM satom_list)
 	outgoing_set = verify_handle_list (satom_list, "cog-link", 2);
 
 	AtomSpace* atomspace = get_as_from_list(satom_list);
-	if (NULL == atomspace) atomspace = ss_get_env_as("cog-link");
+	if (nullptr == atomspace) atomspace = ss_get_env_as("cog-link");
 
 	// Now, look to find the actual link... in the actual atom space.
 	Handle h(atomspace->get_handle(t, outgoing_set));

--- a/opencog/guile/SchemeSmobValue.cc
+++ b/opencog/guile/SchemeSmobValue.cc
@@ -252,7 +252,8 @@ SCM SchemeSmob::ss_set_value (SCM satom, SCM skey, SCM svalue)
 
 	// Note that pa might be a null pointer, if svalue is '() or #f
 	// In this case, the key is removed.
-	atom->setValue(key, pa);
+	AtomSpace* as = ss_get_env_as("cog-set-value!");
+	as->set_value(atom, key, pa);
 	return satom;
 }
 

--- a/opencog/guile/SchemeSmobValue.cc
+++ b/opencog/guile/SchemeSmobValue.cc
@@ -253,8 +253,9 @@ SCM SchemeSmob::ss_set_value (SCM satom, SCM skey, SCM svalue)
 	// Note that pa might be a null pointer, if svalue is '() or #f
 	// In this case, the key is removed.
 	AtomSpace* as = ss_get_env_as("cog-set-value!");
-	as->set_value(atom, key, pa);
-	return satom;
+	Handle newh = as->set_value(atom, key, pa);
+	if (atom == newh) return satom;
+	return handle_to_scm(newh);
 }
 
 SCM SchemeSmob::ss_value (SCM satom, SCM skey)

--- a/opencog/guile/SchemeSmobValue.cc
+++ b/opencog/guile/SchemeSmobValue.cc
@@ -253,9 +253,16 @@ SCM SchemeSmob::ss_set_value (SCM satom, SCM skey, SCM svalue)
 	// Note that pa might be a null pointer, if svalue is '() or #f
 	// In this case, the key is removed.
 	AtomSpace* as = ss_get_env_as("cog-set-value!");
-	Handle newh = as->set_value(atom, key, pa);
-	if (atom == newh) return satom;
-	return handle_to_scm(newh);
+	try
+	{
+		Handle newh = as->set_value(atom, key, pa);
+		if (atom == newh) return satom;
+		return handle_to_scm(newh);
+	}
+	catch (const std::exception& ex)
+	{
+		throw_exception(ex, "cog-set-value!", satom);
+	}
 }
 
 SCM SchemeSmob::ss_value (SCM satom, SCM skey)

--- a/opencog/persist/sql/multi-driver/SQLResponse.h
+++ b/opencog/persist/sql/multi-driver/SQLResponse.h
@@ -213,6 +213,12 @@ class SQLAtomStorage::Response
 					store->_tlbuf.addAtom(h, uuid);
 				}
 			}
+			else
+			{
+				// In case it's still in the TLB, but was
+				// previously removed from the atomspace.
+				h = table->add(h, false);
+			}
 
 			// Clobber all values, including truth values.
 			store->get_atom_values(h);

--- a/opencog/scm/opencog/base/utilities.scm
+++ b/opencog/scm/opencog/base/utilities.scm
@@ -304,8 +304,8 @@
 "
   traverse-roots -- Applies func to every root atom in the atomspace.
 
-  The root atoms are those, which have no incoming atoms,
-  located in the atomspace or its ancestors (i.e. visible from the atomspace).
+  The root atoms are those, which have no incoming atoms, located
+  in the atomspace or its ancestors (i.e. visible from the atomspace).
 "
 	(define (is-visible? atom)
 		(member
@@ -326,10 +326,11 @@
 "
   cog-prt-atomspace -- Prints all atoms in the atomspace
 
-  This will print all of the atoms in the atomspace: specifically, only
-  those atoms that have no incoming set in the atomspace or its ancestors,
-  and thus are at the top of a tree.  All other atoms (those which do
-  have an incoming set) will appear somewhere underneath these top-most atoms.
+  This will print all of the atoms in the atomspace: specifically,
+  only those atoms that have no incoming set in the atomspace or its
+  ancestors, and thus are at the top of a tree.  All other atoms
+  (those which do have an incoming set) will appear somewhere
+  underneath these top-most atoms.
 "
 	(traverse-roots display)
 )

--- a/opencog/scm/opencog/base/utilities.scm
+++ b/opencog/scm/opencog/base/utilities.scm
@@ -307,12 +307,13 @@
   The root atoms are those, which have no incoming atoms, located
   in the atomspace or its ancestors (i.e. visible from the atomspace).
 "
-	(define (is-visible? atom)
-		(member
-			(cog-as atom)
-			(get-atomspace-and-parents)))
-	(define (get-atomspace-and-parents)
+	; A list of the atomspace and all parents
+	(define atomspace-and-parents
 		(unfold null? identity cog-atomspace-env (cog-atomspace)))
+
+	; Is the atom in any of the atomspaces?
+	(define (is-visible? atom)
+		(member (cog-as atom) atomspace-and-parents))
 
 	(define (apply-if-root h)
 		(if (not (any is-visible? (cog-incoming-set h)))

--- a/tests/atomspace/CMakeLists.txt
+++ b/tests/atomspace/CMakeLists.txt
@@ -21,6 +21,7 @@ ADD_CXXTEST(AtomSpaceUTest)
 ADD_CXXTEST(AtomSpaceAsyncUTest)
 ADD_CXXTEST(UseCountUTest)
 ADD_CXXTEST(MultiSpaceUTest)
+ADD_CXXTEST(COWSpaceUTest)
 ADD_CXXTEST(RemoveUTest)
 ADD_CXXTEST(ThreadSafeHandleMapUTest)
 

--- a/tests/atomspace/COWSpaceUTest.cxxtest
+++ b/tests/atomspace/COWSpaceUTest.cxxtest
@@ -20,6 +20,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <opencog/util/Logger.h>
+
 #include <opencog/atoms/base/Node.h>
 #include <opencog/atoms/base/Link.h>
 #include <opencog/atomspace/AtomSpace.h>
@@ -52,6 +54,7 @@ public:
 
 	void testSimple()
 	{
+		logger().debug("BEGIN TEST: %s", __FUNCTION__);
 		TruthValuePtr tv1(SimpleTruthValue::createTV(0.1, 0.1));
 		TruthValuePtr tv2(SimpleTruthValue::createTV(0.2, 0.2));
 
@@ -92,5 +95,7 @@ public:
 		Handle h2c = base->add_node(CONCEPT_NODE, "Grade A2");
 		TS_ASSERT(h2 == h2c);
 		TS_ASSERT(h2c->getTruthValue() == tv2);
+
+		logger().debug("END TEST: %s", __FUNCTION__);
 	}
 };

--- a/tests/atomspace/COWSpaceUTest.cxxtest
+++ b/tests/atomspace/COWSpaceUTest.cxxtest
@@ -1,0 +1,87 @@
+/*
+ * tests/atomspace/COWSpaceUTest.cxxtest
+ *
+ * Copyright (C) 2014,2015,2018 Linas Vepstas
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/atoms/base/Node.h>
+#include <opencog/atoms/base/Link.h>
+#include <opencog/atomspace/AtomSpace.h>
+#include <opencog/truthvalue/SimpleTruthValue.h>
+
+#include <cxxtest/TestSuite.h>
+
+using namespace opencog;
+
+// Test permsissions and Copy-On-Write(COW) support for multiple
+// atomspaces. This is pursuant to github bug #1855 -- having
+// permissioned access to values is a good thing to have.
+//
+class COWSpaceUTest :  public CxxTest::TestSuite
+{
+private:
+
+	AtomSpace base;
+	AtomSpace overlay;
+
+public:
+	COWSpaceUTest() {}
+
+	void setUp() {}
+
+	void tearDown() {}
+
+	void testSimple()
+	{
+		TruthValuePtr tv1(SimpleTruthValue::createTV(0.1, 0.1));
+		TruthValuePtr tv2(SimpleTruthValue::createTV(0.2, 0.2));
+
+		// Create three atoms in three different atomspaces
+		Handle h1 = base.add_node(CONCEPT_NODE, "A1 beef");
+		h1->setTruthValue(tv1);
+		Handle h2 = base.add_node(CONCEPT_NODE, "Grade A2");
+		h2->setTruthValue(tv2);
+
+		base.set_read_only();
+		Handle h3 = base.add_node(CONCEPT_NODE, "3");
+
+		TruthValuePtr tv3(SimpleTruthValue::createTV(0.3, 0.3));
+		// Fetch three atoms in three different atomspaces
+		Handle hn1 = as1.add_node(CONCEPT_NODE, "1");
+		Handle hn2 = as2.add_node(NUMBER_NODE, "2");
+		Handle hn3 = as3.add_node(VARIABLE_NODE, "3");
+
+		// They should match the old handles
+		TS_ASSERT(h1 == hn1);
+		TS_ASSERT(h2 == hn2);
+		TS_ASSERT(h3 == hn3);
+
+		// ... and they should refer to the same atoms.
+		TS_ASSERT(hn1->get_type() == h1->get_type());
+		TS_ASSERT(hn2->get_type() == h2->get_type());
+		TS_ASSERT(hn3->get_type() == h3->get_type());
+
+		// The truth value *pointers* should be identical, as they
+		// should point to the same exact truth value instance.
+		TS_ASSERT(hn1->getTruthValue() == h1->getTruthValue());
+		TS_ASSERT(hn2->getTruthValue() == h2->getTruthValue());
+		TS_ASSERT(hn3->getTruthValue() == h3->getTruthValue());
+	}
+
+};

--- a/tests/atomspace/COWSpaceUTest.cxxtest
+++ b/tests/atomspace/COWSpaceUTest.cxxtest
@@ -37,13 +37,16 @@ class COWSpaceUTest :  public CxxTest::TestSuite
 {
 private:
 
-	AtomSpace base;
-	AtomSpace overlay;
+	AtomSpace* base;
+	AtomSpace* ovly;
 
 public:
 	COWSpaceUTest() {}
 
-	void setUp() {}
+	void setUp() {
+		base = new AtomSpace();
+		ovly = new AtomSpace(base);
+	}
 
 	void tearDown() {}
 
@@ -52,36 +55,42 @@ public:
 		TruthValuePtr tv1(SimpleTruthValue::createTV(0.1, 0.1));
 		TruthValuePtr tv2(SimpleTruthValue::createTV(0.2, 0.2));
 
-		// Create three atoms in three different atomspaces
-		Handle h1 = base.add_node(CONCEPT_NODE, "A1 beef");
-		h1->setTruthValue(tv1);
-		Handle h2 = base.add_node(CONCEPT_NODE, "Grade A2");
-		h2->setTruthValue(tv2);
+		// Create two atoms in the base atomspace
+		Handle h1 = base->add_node(CONCEPT_NODE, "A1 beef");
+		Handle h1t = base->set_truthvalue(h1, tv1);
+		TS_ASSERT(h1 == h1t);
 
-		base.set_read_only();
-		Handle h3 = base.add_node(CONCEPT_NODE, "3");
+		Handle h2 = base->add_node(CONCEPT_NODE, "Grade A2");
+		Handle h2t = base->set_truthvalue(h2, tv2);
+		TS_ASSERT(h2 == h2t);
 
+		// Setting base to read-only should prevent insertion
+		base->set_read_only();
+		Handle h3 = base->add_node(CONCEPT_NODE, "3");
+		printf("Read-only add: %p\n", h3.operator->());
+		TS_ASSERT(h3 == nullptr);
+
+		// Setting truth value in overlay should trigger COW
 		TruthValuePtr tv3(SimpleTruthValue::createTV(0.3, 0.3));
-		// Fetch three atoms in three different atomspaces
-		Handle hn1 = as1.add_node(CONCEPT_NODE, "1");
-		Handle hn2 = as2.add_node(NUMBER_NODE, "2");
-		Handle hn3 = as3.add_node(VARIABLE_NODE, "3");
+		Handle h2o = ovly->set_truthvalue(h2, tv3);
+		TS_ASSERT(h2 != h2o);
+		TS_ASSERT(h2o->getTruthValue() == tv3);
+		TS_ASSERT(h2->getTruthValue() == tv2);
 
-		// They should match the old handles
-		TS_ASSERT(h1 == hn1);
-		TS_ASSERT(h2 == hn2);
-		TS_ASSERT(h3 == hn3);
+		Handle h2b = base->add_node(CONCEPT_NODE, "Grade A2");
+		TS_ASSERT(h2 == h2b);
+		TS_ASSERT(h2b->getTruthValue() == tv2);
 
-		// ... and they should refer to the same atoms.
-		TS_ASSERT(hn1->get_type() == h1->get_type());
-		TS_ASSERT(hn2->get_type() == h2->get_type());
-		TS_ASSERT(hn3->get_type() == h3->get_type());
+		// Setting truth value a second time in overlay should NOT COW
+		TruthValuePtr tv4(SimpleTruthValue::createTV(0.4, 0.4));
+		Handle h2v = ovly->set_truthvalue(h2, tv4);
+		TS_ASSERT(h2 != h2v);
+		TS_ASSERT(h2o == h2v);
+		TS_ASSERT(h2o->getTruthValue() == tv4);
+		TS_ASSERT(h2->getTruthValue() == tv2);
 
-		// The truth value *pointers* should be identical, as they
-		// should point to the same exact truth value instance.
-		TS_ASSERT(hn1->getTruthValue() == h1->getTruthValue());
-		TS_ASSERT(hn2->getTruthValue() == h2->getTruthValue());
-		TS_ASSERT(hn3->getTruthValue() == h3->getTruthValue());
+		Handle h2c = base->add_node(CONCEPT_NODE, "Grade A2");
+		TS_ASSERT(h2 == h2c);
+		TS_ASSERT(h2c->getTruthValue() == tv2);
 	}
-
 };

--- a/tests/persist/sql/multi-driver/FetchUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/FetchUTest.cxxtest
@@ -86,6 +86,7 @@ class FetchUTest :  public CxxTest::TestSuite
 
 		void atomCompare(AtomPtr, AtomPtr, std::string);
 		void test_stuff(void);
+		void test_readonly(void);
 };
 
 FetchUTest::FetchUTest(void)
@@ -275,6 +276,54 @@ void FetchUTest::test_stuff(void)
 	TS_ASSERT((*tv) == (*dtv));
 	printf("Expecting %s\n", dtv->to_string().c_str());
 	printf("Got %s\n", tv->to_string().c_str());
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+// ============================================================
+
+void FetchUTest::test_readonly(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	// First, initialize the database
+	eval->eval("(use-modules (opencog persist) (opencog persist-sql))");
+	eval->eval(sql_open);
+	eval->eval(R"((cog-set-tv! (Concept "AAA") (stv 0.1 0.11)))");
+	eval->eval(R"((cog-set-tv! (Concept "BBB") (stv 0.2 0.22)))");
+	eval->eval(R"((List (Concept "AAA") (Concept "BBB")))");
+	eval->eval("(sql-store)");
+	eval->eval("(sql-close)");
+
+	delete _as;
+	_as = new AtomSpace();
+	_as->set_read_only();
+	eval = SchemeEval::get_evaluator(_as);
+	eval->eval(sql_open);
+
+	// Despite the atomsspace being eadonly, we should still be
+	// able to load atoms from the database.
+	eval->eval(R"((load-atoms-of-type 'ConceptNode))");
+	std::string prt = eval->eval("(cog-prt-atomspace)");
+	printf("Atomspace contents:\n%s\n", prt.c_str());
+	Handle a = eval->eval_h(R"((Concept "AAA"))");
+	TS_ASSERT(nullptr != a);
+
+	TruthValuePtr tv = eval->eval_tv(R"((cog-tv (Concept "AAA")))");
+	TruthValuePtr etv = SimpleTruthValue::createTV(0.1, 0.11);
+	TS_ASSERT((*tv) == (*etv));
+	printf("Expecting %s\n", etv->to_string().c_str());
+	printf("Got %s\n", tv->to_string().c_str());
+
+	// No one is messing with the flag, eh?
+	TS_ASSERT(true == _as->get_read_only());
+	Handle c = _as->add_node(CONCEPT_NODE, "foobar");
+	TS_ASSERT(c == nullptr);
+
+	// Try to change TV on A -- should fail.
+	eval->eval(R"((cog-set-tv! (Concept "AAA") (stv 0.3 0.33)))");
+	tv = eval->eval_tv(R"((cog-tv (Concept "AAA")))");
+	TS_ASSERT((*tv) == (*etv));
 
 	logger().debug("END TEST: %s", __FUNCTION__);
 }

--- a/tests/persist/sql/multi-driver/FetchUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/FetchUTest.cxxtest
@@ -320,10 +320,25 @@ void FetchUTest::test_readonly(void)
 	Handle c = _as->add_node(CONCEPT_NODE, "foobar");
 	TS_ASSERT(c == nullptr);
 
-	// Try to change TV on A -- should fail.
+	// Try to change TV on A -- should fail; should get old value.
 	eval->eval(R"((cog-set-tv! (Concept "AAA") (stv 0.3 0.33)))");
 	tv = eval->eval_tv(R"((cog-tv (Concept "AAA")))");
 	TS_ASSERT((*tv) == (*etv));
+
+	// Should be possible to extract, even though its read-only
+	TS_ASSERT(2 == _as->get_size());
+	eval->eval(R"((cog-extract (Concept "AAA")))");
+	eval->eval(R"((cog-extract (Concept "BBB")))");
+	TS_ASSERT(0 == _as->get_size());
+
+	// And re-load them again.
+	eval->eval(R"((load-atoms-of-type 'ConceptNode))");
+	TS_ASSERT(2 == _as->get_size());
+
+	TS_ASSERT(true == _as->get_read_only());
+	Handle d = _as->add_node(CONCEPT_NODE, "barfoo");
+	TS_ASSERT(d == nullptr);
+	TS_ASSERT(2 == _as->get_size());
 
 	logger().debug("END TEST: %s", __FUNCTION__);
 }


### PR DESCRIPTION
This is a basic implementation of a solution for issue #1855.  This allows user to create a base atomspace that acts as a cache of atoms from a database, and mark it read-only.  An overlay atomspace can be use with this, and atoms can be modified in the overlay.   If an attempt is made to set a truth value (or a generic value) on an atom in the read-only base space, it is automatically copied into the overlay space, where the value can be changed. The atom in the base space is left untouched.

Basic example in `examples/atomspace/copy-on-write.scm`. It works. Includes unit tests.

Note also: even though an atomspace is marked "read-only", one can still fetch from the database, and also extract atoms from the atomspace, thus allowing RAM usage to be managed, without altering the read-only nature of the data in the database.

