### PR TITLE
Return correct value class from atom

### DIFF
--- a/examples/atomspace/my_py_func.py
+++ b/examples/atomspace/my_py_func.py
@@ -5,8 +5,9 @@
 # example. The code below is called, when a GroundedSchemaNode and
 # a GroundedPredicateNode is triggered.
 #
-from opencog.atomspace import AtomSpace, TruthValue
+from opencog.atomspace import AtomSpace
 from opencog.atomspace import types
+from opencog.type_constructors import TruthValue
 
 asp = AtomSpace()
 

--- a/examples/atomspace/python.scm
+++ b/examples/atomspace/python.scm
@@ -27,8 +27,9 @@
 ; whitespace indentation is used to define a multi-line block of python
 ; code.
 (python-eval "
-from opencog.atomspace import AtomSpace, TruthValue
+from opencog.atomspace import AtomSpace
 from opencog.atomspace import types
+from opencog.type_constructors import TruthValue
 
 def foo(atspace):
     TV = TruthValue(0.42, 0.69)
@@ -50,7 +51,7 @@ def foo(atspace):
 ; using (in the current thread).
 (python-eval "
 from opencog.scheme_wrapper import scheme_eval_as
-from opencog.atomspace import TruthValue
+from opencog.type_constructors import TruthValue
 from opencog.atomspace import types
 
 # Get the atomspace...

--- a/examples/python/create_atoms_by_type.py
+++ b/examples/python/create_atoms_by_type.py
@@ -7,8 +7,9 @@ Simple example of how to create atoms in the AtomSpace.
 See also create_atomspace_simple.py for an alternate interface.
 """
 
-from opencog.atomspace import AtomSpace, TruthValue, Atom
+from opencog.atomspace import AtomSpace, Atom
 from opencog.atomspace import types
+from opencog.type_constructors import TruthValue
 
 a = AtomSpace()
 

--- a/examples/python/create_atoms_simple.py
+++ b/examples/python/create_atoms_simple.py
@@ -7,7 +7,7 @@ A simple way of creating atoms in the AtomSpace.
 See also create_stoms_by_type.py for an alternate API for atoms.
 """
 
-from opencog.atomspace import AtomSpace, TruthValue
+from opencog.atomspace import AtomSpace
 from opencog.atomspace import types
 from opencog.type_constructors import *
 

--- a/examples/python/ground/ground.py
+++ b/examples/python/ground/ground.py
@@ -1,5 +1,5 @@
 import sys
-from opencog.atomspace import AtomSpace, TruthValue
+from opencog.atomspace import AtomSpace
 from opencog.atomspace import types
 from opencog.type_constructors import *
 from opencog.bindlink import execute_atom

--- a/examples/python/scheme/scheme_timer.py
+++ b/examples/python/scheme/scheme_timer.py
@@ -9,8 +9,9 @@ total execution time
 
 __author__ = 'Cosmo Harrigan'
 
-from opencog.atomspace import AtomSpace, TruthValue
+from opencog.atomspace import AtomSpace
 from opencog.scheme_wrapper import scheme_eval, scheme_eval_h
+from opencog.type_constructors import TruthValue
 atomspace = AtomSpace()
 
 NUMBER_OF_ITERATIONS = 50000

--- a/examples/python/stop_go.py
+++ b/examples/python/stop_go.py
@@ -18,7 +18,7 @@ matcher. When a match is seen, the matcher moves on to the next
 clause.
 """
 
-from opencog.atomspace import AtomSpace, TruthValue, types, get_type_name
+from opencog.atomspace import AtomSpace, types, get_type_name
 from opencog.bindlink import satisfaction_link
 from opencog.type_constructors import *
 from opencog.logger import Logger, log

--- a/examples/python/values.py
+++ b/examples/python/values.py
@@ -6,7 +6,7 @@
 An example of using values via Python API
 """
 
-from opencog.atomspace import AtomSpace, TruthValue
+from opencog.atomspace import AtomSpace
 from opencog.type_constructors import *
 from opencog.scheme_wrapper import scheme_eval_v
 

--- a/opencog/cython/opencog/atom.pyx
+++ b/opencog/cython/opencog/atom.pyx
@@ -24,8 +24,7 @@ cdef class Atom(Value):
         UNDEFINED or doesn't exist in AtomSpace """
         if self.handle:
             return self.atomspace.is_valid(self)
-        else:
-            return False
+        return False
 
     property atomspace:
         def __get__(self):

--- a/opencog/cython/opencog/atom.pyx
+++ b/opencog/cython/opencog/atom.pyx
@@ -53,7 +53,7 @@ cdef class Atom(Value):
             tvp = atom_ptr.getTruthValue()
             if (not tvp.get()):
                 raise AttributeError('cAtom returned NULL TruthValue pointer')
-            return TruthValue(tvp.get().get_mean(), tvp.get().get_confidence())
+            return createTruthValue(tvp.get().get_mean(), tvp.get().get_confidence())
 
         def __set__(self, truth_value):
             try:
@@ -210,7 +210,7 @@ cdef class Atom(Value):
         return convert_handle_seq_to_python_list(handle_vector, self.atomspace)
 
     def truth_value(self, mean, count):
-        self.tv = TruthValue(mean, count)
+        self.tv = createTruthValue(mean, count)
         return self
 
     def handle_ptr(self):

--- a/opencog/cython/opencog/atom.pyx
+++ b/opencog/cython/opencog/atom.pyx
@@ -164,10 +164,11 @@ cdef class Atom(Value):
     def get_value(self, key):
         cdef cValuePtr value = self.get_c_handle().get().getValue(
             deref((<Atom>key).handle))
-        if (value != NULL):
-            return Value.create(value)
-        else:
+        if value.get() == NULL:
             return None
+        return create_value_by_type(value.get().get_type(),
+                                    PtrHolder.create(<shared_ptr[void]&>value),
+                                    self.atomspace)
 
     def get_out(self):
         cdef cAtom* atom_ptr = self.handle.atom_ptr()

--- a/opencog/cython/opencog/atomspace.pxd
+++ b/opencog/cython/opencog/atomspace.pxd
@@ -36,7 +36,6 @@ cdef extern from "opencog/atoms/atom_types/NameServer.h" namespace "opencog":
 cdef extern from "opencog/atoms/atom_types/atom_types.h" namespace "opencog":
     cdef Type NOTYPE
 
-
 # Value
 cdef extern from "opencog/atoms/value/Value.h" namespace "opencog":
     cdef cppclass cValue "opencog::Value":
@@ -220,20 +219,20 @@ cdef extern from "opencog/attentionbank/AttentionBank.h" namespace "opencog":
 # FloatValue
 cdef extern from "opencog/atoms/value/FloatValue.h" namespace "opencog":
     cdef cppclass cFloatValue "opencog::FloatValue":
-        const vector[double]& value() const;
-
-    cdef cValuePtr createFloatValue(...)
+        cFloatValue(double value)
+        cFloatValue(const vector[double]& values)
+        const vector[double]& value() const
 
 # StringValue
 cdef extern from "opencog/atoms/value/StringValue.h" namespace "opencog":
     cdef cppclass cStringValue "opencog::StringValue":
-        const vector[string]& value() const;
-
-    cdef cValuePtr createStringValue(...)
+        cStringValue(const string& value)
+        cStringValue(const vector[string]& values)
+        const vector[string]& value() const
 
 # LinkValue
 cdef extern from "opencog/atoms/value/LinkValue.h" namespace "opencog":
     cdef cppclass cLinkValue "opencog::LinkValue":
-        const vector[cValuePtr]& value() const;
+        cLinkValue(const vector[cValuePtr]& values)
+        const vector[cValuePtr]& value() const
 
-    cdef cValuePtr createLinkValue(...)

--- a/opencog/cython/opencog/backwardchainer.pyx
+++ b/opencog/cython/opencog/backwardchainer.pyx
@@ -1,6 +1,6 @@
 from cython.operator cimport dereference as deref
 from opencog.atomspace cimport Atom
-from opencog.atomspace cimport cHandle, AtomSpace, TruthValue
+from opencog.atomspace cimport cHandle, AtomSpace
 from opencog.atomspace import types
 from backwardchainer cimport cBackwardChainer
 

--- a/opencog/cython/opencog/bindlink.pyx
+++ b/opencog/cython/opencog/bindlink.pyx
@@ -1,7 +1,8 @@
-from opencog.atomspace cimport Atom, AtomSpace, TruthValue
+from opencog.atomspace cimport Atom, AtomSpace
 from opencog.atomspace cimport cHandle, cAtomSpace, cTruthValue
 from opencog.atomspace cimport tv_ptr, strength_t, count_t
 from cython.operator cimport dereference as deref
+from opencog.type_constructors import TruthValue
 
 def af_bindlink(AtomSpace atomspace, Atom atom):
     if atom == None: raise ValueError("af_bindlink atom is: None")

--- a/opencog/cython/opencog/float_value.pyx
+++ b/opencog/cython/opencog/float_value.pyx
@@ -1,13 +1,16 @@
 
+def createFloatValue(arg):
+    cdef shared_ptr[cFloatValue] c_ptr
+    if (isinstance(arg, list)):
+        c_ptr.reset(new cFloatValue(FloatValue.list_of_doubles_to_vector(arg)))
+    else:
+        c_ptr.reset(new cFloatValue(<double>arg))
+    return FloatValue(PtrHolder.create(<shared_ptr[void]&>c_ptr))
+
 cdef class FloatValue(Value):
 
-    def __init__(self, arg):
-        cdef cValuePtr result
-        if (isinstance(arg, list)):
-            result = createFloatValue(FloatValue.list_of_doubles_to_vector(arg))
-        else:
-            result = createFloatValue(<double>arg)
-        super(FloatValue, self).__init__(PtrHolder.create(<shared_ptr[void]&>result))
+    def __init__(self, ptr_holder):
+        super(FloatValue, self).__init__(ptr_holder)
 
     def to_list(self):
         return FloatValue.vector_of_doubles_to_list(

--- a/opencog/cython/opencog/link_value.pyx
+++ b/opencog/cython/opencog/link_value.pyx
@@ -1,13 +1,16 @@
 
+def createLinkValue(arg):
+    cdef shared_ptr[cLinkValue] c_ptr
+    if (isinstance(arg, list)):
+        c_ptr.reset(new cLinkValue(LinkValue.list_of_values_to_vector(arg)))
+    else:
+        c_ptr.reset(new cLinkValue(LinkValue.list_of_values_to_vector([arg])))
+    return LinkValue(PtrHolder.create(<shared_ptr[void]&>c_ptr))
+
 cdef class LinkValue(Value):
 
-    def __init__(self, arg):
-        cdef cValuePtr result
-        if (isinstance(arg, list)):
-            result = createLinkValue(LinkValue.list_of_values_to_vector(arg))
-        else:
-            result = createLinkValue(LinkValue.list_of_values_to_vector([arg]))
-        super(LinkValue, self).__init__(PtrHolder.create(<shared_ptr[void]&>result))
+    def __init__(self, ptr_holder):
+        super(LinkValue, self).__init__(ptr_holder)
 
     def to_list(self):
         return LinkValue.vector_of_values_to_list(

--- a/opencog/cython/opencog/string_value.pyx
+++ b/opencog/cython/opencog/string_value.pyx
@@ -1,13 +1,16 @@
 
+def createStringValue(arg):
+    cdef shared_ptr[cStringValue] c_ptr
+    if (isinstance(arg, list)):
+        c_ptr.reset(new cStringValue(StringValue.list_of_strings_to_vector(arg)))
+    else:
+        c_ptr.reset(new cStringValue(<string>(arg.encode('UTF-8'))))
+    return StringValue(PtrHolder.create(<shared_ptr[void]&>c_ptr))
+
 cdef class StringValue(Value):
 
-    def __init__(self, arg):
-        cdef cValuePtr result
-        if (isinstance(arg, list)):
-            result = createStringValue(StringValue.list_of_strings_to_vector(arg))
-        else:
-            result = createStringValue(<string>(arg.encode('UTF-8')))
-        super(StringValue, self).__init__(PtrHolder.create(<shared_ptr[void]&>result))
+    def __init__(self, ptr_holder):
+        super(StringValue, self).__init__(ptr_holder)
 
     def to_list(self):
         return StringValue.vector_of_strings_to_list(

--- a/opencog/cython/opencog/truth_value.pyx
+++ b/opencog/cython/opencog/truth_value.pyx
@@ -2,6 +2,11 @@ from cython.operator cimport dereference as deref
 from libcpp.memory cimport shared_ptr
 from atomspace cimport cTruthValue, cSimpleTruthValue, tv_ptr, Value
 
+def createTruthValue(strength = 1.0, confidence = 1.0):
+    cdef tv_ptr c_ptr
+    c_ptr.reset(new cSimpleTruthValue(strength, confidence))
+    return TruthValue(PtrHolder.create(<shared_ptr[void]&>c_ptr))
+
 cdef class TruthValue(Value):
     """ The truth value represents the strength and confidence of
         a relationship or term. In OpenCog there are a number of TruthValue
@@ -10,10 +15,8 @@ cdef class TruthValue(Value):
 
         @todo Support IndefiniteTruthValue, DistributionalTV, NullTV etc
     """
-    def __init__(self, strength=1.0, confidence=0.0):
-        cdef tv_ptr c_ptr
-        c_ptr.reset(new cSimpleTruthValue(strength, confidence))
-        super(TruthValue, self).__init__(PtrHolder.create(<shared_ptr[void]&>c_ptr))
+    def __init__(self, ptr_holder):
+        super(TruthValue, self).__init__(ptr_holder)
 
     property mean:
         def __get__(self): return self._mean()

--- a/opencog/cython/opencog/type_constructors.pyx
+++ b/opencog/cython/opencog/type_constructors.pyx
@@ -7,8 +7,9 @@
 # This imports all the python wrappers for atom creation.
 #
 
+from opencog.atomspace import (createFloatValue, createLinkValue,
+                                createStringValue, createTruthValue)
 from opencog.atomspace import AtomSpace, types
-from opencog.atomspace import TruthValue, FloatValue, StringValue, LinkValue
 
 atomspace = None
 def set_type_ctor_atomspace(new_atomspace):
@@ -16,3 +17,15 @@ def set_type_ctor_atomspace(new_atomspace):
     atomspace = new_atomspace
 
 include "opencog/atoms/atom_types/core_types.pyx"
+
+def FloatValue(arg):
+    return createFloatValue(arg)
+
+def LinkValue(arg):
+    return createLinkValue(arg)
+
+def StringValue(arg):
+    return createStringValue(arg)
+
+def TruthValue(strength=1.0, confidence=1.0):
+    return createTruthValue(strength, confidence)

--- a/opencog/scm/opencog/python.scm
+++ b/opencog/scm/opencog/python.scm
@@ -31,8 +31,9 @@
 
     A more complicated example:
       (python-eval \"
-      from opencog.atomspace import AtomSpace, TruthValue
+      from opencog.atomspace import AtomSpace
       from opencog.atomspace import types
+      from opencog.type_constructors import TruthValue
 
       def foo(asp):
           TV = TruthValue(0.42, 0.69)

--- a/tests/cython/PythonEvalUTest.cxxtest
+++ b/tests/cython/PythonEvalUTest.cxxtest
@@ -255,7 +255,8 @@ public:
 
         // Define python functions for use by scheme.
         python->eval(
-            "from opencog.atomspace import types, Atom, TruthValue\n"
+            "from opencog.atomspace import types, Atom\n"
+            "from opencog.type_constructors import TruthValue\n"
             "def add_link(atom1, atom2):\n"
             "    link = ATOMSPACE.add_link(types.ListLink, [atom1, atom2])\n"
             "    print ('add_link(',atom1,',',atom2,') = ', link)\n"

--- a/tests/cython/atomspace/test_atom.py
+++ b/tests/cython/atomspace/test_atom.py
@@ -1,0 +1,27 @@
+from unittest import TestCase
+
+from opencog.atomspace import AtomSpace, Atom
+from opencog.atomspace import types, is_a, get_type, get_type_name, create_child_atomspace
+
+from opencog.type_constructors import *
+from opencog.utilities import initialize_opencog, finalize_opencog
+
+from time import sleep
+
+class AtomTest(TestCase):
+
+    def setUp(self):
+        self.space = AtomSpace()
+        initialize_opencog(self.space)
+
+    def tearDown(self):
+        finalize_opencog()
+        del self.space
+
+    def test_get_value(self):
+        atom = ConceptNode('foo')
+        key = PredicateNode('bar')
+        value = FloatValue([1.0, 2.0, 3.0])
+        atom.set_value(key, value)
+        self.assertEqual(value.__class__, atom.get_value(key).__class__)
+

--- a/tests/cython/atomspace/test_atomspace.py
+++ b/tests/cython/atomspace/test_atomspace.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from opencog.atomspace import AtomSpace, TruthValue, Atom
+from opencog.atomspace import AtomSpace, Atom
 from opencog.atomspace import types, is_a, get_type, get_type_name, create_child_atomspace
 
 from opencog.type_constructors import *

--- a/tests/cython/backwardchainer/test_bc.py
+++ b/tests/cython/backwardchainer/test_bc.py
@@ -1,7 +1,6 @@
 import os
 from unittest import TestCase
 from opencog.scheme_wrapper import scheme_eval
-from opencog.atomspace import TruthValue
 from opencog.backwardchainer import BackwardChainer
 from opencog.type_constructors import *
 from opencog.utilities import initialize_opencog

--- a/tests/cython/bindlink/bindlink.py
+++ b/tests/cython/bindlink/bindlink.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 import os
 
-from opencog.atomspace import AtomSpace, TruthValue, Atom, types
+from opencog.atomspace import AtomSpace, Atom, types
 from opencog.bindlink import    stub_bindlink, bindlink, single_bindlink,\
                                 af_bindlink, execute_atom, evaluate_atom
 from opencog.utilities import initialize_opencog, finalize_opencog

--- a/tests/cython/bindlink/test_bindlink.py
+++ b/tests/cython/bindlink/test_bindlink.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 import os
 
-from opencog.atomspace import AtomSpace, TruthValue, Atom, types
+from opencog.atomspace import AtomSpace, Atom, types
 from opencog.bindlink import af_bindlink, execute_atom, evaluate_atom
 
 from opencog.type_constructors import *

--- a/tests/cython/bindlink/test_functions.py
+++ b/tests/cython/bindlink/test_functions.py
@@ -1,7 +1,7 @@
 # 
 # Test Functions
 
-from opencog.atomspace import types, Atom, TruthValue
+from opencog.atomspace import types, Atom
 from opencog.type_constructors import *
 
 def print_arguments(argOne, argTwo):

--- a/tests/cython/guile/test_pattern.py
+++ b/tests/cython/guile/test_pattern.py
@@ -1,8 +1,9 @@
 from unittest import TestCase
 
-from opencog.atomspace import AtomSpace, TruthValue, Atom
+from opencog.atomspace import AtomSpace, Atom
 from opencog.atomspace import types, is_a, get_type, get_type_name
 from opencog.scheme_wrapper import load_scm, scheme_eval, scheme_eval_h
+from opencog.type_constructors import TruthValue
 import os
 
 

--- a/tests/scm/scm-python-arity.scm
+++ b/tests/scm/scm-python-arity.scm
@@ -14,8 +14,8 @@
 
 ; Define a python func returning a TV
 (python-eval "
-from opencog.atomspace import AtomSpace, TruthValue, types
-from opencog.type_constructors import atomspace
+from opencog.atomspace import AtomSpace, types
+from opencog.type_constructors import atomspace, TruthValue
 
 # Twiddle some atoms in the atomspace
 def foo(atom_a, atom_b) :

--- a/tests/scm/scm-python-shared-atomspace.scm
+++ b/tests/scm/scm-python-shared-atomspace.scm
@@ -16,8 +16,8 @@
 
 ; Define a python func returning a TV
 (python-eval "
-from opencog.atomspace import AtomSpace, TruthValue, types
-from opencog.type_constructors import atomspace
+from opencog.atomspace import AtomSpace, types
+from opencog.type_constructors import atomspace, TruthValue
 
 # Twiddle some atoms in the atomspace
 def foo(atom_a, atom_b):


### PR DESCRIPTION
NB: This PR breaks compatibility as it moves TruthValue type constructor to the `opencog.type_constructors` package. Similar changes in `opencog` repository are required.
- move `TruthValue` type constructor into `opencog.type_constructors` package
- add values constructor to construct from c shared_ptr
- add separate type constructors to construct from Python values 
- return correct value class from `Atom.get_value`
- add unit test to check that `Atom.get_value` returns correct type