### PR TITLE
Allow EvaluationLinks without ListLinks

### DIFF
--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -375,18 +375,32 @@ TruthValuePtr EvaluationLink::do_eval_scratch(AtomSpace* as,
 	{
 		const HandleSeq& sna(evelnk->getOutgoingSet());
 
-		if (2 != sna.size())
-			throw SyntaxException(TRACE_INFO,
-				"Incorrect number of arguments, expecting 2, got %lu",
-				sna.size());
-
 		// An ungrounded predicate evaluates to itself
 		if (sna.at(0)->get_type() == PREDICATE_NODE)
 			return evelnk->getTruthValue();
 
+		Handle args(sna.at(1));
+		if (2 != sna.size())
+		{
+			if (LIST_LINK == args->get_type())
+				throw SyntaxException(TRACE_INFO,
+					"EvaluationLink: Incorrect number of arguments, "
+					"expecting 2, got %lu",
+					sna.size());
+
+			// package up the remainder.
+			HandleSeq rest;
+			size_t sz = sna.size();
+			for (size_t i=1; i<sz; i++)
+			{
+				rest.push_back(sna[i]);
+			}
+			args = createLink(rest, LIST_LINK);
+		}
+
 		// Extract the args, and run the evaluation with them.
 		TruthValuePtr tvp(do_eval_with_args(scratch,
-		                                sna.at(0), sna.at(1), silent));
+		                                sna.at(0), args, silent));
 		evelnk->setTruthValue(tvp);
 		return tvp;
 	}

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -237,7 +237,7 @@ static HandleSeq get_seq(const Handle& cargs)
 
 /// Evalaute a formula defined by a PREDICATE_FORMULA_LINK
 static TruthValuePtr eval_formula(const Handle& predform,
-                                  const Handle& cargs)
+                                  const HandleSeq& cargs)
 {
 	// Collect up two floating point values.
 	std::vector<double> nums;
@@ -258,7 +258,7 @@ static TruthValuePtr eval_formula(const Handle& predform,
 		if (LAMBDA_LINK == h->get_type())
 		{
 			// Set flh and fall through, where it is executed.
-			flh = LambdaLinkCast(h)->beta_reduce(get_seq(cargs));
+			flh = LambdaLinkCast(h)->beta_reduce(cargs);
 		}
 
 		// At this point, we expect a FunctionLink of some kind.
@@ -271,7 +271,7 @@ static TruthValuePtr eval_formula(const Handle& predform,
 		const FreeVariables& fvars = flp->get_vars();
 		if (not fvars.empty())
 		{
-			flh = fvars.substitute_nocheck(flh, get_seq(cargs));
+			flh = fvars.substitute_nocheck(flh, cargs);
 			flp = FunctionLinkCast(flh);
 		}
 
@@ -704,7 +704,7 @@ TruthValuePtr EvaluationLink::do_eval_with_args(AtomSpace* as,
 
 		if (PREDICATE_FORMULA_LINK == dtype)
 		{
-			return eval_formula(defn, cargs);
+			return eval_formula(defn, get_seq(cargs));
 		}
 
 		// If its not a LambdaLink, then I don't know what to do...
@@ -724,7 +724,7 @@ TruthValuePtr EvaluationLink::do_eval_with_args(AtomSpace* as,
 	// AtomSpace.
 	if (PREDICATE_FORMULA_LINK == pntype)
 	{
-		return eval_formula(pn, cargs);
+		return eval_formula(pn, get_seq(cargs));
 	}
 
 	if (GROUNDED_PREDICATE_NODE != pntype)

--- a/opencog/atoms/execution/EvaluationLink.h
+++ b/opencog/atoms/execution/EvaluationLink.h
@@ -52,7 +52,7 @@ public:
 	                                     bool silent=false);
 	static TruthValuePtr do_eval_with_args(AtomSpace*,
 	                                       const Handle& schema,
-	                                       const Handle& args,
+	                                       const HandleSeq& args,
 	                                       bool silent=false);
 
 	static Handle factory(const Handle&);


### PR DESCRIPTION
The ListLink in an EvaluationLink serves no partiicular purpose, other than to take up space. Allow EvaluationLinks without it. (Remain backwards compat if it is there).