### PR TITLE
Fix unit test

### DIFF
--- a/tests/atoms/base/ClassServerUTest.cxxtest
+++ b/tests/atoms/base/ClassServerUTest.cxxtest
@@ -231,6 +231,6 @@ public:
 
 		class_server->addValidator(NODE_B, validator_b);
 
-		TS_ASSERT_EQUALS(factory_b, class_server->getFactory(NODE_B));
+		TS_ASSERT_EQUALS(factory_a, class_server->getFactory(NODE_B));
 	}
 };


### PR DESCRIPTION
fix `ClassServerUTest::test_implicitly_set_factory_is_not_replaced_by_validating_factory` according scenario:
- B inherits A
- call addFactory(A, factoryA)
- call addValidator(B, validatorB)
- call getFactory(B)
- expected result: factoryA
- actual result: validating_factory