### PR TITLE
Fix class server behavior

### DIFF
--- a/opencog/atoms/base/ClassServer.cc
+++ b/opencog/atoms/base/ClassServer.cc
@@ -127,6 +127,6 @@ Handle ClassServer::factory(const Handle& h) const
 
 ClassServer& opencog::classserver()
 {
-    static std::unique_ptr<ClassServer> instance(new ClassServer(nameserver()));
-    return *instance;
+	static std::unique_ptr<ClassServer> instance(new ClassServer(nameserver()));
+	return *instance;
 }

--- a/opencog/atoms/base/ClassServer.cc
+++ b/opencog/atoms/base/ClassServer.cc
@@ -123,12 +123,23 @@ ClassServer::Validator* ClassServer::getValidator(Type t) const
 
 Handle ClassServer::factory(const Handle& h) const
 {
+	Handle result = h;
+
 	// If there is a factory, then use it.
 	AtomFactory* fact = getFactory(h->get_type());
 	if (fact)
-		return (*fact)(h);
+		result = (*fact)(h);
 
-	return h;
+	/* Look to see if we have static typechecking to do */
+	Validator* checker =
+		classserver().getValidator(result->get_type());
+
+	/* Well, is it OK, or not? */
+	if (checker and not checker(result))
+		throw SyntaxException(TRACE_INFO,
+				"Invalid Atom syntax: %s", result->to_string().c_str());
+
+	return result;
 }
 
 ClassServer& opencog::classserver()

--- a/opencog/atoms/base/ClassServer.cc
+++ b/opencog/atoms/base/ClassServer.cc
@@ -53,6 +53,9 @@ void ClassServer::splice(std::vector<T>& methods, Type t, T fact)
 	// then the code will not work properly anyway. Before a factory is registered,
 	// the complete class hierarchy must be known.
 	
+	std::unique_lock<std::mutex> l(factory_mutex);
+	methods.resize(_nameServer.getNumberOfClasses());
+
 	// Find all the factories that belong to parents of this type.
 	std::set<T> ok_to_clobber;
 	for (Type parent=0; parent < t; parent++)
@@ -77,15 +80,11 @@ void ClassServer::splice(std::vector<T>& methods, Type t, T fact)
 
 void ClassServer::addFactory(Type t, AtomFactory* fact)
 {
-	std::unique_lock<std::mutex> l(factory_mutex);
-	_atomFactory.resize(_nameServer.getNumberOfClasses());
 	splice(_atomFactory, t, fact);
 }
 
 void ClassServer::addValidator(Type t, Validator* checker)
 {
-	std::unique_lock<std::mutex> l(factory_mutex);
-	_validator.resize(_nameServer.getNumberOfClasses());
 	splice(_validator, t, checker);
 }
 

--- a/opencog/atoms/base/ClassServer.h
+++ b/opencog/atoms/base/ClassServer.h
@@ -116,15 +116,6 @@ Handle CNAME::factory(const Handle& base)                         \
    /* If it's castable, nothing to do. */                         \
    if (CNAME##Cast(base)) return base;                            \
                                                                   \
-   /* Look to see if we have static typechecking to do */         \
-   ClassServer::Validator* checker =                              \
-       classserver().getValidator(base->get_type());              \
-                                                                  \
-   /* Well, is it OK, or not? */                                  \
-   if (checker and not checker(base))                             \
-       throw SyntaxException(TRACE_INFO,                          \
-           "Invalid Atom syntax: %s", base->to_string().c_str()); \
-                                                                  \
    Handle h(create##CNAME(base->getOutgoingSet(), base->get_type())); \
    return h;                                                      \
 }                                                                 \

--- a/opencog/atoms/base/ClassServer.h
+++ b/opencog/atoms/base/ClassServer.h
@@ -81,6 +81,8 @@ private:
 
     const NameServer & _nameServer;
 
+    AtomFactory* getFactory(Type) const;
+
 public:
     /** Gets the singleton instance (following meyer's design pattern) */
     friend ClassServer& classserver();
@@ -89,7 +91,6 @@ public:
      * Declare a factory for an atom type.
      */
     void addFactory(Type, AtomFactory*);
-    AtomFactory* getFactory(Type) const;
 
     /**
      * Declare a validator for an atom type.

--- a/opencog/atoms/base/ClassServer.h
+++ b/opencog/atoms/base/ClassServer.h
@@ -77,7 +77,8 @@ private:
     mutable std::vector<AtomFactory*> _atomFactory;
     mutable std::vector<Validator*> _validator;
 
-    void spliceFactory(Type, AtomFactory*);
+    template<typename T>
+    void splice(std::vector<T>&, Type, T);
 
     const NameServer & _nameServer;
 

--- a/tests/atoms/CMakeLists.txt
+++ b/tests/atoms/CMakeLists.txt
@@ -3,6 +3,8 @@ ADD_SUBDIRECTORY (atom_types)
 
 ADD_SUBDIRECTORY (base)
 
+ADD_SUBDIRECTORY (core)
+
 ADD_SUBDIRECTORY (truthvalue)
 
 IF(HAVE_GUILE)

--- a/tests/atoms/base/ClassServerUTest.cxxtest
+++ b/tests/atoms/base/ClassServerUTest.cxxtest
@@ -231,6 +231,6 @@ public:
 
 		class_server->addValidator(NODE_B, validator_b);
 
-		TS_ASSERT_EQUALS(factory_b, class_server->getFactory(NODE_B));
+		TS_ASSERT_EQUALS(factory_a, class_server->getFactory(NODE_B));
 	}
 };

--- a/tests/atoms/base/ClassServerUTest.cxxtest
+++ b/tests/atoms/base/ClassServerUTest.cxxtest
@@ -201,20 +201,6 @@ public:
 		TS_ASSERT_EQUALS(validator_c, class_server->getValidator(NODE_C));
 	}
 
-	void test_add_validating_factory()
-	{
-		class_server->addValidator(NODE_B, validator_b);
-
-		TS_ASSERT(class_server->getFactory(NODE_B));
-	}
-
-	void test_add_validating_factory_to_descendants()
-	{
-		class_server->addValidator(NODE_B, validator_b);
-
-		TS_ASSERT(class_server->getFactory(NODE_C));
-	}
-
 	void test_explicitly_set_factory_is_not_replaced_by_validating_factory()
 	{
 		class_server->addFactory(NODE_B, factory_b);
@@ -226,7 +212,6 @@ public:
 
 	void test_implicitly_set_factory_is_not_replaced_by_validating_factory()
 	{
-		TS_SKIP("fails");
 		class_server->addFactory(NODE_A, factory_a);
 
 		class_server->addValidator(NODE_B, validator_b);

--- a/tests/atoms/base/ClassServerUTest.cxxtest
+++ b/tests/atoms/base/ClassServerUTest.cxxtest
@@ -193,7 +193,6 @@ public:
 
 	void test_explicitly_set_validator_is_not_replaced()
 	{
-		TS_SKIP("fails");
 		class_server->addValidator(NODE_C, validator_c);
 
 		class_server->addValidator(NODE_B, validator_b);

--- a/tests/atoms/core/CMakeLists.txt
+++ b/tests/atoms/core/CMakeLists.txt
@@ -1,0 +1,9 @@
+
+LINK_LIBRARIES(
+	atomspace
+	atomcore
+)
+
+
+ADD_CXXTEST(CheckersUTest)
+

--- a/tests/atoms/core/CheckersUTest.cxxtest
+++ b/tests/atoms/core/CheckersUTest.cxxtest
@@ -1,0 +1,77 @@
+/*
+ * tests/atoms/core/CheckersUTest.cxxtest
+ *
+ * Copyright (C) 2019 OpenGog Foundation
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/atomspace/AtomSpace.h>
+
+using namespace opencog;
+using namespace std;
+
+#define node atomspace.add_node
+#define lnk atomspace.add_link
+
+class CheckersUTest :  public CxxTest::TestSuite
+{
+private:
+
+	AtomSpace atomspace;
+
+public:
+
+	void test_boolean_link_cannot_contain_non_evaluatable()
+	{
+		TS_ASSERT_THROWS_ASSERT(
+			lnk(OR_LINK,
+				node(NUMBER_NODE, "3"),
+				node(NUMBER_NODE, "0")
+			),
+			const SyntaxException& e,
+			TS_ASSERT(std::string(e.get_message())
+				.find("Invalid Atom syntax:") == 0)
+		);
+	}
+
+	void test_numeric_link_cannot_contain_non_numeric()
+	{
+		TS_ASSERT_THROWS_ASSERT(
+			lnk(PLUS_LINK,
+				node(CONCEPT_NODE, "3"),
+				node(CONCEPT_NODE, "4")
+			),
+			const SyntaxException& e,
+			TS_ASSERT(std::string(e.get_message())
+				.find("Invalid Atom syntax:") == 0)
+		);
+	}
+
+	void test_type_cannot_contain_non_type()
+	{
+		TS_ASSERT_THROWS_ASSERT(
+			lnk(TYPE_SET_LINK,
+				node(CONCEPT_NODE, "test")
+			),
+			const SyntaxException& e,
+			TS_ASSERT(std::string(e.get_message())
+				.find("Invalid Atom syntax:") == 0)
+		);
+	}
+
+};


### PR DESCRIPTION
First steps from issue https://github.com/opencog/atomspace/issues/2024:
- move validator call from DEFINE_LINK_FACTORY DEFINE_NODE_FACTORY to the ClassFactory::factory method
- stop replacing factories by validating_factory in ClassServer::addValidator method, just call proper validator instead in ClassFactory::factory
- reuse ClassServer::spliceFactory method to splice not only factories but validators as well
- fix unit tests from PR https://github.com/opencog/atomspace/pull/2023

This PR incorporates unit test fix from https://github.com/opencog/atomspace/pull/2028
