### PR TITLE
Overload oc_to_string for ValuePtr

### DIFF
--- a/opencog/atoms/value/CMakeLists.txt
+++ b/opencog/atoms/value/CMakeLists.txt
@@ -15,6 +15,7 @@ INCLUDE_DIRECTORIES(${CMAKE_BINARY_DIR})
 
 ADD_LIBRARY (value
 	atom_types_init.cc
+	Value.cc
 	FloatValue.cc
 	LinkValue.cc
 	NameServer.cc

--- a/opencog/atoms/value/Value.cc
+++ b/opencog/atoms/value/Value.cc
@@ -1,0 +1,35 @@
+/*
+ * opencog/atoms/value/Value.cc
+ *
+ * Copyright (C) 2018 SingularityNET Foundation
+ * All Rights Reserved
+ *
+ * Author: Nil Geisweiller
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "Value.h"
+
+namespace opencog
+{
+
+std::string oc_to_string(const ValuePtr& vp, const std::string& indent)
+{
+	return vp->to_string(indent);
+}
+
+} // ~namespace std

--- a/opencog/atoms/value/Value.h
+++ b/opencog/atoms/value/Value.h
@@ -99,6 +99,13 @@ typedef std::shared_ptr<Value> ValuePtr;
 
 typedef std::vector<ValuePtr> ProtomSeq;
 
+// Debugging helpers see
+// http://wiki.opencog.org/w/Development_standards#Print_OpenCog_Objects
+// The reason indent is not an optional argument with default is
+// because gdb doesn't support that, see
+// http://stackoverflow.com/questions/16734783 for more explanation.
+std::string oc_to_string(const ValuePtr& vp, const std::string& indent);
+
 /** @}*/
 } // namespace opencog
 


### PR DESCRIPTION
For gdb, see https://wiki.opencog.org/w/Development_standards#Pretty_Print_OpenCog_Objects