### PR TITLE
Bugfix temporary atomspace management

### DIFF
--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -53,11 +53,6 @@ private:
 		COG_EXTEND      // callbacks into C++ code.
 	};
 
-	// Encrypt and decrypt atomspace pointer, work around to bug
-	// https://github.com/opencog/atomspace/issues/1382
-    static AtomSpace* encrypt(AtomSpace* as);
-    static AtomSpace* decrypt(AtomSpace* as);
-
 	static std::atomic_flag is_inited;
 	static void module_init(void*);
 	static void register_procs();

--- a/opencog/guile/SchemeSmobAS.cc
+++ b/opencog/guile/SchemeSmobAS.cc
@@ -54,7 +54,7 @@ std::string SchemeSmob::as_to_string(const AtomSpace *as)
  * Create SCM object wrapping the atomspace.
  * Do NOT take over memory management of it!
  */
-SCM SchemeSmob::make_as (AtomSpace *as)
+SCM SchemeSmob::make_as(AtomSpace *as)
 {
 	SCM smob;
 	SCM_NEWSMOB (smob, cog_misc_tag, encrypt(as));
@@ -126,7 +126,8 @@ SCM SchemeSmob::ss_new_as (SCM s)
 	// with the code below;  it will crash, because the initial
 	// AS gets erroneously garbage-collected.  Guile is trying
 	// to release the main AS every time through the loop.  I can't
-	// figure out why.
+	// figure out why. This no longer happens for guile-2.2, but
+	// the work-around seems harmless, so whatever.
 /******
 (use-modules (opencog))
 (use-modules (opencog exec))

--- a/opencog/guile/SchemeSmobGC.cc
+++ b/opencog/guile/SchemeSmobGC.cc
@@ -59,7 +59,7 @@ size_t SchemeSmob::free_misc(SCM node)
 	{
 		case COG_AS:
 		{
-			AtomSpace *as = (AtomSpace *) SCM_SMOB_DATA(node);
+			AtomSpace *as = decrypt((AtomSpace *) SCM_SMOB_DATA(node));
 			release_as(as);
 			scm_remember_upto_here_1(node);
 			return 0;

--- a/opencog/guile/SchemeSmobGC.cc
+++ b/opencog/guile/SchemeSmobGC.cc
@@ -59,7 +59,7 @@ size_t SchemeSmob::free_misc(SCM node)
 	{
 		case COG_AS:
 		{
-			AtomSpace *as = decrypt((AtomSpace *) SCM_SMOB_DATA(node));
+			AtomSpace *as = (AtomSpace *) SCM_SMOB_DATA(node);
 			release_as(as);
 			scm_remember_upto_here_1(node);
 			return 0;

--- a/opencog/scm/opencog/base/utilities.scm
+++ b/opencog/scm/opencog/base/utilities.scm
@@ -1066,13 +1066,15 @@
 	(begin
 		(if (null-list? cog-atomspace-stack)
 			(throw 'badpop "More pops than pushes!"))
+
+		; guile gc will eventually garbage-collect this atomspace.
+		; However, gc might not run for a while; in the meanwhile,
+		; we do all the cruft it contained to be gone. So just
+		; brute-force clear it.
+		(cog-atomspace-clear)
 		(cog-set-atomspace! (car cog-atomspace-stack))
 		(set! cog-atomspace-stack (cdr cog-atomspace-stack))
-		; Performing a gc here helps ensure that the removed atomspace
-		; is deleted, thus cleaning up incoming sets of many atoms.
-		; The pattern matcher will work correctly without this cleanup,
-		; but I think it helps. Do it twice; once is sometimes not enough.
-		(gc) (gc)))
+	))
 
 ; ---------------------------------------------------------------------
 

--- a/tests/scm/pm.scm
+++ b/tests/scm/pm.scm
@@ -1,10 +1,9 @@
 ;; File to reproduce a bug when operating on multiple atomspaces
 ;; created from scheme.
 
-(use-modules (opencog logger))
-
+(use-modules (opencog))
 (use-modules (opencog exec))
-(use-modules (opencog rule-engine))
+(use-modules (opencog logger))
 
 ;; Create a new atomspace to not by-pass the problem (due to
 ;; WORK_AROUND_GUILE_20_GC_BUG in SchemeSmobAS.cc)
@@ -33,8 +32,7 @@
 )
 )
 
-;; Run and-bit-prior rule base over bug-as and copy its results to
-;; history-as.
+;; Run and-bit-prior rule base over bug-as
 (define (run-bug i)
   (cog-logger-debug "run-bug ~a" i)
   (cog-execute! query)


### PR DESCRIPTION
Temporary atomspaces (created in guile) were  not  being garbage-collected! Fixes bug noticed in #2018