### PR TITLE
Disable supposedly fix (and by that fix something else)

### DIFF
--- a/opencog/atoms/core/RewriteLink.cc
+++ b/opencog/atoms/core/RewriteLink.cc
@@ -335,11 +335,16 @@ Handle RewriteLink::consume_quotations(const Variables& variables,
 	// Base case
 	if (h->is_node())
 	{
-		// Make sure quotation is removed around GroundedPredicateNode
-		// as it otherwise changes the pattern matcher semantics as it
-		// will consider those as virtual.
-		if (t == GROUNDED_PREDICATE_NODE)
-			needless_quotation = false;
+		// TODO: the following has no unit test!!! Yet it introduces a
+		// bug covered by RewriteLinkUTest::test_consume_quotations_4(),
+		// thus this code is disable till a unit test it created for it
+		// and we understand what it fixes and how it fixes.
+		//
+		// // Make sure quotation is not removed around
+		// // GroundedPredicateNode as it otherwise changes the pattern
+		// // matcher semantics as it will consider those as virtual.
+		// if (t == GROUNDED_PREDICATE_NODE)
+		// 	needless_quotation = false;
 
 		return h;
 	}

--- a/tests/atoms/RewriteLinkUTest.cxxtest
+++ b/tests/atoms/RewriteLinkUTest.cxxtest
@@ -77,6 +77,7 @@ public:
 	void test_consume_quotations_1();
 	void test_consume_quotations_2();
 	void test_consume_quotations_3();
+	void test_consume_quotations_4();
 };
 
 #define NA _asa.add_node
@@ -308,6 +309,29 @@ void RewriteLinkUTest::test_consume_quotations_3()
 	// gpn is evaluatable
 	Handle result = RewriteLink::consume_quotations(vardecl, quoted_clauses, true),
 		expected = _eval.eval_h("consumed-quoted-clauses");
+
+	std::cout << "result = " << oc_to_string(result);
+	std::cout << "expected = " << oc_to_string(expected);
+
+	TS_ASSERT(content_eq(result, expected));
+}
+
+void RewriteLinkUTest::test_consume_quotations_4()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	std::string rs = _eval.eval("(load-from-path \"tests/atoms/quotations.scm\")");
+	logger().debug() << "rs = " << rs;
+
+	// Test simple RewriteLink
+	Handle vardecl = al(VARIABLE_LIST),
+		quoted_clauses = _eval.eval_h("quoted-grounded-predicate-argument");
+
+	// Remove the UnquoteLink wrapping gpn as it is useless, and even
+	// harmful to the pattern matcher as it makes it believe that the
+	// gpn is evaluatable
+	Handle result = RewriteLink::consume_quotations(vardecl, quoted_clauses, true),
+		expected = _eval.eval_h("consumed-quoted-grounded-predicate-argument");
 
 	std::cout << "result = " << oc_to_string(result);
 	std::cout << "expected = " << oc_to_string(expected);

--- a/tests/atoms/quotations.scm
+++ b/tests/atoms/quotations.scm
@@ -129,3 +129,43 @@
   )
 )
 )
+
+(define quoted-grounded-predicate-argument
+  (EvaluationLink
+    (GroundedPredicateNode "scm: absolutely-true")
+    (EvaluationLink
+      (PredicateNode "minsup")
+      (ListLink
+        (QuoteLink
+          (LambdaLink
+            (UnquoteLink
+              (VariableNode "$X")
+            )
+            (Unquote
+              (VariableNode "$X")
+            )
+          )
+        )
+        (ConceptNode "texts")
+        (NumberNode "5.000000")
+      )
+    )
+  )
+)
+
+(define consumed-quoted-grounded-predicate-argument
+  (EvaluationLink
+    (GroundedPredicateNode "scm: absolutely-true")
+    (EvaluationLink
+      (PredicateNode "minsup")
+      (ListLink
+        (LambdaLink
+          (VariableNode "$X")
+          (VariableNode "$X")
+        )
+        (ConceptNode "texts")
+        (NumberNode "5.000000")
+      )
+    )
+  )
+)


### PR DESCRIPTION
Disable some code that prevented `RewriteLink::consume_quotations` to properly consume some quotations of virtual links involving `GroundedPredicateNode`.

That code was probably (badly) fixing another bug, but it wasn't covered by any unit test.

No unit test, no speech.