### PR TITLE
Storing PLN formulas in the AtomSpace

### DIFF
--- a/examples/atomspace/formulas.scm
+++ b/examples/atomspace/formulas.scm
@@ -32,6 +32,22 @@
 	(EvaluationLink
 		; Compute TV = (1-sA*sB, cA*cB)
 		(PredicateFormulaLink
+			(MinusLink
+				(Number 1)
+				(TimesLink
+					(StrengthOf (Variable "$X"))
+					(StrengthOf (Variable "$Y"))))
+			(TimesLink
+				(ConfidenceOf (Variable "$X"))
+				(ConfidenceOf (Variable "$Y"))))
+		(List
+			(Concept "A")
+			(Concept "B"))))
+
+(cog-evaluate!
+	(EvaluationLink
+		; Compute TV = (1-sA*sB, cA*cB)
+		(PredicateFormulaLink
 			(Lambda (MinusLink
 				(Number 1)
 				(TimesLink

--- a/examples/atomspace/formulas.scm
+++ b/examples/atomspace/formulas.scm
@@ -8,7 +8,7 @@
 
 (cog-execute! (StrengthOf (Concept "A" (stv 0.8 1.0))))
 
-(Concept "B" (stv 0.6 1.0))
+(Concept "B" (stv 0.6 0.9))
 
 (cog-execute! 
 	(TimesLink (StrengthOf (Concept "A")) (StrengthOf (Concept "B"))))
@@ -18,14 +18,15 @@
 		(TimesLink (StrengthOf (Concept "A")) (StrengthOf (Concept "B")))
 		(TimesLink (ConfidenceOf (Concept "A")) (ConfidenceOf (Concept "B")))))
 
-(EvaluationLink
-	(PredicateFormulaLink
-		(TimesLink
-			(StrengthOf (Concept "A"))
-			(StrengthOf (Concept "B")))
-	(List
-		(Concept "A")
-		(Concept "B")))
+(cog-evaluate!
+	(PredicateFormulaLink (Number 0.7) (Number 0.314))
+
+(cog-evaluate!
+	(EvaluationLink
+		(PredicateFormulaLink (Number 0.7) (Number 0.314))
+		(List
+			(Concept "A")
+			(Concept "B"))))
 
 (EvaluationLink
 	(TimesLink (StrengthOf (Variable "$A") (Variable "$B")))

--- a/examples/atomspace/formulas.scm
+++ b/examples/atomspace/formulas.scm
@@ -90,3 +90,37 @@
 		(List
 			(Concept "A")
 			(Concept "B"))))
+
+
+; The PedicateFormulaLink behaves just like any other algebraic
+; expression with VariableNodes in it. When executed, it might
+; reduce a bit, but that is all.
+(cog-execute!
+	(PredicateFormula
+		(Plus (Number 41)
+			(Minus
+				(Number 1)
+				(Times
+					(StrengthOf (Variable "$VA"))
+					(StrengthOf (Variable "$VB")))))
+			(Times
+				(ConfidenceOf (Variable "$VA"))
+				(ConfidenceOf (Variable "$VB")))))
+
+(cog-execute!
+	(PutLink
+		(VariableList (Variable "$VA") (Variable "$VB"))
+		(Evaluation
+			; Compute TV = (1-sA*sB, cA*cB)
+			(PredicateFormula
+				(Minus
+					(Number 1)
+					(Times
+						(StrengthOf (Variable "$VA"))
+						(StrengthOf (Variable "$VB"))))
+				(Times
+					(ConfidenceOf (Variable "$VA"))
+					(ConfidenceOf (Variable "$VB"))))
+			(List
+				(Variable "$VA") (Variable "$VB")))
+	(Set (List (Concept "A") (Concept "B")))))

--- a/examples/atomspace/formulas.scm
+++ b/examples/atomspace/formulas.scm
@@ -52,6 +52,11 @@
 			(Concept "A")
 			(Concept "B"))))
 
+; More typically, one wishes to have a formula in the abstract,
+; with variables in it, so that one can apply it in any one of
+; a number of different situations. In the below, the variables
+; are automatically reduced with the Atoms in the ListLink, and
+; then the formula is evaluated to obtain a TruthValue.
 (cog-evaluate!
 	(Evaluation
 		; Compute TV = (1-sA*sB, cA*cB)
@@ -68,6 +73,8 @@
 			(Concept "A")
 			(Concept "B"))))
 
+; Optionally, you can wrap formulas with LambdaLinks. This doesn't
+; really change anything; formulas work fine without LambdaLinks.
 (cog-evaluate!
 	(Evaluation
 		; Compute TV = (1-sA*sB, cA*cB)

--- a/examples/atomspace/formulas.scm
+++ b/examples/atomspace/formulas.scm
@@ -1,43 +1,67 @@
 ;
 ; formulas.scm -- Declaring formulas that compute truth values.
 ;
+; The rule engine, PLN and other subsystems need to be able to compute
+; and alter truth values. If those formulas are known a-priori, then
+; thay can be hard-coded into GroundedPredicateNodes.  However, it is
+; possible that those formulas are not yet known: that they will be
+; learned using some learning algorithm, for example, MOSES, or maybe
+; the Pattern Miner, or some neural network.
+;
+; In this case, the formulas need to be placed where they can be
+; accessed during computation: in the AtomSpace. The example below
+; shows how formulas can be declared in the AtomSpace, but in such a
+; way that they can also be evaluated to yeild an actual truth value,
+; which is then attached to some Atom.
+;
 (use-modules (opencog) (opencog exec))
 
-; Declare a very simplified example of a truth-value formula used by
-; PLN.  This merely multiplies a pair of strengths.
-
+; The StrengthOfLink returns a single floating-point number,
+; the strength of a TruthValue.
 (cog-execute! (StrengthOf (Concept "A" (stv 0.8 1.0))))
 
+; The demo needs at least one more Atom.
 (Concept "B" (stv 0.6 0.9))
 
+; Multiple the strength of the TV's of two atoms.
 (cog-execute!
-	(TimesLink (StrengthOf (Concept "A")) (StrengthOf (Concept "B"))))
+	(Times (StrengthOf (Concept "A")) (StrengthOf (Concept "B"))))
 
+; Create a SimpleTruthValue with a non-trivial formula:
+; It will be the TV := (1-sA*sB, cA*cB) where sA and sB are strenghts
+; and cA, cB are confidence values. The PredicateFormulaLink assembles
+; two floating-point values, and create a SimpleTruthValue out of them.
+;
 (cog-evaluate!
-	(PredicateFormulaLink
-		(TimesLink (StrengthOf (Concept "A")) (StrengthOf (Concept "B")))
-		(TimesLink (ConfidenceOf (Concept "A")) (ConfidenceOf (Concept "B")))))
+	(PredicateFormula
+		(Minus
+			(Number 1)
+			(Times (StrengthOf (Concept "A")) (StrengthOf (Concept "B"))))
+		(Times (ConfidenceOf (Concept "A")) (ConfidenceOf (Concept "B")))))
 
+; The values do not need to be formulas; tehy can be hard-coded numbers.
 (cog-evaluate!
-	(PredicateFormulaLink (Number 0.7) (Number 0.314)))
+	(PredicateFormula (Number 0.7) (Number 0.314)))
 
+; The below computes a truth value, and attaches it to the
+; EvaluationLink.
 (cog-evaluate!
-	(EvaluationLink
-		(PredicateFormulaLink (Number 0.7) (Number 0.314))
+	(Evaluation
+		(PredicateFormula (Number 0.7) (Number 0.314))
 		(List
 			(Concept "A")
 			(Concept "B"))))
 
 (cog-evaluate!
-	(EvaluationLink
+	(Evaluation
 		; Compute TV = (1-sA*sB, cA*cB)
-		(PredicateFormulaLink
-			(MinusLink
+		(PredicateFormula
+			(Minus
 				(Number 1)
-				(TimesLink
+				(Times
 					(StrengthOf (Variable "$X"))
 					(StrengthOf (Variable "$Y"))))
-			(TimesLink
+			(Times
 				(ConfidenceOf (Variable "$X"))
 				(ConfidenceOf (Variable "$Y"))))
 		(List
@@ -45,15 +69,15 @@
 			(Concept "B"))))
 
 (cog-evaluate!
-	(EvaluationLink
+	(Evaluation
 		; Compute TV = (1-sA*sB, cA*cB)
-		(PredicateFormulaLink
-			(Lambda (MinusLink
+		(PredicateFormula
+			(Lambda (Minus
 				(Number 1)
-				(TimesLink
+				(Times
 					(StrengthOf (Variable "$X"))
 					(StrengthOf (Variable "$Y")))))
-			(Lambda (TimesLink
+			(Lambda (Times
 				(ConfidenceOf (Variable "$X"))
 				(ConfidenceOf (Variable "$Y")))))
 		(List

--- a/examples/atomspace/formulas.scm
+++ b/examples/atomspace/formulas.scm
@@ -10,7 +10,7 @@
 
 (Concept "B" (stv 0.6 0.9))
 
-(cog-execute! 
+(cog-execute!
 	(TimesLink (StrengthOf (Concept "A")) (StrengthOf (Concept "B"))))
 
 (cog-evaluate!
@@ -19,7 +19,7 @@
 		(TimesLink (ConfidenceOf (Concept "A")) (ConfidenceOf (Concept "B")))))
 
 (cog-evaluate!
-	(PredicateFormulaLink (Number 0.7) (Number 0.314))
+	(PredicateFormulaLink (Number 0.7) (Number 0.314)))
 
 (cog-evaluate!
 	(EvaluationLink
@@ -28,5 +28,18 @@
 			(Concept "A")
 			(Concept "B"))))
 
-(EvaluationLink
-	(TimesLink (StrengthOf (Variable "$A") (Variable "$B")))
+(cog-evaluate!
+	(EvaluationLink
+		; Compute TV = (1-sA*sB, cA*cB)
+		(PredicateFormulaLink
+			(Lambda (MinusLink
+				(Number 1)
+				(TimesLink
+					(StrengthOf (Variable "$X"))
+					(StrengthOf (Variable "$Y")))))
+			(Lambda (TimesLink
+				(ConfidenceOf (Variable "$X"))
+				(ConfidenceOf (Variable "$Y")))))
+		(List
+			(Concept "A")
+			(Concept "B"))))

--- a/examples/atomspace/formulas.scm
+++ b/examples/atomspace/formulas.scm
@@ -40,7 +40,7 @@
 			(Times (StrengthOf (Concept "A")) (StrengthOf (Concept "B"))))
 		(Times (ConfidenceOf (Concept "A")) (ConfidenceOf (Concept "B")))))
 
-; The values do not need to be formulas; tehy can be hard-coded numbers.
+; The values do not need to be formulas; they can be hard-coded numbers.
 (cog-evaluate!
 	(PredicateFormula (Number 0.7) (Number 0.314)))
 

--- a/examples/atomspace/formulas.scm
+++ b/examples/atomspace/formulas.scm
@@ -1,0 +1,31 @@
+;
+; formulas.scm -- Declaring formulas that compute truth values.
+;
+(use-modules (opencog) (opencog exec))
+
+; Declare a very simplified example of a truth-value formula used by
+; PLN.  This merely multiplies a pair of strengths.
+
+(cog-execute! (StrengthOf (Concept "A" (stv 0.8 1.0))))
+
+(Concept "B" (stv 0.6 1.0))
+
+(cog-execute! 
+	(TimesLink (StrengthOf (Concept "A")) (StrengthOf (Concept "B"))))
+
+(cog-evaluate!
+	(PredicateFormulaLink
+		(TimesLink (StrengthOf (Concept "A")) (StrengthOf (Concept "B")))
+		(TimesLink (ConfidenceOf (Concept "A")) (ConfidenceOf (Concept "B")))))
+
+(EvaluationLink
+	(PredicateFormulaLink
+		(TimesLink
+			(StrengthOf (Concept "A"))
+			(StrengthOf (Concept "B")))
+	(List
+		(Concept "A")
+		(Concept "B")))
+
+(EvaluationLink
+	(TimesLink (StrengthOf (Variable "$A") (Variable "$B")))

--- a/examples/atomspace/formulas.scm
+++ b/examples/atomspace/formulas.scm
@@ -107,20 +107,43 @@
 				(ConfidenceOf (Variable "$VA"))
 				(ConfidenceOf (Variable "$VB")))))
 
-(cog-execute!
-	(PutLink
-		(VariableList (Variable "$VA") (Variable "$VB"))
-		(Evaluation
-			; Compute TV = (1-sA*sB, cA*cB)
-			(PredicateFormula
-				(Minus
-					(Number 1)
+; Beta-reducation works as normal. The below will create an
+; EvaluationLink with ConceptNode A and B in it, and will set the
+; truth value according to the formula.
+(define the-put-result
+	(cog-execute!
+		(PutLink
+			(VariableList (Variable "$VA") (Variable "$VB"))
+			(Evaluation
+				; Compute TV = (1-sA*sB, cA*cB)
+				(PredicateFormula
+					(Minus
+						(Number 1)
+						(Times
+							(StrengthOf (Variable "$VA"))
+							(StrengthOf (Variable "$VB"))))
 					(Times
-						(StrengthOf (Variable "$VA"))
-						(StrengthOf (Variable "$VB"))))
-				(Times
-					(ConfidenceOf (Variable "$VA"))
-					(ConfidenceOf (Variable "$VB"))))
-			(List
-				(Variable "$VA") (Variable "$VB")))
-	(Set (List (Concept "A") (Concept "B")))))
+						(ConfidenceOf (Variable "$VA"))
+						(ConfidenceOf (Variable "$VB"))))
+				(List
+					(Variable "$VA") (Variable "$VB")))
+		(Set (List (Concept "A") (Concept "B"))))))
+
+; The scheme variable `the-put-result` contains a SetLink with the
+; result in it. Lets unwrap it, so that `evelnk` is just the
+; EvaluationLink. And tehn we play a little trick.
+(define evelnk (cog-outgoing-atom the-put-result 0))
+
+; Change the truth value on the two concept nodes ...
+(Concept "A" (stv 0.3 0.5))
+(Concept "B" (stv 0.4 0.5))
+
+; Re-evaluate the EvaluationLink. Note the TV has been updated!
+(cog-evaluate! evelnk)
+
+; Do it again, for good luck!
+(Concept "A" (stv 0.1 0.99))
+(Concept "B" (stv 0.1 0.99))
+
+; Re-evaluate the EvaluationLink. The TV is again recomputed!
+(cog-evaluate! evelnk)

--- a/examples/atomspace/formulas.scm
+++ b/examples/atomspace/formulas.scm
@@ -157,6 +157,7 @@
 ; Re-evaluate the EvaluationLink. The TV is again recomputed!
 (cog-evaluate! evelnk)
 
+; One can also use DefinedPredicates, to give the formula a name.
 (DefineLink
 	(DefinedPredicate "has a reddish color")
 	(PredicateFormula
@@ -172,6 +173,7 @@
 (Concept "A" (stv 0.9 0.98))
 (Concept "B" (stv 0.9 0.98))
 
+; The will cause the formula to evaluate.
 (cog-evaluate!
 	(Evaluation
 		(DefinedPredicate "has a reddish color")

--- a/examples/atomspace/formulas.scm
+++ b/examples/atomspace/formulas.scm
@@ -45,13 +45,21 @@
 	(PredicateFormula (Number 0.7) (Number 0.314)))
 
 ; The below computes a truth value, and attaches it to the
-; EvaluationLink.
-(cog-evaluate!
+; EvaluationLink. Let's demo this in three parts: first define it,
+; then evaluate it, then look at it.
+;
+(define my-ev-link
 	(Evaluation
 		(PredicateFormula (Number 0.7) (Number 0.314))
 		(List
 			(Concept "A")
 			(Concept "B"))))
+
+; Evaluate ...
+(cog-evaluate! my-ev-link)
+
+; Print.
+(display my-ev-link)
 
 ; More typically, one wishes to have a formula in the abstract,
 ; with variables in it, so that one can apply it in any one of

--- a/examples/atomspace/formulas.scm
+++ b/examples/atomspace/formulas.scm
@@ -156,3 +156,25 @@
 
 ; Re-evaluate the EvaluationLink. The TV is again recomputed!
 (cog-evaluate! evelnk)
+
+(DefineLink
+	(DefinedPredicate "has a reddish color")
+	(PredicateFormula
+		(Minus
+			(Number 1)
+			(Times
+				(StrengthOf (Variable "$X"))
+				(StrengthOf (Variable "$Y"))))
+		(Times
+			(ConfidenceOf (Variable "$X"))
+			(ConfidenceOf (Variable "$Y")))))
+
+(Concept "A" (stv 0.9 0.98))
+(Concept "B" (stv 0.9 0.98))
+
+(cog-evaluate!
+	(Evaluation
+		(DefinedPredicate "has a reddish color")
+		(List
+			(Concept "A")
+			(Concept "B"))))

--- a/opencog/atoms/atom_types/atom_types.script
+++ b/opencog/atoms/atom_types/atom_types.script
@@ -579,6 +579,13 @@ TRUTH_VALUE_OF_LINK <- VALUE_OF_LINK
 STRENGTH_OF_LINK <- VALUE_OF_LINK
 CONFIDENCE_OF_LINK <- VALUE_OF_LINK
 
+// The opposite of the above: given something that evaluates to a
+// FloatValue, return a TruthValue.  Kind-of-like
+// GROUNDED_PREDICATE_NODE, but holding the forumla in the atomspace.
+// This is not really needed, but will make the transition process
+// smoother.
+PREDICATE_FORMULA_LINK <- EVALUATABLE_LINK
+
 // Basic arithmetic operators
 FOLD_LINK <- FUNCTION_LINK
 ARITHMETIC_LINK <- FOLD_LINK,NUMERIC_LINK,NUMERIC_OUTPUT_LINK

--- a/opencog/atoms/atom_types/atom_types.script
+++ b/opencog/atoms/atom_types/atom_types.script
@@ -571,9 +571,13 @@ FUNCTION_LINK <- FREE_LINK
 EXECUTION_OUTPUT_LINK <- FUNCTION_LINK
 
 // Return the indicated value on the indicated atom.
-// XXX It doesn't *always* return numbers ...
+// XXX It's marked as "NUMERIC_OUTPUT, but doesn't *always* return
+// numbers ... Probably should have a FLOAT_VALUE_OF_LINK to fix this.
+// Ignore this issue for now ...
 VALUE_OF_LINK <- FUNCTION_LINK,NUMERIC_OUTPUT_LINK
 TRUTH_VALUE_OF_LINK <- VALUE_OF_LINK
+STRENGTH_OF_LINK <- VALUE_OF_LINK
+CONFIDENCE_OF_LINK <- VALUE_OF_LINK
 
 // Basic arithmetic operators
 FOLD_LINK <- FUNCTION_LINK

--- a/opencog/atoms/base/ClassServer.h
+++ b/opencog/atoms/base/ClassServer.h
@@ -102,6 +102,9 @@ public:
 
 ClassServer& classserver();
 
+#define TOKENPASTE(x, y) x ## y
+#define TOKENPASTE2(x, y) TOKENPASTE(x, y)
+
 #define DEFINE_LINK_FACTORY(CNAME,CTYPE)                          \
                                                                   \
 Handle CNAME::factory(const Handle& base)                         \
@@ -123,7 +126,8 @@ Handle CNAME::factory(const Handle& base)                         \
 }                                                                 \
                                                                   \
 /* This runs when the shared lib is loaded. */                    \
-static __attribute__ ((constructor)) void init(void)              \
+static __attribute__ ((constructor)) void                         \
+   TOKENPASTE2(init, __COUNTER__)(void)                           \
 {                                                                 \
    classserver().addFactory(CTYPE, &CNAME::factory);              \
 }
@@ -138,7 +142,8 @@ Handle CNAME::factory(const Handle& base)                         \
 }                                                                 \
                                                                   \
 /* This runs when the shared lib is loaded. */                    \
-static __attribute__ ((constructor)) void init(void)              \
+static __attribute__ ((constructor)) void                         \
+   TOKENPASTE2(init, __COUNTER__)(void)                           \
 {                                                                 \
    classserver().addFactory(CTYPE, &CNAME::factory);              \
 }

--- a/opencog/atoms/core/PrenexLink.cc
+++ b/opencog/atoms/core/PrenexLink.cc
@@ -89,7 +89,9 @@ Handle PrenexLink::reassemble(Type prenex,
 	// prenexed.  Check for PutLink to avoid infinite recursion.
 	if (PUT_LINK != prenex and not final_varlist.empty() and
 	    nameserver().isA(prenex, PRENEX_LINK))
+	{
 		return Handle(createLink(prenex, vdecl, newbod));
+	}
 
 	// Otherwise, we are done with the beta-reduction.
 	return newbod;

--- a/opencog/atoms/core/TruthValueOfLink.cc
+++ b/opencog/atoms/core/TruthValueOfLink.cc
@@ -61,6 +61,92 @@ ValuePtr TruthValueOfLink::execute() const
 	return ValueCast(_outgoing[0]->getTruthValue());
 }
 
+// =============================================================
+
+StrengthOfLink::StrengthOfLink(const HandleSeq& oset, Type t)
+	: ValueOfLink(oset, t)
+{
+	if (not nameserver().isA(t, STRENGTH_OF_LINK))
+	{
+		const std::string& tname = nameserver().getTypeName(t);
+		throw InvalidParamException(TRACE_INFO,
+			"Expecting an StrengthOfLink, got %s", tname.c_str());
+	}
+}
+
+StrengthOfLink::StrengthOfLink(const Link &l)
+	: ValueOfLink(l)
+{
+	// Type must be as expected
+	Type tscope = l.get_type();
+	if (not nameserver().isA(tscope, STRENGTH_OF_LINK))
+	{
+		const std::string& tname = nameserver().getTypeName(tscope);
+		throw InvalidParamException(TRACE_INFO,
+			"Expecting an StrengthOfLink, got %s", tname.c_str());
+	}
+}
+
+// ---------------------------------------------------------------
+
+/// When executed, this will return the Strengths of all of the
+/// atoms in the outgoing set.
+ValuePtr StrengthOfLink::execute() const
+{
+	std::vector<double> strengths;
+
+	for (const Handle& h : _outgoing)
+	{
+		strengths.push_back(h->getTruthValue()->get_mean());
+	}
+
+	return createFloatValue(strengths);
+}
+
+// =============================================================
+
+ConfidenceOfLink::ConfidenceOfLink(const HandleSeq& oset, Type t)
+	: ValueOfLink(oset, t)
+{
+	if (not nameserver().isA(t, CONFIDENCE_OF_LINK))
+	{
+		const std::string& tname = nameserver().getTypeName(t);
+		throw InvalidParamException(TRACE_INFO,
+			"Expecting an ConfidenceOfLink, got %s", tname.c_str());
+	}
+}
+
+ConfidenceOfLink::ConfidenceOfLink(const Link &l)
+	: ValueOfLink(l)
+{
+	// Type must be as expected
+	Type tscope = l.get_type();
+	if (not nameserver().isA(tscope, CONFIDENCE_OF_LINK))
+	{
+		const std::string& tname = nameserver().getTypeName(tscope);
+		throw InvalidParamException(TRACE_INFO,
+			"Expecting an ConfidenceOfLink, got %s", tname.c_str());
+	}
+}
+
+// ---------------------------------------------------------------
+
+/// When executed, this will return the Confidences of all of the
+/// atoms in the outgoing set.
+ValuePtr ConfidenceOfLink::execute() const
+{
+	std::vector<double> confids;
+
+	for (const Handle& h : _outgoing)
+	{
+		confids.push_back(h->getTruthValue()->get_confidence());
+	}
+
+	return createFloatValue(confids);
+}
+
 DEFINE_LINK_FACTORY(TruthValueOfLink, TRUTH_VALUE_OF_LINK)
+// DEFINE_LINK_FACTORY(StrengthOfLink, STRENGTH_OF_LINK)
+// DEFINE_LINK_FACTORY(ConfidenceOfLink, CONFIDENCE_OF_LINK)
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/core/TruthValueOfLink.cc
+++ b/opencog/atoms/core/TruthValueOfLink.cc
@@ -146,7 +146,7 @@ ValuePtr ConfidenceOfLink::execute() const
 }
 
 DEFINE_LINK_FACTORY(TruthValueOfLink, TRUTH_VALUE_OF_LINK)
-// DEFINE_LINK_FACTORY(StrengthOfLink, STRENGTH_OF_LINK)
-// DEFINE_LINK_FACTORY(ConfidenceOfLink, CONFIDENCE_OF_LINK)
+DEFINE_LINK_FACTORY(StrengthOfLink, STRENGTH_OF_LINK)
+DEFINE_LINK_FACTORY(ConfidenceOfLink, CONFIDENCE_OF_LINK)
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/core/TruthValueOfLink.cc
+++ b/opencog/atoms/core/TruthValueOfLink.cc
@@ -97,6 +97,11 @@ ValuePtr StrengthOfLink::execute() const
 
 	for (const Handle& h : _outgoing)
 	{
+		// Cannot take the strength of an ungrounded variable.
+		Type t = h->get_type();
+		if (VARIABLE_NODE == t or GLOB_NODE == t)
+			return get_handle();
+
 		strengths.push_back(h->getTruthValue()->get_mean());
 	}
 
@@ -139,6 +144,11 @@ ValuePtr ConfidenceOfLink::execute() const
 
 	for (const Handle& h : _outgoing)
 	{
+		// Cannot take the confidence of an ungrounded variable.
+		Type t = h->get_type();
+		if (VARIABLE_NODE == t or GLOB_NODE == t)
+			return get_handle();
+
 		confids.push_back(h->getTruthValue()->get_confidence());
 	}
 

--- a/opencog/atoms/core/TruthValueOfLink.h
+++ b/opencog/atoms/core/TruthValueOfLink.h
@@ -39,7 +39,7 @@ public:
 	TruthValueOfLink(const HandleSeq&, Type=TRUTH_VALUE_OF_LINK);
 	TruthValueOfLink(const Link &l);
 
-	// Return a pointer to the atom being specified.
+	// Return a pointer to the extracted value.
 	virtual ValuePtr execute() const;
 
 	static Handle factory(const Handle&);
@@ -52,6 +52,56 @@ static inline TruthValueOfLinkPtr TruthValueOfLinkCast(AtomPtr a)
 	{ return std::dynamic_pointer_cast<TruthValueOfLink>(a); }
 
 #define createTruthValueOfLink std::make_shared<TruthValueOfLink>
+
+// ====================================================================
+
+/// The StrengthOfLink returns the strength of a truth value on the
+/// indicated atom. (Strength is the first of the sequence of floats).
+///
+class StrengthOfLink : public ValueOfLink
+{
+public:
+	StrengthOfLink(const HandleSeq&, Type=STRENGTH_OF_LINK);
+	StrengthOfLink(const Link &l);
+
+	// Return a pointer to the extracted value.
+	virtual ValuePtr execute() const;
+
+	static Handle factory(const Handle&);
+};
+
+typedef std::shared_ptr<StrengthOfLink> StrengthOfLinkPtr;
+static inline StrengthOfLinkPtr StrengthOfLinkCast(const Handle& h)
+	{ return std::dynamic_pointer_cast<StrengthOfLink>(h); }
+static inline StrengthOfLinkPtr StrengthOfLinkCast(AtomPtr a)
+	{ return std::dynamic_pointer_cast<StrengthOfLink>(a); }
+
+#define createStrengthOfLink std::make_shared<StrengthOfLink>
+
+// ====================================================================
+
+/// The ConfidenceOfLink returns the strength of a truth value on the
+/// indicated atom. (Confidence is the first of the sequence of floats).
+///
+class ConfidenceOfLink : public ValueOfLink
+{
+public:
+	ConfidenceOfLink(const HandleSeq&, Type=CONFIDENCE_OF_LINK);
+	ConfidenceOfLink(const Link &l);
+
+	// Return a pointer to the extracted value.
+	virtual ValuePtr execute() const;
+
+	static Handle factory(const Handle&);
+};
+
+typedef std::shared_ptr<ConfidenceOfLink> ConfidenceOfLinkPtr;
+static inline ConfidenceOfLinkPtr ConfidenceOfLinkCast(const Handle& h)
+	{ return std::dynamic_pointer_cast<ConfidenceOfLink>(h); }
+static inline ConfidenceOfLinkPtr ConfidenceOfLinkCast(AtomPtr a)
+	{ return std::dynamic_pointer_cast<ConfidenceOfLink>(a); }
+
+#define createConfidenceOfLink std::make_shared<ConfidenceOfLink>
 
 /** @}*/
 }

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -505,6 +505,19 @@ TruthValuePtr EvaluationLink::do_eval_scratch(AtomSpace* as,
 	{
 		return evelnk->getTruthValue();
 	}
+	else if (PREDICATE_FORMULA_LINK == t)
+	{
+		std::vector<double> nums;
+		for (const Handle& h: evelnk->getOutgoingSet())
+		{
+			if (not nameserver().isA(h->get_type(), FUNCTION_LINK))
+				throw NotEvaluatableException();
+			ValuePtr v(FunctionLinkCast(h)->execute());
+			FloatValuePtr fv(FloatValueCast(v));
+			nums.push_back(fv->value()[0]);
+		}
+		return createSimpleTruthValue(nums);
+	}
 	else if (TRUTH_VALUE_OF_LINK == t)
 	{
 		// If the truth value of the link is being requested,

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -237,8 +237,7 @@ static HandleSeq get_seq(const Handle& cargs)
 
 /// Evalaute a formula defined by a PREDICATE_FORMULA_LINK
 static TruthValuePtr eval_formula(const Handle& predform,
-                                  const Handle& cargs,
-                                  bool silent)
+                                  const Handle& cargs)
 {
 	// Collect up two floating point values.
 	std::vector<double> nums;
@@ -264,7 +263,7 @@ static TruthValuePtr eval_formula(const Handle& predform,
 
 		// At this point, we expect a FunctionLink of some kind.
 		if (not nameserver().isA(flh->get_type(), FUNCTION_LINK))
-			throwSyntaxException(silent, "Expecting a FunctionLink");
+			throw SyntaxException(TRACE_INFO, "Expecting a FunctionLink");
 
 		// If the FunctionLink has free variables in it,
 		// reduce them with the provided arguments.
@@ -598,6 +597,7 @@ TruthValuePtr EvaluationLink::do_eval_scratch(AtomSpace* as,
 	}
 	else if (PREDICATE_FORMULA_LINK == t)
 	{
+		// A shortened, argument-free version of eval_formula()
 		std::vector<double> nums;
 		for (const Handle& h: evelnk->getOutgoingSet())
 		{
@@ -608,7 +608,7 @@ TruthValuePtr EvaluationLink::do_eval_scratch(AtomSpace* as,
 			}
 
 			if (not nameserver().isA(h->get_type(), FUNCTION_LINK))
-				throwSyntaxException(silent, "Expecting a FunctionLink");
+				throw SyntaxException(TRACE_INFO, "Expecting a FunctionLink");
 
 			ValuePtr v(FunctionLinkCast(h)->execute());
 			FloatValuePtr fv(FloatValueCast(v));
@@ -705,7 +705,7 @@ TruthValuePtr EvaluationLink::do_evaluate(AtomSpace* as,
 
 		if (PREDICATE_FORMULA_LINK == dtype)
 		{
-			return eval_formula(defn, cargs, silent);
+			return eval_formula(defn, cargs);
 		}
 
 		// If its not a LambdaLink, then I don't know what to do...
@@ -725,7 +725,7 @@ TruthValuePtr EvaluationLink::do_evaluate(AtomSpace* as,
 	// AtomSpace.
 	if (PREDICATE_FORMULA_LINK == pntype)
 	{
-		return eval_formula(pn, cargs, silent);
+		return eval_formula(pn, cargs);
 	}
 
 	if (GROUNDED_PREDICATE_NODE != pntype)

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -300,7 +300,9 @@ TruthValuePtr EvaluationLink::do_eval_scratch(AtomSpace* as,
 		Instantiator inst(scratch);
 		Handle args(HandleCast(inst.execute(sna.at(1), silent)));
 
-		return do_evaluate(scratch, sna.at(0), args, silent);
+		TruthValuePtr tvp(do_evaluate(scratch, sna.at(0), args, silent));
+		evelnk->setTruthValue(tvp);
+		return tvp;
 	}
 	else if (IDENTICAL_LINK == t)
 	{

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -619,6 +619,20 @@ TruthValuePtr EvaluationLink::do_evaluate(AtomSpace* as,
 		return do_evaluate(as, reduct, silent);
 	}
 
+	if (PREDICATE_FORMULA_LINK == pntype)
+	{
+		std::vector<double> nums;
+		for (const Handle& h: pn->getOutgoingSet())
+		{
+			if (not nameserver().isA(h->get_type(), FUNCTION_LINK))
+				throw NotEvaluatableException();
+			ValuePtr v(FunctionLinkCast(h)->execute());
+			FloatValuePtr fv(FloatValueCast(v));
+			nums.push_back(fv->value()[0]);
+		}
+		return createSimpleTruthValue(nums);
+	}
+
 	if (GROUNDED_PREDICATE_NODE != pntype)
 	{
 		// Throw a silent exception; this is called in some try..catch blocks.

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -155,7 +155,7 @@ static TruthValuePtr greater(AtomSpace* as, const Handle& h)
 {
 	const HandleSeq& oset = h->getOutgoingSet();
 	if (2 != oset.size())
-		throw RuntimeException(TRACE_INFO,
+		throw SyntaxException(TRACE_INFO,
 		     "GreaterThankLink expects two arguments");
 
 	Instantiator inst(as);
@@ -176,7 +176,7 @@ static TruthValuePtr identical(const Handle& h)
 {
 	const HandleSeq& oset = h->getOutgoingSet();
 	if (2 != oset.size())
-		throw RuntimeException(TRACE_INFO,
+		throw SyntaxException(TRACE_INFO,
 		     "IdenticalLink expects two arguments");
 
 	if (oset[0] == oset[1])
@@ -190,7 +190,7 @@ static TruthValuePtr equal(AtomSpace* as, const Handle& h, bool silent)
 {
 	const HandleSeq& oset = h->getOutgoingSet();
 	if (2 != oset.size())
-		throw RuntimeException(TRACE_INFO,
+		throw SyntaxException(TRACE_INFO,
 		     "EqualLink expects two arguments");
 
 	Instantiator inst(as);
@@ -661,7 +661,7 @@ TruthValuePtr EvaluationLink::do_evaluate(AtomSpace* as,
 {
 	if (2 != sna.size())
 	{
-		throw RuntimeException(TRACE_INFO,
+		throw SyntaxException(TRACE_INFO,
 		     "Incorrect arity for an EvaluationLink!");
 	}
 	return do_evaluate(as, sna[0], sna[1], silent);
@@ -703,14 +703,14 @@ TruthValuePtr EvaluationLink::do_evaluate(AtomSpace* as,
 
 		// If its not a LambdaLink, then I don't know what to do...
 		if (LAMBDA_LINK != dtype)
-			throw RuntimeException(TRACE_INFO,
+			throw SyntaxException(TRACE_INFO,
 				"Expecting definition to be a LambdaLink, got %s",
 				defn->to_string().c_str());
 
 		// Treat it as if it were a PutLink -- perform the
 		// beta-reduction, and evaluate the result.
 		LambdaLinkPtr lam(LambdaLinkCast(defn));
-		Handle reduct = lam->beta_reduce(get_args(cargs));
+		Handle reduct = lam->beta_reduce(get_seq(cargs));
 		return do_evaluate(as, reduct, silent);
 	}
 
@@ -774,7 +774,8 @@ TruthValuePtr EvaluationLink::do_evaluate(AtomSpace* as,
 		return applier->apply_tv(schema.substr(pos), args);
 #else
 		throw RuntimeException(TRACE_INFO,
-			 "Cannot evaluate scheme GroundedPredicateNode!");
+			"This binary does not have scheme support in it; "
+			"Cannot evaluate scheme GroundedPredicateNode!");
 #endif /* HAVE_GUILE */
 	}
 
@@ -790,7 +791,8 @@ TruthValuePtr EvaluationLink::do_evaluate(AtomSpace* as,
 		return applier.apply_tv(as, schema.substr(pos), args);
 #else
 		throw RuntimeException(TRACE_INFO,
-			 "Cannot evaluate python GroundedPredicateNode!");
+			"This binary does not have python support in it; "
+			"Cannot evaluate python GroundedPredicateNode!");
 #endif /* HAVE_CYTHON */
 	}
 
@@ -819,7 +821,7 @@ TruthValuePtr EvaluationLink::do_evaluate(AtomSpace* as,
 			if (silent)
 				throw NotEvaluatableException();
 
-			throw RuntimeException(TRACE_INFO,
+			throw SyntaxException(TRACE_INFO,
 			                       "Invalid return value from predicate %s\nArgs: %s",
 			                       pn->to_string().c_str(),
 			                       cargs->to_string().c_str());

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -510,6 +510,11 @@ TruthValuePtr EvaluationLink::do_eval_scratch(AtomSpace* as,
 		std::vector<double> nums;
 		for (const Handle& h: evelnk->getOutgoingSet())
 		{
+			if (NUMBER_NODE == h->get_type())
+			{
+				nums.push_back(NumberNodeCast(h)->get_value());
+				continue;
+			}
 			if (not nameserver().isA(h->get_type(), FUNCTION_LINK))
 				throw NotEvaluatableException();
 			ValuePtr v(FunctionLinkCast(h)->execute());
@@ -637,6 +642,11 @@ TruthValuePtr EvaluationLink::do_evaluate(AtomSpace* as,
 		std::vector<double> nums;
 		for (const Handle& h: pn->getOutgoingSet())
 		{
+			if (NUMBER_NODE == h->get_type())
+			{
+				nums.push_back(NumberNodeCast(h)->get_value());
+				continue;
+			}
 			if (not nameserver().isA(h->get_type(), FUNCTION_LINK))
 				throw NotEvaluatableException();
 			ValuePtr v(FunctionLinkCast(h)->execute());

--- a/opencog/atoms/execution/Instantiator.cc
+++ b/opencog/atoms/execution/Instantiator.cc
@@ -493,6 +493,14 @@ Handle Instantiator::walk_tree(const Handle& expr, bool silent)
 		return beta_reduce(expr, *_vmap);
 	}
 
+	// Do not reduce PredicateFormulaLink. That is because it contains
+	// formulas that we will need to re-evaluate in the future, so we
+	// must not clobber them.
+	if (PREDICATE_FORMULA_LINK == t)
+	{
+		return expr;
+	}
+
 	// If an atom is wrapped by the DontExecLink, then unwrap it,
 	// beta-reduce it, but don't execute it. Consume the DontExecLink.
 	// Actually, don't consume it. See discussion at issue #1303.

--- a/opencog/atoms/execution/Instantiator.cc
+++ b/opencog/atoms/execution/Instantiator.cc
@@ -271,7 +271,9 @@ Handle Instantiator::walk_tree(const Handle& expr, bool silent)
 				else
 				{
 					try {
-						EvaluationLink::do_evaluate(_as, plo, true);
+						TruthValuePtr tvp =
+							EvaluationLink::do_evaluate(_as, plo, true);
+						plo->setTruthValue(tvp);
 					}
 					catch (const NotEvaluatableException& ex) {}
 					unwrap.push_back(plo);

--- a/tests/atoms/CMakeLists.txt
+++ b/tests/atoms/CMakeLists.txt
@@ -1,6 +1,9 @@
 
 ADD_SUBDIRECTORY (truthvalue)
+
 IF(HAVE_GUILE)
+	ADD_CXXTEST(HashUTest)
+	TARGET_LINK_LIBRARIES(HashUTest smob atomspace)
 	ADD_CXXTEST(FreeLinkUTest)
 	TARGET_LINK_LIBRARIES(FreeLinkUTest smob atomspace)
 	ADD_CXXTEST(MapLinkUTest)
@@ -19,8 +22,8 @@ IF(HAVE_GUILE)
 	TARGET_LINK_LIBRARIES(PutLinkUTest execution smob atomspace)
 	ADD_CXXTEST(QuotationUTest)
 	TARGET_LINK_LIBRARIES(QuotationUTest execution smob atomspace)
-	ADD_CXXTEST(HashUTest)
-	TARGET_LINK_LIBRARIES(HashUTest smob atomspace)
+	ADD_CXXTEST(FormulaUTest)
+	TARGET_LINK_LIBRARIES(FormulaUTest execution smob atomspace)
 ENDIF(HAVE_GUILE)
 
 ADD_CXXTEST(AlphaConvertUTest)

--- a/tests/atoms/FormulaUTest.cxxtest
+++ b/tests/atoms/FormulaUTest.cxxtest
@@ -53,6 +53,7 @@ public:
 	void test_formula();
 	void test_evaluation();
 	void test_evalform();
+	void test_putlink();
 };
 
 #define MAXERR 1.0e-12
@@ -180,6 +181,62 @@ void FormulaUTest::test_evalform()
 	fvp = FloatValueCast(ValueCast(tvp));
 	TS_ASSERT_LESS_THAN(fabs(fvp->value()[0] - 0.52), MAXERR);
 	TS_ASSERT_LESS_THAN(fabs(fvp->value()[1] - 0.9), MAXERR);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void FormulaUTest::test_putlink()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle hset = _eval.eval_h("(cog-execute! put-link)");
+	Handle hevo = hset->getOutgoingAtom(0);
+
+	TruthValuePtr tvp = hevo->getTruthValue();
+	printf("Putter result=%s\n", tvp->to_string().c_str());
+	TS_ASSERT_EQUALS(tvp->get_type(), SIMPLE_TRUTH_VALUE);
+	FloatValuePtr fvp = FloatValueCast(ValueCast(tvp));
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[0] - 0.52), MAXERR);
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[1] - 0.9), MAXERR);
+
+	_eval.eval("(define putex (cog-execute! put-link))");
+	_eval.eval("(define pevu (cog-outgoing-atom putex 0))");
+
+	// --------------
+	_eval.eval("(Concept \"A\" (stv 0.3 0.5))");
+	_eval.eval("(Concept \"B\" (stv 0.4 0.5))");
+
+	tvp = _eval.eval_tv("(cog-evaluate! pevu)");
+	printf("New pevu=%s\n", tvp->to_string().c_str());
+	TS_ASSERT_EQUALS(tvp->get_type(), SIMPLE_TRUTH_VALUE);
+	fvp = FloatValueCast(ValueCast(tvp));
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[0] - 0.88), MAXERR);
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[1] - 0.25), MAXERR);
+
+	tvp = _eval.eval_tv("(cog-tv pevu)");
+	printf("Pevu-tv=%s\n", tvp->to_string().c_str());
+	TS_ASSERT_EQUALS(tvp->get_type(), SIMPLE_TRUTH_VALUE);
+	fvp = FloatValueCast(ValueCast(tvp));
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[0] - 0.88), MAXERR);
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[1] - 0.25), MAXERR);
+
+	// --------------
+	_eval.eval("(Concept \"A\" (stv 0.1 0.99))");
+	_eval.eval("(Concept \"B\" (stv 0.1 0.99))");
+
+	tvp = _eval.eval_tv("(cog-evaluate! pevu)");
+	printf("New pevu=%s\n", tvp->to_string().c_str());
+	TS_ASSERT_EQUALS(tvp->get_type(), SIMPLE_TRUTH_VALUE);
+	fvp = FloatValueCast(ValueCast(tvp));
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[0] - 0.99), MAXERR);
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[1] - 0.9801), MAXERR);
+
+	tvp = _eval.eval_tv("(cog-tv pevu)");
+	printf("Pevu-tv=%s\n", tvp->to_string().c_str());
+	TS_ASSERT_EQUALS(tvp->get_type(), SIMPLE_TRUTH_VALUE);
+	fvp = FloatValueCast(ValueCast(tvp));
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[0] - 0.99), MAXERR);
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[1] - 0.9801), MAXERR);
 
 	logger().info("END TEST: %s", __FUNCTION__);
 }

--- a/tests/atoms/FormulaUTest.cxxtest
+++ b/tests/atoms/FormulaUTest.cxxtest
@@ -51,6 +51,7 @@ public:
 
 	void test_strength_of();
 	void test_formula();
+	void test_evaluation();
 };
 
 #define MAXERR 1.0e-12
@@ -100,6 +101,34 @@ void FormulaUTest::test_formula()
 	fvp = FloatValueCast(ValueCast(tvp));
 	TS_ASSERT_LESS_THAN(fabs(fvp->value()[0] - 0.52), MAXERR);
 	TS_ASSERT_LESS_THAN(fabs(fvp->value()[1] - 0.9), MAXERR);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void FormulaUTest::test_evaluation()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	TruthValuePtr tvp = _eval.eval_tv("(cog-tv my-ev-link)");
+	printf("Get before-ev-stv=%s\n", tvp->to_string().c_str());
+	TS_ASSERT_EQUALS(tvp->get_type(), SIMPLE_TRUTH_VALUE);
+	FloatValuePtr fvp = FloatValueCast(ValueCast(tvp));
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[0] - 1.0), MAXERR);
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[1] - 0.0), MAXERR);
+
+	tvp = _eval.eval_tv("(cog-evaluate! my-ev-link)");
+	printf("Get eval-tv=%s\n", tvp->to_string().c_str());
+	TS_ASSERT_EQUALS(tvp->get_type(), SIMPLE_TRUTH_VALUE);
+	fvp = FloatValueCast(ValueCast(tvp));
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[0] - 0.75), MAXERR);
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[1] - 0.628), MAXERR);
+
+	tvp = _eval.eval_tv("(cog-tv my-ev-link)");
+	printf("Get after-eval-stv=%s\n", tvp->to_string().c_str());
+	TS_ASSERT_EQUALS(tvp->get_type(), SIMPLE_TRUTH_VALUE);
+	fvp = FloatValueCast(ValueCast(tvp));
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[0] - 0.75), MAXERR);
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[1] - 0.628), MAXERR);
 
 	logger().info("END TEST: %s", __FUNCTION__);
 }

--- a/tests/atoms/FormulaUTest.cxxtest
+++ b/tests/atoms/FormulaUTest.cxxtest
@@ -50,7 +50,7 @@ public:
 	void tearDown() {}
 
 	void test_strength_of();
-
+	void test_formula();
 };
 
 #define MAXERR 1.0e-12
@@ -73,6 +73,33 @@ void FormulaUTest::test_strength_of()
 	TS_ASSERT_EQUALS(cof->get_type(), FLOAT_VALUE);
 	fvp = FloatValueCast(cof);
 	TS_ASSERT_LESS_THAN(fabs(fvp->value()[0] - 0.9), MAXERR);
+
+	ValuePtr pof = _eval.eval_v("(cog-execute! prod)");
+	printf("Get product=%s\n", pof->to_string().c_str());
+	TS_ASSERT_EQUALS(pof->get_type(), FLOAT_VALUE);
+	fvp = FloatValueCast(pof);
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[0] - 0.48), MAXERR);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void FormulaUTest::test_formula()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	TruthValuePtr tvp = _eval.eval_tv("(cog-evaluate! stv-const)");
+	printf("Get stv-const=%s\n", tvp->to_string().c_str());
+	TS_ASSERT_EQUALS(tvp->get_type(), SIMPLE_TRUTH_VALUE);
+	FloatValuePtr fvp = FloatValueCast(ValueCast(tvp));
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[0] - 0.7), MAXERR);
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[1] - 0.314), MAXERR);
+
+	tvp = _eval.eval_tv("(cog-evaluate! formula-stv)");
+	printf("Get formula-stv=%s\n", tvp->to_string().c_str());
+	TS_ASSERT_EQUALS(tvp->get_type(), SIMPLE_TRUTH_VALUE);
+	fvp = FloatValueCast(ValueCast(tvp));
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[0] - 0.52), MAXERR);
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[1] - 0.9), MAXERR);
 
 	logger().info("END TEST: %s", __FUNCTION__);
 }

--- a/tests/atoms/FormulaUTest.cxxtest
+++ b/tests/atoms/FormulaUTest.cxxtest
@@ -54,6 +54,7 @@ public:
 	void test_evaluation();
 	void test_evalform();
 	void test_putlink();
+	void test_define();
 };
 
 #define MAXERR 1.0e-12
@@ -237,6 +238,56 @@ void FormulaUTest::test_putlink()
 	fvp = FloatValueCast(ValueCast(tvp));
 	TS_ASSERT_LESS_THAN(fabs(fvp->value()[0] - 0.99), MAXERR);
 	TS_ASSERT_LESS_THAN(fabs(fvp->value()[1] - 0.9801), MAXERR);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void FormulaUTest::test_define()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	TruthValuePtr tvp = _eval.eval_tv("(cog-tv red-form)");
+	printf("Get before red-form=%s\n", tvp->to_string().c_str());
+	TS_ASSERT_EQUALS(tvp->get_type(), SIMPLE_TRUTH_VALUE);
+	FloatValuePtr fvp = FloatValueCast(ValueCast(tvp));
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[0] - 1.0), MAXERR);
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[1] - 0.0), MAXERR);
+
+	// --------------
+	_eval.eval("(Concept \"A\" (stv 0.3 0.5))");
+	_eval.eval("(Concept \"B\" (stv 0.4 0.5))");
+
+	tvp = _eval.eval_tv("(cog-evaluate! red-form)");
+	printf("New red-form=%s\n", tvp->to_string().c_str());
+	TS_ASSERT_EQUALS(tvp->get_type(), SIMPLE_TRUTH_VALUE);
+	fvp = FloatValueCast(ValueCast(tvp));
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[0] - 0.88), MAXERR);
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[1] - 0.25), MAXERR);
+
+	tvp = _eval.eval_tv("(cog-tv red-form)");
+	printf("red-form-tv=%s\n", tvp->to_string().c_str());
+	TS_ASSERT_EQUALS(tvp->get_type(), SIMPLE_TRUTH_VALUE);
+	fvp = FloatValueCast(ValueCast(tvp));
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[0] - 0.88), MAXERR);
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[1] - 0.25), MAXERR);
+
+	// --------------
+	_eval.eval("(Concept \"A\" (stv 0.2 0.98))");
+	_eval.eval("(Concept \"B\" (stv 0.2 0.98))");
+
+	tvp = _eval.eval_tv("(cog-evaluate! red-form)");
+	printf("New red-form=%s\n", tvp->to_string().c_str());
+	TS_ASSERT_EQUALS(tvp->get_type(), SIMPLE_TRUTH_VALUE);
+	fvp = FloatValueCast(ValueCast(tvp));
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[0] - 0.96), MAXERR);
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[1] - 0.9604), MAXERR);
+
+	tvp = _eval.eval_tv("(cog-tv red-form)");
+	printf("red-form-tv=%s\n", tvp->to_string().c_str());
+	TS_ASSERT_EQUALS(tvp->get_type(), SIMPLE_TRUTH_VALUE);
+	fvp = FloatValueCast(ValueCast(tvp));
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[0] - 0.96), MAXERR);
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[1] - 0.9604), MAXERR);
 
 	logger().info("END TEST: %s", __FUNCTION__);
 }

--- a/tests/atoms/FormulaUTest.cxxtest
+++ b/tests/atoms/FormulaUTest.cxxtest
@@ -52,6 +52,7 @@ public:
 	void test_strength_of();
 	void test_formula();
 	void test_evaluation();
+	void test_evalform();
 };
 
 #define MAXERR 1.0e-12
@@ -129,6 +130,56 @@ void FormulaUTest::test_evaluation()
 	fvp = FloatValueCast(ValueCast(tvp));
 	TS_ASSERT_LESS_THAN(fabs(fvp->value()[0] - 0.75), MAXERR);
 	TS_ASSERT_LESS_THAN(fabs(fvp->value()[1] - 0.628), MAXERR);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void FormulaUTest::test_evalform()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	TruthValuePtr tvp = _eval.eval_tv("(cog-tv eval-formula)");
+	printf("Get before-ev-form=%s\n", tvp->to_string().c_str());
+	TS_ASSERT_EQUALS(tvp->get_type(), SIMPLE_TRUTH_VALUE);
+	FloatValuePtr fvp = FloatValueCast(ValueCast(tvp));
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[0] - 1.0), MAXERR);
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[1] - 0.0), MAXERR);
+
+	tvp = _eval.eval_tv("(cog-evaluate! eval-formula)");
+	printf("Get eval-formula=%s\n", tvp->to_string().c_str());
+	TS_ASSERT_EQUALS(tvp->get_type(), SIMPLE_TRUTH_VALUE);
+	fvp = FloatValueCast(ValueCast(tvp));
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[0] - 0.52), MAXERR);
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[1] - 0.9), MAXERR);
+
+	tvp = _eval.eval_tv("(cog-tv eval-formula)");
+	printf("Get after-eval-form=%s\n", tvp->to_string().c_str());
+	TS_ASSERT_EQUALS(tvp->get_type(), SIMPLE_TRUTH_VALUE);
+	fvp = FloatValueCast(ValueCast(tvp));
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[0] - 0.52), MAXERR);
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[1] - 0.9), MAXERR);
+
+	// ------------------
+	tvp = _eval.eval_tv("(cog-tv eval-lambda)");
+	printf("Get before-ev-lambda=%s\n", tvp->to_string().c_str());
+	TS_ASSERT_EQUALS(tvp->get_type(), SIMPLE_TRUTH_VALUE);
+	fvp = FloatValueCast(ValueCast(tvp));
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[0] - 1.0), MAXERR);
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[1] - 0.0), MAXERR);
+
+	tvp = _eval.eval_tv("(cog-evaluate! eval-lambda)");
+	printf("Get eval-lambda=%s\n", tvp->to_string().c_str());
+	TS_ASSERT_EQUALS(tvp->get_type(), SIMPLE_TRUTH_VALUE);
+	fvp = FloatValueCast(ValueCast(tvp));
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[0] - 0.52), MAXERR);
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[1] - 0.9), MAXERR);
+
+	tvp = _eval.eval_tv("(cog-tv eval-lambda)");
+	printf("Get after-eval-lambda=%s\n", tvp->to_string().c_str());
+	TS_ASSERT_EQUALS(tvp->get_type(), SIMPLE_TRUTH_VALUE);
+	fvp = FloatValueCast(ValueCast(tvp));
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[0] - 0.52), MAXERR);
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[1] - 0.9), MAXERR);
 
 	logger().info("END TEST: %s", __FUNCTION__);
 }

--- a/tests/atoms/FormulaUTest.cxxtest
+++ b/tests/atoms/FormulaUTest.cxxtest
@@ -1,0 +1,78 @@
+/*
+ * tests/atoms/FormulaUTest.cxxtest
+ *
+ * Copyright (C) 2019 Linas Vepstas
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <math.h>
+#include <opencog/guile/SchemeEval.h>
+#include <opencog/atoms/base/Atom.h>
+#include <opencog/atomspace/AtomSpace.h>
+
+#include <cxxtest/TestSuite.h>
+
+using namespace opencog;
+
+class FormulaUTest :  public CxxTest::TestSuite
+{
+private:
+	AtomSpace _as;
+	SchemeEval _eval;
+
+public:
+	FormulaUTest() : _eval(&_as)
+	{
+		logger().set_timestamp_flag(false);
+		logger().set_print_to_stdout_flag(true);
+
+		_eval.eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+		_eval.eval("(load-from-path \"tests/atoms/formulas.scm\")");
+	}
+
+	void setUp() {}
+
+	void tearDown() {}
+
+	void test_strength_of();
+
+};
+
+#define MAXERR 1.0e-12
+
+void FormulaUTest::test_strength_of()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	_eval.eval("(Concept \"A\" (stv 0.8 1.0))");
+	_eval.eval("(Concept \"B\" (stv 0.6 0.9))");
+
+	ValuePtr sof = _eval.eval_v("(cog-execute! (StrengthOf (Concept \"A\")))");
+	printf("Get strenght_of=%s\n", sof->to_string().c_str());
+	TS_ASSERT_EQUALS(sof->get_type(), FLOAT_VALUE);
+	FloatValuePtr fvp = FloatValueCast(sof);
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[0] - 0.8), MAXERR);
+
+	ValuePtr cof = _eval.eval_v("(cog-execute! (ConfidenceOf (Concept \"B\")))");
+	printf("Get conf_of=%s\n", cof->to_string().c_str());
+	TS_ASSERT_EQUALS(cof->get_type(), FLOAT_VALUE);
+	fvp = FloatValueCast(cof);
+	TS_ASSERT_LESS_THAN(fabs(fvp->value()[0] - 0.9), MAXERR);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}

--- a/tests/atoms/formulas.scm
+++ b/tests/atoms/formulas.scm
@@ -92,3 +92,28 @@
 				(List
 					(Variable "$VA") (Variable "$VB")))
 		(Set (List (Concept "A") (Concept "B")))))
+
+
+; One can also use DefinedPredicates, to give the formula a name.
+(DefineLink
+	(DefinedPredicate "has a reddish color")
+	(PredicateFormula
+		(Minus
+			(Number 1)
+			(Times
+				(StrengthOf (Variable "$X"))
+				(StrengthOf (Variable "$Y"))))
+		(Times
+			(ConfidenceOf (Variable "$X"))
+			(ConfidenceOf (Variable "$Y")))))
+
+(Concept "A" (stv 0.9 0.98))
+(Concept "B" (stv 0.9 0.98))
+
+; The will cause the formula to evaluate.
+(define red-form
+	(Evaluation
+		(DefinedPredicate "has a reddish color")
+		(List
+			(Concept "A")
+			(Concept "B"))))

--- a/tests/atoms/formulas.scm
+++ b/tests/atoms/formulas.scm
@@ -1,30 +1,17 @@
 ;
 ; formulas.scm -- Declaring formulas that compute truth values.
 ;
-; The rule engine, PLN and other subsystems need to be able to compute
-; and alter truth values. If those formulas are known a-priori, then
-; thay can be hard-coded into GroundedPredicateNodes.  However, it is
-; possible that those formulas are not yet known: that they will be
-; learned using some learning algorithm, for example, MOSES, or maybe
-; the Pattern Miner, or some neural network.
-;
-; In this case, the formulas need to be placed where they can be
-; accessed during computation: in the AtomSpace. The example below
-; shows how formulas can be declared in the AtomSpace, but in such a
-; way that they can also be evaluated to yeild an actual truth value,
-; which is then attached to some Atom.
+; This is a modified copy of an example program. It helps verify that
+; the example actually works.
 ;
 (use-modules (opencog) (opencog exec))
 
 ; The StrengthOfLink returns a single floating-point number,
 ; the strength of a TruthValue.
-(Concept "A" (stv 0.8 1.0))
-(cog-execute! (StrengthOf (Concept "A")))
+(define atom-a (Concept "A" (stv 0.8 1.0)))
+(define atom-b (Concept "B" (stv 0.6 0.9)))
 
-; The demo needs at least one more Atom.
-(Concept "B" (stv 0.6 0.9))
-
-; Multiply the strength of the TV's of two atoms.
+; Multiple the strength of the TV's of two atoms.
 (cog-execute!
 	(Times (StrengthOf (Concept "A")) (StrengthOf (Concept "B"))))
 
@@ -133,18 +120,18 @@
 ; The scheme variable `the-put-result` contains a SetLink with the
 ; result in it. Lets unwrap it, so that `evelnk` is just the
 ; EvaluationLink. And tehn we play a little trick.
-(define evelnk (cog-outgoing-atom the-put-result 0))
+; (define evelnk (cog-outgoing-atom the-put-result 0))
 
 ; Change the truth value on the two concept nodes ...
-(Concept "A" (stv 0.3 0.5))
-(Concept "B" (stv 0.4 0.5))
+; (Concept "A" (stv 0.3 0.5))
+; (Concept "B" (stv 0.4 0.5))
 
 ; Re-evaluate the EvaluationLink. Note the TV has been updated!
-(cog-evaluate! evelnk)
+; (cog-evaluate! evelnk)
 
 ; Do it again, for good luck!
-(Concept "A" (stv 0.1 0.99))
-(Concept "B" (stv 0.1 0.99))
+; (Concept "A" (stv 0.1 0.99))
+; (Concept "B" (stv 0.1 0.99))
 
 ; Re-evaluate the EvaluationLink. The TV is again recomputed!
-(cog-evaluate! evelnk)
+; (cog-evaluate! evelnk)

--- a/tests/atoms/formulas.scm
+++ b/tests/atoms/formulas.scm
@@ -6,30 +6,21 @@
 ;
 (use-modules (opencog) (opencog exec))
 
-; The StrengthOfLink returns a single floating-point number,
-; the strength of a TruthValue.
 (define atom-a (Concept "A" (stv 0.8 1.0)))
 (define atom-b (Concept "B" (stv 0.6 0.9)))
 
-; Multiple the strength of the TV's of two atoms.
-(cog-execute!
+; Multiply the strength of the TV's of two atoms.
+(define prod
 	(Times (StrengthOf (Concept "A")) (StrengthOf (Concept "B"))))
 
-; Create a SimpleTruthValue with a non-trivial formula:
-; It will be the TV := (1-sA*sB, cA*cB) where sA and sB are strenghts
-; and cA, cB are confidence values. The PredicateFormulaLink assembles
-; two floating-point values, and create a SimpleTruthValue out of them.
-;
-(cog-evaluate!
+(define stv-const (PredicateFormula (Number 0.7) (Number 0.314)))
+
+(define formula-stv
 	(PredicateFormula
 		(Minus
 			(Number 1)
 			(Times (StrengthOf (Concept "A")) (StrengthOf (Concept "B"))))
 		(Times (ConfidenceOf (Concept "A")) (ConfidenceOf (Concept "B")))))
-
-; The values do not need to be formulas; tehy can be hard-coded numbers.
-(cog-evaluate!
-	(PredicateFormula (Number 0.7) (Number 0.314)))
 
 ; The below computes a truth value, and attaches it to the
 ; EvaluationLink.

--- a/tests/atoms/formulas.scm
+++ b/tests/atoms/formulas.scm
@@ -24,9 +24,9 @@
 
 ; The below computes a truth value, and attaches it to the
 ; EvaluationLink.
-(cog-evaluate!
+(define my-ev-link
 	(Evaluation
-		(PredicateFormula (Number 0.7) (Number 0.314))
+		(PredicateFormula (Number 0.75) (Number 0.628))
 		(List
 			(Concept "A")
 			(Concept "B"))))

--- a/tests/atoms/formulas.scm
+++ b/tests/atoms/formulas.scm
@@ -31,12 +31,8 @@
 			(Concept "A")
 			(Concept "B"))))
 
-; More typically, one wishes to have a formula in the abstract,
-; with variables in it, so that one can apply it in any one of
-; a number of different situations. In the below, the variables
-; are automatically reduced with the Atoms in the ListLink, and
-; then the formula is evaluated to obtain a TruthValue.
-(cog-evaluate!
+; Formula with variables
+(define eval-formula
 	(Evaluation
 		; Compute TV = (1-sA*sB, cA*cB)
 		(PredicateFormula
@@ -54,37 +50,27 @@
 
 ; Optionally, you can wrap formulas with LambdaLinks. This doesn't
 ; really change anything; formulas work fine without LambdaLinks.
-(cog-evaluate!
+(define eval-lambda
 	(Evaluation
 		; Compute TV = (1-sA*sB, cA*cB)
 		(PredicateFormula
-			(Lambda (Minus
-				(Number 1)
+			(Lambda
+				; Lambda without a decl, intentionally so.
+				; (NopeVariableList (Variable "$X") (Variable "$Y"))
+				(Minus
+					(Number 1)
+					(Times
+						(StrengthOf (Variable "$X"))
+						(StrengthOf (Variable "$Y")))))
+			(Lambda
+				(VariableList (Variable "$X") (Variable "$Y"))
 				(Times
-					(StrengthOf (Variable "$X"))
-					(StrengthOf (Variable "$Y")))))
-			(Lambda (Times
-				(ConfidenceOf (Variable "$X"))
-				(ConfidenceOf (Variable "$Y")))))
+					(ConfidenceOf (Variable "$X"))
+					(ConfidenceOf (Variable "$Y")))))
 		(List
 			(Concept "A")
 			(Concept "B"))))
 
-
-; The PedicateFormulaLink behaves just like any other algebraic
-; expression with VariableNodes in it. When executed, it might
-; reduce a bit, but that is all.
-(cog-execute!
-	(PredicateFormula
-		(Plus (Number 41)
-			(Minus
-				(Number 1)
-				(Times
-					(StrengthOf (Variable "$VA"))
-					(StrengthOf (Variable "$VB")))))
-			(Times
-				(ConfidenceOf (Variable "$VA"))
-				(ConfidenceOf (Variable "$VB")))))
 
 ; Beta-reducation works as normal. The below will create an
 ; EvaluationLink with ConceptNode A and B in it, and will set the

--- a/tests/atoms/formulas.scm
+++ b/tests/atoms/formulas.scm
@@ -75,8 +75,7 @@
 ; Beta-reducation works as normal. The below will create an
 ; EvaluationLink with ConceptNode A and B in it, and will set the
 ; truth value according to the formula.
-(define the-put-result
-	(cog-execute!
+(define put-link
 		(PutLink
 			(VariableList (Variable "$VA") (Variable "$VB"))
 			(Evaluation
@@ -92,23 +91,4 @@
 						(ConfidenceOf (Variable "$VB"))))
 				(List
 					(Variable "$VA") (Variable "$VB")))
-		(Set (List (Concept "A") (Concept "B"))))))
-
-; The scheme variable `the-put-result` contains a SetLink with the
-; result in it. Lets unwrap it, so that `evelnk` is just the
-; EvaluationLink. And tehn we play a little trick.
-; (define evelnk (cog-outgoing-atom the-put-result 0))
-
-; Change the truth value on the two concept nodes ...
-; (Concept "A" (stv 0.3 0.5))
-; (Concept "B" (stv 0.4 0.5))
-
-; Re-evaluate the EvaluationLink. Note the TV has been updated!
-; (cog-evaluate! evelnk)
-
-; Do it again, for good luck!
-; (Concept "A" (stv 0.1 0.99))
-; (Concept "B" (stv 0.1 0.99))
-
-; Re-evaluate the EvaluationLink. The TV is again recomputed!
-; (cog-evaluate! evelnk)
+		(Set (List (Concept "A") (Concept "B")))))


### PR DESCRIPTION
The current PLN implementation encodes all formulas in scheme, and uses GPN's to apply those formulas. This is an experimental system to hold those formulas in the AtomSpace, instead.  This has two benefits:

* The formulas can be obtained from some learning system, e.g. MOSES, or pattern-mining, or neural nets, or whatever, without any need to convert them to scheme.

* It's faster; this avoids the 50-microsecond overhead of getting into and out of the guile interpreter.

Take a look at the example "formulas.scm". It works.

This is a demo of one of the two ideas described in #2004