### PR TITLE
dynamically load the scheme evaluator

### DIFF
--- a/opencog/atoms/execution/CMakeLists.txt
+++ b/opencog/atoms/execution/CMakeLists.txt
@@ -7,6 +7,7 @@ IF (HAVE_CYTHON)
 ENDIF (HAVE_CYTHON)
 
 ADD_LIBRARY (execution
+	DLScheme.cc
 	Force.cc
 	EvaluationLink.cc
 	ExecutionOutputLink.cc
@@ -20,7 +21,6 @@ ADD_DEPENDENCIES(execution opencog_atom_types)
 
 TARGET_LINK_LIBRARIES(execution
 	query-engine
-	smob
 	atomspace
 	atombase
 	clearbox

--- a/opencog/atoms/execution/DLScheme.cc
+++ b/opencog/atoms/execution/DLScheme.cc
@@ -51,5 +51,9 @@ SchemeEval* opencog::get_evaluator_for_scheme(AtomSpace* as)
 
 static __attribute__ ((destructor)) void fini(void)
 {
-	if (library) dlclose(library);
+	// Don't bother. This can trigger a pointless error:
+	//    Inconsistency detected by ld.so: dl-close.c: 811: _dl_close:
+	//    Assertion `map->l_init_called' failed!
+	// or we can just RTLD_NODELETE during the open, instead.
+	// if (library) dlclose(library);
 }

--- a/opencog/atoms/execution/DLScheme.cc
+++ b/opencog/atoms/execution/DLScheme.cc
@@ -1,0 +1,39 @@
+/*
+ * opencog/atoms/execution/DLScheme.cc
+ *
+ * Copyright (C) 2019 Linas Vepstas
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <dlfcn.h>
+#include "DLScheme.h"
+
+using namespace opencog;
+
+SchemeEval* opencog::get_evaluator_for_scheme(AtomSpace* as)
+{
+	static void* library = dlopen("libsmob.so", RTLD_LAZY);
+	static void* getev = dlsym(library, "get_scheme_evaluator");
+
+	typedef SchemeEval* (*SEGetter)(AtomSpace*);
+
+	// static SEGetter getter = std::reinterpret_cast<SEGetter>(getev);
+	static SEGetter getter = (SEGetter) getev;
+
+	return getter(as);
+}

--- a/opencog/atoms/execution/DLScheme.h
+++ b/opencog/atoms/execution/DLScheme.h
@@ -1,0 +1,33 @@
+/*
+ * opencog/atoms/execution/DLScheme.h
+ *
+ * Copyright (C) 2019 Linas Vepstas
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef _OPENCOG_DL_SCHEME_H
+#define _OPENCOG_DL_SCHEME_H
+
+#include <opencog/guile/SchemeEval.h>
+
+namespace opencog
+{
+SchemeEval* get_evaluator_for_scheme(AtomSpace*);
+}
+
+#endif // _OPENCOG_DL_SCHEME_H

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -38,6 +38,7 @@
 #include <opencog/guile/SchemeEval.h>
 #include <opencog/query/BindLinkAPI.h>
 
+#include "DLScheme.h"
 #include "Force.h"
 #include "EvaluationLink.h"
 #include "LibraryManager.h"
@@ -772,7 +773,7 @@ TruthValuePtr EvaluationLink::do_eval_with_args(AtomSpace* as,
 		size_t pos = 4;
 		while (' ' == schema[pos]) pos++;
 
-		SchemeEval* applier = SchemeEval::get_evaluator(as);
+		SchemeEval* applier = get_evaluator_for_scheme(as);
 		return applier->apply_tv(schema.substr(pos), args);
 #else
 		throw RuntimeException(TRACE_INFO,

--- a/opencog/atoms/execution/ExecutionOutputLink.cc
+++ b/opencog/atoms/execution/ExecutionOutputLink.cc
@@ -28,6 +28,7 @@
 #include <opencog/cython/PythonEval.h>
 #include <opencog/guile/SchemeEval.h>
 
+#include "DLScheme.h"
 #include "ExecutionOutputLink.h"
 #include "Force.h"
 #include "LibraryManager.h"
@@ -142,7 +143,7 @@ Handle ExecutionOutputLink::do_execute(AtomSpace* as,
 	if (lang == "scm")
 	{
 #ifdef HAVE_GUILE
-		SchemeEval* applier = SchemeEval::get_evaluator(as);
+		SchemeEval* applier = get_evaluator_for_scheme(as);
 		result = applier->apply(fun, args);
 
 		// Exceptions were already caught, before leaving guile mode,

--- a/opencog/guile/CMakeLists.txt
+++ b/opencog/guile/CMakeLists.txt
@@ -36,7 +36,7 @@ TARGET_LINK_LIBRARIES(smob
 	${NO_AS_NEEDED}
 	clearbox
 	lambda
-	# execution
+	execution
 	atomcore
 	atombase
 	truthvalue

--- a/opencog/guile/SchemeEval.cc
+++ b/opencog/guile/SchemeEval.cc
@@ -1190,4 +1190,14 @@ void SchemeEval::init_scheme(void)
 	SchemeEval sch;
 }
 
+extern "C" {
+// Thin wrapper for easy dlopen/dlsym dynamic loading
+opencog::SchemeEval* get_scheme_evaluator(opencog::AtomSpace* as)
+{
+	return opencog::SchemeEval::get_evaluator(as);
+}
+
+};
+
+
 /* ===================== END OF FILE ============================ */

--- a/opencog/guile/SchemeEval.h
+++ b/opencog/guile/SchemeEval.h
@@ -178,7 +178,7 @@ class SchemeEval : public GenericEval
 		AtomSpace* eval_as(const std::string&);
 
 		// Apply expression to args, returning Handle or TV
-		ValuePtr apply_v(const std::string& func, Handle varargs);
+		virtual ValuePtr apply_v(const std::string& func, Handle varargs);
 		Handle apply(const std::string& func, Handle varargs) {
 			return HandleCast(apply_v(func, varargs)); }
 		TruthValuePtr apply_tv(const std::string& func, Handle varargs) {
@@ -188,10 +188,13 @@ class SchemeEval : public GenericEval
 		bool recursing(void) { return _in_eval; }
 };
 
-
-
 /** @}*/
 }
+
+extern "C" {
+	// For shared-library loading
+	opencog::SchemeEval* get_scheme_evaluator(opencog::AtomSpace*);
+};
 
 #endif/* HAVE_GUILE */
 

--- a/opencog/query/CMakeLists.txt
+++ b/opencog/query/CMakeLists.txt
@@ -10,9 +10,6 @@ ADD_LIBRARY(query-engine
 	Recognizer.cc
 	Satisfier.cc
 )
-ADD_LIBRARY(query
-	PatternSCM.cc
-)
 
 ADD_DEPENDENCIES(query-engine
 	opencog_atom_types
@@ -22,6 +19,10 @@ TARGET_LINK_LIBRARIES(query-engine
 	lambda
 	atomspace
 #	execution # still a circular dependency
+)
+
+ADD_LIBRARY(query
+	PatternSCM.cc
 )
 
 TARGET_LINK_LIBRARIES(query

--- a/tests/atoms/ValueOfUTest.cxxtest
+++ b/tests/atoms/ValueOfUTest.cxxtest
@@ -24,6 +24,7 @@
 #include <opencog/atoms/core/ValueOfLink.h>
 #include <opencog/atoms/execution/EvaluationLink.h>
 #include <opencog/atoms/execution/Instantiator.h>
+#include <opencog/atoms/reduct/PlusLink.h>
 #include <opencog/atoms/value/FloatValue.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/util/Logger.h>
@@ -64,6 +65,9 @@ ValueOfUTest::ValueOfUTest(void)
 {
 	logger().set_level(Logger::INFO);
 	logger().set_print_to_stdout_flag(true);
+
+	// Hack to force library to load to work around linking bug.
+	createPlusLink(HandleSeq());
 }
 
 void ValueOfUTest::setUp(void)

--- a/tests/matrix/CMakeLists.txt
+++ b/tests/matrix/CMakeLists.txt
@@ -14,6 +14,7 @@ LINK_LIBRARIES(
 	atomspace
 	persist
 	persist-sql
+	smob
 )
 
 ADD_CXXTEST(VectorAPIUTest)

--- a/tests/matrix/CMakeLists.txt
+++ b/tests/matrix/CMakeLists.txt
@@ -12,7 +12,6 @@ LINK_DIRECTORIES(
 
 LINK_LIBRARIES(
 	atomspace
-	smob
 	clearbox
 	execution
 	persist

--- a/tests/matrix/CMakeLists.txt
+++ b/tests/matrix/CMakeLists.txt
@@ -12,11 +12,8 @@ LINK_DIRECTORIES(
 
 LINK_LIBRARIES(
 	atomspace
-	clearbox
-	execution
 	persist
 	persist-sql
-	${GUILE_LIBRARIES}
 )
 
 ADD_CXXTEST(VectorAPIUTest)

--- a/tests/matrix/VectorAPIUTest.cxxtest
+++ b/tests/matrix/VectorAPIUTest.cxxtest
@@ -116,6 +116,10 @@ void VectorAPIUTest::setUp(void)
 	CHKERR;
 	eval->eval("(load-from-path \"tests/matrix/basic-api.scm\")");
 	CHKERR;
+
+	// XXX FIXME not needed, but get a weird link bug without this
+	eval->eval("(use-modules (opencog exec))");
+	CHKERR;
 }
 
 void VectorAPIUTest::tearDown(void)


### PR DESCRIPTION
This breaks another circular dependency, this time, a hard one to break. For #1673 