### PR TITLE
Fix EqualLink quote consumption

### DIFF
--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -109,6 +109,23 @@ FreeVariables::FreeVariables(const std::initializer_list<Handle>& variables)
 		index.insert({var, i++});
 }
 
+bool FreeVariables::is_identical(const FreeVariables& other) const
+{
+	Arity ary = varseq.size();
+	if (ary != other.varseq.size()) return false;
+	for (Arity i=0; i< ary; i++)
+	{
+		if (*((AtomPtr) varseq[i]) != *((AtomPtr) other.varseq[i]))
+			return false;
+	}
+	return true;
+}
+
+bool FreeVariables::is_in_varset(const Handle& v) const
+{
+	return varset.end() != varset.find(v);
+}
+
 void FreeVariables::find_variables(const HandleSeq& oset)
 {
 	VarScraper vsc;
@@ -154,11 +171,6 @@ void FreeVariables::erase(const Handle& var)
 	}
 }
 
-bool FreeVariables::operator<(const FreeVariables& other) const
-{
-	return varseq < other.varseq;
-}
-
 /* ================================================================= */
 
 Handle FreeVariables::substitute_nocheck(const Handle& term,
@@ -173,6 +185,36 @@ Handle FreeVariables::substitute_nocheck(const Handle& term,
                                          bool silent) const
 {
 	return substitute_scoped(term, make_sequence(vm), silent, index, 0);
+}
+
+bool FreeVariables::operator<(const FreeVariables& other) const
+{
+	return varseq < other.varseq;
+}
+
+std::size_t FreeVariables::size() const
+{
+	return varseq.size();
+}
+
+bool FreeVariables::empty() const
+{
+	return varseq.empty();
+}
+
+std::string FreeVariables::to_string(const std::string& indent) const
+{
+	std::stringstream ss;
+
+	// Varseq
+	ss << indent << "varseq:" << std::endl
+	   << oc_to_string(varseq, indent + OC_TO_STRING_INDENT);
+
+	// index
+	ss << indent << "index:" << std::endl
+	   << oc_to_string(index, indent + OC_TO_STRING_INDENT);
+
+	return ss.str();
 }
 
 /// Perform beta-reduction on the term.  This is more-or-less a purely
@@ -284,19 +326,6 @@ Handle FreeVariables::substitute_scoped(const Handle& term,
 	}
 
 	return createLink(oset, term->get_type());
-}
-
-/* ================================================================= */
-
-bool FreeVariables::is_identical(const FreeVariables& other) const
-{
-	Arity ary = varseq.size();
-	if (ary != other.varseq.size()) return false;
-	for (Arity i=0; i< ary; i++)
-	{
-		if (*((AtomPtr) varseq[i]) != *((AtomPtr) other.varseq[i])) return false;
-	}
-	return true;
 }
 
 /* ================================================================= */
@@ -712,16 +741,6 @@ bool Variables::operator<(const Variables& other) const
 		        and _fuzzy_typemap < other._fuzzy_typemap));
 }
 
-std::size_t FreeVariables::size() const
-{
-	return varseq.size();
-}
-
-bool FreeVariables::empty() const
-{
-	return varseq.empty();
-}
-
 /// Look up the type declaration for `var`, but create the actual
 /// declaration for `alt`.  This is an alpha-renaming.
 Handle Variables::get_type_decl(const Handle& var, const Handle& alt) const
@@ -773,9 +792,8 @@ std::string Variables::to_string(const std::string& indent) const
 {
 	std::stringstream ss;
 
-	// Varseq
-	ss << indent << "varseq:" << std::endl
-	   << oc_to_string(varseq, indent + OC_TO_STRING_INDENT);
+	// FreeVariables
+	ss << FreeVariables::to_string(indent);
 
 	// Simple typemap
 	ss << indent << "_simple_typemap:" << std::endl;
@@ -791,7 +809,25 @@ std::string Variables::to_string(const std::string& indent) const
 		ss << std::endl;
 		i++;
 	}
+
 	return ss.str();
+}
+
+std::string oc_to_string(const FreeVariables::IndexMap& imap,
+                         const std::string& indent)
+{
+	std::stringstream ss;
+	ss << indent << "size = " << imap.size() << std::endl;
+	for (const auto& el : imap) {
+		ss << indent << "index[" << el.second << "]: "
+		   << el.first->id_to_string() << std::endl;
+	}
+	return ss.str();
+}
+
+std::string oc_to_string(const FreeVariables& var, const std::string& indent)
+{
+	return var.to_string(indent);
 }
 
 std::string oc_to_string(const Variables& var, const std::string& indent)

--- a/opencog/atoms/core/Variables.h
+++ b/opencog/atoms/core/Variables.h
@@ -73,9 +73,7 @@ struct FreeVariables
 	bool is_identical(const FreeVariables& other) const;
 
 	/// Return true if variable `var` is in this variableset.
-	bool is_in_varset(const Handle& v) const {
-		return varset.end() != varset.find(v);
-	}
+	bool is_in_varset(const Handle& v) const;
 
 	/// Return true if all variables within the given range is in
 	/// varset.
@@ -142,6 +140,9 @@ struct FreeVariables
 
 	/// Return true, if there are no free variables.
 	bool empty() const;
+
+	/// Useful for debugging
+	std::string to_string(const std::string& indent=empty_string) const;
 
 protected:
 	Handle substitute_scoped(const Handle&, const HandleSeq&, bool,
@@ -270,7 +271,7 @@ struct Variables : public FreeVariables,
 	Handle get_vardecl() const;
 
 	// Useful for debugging
-	std::string to_string(const std::string& indent="") const;
+	std::string to_string(const std::string& indent=empty_string) const;
 };
 
 // Debugging helpers see
@@ -278,6 +279,10 @@ struct Variables : public FreeVariables,
 // The reason indent is not an optional argument with default is
 // because gdb doesn't support that, see
 // http://stackoverflow.com/questions/16734783 for more explanation.
+std::string oc_to_string(const FreeVariables::IndexMap& imap,
+                         const std::string& indent=empty_string);
+std::string oc_to_string(const FreeVariables& var,
+                         const std::string& indent=empty_string);
 std::string oc_to_string(const Variables& var,
                          const std::string& indent=empty_string);
 

--- a/opencog/atoms/execution/Instantiator.cc
+++ b/opencog/atoms/execution/Instantiator.cc
@@ -45,7 +45,7 @@ Instantiator::Instantiator(AtomSpace* as)
 /// member of the pair is the variable; the second is the value that
 /// should be used as its replacement.  (Note that "variables" do not
 /// have to actually be VariableNode's; they can be any atom.)
-static Handle beta_reduce(const Handle& expr, const HandleMap vmap)
+static Handle beta_reduce(const Handle& expr, const HandleMap& vmap)
 {
 	// Format conversion. FreeVariables::substitute_nocheck() performs
 	// beta-reduction correctly, so we just use that. But we have to

--- a/opencog/atoms/execution/Instantiator.cc
+++ b/opencog/atoms/execution/Instantiator.cc
@@ -480,7 +480,7 @@ Handle Instantiator::walk_tree(const Handle& expr, bool silent)
 	// However, some of these may hold embedded executable links
 	// inside of them, which the current unit tests and code
 	// expect to be executed.  Thus, for right now, we only avoid
-	// evaluating VirtualLinks, as these all are capable of thier
+	// evaluating VirtualLinks, as these all are capable of their
 	// own lazy-evaluation, and so, if evaluation is needed,
 	// it will be triggered by something else.
 	// Non-virtual evaluatables fall through and are handled

--- a/opencog/atoms/execution/Instantiator.h
+++ b/opencog/atoms/execution/Instantiator.h
@@ -135,7 +135,7 @@ public:
 	}
 
 	ProtoAtomPtr instantiate(const Handle& expr,
-	                         const HandleMap &vars,
+	                         const HandleMap& vars,
 	                         bool silent=false);
 	ProtoAtomPtr execute(const Handle& expr, bool silent=false)
 	{

--- a/opencog/atoms/pattern/PatternTerm.cc
+++ b/opencog/atoms/pattern/PatternTerm.cc
@@ -27,12 +27,14 @@
 namespace opencog {
 
 PatternTerm::PatternTerm()
-	: _handle(Handle::UNDEFINED), _parent(PatternTerm::UNDEFINED),
+	: _handle(Handle::UNDEFINED),
+	  _quote(Handle::UNDEFINED),
+	  _parent(PatternTerm::UNDEFINED),
 	  _has_any_bound_var(false)
 {}
 
 PatternTerm::PatternTerm(const PatternTermPtr& parent, const Handle& h)
-	: _handle(h), _parent(parent),
+	: _handle(h), _quote(Handle::UNDEFINED), _parent(parent),
 	  _quotation(parent->_quotation.level(),
 	             false /* necessarily false since it is local */),
 	  _has_any_bound_var(false)
@@ -46,6 +48,8 @@ PatternTerm::PatternTerm(const PatternTermPtr& parent, const Handle& h)
 			throw InvalidParamException(TRACE_INFO,
 			                            "QuoteLink/UnquoteLink/LocalQuoteLink has "
 			                            "unexpected arity!");
+		// Save the quotes, useful for mapping patterns to grounds
+		_quote = _handle;
 		_handle = h->getOutgoingAtom(0);
 	}
 
@@ -61,6 +65,11 @@ void PatternTerm::addOutgoingTerm(const PatternTermPtr& ptm)
 const Handle& PatternTerm::getHandle() const
 {
 	return _handle;
+}
+
+const Handle& PatternTerm::getQuote() const
+{
+	return _quote;
 }
 
 PatternTermPtr PatternTerm::getParent()

--- a/opencog/atoms/pattern/PatternTerm.cc
+++ b/opencog/atoms/pattern/PatternTerm.cc
@@ -58,7 +58,7 @@ void PatternTerm::addOutgoingTerm(const PatternTermPtr& ptm)
 	_outgoing.push_back(ptm);
 }
 
-Handle PatternTerm::getHandle()
+const Handle& PatternTerm::getHandle() const
 {
 	return _handle;
 }

--- a/opencog/atoms/pattern/PatternTerm.h
+++ b/opencog/atoms/pattern/PatternTerm.h
@@ -89,6 +89,7 @@ class PatternTerm
 {
 protected:
 	Handle _handle;
+	Handle _quote;
 	PatternTermPtr _parent;
 	PatternTermWSeq _outgoing;
 
@@ -110,6 +111,8 @@ public:
 	void addOutgoingTerm(const PatternTermPtr& ptm);
 
 	const Handle& getHandle() const;
+
+	const Handle& getQuote() const;
 
 	PatternTermPtr getParent();
 

--- a/opencog/atoms/pattern/PatternTerm.h
+++ b/opencog/atoms/pattern/PatternTerm.h
@@ -109,7 +109,7 @@ public:
 
 	void addOutgoingTerm(const PatternTermPtr& ptm);
 
-	Handle getHandle();
+	const Handle& getHandle() const;
 
 	PatternTermPtr getParent();
 

--- a/opencog/query/DefaultPatternMatchCB.cc
+++ b/opencog/query/DefaultPatternMatchCB.cc
@@ -676,7 +676,7 @@ bool DefaultPatternMatchCB::eval_term(const Handle& virt,
 	DO_LOG({LAZY_LOG_FINE << "Eval_term evaluation yeilded tv="
 	              << tvp->to_string() << std::endl;})
 
-	// XXX FIXME: we are making a crsip-logic go/no-go decision
+	// XXX FIXME: we are making a crisp-logic go/no-go decision
 	// based on the TV strength. Perhaps something more subtle might be
 	// wanted, here.
 	bool relation_holds = tvp->get_mean() > 0.5;

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -249,7 +249,7 @@ bool PatternMatchEngine::ordered_compare(const PatternTermPtr& ptm,
 	if (not match) return false;
 
 	// If we've found a grounding, record it.
-	if (hp != hg) var_grounding[hp] = hg;
+	record_grounding(ptm, hg);
 
 	return true;
 }
@@ -308,7 +308,7 @@ bool PatternMatchEngine::choice_compare(const PatternTermPtr& ptm,
 				solution_drop();
 
 				// If the grounding is accepted, record it.
-				if (hp != hg) var_grounding[hp] = hg;
+				record_grounding(ptm, hg);
 
 				_choice_state[GndChoice(ptm, hg)] = icurr;
 				return true;
@@ -592,7 +592,7 @@ bool PatternMatchEngine::unorder_compare(const PatternTermPtr& ptm,
 				solution_drop();
 
 				// If the grounding is accepted, record it.
-				if (hp != hg) var_grounding[hp] = hg;
+				record_grounding(ptm, hg);
 
 				// Handle case 5&7 of description above.
 				have_more = true;
@@ -2101,6 +2101,24 @@ bool PatternMatchEngine::explore_clause(const Handle& term,
 		return clause_accept(clause, grnd);
 
 	return false;
+}
+
+void PatternMatchEngine::record_grounding(const PatternTermPtr& ptm,
+                                          const Handle& hg)
+{
+	const Handle& hp = ptm->getHandle();
+	// Likely a closed pattern, no need to save it
+	if (hp == hg)
+		return;
+
+	// Only record if the pattern is not quoted, otherwise the pattern
+	// is not completely self-contained.
+	if (not ptm->isQuoted())
+		var_grounding[hp] = hg;
+	// If quoted, try one last chance by checking if the quote is
+	// hidden in ptm.
+	else if (const Handle& quote = ptm->getQuote())
+		var_grounding[quote] = hg;
 }
 
 /**

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -501,12 +501,12 @@ bool PatternMatchEngine::unorder_compare(const PatternTermPtr& ptm,
 	const HandleSeq& osg = hg->getOutgoingSet();
 	PatternTermSeq osp = ptm->getOutgoingSet();
 	size_t arity = osp.size();
-	bool has_glob = (0 < _pat->globby_holders.count(ptm->getHandle()));
+	bool has_glob = (0 < _pat->globby_holders.count(hp));
 
 	// They've got to be the same size, at the least!
 	// unless there are globs in the pattern
 	if (osg.size() != arity and not has_glob)
-		return _pmc.fuzzy_match(ptm->getHandle(), hg);
+		return _pmc.fuzzy_match(hp, hg);
 
 	// Test for case A, described above.
 	OC_ASSERT (not (take_step and have_more),

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -93,6 +93,16 @@ private:
 	// Map of clauses to their current groundings
 	HandleMap clause_grounding;
 
+	// Insert association between pattern ptm and its grounding hg into
+	// var_grounding.
+	//
+	// Takes quotation into account, that is only insert unquoted
+	// pattern, and if it is quoted, attempt to restore the unquoted
+	// pattern (as the quote is hidden inside the PatternTerm). This is
+	// especially useful for recording subclause patterns, which turn
+	// out to be useful during instantiation.
+	void record_grounding(const PatternTermPtr& ptm, const Handle& hg);
+
 	void clear_current_state(void);  // clear the stuff above
 
 	// -------------------------------------------

--- a/tests/query/GetLinkUTest.cxxtest
+++ b/tests/query/GetLinkUTest.cxxtest
@@ -73,6 +73,7 @@ _exit(rc); // XXX hack to avoid double-free in __run_exit_handlers
 	void test_disconnected_empty(void);
 	void test_not_equal(void);
 	void test_disconnected_const_eval(void);
+	void test_quote_equal(void);
 };
 
 void GetLinkUTest::tearDown(void)
@@ -316,6 +317,29 @@ void GetLinkUTest::test_disconnected_const_eval(void)
 	expect = al(SET_LINK, HandleSeq());
 	printf("Expected this: %s\n", expect->to_string().c_str());
 	printf("Found this answer: %s\n", result->to_string().c_str());
+	TS_ASSERT_EQUALS(result, expect);
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+/*
+ * Make sure that quotation is properly consumed before testing for
+ * equality.
+ */
+void GetLinkUTest::test_quote_equal(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	as->clear();
+	eval->eval("(load-from-path \"tests/query/get-link-equal.scm\")");
+
+	Handle gl = eval->eval_h("gl");
+	Handle result = satisfying_set(as, gl);
+	Handle expect = eval->eval_h("expect");
+
+	printf("Expected this: %s\n", expect->to_string().c_str());
+	printf("Found this answer: %s\n", result->to_string().c_str());
+
 	TS_ASSERT_EQUALS(result, expect);
 
 	logger().debug("END TEST: %s", __FUNCTION__);

--- a/tests/query/get-link-equal.scm
+++ b/tests/query/get-link-equal.scm
@@ -1,0 +1,92 @@
+;; Test quotation consumption in EqualLink
+;;
+;; The main clause of `gl`
+;;
+;;       (QuoteLink
+;;         (LambdaLink
+;;           (UnquoteLink
+;;             (VariableNode "$vardecl"))
+;;           (UnquoteLink
+;;             (VariableNode "$body"))))
+;;
+;; matches the grounding `top`
+;;
+;;   (Lambda
+;;     (Variable "$X")
+;;     (Variable "$X"))
+;;
+;; However, if quotation consumption is not subsequently properly
+;; handled, the virtual clause
+;;
+;;       (top?
+;;         (QuoteLink
+;;           (LambdaLink
+;;             (UnquoteLink
+;;               (VariableNode "$vardecl"))
+;;             (UnquoteLink
+;;               (VariableNode "$body")))))))
+;;
+;; produces
+;;
+;; (EqualLink
+;;   (QuoteLink
+;;     (LambdaLink
+;;       (UnquoteLink
+;;         (Variable "$X"))
+;;       (UnquoteLink
+;;         (Variable "$X"))))
+;;   (Lambda
+;;     (Variable "$X")
+;;     (Variable "$X")))
+;;
+;; instead of
+;;
+;; (EqualLink
+;;   (Lambda
+;;     (Variable "$X")
+;;     (Variable "$X"))
+;;   (Lambda
+;;     (Variable "$X")
+;;     (Variable "$X")))
+;;
+;; thus falsely discarding the match.
+
+(define top
+  (Lambda
+    (Variable "$X")
+    (Variable "$X"))
+)
+
+(define (top? x)
+  (Equal
+    x
+    top)
+)
+
+(define gl
+  (GetLink
+    (VariableList
+      (VariableNode "$vardecl")
+      (VariableNode "$body"))
+    (AndLink
+      (QuoteLink
+        (LambdaLink
+          (UnquoteLink
+            (VariableNode "$vardecl"))
+          (UnquoteLink
+            (VariableNode "$body"))))
+      (top?
+        (QuoteLink
+          (LambdaLink
+            (UnquoteLink
+              (VariableNode "$vardecl"))
+            (UnquoteLink
+              (VariableNode "$body")))))))
+)
+
+(define expect
+  (SetLink
+    (ListLink
+      (VariableNode "$X")
+      (VariableNode "$X")))
+)


### PR DESCRIPTION
Fixing a bug in quotation consumption of EqualLink and other virtual links, for instance without that fix the following
```
(EqualLink
  (QuoteLink
    (LambdaLink
      (UnquoteLink
        (Variable "$X"))
      (UnquoteLink
        (Variable "$X"))))
  (Lambda
    (Variable "$X")
    (Variable "$X")))
```
instead of
```
(EqualLink
  (Lambda
    (Variable "$X")
    (Variable "$X"))
  (Lambda
    (Variable "$X")
    (Variable "$X")))
```
thus falsely discarding the match. See `GetLinkUTest::test_quote_equal` for more info.