### PR TITLE
correct initializaiton of backwardchainer in wrapper

### DIFF
--- a/opencog/cython/opencog/backwardchainer.pyx
+++ b/opencog/cython/opencog/backwardchainer.pyx
@@ -1,4 +1,3 @@
-from libcpp.set cimport set
 from cython.operator cimport dereference as deref
 from opencog.atomspace cimport Atom
 from opencog.atomspace cimport void_from_candle
@@ -26,15 +25,17 @@ cdef class BackwardChainer:
                   AtomSpace trace_as=None,
                   AtomSpace control_as=None,
                   Atom focus_set=None):
-
+        cdef cHandle c_vardecl
         if vardecl is None:
-            vardecl = _as.add_link(types.VariableList, [])
+            c_vardecl = c_vardecl.UNDEFINED
+        else:
+            c_vardecl = deref(vardecl.handle)
         if focus_set is None:
             focus_set = _as.add_link(types.SetLink, [])
         self.chainer = new cBackwardChainer(deref(_as.atomspace),
                                         deref(rbs.handle),
                                         deref(target.handle),
-                                        deref(vardecl.handle),
+                                        c_vardecl,
                                         <cAtomSpace*> (NULL if trace_as is None else trace_as.atomspace),
                                         <cAtomSpace*> (NULL if control_as is None else control_as.atomspace),
                                         deref(focus_set.handle))

--- a/tests/cython/backwardchainer/scm/conjunction-rule-base-config.scm
+++ b/tests/cython/backwardchainer/scm/conjunction-rule-base-config.scm
@@ -1,0 +1,57 @@
+;;
+;; URE Configuration file for a mere fuzzy conjunction rule
+;;
+;; Before running any PLN inference you must load that file in the
+;; AtomSpace
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Load required modules and utils ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(use-modules (opencog))
+(use-modules (opencog rule-engine))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Define a rule-based system ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define conjunction-rule-base (ConceptNode "conjunction-rule-base"))
+(InheritanceLink
+   conjunction-rule-base
+   (ConceptNode "URE")
+)
+
+;; Define conj-bc for convenience
+(define (conj-bc target) (cog-bc conjunction-rule-base target))
+
+;;;;;;;;;;;;;;;;
+;; Load rules ;;
+;;;;;;;;;;;;;;;;
+
+;; Load the fuzzy conjunction rule
+(load-from-path "fuzzy-conjunction-introduction.scm")
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Associate rules to the conjunction rule base ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; List the rules
+(define rules
+  (list
+        fuzzy-conjunction-introduction-1ary-rule-name
+        fuzzy-conjunction-introduction-2ary-rule-name
+        fuzzy-conjunction-introduction-3ary-rule-name
+        fuzzy-conjunction-introduction-4ary-rule-name
+        fuzzy-conjunction-introduction-5ary-rule-name
+  )
+)
+;; Associate rules to the conjunction rule base
+(ure-add-rules conjunction-rule-base rules)
+
+;;;;;;;;;;;;;;;;;;;;;;
+;; Other parameters ;;
+;;;;;;;;;;;;;;;;;;;;;;
+
+;; Termination criteria parameters. Two iterations are needed, one for
+;; initializing the BIT, the other to calculate the conjunction.
+(ure-set-num-parameter conjunction-rule-base "URE:maximum-iterations" 2)

--- a/tests/cython/backwardchainer/scm/crisp-config.scm
+++ b/tests/cython/backwardchainer/scm/crisp-config.scm
@@ -5,8 +5,8 @@
 ; Before running any inference you must load that file
 
 ; Load the rules (use load for relative path w.r.t. to that file)
-(load "./rules/crisp-modus-ponens-rule.scm")
-(load "./rules/crisp-deduction-rule.scm")
+(load "crisp-modus-ponens-rule.scm")
+(load "crisp-deduction-rule.scm")
 
 ; Define a new rule base (aka rule-based system)
 (define crisp-rbs (ConceptNode "crisp-rule-base"))

--- a/tests/cython/backwardchainer/scm/fuzzy-conjunction-introduction.scm
+++ b/tests/cython/backwardchainer/scm/fuzzy-conjunction-introduction.scm
@@ -1,0 +1,78 @@
+;; =============================================================================
+;; Fuzzy conjunction introduction rule
+;;
+;; A1
+;; ...
+;; An
+;; |-
+;; AndLink
+;;   A1
+;;   ...
+;;   An
+;;
+;; Where A1 to An are atoms with a fuzzy TV
+;; -----------------------------------------------------------------------------
+
+(use-modules (srfi srfi-1))
+(use-modules (opencog rule-engine))
+
+;; Generate a fuzzy conjunction introduction rule for an n-ary
+;; conjunction
+(define (gen-fuzzy-conjunction-introduction-rule nary)
+  (let* ((variables (gen-variables "$X" nary))
+         (EvaluationT (Type "EvaluationLink"))
+         (InheritanceT (Type "InheritanceLink"))
+         (OrT (Type "OrLink"))
+         (NotT (Type "NotLink"))
+         (ExecutionT (Type "ExecutionLink"))
+         ;; Not AndLink because we'd rather have that already flattened
+         (type (TypeChoice EvaluationT InheritanceT OrT NotT ExecutionT))
+         (gen-typed-variable (lambda (x) (TypedVariable x type)))
+         (vardecl (VariableList (map gen-typed-variable variables)))
+         (pattern (And variables))
+         (rewrite (ExecutionOutput
+                    (GroundedSchema "scm: fuzzy-conjunction-introduction-formula")
+                    ;; We wrap the variables in Set because the order
+                    ;; doesn't matter and this may speed up the URE.
+                    (List (And variables) (Set variables)))))
+    (Bind
+      vardecl
+      pattern
+      rewrite)))
+
+(define (fuzzy-conjunction-introduction-formula A S)
+  (let* ((andees (cog-outgoing-set S))
+         (min-s-atom (min-element-by-key andees cog-stv-strength))
+         (min-c-atom (min-element-by-key andees cog-stv-confidence))
+         (min-s (cog-stv-strength min-s-atom))
+         (min-c (cog-stv-confidence min-c-atom)))
+    (cog-merge-hi-conf-tv! A (stv min-s min-c))))
+
+;; Name the rules
+;;
+;; Lame enumeration, maybe scheme can do better?
+(define fuzzy-conjunction-introduction-1ary-rule-name
+  (DefinedSchema "fuzzy-conjunction-introduction-1ary-rule"))
+(DefineLink
+  fuzzy-conjunction-introduction-1ary-rule-name
+  (gen-fuzzy-conjunction-introduction-rule 1))
+(define fuzzy-conjunction-introduction-2ary-rule-name
+  (DefinedSchema "fuzzy-conjunction-introduction-2ary-rule"))
+(DefineLink
+  fuzzy-conjunction-introduction-2ary-rule-name
+  (gen-fuzzy-conjunction-introduction-rule 2))
+(define fuzzy-conjunction-introduction-3ary-rule-name
+  (DefinedSchema "fuzzy-conjunction-introduction-3ary-rule"))
+(DefineLink
+  fuzzy-conjunction-introduction-3ary-rule-name
+  (gen-fuzzy-conjunction-introduction-rule 3))
+(define fuzzy-conjunction-introduction-4ary-rule-name
+  (DefinedSchema "fuzzy-conjunction-introduction-4ary-rule"))
+(DefineLink
+  fuzzy-conjunction-introduction-4ary-rule-name
+  (gen-fuzzy-conjunction-introduction-rule 4))
+(define fuzzy-conjunction-introduction-5ary-rule-name
+  (DefinedSchema "fuzzy-conjunction-introduction-5ary-rule"))
+(DefineLink
+  fuzzy-conjunction-introduction-5ary-rule-name
+  (gen-fuzzy-conjunction-introduction-rule 5))

--- a/tests/cython/backwardchainer/test_bc.py
+++ b/tests/cython/backwardchainer/test_bc.py
@@ -6,10 +6,23 @@ from opencog.backwardchainer import BackwardChainer
 from opencog.type_constructors import *
 from opencog.utilities import initialize_opencog
 from opencog.scheme_wrapper import load_scm
+import opencog.logger
+import __main__
 
 
-class CrispTest(TestCase):
-    """port of crisp.scm from examples/rule-engine/simple"""
+def run_predicate(a, b):
+    print(a.name)
+    print(b.name)
+    if a.name == "Item0" and b.name == "large":
+    	return TruthValue(0.8, 1.0)
+    if a.name == "Item1" and b.name == "small":
+    	return TruthValue(0.8, 1.0)
+    return TruthValue(0.2, 0.8)
+
+__main__.run_predicate = run_predicate
+
+
+class BCTest(TestCase):
 
     def setUp(self):
         self.atomspace = AtomSpace()
@@ -18,21 +31,55 @@ class CrispTest(TestCase):
         scheme_eval(self.atomspace, '(use-modules (opencog exec))')
         scheme_eval(self.atomspace, '(use-modules (opencog query))')
         scheme_eval(self.atomspace, '(use-modules (opencog logger))')
+        scheme_eval(self.atomspace, '(use-modules (opencog rule-engine))')
         scm_dir = os.environ["SCM_DIR"]
         scheme_eval(self.atomspace, '(add-to-load-path "{0}")'.format(scm_dir))
-        load_scm(self.atomspace, "crisp-config.scm")
 
-    def testCrisp(self):
+    def test_crisp(self):
+        """port of crisp.scm from examples/rule-engine/simple"""
+        scheme_eval(self.atomspace, '(load-from-path "crisp-config.scm")')
         A = PredicateNode("A", TruthValue(1, 1))
         B = PredicateNode("B")
         C = PredicateNode("C")
-        AB = ImplicationLink(TruthValue(1, 1), A, B)
-        BC = ImplicationLink(TruthValue(1, 1), B, C)
-        BC = ImplicationLink(TruthValue(1, 1), B, C)
+        AB = ImplicationLink(A, B)
+        AB.tv = TruthValue(1, 1)
+        BC = ImplicationLink(B, C)
+        BC.tv = TruthValue(1, 1)
         crisprbs = ConceptNode("crisp-rule-base")
         InheritanceLink(crisprbs, ConceptNode("URE"))
         trace_as = AtomSpace()
-        chainer = BackwardChainer(self.atomspace, crisprbs, C, trace_as=trace_as)
+        scheme_eval(self.atomspace, '(crisp-fc (ImplicationLink (stv 1 1) (PredicateNode "A") (PredicateNode "B")))')
+        chainer = BackwardChainer(self.atomspace, crisprbs, C)
         chainer.do_chain()
         results = chainer.get_results()
         self.assertTrue(results.get_out()[0].name == "C")
+        self.assertTrue(results.get_out()[0].tv == AB.tv)
+
+    def test_conjunction_fuzzy_with_virtual_evaluation(self):
+        """Test for correct vardecl parameter initialization in BackwardChainer
+
+	vardecl = VariableList() would cause empty set as backward chaining result
+        vardecl = UNDEFINED should produce two results: (Item0, large), (Item1, small)
+	"""
+        scheme_eval(self.atomspace, '(load-from-path "conjunction-rule-base-config.scm")')
+        rbs = ConceptNode("conjunction-rule-base")
+
+        item0 = ConceptNode("Item0")
+        item1 = ConceptNode("Item1")
+        size = ConceptNode("Size")
+        small = ConceptNode("small")
+        large = ConceptNode("large")
+        InheritanceLink(item0, ConceptNode("Items")).tv = TruthValue(0.9, 0.9)
+        InheritanceLink(item1, ConceptNode("Items")).tv = TruthValue(0.9, 0.9)
+        InheritanceLink(small, size).tv = TruthValue(1.0, 1.0)
+        InheritanceLink(large, size).tv = TruthValue(1.0, 1.0)
+        P = GroundedPredicateNode("py:run_predicate")
+        X = VariableNode("$X")
+        Y = VariableNode("$Y")
+        P_A = EvaluationLink(P, ListLink(X, Y))
+        target = AndLink(InheritanceLink(Y, size), InheritanceLink(X, ConceptNode("Items")), P_A)
+
+        bc = BackwardChainer(self.atomspace, rbs, target)
+        bc.do_chain()
+        results = bc.get_results()
+        self.assertTrue(len(results.get_out()) == 2)


### PR DESCRIPTION
passing vardecl = empy variable list to BackwardChainer constructor leads to failed search in some cases
This pull request contains necessary unit test and bugfix
