### PR TITLE
Allow extending of ExecutionOutputLink::check_schema() in child classes

### DIFF
--- a/opencog/atoms/execution/ExecutionOutputLink.cc
+++ b/opencog/atoms/execution/ExecutionOutputLink.cc
@@ -34,7 +34,7 @@
 
 using namespace opencog;
 
-void ExecutionOutputLink::check_schema(const Handle& schema) const
+void ExecutionOutputLink::check_schema(const Handle& schema)
 {
 	if (not nameserver().isA(schema->get_type(), SCHEMA_NODE) and
 	    LAMBDA_LINK != schema->get_type() and
@@ -47,7 +47,7 @@ void ExecutionOutputLink::check_schema(const Handle& schema) const
 	}
 }
 
-void ExecutionOutputLink::init()
+void ExecutionOutputLink::init(check_schema_function check_schema)
 {
 	if (!nameserver().isA(get_type(), EXECUTION_OUTPUT_LINK))
 		throw SyntaxException(TRACE_INFO,
@@ -62,23 +62,29 @@ void ExecutionOutputLink::init()
 	check_schema(oset[0]);
 }
 
+ExecutionOutputLink::ExecutionOutputLink(const HandleSeq& oset, Type t,
+		check_schema_function check_schema_external) : FunctionLink(oset, t)
+{
+	init(check_schema_external);
+}
+
 ExecutionOutputLink::ExecutionOutputLink(const HandleSeq& oset, Type t)
 	: FunctionLink(oset, t)
 {
-	init();
+	init(check_schema);
 }
 
 ExecutionOutputLink::ExecutionOutputLink(const Handle& schema,
                                          const Handle& args)
 	: FunctionLink({schema, args}, EXECUTION_OUTPUT_LINK)
 {
-	init();
+	init(check_schema);
 }
 
 ExecutionOutputLink::ExecutionOutputLink(const Link& l)
 	: FunctionLink(l)
 {
-	init();
+	init(check_schema);
 }
 
 /// execute -- execute the function defined in an ExecutionOutputLink

--- a/opencog/atoms/execution/ExecutionOutputLink.cc
+++ b/opencog/atoms/execution/ExecutionOutputLink.cc
@@ -47,13 +47,13 @@ void ExecutionOutputLink::check_schema(const Handle& schema) const
 	}
 }
 
-ExecutionOutputLink::ExecutionOutputLink(const HandleSeq& oset, Type t)
-	: FunctionLink(oset, t)
+void ExecutionOutputLink::init()
 {
-	if (!nameserver().isA(t, EXECUTION_OUTPUT_LINK))
+	if (!nameserver().isA(get_type(), EXECUTION_OUTPUT_LINK))
 		throw SyntaxException(TRACE_INFO,
 		                      "Expection an ExecutionOutputLink!");
 
+	const HandleSeq& oset = getOutgoingSet();
 	if (2 != oset.size())
 		throw SyntaxException(TRACE_INFO,
 		                      "ExecutionOutputLink must have schema and args! Got arity=%d",
@@ -62,22 +62,23 @@ ExecutionOutputLink::ExecutionOutputLink(const HandleSeq& oset, Type t)
 	check_schema(oset[0]);
 }
 
+ExecutionOutputLink::ExecutionOutputLink(const HandleSeq& oset, Type t)
+	: FunctionLink(oset, t)
+{
+	init();
+}
+
 ExecutionOutputLink::ExecutionOutputLink(const Handle& schema,
                                          const Handle& args)
 	: FunctionLink({schema, args}, EXECUTION_OUTPUT_LINK)
 {
-	check_schema(schema);
+	init();
 }
 
 ExecutionOutputLink::ExecutionOutputLink(const Link& l)
 	: FunctionLink(l)
 {
-	Type tscope = l.get_type();
-	if (EXECUTION_OUTPUT_LINK != tscope)
-		throw SyntaxException(TRACE_INFO,
-		                      "Expection an ExecutionOutputLink!");
-
-	check_schema(l.getOutgoingAtom(0));
+	init();
 }
 
 /// execute -- execute the function defined in an ExecutionOutputLink

--- a/opencog/atoms/execution/ExecutionOutputLink.h
+++ b/opencog/atoms/execution/ExecutionOutputLink.h
@@ -40,8 +40,11 @@ private:
 	                         bool silent=false);
 
 protected:
-	virtual void check_schema(const Handle& schema) const;
-	void init();
+	typedef void (*check_schema_function)(const Handle& schema);
+	static void check_schema(const Handle& schema);
+	void init(check_schema_function);
+
+	ExecutionOutputLink(const HandleSeq&, Type, check_schema_function);
 
 public:
 	/**

--- a/opencog/atoms/execution/ExecutionOutputLink.h
+++ b/opencog/atoms/execution/ExecutionOutputLink.h
@@ -41,6 +41,7 @@ private:
 
 protected:
 	virtual void check_schema(const Handle& schema) const;
+	void init();
 
 public:
 	/**
@@ -52,7 +53,7 @@ public:
 	static void lang_lib_fun(const std::string& schema,
 	                         std::string& lang,
 	                         std::string& lib,
-	                         std::string& fun);;
+	                         std::string& fun);
 
 	ExecutionOutputLink(const HandleSeq&, Type=EXECUTION_OUTPUT_LINK);
 	ExecutionOutputLink(const Handle& schema, const Handle& args);


### PR DESCRIPTION
Adding protected ExecutionOutputLink constructor to extend `check_schema()` method in child classes.
Related to issue https://github.com/opencog/atomspace/issues/1993