### PR TITLE
Allow adding children of execution output link

### DIFF
--- a/opencog/atoms/execution/ExecutionOutputLink.cc
+++ b/opencog/atoms/execution/ExecutionOutputLink.cc
@@ -50,7 +50,7 @@ void ExecutionOutputLink::check_schema(const Handle& schema) const
 ExecutionOutputLink::ExecutionOutputLink(const HandleSeq& oset, Type t)
 	: FunctionLink(oset, t)
 {
-	if (EXECUTION_OUTPUT_LINK != t)
+	if (!nameserver().isA(t, EXECUTION_OUTPUT_LINK))
 		throw SyntaxException(TRACE_INFO,
 		                      "Expection an ExecutionOutputLink!");
 

--- a/opencog/atoms/execution/ExecutionOutputLink.h
+++ b/opencog/atoms/execution/ExecutionOutputLink.h
@@ -39,7 +39,8 @@ private:
 	static Handle do_execute(AtomSpace*, const Handle& schema, const Handle& args,
 	                         bool silent=false);
 
-	void check_schema(const Handle& schema) const;
+protected:
+	virtual void check_schema(const Handle& schema) const;
 
 public:
 	/**

--- a/opencog/atoms/execution/Instantiator.cc
+++ b/opencog/atoms/execution/Instantiator.cc
@@ -343,7 +343,7 @@ Handle Instantiator::walk_tree(const Handle& expr, bool silent)
 	// it might do.  It would be great if the authors of ExOutLinks
 	// did the lazy execution themselves... but this is too much to
 	// ask for. So we always eager-evaluate those args.
-	if (EXECUTION_OUTPUT_LINK == t)
+	if (nameserver().isA(t, EXECUTION_OUTPUT_LINK))
 	{
 		ExecutionOutputLinkPtr eolp(ExecutionOutputLinkCast(expr));
 
@@ -402,7 +402,8 @@ Handle Instantiator::walk_tree(const Handle& expr, bool silent)
 			args = beta_reduce(args, *_vmap);
 		}
 
-		ExecutionOutputLinkPtr geolp(createExecutionOutputLink(sn, args));
+		Handle eolh = createLink(t, sn, args);
+		ExecutionOutputLinkPtr geolp(ExecutionOutputLinkCast(eolh));
 		return geolp->execute(_as, silent);
 	}
 


### PR DESCRIPTION
Fix for issue #1993 to allow adding children of `ExecutionOutputLink` which extends its functionality.