### PR TITLE
Export get value ptr cython function

### DIFF
--- a/opencog/cython/opencog/atomspace.pxd
+++ b/opencog/cython/opencog/atomspace.pxd
@@ -88,12 +88,12 @@ cdef extern from "opencog/atoms/value/Value.h" namespace "opencog":
         bint is_atom()
         bint is_node()
         bint is_link()
-        
+
         string to_string()
         string to_short_string()
         bint operator==(const cValue&)
         bint operator!=(const cValue&)
-    
+
     ctypedef shared_ptr[cValue] cValuePtr "opencog::ValuePtr"
 
 cdef class Value:
@@ -128,7 +128,7 @@ cdef extern from "opencog/atoms/base/Atom.h" namespace "opencog":
 # Handle
 cdef extern from "opencog/atoms/base/Handle.h" namespace "opencog":
     ctypedef shared_ptr[cAtom] cAtomPtr "opencog::AtomPtr"
-    
+
     cdef cppclass cHandle "opencog::Handle" (cAtomPtr):
         cHandle()
         cHandle(const cHandle&)
@@ -236,13 +236,13 @@ cdef extern from "opencog/atomutils/AtomUtils.h" namespace "opencog":
 cdef extern from "opencog/atoms/value/FloatValue.h" namespace "opencog":
     cdef cppclass cFloatValue "opencog::FloatValue":
         const vector[double]& value() const;
-    
+
     cdef cValuePtr createFloatValue(...)
 
 cdef extern from "opencog/atoms/value/StringValue.h" namespace "opencog":
     cdef cppclass cStringValue "opencog::StringValue":
         const vector[string]& value() const;
-    
+
     cdef cValuePtr createStringValue(...)
 
 cdef extern from "opencog/atoms/value/LinkValue.h" namespace "opencog":

--- a/opencog/cython/opencog/atomspace.pxd
+++ b/opencog/cython/opencog/atomspace.pxd
@@ -250,3 +250,6 @@ cdef extern from "opencog/atoms/value/LinkValue.h" namespace "opencog":
         const vector[cValuePtr]& value() const;
 
     cdef cValuePtr createLinkValue(...)
+
+cdef cValue* get_value_ptr(Value protoAtom)
+


### PR DESCRIPTION
Adding `get_value_ptr` to the `atomspace.pxd` in order to export it from Cython `atomspace.so` library and reuse it to implement custom `Value` wrappers.