### PR TITLE
Bug-fix for the scm test runner.

### DIFF
--- a/cmake/OpenCogFunctions.cmake
+++ b/cmake/OpenCogFunctions.cmake
@@ -144,7 +144,9 @@ FUNCTION(ADD_GUILE_TEST TEST_NAME FILE_NAME)
                 ${CMAKE_CURRENT_SOURCE_DIR})
         ENDIF()
 
-        ADD_TEST(${TEST_NAME} guile --use-srfi=64 ${FILE_PATH}
+        ADD_TEST(${TEST_NAME} guile --use-srfi=64
+            -L ${DATADIR}/scm
+            ${FILE_PATH}
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
     ENDIF()


### PR DESCRIPTION
The test runner fails, if the guile module path is not specified
in some way. Specify the install path.