### PR TITLE
Fix a trivial pattern match.

### DIFF
--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -75,8 +75,14 @@ void PatternLink::common_init(void)
 	// we are being run with the DefaultPatternMatchCB, and so we assume
 	// that the logical connectives are AndLink, OrLink and NotLink.
 	// Tweak the evaluatable_holders to reflect this.
+	// XXX FIXME; long-term, this should be replaced by a check to
+	// see if a link inherits from EvaluatableLink. However, this can
+	// only be done after all existing BindLinks have been converted to
+	// use PresentLink... so this might not be practical to fix, for a
+	// while.
 	TypeSet connectives({AND_LINK, SEQUENTIAL_AND_LINK,
-	                     OR_LINK, SEQUENTIAL_OR_LINK, NOT_LINK});
+	                     OR_LINK, SEQUENTIAL_OR_LINK,
+	                     NOT_LINK, TRUE_LINK, FALSE_LINK});
 
 	// Icky. Yuck. Some pre-historic API's do not set the pattern body.
 	// These appear only in the unit tests, never in real code. For now,

--- a/opencog/query/DefaultPatternMatchCB.cc
+++ b/opencog/query/DefaultPatternMatchCB.cc
@@ -685,7 +685,7 @@ bool DefaultPatternMatchCB::eval_term(const Handle& virt,
 /* ======================================================== */
 
 /**
- * This implements the evaluation of a classical boolean-logic
+ * This implements the evaluation of a classical binary-logic
  * "sentence": a well-formed formula with no free variables,
  * having a crisp true/false truth value.  Here, "top" holds
  * the sentence (with variables), 'gnds' holds the bindings of
@@ -709,9 +709,6 @@ bool DefaultPatternMatchCB::eval_sentence(const Handle& top,
 	            top->to_short_string().c_str());
 
 	const HandleSeq& oset = top->getOutgoingSet();
-	if (0 == oset.size())
-		throw InvalidParamException(TRACE_INFO,
-		   "Expecting logical connective to have at least one child!");
 
 	Type term_type = top->get_type();
 	if (OR_LINK == term_type or SEQUENTIAL_OR_LINK == term_type)
@@ -798,8 +795,8 @@ bool DefaultPatternMatchCB::eval_sentence(const Handle& top,
 	// If we are here, then what we have is some atom that is not
 	// normally "truth-valued". We can do one of three things:
 	// a) Throw an exception and complain.
-	// b) Invent a new link type: GetTruthValueLink, that 'returns'
-	//    the TV of the atom that it wraps.
+	// b) Tell user that they must use the TruthValueOfLink, which
+	//   'returns' the TV of the atom that it wraps.
 	// c) Do the above, without inventing a new link type.
 	// The below implements choice (c): i.e. it gets the TV of this
 	// atom, and checks to see if it is greater than 0.5 or not.

--- a/tests/query/SequenceUTest.cxxtest
+++ b/tests/query/SequenceUTest.cxxtest
@@ -50,8 +50,6 @@ public:
 		// Erase the log file if no assertions failed.
 		if (!CxxTest::TestTracker::tracker().suiteFailed())
 			std::remove(logger().get_filename().c_str());
-int rc = CxxTest::TestTracker::tracker().suiteFailed();
-_exit(rc); // XXX hack to avoid double-free in __run_exit_handlers
 	}
 
 	void setUp(void);

--- a/tests/query/SequenceUTest.cxxtest
+++ b/tests/query/SequenceUTest.cxxtest
@@ -59,6 +59,7 @@ public:
 	void test_presence(void);
 	void test_fallback(void);
 	void test_pass_presence(void);
+	void test_trivial(void);
 	void test_or_put(void);
 };
 
@@ -257,6 +258,32 @@ void SequenceUTest::test_pass_presence(void)
 #endif
 
 	// ----
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+/*
+ * Trivial SequenceLink unit test.
+ * Actually, this is testing BindLink, as a surrogate for a trivial
+ * SequenceLink. This trivial case was failing yesterday... :-/
+ */
+void SequenceUTest::test_trivial(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	eval->eval("(load-from-path \"tests/query/seq-trivial.scm\")");
+
+	Handle result = eval->eval_h("(cog-execute! get-something)");
+	TS_ASSERT_EQUALS(result->get_arity(), 1);
+
+	result = eval->eval_h("(cog-execute! get-nothing)");
+	TS_ASSERT_EQUALS(result->get_arity(), 0);
+
+	result = eval->eval_h("(cog-execute! get-not-true)");
+	TS_ASSERT_EQUALS(result->get_arity(), 0);
+
+	result = eval->eval_h("(cog-execute! get-not-false)");
+	TS_ASSERT_EQUALS(result->get_arity(), 1);
+
 	logger().debug("END TEST: %s", __FUNCTION__);
 }
 

--- a/tests/query/seq-absence.scm
+++ b/tests/query/seq-absence.scm
@@ -12,6 +12,20 @@
 
 ; ------------------------------------------------------
 
+; Unit test makes the PresentLink true
+(define or-visible-put
+	(SatisfactionLink
+		;; SequentialOrLink - verify predicates in sequential order.
+		(SequentialOrLink
+			(PresentLink (EvaluationLink (PredicateNode "yes-visible")
+					(ListLink (VariableNode "$x"))))
+			;; If above fails then set state
+			(TrueLink (PutLink
+					(StateLink (AnchorNode "state") (VariableNode "$yy"))
+					(ConceptNode "ohhh noot visible")))
+		)))
+
+; Same as above, except unit test makes the PresentLink false
 (define or-put
 	(SatisfactionLink
 		;; SequentialOrLink - verify predicates in sequential order.
@@ -24,17 +38,6 @@
 					(ConceptNode "not-vis")))
 		)))
 
-(define or-visible-put
-	(SatisfactionLink
-		;; SequentialOrLink - verify predicates in sequential order.
-		(SequentialOrLink
-			(PresentLink (EvaluationLink (PredicateNode "yes-visible")
-					(ListLink (VariableNode "$x"))))
-			;; If above fails then set state
-			(TrueLink (PutLink
-					(StateLink (AnchorNode "state") (VariableNode "$yy"))
-					(ConceptNode "ohhh noot visible")))
-		)))
 
 (define trig 0)
 (define (incr-trig) (set! trig (+ trig 1)) (stv 1 1))

--- a/tests/query/seq-trivial.scm
+++ b/tests/query/seq-trivial.scm
@@ -1,0 +1,9 @@
+;
+; Some trivial sequences.
+
+(use-modules (opencog) (opencog exec))
+
+(define get-something (Bind (True) (Concept "it's true")))
+(define get-nothing   (Bind (False) (Concept "it's false")))
+(define get-not-true  (Bind (Not (True)) (Concept "it's not true")))
+(define get-not-false (Bind (Not (False)) (Concept "it's not false")))


### PR DESCRIPTION
Curiously, the trivial query `(cog-execute! (Bind (False) (Concept "it's false")))` was broken.