### PR TITLE
Allow guile site dir overriding

### DIFF
--- a/cmake/OpenCogFunctions.cmake
+++ b/cmake/OpenCogFunctions.cmake
@@ -14,6 +14,12 @@
 #   for it be importable, as per guile's specification. See reference
 #   links above.
 
+# By default Guile return the path to its installation location.
+# Such path will not work for users who wants to compile and install
+# the project with a custom CMAKE_INSTALL_PREFIX. Compiling with 
+# custom PREFIX is a common practice. To support custom PREFIX 
+# this condition is added to override GUILE_SITE_DIR value using
+# `cmake -DGUILE_SITE_DIR=...`.
 IF (NOT DEFINED GUILE_SITE_DIR)
     IF(HAVE_GUILE)
         EXECUTE_PROCESS(COMMAND guile -c "(display (%site-dir))"

--- a/cmake/OpenCogFunctions.cmake
+++ b/cmake/OpenCogFunctions.cmake
@@ -14,10 +14,12 @@
 #   for it be importable, as per guile's specification. See reference
 #   links above.
 
-IF(HAVE_GUILE)
-    EXECUTE_PROCESS(COMMAND guile -c "(display (%site-dir))"
-        OUTPUT_VARIABLE GUILE_SITE_DIR
-        OUTPUT_STRIP_TRAILING_WHITESPACE)
+IF (NOT DEFINED GUILE_SITE_DIR)
+    IF(HAVE_GUILE)
+        EXECUTE_PROCESS(COMMAND guile -c "(display (%site-dir))"
+            OUTPUT_VARIABLE GUILE_SITE_DIR
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+    ENDIF()
 ENDIF()
 ADD_DEFINITIONS(-DGUILE_SITE_DIR="${GUILE_SITE_DIR}")
 


### PR DESCRIPTION
Fix for issue https://github.com/opencog/atomspace/issues/1968

Allow using `cmake -DGUILE_SITE_DIR` to override default dir.

Have checked it with `-DGUILE_SITE_DIR` and without it.