### PR TITLE
Return correct value class from atom

### DIFF
--- a/opencog/cython/opencog/atom.pyx
+++ b/opencog/cython/opencog/atom.pyx
@@ -24,8 +24,7 @@ cdef class Atom(Value):
         UNDEFINED or doesn't exist in AtomSpace """
         if self.handle:
             return self.atomspace.is_valid(self)
-        else:
-            return False
+        return False
 
     property atomspace:
         def __get__(self):

--- a/opencog/cython/opencog/atom.pyx
+++ b/opencog/cython/opencog/atom.pyx
@@ -53,7 +53,7 @@ cdef class Atom(Value):
             tvp = atom_ptr.getTruthValue()
             if (not tvp.get()):
                 raise AttributeError('cAtom returned NULL TruthValue pointer')
-            return TruthValue(tvp.get().get_mean(), tvp.get().get_confidence())
+            return createTruthValue(tvp.get().get_mean(), tvp.get().get_confidence())
 
         def __set__(self, truth_value):
             try:
@@ -210,7 +210,7 @@ cdef class Atom(Value):
         return convert_handle_seq_to_python_list(handle_vector, self.atomspace)
 
     def truth_value(self, mean, count):
-        self.tv = TruthValue(mean, count)
+        self.tv = createTruthValue(mean, count)
         return self
 
     def handle_ptr(self):

--- a/opencog/cython/opencog/atom.pyx
+++ b/opencog/cython/opencog/atom.pyx
@@ -164,10 +164,11 @@ cdef class Atom(Value):
     def get_value(self, key):
         cdef cValuePtr value = self.get_c_handle().get().getValue(
             deref((<Atom>key).handle))
-        if (value != NULL):
-            return Value.create(value)
-        else:
+        if value.get() == NULL:
             return None
+        return create_value_by_type(value.get().get_type(),
+                                    PtrHolder.create(<shared_ptr[void]&>value),
+                                    self.atomspace)
 
     def get_out(self):
         cdef cAtom* atom_ptr = self.handle.atom_ptr()

--- a/opencog/cython/opencog/atomspace.pxd
+++ b/opencog/cython/opencog/atomspace.pxd
@@ -36,7 +36,6 @@ cdef extern from "opencog/atoms/atom_types/NameServer.h" namespace "opencog":
 cdef extern from "opencog/atoms/atom_types/atom_types.h" namespace "opencog":
     cdef Type NOTYPE
 
-
 # Value
 cdef extern from "opencog/atoms/value/Value.h" namespace "opencog":
     cdef cppclass cValue "opencog::Value":
@@ -220,20 +219,20 @@ cdef extern from "opencog/attentionbank/AttentionBank.h" namespace "opencog":
 # FloatValue
 cdef extern from "opencog/atoms/value/FloatValue.h" namespace "opencog":
     cdef cppclass cFloatValue "opencog::FloatValue":
-        const vector[double]& value() const;
-
-    cdef cValuePtr createFloatValue(...)
+        cFloatValue(double value)
+        cFloatValue(const vector[double]& values)
+        const vector[double]& value() const
 
 # StringValue
 cdef extern from "opencog/atoms/value/StringValue.h" namespace "opencog":
     cdef cppclass cStringValue "opencog::StringValue":
-        const vector[string]& value() const;
-
-    cdef cValuePtr createStringValue(...)
+        cStringValue(const string& value)
+        cStringValue(const vector[string]& values)
+        const vector[string]& value() const
 
 # LinkValue
 cdef extern from "opencog/atoms/value/LinkValue.h" namespace "opencog":
     cdef cppclass cLinkValue "opencog::LinkValue":
-        const vector[cValuePtr]& value() const;
+        cLinkValue(const vector[cValuePtr]& values)
+        const vector[cValuePtr]& value() const
 
-    cdef cValuePtr createLinkValue(...)

--- a/opencog/cython/opencog/float_value.pyx
+++ b/opencog/cython/opencog/float_value.pyx
@@ -1,13 +1,16 @@
 
+def createFloatValue(arg):
+    cdef shared_ptr[cFloatValue] c_ptr
+    if (isinstance(arg, list)):
+        c_ptr.reset(new cFloatValue(FloatValue.list_of_doubles_to_vector(arg)))
+    else:
+        c_ptr.reset(new cFloatValue(<double>arg))
+    return FloatValue(PtrHolder.create(<shared_ptr[void]&>c_ptr))
+
 cdef class FloatValue(Value):
 
-    def __init__(self, arg):
-        cdef cValuePtr result
-        if (isinstance(arg, list)):
-            result = createFloatValue(FloatValue.list_of_doubles_to_vector(arg))
-        else:
-            result = createFloatValue(<double>arg)
-        super(FloatValue, self).__init__(PtrHolder.create(<shared_ptr[void]&>result))
+    def __init__(self, ptr_holder):
+        super(FloatValue, self).__init__(ptr_holder)
 
     def to_list(self):
         return FloatValue.vector_of_doubles_to_list(

--- a/opencog/cython/opencog/link_value.pyx
+++ b/opencog/cython/opencog/link_value.pyx
@@ -1,13 +1,16 @@
 
+def createLinkValue(arg):
+    cdef shared_ptr[cLinkValue] c_ptr
+    if (isinstance(arg, list)):
+        c_ptr.reset(new cLinkValue(LinkValue.list_of_values_to_vector(arg)))
+    else:
+        c_ptr.reset(new cLinkValue(LinkValue.list_of_values_to_vector([arg])))
+    return LinkValue(PtrHolder.create(<shared_ptr[void]&>c_ptr))
+
 cdef class LinkValue(Value):
 
-    def __init__(self, arg):
-        cdef cValuePtr result
-        if (isinstance(arg, list)):
-            result = createLinkValue(LinkValue.list_of_values_to_vector(arg))
-        else:
-            result = createLinkValue(LinkValue.list_of_values_to_vector([arg]))
-        super(LinkValue, self).__init__(PtrHolder.create(<shared_ptr[void]&>result))
+    def __init__(self, ptr_holder):
+        super(LinkValue, self).__init__(ptr_holder)
 
     def to_list(self):
         return LinkValue.vector_of_values_to_list(

--- a/opencog/cython/opencog/nameserver.pyx
+++ b/opencog/cython/opencog/nameserver.pyx
@@ -72,7 +72,7 @@ def create_value_by_type(type, ptr_holder, atomspace = None):
     thismodule = sys.modules[__name__]
     clazz = getattr(thismodule, type_name, None)
     if clazz is not None:
-        return clazz(ptr_holder)
+        return clazz(ptr_holder = ptr_holder)
 
     cdef cValue *c_ptr = (<cValuePtr&>((<PtrHolder>ptr_holder).shared_ptr)).get()
     if c_ptr.is_atom() and atomspace is not None:

--- a/opencog/cython/opencog/string_value.pyx
+++ b/opencog/cython/opencog/string_value.pyx
@@ -1,13 +1,16 @@
 
+def createStringValue(arg):
+    cdef shared_ptr[cStringValue] c_ptr
+    if (isinstance(arg, list)):
+        c_ptr.reset(new cStringValue(StringValue.list_of_strings_to_vector(arg)))
+    else:
+        c_ptr.reset(new cStringValue(<string>(arg.encode('UTF-8'))))
+    return StringValue(PtrHolder.create(<shared_ptr[void]&>c_ptr))
+
 cdef class StringValue(Value):
 
-    def __init__(self, arg):
-        cdef cValuePtr result
-        if (isinstance(arg, list)):
-            result = createStringValue(StringValue.list_of_strings_to_vector(arg))
-        else:
-            result = createStringValue(<string>(arg.encode('UTF-8')))
-        super(StringValue, self).__init__(PtrHolder.create(<shared_ptr[void]&>result))
+    def __init__(self, ptr_holder):
+        super(StringValue, self).__init__(ptr_holder)
 
     def to_list(self):
         return StringValue.vector_of_strings_to_list(

--- a/opencog/cython/opencog/truth_value.pyx
+++ b/opencog/cython/opencog/truth_value.pyx
@@ -5,7 +5,7 @@ from atomspace cimport cTruthValue, cSimpleTruthValue, tv_ptr, Value
 def createTruthValue(strength = 1.0, confidence = 1.0):
     cdef tv_ptr c_ptr
     c_ptr.reset(new cSimpleTruthValue(strength, confidence))
-    return TruthValue(PtrHolder.create(<shared_ptr[void]&>c_ptr))
+    return TruthValue(ptr_holder = PtrHolder.create(<shared_ptr[void]&>c_ptr))
 
 cdef class TruthValue(Value):
     """ The truth value represents the strength and confidence of
@@ -15,8 +15,18 @@ cdef class TruthValue(Value):
 
         @todo Support IndefiniteTruthValue, DistributionalTV, NullTV etc
     """
-    def __init__(self, ptr_holder):
-        super(TruthValue, self).__init__(ptr_holder)
+    # Type constructors for all atoms and values are exported via
+    # opencog.type_constructors module. Except TruthValue which is historically
+    # exported in opencog.atomspace. To keep it work before proper fix
+    # TruthValue constructor is modified to accept both old parameters
+    # (strength and confidence) and new ptr_holder parameter.
+    def __init__(self, strength=1.0, confidence=1.0, ptr_holder = None):
+        cdef tv_ptr c_ptr
+        if ptr_holder is not None:
+            super(TruthValue, self).__init__(ptr_holder)
+        else:
+            c_ptr.reset(new cSimpleTruthValue(strength, confidence))
+            super(TruthValue, self).__init__(PtrHolder.create(<shared_ptr[void]&>c_ptr))
 
     property mean:
         def __get__(self): return self._mean()

--- a/opencog/cython/opencog/truth_value.pyx
+++ b/opencog/cython/opencog/truth_value.pyx
@@ -2,6 +2,11 @@ from cython.operator cimport dereference as deref
 from libcpp.memory cimport shared_ptr
 from atomspace cimport cTruthValue, cSimpleTruthValue, tv_ptr, Value
 
+def createTruthValue(strength = 1.0, confidence = 1.0):
+    cdef tv_ptr c_ptr
+    c_ptr.reset(new cSimpleTruthValue(strength, confidence))
+    return TruthValue(PtrHolder.create(<shared_ptr[void]&>c_ptr))
+
 cdef class TruthValue(Value):
     """ The truth value represents the strength and confidence of
         a relationship or term. In OpenCog there are a number of TruthValue
@@ -10,10 +15,8 @@ cdef class TruthValue(Value):
 
         @todo Support IndefiniteTruthValue, DistributionalTV, NullTV etc
     """
-    def __init__(self, strength=1.0, confidence=0.0):
-        cdef tv_ptr c_ptr
-        c_ptr.reset(new cSimpleTruthValue(strength, confidence))
-        super(TruthValue, self).__init__(PtrHolder.create(<shared_ptr[void]&>c_ptr))
+    def __init__(self, ptr_holder):
+        super(TruthValue, self).__init__(ptr_holder)
 
     property mean:
         def __get__(self): return self._mean()

--- a/opencog/cython/opencog/type_constructors.pyx
+++ b/opencog/cython/opencog/type_constructors.pyx
@@ -7,8 +7,9 @@
 # This imports all the python wrappers for atom creation.
 #
 
+from opencog.atomspace import (createFloatValue, createLinkValue,
+                                createStringValue, createTruthValue)
 from opencog.atomspace import AtomSpace, types
-from opencog.atomspace import TruthValue, FloatValue, StringValue, LinkValue
 
 atomspace = None
 def set_type_ctor_atomspace(new_atomspace):
@@ -16,3 +17,15 @@ def set_type_ctor_atomspace(new_atomspace):
     atomspace = new_atomspace
 
 include "opencog/atoms/atom_types/core_types.pyx"
+
+def FloatValue(arg):
+    return createFloatValue(arg)
+
+def LinkValue(arg):
+    return createLinkValue(arg)
+
+def StringValue(arg):
+    return createStringValue(arg)
+
+def TruthValue(strength=1.0, confidence=1.0):
+    return createTruthValue(strength, confidence)

--- a/tests/cython/atomspace/test_atom.py
+++ b/tests/cython/atomspace/test_atom.py
@@ -1,0 +1,27 @@
+from unittest import TestCase
+
+from opencog.atomspace import AtomSpace, Atom
+from opencog.atomspace import types, is_a, get_type, get_type_name, create_child_atomspace
+
+from opencog.type_constructors import *
+from opencog.utilities import initialize_opencog, finalize_opencog
+
+from time import sleep
+
+class AtomTest(TestCase):
+
+    def setUp(self):
+        self.space = AtomSpace()
+        initialize_opencog(self.space)
+
+    def tearDown(self):
+        finalize_opencog()
+        del self.space
+
+    def test_get_value(self):
+        atom = ConceptNode('foo')
+        key = PredicateNode('bar')
+        value = FloatValue([1.0, 2.0, 3.0])
+        atom.set_value(key, value)
+        self.assertEqual(value.__class__, atom.get_value(key).__class__)
+


### PR DESCRIPTION
Version of PR https://github.com/opencog/atomspace/pull/2063, without moving TruthValue type constructor into `opencog.type_constructors` module. So it doesn't break compatibility.

Things done:
* add values constructor to construct from c shared_ptr
* add separate type constructors to construct from Python values
* return correct value class from `Atom.get_value`
* add unit test to check that `Atom.get_value` returns correct type