### PR TITLE
Remove obsolete crud from backingstore

### DIFF
--- a/opencog/atomspace/BackingStore.cc
+++ b/opencog/atomspace/BackingStore.cc
@@ -28,43 +28,6 @@
 
 using namespace opencog;
 
-#define DEBUG_IGNORE 0
-
-#if DEBUG_IGNORE
-std::string s_indent("");
-int s_ignore_count = 0;
-#endif
-
-bool BackingStore::ignoreAtom(const Handle& h) const
-{
-#if DEBUG_IGNORE
-	fprintf(stderr, "%signoreAtom(%lu)\n", s_indent.c_str(),
-	        s_ignore_count++);
-#endif
-
-	// If the handle is a uuid only, and no atom, we can't ignore it.
-	if (nullptr == h) return false;
-
-	// If the atom is of an ignoreable type, then ignore.
-	if (ignoreType(h->get_type())) return true;
-
-	// If its a link, then scan the outgoing set.
-	if (not h->is_link()) return false;
-
-#if DEBUG_IGNORE
-	s_indent += "  ";
-#endif
-	bool should_ignore = false;
-	const HandleSeq& hs = h->getOutgoingSet();
-	if (std::any_of(hs.begin(), hs.end(), [this](Handle ho) { return ignoreAtom(ho); }))
-		should_ignore = true;
-#if DEBUG_IGNORE
-	s_indent.resize(max(s_indent.size() - 2, 0));
-#endif
-
-	return should_ignore;
-}
-
 void BackingStore::registerWith(AtomSpace* atomspace)
 {
 	atomspace->registerBackingStore(this);
@@ -74,4 +37,3 @@ void BackingStore::unregisterWith(AtomSpace* atomspace)
 {
 	atomspace->unregisterBackingStore(this);
 }
-

--- a/opencog/atomspace/BackingStore.h
+++ b/opencog/atomspace/BackingStore.h
@@ -115,28 +115,6 @@ class BackingStore
 		virtual void barrier() = 0;
 
 		/**
-		 * Returns true if the backing store will ignore this type.
-		 * This is used for performance optimization, as asking the
-		 * backend to retreive an atom can take a long time. If an atom
-		 * is of this given type, it will not be fetched.
-		 */
-		virtual bool ignoreType(Type t) const {
-			 return (_ignored_types.end() != _ignored_types.find(t));
-		}
-
-		/**
-		 * Returns true if the backing store will ignore this atom,
-		 * either because it is of an ignorable type, or is a link
-		 * which contains an atom that is of an ignorable type.
-		 */
-		virtual bool ignoreAtom(const Handle&) const;
-
-		/**
-		 * The set of ignored atom types.
-		 */
-		TypeSet _ignored_types;
-
-		/**
 		 * Register this backing store with the atomspace.
 		 */
 		void registerWith(AtomSpace*);


### PR DESCRIPTION
It was a temporary hack from long ago. It's dead.