### PR TITLE
Use SchemeModule ModuleWrap in PersistSCM

### DIFF
--- a/opencog/persist/guile/PersistSCM.cc
+++ b/opencog/persist/guile/PersistSCM.cc
@@ -29,24 +29,12 @@
 using namespace opencog;
 
 PersistSCM::PersistSCM(void)
+	: ModuleWrap("opencog persist")
 {
 	static bool is_init = false;
 	if (is_init) return;
 	is_init = true;
-	scm_with_guile(init_in_guile, this);
-}
-
-void* PersistSCM::init_in_guile(void* self)
-{
-	scm_c_define_module("opencog persist", init_in_module, self);
-	scm_c_use_module("opencog persist");
-	return NULL;
-}
-
-void PersistSCM::init_in_module(void* data)
-{
-	PersistSCM* self = (PersistSCM*) data;
-	self->init();
+	module_init();
 }
 
 void PersistSCM::init(void)

--- a/opencog/persist/guile/PersistSCM.h
+++ b/opencog/persist/guile/PersistSCM.h
@@ -26,6 +26,7 @@
 
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/atoms/base/Handle.h>
+#include <opencog/guile/SchemeModule.h>
 
 namespace opencog
 {
@@ -33,11 +34,9 @@ namespace opencog
  *  @{
  */
 
-class PersistSCM
+class PersistSCM : public ModuleWrap
 {
 private:
-	static void* init_in_guile(void*);
-	static void init_in_module(void*);
 	void init(void);
 
 	Handle fetch_atom(Handle);


### PR DESCRIPTION
PersistSCM had duplicated code from ModuleWrap. So now PersistSCM
inherits from ModuleWrap.