### PR TITLE
Partial fix for bug #2070

### DIFF
--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -519,7 +519,7 @@ bool Variables::is_type(const Handle& var, const Handle& val) const
  */
 bool Variables::is_type(const HandleSeq& hseq) const
 {
-	// The arity must be one for there to be a match.
+	// The arities must be equal for there to be a match.
 	size_t len = hseq.size();
 	if (varset.size() != len) return false;
 
@@ -529,6 +529,27 @@ bool Variables::is_type(const HandleSeq& hseq) const
 		if (not is_type(varseq[i], hseq[i])) return false;
 	}
 	return true;
+}
+
+/**
+ * Return true if we contain just a single variable, and this one
+ * variable is of type gtype (or is untyped). A typical use is that
+ * gtype==VARIABLE_LIST.
+ */
+bool Variables::is_type(Type gtype) const
+{
+	if (1 != varseq.size()) return false;
+
+	// Are there any type restrictions?
+	const Handle& var = varseq[0];
+	VariableTypeMap::const_iterator tit = _simple_typemap.find(var);
+	if (_simple_typemap.end() == tit) return true;
+	const TypeSet &tchoice = tit->second;
+
+	// There are type restrictions; do they match?
+	TypeSet::const_iterator allow = tchoice.find(gtype);
+	if (allow != tchoice.end()) return true;
+	return false;
 }
 
 /**

--- a/opencog/atoms/core/Variables.h
+++ b/opencog/atoms/core/Variables.h
@@ -216,7 +216,11 @@ struct Variables : public FreeVariables,
 	// Return true if we are holding a single variable, and the handle
 	// given as the argument satisfies the type restrictions (if any).
 	// Else return false.
-	bool is_type(const Handle& h) const;
+	bool is_type(const Handle&) const;
+
+	// Return true if we are holding a single variable, and it can
+	// be the indicated type.
+	bool is_type(Type) const;
 
 	// Return true if we are holding the variable `var`, and `val`
 	// satisfies the type restrictions that apply to `var`.

--- a/opencog/query/DefaultPatternMatchCB.cc
+++ b/opencog/query/DefaultPatternMatchCB.cc
@@ -299,8 +299,11 @@ bool DefaultPatternMatchCB::link_match(const PatternTermPtr& ptm,
 		//     if (not _pat_bound_vars->is_equal(*_gnd_bound_vars))
 		// because that prevents searches for narrowly-typed grounds
 		// (as is done in the ForwardChainerUTest, see bug #934)
+		// Alternately, a single variable can match an entire
+		// VariableList (per bug #2070).
 		if (*_pat_bound_vars != *_gnd_bound_vars
-		    and not _pat_bound_vars->is_type(_gnd_bound_vars->varseq))
+		      and not _pat_bound_vars->is_type(VARIABLE_LIST)
+		      and not _pat_bound_vars->is_type(_gnd_bound_vars->varseq))
 		{
 			_pat_bound_vars = nullptr;
 			_gnd_bound_vars = nullptr;


### PR DESCRIPTION
This allows the following query to succeed:
```
(use-modules (opencog) (opencog exec))

(define X (Variable "$X"))
(define Y (Variable "$Y"))
(define A (Concept "A"))
(define InhXA (Inheritance X A))
(define InhYA (Inheritance Y A))
(define PX (Lambda X InhXA))
(define PY (Lambda Y InhYA))
(define VarXY (VariableList X Y))
(define PXY (Lambda VarXY (And InhXA InhYA)))

(define q3 (Get (VariableList
                  (Variable "$vardecl")
                  (Variable "$body-0")
                  (Variable "$body-1"))
                (Present (Lambda
                           (Variable "$vardecl")
                           (And (Variable "$body-0")
                             (Variable "$body-1"))))))

(cog-execute! q3)
```

I think that this is an over-all beneficial change.  I think this makes sense ...