### PR TITLE
Kill warning messages

### DIFF
--- a/opencog/attentionbank/AttentionBank.cc
+++ b/opencog/attentionbank/AttentionBank.cc
@@ -35,9 +35,11 @@ using namespace opencog;
 
 AttentionBank::AttentionBank(AtomSpace* asp)
 {
+#if 0
     // XXX FIXME -- should not use config() to get these values;
     // The user of this class should call config(), instead!
 
+This generates warnings whenever the unit tests run.
     startingFundsSTI = fundsSTI = config().get_double("STARTING_STI_FUNDS", 100000);
     startingFundsLTI = fundsLTI = config().get_double("STARTING_LTI_FUNDS", 100000);
     stiFundsBuffer = config().get_double("STI_FUNDS_BUFFER", 10000);
@@ -47,6 +49,16 @@ AttentionBank::AttentionBank(AtomSpace* asp)
     STIAtomWage = config().get_double("ECAN_STARTING_ATOM_STI_WAGE", 10);
     LTIAtomWage = config().get_double("ECAN_STARTING_ATOM_LTI_WAGE", 10);
     maxAFSize = config().get_int("ECAN_MAX_AF_SIZE", 100);
+#endif
+    startingFundsSTI = fundsSTI = 100000;
+    startingFundsLTI = fundsLTI = 100000;
+    stiFundsBuffer = 10000;
+    ltiFundsBuffer = 10000;
+    targetLTI = 10000;
+    targetSTI = 10000;
+    STIAtomWage = 10;
+    LTIAtomWage = 10;
+    maxAFSize = 100;
 
     _as = asp;
     _remove_signal = &asp->atomRemovedSignal();

--- a/opencog/attentionbank/AttentionalFocusCB.cc
+++ b/opencog/attentionbank/AttentionalFocusCB.cc
@@ -28,7 +28,7 @@ using namespace opencog;
 
 // XXX FIXME -- do we need this function, at all?  Why isn't it
 // sufficient to just do a normal pattern search, and weed out
-// the atttention focus after the fact? I find it very hard to
+// the attention focus after the fact? I find it very hard to
 // beleive that this provides any significant performance kick
 // over a simpler, more modular design.
 

--- a/tests/attentionbank/AttentionUTest.cxxtest
+++ b/tests/attentionbank/AttentionUTest.cxxtest
@@ -35,14 +35,12 @@ class AttentionUTest :  public CxxTest::TestSuite
         AtomSpace _as;
 
     public:
-        AttentionUTest()
-        {
-            config().set("ECAN_MAX_AF_SIZE", "10");
-        }
+        AttentionUTest() {}
 
         void testTopSTIValues()
         {
             AttentionBank _ab(&_as);
+            _ab.set_af_size(10);
             for(int i = 0; i < 50; i++) {
                 Handle h = _as.add_node(CONCEPT_NODE, "cnode-"+ std::to_string(i));
                 _ab.set_sti(h, i*10);
@@ -61,6 +59,7 @@ class AttentionUTest :  public CxxTest::TestSuite
         void testGetRandomAtoms()
         {
             AttentionBank _ab(&_as);
+            _ab.set_af_size(10);
             // Check Valid atoms are selected.
             for(int i = 0; i < 1000; i++) {
                 Handle h = _as.add_node(CONCEPT_NODE, "cnode-"+ std::to_string(i));


### PR DESCRIPTION
These warning messages have been getting printed for years. It's time to be rid of them.