### PR TITLE
Refactor the flow of the atomspace through the pattern matcher

### DIFF
--- a/opencog/atoms/pattern/BindLink.h
+++ b/opencog/atoms/pattern/BindLink.h
@@ -52,7 +52,7 @@ public:
 	BindLink(const Handle& body, const Handle& rewrite);
 	explicit BindLink(const Link &l);
 
-	bool imply(PatternMatchCallback&, AtomSpace* as,
+	bool imply(PatternMatchCallback&,
 	           bool check_connectivity=false);
 	const Handle& get_implicand(void) { return _implicand; }
 

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -945,7 +945,7 @@ void PatternLink::remove_constant_clauses(const AtomSpace* queried_as)
 	// but it remains unclear why this check needed to be deferred
 	// like this. This is causing other issues, so Um ??? wtf?
 	bool bogus = remove_constants(_varlist.varset, _pat, _components,
-	                              _component_patterns, queried_as);
+	                              _component_patterns);
 	if (bogus)
 	{
 		logger().warn("%s: Constant clauses removed from pattern %s",

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -931,7 +931,7 @@ static const Handle& groundings_key(void)
 	return gk;
 }
 
-void PatternLink::remove_constant_clauses(const AtomSpace* queried_as)
+void PatternLink::remove_constant_clauses(void)
 {
 	// Make sure that the user did not pass in bogus clauses
 	// in the queried atomspace.

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -51,6 +51,7 @@ void PatternLink::common_init(void)
 		return;
 	}
 
+	remove_constants(_varlist.varset, _pat, _components, _component_patterns);
 	validate_clauses(_varlist.varset, _pat.clauses, _pat.constants);
 	extract_optionals(_varlist.varset, _pat.clauses);
 
@@ -453,20 +454,17 @@ void PatternLink::locate_globs(HandleSeq& clauses)
 
 /* ================================================================= */
 /**
- * A simple validatation a collection of clauses for correctness.
- *
- * Every clause should contain at least one variable in it; clauses
- * that are constants and can be trivially discarded.
+ * Make sure that each declared variable appears in some clause.
+ * We can't ground variables that don't show up in a clause; there's
+ * just no way to know.  Throw, because they are presumably there due
+ * to programmer error. Quoted variables are constants, and so don't
+ * count.
  */
 void PatternLink::validate_clauses(HandleSet& vars,
                                    HandleSeq& clauses,
                                    HandleSeq& constants)
 
 {
-	// Make sure that each declared variable appears in some clause.
-	// We won't (can't) ground variables that don't show up in a
-	// clause.  They are presumably there due to programmer error.
-	// Quoted variables are constants, and so don't count.
 	for (const Handle& v : vars)
 	{
 		if (not is_unquoted_in_any_tree(clauses, v))

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -931,7 +931,7 @@ static const Handle& groundings_key(void)
 	return gk;
 }
 
-void PatternLink::remove_constant_clauses(const AtomSpace& queried_as)
+void PatternLink::remove_constant_clauses(const AtomSpace* queried_as)
 {
 	// Make sure that the user did not pass in bogus clauses
 	// in the queried atomspace.

--- a/opencog/atoms/pattern/PatternLink.h
+++ b/opencog/atoms/pattern/PatternLink.h
@@ -175,8 +175,8 @@ public:
 	const HandleSeq& get_virtual(void) const { return _virtual; }
 
 	// Given the queried atomspace, only remove constants if present
-	// in queried_as.
-	void remove_constant_clauses(const AtomSpace& queried_as);
+	// in queried_as. WTF???
+	void remove_constant_clauses(const AtomSpace* queried_as);
 
 	bool satisfy(PatternMatchCallback&) const;
 

--- a/opencog/atoms/pattern/PatternLink.h
+++ b/opencog/atoms/pattern/PatternLink.h
@@ -174,9 +174,7 @@ public:
 	const HandleSeq& get_fixed(void) const { return _fixed; }
 	const HandleSeq& get_virtual(void) const { return _virtual; }
 
-	// Given the queried atomspace, only remove constants if present
-	// in queried_as. WTF???
-	void remove_constant_clauses(const AtomSpace* queried_as);
+	void remove_constant_clauses(void);
 
 	bool satisfy(PatternMatchCallback&) const;
 

--- a/opencog/atoms/pattern/PatternUtils.cc
+++ b/opencog/atoms/pattern/PatternUtils.cc
@@ -64,8 +64,7 @@ namespace opencog {
 bool remove_constants(const HandleSet& vars,
                       Pattern& pat,
                       HandleSeqSeq& components,
-                      HandleSeq& component_patterns,
-                      const AtomSpace *queried_as)
+                      HandleSeq& component_patterns)
 {
 	bool modified = false;
 
@@ -74,14 +73,6 @@ bool remove_constants(const HandleSet& vars,
 	for (i = pat.clauses.begin(); i != pat.clauses.end();)
 	{
 		Handle clause(*i);
-
-		// XXX?? why does this check matter ?? How is it even
-		// possible?  XXX Something is foobared, somewhere.
-		if (nullptr != queried_as and
-		    not is_in_atomspace(clause, *queried_as))
-		{
-			++i; continue;
-		}
 
 		if (not is_constant(vars, clause))
 		{

--- a/opencog/atoms/pattern/PatternUtils.cc
+++ b/opencog/atoms/pattern/PatternUtils.cc
@@ -23,7 +23,6 @@
 #include <boost/range/algorithm/find.hpp>
 
 #include <opencog/atoms/core/FindUtils.h>
-#include <opencog/atomspace/AtomSpace.h>
 #include "PatternUtils.h"
 
 using namespace opencog;
@@ -109,11 +108,6 @@ bool remove_constants(const HandleSet& vars,
 	}
 
 	return modified;
-}
-
-bool is_in_atomspace(const Handle& handle, const AtomSpace& atomspace)
-{
-	return nullptr != atomspace.get_atom(handle);
 }
 
 bool is_constant(const HandleSet& vars, const Handle& clause)

--- a/opencog/atoms/pattern/PatternUtils.h
+++ b/opencog/atoms/pattern/PatternUtils.h
@@ -42,8 +42,7 @@ namespace opencog {
 bool remove_constants(const HandleSet& vars,
                       Pattern& pat,
                       HandleSeqSeq& components,
-                      HandleSeq& component_patterns,
-                      const AtomSpace *queried_as);
+                      HandleSeq& component_patterns);
 
 // check whether an Atom exists in a given atomspace.
 bool is_in_atomspace(const Handle& clause, const AtomSpace& atomspace);

--- a/opencog/atoms/pattern/PatternUtils.h
+++ b/opencog/atoms/pattern/PatternUtils.h
@@ -44,9 +44,6 @@ bool remove_constants(const HandleSet& vars,
                       HandleSeqSeq& components,
                       HandleSeq& component_patterns);
 
-// check whether an Atom exists in a given atomspace.
-bool is_in_atomspace(const Handle& clause, const AtomSpace& atomspace);
-
 // Return true iff the clause is constant.
 bool is_constant(const HandleSet& vars, const Handle& clause);
 

--- a/opencog/atoms/pattern/PatternUtils.h
+++ b/opencog/atoms/pattern/PatternUtils.h
@@ -43,15 +43,13 @@ bool remove_constants(const HandleSet& vars,
                       Pattern& pat,
                       HandleSeqSeq& components,
                       HandleSeq& component_patterns,
-                      const AtomSpace &queried_as);
+                      const AtomSpace *queried_as);
 
 // check whether an Atom exists in a given atomspace.
 bool is_in_atomspace(const Handle& clause, const AtomSpace& atomspace);
 
-// Return true iff the clause is constant. If an atomspace is provided
-// it also check that it is present in it.
-bool is_constant(const HandleSet& vars, const Handle& clause,
-                 const AtomSpace* queried_as=nullptr);
+// Return true iff the clause is constant.
+bool is_constant(const HandleSet& vars, const Handle& clause);
 
 // See C file for description
 void get_connected_components(const HandleSet& vars,

--- a/opencog/query/Implicator.cc
+++ b/opencog/query/Implicator.cc
@@ -96,7 +96,7 @@ Handle do_imply(AtomSpace* as,
 
 	impl.implicand = bl->get_implicand();
 
-	bl->imply(impl, as, do_conn_check);
+	bl->imply(impl, do_conn_check);
 
 	// If we got a non-empty answer, just return it.
 	if (0 < impl.get_result_list().size())

--- a/opencog/query/PatternMatch.cc
+++ b/opencog/query/PatternMatch.cc
@@ -333,7 +333,7 @@ bool BindLink::imply(PatternMatchCallback& pmc, AtomSpace* as, bool check_conn)
 		                            "BindLink consists of multiple "
 		                            "disconnected components!");
 
-	remove_constant_clauses(as);
+	remove_constant_clauses();
 
 	return PatternLink::satisfy(pmc);
 }

--- a/opencog/query/PatternMatch.cc
+++ b/opencog/query/PatternMatch.cc
@@ -326,7 +326,7 @@ bool PatternMatch::recursive_virtual(PatternMatchCallback& cb,
  * to indicate the bindings of the variables, and (optionally) limit
  * the types of acceptable groundings for the variables.
  */
-bool BindLink::imply(PatternMatchCallback& pmc, AtomSpace* as, bool check_conn)
+bool BindLink::imply(PatternMatchCallback& pmc, bool check_conn)
 {
 	if (check_conn and 0 == _virtual.size() and 1 < _components.size())
 		throw InvalidParamException(TRACE_INFO,

--- a/opencog/query/PatternMatch.cc
+++ b/opencog/query/PatternMatch.cc
@@ -333,8 +333,6 @@ bool BindLink::imply(PatternMatchCallback& pmc, bool check_conn)
 		                            "BindLink consists of multiple "
 		                            "disconnected components!");
 
-	remove_constant_clauses();
-
 	return PatternLink::satisfy(pmc);
 }
 

--- a/opencog/query/Satisfier.cc
+++ b/opencog/query/Satisfier.cc
@@ -153,7 +153,6 @@ TruthValuePtr opencog::satisfaction_link(AtomSpace* as, const Handle& hlink)
 	PatternLinkPtr plp(PatternLinkCast(hlink));
 
 	Satisfier sater(as);
-	plp->remove_constant_clauses();
 	plp->satisfy(sater);
 
 #define PLACE_RESULTS_IN_ATOMSPACE
@@ -195,7 +194,6 @@ Handle opencog::satisfying_set(AtomSpace* as, const Handle& hlink, size_t max_re
 
 	SatisfyingSet sater(as);
 	sater.max_results = max_results;
-	bl->remove_constant_clauses();
 	bl->satisfy(sater);
 
 	// Create the satisfying set, and cache it.

--- a/opencog/query/Satisfier.cc
+++ b/opencog/query/Satisfier.cc
@@ -153,7 +153,7 @@ TruthValuePtr opencog::satisfaction_link(AtomSpace* as, const Handle& hlink)
 	PatternLinkPtr plp(PatternLinkCast(hlink));
 
 	Satisfier sater(as);
-	plp->remove_constant_clauses(as);
+	plp->remove_constant_clauses();
 	plp->satisfy(sater);
 
 #define PLACE_RESULTS_IN_ATOMSPACE
@@ -195,7 +195,7 @@ Handle opencog::satisfying_set(AtomSpace* as, const Handle& hlink, size_t max_re
 
 	SatisfyingSet sater(as);
 	sater.max_results = max_results;
-	bl->remove_constant_clauses(as);
+	bl->remove_constant_clauses();
 	bl->satisfy(sater);
 
 	// Create the satisfying set, and cache it.

--- a/opencog/rule-engine/forwardchainer/ForwardChainer.cc
+++ b/opencog/rule-engine/forwardchainer/ForwardChainer.cc
@@ -388,7 +388,7 @@ HandleSet ForwardChainer::apply_rule(const Rule& rule)
 			BindLinkPtr bl = BindLinkCast(rhcpy);
 			FocusSetPMCB fs_pmcb(&derived_rule_as, &_kb_as);
 			fs_pmcb.implicand = bl->get_implicand();
-			bl->imply(fs_pmcb, &_focus_set_as, false);
+			bl->imply(fs_pmcb, false);
 			add_results(_focus_set_as, fs_pmcb.get_result_list());
 		}
 		// Search the whole atomspace.

--- a/opencog/unify/Unify.cc
+++ b/opencog/unify/Unify.cc
@@ -392,6 +392,17 @@ Handle Unify::substitute_vardecl(const Handle& vardecl,
 	return createLink(oset, t);
 }
 
+// Is a clause constant, relative to some atomspace?
+// Why would it matter whether or not it is in some atomspace?
+static bool not_constant(const HandleSet& vars,
+                         const Handle& clause,
+                         const AtomSpace* as)
+{
+	return
+		(nullptr != as and not is_in_atomspace(clause, *as))
+			or not is_constant(vars, clause);
+}
+
 // TODO: for now it is assumed clauses are connected by an AndLink
 // only. To fix that one needs to generalize
 // PatternLink::unbundle_clauses to make it usable in that code too.
@@ -409,11 +420,11 @@ Handle Unify::remove_constant_clauses(const Handle& vardecl,
 	HandleSeq hs;
 	if (t == AND_LINK) {
 		for (const Handle& clause : clauses->getOutgoingSet()) {
-			if (not is_constant(vars, clause, as)) {
+			if (not_constant(vars, clause, as)) {
 				hs.push_back(clause);
 			}
 		}
-	} else if (not is_constant(vars, clauses, as)) {
+	} else if (not_constant(vars, clauses, as)) {
 		return clauses;
 	}
 	return createLink(hs, AND_LINK);

--- a/opencog/unify/Unify.cc
+++ b/opencog/unify/Unify.cc
@@ -35,6 +35,7 @@
 // #include <opencog/atoms/core/Variables.h>
 #include <opencog/atoms/core/RewriteLink.h>
 #include <opencog/atoms/pattern/PatternUtils.h>
+#include <opencog/atomspace/AtomSpace.h>
 
 namespace opencog {
 
@@ -392,15 +393,20 @@ Handle Unify::substitute_vardecl(const Handle& vardecl,
 	return createLink(oset, t);
 }
 
+
+static bool not_in_atomspace(const Handle& handle, const AtomSpace* atomspace)
+{
+	return nullptr != atomspace
+	   and nullptr == atomspace->get_atom(handle);
+}
+
 // Is a clause constant, relative to some atomspace?
 // Why would it matter whether or not it is in some atomspace?
 static bool not_constant(const HandleSet& vars,
                          const Handle& clause,
                          const AtomSpace* as)
 {
-	return
-		(nullptr != as and not is_in_atomspace(clause, *as))
-			or not is_constant(vars, clause);
+	return not_in_atomspace(clause, as) or not is_constant(vars, clause);
 }
 
 // TODO: for now it is assumed clauses are connected by an AndLink

--- a/tests/query/imply.h
+++ b/tests/query/imply.h
@@ -30,7 +30,7 @@ static inline Handle imply(AtomSpace* as, Handle hclauses, Handle himplicand)
 	DefaultImplicator impl(as);
 	impl.implicand = himplicand;
 
-	bl->imply(impl, as);
+	bl->imply(impl);
 
 	// The result_list contains a list of the grounded expressions.
 	// Turn it into a true list, and return it.


### PR DESCRIPTION
This is blocking pending work on removing shared-library circular dependencies.  I've almost got the knot unravelled... 