### PR TITLE
Convert executable atom types to use new execute() API

### DIFF
--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -262,7 +262,7 @@ public:
         throw RuntimeException(TRACE_INFO,
             "Not executable! %s", to_string().c_str());
     }
-    virtual ValuePtr execute(void) { return execute(_atom_space); }
+    virtual ValuePtr execute(void) { return execute(_atom_space, false); }
     virtual bool is_executable() const { return false; }
 
     /** Returns the handle of the atom. */

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -256,12 +256,14 @@ public:
     virtual TruthValuePtr evaluate(AtomSpace*, bool silent=false) {
         throw RuntimeException(TRACE_INFO, "Not evaluatable!");
     }
+    virtual bool is_evaluatable() const { return false; }
 
     virtual ValuePtr execute(AtomSpace*, bool silent=false) {
         throw RuntimeException(TRACE_INFO,
             "Not executable! %s", to_string().c_str());
     }
     virtual ValuePtr execute(void) { return execute(_atom_space); }
+    virtual bool is_executable() const { return false; }
 
     /** Returns the handle of the atom. */
     inline Handle get_handle() const {

--- a/opencog/atoms/core/ArityLink.cc
+++ b/opencog/atoms/core/ArityLink.cc
@@ -53,16 +53,16 @@ ArityLink::ArityLink(const Link &l)
 
 // ---------------------------------------------------------------
 
-ValuePtr ArityLink::execute()
+/// Return the Arity, as a NumberNode.  Contrast this with
+/// ArityValueOf, which returns a FloatValue, instead.
+ValuePtr ArityLink::execute(AtomSpace* as, bool silent)
 {
 	size_t ary = 0;
 	for (const Handle& h : _outgoing)
 	{
-		FunctionLinkPtr flp(FunctionLinkCast(h));
-		if (nullptr != flp)
+		if (h->is_executable())
 		{
-			ValuePtr pap(h);
-			pap = flp->execute();
+			ValuePtr pap(h->execute(as, silent));
 			if (pap->is_link()) ary += HandleCast(pap)->get_arity();
 
 			// XXX TODO sum up length of values. (!?)

--- a/opencog/atoms/core/ArityLink.h
+++ b/opencog/atoms/core/ArityLink.h
@@ -51,7 +51,7 @@ public:
 	ArityLink(const Link &l);
 
 	// Return a pointer to the atom being specified.
-	virtual ValuePtr execute();
+	virtual ValuePtr execute(AtomSpace*, bool);
 
 	static Handle factory(const Handle&);
 };

--- a/opencog/atoms/core/AttentionValueOfLink.cc
+++ b/opencog/atoms/core/AttentionValueOfLink.cc
@@ -69,7 +69,7 @@ static AttentionValuePtr get_av(const Handle& h)
 // ---------------------------------------------------------------
 
 /// When executed, this will return the AttentionValue
-ValuePtr AttentionValueOfLink::execute()
+ValuePtr AttentionValueOfLink::execute(AtomSpace* as, bool silent)
 {
 	size_t ary = _outgoing.size();
 	if (1 != ary)
@@ -108,7 +108,7 @@ StiOfLink::StiOfLink(const Link &l)
 
 /// When executed, this will return the Strengths of all of the
 /// atoms in the outgoing set.
-ValuePtr StiOfLink::execute()
+ValuePtr StiOfLink::execute(AtomSpace* as, bool silent)
 {
 	std::vector<double> strengths;
 
@@ -155,7 +155,7 @@ LtiOfLink::LtiOfLink(const Link &l)
 
 /// When executed, this will return the Confidences of all of the
 /// atoms in the outgoing set.
-ValuePtr LtiOfLink::execute()
+ValuePtr LtiOfLink::execute(AtomSpace* as, bool silent)
 {
 	std::vector<double> confids;
 

--- a/opencog/atoms/core/AttentionValueOfLink.h
+++ b/opencog/atoms/core/AttentionValueOfLink.h
@@ -41,7 +41,7 @@ public:
 	AttentionValueOfLink(const Link &l);
 
 	// Return a pointer to the extracted value.
-	virtual ValuePtr execute();
+	virtual ValuePtr execute(AtomSpace*, bool);
 
 	static Handle factory(const Handle&);
 };
@@ -66,7 +66,7 @@ public:
 	StiOfLink(const Link &l);
 
 	// Return a pointer to the extracted value.
-	virtual ValuePtr execute();
+	virtual ValuePtr execute(AtomSpace*, bool);
 
 	static Handle factory(const Handle&);
 };
@@ -91,7 +91,7 @@ public:
 	LtiOfLink(const Link &l);
 
 	// Return a pointer to the extracted value.
-	virtual ValuePtr execute();
+	virtual ValuePtr execute(AtomSpace*, bool);
 
 	static Handle factory(const Handle&);
 };

--- a/opencog/atoms/core/FunctionLink.h
+++ b/opencog/atoms/core/FunctionLink.h
@@ -73,6 +73,7 @@ public:
 	FunctionLink(const Link& l);
 	virtual ~FunctionLink() {}
 
+	virtual bool is_executable(void) const { return true; }
 	static Handle factory(const Handle&);
 };
 

--- a/opencog/atoms/core/RandomChoice.cc
+++ b/opencog/atoms/core/RandomChoice.cc
@@ -122,18 +122,17 @@ RandomChoiceLink::RandomChoiceLink(const Link &l)
 
 // XXX FIXME - fix this so it can also choose a single value
 // out of a vector of values.
-ValuePtr RandomChoiceLink::execute()
+ValuePtr RandomChoiceLink::execute(AtomSpace* as, bool silent)
 {
 	size_t ary = _outgoing.size();
 	if (0 == ary) return ValuePtr();
 
-	Handle ofirst = _outgoing[0];
+	Handle ofirst(_outgoing[0]);
 
 	// We need to have our first arg to be a set or a list or
 	// something of that sort.
-	FunctionLinkPtr flp(FunctionLinkCast(ofirst));
-	if (flp)
-		ofirst = HandleCast(flp->execute());
+	if (ofirst->is_executable())
+		ofirst = HandleCast(ofirst->execute(as, silent));
 
 	// Special-case handling for SetLinks, so it works with
 	// dynamically-evaluated PutLinks ...
@@ -150,11 +149,11 @@ ValuePtr RandomChoiceLink::execute()
 			const HandleSeq& oset = h->getOutgoingSet();
 			if (2 != oset.size()) goto uniform;
 
-			Handle hw = oset[0];
-			FunctionLinkPtr flp(FunctionLinkCast(hw));
-			if (nullptr != flp)
-				hw = HandleCast(flp->execute());
+			Handle hw(oset[0]);
+			if (hw->is_executable())
+				hw = HandleCast(hw->execute(as, silent));
 
+			// XXX TODO if execute() above returns FloatValue, use that!
 			NumberNodePtr nn(NumberNodeCast(hw));
 			if (nullptr == nn) // goto uniform;
 				throw SyntaxException(TRACE_INFO,
@@ -190,9 +189,9 @@ uniform:
 		std::vector<double> weights;
 		for (Handle h : ofirst->getOutgoingSet())
 		{
-			FunctionLinkPtr flp(FunctionLinkCast(h));
-			if (nullptr != flp)
-				h = HandleCast(flp->execute());
+			// XXX FIXME, also allow a FloatValue!!
+			if (h->is_executable())
+				h = HandleCast(h->execute(as, silent));
 
 			NumberNodePtr nn(NumberNodeCast(h));
 			if (nullptr == nn)

--- a/opencog/atoms/core/RandomChoice.h
+++ b/opencog/atoms/core/RandomChoice.h
@@ -66,7 +66,7 @@ public:
 	RandomChoiceLink(const Link &l);
 
 	// Return a pointer to the atom being specified.
-	virtual ValuePtr execute();
+	virtual ValuePtr execute(AtomSpace*, bool);
 
 	static Handle factory(const Handle&);
 };

--- a/opencog/atoms/core/RandomNumber.cc
+++ b/opencog/atoms/core/RandomNumber.cc
@@ -82,7 +82,7 @@ static std::vector<double> unwrap_set(AtomSpace *as, const Handle& h)
 	if (NUMBER_NODE == t)
 	{
 		NumberNodePtr na(NumberNodeCast(h));
-		return std::vector<double>(na->get_value());
+		return std::vector<double>(1, na->get_value());
 	}
 	if (SET_LINK == t)
 	{
@@ -109,7 +109,7 @@ static std::vector<double> unwrap_set(AtomSpace *as, const Handle& h)
 }
 
 
-ValuePtr RandomNumberLink::execute(AtomSpace *as)
+ValuePtr RandomNumberLink::execute(AtomSpace *as, bool silent)
 {
 	std::vector<double> nmin(unwrap_set(as, _outgoing[0]));
 	std::vector<double> nmax(unwrap_set(as, _outgoing[1]));

--- a/opencog/atoms/core/RandomNumber.cc
+++ b/opencog/atoms/core/RandomNumber.cc
@@ -80,7 +80,6 @@ static double get_dbl(AtomSpace* as, bool silent, const Handle& h)
 	}
 	throw SyntaxException(TRACE_INFO,
 		"Expecting a number, got %s", h->to_string().c_str());
-	return 0.0;
 }
 
 // The pattern matcher returns sets of atoms; if that set contains

--- a/opencog/atoms/core/RandomNumber.cc
+++ b/opencog/atoms/core/RandomNumber.cc
@@ -124,6 +124,13 @@ static std::vector<double> unwrap_set(AtomSpace *as, bool silent,
 	return std::vector<double>();
 }
 
+static Handle get_ran(double cept, double nmax)
+{
+	// Linear algebra slope-intercept formula.
+	double slope = nmax - cept;
+	return HandleCast(createNumberNode(slope * randy.randdouble() + cept));
+}
+
 /// RandomNumberLink always returns either a NumberNode, or a
 /// set of NumberNodes.  This is in contrast to a RandomValue,
 /// which always returns a vector of doubles.
@@ -139,23 +146,12 @@ ValuePtr RandomNumberLink::execute(AtomSpace *as, bool silent)
 				nmin.size(), nmax.size());
 
 	if (1 == len)
-	{
-		double cept = nmin[0];
-		double slope = nmax[0] - cept;
-		double ary = slope * randy.randdouble() + cept;
-
-		return ValuePtr(createNumberNode(ary));
-	}
+		return get_ran(nmin[0], nmax[0]);
 
 	HandleSeq oset;
 	for (size_t i=0; i< len; i++)
-	{
-		double cept = nmin[i];
-		double slope = nmax[i] - cept;
-		double ary = slope * randy.randdouble() + cept;
+		oset.push_back(get_ran(nmin[i], nmax[i]));
 
-		oset.push_back(HandleCast(createNumberNode(ary)));
-	}
 	return ValuePtr(createLink(oset, SET_LINK));
 }
 

--- a/opencog/atoms/core/RandomNumber.h
+++ b/opencog/atoms/core/RandomNumber.h
@@ -52,7 +52,7 @@ public:
 	RandomNumberLink(const Link &l);
 
 	// Return a pointer to the atom being specified.
-	virtual ValuePtr execute();
+	virtual ValuePtr execute(AtomSpace*);
 
 	static Handle factory(const Handle&);
 };

--- a/opencog/atoms/core/RandomNumber.h
+++ b/opencog/atoms/core/RandomNumber.h
@@ -52,7 +52,7 @@ public:
 	RandomNumberLink(const Link &l);
 
 	// Return a pointer to the atom being specified.
-	virtual ValuePtr execute(AtomSpace*);
+	virtual ValuePtr execute(AtomSpace*, bool);
 
 	static Handle factory(const Handle&);
 };

--- a/opencog/atoms/core/SleepLink.cc
+++ b/opencog/atoms/core/SleepLink.cc
@@ -69,21 +69,36 @@ SleepLink::SleepLink(const Link &l)
 
 /// Return number of seconds left to sleep.
 /// Normally, this is zero, unless the sleep was interrupted.
-ValuePtr SleepLink::execute()
+ValuePtr SleepLink::execute(AtomSpace*as, bool silent)
 {
-	Handle time(_outgoing[0]);
-	FunctionLinkPtr flp(FunctionLinkCast(time));
-	if (flp)
-		time = HandleCast(flp->execute());
+	// Try to come up with a number, either from executing, or directly
+	Handle time(_outgoing.at(0));
+	double length = 0.0;
+	if (time->is_executable())
+	{
+		ValuePtr vp = time->execute(as, silent);
+		if (vp->is_atom())
+		{
+			time = HandleCast(vp);
+		}
+		else if (nameserver().isA(vp->get_type(), FLOAT_VALUE))
+		{
+			time = nullptr;
+			length = FloatValueCast(vp)->value().at(0);
+		}
+	}
 
-	NumberNodePtr nsle = NumberNodeCast(time);
-	if (nullptr == nsle)
-		throw RuntimeException(TRACE_INFO,
-			"Expecting an NumberNode, got %s",
-				(nullptr == time) ? "<invalid handle>" :
-					nameserver().getTypeName(time->get_type()).c_str());
+	if (time)
+	{
+		NumberNodePtr nsle = NumberNodeCast(time);
+		if (nullptr == nsle)
+			throw RuntimeException(TRACE_INFO,
+				"Expecting a number, got %s",
+					(nullptr == _outgoing.at(0)) ? "<invalid handle>" :
+						_outgoing.at(0)->to_string().c_str());
 
-	double length = nsle->get_value();
+		length = nsle->get_value();
+	}
 	unsigned int secs = floor(length);
 	useconds_t usec = 1000000 * (length - secs);
 	

--- a/opencog/atoms/core/SleepLink.h
+++ b/opencog/atoms/core/SleepLink.h
@@ -42,7 +42,7 @@ public:
 	SleepLink(const Link &l);
 
 	// Return number of seconds left to sleep.
-	virtual ValuePtr execute();
+	virtual ValuePtr execute(AtomSpace*, bool);
 
 	static Handle factory(const Handle&);
 };

--- a/opencog/atoms/core/TimeLink.cc
+++ b/opencog/atoms/core/TimeLink.cc
@@ -59,7 +59,7 @@ TimeLink::TimeLink(const Link &l)
 
 // ---------------------------------------------------------------
 
-ValuePtr TimeLink::execute()
+ValuePtr TimeLink::execute(AtomSpace* as, bool silent)
 {
 	// time_t now = time(nullptr);
 	struct timeval tv;

--- a/opencog/atoms/core/TimeLink.h
+++ b/opencog/atoms/core/TimeLink.h
@@ -41,7 +41,7 @@ public:
 	TimeLink(const Link&);
 
 	// Return a pointer to the atom being specified.
-	virtual ValuePtr execute();
+	virtual ValuePtr execute(AtomSpace*, bool);
 
 	static Handle factory(const Handle&);
 };

--- a/opencog/atoms/core/TruthValueOfLink.cc
+++ b/opencog/atoms/core/TruthValueOfLink.cc
@@ -52,7 +52,7 @@ TruthValueOfLink::TruthValueOfLink(const Link &l)
 // ---------------------------------------------------------------
 
 /// When executed, this will return the TruthValue
-ValuePtr TruthValueOfLink::execute()
+ValuePtr TruthValueOfLink::execute(AtomSpace* as, bool silent)
 {
 	size_t ary = _outgoing.size();
 	if (1 != ary)
@@ -91,7 +91,7 @@ StrengthOfLink::StrengthOfLink(const Link &l)
 
 /// When executed, this will return the Strengths of all of the
 /// atoms in the outgoing set.
-ValuePtr StrengthOfLink::execute()
+ValuePtr StrengthOfLink::execute(AtomSpace* as, bool silent)
 {
 	std::vector<double> strengths;
 
@@ -138,7 +138,7 @@ ConfidenceOfLink::ConfidenceOfLink(const Link &l)
 
 /// When executed, this will return the Confidences of all of the
 /// atoms in the outgoing set.
-ValuePtr ConfidenceOfLink::execute()
+ValuePtr ConfidenceOfLink::execute(AtomSpace* as, bool silent)
 {
 	std::vector<double> confids;
 

--- a/opencog/atoms/core/TruthValueOfLink.h
+++ b/opencog/atoms/core/TruthValueOfLink.h
@@ -40,7 +40,7 @@ public:
 	TruthValueOfLink(const Link &l);
 
 	// Return a pointer to the extracted value.
-	virtual ValuePtr execute();
+	virtual ValuePtr execute(AtomSpace*, bool);
 
 	static Handle factory(const Handle&);
 };
@@ -65,7 +65,7 @@ public:
 	StrengthOfLink(const Link &l);
 
 	// Return a pointer to the extracted value.
-	virtual ValuePtr execute();
+	virtual ValuePtr execute(AtomSpace*, bool);
 
 	static Handle factory(const Handle&);
 };
@@ -90,7 +90,7 @@ public:
 	ConfidenceOfLink(const Link &l);
 
 	// Return a pointer to the extracted value.
-	virtual ValuePtr execute();
+	virtual ValuePtr execute(AtomSpace*, bool);
 
 	static Handle factory(const Handle&);
 };

--- a/opencog/atoms/core/ValueOfLink.cc
+++ b/opencog/atoms/core/ValueOfLink.cc
@@ -53,7 +53,7 @@ ValueOfLink::ValueOfLink(const Link &l)
 // ---------------------------------------------------------------
 
 /// When executed, this will return the value at the indicated key.
-ValuePtr ValueOfLink::execute()
+ValuePtr ValueOfLink::execute(AtomSpace* as, bool silent)
 {
 	size_t ary = _outgoing.size();
 	if (2 != ary)

--- a/opencog/atoms/core/ValueOfLink.h
+++ b/opencog/atoms/core/ValueOfLink.h
@@ -41,7 +41,7 @@ public:
 	ValueOfLink(const Link &l);
 
 	// Return a pointer to the atom being specified.
-	virtual ValuePtr execute();
+	virtual ValuePtr execute(AtomSpace*, bool);
 
 	static Handle factory(const Handle&);
 };

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -267,11 +267,10 @@ static TruthValuePtr eval_formula(const Handle& predform,
 		if (not fvars.empty())
 		{
 			flh = fvars.substitute_nocheck(flh, cargs);
-			flp = FunctionLinkCast(flh);
 		}
 
 		// Expecting a FunctionLink without variables.
-		ValuePtr v(flp->execute());
+		ValuePtr v(flh->execute());
 		FloatValuePtr fv(FloatValueCast(v));
 		nums.push_back(fv->value()[0]);
 	}
@@ -622,9 +621,9 @@ TruthValuePtr EvaluationLink::do_eval_scratch(AtomSpace* as,
 			if (not nameserver().isA(h->get_type(), FUNCTION_LINK))
 				throw SyntaxException(TRACE_INFO, "Expecting a FunctionLink");
 
-			ValuePtr v(FunctionLinkCast(h)->execute());
+			ValuePtr v(h->execute());
 			FloatValuePtr fv(FloatValueCast(v));
-			nums.push_back(fv->value()[0]);
+			nums.push_back(fv->value().at(0));
 		}
 		return createSimpleTruthValue(nums);
 	}

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -644,7 +644,7 @@ TruthValuePtr EvaluationLink::do_eval_scratch(AtomSpace* as,
 
 	else if (nameserver().isA(t, VALUE_OF_LINK))
 	{
-		ValuePtr pap(ValueOfLinkCast(evelnk)->execute());
+		ValuePtr pap(evelnk->execute());
 		// If it's an atom, recursively evaluate.
 		if (pap->is_atom())
 			return EvaluationLink::do_eval_scratch(as,

--- a/opencog/atoms/execution/Instantiator.cc
+++ b/opencog/atoms/execution/Instantiator.cc
@@ -420,22 +420,6 @@ Handle Instantiator::walk_tree(const Handle& expr, bool silent)
 		return Handle::UNDEFINED;
 	}
 
-	if (MAP_LINK == t)
-	{
-		if (_eager)
-		{
-			HandleSeq oset_results;
-			walk_sequence(oset_results, expr->getOutgoingSet(), silent);
-			MapLinkPtr mlp(MapLinkCast(createLink(oset_results, t)));
-			return mlp->execute(_as);
-		}
-		else
-		{
-			MapLinkPtr mlp(MapLinkCast(expr));
-			return mlp->execute(_as);
-		}
-	}
-
 	// Fire any other function links, not handled above.
 	if (nameserver().isA(t, FUNCTION_LINK))
 	{
@@ -454,7 +438,7 @@ Handle Instantiator::walk_tree(const Handle& expr, bool silent)
 			walk_sequence(oset_results, expr->getOutgoingSet(), silent);
 
 			Handle flp(createLink(oset_results, t));
-			return HandleCast(flp->execute());
+			return HandleCast(flp->execute(_as, silent));
 		}
 		else
 		{
@@ -463,7 +447,7 @@ Handle Instantiator::walk_tree(const Handle& expr, bool silent)
 			// Also, the number of arguments is not fixed, its always variadic.
 			// Perform substitution on all arguments before applying the
 			// function itself.
-			return HandleCast(expr->execute());
+			return HandleCast(expr->execute(_as, silent));
 		}
 	}
 
@@ -471,7 +455,7 @@ Handle Instantiator::walk_tree(const Handle& expr, bool silent)
 	// and return the satisfying set.
 	if (nameserver().isA(t, SATISFYING_LINK))
 	{
-		return HandleCast(expr->execute(_as));
+		return HandleCast(expr->execute(_as, silent));
 	}
 
 	// Ideally, we should not evaluate any EvaluatableLinks.

--- a/opencog/atoms/execution/Instantiator.cc
+++ b/opencog/atoms/execution/Instantiator.cc
@@ -588,8 +588,8 @@ ValuePtr Instantiator::instantiate(const Handle& expr,
 				if (hg) oset_results.push_back(hg);
 			}
 		}
-		FunctionLinkPtr flp(FunctionLinkCast(createLink(oset_results, t)));
-		ValuePtr pap(flp->execute());
+		Handle flp(createLink(oset_results, t));
+		ValuePtr pap(flp->execute(_as, silent));
 		if (pap->is_atom())
 			return _as->add_atom(HandleCast(pap));
 		return pap;

--- a/opencog/atoms/execution/Instantiator.cc
+++ b/opencog/atoms/execution/Instantiator.cc
@@ -453,7 +453,7 @@ Handle Instantiator::walk_tree(const Handle& expr, bool silent)
 			HandleSeq oset_results;
 			walk_sequence(oset_results, expr->getOutgoingSet(), silent);
 
-			FunctionLinkPtr flp(FunctionLinkCast(createLink(oset_results, t)));
+			Handle flp(createLink(oset_results, t));
 			return HandleCast(flp->execute());
 		}
 		else
@@ -463,8 +463,7 @@ Handle Instantiator::walk_tree(const Handle& expr, bool silent)
 			// Also, the number of arguments is not fixed, its always variadic.
 			// Perform substitution on all arguments before applying the
 			// function itself.
-			FunctionLinkPtr flp(FunctionLinkCast(expr));
-			return HandleCast(flp->execute());
+			return HandleCast(expr->execute());
 		}
 	}
 

--- a/opencog/atoms/execution/MapLink.cc
+++ b/opencog/atoms/execution/MapLink.cc
@@ -373,7 +373,7 @@ Handle MapLink::rewrite_one(const Handle& cterm, AtomSpace* scratch) const
 	return Handle::UNDEFINED;
 }
 
-Handle MapLink::execute(AtomSpace* scratch) const
+ValuePtr MapLink::execute(AtomSpace* scratch, bool silent)
 {
 	const Handle& valh = _outgoing[1];
 

--- a/opencog/atoms/execution/MapLink.h
+++ b/opencog/atoms/execution/MapLink.h
@@ -70,7 +70,7 @@ public:
 	// Align the pattern and the term side-by-side, and extract the
 	// values that match up with the variables.  If the term is not of
 	// the same type as the pattern, return the undefined handle.
-	virtual Handle execute(AtomSpace* = NULL) const;
+	virtual ValuePtr execute(AtomSpace*, bool);
 
 	static Handle factory(const Handle&);
 };

--- a/opencog/atoms/reduct/ArithmeticLink.cc
+++ b/opencog/atoms/reduct/ArithmeticLink.cc
@@ -161,7 +161,7 @@ ValuePtr ArithmeticLink::get_value(ValuePtr vptr) const
 {
 	while (nameserver().isA(vptr->get_type(), FUNCTION_LINK))
 	{
-		ValuePtr red(FunctionLinkCast(vptr)->execute());
+		ValuePtr red(HandleCast(vptr)->execute());
 
 		// It would probably be better to throw a silent exception, here?
 		if (nullptr == red) return vptr;
@@ -173,7 +173,7 @@ ValuePtr ArithmeticLink::get_value(ValuePtr vptr) const
 
 // ===========================================================
 /// execute() -- Execute the expression
-ValuePtr ArithmeticLink::execute()
+ValuePtr ArithmeticLink::execute(AtomSpace* as, bool silent)
 {
 	return delta_reduce();
 }

--- a/opencog/atoms/reduct/ArithmeticLink.h
+++ b/opencog/atoms/reduct/ArithmeticLink.h
@@ -50,7 +50,8 @@ public:
 	ArithmeticLink(const Link& l);
 
 	virtual ValuePtr delta_reduce(void) const;
-	virtual ValuePtr execute();
+	virtual ValuePtr execute(AtomSpace*, bool);
+	virtual ValuePtr execute(void) { return execute(_atom_space, false); }
 };
 
 typedef std::shared_ptr<ArithmeticLink> ArithmeticLinkPtr;

--- a/opencog/rule-engine/backwardchainer/ControlPolicy.cc
+++ b/opencog/rule-engine/backwardchainer/ControlPolicy.cc
@@ -322,7 +322,7 @@ bool ControlPolicy::match(const Handle& pattern, const Handle& term,
 		impl = tmp_as.add_link(IMPLICATION_SCOPE_LINK,
 		                       vardecl, pattern, rewrite),
 		tmp_term = tmp_as.add_atom(term),
-		result = MapLink(impl, tmp_term).execute(&tmp_as);
+		result = HandleCast(MapLink(impl, tmp_term).execute(&tmp_as, false));
 
 	return (bool)result;
 }


### PR DESCRIPTION
Various existing atoms used the old API. Convert them to the new one. This allows the removal of several un-needed casts.

Also update RandomNumberLink to work with Values.