### PR TITLE
Documentation cleanup (mostly)

### DIFF
--- a/opencog/atoms/core/ArityLink.cc
+++ b/opencog/atoms/core/ArityLink.cc
@@ -65,7 +65,7 @@ ValuePtr ArityLink::execute() const
 			pap = flp->execute();
 			if (pap->is_link()) ary += HandleCast(pap)->get_arity();
 
-			// XXX TODO sum up lingth of values
+			// XXX TODO sum up length of values. (!?)
 		}
 		else
 		{

--- a/opencog/atoms/core/PrenexLink.cc
+++ b/opencog/atoms/core/PrenexLink.cc
@@ -160,16 +160,16 @@ Handle PrenexLink::beta_reduce(const HandleSeq& seq) const
 	//
 	// The above is a function that expects three arguments: x,y,z.
 	// Lets compose it with a function that takes one argument, but
-	// returns three values (function coposition):
+	// returns three results (function composition):
 	//
-	// (define func-returns-three-values
+	// (define func-returns-three-results
 	//    (Lambda (Variable "$w")
 	//      (List (Concept "animal") (Concept "foobar") (Variable"$w"))))
 	//
 	// Composing these two should return a function that takes one
 	// argument, namely $w.
 	//
-	//    (Put func-with-three-args func-returns-three-values)
+	//    (Put func-with-three-args func-returns-three-results)
 	//
 	// We expect as a result:
 	//
@@ -178,7 +178,7 @@ Handle PrenexLink::beta_reduce(const HandleSeq& seq) const
 	// Note that this is NOT compatible with beta-reduction in classical
 	// lambda calculus, which would leave $w free. We really want to
 	// eta-convert this, and keep $w bound, so that it looks like
-	// ordinary function composition. Atomese is not lambda calculus.
+	// ordinary function composition. Atomese is not lambda calculus!
 
 	// ------- Lets begin.
 	// For a valid eta conversion, there must be just one argument,
@@ -235,7 +235,7 @@ Handle PrenexLink::beta_reduce(const HandleMap& vmap) const
 {
 	HandleMap vm = vmap;
 
-	// If any of the mapped values are ScopeLinks, we need to discover
+	// If any of the mapped arguments are ScopeLinks, we need to discover
 	// and collect up the variables that they bind. We also need to
 	// make sure that they are "fresh", i.e. don't have naming
 	// collisions.
@@ -259,12 +259,12 @@ Handle PrenexLink::beta_reduce(const HandleMap& vmap) const
 			continue;
 		}
 
-		Type valuetype = pare->second->get_type();
+		Type argtype = pare->second->get_type();
 
 		// If we are here, then var will be beta-reduced.
-		// But if the value is another variable, then alpha-convert,
-		// instead.
-		if (VARIABLE_NODE == valuetype)
+		// But if the argument is another variable, then
+		// alpha-convert, instead.
+		if (VARIABLE_NODE == argtype)
 		{
 			Handle alt = collect(vtool, var, pare->second,
 			                     final_varlist, used_vars, issued);
@@ -274,11 +274,11 @@ Handle PrenexLink::beta_reduce(const HandleMap& vmap) const
 		}
 
 		// If we are here, then var will be beta-reduced.
-		// Is the value a PrenexLink? If so, we need to disassmeble
+		// Is the argument a PrenexLink? If so, we need to disassmeble
 		// it, yank out the variables, and then reassemble it
 		// again, so that the variables are declared in the
 		// outer-most scope.
-		if (nameserver().isA(valuetype, PRENEX_LINK))
+		if (nameserver().isA(argtype, PRENEX_LINK))
 		{
 			PrenexLinkPtr sc = PrenexLinkCast(pare->second);
 			const Variables& bound = sc->get_variables();
@@ -290,7 +290,7 @@ Handle PrenexLink::beta_reduce(const HandleMap& vmap) const
 			if (nullptr == body)
 			{
 				throw SyntaxException(TRACE_INFO,
-				                      "PrenexLink given a malformed value=%s",
+				                      "PrenexLink given a malformed argument=%s",
 				                      sc->to_string().c_str());
 			}
 
@@ -314,7 +314,7 @@ Handle PrenexLink::beta_reduce(const HandleMap& vmap) const
 			// were multiple variables, and they weren's all LambdaLinks,
 			// for example. In that case, things are borked, and there's
 			// a bug here.  For now, we punt.
-			prenex = valuetype;
+			prenex = argtype;
 		}
 	}
 

--- a/opencog/atoms/core/PutLink.cc
+++ b/opencog/atoms/core/PutLink.cc
@@ -44,9 +44,9 @@ PutLink::PutLink(const Link& l)
 
 /// PutLink expects a very strict format: an arity-2 link, with
 /// the first part being a pattern, and the second a list or set
-/// of values. If the pattern has N variables, then the seccond
-/// part must have N values.  Furthermore, any type restrictions on
-/// the variables must be satisfied by the values.
+/// of arguments. If the pattern has N variables, then the seccond
+/// part must have N arguments.  Furthermore, any type restrictions
+/// on the variables must be satisfied by the arguments.
 ///
 /// The following formats are understood:
 ///
@@ -94,20 +94,20 @@ void PutLink::init(void)
 		// type declarations for it, then ScopeLink gets confused.
 		_vardecl = Handle::UNDEFINED;
 		_body = _outgoing[0];
-		_values = _outgoing[1];
+		_arguments = _outgoing[1];
 	}
 	else
-		_values = _outgoing[2];
+		_arguments = _outgoing[2];
 
-	static_typecheck_values();
+	static_typecheck_arguments();
 }
 
 
-/// Check that the values in the PutLink obey the type constraints.
+/// Check that the arguments in the PutLink obey the type constraints.
 /// This only performs "static" typechecking, at construction-time;
-/// since the values may be dynamically obtained at run-time, we cannot
+/// since the arguments may be dynamically obtained at run-time, we cannot
 /// check these here.
-void PutLink::static_typecheck_values(void)
+void PutLink::static_typecheck_arguments(void)
 {
 	// Cannot typecheck at this pont in time, because the schema
 	// might not be defined yet...
@@ -123,7 +123,7 @@ void PutLink::static_typecheck_values(void)
 	if (nameserver().isA(btype, TYPE_NODE) or TYPE_CHOICE == btype)
 		return;
 
-	Handle valley = _values;
+	Handle valley = _arguments;
 	Type vtype = valley->get_type();
 
 	// If it's body or value is an UnquoteLink then the PutLink is
@@ -136,7 +136,7 @@ void PutLink::static_typecheck_values(void)
 	// eta-reducible when it's body is a ListLink.
 	if (LAMBDA_LINK == vtype)
 	{
-		LambdaLinkPtr lam(LambdaLinkCast(_values));
+		LambdaLinkPtr lam(LambdaLinkCast(_arguments));
 		Handle body = lam->get_body();
 
 		// The body might not exist, if there's an unmantched
@@ -187,19 +187,19 @@ void PutLink::static_typecheck_values(void)
 	if (LIST_LINK == vtype)
 	{
 		// is_type() verifies that the arity of the vars
-		// and the values matches up.
+		// and the arguments matches up.
 		if (not _varlist.is_type(valley->getOutgoingSet()))
 		{
 			if (_vardecl)
 				throw SyntaxException(TRACE_INFO,
 					"PutLink has mismatched value list! vardecl=%s\nvals=%s",
 					_vardecl->to_string().c_str(),
-					_values->to_string().c_str());
+					_arguments->to_string().c_str());
 			else
 				throw SyntaxException(TRACE_INFO,
 					"PutLink has mismatched value list! body=%s\nvals=%s",
 					_body->to_string().c_str(),
-					_values->to_string().c_str());
+					_arguments->to_string().c_str());
 		}
 		return;
 	}
@@ -221,7 +221,8 @@ void PutLink::static_typecheck_values(void)
 	{
 		for (const Handle& h : valley->getOutgoingSet())
 		{
-			// If the arity is greater than one, then the values must be in a list.
+			// If the arity is greater than one,
+			// then the arguments must be in a list.
 			if (h->get_type() != LIST_LINK)
 				throw InvalidParamException(TRACE_INFO,
 					"PutLink expected value list!");
@@ -233,7 +234,7 @@ void PutLink::static_typecheck_values(void)
 		return;
 	}
 
-	// If the arity is one, the values must obey type constraint.
+	// If the arity is one, the arguments must obey type constraint.
 	for (const Handle& h : valley->getOutgoingSet())
 	{
 		if (not _varlist.is_type(h))
@@ -253,7 +254,7 @@ static inline Handle reddy(PrenexLinkPtr& subs, const HandleSeq& oset)
 /**
  * Perform the actual beta reduction --
  *
- * Substitute values for the variables in the pattern tree.
+ * Substitute arguments for the variables in the pattern tree.
  * This is a lot like applying the function fun to the argument list
  * args, except that no actual evaluation is performed; only
  * substitution.  The resulting tree is NOT placed into any atomspace,
@@ -279,8 +280,8 @@ static inline Handle reddy(PrenexLinkPtr& subs, const HandleSeq& oset)
  *         ConceptNode "cowpie"
  *         ConceptNode "hot patootie"
  *
- * Type checking is performed during substitution; if the values fail to
- * have the desired types, no substitution is performed.  In this case,
+ * Type checking is performed during substitution; if the arguments fail
+ * to have the desired types, no substitution is performed.  In this case,
  * an undefined handle is returned. For set substitutions, this acts as
  * a filter, removing (filtering out) the mismatched types.
  *
@@ -328,8 +329,8 @@ Handle PutLink::do_reduce(void) const
 		subs = lam;
 	}
 
-	// Now get the values that we will plug into the body.
-	Type vtype = _values->get_type();
+	// Now get the arguments that we will plug into the body.
+	Type vtype = _arguments->get_type();
 	size_t nvars = vars.varseq.size();
 
 	// FunctionLinks behave like pointless lambdas; that is, one can
@@ -347,7 +348,7 @@ Handle PutLink::do_reduce(void) const
 		if (LIST_LINK == vtype)
 		{
 			HandleSeq oset(bods->getOutgoingSet());
-			const HandleSeq& rest = _values->getOutgoingSet();
+			const HandleSeq& rest = _arguments->getOutgoingSet();
 			oset.insert(oset.end(), rest.begin(), rest.end());
 			return createLink(oset, btype);
 		}
@@ -355,13 +356,13 @@ Handle PutLink::do_reduce(void) const
 		if (SET_LINK != vtype)
 		{
 			HandleSeq oset(bods->getOutgoingSet());
-			oset.emplace_back(_values);
+			oset.emplace_back(_arguments);
 			return createLink(oset, btype);
 		}
 
-		// If the values are given in a set, then iterate over the set...
+		// If the arguments are given in a set, then iterate over the set...
 		HandleSeq bset;
-		for (const Handle& h : _values->getOutgoingSet())
+		for (const Handle& h : _arguments->getOutgoingSet())
 		{
 			if (LIST_LINK == h->get_type())
 			{
@@ -385,12 +386,12 @@ Handle PutLink::do_reduce(void) const
 	{
 		if (SET_LINK != vtype)
 		{
-			return reddy(subs, {_values});
+			return reddy(subs, {_arguments});
 		}
 
-		// If the values are given in a set, then iterate over the set...
+		// If the arguments are given in a set, then iterate over the set...
 		HandleSeq bset;
-		for (const Handle& h : _values->getOutgoingSet())
+		for (const Handle& h : _arguments->getOutgoingSet())
 		{
 			HandleSeq oset;
 			oset.emplace_back(h);
@@ -404,11 +405,12 @@ Handle PutLink::do_reduce(void) const
 	}
 
 	// If we are here, then there are multiple variables in the body.
-	// See how many values there are.  If the values are a ListLink,
-	// then assume that there is only a single set of values to plug in.
+	// See how many arguments there are.  If the arguments are in a
+	// ListLink, then assume that there is only a single set of
+	// arguments to plug in.
 	if (LIST_LINK == vtype)
 	{
-		const HandleSeq& oset = _values->getOutgoingSet();
+		const HandleSeq& oset = _arguments->getOutgoingSet();
 		return reddy(subs, oset);
 	}
 
@@ -418,11 +420,11 @@ Handle PutLink::do_reduce(void) const
 	if (LAMBDA_LINK == vtype)
 	{
 		HandleSeq oset;
-		oset.emplace_back(_values);
+		oset.emplace_back(_arguments);
 		return reddy(subs, oset);
 	}
 
-	// If we are here, then there are multiple values.
+	// If we are here, then there are multiple arguments.
 	// These MUST be given to us as a SetLink.
 	if (SET_LINK != vtype)
 	{
@@ -434,7 +436,7 @@ Handle PutLink::do_reduce(void) const
 	}
 
 	HandleSeq bset;
-	for (const Handle& h : _values->getOutgoingSet())
+	for (const Handle& h : _arguments->getOutgoingSet())
 	{
 		const HandleSeq& oset = h->getOutgoingSet();
 		try

--- a/opencog/atoms/core/PutLink.cc
+++ b/opencog/atoms/core/PutLink.cc
@@ -126,7 +126,7 @@ void PutLink::static_typecheck_arguments(void)
 	Handle valley = _arguments;
 	Type vtype = valley->get_type();
 
-	// If it's body or value is an UnquoteLink then the PutLink is
+	// If it's body or argument is an UnquoteLink then the PutLink is
 	// likely quoted and thus there is nothing to do
 	if (btype == UNQUOTE_LINK or vtype == UNQUOTE_LINK)
 		return;
@@ -192,12 +192,12 @@ void PutLink::static_typecheck_arguments(void)
 		{
 			if (_vardecl)
 				throw SyntaxException(TRACE_INFO,
-					"PutLink has mismatched value list! vardecl=%s\nvals=%s",
+					"PutLink has mismatched argument list! vardecl=%s\nvals=%s",
 					_vardecl->to_string().c_str(),
 					_arguments->to_string().c_str());
 			else
 				throw SyntaxException(TRACE_INFO,
-					"PutLink has mismatched value list! body=%s\nvals=%s",
+					"PutLink has mismatched argument list! body=%s\nvals=%s",
 					_body->to_string().c_str(),
 					_arguments->to_string().c_str());
 		}
@@ -225,11 +225,11 @@ void PutLink::static_typecheck_arguments(void)
 			// then the arguments must be in a list.
 			if (h->get_type() != LIST_LINK)
 				throw InvalidParamException(TRACE_INFO,
-					"PutLink expected value list!");
+					"PutLink expected argument list!");
 
 			if (not _varlist.is_type(h->getOutgoingSet()))
 				throw InvalidParamException(TRACE_INFO,
-					"PutLink bad value list!");
+					"PutLink bad argument list!");
 		}
 		return;
 	}
@@ -262,7 +262,7 @@ static inline Handle reddy(PrenexLinkPtr& subs, const HandleSeq& oset)
  * evaluation or execution to happen during or after sustitution, use
  * either the EvaluationLink, the ExecutionOutputLink, or the Instantiator.
  *
- * So, for example, if this PutLink looks like this:
+ * So, for example, if the PutLink looks like this:
  *
  *   PutLink
  *      EvaluationLink
@@ -272,7 +272,7 @@ static inline Handle reddy(PrenexLinkPtr& subs, const HandleSeq& oset)
  *            ConceptNode "hot patootie"
  *      ConceptNode "cowpie"
  *
- * then the reduced value will be
+ * then the reduced body will be
  *
  *   EvaluationLink
  *      PredicateNode "is a kind of"
@@ -414,7 +414,7 @@ Handle PutLink::do_reduce(void) const
 		return reddy(subs, oset);
 	}
 
-	// If the value is a LambdaLink, it will eta-reducible.
+	// If the argument is a LambdaLink, it will eta-reducible.
 	// We already checked this earlier (a static check), so we
 	// don't need any more checking. Just pass it through.
 	if (LAMBDA_LINK == vtype)

--- a/opencog/atoms/core/PutLink.h
+++ b/opencog/atoms/core/PutLink.h
@@ -36,9 +36,9 @@ namespace opencog
  * version of MemberLink, with arguments reversed.
  *
  * A beta redex is a concatentation or composition of a combinator, and
- * a list of values.  Typically, the combinator will be a LambdaLink,
+ * a list of arguments.  Typically, the combinator will be a LambdaLink,
  * typically with N declared variables in it. To go with it, the PutLink
- * expects a list of N values to be plugged in for these variables.
+ * expects a list of N arguments to be plugged in for these variables.
  * Thus, for example:
  * (Put (Lambda (Variable "x") ...stuff...) (Concept "foo"))
  * when reduced, will plug "foo" into ...stuff...
@@ -51,7 +51,7 @@ namespace opencog
  * (Put (Plus (Number 6) (Number 8)) (List (Number 5) (Number 9)))
  *
  * The natural form for a beta redex is in the unreduced
- * form: the values are not (yet) substituted for the variables; they
+ * form: the arguments are not (yet) substituted for the variables; they
  * are simply sitting there, ready and waiting for that reduction to
  * happen.
  *
@@ -67,17 +67,17 @@ namespace opencog
  * them, and then wrap the answers back up with a SetLink.
  *
  * Another "enhancement" is that when there are N>1 variables, the
- * values must be wrapped in a ListLink, to be consistent with other
+ * arguments must be wrapped in a ListLink, to be consistent with other
  * parts of atomese. However, for N=1, the ListLink is optional.
  */
 class PutLink : public PrenexLink
 {
 protected:
-	/// The values that are to be placed into the body.
-	Handle _values;
+	/// The arguments that are to be placed into the body.
+	Handle _arguments;
 
 	void init(void);
-	void static_typecheck_values(void);
+	void static_typecheck_arguments(void);
 
 	Handle do_reduce(void) const;
 
@@ -86,8 +86,8 @@ public:
 	PutLink(const Link& l);
 	virtual ~PutLink() {}
 
-	// PutLink values may be e second or the third outset elt.
-	Handle get_values() { return _values; }
+	// PutLink arguments may be the second or the third outgoing-set elt.
+	Handle get_arguments() { return _arguments; }
 	virtual Handle reduce(void);
 
 	static Handle factory(const Handle&);

--- a/opencog/atoms/core/RewriteLink.h
+++ b/opencog/atoms/core/RewriteLink.h
@@ -54,7 +54,7 @@ protected:
 	/**
 	 * Perform "substitution" on a variable declaration.  This
 	 * returns a new variable declaration, where one of two things
-	 * were done.  If the map held a constant value for a variable,
+	 * were done.  If the map held a constant argument for a variable,
 	 * then that variable is removed.  If the map held a different
 	 * variable, then the alpha-conversion is performed. This might
 	 * return the invalid handle, if all variables were reduced by
@@ -72,7 +72,7 @@ protected:
 	 *
 	 * The substitution performs either a beta-reduction, or an
 	 * alpha-conversion, depending on the map. If the map specifies
-	 * variable->value, then a normal beta reduction is done. If
+	 * variable->argument, then a normal beta reduction is done. If
 	 * the maps specifies variable->variable, then an alpha renaming
 	 * is done.
 	 *
@@ -83,8 +83,8 @@ protected:
 	                            const HandleMap& vm) const;
 
 	/**
-	 * Like above but uses a mapping from variables to values instead
-	 * of a sequence of values.
+	 * Like above but uses a mapping from variables to arguments instead
+	 * of a sequence of arguments.
 	 */
 	Handle substitute_body(const Handle& nvardecl,
 	                       const Handle& body,
@@ -135,7 +135,7 @@ public:
 	 * Perform a beta-reduction and optional alpha-conversion,
 	 * returning the reduced RewriteLink.
 	 *
-	 * If the map specifies a variable->value, then a standard
+	 * If the map specifies a variable->argument, then a standard
 	 * beta-reduction is performed, and the variable is removed
 	 * from the returned RewriteLink.
 	 *
@@ -155,16 +155,16 @@ public:
 	virtual Handle beta_reduce(const HandleMap& vm) const;
 
 	/**
-	 * Like the above, but uses a sequence of values, presumed to be
+	 * Like the above, but uses a sequence of arguments, presumed to be
 	 * in the same order as the variable declarations. The number of
-	 * values must match the number of variables, or there must be
-	 * a single value that is eta-convertible and gives the right
-	 * number of values.
+	 * arguments must match the number of variables, or there must be
+	 * a single argument that is eta-convertible and gives the right
+	 * number of arguments.
 	 */
-	virtual Handle beta_reduce(const HandleSeq& values) const;
+	virtual Handle beta_reduce(const HandleSeq& arguments) const;
 
 	/**
-	 * Like the above, but accepting a sequence of values.
+	 * Like the above, but accepting a sequence of arguments.
 	 */
 	HandleSeq beta_reduce_bodies(const Handle& nvardecl,
 	                             const HandleMap& vm) const;

--- a/opencog/atoms/core/TypeNode.h
+++ b/opencog/atoms/core/TypeNode.h
@@ -39,20 +39,20 @@ namespace opencog
 class TypeNode : public Node
 {
 protected:
-	Type value;
+	Type _kind;
 
 public:
 	// Please do NOT use this constructor!
 	TypeNode(Type t, const std::string& s)
 		// Convert to number and back to string to avoid miscompares.
 		: Node(t, s),
-		  value(nameserver().getType(s))
+		  _kind(nameserver().getType(s))
 	{
 		// Perform strict checking only for TypeNode.  The
 		// DefinedTypeNode, which inherits from this class,
 		// allows user-defined types which the classerver
 		// currently does not know about.
-		if (TYPE_NODE == t and NOTYPE == value)
+		if (TYPE_NODE == t and NOTYPE == _kind)
 			throw InvalidParamException(TRACE_INFO,
 				"Not a valid typename: '%s'", s.c_str());
 	}
@@ -61,30 +61,30 @@ public:
 	TypeNode(const std::string& s)
 		// Convert to number and back to string to avoid miscompares.
 		: Node(TYPE_NODE, s),
-		  value(nameserver().getType(s))
+		  _kind(nameserver().getType(s))
 	{
-		if (NOTYPE == value)
+		if (NOTYPE == _kind)
 			throw InvalidParamException(TRACE_INFO,
 				"Not a valid typename: '%s'", s.c_str());
 	}
 
 	TypeNode(Type t)
 		: Node(TYPE_NODE, nameserver().getTypeName(t)),
-		  value(t)
+		  _kind(t)
 	{}
 
 	TypeNode(Node &n)
 		: Node(n),
-		  value(nameserver().getType(n.get_name()))
+		  _kind(nameserver().getType(n.get_name()))
 	{
 		OC_ASSERT(nameserver().isA(n.get_type(), TYPE_NODE),
 			"Bad TypeNode constructor!");
 
-		if (DEFINED_TYPE_NODE != _type and NOTYPE == value)
+		if (DEFINED_TYPE_NODE != _type and NOTYPE == _kind)
 			throw InvalidParamException(TRACE_INFO,
 				"Not a valid typename: '%s'", n.get_name().c_str());
 
-		if (DEFINED_TYPE_NODE == _type and NOTYPE != value)
+		if (DEFINED_TYPE_NODE == _type and NOTYPE != _kind)
 			throw InvalidParamException(TRACE_INFO,
 				"Redefinition of a built-in typename: '%s'", n.get_name().c_str());
 	}
@@ -101,7 +101,7 @@ public:
 				"Not a valid typename: '%s'", str.c_str());
 	}
 
-	Type get_value(void) { return value; }
+	Type get_kind(void) { return _kind; }
 
 	static Handle factory(const Handle&);
 };

--- a/opencog/atoms/core/VariableList.cc
+++ b/opencog/atoms/core/VariableList.cc
@@ -225,7 +225,7 @@ void VariableList::get_vartype(const Handle& htypelink)
 	// The vartype is either a single type name, or a list of typenames.
 	if (TYPE_NODE == t)
 	{
-		Type vt = TypeNodeCast(vartype)->get_value();
+		Type vt = TypeNodeCast(vartype)->get_kind();
 		if (vt != ATOM)  // Atom type is same as untyped.
 		{
 			TypeSet ts = {vt};
@@ -234,7 +234,7 @@ void VariableList::get_vartype(const Handle& htypelink)
 	}
 	else if (TYPE_INH_NODE == t)
 	{
-		Type vt = TypeNodeCast(vartype)->get_value();
+		Type vt = TypeNodeCast(vartype)->get_kind();
 		TypeSet ts;
 		TypeSet::iterator it = ts.begin();
 		nameserver().getChildren(vt, std::inserter(ts, it));
@@ -242,7 +242,7 @@ void VariableList::get_vartype(const Handle& htypelink)
 	}
 	else if (TYPE_CO_INH_NODE == t)
 	{
-		Type vt = TypeNodeCast(vartype)->get_value();
+		Type vt = TypeNodeCast(vartype)->get_kind();
 		TypeSet ts;
 		TypeSet::iterator it = ts.begin();
 		nameserver().getChildren(vt, std::inserter(ts, it));
@@ -262,7 +262,7 @@ void VariableList::get_vartype(const Handle& htypelink)
 			Type var_type = ht->get_type();
 			if (TYPE_NODE == var_type)
 			{
-				Type vt = TypeNodeCast(ht)->get_value();
+				Type vt = TypeNodeCast(ht)->get_kind();
 				if (ATOM != vt) typeset.insert(vt);
 			}
 			else if (SIGNATURE_LINK == var_type)

--- a/opencog/atoms/core/VariableList.h
+++ b/opencog/atoms/core/VariableList.h
@@ -84,11 +84,11 @@ public:
 	bool is_type(const HandleSeq& hseq) const { return _varlist.is_type(hseq); }
 
 	// Given the tree `tree` containing variables in it, create and
-	// return a new tree with the indicated values `vals` substituted
-	// for the variables. The vals must pass the typecheck, else an
+	// return a new tree with the indicated arguments `args` substituted
+	// for the variables. The `args` must pass the typecheck, else an
 	// exception is thrown.
-	Handle substitute(const Handle& tree, const HandleSeq& vals) const
-		{ return _varlist.substitute(tree, vals); }
+	Handle substitute(const Handle& tree, const HandleSeq& args) const
+		{ return _varlist.substitute(tree, args); }
 
 	static Handle factory(const Handle&);
 };

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -144,13 +144,13 @@ void FreeVariables::find_variables(const Handle& h)
 
 HandleSeq FreeVariables::make_sequence(const HandleMap& varmap) const
 {
-	HandleSeq values;
+	HandleSeq arguments;
 	for (const Handle& var : varseq)
 	{
 		HandleMap::const_iterator it = varmap.find(var);
-		values.push_back(it == varmap.end() ? var : it->second);
+		arguments.push_back(it == varmap.end() ? var : it->second);
 	}
-	return values;
+	return arguments;
 }
 
 void FreeVariables::erase(const Handle& var)
@@ -161,7 +161,7 @@ void FreeVariables::erase(const Handle& var)
 	// Remove from index
 	index.erase(var);
 
-	// Remove from varseq and update all values in the subsequent
+	// Remove from varseq and update all arguments in the subsequent
 	// index as they have changed.
 	auto it = std::find(varseq.begin(), varseq.end(), var);
 	if (it != varseq.end()) {
@@ -233,7 +233,7 @@ Handle FreeVariables::substitute_scoped(const Handle& term,
 	bool unquoted = quotation.is_unquoted();
 
 	// If we are not in a quote context, and `term` is a variable,
-	// then just return the corresponding value.
+	// then just return the corresponding argument.
 	if (unquoted)
 	{
 		IndexMap::const_iterator idx = index_map.find(term);
@@ -309,8 +309,8 @@ Handle FreeVariables::substitute_scoped(const Handle& term,
 	HandleSeq oset;
 	for (const Handle& h : term->getOutgoingSet())
 	{
-		// GlobNodes are matched with a list of one or more values.
-		// Those values need to be in-lined, stripping off the list
+		// GlobNodes are matched with a list of one or more arguments.
+		// Those arguments need to be in-lined, stripping off the list
 		// that wraps them up.  See MapLinkUTest for examples.
 		if (GLOB_NODE == h->get_type())
 		{
@@ -468,7 +468,7 @@ bool Variables::is_type(const Handle& var, const Handle& val) const
 		Type htype = val->get_type();
 		TypeSet::const_iterator allow = tchoice.find(htype);
 
-		// If the value has the simple type, then we are good to go;
+		// If the argument has the simple type, then we are good to go;
 		// we are done.  Else, fall through, and see if one of the
 		// others accept the match.
 		if (allow != tchoice.end()) return true;
@@ -576,7 +576,7 @@ bool Variables::is_upper_bound(const Handle& glob, size_t n) const
 
 /* ================================================================= */
 /**
- * Substitute the given values for the variables occuring in a tree.
+ * Substitute the given arguments for the variables occuring in a tree.
  * That is, perform beta-reduction.  This is a lot like applying the
  * function `func` to the argument list `args`, except that no actual
  * evaluation is performed; only substitution.
@@ -605,7 +605,7 @@ bool Variables::is_upper_bound(const Handle& glob, size_t n) const
  *      ConceptNode "one"
  *      NumberNode 2.0000
  *
- * then the returned value will be
+ * then the returned result will be
  *
  *   EvaluationLink
  *      PredicateNode "something"
@@ -613,7 +613,7 @@ bool Variables::is_upper_bound(const Handle& glob, size_t n) const
  *          NumberNode 2.0000    ; note reversed order here, also
  *          ConceptNode "one"
  *
- * That is, the values `one` and `2.0` were substituted for `$a` and `$b`.
+ * That is, the arguments `one` and `2.0` were substituted for `$a` and `$b`.
  *
  * The `func` can be, for example, a single variable name(!) In this
  * case, the corresponding `arg` is returned. So, for example, if the
@@ -645,10 +645,10 @@ Handle Variables::substitute(const Handle& func,
 
 	// XXX TODO type-checking could be lazy; if the function is not
 	// actually using one of the args, it's type should not be checked.
-	// Viz., one of the values might be undefined, and that's OK, if that
-	// value is never actually used.  Fixing this requires a cut-n-paste
-	// of the substitute_nocheck code. I'm too lazy to do this ... no one
-	// wants this whizzy-ness just right yet.
+	// Viz., one of the arguments might be undefined, and that's OK,
+	// if that argument is never actually used.  Fixing this requires a
+	// cut-n-paste of the substitute_nocheck code. I'm too lazy to do
+	// this ... no one wants this whizzy-ness just right yet.
 	if (not is_type(args))
 	{
 		if (silent) throw TypeCheckException();

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -483,7 +483,7 @@ bool Variables::is_type(const Handle& var, const Handle& val) const
 		const HandleSet &sigset = dit->second;
 		for (const Handle& sig : sigset)
 		{
-			if (value_is_type(sig, val)) return true;
+			if (arg_is_type(sig, val)) return true;
 		}
 		ret = false;
 	}

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -483,7 +483,7 @@ bool Variables::is_type(const Handle& var, const Handle& val) const
 		const HandleSet &sigset = dit->second;
 		for (const Handle& sig : sigset)
 		{
-			if (arg_is_type(sig, val)) return true;
+			if (value_is_type(sig, val)) return true;
 		}
 		ret = false;
 	}

--- a/opencog/atoms/core/Variables.h
+++ b/opencog/atoms/core/Variables.h
@@ -43,7 +43,7 @@ namespace opencog
 /// goal of this structure is to make it easier and faster to work with
 /// VariableNodes in C++; specifically, to find thier locations within
 /// a hypergraph, and to perform beta-substitution (to substitute a
-/// value for the variable).  This class implements the data that is
+/// argument for the variable).  This class implements the data that is
 /// used by FreeLink to work with free variables.
 ///
 struct FreeVariables
@@ -107,10 +107,10 @@ struct FreeVariables
 	void find_variables(const Handle&);
 	void find_variables(const HandleSeq&);
 
-	/// Convert a variable->value mapping into a sequence of "values"
-	/// that are in the same order as the free variables in this
-	/// class.  If the mapping does not mention a variable, then
-	/// that variable itself is used as the value.  This sequence
+	/// Convert a variable->argument mapping into a sequence of
+	/// "arguments" that are in the same order as the free variables
+	/// in this class.  If the mapping does not mention a variable,
+	/// then that variable itself is used as the argument.  This sequence
 	/// can be used with the substitute_nocheck() function below.
 	HandleSeq make_sequence(const HandleMap&) const;
 
@@ -118,7 +118,7 @@ struct FreeVariables
 	void erase(const Handle&);
 
 	// Given the tree `tree` containing variables in it, create and
-	// return a new tree with the indicated values `vals` substituted
+	// return a new tree with the indicated arguments `args` substituted
 	// for the variables.  "nocheck" == no type checking is done.
 	// This performs an almost pure, syntactic beta-reduction; its
 	// almost-pure because it does honour the semantics of QuoteLink.
@@ -126,7 +126,7 @@ struct FreeVariables
 	                          const HandleSeq&,
 	                          bool silent=false) const;
 
-	// Like the above, but takes a mapping from variables to values.
+	// Like the above, but takes a mapping from variables to arguments.
 	Handle substitute_nocheck(const Handle&,
 	                          const HandleMap&,
 	                          bool silent=false) const;
@@ -236,13 +236,13 @@ struct Variables : public FreeVariables,
 	bool is_upper_bound(const Handle& glob, size_t n) const;
 
 	// Given the tree `tree` containing variables in it, create and
-	// return a new tree with the indicated values `vals` substituted
-	// for the variables. The vals must pass the typecheck, else an
+	// return a new tree with the indicated arguments `args` substituted
+	// for the variables. The `args` must pass the typecheck, else an
 	// exception is thrown. If "silent" is true, then the exception
 	// will not be logged; this allows this method to be used for
 	// filtering, where type mis-checks are expected and normal.
 	Handle substitute(const Handle& tree,
-	                  const HandleSeq& vals,
+	                  const HandleSeq& args,
 	                  bool silent=false) const;
 
 	// Like the above, but using a partial map.

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -726,16 +726,12 @@ TruthValuePtr EvaluationLink::do_eval_with_args(AtomSpace* as,
 		throw NotEvaluatableException();
 	}
 
-	// The arguments may need to be executed...
-	Instantiator inst(as);
-	Handle dargs(HandleCast(inst.execute(cargs, silent)));
-
 	// Force execution of the arguments. We have to do this, because
 	// the user-defined functions are black-boxes, and cannot be trusted
 	// to do lazy execution correctly. Right now, forcing is the policy.
 	// We could add "scm-lazy:" and "py-lazy:" URI's for user-defined
 	// functions smart enough to do lazy evaluation.
-	Handle args = force_execute(as, dargs, silent);
+	Handle args = force_execute(as, cargs, silent);
 
 	// Get the schema name.
 	const std::string& schema = pn->get_name();

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -557,10 +557,10 @@ TruthValuePtr EvaluationLink::do_eval_scratch(AtomSpace* as,
 		PutLinkPtr pl(PutLinkCast(evelnk));
 
 		// Evalating a PutLink requires three steps:
-		// (1) execute the values, first,
-		// (2) beta reduce (put values into body)
+		// (1) execute the arguments, first,
+		// (2) beta reduce (put arguments into body)
 		// (3) evaluate the resulting body.
-		Handle pvals = pl->get_values();
+		Handle pvals = pl->get_arguments();
 		Instantiator inst(as);
 		// Step (1)
 		Handle gvals(HandleCast(inst.execute(pvals, silent)));

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -652,28 +652,11 @@ TruthValuePtr EvaluationLink::do_evaluate(AtomSpace* as,
 	return do_eval_scratch(as, evelnk, as, silent);
 }
 
-/// do_evaluate -- evaluate the GroundedPredicateNode of the EvaluationLink
-///
-/// Expects the sequence to be exactly two atoms long.
-/// Expects the first handle of the sequence to be a GroundedPredicateNode
-/// Expects the second handle of the sequence to be a ListLink
-/// Executes the GroundedPredicateNode, supplying the second handle as argument
-///
-TruthValuePtr EvaluationLink::do_evaluate(AtomSpace* as,
-                                          const HandleSeq& sna,
-                                          bool silent)
-{
-	if (2 != sna.size())
-	{
-		throw SyntaxException(TRACE_INFO,
-		     "Incorrect arity for an EvaluationLink!");
-	}
-	return do_eval_with_args(as, sna[0], sna[1], silent);
-}
-
-// Fixme: added here, because lang_lib_fun is declared inside ExecutionOutputLink class
-// It would be better to move lang_lib_fun to LibraryManager, but BackwardChainer also
-// uses this function, so more refactoring would be needed
+// XXX FIXME: added here, because lang_lib_fun is declared inside
+// ExecutionOutputLink class. It would be better to move
+// lang_lib_fun to LibraryManager, but BackwardChainer also
+// uses this function, so more refactoring would be needed.
+// XXX Really? Can we do this, already?
 #include "ExecutionOutputLink.h"
 
 /// do_eval_with_args -- evaluate a PredicateNode with arguments.

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -384,7 +384,8 @@ TruthValuePtr EvaluationLink::do_eval_scratch(AtomSpace* as,
 		if (sna.at(0)->get_type() == PREDICATE_NODE)
 			return evelnk->getTruthValue();
 
-		TruthValuePtr tvp(do_evaluate(scratch, sna.at(0), sna.at(1), silent));
+		TruthValuePtr tvp(do_eval_with_args(scratch,
+		                                sna.at(0), sna.at(1), silent));
 		evelnk->setTruthValue(tvp);
 		return tvp;
 	}
@@ -667,7 +668,7 @@ TruthValuePtr EvaluationLink::do_evaluate(AtomSpace* as,
 		throw SyntaxException(TRACE_INFO,
 		     "Incorrect arity for an EvaluationLink!");
 	}
-	return do_evaluate(as, sna[0], sna[1], silent);
+	return do_eval_with_args(as, sna[0], sna[1], silent);
 }
 
 // Fixme: added here, because lang_lib_fun is declared inside ExecutionOutputLink class
@@ -675,7 +676,7 @@ TruthValuePtr EvaluationLink::do_evaluate(AtomSpace* as,
 // uses this function, so more refactoring would be needed
 #include "ExecutionOutputLink.h"
 
-/// do_evaluate -- evaluate a PredicateNode with arguments.
+/// do_eval_with_args -- evaluate a PredicateNode with arguments.
 ///
 /// Expects "pn" to be any actively-evaluatable predicate type.
 ///     Currently, this includes the GroundedPredicateNode, the
@@ -692,7 +693,7 @@ TruthValuePtr EvaluationLink::do_evaluate(AtomSpace* as,
 /// The arguments are then inserted into the predicate, and the
 /// predicate as a whole is then evaluated.
 ///
-TruthValuePtr EvaluationLink::do_evaluate(AtomSpace* as,
+TruthValuePtr EvaluationLink::do_eval_with_args(AtomSpace* as,
                                           const Handle& pn,
                                           const Handle& cargs,
                                           bool silent)

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -338,12 +338,12 @@ static void thread_eval_tv(AtomSpace* as,
 ///
 /// For example, evaluating a TrueLink returns TruthValue::TRUE_TV, and
 /// evaluating a FalseLink returns TruthValue::FALSE_TV.  Evaluating
-/// AndLink, OrLink returns the boolean and, or of their respective
+/// AndLink, OrLink returns the binary and/or of their respective
 /// arguments.  A wide variety of Link types are evaluatable, this
 /// handles them all.
 ///
-/// If the argument to be an EvaluationLink, it should have the
-/// following structure:
+/// If the argument is an EvaluationLink with a GPN in it, it should
+/// have the following structure:
 ///
 ///     EvaluationLink
 ///         GroundedPredicateNode "lang: func_name"
@@ -351,9 +351,9 @@ static void thread_eval_tv(AtomSpace* as,
 ///             SomeAtom
 ///             OtherAtom
 ///
-/// The "lang:" should be either "scm:" for scheme, or "py:" for python.
-/// This method will then invoke "func_name" on the provided ListLink
-/// of arguments to the function.
+/// The `lang:` should be either `scm:` for scheme, `py:` for python,
+/// or `lib:` for haskell.  This method will then invoke `func_name`
+/// on the provided ListLink of arguments.
 ///
 /// This function takes TWO atomspace arguments!  The first is the
 /// "main" atomspace, the second is a "scratch" or "temporary"
@@ -384,6 +384,7 @@ TruthValuePtr EvaluationLink::do_eval_scratch(AtomSpace* as,
 		if (sna.at(0)->get_type() == PREDICATE_NODE)
 			return evelnk->getTruthValue();
 
+		// Extract the args, and run the evaluation with them.
 		TruthValuePtr tvp(do_eval_with_args(scratch,
 		                                sna.at(0), sna.at(1), silent));
 		evelnk->setTruthValue(tvp);
@@ -705,8 +706,8 @@ TruthValuePtr EvaluationLink::do_eval_with_args(AtomSpace* as,
 				"Expecting definition to be a LambdaLink, got %s",
 				defn->to_string().c_str());
 
-		// Treat it as if it were a PutLink -- perform the
-		// beta-reduction, and evaluate the result.
+		// Treat LambdaLink as if it were a PutLink -- perform
+		// the beta-reduction, and evaluate the result.
 		LambdaLinkPtr lam(LambdaLinkCast(defn));
 		Handle reduct = lam->beta_reduce(get_seq(cargs));
 		return do_evaluate(as, reduct, silent);

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -384,11 +384,7 @@ TruthValuePtr EvaluationLink::do_eval_scratch(AtomSpace* as,
 		if (sna.at(0)->get_type() == PREDICATE_NODE)
 			return evelnk->getTruthValue();
 
-		// The arguments may need to be executed...
-		Instantiator inst(scratch);
-		Handle args(HandleCast(inst.execute(sna.at(1), silent)));
-
-		TruthValuePtr tvp(do_evaluate(scratch, sna.at(0), args, silent));
+		TruthValuePtr tvp(do_evaluate(scratch, sna.at(0), sna.at(1), silent));
 		evelnk->setTruthValue(tvp);
 		return tvp;
 	}
@@ -734,12 +730,16 @@ TruthValuePtr EvaluationLink::do_evaluate(AtomSpace* as,
 		throw NotEvaluatableException();
 	}
 
+	// The arguments may need to be executed...
+	Instantiator inst(as);
+	Handle dargs(HandleCast(inst.execute(cargs, silent)));
+
 	// Force execution of the arguments. We have to do this, because
 	// the user-defined functions are black-boxes, and cannot be trusted
 	// to do lazy execution correctly. Right now, forcing is the policy.
 	// We could add "scm-lazy:" and "py-lazy:" URI's for user-defined
 	// functions smart enough to do lazy evaluation.
-	Handle args = force_execute(as, cargs, silent);
+	Handle args = force_execute(as, dargs, silent);
 
 	// Get the schema name.
 	const std::string& schema = pn->get_name();

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -731,7 +731,7 @@ TruthValuePtr EvaluationLink::do_eval_with_args(AtomSpace* as,
 	// to do lazy execution correctly. Right now, forcing is the policy.
 	// We could add "scm-lazy:" and "py-lazy:" URI's for user-defined
 	// functions smart enough to do lazy evaluation.
-	Handle args = force_execute(as, cargs, silent);
+	Handle args(force_execute(as, cargs, silent));
 
 	// Get the schema name.
 	const std::string& schema = pn->get_name();

--- a/opencog/atoms/execution/EvaluationLink.h
+++ b/opencog/atoms/execution/EvaluationLink.h
@@ -50,12 +50,10 @@ public:
 	                                     const Handle&,
 	                                     AtomSpace* scratch,
 	                                     bool silent=false);
-	static TruthValuePtr do_evaluate(AtomSpace*,
-	                                 const HandleSeq& schema_and_args,
-	                                 bool silent=false);
 	static TruthValuePtr do_eval_with_args(AtomSpace*,
-	                                 const Handle& schema, const Handle& args,
-	                                 bool silent=false);
+	                                       const Handle& schema,
+	                                       const Handle& args,
+	                                       bool silent=false);
 
 	static Handle factory(const Handle&);
 };

--- a/opencog/atoms/execution/EvaluationLink.h
+++ b/opencog/atoms/execution/EvaluationLink.h
@@ -53,7 +53,7 @@ public:
 	static TruthValuePtr do_evaluate(AtomSpace*,
 	                                 const HandleSeq& schema_and_args,
 	                                 bool silent=false);
-	static TruthValuePtr do_evaluate(AtomSpace*,
+	static TruthValuePtr do_eval_with_args(AtomSpace*,
 	                                 const Handle& schema, const Handle& args,
 	                                 bool silent=false);
 

--- a/opencog/atoms/execution/Force.cc
+++ b/opencog/atoms/execution/Force.cc
@@ -43,8 +43,8 @@ using namespace opencog;
 /// recursive.
 ///
 /// When executing, if the results are different, the new results
-/// are added to the atomspace. We need to do this, because scheme,
-/// and python expects to find their arguments in the atomspace.
+/// are added to the atomspace. We need to do this, because scheme
+/// and python expect to find their arguments in the atomspace.
 /// Users who do not want to pollute the atomspace should use a
 /// temporary (scratch) atomspace.
 ///

--- a/opencog/atoms/execution/Instantiator.cc
+++ b/opencog/atoms/execution/Instantiator.cc
@@ -210,10 +210,10 @@ Handle Instantiator::walk_tree(const Handle& expr, bool silent)
 		if (_eager)
 		{
 			ppp = PutLinkCast(expr);
-			// Execute the values in the PutLink before doing the
-			// beta-reduction. Execute the PutLink only after the
-			// beta-reduction has been done.
-			Handle pvals = ppp->get_values();
+			// Execute the arguments in the PutLink before doing
+			// the beta-reduction. Execute the PutLink only after
+			// the beta-reduction has been done.
+			Handle pvals = ppp->get_arguments();
 			Handle gargs = walk_tree(pvals, silent);
 			if (gargs != pvals)
 			{
@@ -250,9 +250,6 @@ Handle Instantiator::walk_tree(const Handle& expr, bool silent)
 		// Step three: XXX this is awkward, but seems to be needed...
 		// If the result is evaluatable, then evaluate it. e.g. if the
 		// result has a GroundedPredicateNode, we need to run it now.
-		// We do, however, ignore the resulting TV, which is also
-		// awkward.  I'm confused about how to handle this best.
-		// The behavior tree uses this!
 		// Anyway, do_evaluate() will throw if rex is not evaluatable.
 		//
 		// The DontExecLink is a weird hack to halt evaluation.

--- a/opencog/atoms/execution/Instantiator.cc
+++ b/opencog/atoms/execution/Instantiator.cc
@@ -213,9 +213,9 @@ Handle Instantiator::walk_tree(const Handle& expr, bool silent)
 			// Execute the arguments in the PutLink before doing
 			// the beta-reduction. Execute the PutLink only after
 			// the beta-reduction has been done.
-			Handle pvals = ppp->get_arguments();
-			Handle gargs = walk_tree(pvals, silent);
-			if (gargs != pvals)
+			Handle pargs = ppp->get_arguments();
+			Handle gargs = walk_tree(pargs, silent);
+			if (gargs != pargs)
 			{
 				HandleSeq groset;
 				if (ppp->get_vardecl())

--- a/opencog/atomutils/TypeUtils.cc
+++ b/opencog/atomutils/TypeUtils.cc
@@ -38,7 +38,7 @@ namespace opencog {
 /**
  * Type checker.  Returns true if `val` is of type `deep`.
  */
-bool arg_is_type(const Handle& spec, const Handle& val)
+bool value_is_type(const Handle& spec, const ValuePtr& val)
 {
 	Handle deep(spec);
 
@@ -81,7 +81,7 @@ bool arg_is_type(const Handle& spec, const Handle& val)
 	{
 		for (const Handle& choice : deep->getOutgoingSet())
 		{
-			if (arg_is_type(choice, val)) return true;
+			if (value_is_type(choice, val)) return true;
 		}
 		return false;
 	}
@@ -91,15 +91,15 @@ bool arg_is_type(const Handle& spec, const Handle& val)
 			"Not implemented! TODO XXX FIXME");
 	}
 
-	// If it is a node, not a link, then it is a type-constant,
+	// If it is not a link, then it is a type-constant,
 	// and thus must match perfectly.
-	if (deep->is_node())
+	if (not deep->is_link())
 		return (deep == val);
 
-	// If a link, then both must be same link type.
+	// If it is a link, then both must be same link type.
 	if (valtype != dpt) return false;
 
-	const HandleSeq& vlo = val->getOutgoingSet();
+	const HandleSeq& vlo = HandleCast(val)->getOutgoingSet();
 	const HandleSeq& dpo = deep->getOutgoingSet();
 	size_t sz = dpo.size();
 
@@ -114,7 +114,7 @@ bool arg_is_type(const Handle& spec, const Handle& val)
 	// Ordered links are compared side-by-side
 	for (size_t i=0; i<sz; i++)
 	{
-		if (not arg_is_type(dpo[i], vlo[i])) return false;
+		if (not value_is_type(dpo[i], vlo[i])) return false;
 	}
 
 	// If we are here, all checks must hav passed.
@@ -129,7 +129,8 @@ bool arg_is_type(const Handle& spec, const Handle& val)
  * a whizzy set-subset operation, one could go all formal operator
  * and etc. but more abstraction seems unlikely to make it better.
  */
-static bool type_match_rec(const Handle& left_, const Handle& right_, bool toplevel)
+static bool type_match_rec(const Handle& left_, const Handle& right_,
+                           bool toplevel)
 {
 	if (left_ == right_) return true;
 
@@ -164,7 +165,7 @@ static bool type_match_rec(const Handle& left_, const Handle& right_, bool tople
 	    DEFINED_TYPE_NODE != rtype and
 	    ARROW_LINK != rtype)
 	{
-		return arg_is_type(left, right_);
+		return value_is_type(left, right_);
 	}
 
 	Handle right(right_);

--- a/opencog/atomutils/TypeUtils.cc
+++ b/opencog/atomutils/TypeUtils.cc
@@ -277,9 +277,11 @@ bool type_match(const Handle& left_, const ValuePtr& right_)
 	return type_match_rec(left_, right_, true);
 }
 
-Handle type_compose(const Handle& left, const Handle& right)
+ValuePtr type_compose(const Handle& left, const ValuePtr& right)
 {
-	return Handle::UNDEFINED;
+	// Interesting. XXX FIXME. This is not yet implemented!
+	throw RuntimeException(TRACE_INFO, "Not implemented!");
+	return nullptr;
 }
 
 Handle filter_vardecl(const Handle& vardecl, const Handle& body)

--- a/opencog/atomutils/TypeUtils.cc
+++ b/opencog/atomutils/TypeUtils.cc
@@ -129,7 +129,8 @@ bool value_is_type(const Handle& spec, const ValuePtr& val)
  * a whizzy set-subset operation, one could go all formal operator
  * and etc. but more abstraction seems unlikely to make it better.
  */
-static bool type_match_rec(const Handle& left_, const Handle& right_,
+static bool type_match_rec(const Handle& left_,
+                           const ValuePtr& right_,
                            bool toplevel)
 {
 	if (left_ == right_) return true;
@@ -168,7 +169,10 @@ static bool type_match_rec(const Handle& left_, const Handle& right_,
 		return value_is_type(left, right_);
 	}
 
-	Handle right(right_);
+	// Everything below here deals with atoms.
+	if (not right_->is_atom()) return false;
+
+	Handle right(HandleCast(right_));
 
 	// If it's a user-defined type, replace by it's defintion.
 	if (DEFINED_TYPE_NODE == rtype)
@@ -228,7 +232,7 @@ static bool type_match_rec(const Handle& left_, const Handle& right_,
 		{
 			// Can everything in the right be found in the left?
 			// If so, then we are OK.
-			for (const Handle& rh : right->getOutgoingSet())
+			for (const Handle& rh : HandleCast(right)->getOutgoingSet())
 			{
 				if (not type_match_rec(left, rh, false)) return false;
 			}
@@ -268,7 +272,7 @@ static bool type_match_rec(const Handle& left_, const Handle& right_,
 	return true;
 }
 
-bool type_match(const Handle& left_, const Handle& right_)
+bool type_match(const Handle& left_, const ValuePtr& right_)
 {
 	return type_match_rec(left_, right_, true);
 }

--- a/opencog/atomutils/TypeUtils.cc
+++ b/opencog/atomutils/TypeUtils.cc
@@ -38,7 +38,7 @@ namespace opencog {
 /**
  * Type checker.  Returns true if `val` is of type `deep`.
  */
-bool value_is_type(const Handle& spec, const Handle& val)
+bool arg_is_type(const Handle& spec, const Handle& val)
 {
 	Handle deep(spec);
 
@@ -61,27 +61,27 @@ bool value_is_type(const Handle& spec, const Handle& val)
 
 	if (TYPE_NODE == dpt)
 	{
-		Type deeptype = TypeNodeCast(deep)->get_value();
+		Type deeptype = TypeNodeCast(deep)->get_kind();
 		return (valtype == deeptype);
 	}
 	else if (TYPE_INH_NODE == dpt)
 	{
 		// Just like above, but allows derived types.
-		Type deeptype = TypeNodeCast(deep)->get_value();
+		Type deeptype = TypeNodeCast(deep)->get_kind();
 		return nameserver().isA(valtype, deeptype);
 	}
 	else if (TYPE_CO_INH_NODE == dpt)
 	{
 		// Just like above, but in the other direction.
 		// That is, it allows base tyes.
-		Type deeptype = TypeNodeCast(deep)->get_value();
+		Type deeptype = TypeNodeCast(deep)->get_kind();
 		return nameserver().isA(deeptype, valtype);
 	}
 	else if (TYPE_CHOICE == dpt)
 	{
 		for (const Handle& choice : deep->getOutgoingSet())
 		{
-			if (value_is_type(choice, val)) return true;
+			if (arg_is_type(choice, val)) return true;
 		}
 		return false;
 	}
@@ -114,7 +114,7 @@ bool value_is_type(const Handle& spec, const Handle& val)
 	// Ordered links are compared side-by-side
 	for (size_t i=0; i<sz; i++)
 	{
-		if (not value_is_type(dpo[i], vlo[i])) return false;
+		if (not arg_is_type(dpo[i], vlo[i])) return false;
 	}
 
 	// If we are here, all checks must hav passed.
@@ -150,9 +150,9 @@ static bool type_match_rec(const Handle& left_, const Handle& right_, bool tople
 		ltype = left->get_type();
 	}
 
-	// If right is not a type, then just use value-check.
+	// If right is not a type, then just use argument-check.
 	// We can only do this at the top level; lower levels
-	// can have value-like links (i.e. duck-types which
+	// can have argument-like links (i.e. duck-types which
 	// we have to type-interence).
 	Type rtype = right_->get_type();
 	if (toplevel and
@@ -164,7 +164,7 @@ static bool type_match_rec(const Handle& left_, const Handle& right_, bool tople
 	    DEFINED_TYPE_NODE != rtype and
 	    ARROW_LINK != rtype)
 	{
-		return value_is_type(left, right_);
+		return arg_is_type(left, right_);
 	}
 
 	Handle right(right_);
@@ -205,19 +205,19 @@ static bool type_match_rec(const Handle& left_, const Handle& right_, bool tople
 	// the top-level; here we do lower levels.
 	if (TYPE_NODE == ltype)
 	{
-		return TypeNodeCast(left)->get_value() == rtype;
+		return TypeNodeCast(left)->get_kind() == rtype;
 	}
 
 	// Like above but allows derived tyes.
 	if (TYPE_INH_NODE == ltype)
 	{
-		return nameserver().isA(rtype, TypeNodeCast(left)->get_value());
+		return nameserver().isA(rtype, TypeNodeCast(left)->get_kind());
 	}
 
 	// Like above, but in the opposite direction: allows base types.
 	if (TYPE_CO_INH_NODE == ltype)
 	{
-		return nameserver().isA(TypeNodeCast(left)->get_value(), rtype);
+		return nameserver().isA(TypeNodeCast(left)->get_kind(), rtype);
 	}
 
 	// If left is a type choice, right must match a choice.

--- a/opencog/atomutils/TypeUtils.h
+++ b/opencog/atomutils/TypeUtils.h
@@ -37,20 +37,20 @@ namespace opencog
 /**
  * Type checker.  Returns true if `val` is of type `type_spec`.
  * More precisely, returns true if `val` will fit into the type
- * specification given by `type_spec`; that the value and the type
+ * specification given by `type_spec`; that the argument and the type
  * specification can be connected, e.g. for beta-reduction, or for
  * pattern matching (searching).
  */
-bool value_is_type(const Handle& type_spec, const Handle& val);
+bool arg_is_type(const Handle& type_spec, const Handle& argument);
 
 /**
  * Type matcher. Returns true if `left` can mate with `right`.
  * Here, `left` can be a type definition, and `right` can be
- * another type defintion, or a value.  Mating is possible whenever
+ * another type defintion, or an argument.  Mating is possible whenever
  * `left` is broader, less restricitve than `right`; equivalently
  * if `right` is narrower than 'left`.
  *
- * Mating types and values:
+ * Mating types and arguments:
  * left == (Type "Concept")    right == (Concept "foo")  can mate.
  * left == (Type "Concept")    right == (Number 13)  cannot.
  *

--- a/opencog/atomutils/TypeUtils.h
+++ b/opencog/atomutils/TypeUtils.h
@@ -35,13 +35,13 @@ namespace opencog
  */
 
 /**
- * Type checker.  Returns true if `val` is of type `type_spec`.
- * More precisely, returns true if `val` will fit into the type
+ * Type checker.  Returns true if `value` is of type `type_spec`.
+ * More precisely, returns true if `value` will fit into the type
  * specification given by `type_spec`; that the argument and the type
  * specification can be connected, e.g. for beta-reduction, or for
  * pattern matching (searching).
  */
-bool arg_is_type(const Handle& type_spec, const Handle& argument);
+bool value_is_type(const Handle& type_spec, const ValuePtr& value);
 
 /**
  * Type matcher. Returns true if `left` can mate with `right`.

--- a/opencog/atomutils/TypeUtils.h
+++ b/opencog/atomutils/TypeUtils.h
@@ -107,7 +107,7 @@ bool type_match(const Handle&, const ValuePtr&);
  *   right == (Arrow (Type "Evaluation") (Type "Concept")
  *   result = (Arrow (Type "Evaluation") (Type "Number"))
  */
-Handle type_compose(const Handle&, const Handle&);
+ValuePtr type_compose(const Handle&, const ValuePtr&);
 
 /**
  * Given a variable declaration (VariableList) and a pattern body,

--- a/opencog/atomutils/TypeUtils.h
+++ b/opencog/atomutils/TypeUtils.h
@@ -37,7 +37,7 @@ namespace opencog
 /**
  * Type checker.  Returns true if `value` is of type `type_spec`.
  * More precisely, returns true if `value` will fit into the type
- * specification given by `type_spec`; that the argument and the type
+ * specification given by `type_spec`; that the value and the type
  * specification can be connected, e.g. for beta-reduction, or for
  * pattern matching (searching).
  */
@@ -46,7 +46,7 @@ bool value_is_type(const Handle& type_spec, const ValuePtr& value);
 /**
  * Type matcher. Returns true if `left` can mate with `right`.
  * Here, `left` can be a type definition, and `right` can be
- * another type defintion, or an argument.  Mating is possible whenever
+ * another type defintion, or a value.  Mating is possible whenever
  * `left` is broader, less restricitve than `right`; equivalently
  * if `right` is narrower than 'left`.
  *
@@ -84,7 +84,7 @@ bool type_match(const Handle&, const ValuePtr&);
 
 /**
  * Same as above, but return the composition (beta-reduction) of the
- * match. If the types do NOT match, the undefined handle is returned.
+ * match. If the types do NOT match, an exception is thrown.
  * If the types do match, then, for many cases, the right side is the
  * result.  The compostion of arrows, however, results either in a
  * new arrow, or a simple return type.

--- a/opencog/atomutils/TypeUtils.h
+++ b/opencog/atomutils/TypeUtils.h
@@ -80,11 +80,11 @@ bool value_is_type(const Handle& type_spec, const ValuePtr& value);
  * Any type specification is valid: SignatureLinks, etc work too.
  */
 
-bool type_match(const Handle&, const Handle&);
+bool type_match(const Handle&, const ValuePtr&);
 
 /**
  * Same as above, but return the composition (beta-reduction) of the
- * match. If the types do NOT match, theundefined handle is returned.
+ * match. If the types do NOT match, the undefined handle is returned.
  * If the types do match, then, for many cases, the right side is the
  * result.  The compostion of arrows, however, results either in a
  * new arrow, or a simple return type.

--- a/opencog/query/PatternSCM.cc
+++ b/opencog/query/PatternSCM.cc
@@ -18,9 +18,11 @@ class PatternSCM : public ModuleWrap
 		virtual void init(void);
 		static std::vector<FunctionWrap*> _binders;
 		Handle find_approximate_match(Handle);
+
+		// The three below belong in a different module...
 		bool value_is_type(Handle, ValuePtr);
 		bool type_match(Handle, ValuePtr);
-		Handle type_compose(Handle, Handle);
+		ValuePtr type_compose(Handle, ValuePtr);
 	public:
 		PatternSCM(void);
 		~PatternSCM();
@@ -64,7 +66,7 @@ bool PatternSCM::type_match(Handle left, ValuePtr right)
 	return opencog::type_match(left, right);
 }
 
-Handle PatternSCM::type_compose(Handle left, Handle right)
+ValuePtr PatternSCM::type_compose(Handle left, ValuePtr right)
 {
 	return opencog::type_compose(left, right);
 }

--- a/opencog/query/PatternSCM.cc
+++ b/opencog/query/PatternSCM.cc
@@ -19,7 +19,7 @@ class PatternSCM : public ModuleWrap
 		static std::vector<FunctionWrap*> _binders;
 		Handle find_approximate_match(Handle);
 		bool value_is_type(Handle, ValuePtr);
-		bool type_match(Handle, Handle);
+		bool type_match(Handle, ValuePtr);
 		Handle type_compose(Handle, Handle);
 	public:
 		PatternSCM(void);
@@ -59,7 +59,7 @@ bool PatternSCM::value_is_type(Handle type, ValuePtr val)
 	return opencog::value_is_type(type, val);
 }
 
-bool PatternSCM::type_match(Handle left, Handle right)
+bool PatternSCM::type_match(Handle left, ValuePtr right)
 {
 	return opencog::type_match(left, right);
 }

--- a/opencog/query/PatternSCM.cc
+++ b/opencog/query/PatternSCM.cc
@@ -18,7 +18,7 @@ class PatternSCM : public ModuleWrap
 		virtual void init(void);
 		static std::vector<FunctionWrap*> _binders;
 		Handle find_approximate_match(Handle);
-		bool value_is_type(Handle, Handle);
+		bool arg_is_type(Handle, Handle);
 		bool type_match(Handle, Handle);
 		Handle type_compose(Handle, Handle);
 	public:
@@ -54,9 +54,9 @@ Handle PatternSCM::find_approximate_match(Handle hp)
 	return as->add_link(LIST_LINK, solns);
 }
 
-bool PatternSCM::value_is_type(Handle type, Handle val)
+bool PatternSCM::arg_is_type(Handle type, Handle val)
 {
-	return opencog::value_is_type(type, val);
+	return opencog::arg_is_type(type, val);
 }
 
 bool PatternSCM::type_match(Handle left, Handle right)
@@ -125,7 +125,7 @@ void PatternSCM::init(void)
 	// Perhaps a deep-type module or type-reasoning module?
 	// dependent-type module? We don't have dependent types, yet.
 	define_scheme_primitive("cog-value-is-type?",
-		&PatternSCM::value_is_type, this, "query");
+		&PatternSCM::arg_is_type, this, "query");
 
 	define_scheme_primitive("cog-type-match?",
 		&PatternSCM::type_match, this, "query");

--- a/opencog/query/PatternSCM.cc
+++ b/opencog/query/PatternSCM.cc
@@ -18,7 +18,7 @@ class PatternSCM : public ModuleWrap
 		virtual void init(void);
 		static std::vector<FunctionWrap*> _binders;
 		Handle find_approximate_match(Handle);
-		bool arg_is_type(Handle, Handle);
+		bool value_is_type(Handle, ValuePtr);
 		bool type_match(Handle, Handle);
 		Handle type_compose(Handle, Handle);
 	public:
@@ -54,9 +54,9 @@ Handle PatternSCM::find_approximate_match(Handle hp)
 	return as->add_link(LIST_LINK, solns);
 }
 
-bool PatternSCM::arg_is_type(Handle type, Handle val)
+bool PatternSCM::value_is_type(Handle type, ValuePtr val)
 {
-	return opencog::arg_is_type(type, val);
+	return opencog::value_is_type(type, val);
 }
 
 bool PatternSCM::type_match(Handle left, Handle right)
@@ -125,7 +125,7 @@ void PatternSCM::init(void)
 	// Perhaps a deep-type module or type-reasoning module?
 	// dependent-type module? We don't have dependent types, yet.
 	define_scheme_primitive("cog-value-is-type?",
-		&PatternSCM::arg_is_type, this, "query");
+		&PatternSCM::value_is_type, this, "query");
 
 	define_scheme_primitive("cog-type-match?",
 		&PatternSCM::type_match, this, "query");

--- a/opencog/scm/opencog/query.scm
+++ b/opencog/scm/opencog/query.scm
@@ -71,3 +71,86 @@
     Run pattern matcher on HANDLE.  HANDLE must be a SatisfactionLink.
     Return a TV. Only satisfaction is performed, no implication.
 ")
+
+; The documentation below belongs in a different module.
+
+(set-procedure-property! cog-value-is-type? 'documentation
+"
+ cog-value-is-type? TYPE-SPEC VALUE
+
+  Type checker.  Returns true if `VALUE` is of type `TYPE-SPEC`.
+  More precisely, returns true if `VALUE` will fit into the type
+  specification given by `TYPE-SPEC`; that the value and the type
+  specification can be connected. This is usefule for beta-reduction,
+  (to check that some argument is reducible) or for pattern matching
+  (searching).
+")
+
+(set-procedure-property! cog-type-match? 'documentation
+"
+ cog-type-match? LEFT RIGHT
+
+  Type matcher. Returns true if `LEFT` can mate with `RIGHT`.
+  Here, `LEFT` can be a type definition, and `RIGHT` can be
+  another type defintion, or a value.  Mating is possible whenever
+  `LEFT` is broader, less restricitve than `RIGHT`; equivalently
+  if `RIGHT` is narrower than 'LEFT`.
+
+  Mating types and arguments:
+  LEFT == (Type "Concept")    RIGHT == (Concept "foo")  can mate.
+  LEFT == (Type "Concept")    RIGHT == (Number 13)  cannot.
+
+  Mating types and types:
+  LEFT == (Type "Concept")    RIGHT == (Type "Concept")  can mate.
+
+  Left is wider (polymorphic, in this case)
+    LEFT == (TypeChoice (Type "Concept") (Type "Number"))
+    RIGHT == (Type "Number")  can mate.
+
+  Function call arguments can be checked:
+    LEFT == (Arrow (Type "Concept") (Type "Number"))
+    RIGHT == (Concept "foo")  can mate.
+
+    LEFT == (Arrow (Type "Concept") (Type "Number"))
+    RIGHT == (Number 13)  cannot.
+
+  Function call chains can be checked:
+    LEFT == (Arrow (Type "Concept") (Type "Number"))
+    RIGHT == (Type "Concept")  can mate.
+
+  The following can mate, because LEFT accepts a concept as input,
+  and RIGHT generates a concept as output:
+    LEFT == (Arrow (Type "Concept") (Type "Number"))
+    RIGHT == (Arrow (Type "Evaluation") (Type "Concept")
+
+  Any type specification is valid: SignatureLinks, etc work too.
+")
+
+(set-procedure-property! cog-type-compose 'documentation
+"
+ cog-type-compose LEFT RIGHT
+
+  Similar to cog-type-match?, but return the composition
+  (beta-reduction) of the match. If the types do NOT match, an
+  exception is thrown.  If the types do match, then, for many
+  cases, the right side is the result.  The compostion of arrows,
+  however, results either in a new arrow, or a simple return type.
+
+  Examples:
+
+  Function call arguments can be checked:
+    LEFT == (Arrow (Type "Concept") (Type "Number"))
+    RIGHT == (Concept "foo")  can mate.
+    result = (Type "Number")
+
+  Function call chains:
+    LEFT == (Arrow (Type "Concept") (Type "Number"))
+    RIGHT == (Type "Concept")  can mate.
+    result = (Type "Number")
+
+  The following can mate, because LEFT accepts a concept as input,
+  and RIGHT generates a concept as output:
+    LEFT == (Arrow (Type "Concept") (Type "Number"))
+    RIGHT == (Arrow (Type "Evaluation") (Type "Concept")
+    result = (Arrow (Type "Evaluation") (Type "Number"))
+")

--- a/opencog/scm/opencog/query.scm
+++ b/opencog/scm/opencog/query.scm
@@ -97,31 +97,31 @@
   if `RIGHT` is narrower than 'LEFT`.
 
   Mating types and arguments:
-  LEFT == (Type "Concept")    RIGHT == (Concept "foo")  can mate.
-  LEFT == (Type "Concept")    RIGHT == (Number 13)  cannot.
+  LEFT == (Type 'ConceptNode)    RIGHT == (Concept \"foo\")  can mate.
+  LEFT == (Type 'ConceptNode)    RIGHT == (Number 13)  cannot.
 
   Mating types and types:
-  LEFT == (Type "Concept")    RIGHT == (Type "Concept")  can mate.
+  LEFT == (Type 'ConceptNode)    RIGHT == (Type 'ConceptNode)  can mate.
 
   Left is wider (polymorphic, in this case)
-    LEFT == (TypeChoice (Type "Concept") (Type "Number"))
-    RIGHT == (Type "Number")  can mate.
+    LEFT == (TypeChoice (Type 'ConceptNode) (Type 'NumberNode))
+    RIGHT == (Type 'NumberNode)  can mate.
 
   Function call arguments can be checked:
-    LEFT == (Arrow (Type "Concept") (Type "Number"))
-    RIGHT == (Concept "foo")  can mate.
+    LEFT == (Arrow (Type 'ConceptNode) (Type 'NumberNode))
+    RIGHT == (Concept 'fooNode)  can mate.
 
-    LEFT == (Arrow (Type "Concept") (Type "Number"))
+    LEFT == (Arrow (Type 'ConceptNode) (Type 'NumberNode))
     RIGHT == (Number 13)  cannot.
 
   Function call chains can be checked:
-    LEFT == (Arrow (Type "Concept") (Type "Number"))
-    RIGHT == (Type "Concept")  can mate.
+    LEFT == (Arrow (Type 'ConceptNode) (Type 'NumberNode))
+    RIGHT == (Type 'ConceptNode)  can mate.
 
   The following can mate, because LEFT accepts a concept as input,
   and RIGHT generates a concept as output:
-    LEFT == (Arrow (Type "Concept") (Type "Number"))
-    RIGHT == (Arrow (Type "Evaluation") (Type "Concept")
+    LEFT == (Arrow (Type 'ConceptNode) (Type 'NumberNode))
+    RIGHT == (Arrow (Type 'EvaluationNode) (Type 'ConceptNode)
 
   Any type specification is valid: SignatureLinks, etc work too.
 ")
@@ -139,18 +139,18 @@
   Examples:
 
   Function call arguments can be checked:
-    LEFT == (Arrow (Type "Concept") (Type "Number"))
-    RIGHT == (Concept "foo")  can mate.
-    result = (Type "Number")
+    LEFT == (Arrow (Type 'ConceptNode) (Type 'NumberNode))
+    RIGHT == (Concept \"foo\")  can mate.
+    result = (Type 'NumberNode)
 
   Function call chains:
-    LEFT == (Arrow (Type "Concept") (Type "Number"))
-    RIGHT == (Type "Concept")  can mate.
-    result = (Type "Number")
+    LEFT == (Arrow (Type 'ConceptNode) (Type 'NumberNode))
+    RIGHT == (Type 'ConceptNode)  can mate.
+    result = (Type 'NumberNode)
 
   The following can mate, because LEFT accepts a concept as input,
   and RIGHT generates a concept as output:
-    LEFT == (Arrow (Type "Concept") (Type "Number"))
-    RIGHT == (Arrow (Type "Evaluation") (Type "Concept")
-    result = (Arrow (Type "Evaluation") (Type "Number"))
+    LEFT == (Arrow (Type 'ConceptNode) (Type 'NumberNode))
+    RIGHT == (Arrow (Type 'EvaluationLink) (Type 'ConceptNode)
+    result = (Arrow (Type 'EvaluationLink) (Type 'NumberNode))
 ")


### PR DESCRIPTION
The word "value" is now a reserved word, in the atomspace, and so one should avoid using the word "value" unless "Value" is intended. 

This also adds missing documentation for `cog-value-is-type?` and `cog-type-match?`

Also some minor cleanup to EvaluationLink code.