### PR TITLE
Add universal casting functions

### DIFF
--- a/opencog/atoms/base/Handle.h
+++ b/opencog/atoms/base/Handle.h
@@ -322,6 +322,30 @@ std::string oc_to_string(const TypeSet& types,
 std::string oc_to_string(const AtomPtr& aptr,
                          const std::string& indent=empty_string);
 
+/**
+ * Cast Handle to the specific Atom subclass. This function is defined only
+ * for T which are subclasses of Atom.
+ */
+template<typename T>
+static inline
+typename std::enable_if< std::is_base_of<Atom, T>::value, std::shared_ptr<T> >::type
+CastFromHandle(const Handle& handle)
+{
+	return std::dynamic_pointer_cast<T>(handle);
+}
+
+/**
+ * Cast AtomPtr to the specific Atom subclass. This function is defined only
+ * for T which are subclasses of Atom.
+ */
+template<typename T>
+static inline
+typename std::enable_if< std::is_base_of<Atom, T>::value, std::shared_ptr<T> >::type
+CastFromAtomPtr(const AtomPtr& atom)
+{
+	return std::dynamic_pointer_cast<T>(atom);
+}
+
 } // namespace opencog
 
 namespace std {

--- a/opencog/atoms/value/Value.h
+++ b/opencog/atoms/value/Value.h
@@ -118,6 +118,18 @@ CastFromValue(const ValuePtr& value)
 	return std::dynamic_pointer_cast<T>(value);
 }
 
+/**
+ * Cast specific Value subclass to ValuePtr. This function is defined only
+ * for T which are subclasses of Value.
+ */
+template<typename T>
+static inline
+typename std::enable_if< std::is_base_of<Value, T>::value, ValuePtr >::type
+CastToValue(const std::shared_ptr<const T>& value)
+{
+	return std::dynamic_pointer_cast<Value>(std::const_pointer_cast<T>(value));
+}
+
 class Atom;
 
 /**

--- a/opencog/atoms/value/Value.h
+++ b/opencog/atoms/value/Value.h
@@ -106,6 +106,33 @@ typedef std::vector<ValuePtr> ValueSeq;
 // http://stackoverflow.com/questions/16734783 for more explanation.
 std::string oc_to_string(const ValuePtr& vp, const std::string& indent);
 
+/**
+ * Cast ValuePtr to the specific Value subclass. This function is defined only
+ * for T which are subclasses of Value.
+ */
+template<typename T>
+static inline
+typename std::enable_if< std::is_base_of<Value, T>::value, std::shared_ptr<T> >::type
+CastFromValue(const ValuePtr& value)
+{
+	return std::dynamic_pointer_cast<T>(value);
+}
+
+class Atom;
+
+/**
+ * Create Value of specific type using appropriate constructor. This function
+ * is defined only for T which are subclasses of Value.
+ */
+template<typename T, typename ... Args>
+static inline
+typename std::enable_if<
+	std::is_base_of<Value, T>::value && !std::is_base_of<Atom, T>::value,
+	std::shared_ptr<T> >::type
+createValue(Args&&... args) {
+	return std::make_shared<T>(std::forward<Args>(args)...);
+}
+
 /** @}*/
 } // namespace opencog
 

--- a/tests/atoms/CMakeLists.txt
+++ b/tests/atoms/CMakeLists.txt
@@ -7,6 +7,8 @@ ADD_SUBDIRECTORY (core)
 
 ADD_SUBDIRECTORY (truthvalue)
 
+ADD_SUBDIRECTORY (value)
+
 IF(HAVE_GUILE)
 	ADD_CXXTEST(HashUTest)
 	TARGET_LINK_LIBRARIES(HashUTest smob atomspace)

--- a/tests/atoms/base/CMakeLists.txt
+++ b/tests/atoms/base/CMakeLists.txt
@@ -5,4 +5,5 @@ LINK_LIBRARIES(
 
 
 ADD_CXXTEST(ClassServerUTest)
+ADD_CXXTEST(HandleUTest)
 

--- a/tests/atoms/base/HandleUTest.cxxtest
+++ b/tests/atoms/base/HandleUTest.cxxtest
@@ -1,0 +1,50 @@
+/*
+ * tests/atoms/base/HandleUTest.cxxtest
+ *
+ * Copyright (C) 2019 OpenCog Foundation
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/atoms/base/Handle.h>
+#include <opencog/atoms/core/NumberNode.h>
+
+using namespace opencog;
+
+class HandleUTest : public CxxTest::TestSuite
+{
+public:
+
+	void test_cast_from_handle()
+	{
+		Handle handle(createNumberNode(4.2));
+
+		NumberNodePtr number_node = CastFromHandle<NumberNode>(handle);
+
+		TS_ASSERT_EQUALS(handle.get(), number_node.get());
+	}
+
+	void test_cast_from_atomptr()
+	{
+		AtomPtr atom(createNumberNode(4.2));
+
+		NumberNodePtr number_node = CastFromAtomPtr<NumberNode>(atom);
+
+		TS_ASSERT_EQUALS(atom.get(), number_node.get());
+	}
+};
+

--- a/tests/atoms/value/CMakeLists.txt
+++ b/tests/atoms/value/CMakeLists.txt
@@ -1,0 +1,5 @@
+LINK_LIBRARIES(
+	value
+)
+
+ADD_CXXTEST(ValueUTest)

--- a/tests/atoms/value/ValueUTest.cxxtest
+++ b/tests/atoms/value/ValueUTest.cxxtest
@@ -20,7 +20,9 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <opencog/atoms/value/Value.h>
 #include <opencog/atoms/value/FloatValue.h>
+#include <opencog/atoms/value/LinkValue.h>
 
 using namespace opencog;
 
@@ -44,6 +46,26 @@ public:
 		FloatValuePtr float_value = CastFromValue<FloatValue>(value);
 
 		TS_ASSERT_EQUALS(value.get(), float_value.get());
+	}
+
+	void test_cast_from_const_value()
+	{
+		FloatValuePtr float_value;
+
+		ValuePtr value = CastToValue(float_value = createFloatValue(4.2));
+
+		TS_ASSERT_EQUALS(value.get(), float_value.get());
+	}
+
+	void test_vast_from_value()
+	{
+		ValuePtr float_value = createValue<FloatValue>(4.2);
+		LinkValuePtr link_value = createValue<LinkValue>(
+			std::vector<ValuePtr>({ float_value })
+		);
+
+		TS_ASSERT_EQUALS(link_value->value(),
+				std::vector<ValuePtr>({ float_value }));
 	}
 
 };

--- a/tests/atoms/value/ValueUTest.cxxtest
+++ b/tests/atoms/value/ValueUTest.cxxtest
@@ -1,0 +1,50 @@
+/*
+ * tests/atoms/value/ValueUTest.cxxtest
+ *
+ * Copyright (C) 2019 OpenCog Foundation
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/atoms/value/FloatValue.h>
+
+using namespace opencog;
+
+class ValueUTest : public CxxTest::TestSuite
+{
+public:
+
+	void test_create_value()
+	{
+		FloatValuePtr float_value = createValue<FloatValue>(4.2);
+
+		std::vector<double> value = float_value->value();
+		TS_ASSERT_EQUALS(1, value.size());
+		TS_ASSERT_DELTA(4.2, value[0], 0.01);
+	}
+
+	void test_cast_from_value()
+	{
+		ValuePtr value = createValue<FloatValue>(4.2);
+
+		FloatValuePtr float_value = CastFromValue<FloatValue>(value);
+
+		TS_ASSERT_EQUALS(value.get(), float_value.get());
+	}
+
+};
+


### PR DESCRIPTION
This PR adds universal cast functions for `Handle`, `AtomPtr` and `ValuePtr` references to not generate `Cast..` functions for each new `Atom` or `Value` instance. Cast functions are defined for `Handle`, `AtomPtr` and `ValuePtr` subclasses only.