### PR TITLE
Bugfix the test-runner scheme module

### DIFF
--- a/opencog/scm/opencog/test-runner.scm
+++ b/opencog/scm/opencog/test-runner.scm
@@ -1,5 +1,6 @@
 (define-module (opencog test-runner)
   #:use-module (srfi srfi-64)
+  #:re-export (test-begin test-assert test-end)
   #:export (opencog-test-runner))
 
 (define (opencog-test-runner)


### PR DESCRIPTION
Add missing exports;  guile-3.0 doesn't work without these.