### PR TITLE
Fix unit tests opencog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,17 +46,17 @@ jobs:
           name: Build
           command: cd build && make -j2
       - run:
-          name: Install AtomSpace
-          command: cd build && make -j2 install && ldconfig
-      - run:
-          name: Build examples
-          command: cd build && make -j2 examples
-      - run:
           name: Build tests
           command: cd build && make -j2 tests
       - run:
           name: Run tests
           command: cd build && make -j2 test ARGS=-j2
+      - run:
+          name: Install AtomSpace
+          command: cd build && make -j2 install && ldconfig
+      - run:
+          name: Build examples
+          command: cd build && make -j2 examples
       - run:
           name: Print test log
           command: cat build/tests/Testing/Temporary/LastTest.log

--- a/tests/cython/CMakeLists.txt
+++ b/tests/cython/CMakeLists.txt
@@ -102,19 +102,19 @@ IF (HAVE_NOSETESTS)
 			${CMAKE_SOURCE_DIR}/tests/cython/backwardchainer/)
 		SET_PROPERTY(TEST CythonBackwardchainer
 			PROPERTY ENVIRONMENT "PYTHONDONTWRITEBYTECODE=1"
-		        "SCM_DIR=${PROJECT_SOURCE_DIR}/tests/cython/backwardchainer/scm"
-			"PYTHONPATH=${PROJECT_BINARY_DIR}/opencog/cython/:${PROJECT_SOURCE_DIR}/opencog/python/:${PROJECT_SOURCE_DIR}/tests/cython/backwardchainer")
+			"SCM_DIR=${PROJECT_SOURCE_DIR}/tests/cython/backwardchainer/scm"
+			"PYTHONPATH=${PROJECT_BINARY_DIR}/opencog/cython/:${PROJECT_SOURCE_DIR}/opencog/python/:${PROJECT_SOURCE_DIR}/tests/cython/backwardchainer"
+			"LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/opencog/guile:$ENV{LD_LIBRARY_PATH}"
+		    )
 	ENDIF (HAVE_ATOMSPACE)
 
 	IF (HAVE_ATOMSPACE AND HAVE_GUILE)
 		ADD_TEST(CythonGuile ${NOSETESTS_EXECUTABLE} -vs
 			${CMAKE_SOURCE_DIR}/tests/cython/guile/)
-		SET_TESTS_PROPERTIES(CythonGuile
-			PROPERTIES
-			DEPENDS atomspace_cython
-			DEPENDS scheme_wrapper
-			ENVIRONMENT "PYTHONDONTWRITEBYTECODE=1"
-			ENVIRONMENT "PYTHONPATH=${PROJECT_BINARY_DIR}/opencog/cython")
+		SET_PROPERTY(TEST CythonGuile
+			PROPERTY ENVIRONMENT "PROJECT_SOURCE_DIR=${PROJECT_SOURCE_DIR}"
+			"PYTHONDONTWRITEBYTECODE=1"
+			"PYTHONPATH=${PROJECT_BINARY_DIR}/opencog/cython")
 	ENDIF (HAVE_ATOMSPACE AND HAVE_GUILE)
 
 ENDIF (HAVE_NOSETESTS)

--- a/tests/cython/CMakeLists.txt
+++ b/tests/cython/CMakeLists.txt
@@ -102,10 +102,9 @@ IF (HAVE_NOSETESTS)
 			${CMAKE_SOURCE_DIR}/tests/cython/backwardchainer/)
 		SET_PROPERTY(TEST CythonBackwardchainer
 			PROPERTY ENVIRONMENT "PYTHONDONTWRITEBYTECODE=1"
-			"SCM_DIR=${PROJECT_SOURCE_DIR}/tests/cython/backwardchainer/scm"
-			"PYTHONPATH=${PROJECT_BINARY_DIR}/opencog/cython/:${PROJECT_SOURCE_DIR}/opencog/python/:${PROJECT_SOURCE_DIR}/tests/cython/backwardchainer"
-			"LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/opencog/guile:$ENV{LD_LIBRARY_PATH}"
-		    )
+				"SCM_DIR=${PROJECT_SOURCE_DIR}/tests/cython/backwardchainer/scm"
+				"PYTHONPATH=${PROJECT_BINARY_DIR}/opencog/cython/:${PROJECT_SOURCE_DIR}/opencog/python/:${PROJECT_SOURCE_DIR}/tests/cython/backwardchainer"
+				"LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/opencog/guile:$ENV{LD_LIBRARY_PATH}")
 	ENDIF (HAVE_ATOMSPACE)
 
 	IF (HAVE_ATOMSPACE AND HAVE_GUILE)
@@ -113,8 +112,10 @@ IF (HAVE_NOSETESTS)
 			${CMAKE_SOURCE_DIR}/tests/cython/guile/)
 		SET_PROPERTY(TEST CythonGuile
 			PROPERTY ENVIRONMENT "PROJECT_SOURCE_DIR=${PROJECT_SOURCE_DIR}"
-			"PYTHONDONTWRITEBYTECODE=1"
-			"PYTHONPATH=${PROJECT_BINARY_DIR}/opencog/cython")
+				"PYTHONDONTWRITEBYTECODE=1"
+				"PYTHONPATH=${PROJECT_BINARY_DIR}/opencog/cython")
+		SET_PROPERTY(TEST CythonGuile
+			PROPERTY DEPENDS atomspace_cython scheme_wrapper)
 	ENDIF (HAVE_ATOMSPACE AND HAVE_GUILE)
 
 ENDIF (HAVE_NOSETESTS)

--- a/tests/cython/PythonEvalUTest.cxxtest
+++ b/tests/cython/PythonEvalUTest.cxxtest
@@ -33,7 +33,6 @@ public:
 
     void testRawPythonInitialization()
     {
-        TS_SKIP("FIXME: this test fais with SEGFAUL");
         logger().debug("[PythonEvalUTest] testRawPythonInitialization()");
 
         // Start up Python.
@@ -75,7 +74,6 @@ public:
 
     void testRawPythonInitializeWithGetSys()
     {
-        TS_SKIP("FIXME: this test fais with SEGFAUL");
         logger().debug("[PythonEvalUTest] testRawPythonInitializeWithGetSys()");
 
         PyObject* pySysPath = NULL;
@@ -136,7 +134,6 @@ public:
 
     void testGlobalPythonInitializationFinalization()
     {
-        TS_SKIP("FIXME: this test fais with SEGFAUL");
         logger().debug("[PythonEvalUTest] testGlobalPythonInitializationFinalization()");
 
         // Initialize and finalize Python.
@@ -152,7 +149,6 @@ public:
 
     void testPythonEvalSingletonCreationDeletion()
     {
-        TS_SKIP("FIXME: this test fais with SEGFAUL");
         logger().debug("[PythonEvalUTest] testPythonEvalSingletonCreationDeletion()");
 
         AtomSpace* atomSpace = NULL;
@@ -221,7 +217,6 @@ public:
 
     void testPythonEvalEvalExpr()
     {
-        TS_SKIP("FIXME: this test fais with SEGFAUL");
         logger().debug("[PythonEvalUTest] testPythonEvalEvalExpr()");
 
         // Initialize Python.
@@ -251,7 +246,6 @@ public:
 
     void testApplyAndApplyTV()
     {
-        TS_SKIP("FIXME: this test fais with SEGFAUL");
         // Initialize Python.
         global_python_initialize();
 
@@ -317,7 +311,6 @@ public:
 
     void testCodeBlockWithNewline()
     {
-        TS_SKIP("FIXME: this test fais with SEGFAUL");
         // Initialize Python.
         global_python_initialize();
 

--- a/tests/cython/PythonEvalUTest.cxxtest
+++ b/tests/cython/PythonEvalUTest.cxxtest
@@ -27,7 +27,9 @@ public:
 
     ~PythonEvalUTest() {}
 
-    void setUp() {}
+    void setUp() {
+        TS_SKIP("FIXME: this test fais with SEGFAUL");
+    }
 
     void tearDown() {}
 

--- a/tests/cython/PythonEvalUTest.cxxtest
+++ b/tests/cython/PythonEvalUTest.cxxtest
@@ -27,14 +27,13 @@ public:
 
     ~PythonEvalUTest() {}
 
-    void setUp() {
-        TS_SKIP("FIXME: this test fais with SEGFAUL");
-    }
+    void setUp() {}
 
     void tearDown() {}
 
     void testRawPythonInitialization()
     {
+        TS_SKIP("FIXME: this test fais with SEGFAUL");
         logger().debug("[PythonEvalUTest] testRawPythonInitialization()");
 
         // Start up Python.
@@ -76,6 +75,7 @@ public:
 
     void testRawPythonInitializeWithGetSys()
     {
+        TS_SKIP("FIXME: this test fais with SEGFAUL");
         logger().debug("[PythonEvalUTest] testRawPythonInitializeWithGetSys()");
 
         PyObject* pySysPath = NULL;
@@ -136,6 +136,7 @@ public:
 
     void testGlobalPythonInitializationFinalization()
     {
+        TS_SKIP("FIXME: this test fais with SEGFAUL");
         logger().debug("[PythonEvalUTest] testGlobalPythonInitializationFinalization()");
 
         // Initialize and finalize Python.
@@ -151,6 +152,7 @@ public:
 
     void testPythonEvalSingletonCreationDeletion()
     {
+        TS_SKIP("FIXME: this test fais with SEGFAUL");
         logger().debug("[PythonEvalUTest] testPythonEvalSingletonCreationDeletion()");
 
         AtomSpace* atomSpace = NULL;
@@ -219,6 +221,7 @@ public:
 
     void testPythonEvalEvalExpr()
     {
+        TS_SKIP("FIXME: this test fais with SEGFAUL");
         logger().debug("[PythonEvalUTest] testPythonEvalEvalExpr()");
 
         // Initialize Python.
@@ -248,6 +251,7 @@ public:
 
     void testApplyAndApplyTV()
     {
+        TS_SKIP("FIXME: this test fais with SEGFAUL");
         // Initialize Python.
         global_python_initialize();
 
@@ -313,6 +317,7 @@ public:
 
     void testCodeBlockWithNewline()
     {
+        TS_SKIP("FIXME: this test fais with SEGFAUL");
         // Initialize Python.
         global_python_initialize();
 

--- a/tests/cython/guile/basic_unify.scm
+++ b/tests/cython/guile/basic_unify.scm
@@ -3,7 +3,6 @@
 ;
 ; Create some misc atoms.
 
-(add-to-load-path "./opencog/scm")
 (use-modules (opencog))
 (use-modules (opencog exec))
 

--- a/tests/cython/guile/test_pattern.py
+++ b/tests/cython/guile/test_pattern.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 from opencog.atomspace import AtomSpace, TruthValue, Atom
 from opencog.atomspace import types, is_a, get_type, get_type_name
 from opencog.scheme_wrapper import load_scm, scheme_eval, scheme_eval_h
+import os
 
 
 # We are poking atoms into this from the scm files, so we want
@@ -14,6 +15,10 @@ class SchemeTest(TestCase):
     def setUp(self):
         global shared_space
         self.space = shared_space
+        scheme_eval(self.space, '(add-to-load-path "' +
+                    os.environ['PROJECT_SOURCE_DIR'] + '")')
+        scheme_eval(self.space, '(add-to-load-path "' +
+                    os.environ['PROJECT_SOURCE_DIR'] + '/opencog/scm")')
 
     def tearDown(self):
         pass
@@ -26,12 +31,11 @@ class SchemeTest(TestCase):
 
         scheme_eval(self.space, "(use-modules (opencog))")
 
-
     # Load a file that results in atoms placed in the atomspace.
     # Make sure the loaded atom is what we think it is.
     def test_b_load_file(self):
 
-        status = load_scm(self.space, "tests/cython/guile/basic_unify.scm")
+        status = scheme_eval(self.space, '(load-from-path "tests/cython/guile/basic_unify.scm")')
         self.assertTrue(status)
 
         a1 = self.space.add_node(types.ConceptNode, "hello")

--- a/tests/matrix/CMakeLists.txt
+++ b/tests/matrix/CMakeLists.txt
@@ -16,6 +16,7 @@ LINK_LIBRARIES(
 	clearbox
 	execution
 	persist
+	persist-sql
 	${GUILE_LIBRARIES}
 )
 

--- a/tests/matrix/CMakeLists.txt
+++ b/tests/matrix/CMakeLists.txt
@@ -15,6 +15,7 @@ LINK_LIBRARIES(
 	smob
 	clearbox
 	execution
+	persist
 	${GUILE_LIBRARIES}
 )
 

--- a/tests/persist/gearman/CMakeLists.txt
+++ b/tests/persist/gearman/CMakeLists.txt
@@ -10,6 +10,7 @@ LINK_DIRECTORIES (
 LINK_LIBRARIES (
 	smob
 	atomspace
+	dist-gearman
 )
 
 # Make sure that the Gearman job server is running.

--- a/tests/persist/sql/multi-driver/CMakeLists.txt
+++ b/tests/persist/sql/multi-driver/CMakeLists.txt
@@ -57,6 +57,7 @@ ENDIF (PSQL_EXECUTABLE)
 
 LINK_LIBRARIES(
     atomspace
+    persist
     persist-sql
 )
 

--- a/tests/query/CMakeLists.txt
+++ b/tests/query/CMakeLists.txt
@@ -16,6 +16,7 @@ LINK_LIBRARIES (
 	clearbox
 	execution
 	atomspace
+	logger
 )
 
 # We want to run the tests in the order below;

--- a/tests/rule-engine/CMakeLists.txt
+++ b/tests/rule-engine/CMakeLists.txt
@@ -2,6 +2,7 @@ LINK_LIBRARIES(
 	ruleengine
 	atomspace
 	clearbox
+	logger
 )
 
 # Run the tests in logical order, not alphabetical order:

--- a/tests/scm/CMakeLists.txt
+++ b/tests/scm/CMakeLists.txt
@@ -31,4 +31,9 @@ ADD_GUILE_TEST(SCMOpenogTestRunnerFail scm-opencog-test-runner-fail.scm)
 # The SCMOpenogTestRunnerFail fails purposely, as it is testing that the
 # scheme opencog-test-runner exits properly; thus requiring the flipping
 # of the test result by setting its properties.
-SET_TESTS_PROPERTIES(SCMOpenogTestRunnerFail PROPERTIES WILL_FAIL TRUE)
+SET_PROPERTY(TEST SCMOpenogTestRunnerFail PROPERTY WILL_FAIL TRUE)
+
+# Add guile code to the load path to make it possible run tests before
+# executing "make install"
+SET_PROPERTY(TEST SCMOpenogTestRunnerPass SCMOpenogTestRunnerFail
+	PROPERTY ENVIRONMENT "GUILE_LOAD_PATH=${PROJECT_SOURCE_DIR}/opencog/scm")

--- a/tests/scm/CMakeLists.txt
+++ b/tests/scm/CMakeLists.txt
@@ -15,6 +15,7 @@ LINK_LIBRARIES(
 	smob
 	clearbox
 	execution
+	logger
 	${GUILE_LIBRARIES}
 )
 


### PR DESCRIPTION
Fix for #1835 

What is done:
- necessary libraries are added as dependencies
- opencog guile code is added as dependency for guile relating tests
- PythonEvalUTest is skipped because of  #1888
