### PR TITLE
Make python api classes hierarchy consistent

### DIFF
--- a/opencog/cython/opencog/atom.pyx
+++ b/opencog/cython/opencog/atom.pyx
@@ -213,55 +213,12 @@ cdef class Atom(Value):
         atom_ptr.getIncomingSetByType(back_inserter(handle_vector), type)
         return convert_handle_seq_to_python_list(handle_vector, self.atomspace)
 
-    property type:
-        def __get__(self):
-            cdef cAtom* atom_ptr
-            if self._atom_type is None:
-                atom_ptr = self.handle.atom_ptr()
-                if atom_ptr == NULL:   # avoid null-pointer deref
-                    return None
-                self._atom_type = atom_ptr.get_type()
-            return self._atom_type
-
-    property type_name:
-        def __get__(self):
-            return get_type_name(self.type)
-
-    property t:
-        def __get__(self):
-            return self.type
-
     def truth_value(self, mean, count):
         self.tv = TruthValue(mean, count)
         return self
 
     def handle_ptr(self):
         return PyLong_FromVoidPtr(self.handle)
-
-    def is_node(self):
-        return is_a(self.t, types.Node)
-
-    def is_link(self):
-        return is_a(self.t, types.Link)
-
-    def is_a(self,t):
-        return is_a(self.t, t)
-
-    def long_string(self):
-        cdef cAtom* atom_ptr = self.handle.atom_ptr()
-        if atom_ptr != NULL:
-            return atom_ptr.to_string().decode('UTF-8')
-        return ""
-
-    def __str__(self):
-        cdef cAtom* atom_ptr = self.handle.atom_ptr()
-        if atom_ptr != NULL:
-            cs = atom_ptr.to_short_string()
-            return cs.decode('UTF-8')
-        return ""
-
-    def __repr__(self):
-        return self.long_string()
 
     def __richcmp__(a1_, a2_, int op):
         if not isinstance(a1_, Atom) or not isinstance(a2_, Atom):

--- a/opencog/cython/opencog/atom.pyx
+++ b/opencog/cython/opencog/atom.pyx
@@ -1,11 +1,3 @@
-
-cdef cAtom* get_atom_ptr(Atom atom):
-    cdef cAtom* atom_ptr = atom.handle.atom_ptr()
-    if atom_ptr == NULL:
-        raise AttributeError('Atom contains NULL reference')
-    return atom_ptr
-
-
 # Atom wrapper object
 cdef class Atom(Value):
 
@@ -22,6 +14,10 @@ cdef class Atom(Value):
         self._name = None
         self._outgoing = None
         self.atomspace = atomspace
+
+    cdef cHandle get_c_handle(Atom self):
+        """Return C++ shared_ptr from PtrHolder instance"""
+        return <cHandle&>(self.ptr_holder.shared_ptr)
 
     def __nonzero__(self):
         """ Allows boolean comparison, return false is handle is
@@ -162,11 +158,11 @@ cdef class Atom(Value):
         attentionbank(self.atomspace.atomspace).dec_vlti(self.handle[0])
 
     def set_value(self, key, value):
-        get_atom_ptr(self).setValue(deref((<Atom>key).handle),
+        self.get_c_handle().get().setValue(deref((<Atom>key).handle),
                                 (<Value>value).get_c_value_ptr())
 
     def get_value(self, key):
-        cdef cValuePtr value = get_atom_ptr(self).getValue(
+        cdef cValuePtr value = self.get_c_handle().get().getValue(
             deref((<Atom>key).handle))
         if (value != NULL):
             return Value.create(value)

--- a/opencog/cython/opencog/atom.pyx
+++ b/opencog/cython/opencog/atom.pyx
@@ -59,9 +59,7 @@ cdef class Atom(object):
                 return None
             tvp = atom_ptr.getTruthValue()
             if (not tvp.get()):
-                pytv = TruthValue()
-                pytv.cobj = new tv_ptr(tvp) # make copy of smart pointer
-                return pytv
+                raise AttributeError('cAtom returned NULL TruthValue pointer')
             return TruthValue(tvp.get().get_mean(), tvp.get().get_confidence())
 
         def __set__(self, truth_value):

--- a/opencog/cython/opencog/atomspace.pxd
+++ b/opencog/cython/opencog/atomspace.pxd
@@ -53,13 +53,13 @@ cdef extern from "opencog/atoms/value/Value.h" namespace "opencog":
 cdef class ValuePtr:
     cdef cValuePtr shared_ptr
     @staticmethod
-    cdef ValuePtr create(cValuePtr shared_ptr)
+    cdef ValuePtr create(cValuePtr& shared_ptr)
 
 cdef class Value:
     cdef ValuePtr value_ptr
     cdef cValuePtr get_c_value_ptr(self)
     @staticmethod
-    cdef Value create(cValuePtr shared_ptr)
+    cdef Value create(cValuePtr& shared_ptr)
 
 ### TruthValue
 ctypedef double count_t

--- a/opencog/cython/opencog/atomspace.pxd
+++ b/opencog/cython/opencog/atomspace.pxd
@@ -36,6 +36,8 @@ cdef extern from "opencog/atoms/atom_types/NameServer.h" namespace "opencog":
 cdef extern from "opencog/atoms/atom_types/atom_types.h" namespace "opencog":
     cdef Type NOTYPE
 
+
+# Value
 cdef extern from "opencog/atoms/value/Value.h" namespace "opencog":
     cdef cppclass cValue "opencog::Value":
         Type get_type()
@@ -61,7 +63,8 @@ cdef class Value:
     @staticmethod
     cdef Value create(cValuePtr& shared_ptr)
 
-### TruthValue
+
+# TruthValue
 ctypedef double count_t
 ctypedef double confidence_t
 ctypedef double strength_t
@@ -154,8 +157,8 @@ cdef class Atom:
     @staticmethod
     cdef Atom create(cHandle& handle, AtomSpace a)
 
-# AtomSpace
 
+# AtomSpace
 cdef extern from "opencog/atomspace/AtomSpace.h" namespace "opencog":
     cdef cppclass cAtomSpace "opencog::AtomSpace":
         cAtomSpace()
@@ -210,18 +213,21 @@ cdef extern from "opencog/attentionbank/AttentionBank.h" namespace "opencog":
 
     cdef cAttentionBank attentionbank(cAtomSpace*)
 
+# FloatValue
 cdef extern from "opencog/atoms/value/FloatValue.h" namespace "opencog":
     cdef cppclass cFloatValue "opencog::FloatValue":
         const vector[double]& value() const;
 
     cdef cValuePtr createFloatValue(...)
 
+# StringValue
 cdef extern from "opencog/atoms/value/StringValue.h" namespace "opencog":
     cdef cppclass cStringValue "opencog::StringValue":
         const vector[string]& value() const;
 
     cdef cValuePtr createStringValue(...)
 
+# LinkValue
 cdef extern from "opencog/atoms/value/LinkValue.h" namespace "opencog":
     cdef cppclass cLinkValue "opencog::LinkValue":
         const vector[cValuePtr]& value() const;

--- a/opencog/cython/opencog/atomspace.pxd
+++ b/opencog/cython/opencog/atomspace.pxd
@@ -52,16 +52,16 @@ cdef extern from "opencog/atoms/value/Value.h" namespace "opencog":
 
     ctypedef shared_ptr[cValue] cValuePtr "opencog::ValuePtr"
 
-cdef class ValuePtr:
-    cdef cValuePtr shared_ptr
+cdef class PtrHolder:
+    cdef shared_ptr[void] shared_ptr
     @staticmethod
-    cdef ValuePtr create(cValuePtr& shared_ptr)
+    cdef PtrHolder create(shared_ptr[void]& ptr)
 
 cdef class Value:
-    cdef ValuePtr value_ptr
+    cdef PtrHolder ptr_holder
     cdef cValuePtr get_c_value_ptr(self)
     @staticmethod
-    cdef Value create(cValuePtr& shared_ptr)
+    cdef Value create(cValuePtr& ptr)
 
 
 # TruthValue

--- a/opencog/cython/opencog/atomspace.pxd
+++ b/opencog/cython/opencog/atomspace.pxd
@@ -154,6 +154,7 @@ cdef class Atom(Value):
     cdef object _atom_type
     cdef object _name
     cdef object _outgoing
+    cdef cHandle get_c_handle(Atom self)
     # Cython compiler complains that signature of the method should be
     # compatible with one from the parent class. It is the reason why we cannot
     # have Atom.create and Value.create at same time.

--- a/opencog/cython/opencog/atomspace.pxd
+++ b/opencog/cython/opencog/atomspace.pxd
@@ -148,14 +148,17 @@ cdef extern from "opencog/atoms/base/Handle.h" namespace "opencog":
 # HandleSeq
     cdef cppclass cHandleSeq "opencog::HandleSeq"
 
-cdef class Atom:
-    cdef cHandle *handle
+cdef class Atom(Value):
+    cdef cHandle* handle
     cdef AtomSpace atomspace
     cdef object _atom_type
     cdef object _name
     cdef object _outgoing
+    # Cython compiler complains that signature of the method should be
+    # compatible with one from the parent class. It is the reason why we cannot
+    # have Atom.create and Value.create at same time.
     @staticmethod
-    cdef Atom create(cHandle& handle, AtomSpace a)
+    cdef Atom createAtom(cHandle& handle, AtomSpace a)
 
 
 # AtomSpace

--- a/opencog/cython/opencog/atomspace.pxd
+++ b/opencog/cython/opencog/atomspace.pxd
@@ -67,24 +67,19 @@ ctypedef double confidence_t
 ctypedef double strength_t
 
 cdef extern from "opencog/atoms/truthvalue/TruthValue.h" namespace "opencog":
-    cdef cppclass tv_ptr "std::shared_ptr<const opencog::TruthValue>":
-        tv_ptr()
-        tv_ptr(tv_ptr copy)
-        tv_ptr(cTruthValue* fun)
-        tv_ptr(cSimpleTruthValue* fun)
-        cTruthValue* get()
+    ctypedef shared_ptr[const cTruthValue] tv_ptr "opencog::TruthValuePtr"
 
-    cdef cppclass cTruthValue "const opencog::TruthValue":
+    cdef cppclass cTruthValue "const opencog::TruthValue"(cValue):
         strength_t get_mean()
         confidence_t get_confidence()
         count_t get_count()
+        @staticmethod
         tv_ptr DEFAULT_TV()
-        string to_string()
         bint operator==(cTruthValue h)
         bint operator!=(cTruthValue h)
 
 cdef extern from "opencog/atoms/truthvalue/SimpleTruthValue.h" namespace "opencog":
-    cdef cppclass cSimpleTruthValue "opencog::SimpleTruthValue":
+    cdef cppclass cSimpleTruthValue "opencog::SimpleTruthValue"(cTruthValue):
         cSimpleTruthValue(double, double)
         strength_t get_mean()
         confidence_t get_confidence()
@@ -96,14 +91,12 @@ cdef extern from "opencog/atoms/truthvalue/SimpleTruthValue.h" namespace "openco
         bint operator==(cTruthValue h)
         bint operator!=(cTruthValue h)
 
-cdef class TruthValue:
-    cdef tv_ptr *cobj
+cdef class TruthValue(Value):
     cdef _mean(self)
     cdef _confidence(self)
     cdef _count(self)
     cdef cTruthValue* _ptr(self)
     cdef tv_ptr* _tvptr(self)
-    cdef _init(self, double mean, double count)
 
 
 # Atom

--- a/opencog/cython/opencog/atomspace.pxd
+++ b/opencog/cython/opencog/atomspace.pxd
@@ -17,43 +17,6 @@ cdef extern from "<vector>" namespace "std":
     cdef cppclass output_iterator "back_insert_iterator<vector<opencog::Handle> >"
     cdef output_iterator back_inserter(vector[cHandle])
 
-
-### TruthValue
-ctypedef double count_t
-ctypedef double confidence_t
-ctypedef double strength_t
-
-cdef extern from "opencog/atoms/truthvalue/TruthValue.h" namespace "opencog":
-    cdef cppclass tv_ptr "std::shared_ptr<const opencog::TruthValue>":
-        tv_ptr()
-        tv_ptr(tv_ptr copy)
-        tv_ptr(cTruthValue* fun)
-        tv_ptr(cSimpleTruthValue* fun)
-        cTruthValue* get()
-
-    cdef cppclass cTruthValue "const opencog::TruthValue":
-        strength_t get_mean()
-        confidence_t get_confidence()
-        count_t get_count()
-        tv_ptr DEFAULT_TV()
-        string to_string()
-        bint operator==(cTruthValue h)
-        bint operator!=(cTruthValue h)
-
-cdef extern from "opencog/atoms/truthvalue/SimpleTruthValue.h" namespace "opencog":
-    cdef cppclass cSimpleTruthValue "opencog::SimpleTruthValue":
-        cSimpleTruthValue(double, double)
-        strength_t get_mean()
-        confidence_t get_confidence()
-        count_t get_count()
-        count_t confidenceToCount(double)
-        confidence_t countToConfidence(double)
-        tv_ptr DEFAULT_TV()
-        string to_string()
-        bint operator==(cTruthValue h)
-        bint operator!=(cTruthValue h)
-
-
 # Basic OpenCog types
 # NameServer
 ctypedef short Type
@@ -97,6 +60,51 @@ cdef class Value:
     cdef cValuePtr get_c_value_ptr(self)
     @staticmethod
     cdef Value create(cValuePtr shared_ptr)
+
+### TruthValue
+ctypedef double count_t
+ctypedef double confidence_t
+ctypedef double strength_t
+
+cdef extern from "opencog/atoms/truthvalue/TruthValue.h" namespace "opencog":
+    cdef cppclass tv_ptr "std::shared_ptr<const opencog::TruthValue>":
+        tv_ptr()
+        tv_ptr(tv_ptr copy)
+        tv_ptr(cTruthValue* fun)
+        tv_ptr(cSimpleTruthValue* fun)
+        cTruthValue* get()
+
+    cdef cppclass cTruthValue "const opencog::TruthValue":
+        strength_t get_mean()
+        confidence_t get_confidence()
+        count_t get_count()
+        tv_ptr DEFAULT_TV()
+        string to_string()
+        bint operator==(cTruthValue h)
+        bint operator!=(cTruthValue h)
+
+cdef extern from "opencog/atoms/truthvalue/SimpleTruthValue.h" namespace "opencog":
+    cdef cppclass cSimpleTruthValue "opencog::SimpleTruthValue":
+        cSimpleTruthValue(double, double)
+        strength_t get_mean()
+        confidence_t get_confidence()
+        count_t get_count()
+        count_t confidenceToCount(double)
+        confidence_t countToConfidence(double)
+        tv_ptr DEFAULT_TV()
+        string to_string()
+        bint operator==(cTruthValue h)
+        bint operator!=(cTruthValue h)
+
+cdef class TruthValue:
+    cdef tv_ptr *cobj
+    cdef _mean(self)
+    cdef _confidence(self)
+    cdef _count(self)
+    cdef cTruthValue* _ptr(self)
+    cdef tv_ptr* _tvptr(self)
+    cdef _init(self, double mean, double count)
+
 
 # Atom
 ctypedef public short av_type
@@ -143,15 +151,6 @@ cdef extern from "opencog/atoms/base/Handle.h" namespace "opencog":
         cHandle UNDEFINED
 # HandleSeq
     cdef cppclass cHandleSeq "opencog::HandleSeq"
-
-cdef class TruthValue:
-    cdef tv_ptr *cobj
-    cdef _mean(self)
-    cdef _confidence(self)
-    cdef _count(self)
-    cdef cTruthValue* _ptr(self)
-    cdef tv_ptr* _tvptr(self)
-    cdef _init(self, double mean, double count)
 
 cdef class Atom:
     cdef cHandle *handle

--- a/opencog/cython/opencog/atomspace_details.pyx
+++ b/opencog/cython/opencog/atomspace_details.pyx
@@ -18,7 +18,7 @@ cdef convert_handle_seq_to_python_list(vector[cHandle] handles, AtomSpace atomsp
     handle_iter = handles.begin()
     while handle_iter != handles.end():
         handle = deref(handle_iter)
-        result.append(Atom.create(handle, atomspace))
+        result.append(Atom.createAtom(handle, atomspace))
         inc(handle_iter)
     return result
 
@@ -96,7 +96,7 @@ cdef class AtomSpace:
         cdef cHandle result = self.atomspace.add_node(t, name)
 
         if result == result.UNDEFINED: return None
-        atom = Atom.create(result, self);
+        atom = Atom.createAtom(result, self);
         if tv :
             atom.tv = tv
         return atom
@@ -117,7 +117,7 @@ cdef class AtomSpace:
         cdef cHandle result
         result = self.atomspace.add_link(t, handle_vector)
         if result == result.UNDEFINED: return None
-        atom = Atom.create(result, self);
+        atom = Atom.createAtom(result, self);
         if tv :
             atom.tv = tv
         return atom
@@ -263,7 +263,7 @@ cdef api object py_atomspace(cAtomSpace *c_atomspace) with gil:
     return atomspace
 
 cdef api object py_atom(const cHandle& h, object atomspace):
-    cdef Atom atom = Atom.create(h, atomspace)
+    cdef Atom atom = Atom.createAtom(h, atomspace)
     return atom
 
 def create_child_atomspace(object atomspace):

--- a/opencog/cython/opencog/backwardchainer.pyx
+++ b/opencog/cython/opencog/backwardchainer.pyx
@@ -44,6 +44,6 @@ cdef class BackwardChainer:
 
     def get_results(self):
         cdef cHandle res_handle = self.chainer.get_results()
-        cdef Atom result = Atom.create(res_handle, self._as)
+        cdef Atom result = Atom.createAtom(res_handle, self._as)
         return result
 

--- a/opencog/cython/opencog/bindlink.pyx
+++ b/opencog/cython/opencog/bindlink.pyx
@@ -7,14 +7,14 @@ def af_bindlink(AtomSpace atomspace, Atom atom):
     if atom == None: raise ValueError("af_bindlink atom is: None")
     cdef cHandle c_result = c_af_bindlink(atomspace.atomspace,
                                           deref(atom.handle))
-    cdef Atom result = Atom.create(c_result, atomspace)
+    cdef Atom result = Atom.createAtom(c_result, atomspace)
     return result
 
 def execute_atom(AtomSpace atomspace, Atom atom):
     if atom == None: raise ValueError("execute_atom atom is: None")
     cdef cHandle c_result = c_execute_atom(atomspace.atomspace,
                                            deref(atom.handle))
-    return Atom.create(c_result, atomspace)
+    return Atom.createAtom(c_result, atomspace)
 
 def evaluate_atom(AtomSpace atomspace, Atom atom):
     if atom == None: raise ValueError("evaluate_atom atom is: None")

--- a/opencog/cython/opencog/float_value.pyx
+++ b/opencog/cython/opencog/float_value.pyx
@@ -7,7 +7,7 @@ cdef class FloatValue(Value):
             result = createFloatValue(FloatValue.list_of_doubles_to_vector(arg))
         else:
             result = createFloatValue(<double>arg)
-        super(FloatValue, self).__init__(ValuePtr.create(result))
+        super(FloatValue, self).__init__(PtrHolder.create(<shared_ptr[void]&>result))
 
     def to_list(self):
         return FloatValue.vector_of_doubles_to_list(

--- a/opencog/cython/opencog/link_value.pyx
+++ b/opencog/cython/opencog/link_value.pyx
@@ -7,7 +7,7 @@ cdef class LinkValue(Value):
             result = createLinkValue(LinkValue.list_of_values_to_vector(arg))
         else:
             result = createLinkValue(LinkValue.list_of_values_to_vector([arg]))
-        super(LinkValue, self).__init__(ValuePtr.create(result))
+        super(LinkValue, self).__init__(PtrHolder.create(<shared_ptr[void]&>result))
 
     def to_list(self):
         return LinkValue.vector_of_values_to_list(

--- a/opencog/cython/opencog/scheme_wrapper.pyx
+++ b/opencog/cython/opencog/scheme_wrapper.pyx
@@ -80,7 +80,7 @@ def scheme_eval_h(AtomSpace a, str pys):
     cdef string expr
     expr = pys.encode('UTF-8')
     ret = eval_scheme_h(a.atomspace, expr)
-    return Atom.create(ret, a)
+    return Atom.createAtom(ret, a)
 
 cdef extern from "opencog/cython/opencog/PyScheme.h" namespace "opencog":
     cAtomSpace* eval_scheme_as(const string& s) except +

--- a/opencog/cython/opencog/string_value.pyx
+++ b/opencog/cython/opencog/string_value.pyx
@@ -7,7 +7,7 @@ cdef class StringValue(Value):
             result = createStringValue(StringValue.list_of_strings_to_vector(arg))
         else:
             result = createStringValue(<string>(arg.encode('UTF-8')))
-        super(StringValue, self).__init__(ValuePtr.create(result))
+        super(StringValue, self).__init__(PtrHolder.create(<shared_ptr[void]&>result))
 
     def to_list(self):
         return StringValue.vector_of_strings_to_list(

--- a/opencog/cython/opencog/truth_value.pyx
+++ b/opencog/cython/opencog/truth_value.pyx
@@ -33,13 +33,6 @@ cdef class TruthValue(Value):
     cdef _count(self):
         return self._ptr().get_count()
 
-    def __richcmp__(TruthValue h1, TruthValue h2, int op):
-        " @todo support the rest of the comparison operators"
-        if op == 2: # ==
-            return deref(h1._ptr()) == deref(h2._ptr())
-
-        raise ValueError, "TruthValue does not yet support most comparison operators"
-
     cdef cTruthValue* _ptr(self):
         return <cTruthValue*>(self.get_c_value_ptr().get())
 
@@ -49,18 +42,3 @@ cdef class TruthValue(Value):
     def truth_value_ptr_object(self):
         return PyLong_FromVoidPtr(<void*>self._tvptr())
 
-    def __str__(self):
-        cs = string(self._ptr().to_string().c_str())
-        return cs.decode('UTF-8')
-
-    def __repr__(self):
-        cs = string(self._ptr().to_string().c_str())
-        return cs.decode('UTF-8')
-
-#    @staticmethod
-#    def confidence_to_count(double conf):
-#        return (<cSimpleTruthValue*> 0).confidenceToCount(conf)
-#
-#    @staticmethod
-#    def count_to_confidence(double count):
-#        return (<cSimpleTruthValue*> 0).countToConfidence(count)

--- a/opencog/cython/opencog/truth_value.pyx
+++ b/opencog/cython/opencog/truth_value.pyx
@@ -1,8 +1,8 @@
 from cython.operator cimport dereference as deref
+from libcpp.memory cimport shared_ptr
+from atomspace cimport cTruthValue, cSimpleTruthValue, tv_ptr, Value
 
-from atomspace cimport cTruthValue, tv_ptr
-
-cdef class TruthValue:
+cdef class TruthValue(Value):
     """ The truth value represents the strength and confidence of
         a relationship or term. In OpenCog there are a number of TruthValue
         types, but as these involve additional complexity we focus primarily on
@@ -10,17 +10,10 @@ cdef class TruthValue:
 
         @todo Support IndefiniteTruthValue, DistributionalTV, NullTV etc
     """
-    # This stores a pointer to a smart pointer to the C++ TruthValue object
-    # Declared in atomspace.pxd
-    # cdef tv_ptr *cobj
-
-    def __cinit__(self, strength=1.0, confidence=0.0):
-        # By default create a SimpleTruthValue
-        self.cobj = new tv_ptr(new cSimpleTruthValue(strength, confidence))
-
-    def __dealloc__(self):
-        # This deletes the *smart pointer*, not the actual pointer
-        del self.cobj
+    def __init__(self, strength=1.0, confidence=0.0):
+        cdef tv_ptr c_ptr
+        c_ptr.reset(new cSimpleTruthValue(strength, confidence))
+        super(TruthValue, self).__init__(ValuePtr.create(<cValuePtr&>c_ptr))
 
     property mean:
         def __get__(self): return self._mean()
@@ -40,9 +33,6 @@ cdef class TruthValue:
     cdef _count(self):
         return self._ptr().get_count()
 
-    cdef _init(self, double mean, double confidence):
-        self.cobj = new tv_ptr(new cSimpleTruthValue(mean, confidence))
-
     def __richcmp__(TruthValue h1, TruthValue h2, int op):
         " @todo support the rest of the comparison operators"
         if op == 2: # ==
@@ -51,13 +41,13 @@ cdef class TruthValue:
         raise ValueError, "TruthValue does not yet support most comparison operators"
 
     cdef cTruthValue* _ptr(self):
-        return self.cobj.get()
+        return <cTruthValue*>(self.get_c_value_ptr().get())
 
     cdef tv_ptr* _tvptr(self):
-        return self.cobj
+        return <tv_ptr*>&(self.value_ptr.shared_ptr)
 
     def truth_value_ptr_object(self):
-        return PyLong_FromVoidPtr(<void*>self.cobj)
+        return PyLong_FromVoidPtr(<void*>self._tvptr())
 
     def __str__(self):
         cs = string(self._ptr().to_string().c_str())

--- a/opencog/cython/opencog/truth_value.pyx
+++ b/opencog/cython/opencog/truth_value.pyx
@@ -13,7 +13,7 @@ cdef class TruthValue(Value):
     def __init__(self, strength=1.0, confidence=0.0):
         cdef tv_ptr c_ptr
         c_ptr.reset(new cSimpleTruthValue(strength, confidence))
-        super(TruthValue, self).__init__(ValuePtr.create(<cValuePtr&>c_ptr))
+        super(TruthValue, self).__init__(PtrHolder.create(<shared_ptr[void]&>c_ptr))
 
     property mean:
         def __get__(self): return self._mean()
@@ -37,7 +37,7 @@ cdef class TruthValue(Value):
         return <cTruthValue*>(self.get_c_value_ptr().get())
 
     cdef tv_ptr* _tvptr(self):
-        return <tv_ptr*>&(self.value_ptr.shared_ptr)
+        return <tv_ptr*>&(self.ptr_holder.shared_ptr)
 
     def truth_value_ptr_object(self):
         return PyLong_FromVoidPtr(<void*>self._tvptr())

--- a/opencog/cython/opencog/type_constructors.pyx
+++ b/opencog/cython/opencog/type_constructors.pyx
@@ -8,11 +8,6 @@
 #
 
 from opencog.atomspace import AtomSpace, types
-from atomspace cimport (cValuePtr, createFloatValue, createStringValue,
-                        createLinkValue, Value, cValuePtr)
-from libcpp.vector cimport vector
-from libcpp.string cimport string
-
 from opencog.atomspace import TruthValue, FloatValue, StringValue, LinkValue
 
 atomspace = None

--- a/opencog/cython/opencog/value.pyx
+++ b/opencog/cython/opencog/value.pyx
@@ -8,7 +8,7 @@ cdef class ValuePtr:
     http://docs.cython.org/en/latest/src/userguide/extension_types.html#instantiation-from-existing-c-c-pointers)."""
 
     @staticmethod
-    cdef ValuePtr create(cValuePtr shared_ptr):
+    cdef ValuePtr create(cValuePtr& shared_ptr):
         """Factory method to construct ValuePtr from C++ cValuePtr"""
         cdef ValuePtr value_ptr = ValuePtr.__new__(ValuePtr)
         value_ptr.shared_ptr = shared_ptr
@@ -18,7 +18,7 @@ cdef class Value:
     """C++ Value object wrapper for Python clients"""
 
     @staticmethod
-    cdef Value create(cValuePtr shared_ptr):
+    cdef Value create(cValuePtr& shared_ptr):
         """Factory method to construct Value from C++ cValuePtr using ValuePtr
         instance."""
         return Value(ValuePtr.create(shared_ptr))

--- a/opencog/cython/opencog/value.pyx
+++ b/opencog/cython/opencog/value.pyx
@@ -1,36 +1,36 @@
 from cpython.object cimport Py_EQ, Py_NE
 
-cdef class ValuePtr:
-    """C++ ValuePtr object wrapper for Python clients. Cython cannot create
+cdef class PtrHolder:
+    """C++ shared_ptr object wrapper for Python clients. Cython cannot create
     Python object constructor which gets C++ pointer. This class is used to
     wrap pointer and make it possible to initialize Value in usual
     constructor (see
     http://docs.cython.org/en/latest/src/userguide/extension_types.html#instantiation-from-existing-c-c-pointers)."""
 
     @staticmethod
-    cdef ValuePtr create(cValuePtr& shared_ptr):
-        """Factory method to construct ValuePtr from C++ cValuePtr"""
-        cdef ValuePtr value_ptr = ValuePtr.__new__(ValuePtr)
-        value_ptr.shared_ptr = shared_ptr
-        return value_ptr
+    cdef PtrHolder create(shared_ptr[void]& ptr):
+        """Factory method to construct PtrHolder from C++ shared_ptr"""
+        cdef PtrHolder ptr_holder = PtrHolder.__new__(PtrHolder)
+        ptr_holder.shared_ptr = ptr
+        return ptr_holder
 
 cdef class Value:
     """C++ Value object wrapper for Python clients"""
 
     @staticmethod
-    cdef Value create(cValuePtr& shared_ptr):
-        """Factory method to construct Value from C++ cValuePtr using ValuePtr
-        instance."""
-        return Value(ValuePtr.create(shared_ptr))
+    cdef Value create(cValuePtr& ptr):
+        """Factory method to construct Value from C++ cValuePtr using
+        PtrHolder instance."""
+        return Value(PtrHolder.create(<shared_ptr[void]&>ptr))
 
-    def __init__(self, value_ptr):
-        if (<ValuePtr>value_ptr).shared_ptr.get() == NULL:
-            raise AttributeError('ValuePtr contains NULL reference')
-        self.value_ptr = value_ptr
+    def __init__(self, ptr_holder):
+        if (<PtrHolder>ptr_holder).shared_ptr.get() == NULL:
+            raise AttributeError('PtrHolder contains NULL reference')
+        self.ptr_holder = ptr_holder
 
     cdef cValuePtr get_c_value_ptr(self):
-        """Return C++ ValuePtr instance"""
-        return self.value_ptr.shared_ptr
+        """Return C++ shared_ptr from PtrHolder instance"""
+        return <cValuePtr&>(self.ptr_holder.shared_ptr)
 
     property type:
          def __get__(self):


### PR DESCRIPTION
- replace `ValuePtr` by general `PtrHolder`
- make `TruthValue` and `Atom` children of `Value`
- some code cleanup