### PR TITLE
Add AlphaEqualLink

### DIFF
--- a/opencog/atoms/atom_types/atom_types.script
+++ b/opencog/atoms/atom_types/atom_types.script
@@ -560,6 +560,10 @@ GREATER_THAN_LINK <- VIRTUAL_LINK,NUMERIC_LINK
 IDENTICAL_LINK <- UNORDERED_LINK,VIRTUAL_LINK
 EQUAL_LINK <- UNORDERED_LINK,VIRTUAL_LINK
 
+// AlphaEqualLink tests to see if both sides are the same, up to an
+// alpha-renaming of any variables that they may have.
+ALPHA_EQUAL_LINK <- UNORDERED_LINK,VIRTUAL_LINK
+
 // --------------------------------------------------------------
 // Functions that do NOT bind variables.
 

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -230,6 +230,28 @@ static TruthValuePtr equal(AtomSpace* as, const Handle& h, bool silent)
 		return TruthValue::FALSE_TV();
 }
 
+/// Check for alpha equivalence
+static TruthValuePtr alpha_equal(AtomSpace* as, const Handle& h, bool silent)
+{
+	const HandleSeq& oset = h->getOutgoingSet();
+	if (2 != oset.size())
+		throw SyntaxException(TRACE_INFO,
+		     "AlphaEqualLink expects two arguments");
+
+	Instantiator inst(as);
+	Handle h0(HandleCast(inst.execute(oset[0], silent)));
+	Handle h1(HandleCast(inst.execute(oset[1], silent)));
+
+	Variables v0, v1;
+	v0.find_variables(h0);
+	v1.find_variables(h1);
+
+	if (v0.is_equal(v1))
+		return TruthValue::TRUE_TV();
+	else
+		return TruthValue::FALSE_TV();
+}
+
 /// Evalaute a formula defined by a PREDICATE_FORMULA_LINK
 static TruthValuePtr eval_formula(const Handle& predform,
                                   const HandleSeq& cargs)
@@ -410,6 +432,10 @@ TruthValuePtr EvaluationLink::do_eval_scratch(AtomSpace* as,
 	else if (EQUAL_LINK == t)
 	{
 		return equal(scratch, evelnk, silent);
+	}
+	else if (ALPHA_EQUAL_LINK == t)
+	{
+		return alpha_equal(scratch, evelnk, silent);
 	}
 	else if (GREATER_THAN_LINK == t)
 	{

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -230,7 +230,12 @@ static TruthValuePtr equal(AtomSpace* as, const Handle& h, bool silent)
 		return TruthValue::FALSE_TV();
 }
 
-/// Check for alpha equivalence
+/// Check for alpha equivalence. If the link contains no free
+/// variables, then this behaves the same as EqualLink. If the
+/// link does contain free variables, and they are in the same
+/// location, and can be alpha-converted to one-another, then yes,
+/// they're equal. If the two expressions cannot be alpha-converted
+/// one into another, then false.
 static TruthValuePtr alpha_equal(AtomSpace* as, const Handle& h, bool silent)
 {
 	const HandleSeq& oset = h->getOutgoingSet();

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -251,10 +251,17 @@ static TruthValuePtr alpha_equal(AtomSpace* as, const Handle& h, bool silent)
 	v0.find_variables(h0);
 	v1.find_variables(h1);
 
-	if (v0.is_equal(v1))
-		return TruthValue::TRUE_TV();
-	else
+	// If the variables are not alpha-convertable, then
+	// there is no possibility of equality.
+	if (not v0.is_equal(v1))
 		return TruthValue::FALSE_TV();
+
+	// Actually alpha-convert, and compare.
+	Handle h1a = v1.substitute_nocheck(h1, v0.varseq, silent);
+	if (*((AtomPtr)h0) != *((AtomPtr)h1a))
+		return TruthValue::FALSE_TV();
+
+	return TruthValue::TRUE_TV();
 }
 
 /// Evalaute a formula defined by a PREDICATE_FORMULA_LINK

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -242,6 +242,11 @@ static TruthValuePtr alpha_equal(AtomSpace* as, const Handle& h, bool silent)
 	Handle h0(HandleCast(inst.execute(oset[0], silent)));
 	Handle h1(HandleCast(inst.execute(oset[1], silent)));
 
+	// Are they strictly equal? Good!
+	if (h0 == h1)
+		return TruthValue::TRUE_TV();
+
+	// Not strictly equal. Are they alpha convertable?
 	Variables v0, v1;
 	v0.find_variables(h0);
 	v1.find_variables(h1);

--- a/tests/atoms/EqualLinkUTest.cxxtest
+++ b/tests/atoms/EqualLinkUTest.cxxtest
@@ -44,6 +44,7 @@ public:
 	void tearDown() {}
 
 	void test_equality();
+	void test_alpha();
 };
 
 #define N _as.add_node
@@ -100,6 +101,41 @@ void EqualLinkUTest::test_equality()
 
 	tv = EvaluationLink::do_evaluate(&_as, equal_asb);
 	TS_ASSERT_LESS_THAN(tv->get_mean(), 0.5); // false
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// Test alpha-conversion equality
+void EqualLinkUTest::test_alpha()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle x_plus_2 =
+		L(PLUS_LINK, N(VARIABLE_NODE, "$x"), N(NUMBER_NODE, "2"));
+
+	Handle x_plus_3 =
+		L(PLUS_LINK, N(VARIABLE_NODE, "$x"), N(NUMBER_NODE, "3"));
+
+	Handle y_plus_3 =
+		L(PLUS_LINK, N(VARIABLE_NODE, "$y"), N(NUMBER_NODE, "3"));
+
+	Handle equal_23 = L(EQUAL_LINK, x_plus_2, x_plus_3);
+	Handle alpha_23 = L(ALPHA_EQUAL_LINK, x_plus_2, x_plus_3);
+	Handle equal_xy = L(EQUAL_LINK, x_plus_3, y_plus_3);
+	Handle alpha_xy = L(ALPHA_EQUAL_LINK, x_plus_3, y_plus_3);
+
+	// -------
+	TruthValuePtr tv = EvaluationLink::do_evaluate(&_as, equal_23);
+	TS_ASSERT_LESS_THAN(tv->get_mean(), 0.5); // false
+
+	tv = EvaluationLink::do_evaluate(&_as, alpha_23);
+	TS_ASSERT_LESS_THAN(tv->get_mean(), 0.5); // false
+
+	tv = EvaluationLink::do_evaluate(&_as, equal_xy);
+	TS_ASSERT_LESS_THAN(tv->get_mean(), 0.5); // false
+
+	tv = EvaluationLink::do_evaluate(&_as, alpha_xy);
+	TS_ASSERT_LESS_THAN(0.5, tv->get_mean());  // true
 
 	logger().info("END TEST: %s", __FUNCTION__);
 }

--- a/tests/atoms/EqualLinkUTest.cxxtest
+++ b/tests/atoms/EqualLinkUTest.cxxtest
@@ -121,6 +121,8 @@ void EqualLinkUTest::test_alpha()
 
 	Handle equal_23 = L(EQUAL_LINK, x_plus_2, x_plus_3);
 	Handle alpha_23 = L(ALPHA_EQUAL_LINK, x_plus_2, x_plus_3);
+	Handle equal_xx = L(EQUAL_LINK, x_plus_3, x_plus_3);
+	Handle alpha_xx = L(ALPHA_EQUAL_LINK, x_plus_3, x_plus_3);
 	Handle equal_xy = L(EQUAL_LINK, x_plus_3, y_plus_3);
 	Handle alpha_xy = L(ALPHA_EQUAL_LINK, x_plus_3, y_plus_3);
 
@@ -130,6 +132,12 @@ void EqualLinkUTest::test_alpha()
 
 	tv = EvaluationLink::do_evaluate(&_as, alpha_23);
 	TS_ASSERT_LESS_THAN(tv->get_mean(), 0.5); // false
+
+	tv = EvaluationLink::do_evaluate(&_as, equal_xx);
+	TS_ASSERT_LESS_THAN(0.5, tv->get_mean());  // true
+
+	tv = EvaluationLink::do_evaluate(&_as, alpha_xx);
+	TS_ASSERT_LESS_THAN(0.5, tv->get_mean());  // true
 
 	tv = EvaluationLink::do_evaluate(&_as, equal_xy);
 	TS_ASSERT_LESS_THAN(tv->get_mean(), 0.5); // false


### PR DESCRIPTION
Useful as a work-around for issue #2070 This allows the following query to work:
```
(use-modules (opencog) (opencog exec))

(define X (Variable "$X"))
(define Y (Variable "$Y"))
(define A (Concept "A"))
(define InhXA (Inheritance X A))
(define InhYA (Inheritance Y A))
(define PX (Lambda X InhXA))
(define PY (Lambda Y InhYA))
(define VarXY (VariableList X Y))
(define PXY (Lambda VarXY (And InhXA InhYA)))

(define b6 (Bind (VariableList
                  (Variable "$vardecl")
                  (Variable "$vardecl-0")
                  (Variable "$vardecl-1")
                  (Variable "$body-0")
                  (Variable "$body-1")
                  (Variable "$body-0-eqv")
                  (Variable "$body-1-eqv"))
                (And (Present (Lambda
                           (Variable "$vardecl")
                           (And (Variable "$body-0")
                             (Variable "$body-1")))
                  (Lambda (Variable "$vardecl-0")
                           (Variable "$body-0-eqv"))
                  (Lambda (Variable "$vardecl-1")
                           (Variable "$body-1-eqv")))
              (AlphaEqual (Variable "$body-0") (Variable "$body-0-eqv"))
              (AlphaEqual (Variable "$body-1") (Variable "$body-1-eqv"))
                )
(List (Concept "here are the vardecls")
                  (Variable "$vardecl")
                  (Variable "$vardecl-0")
                  (Variable "$vardecl-1")
 (Concept "here are the bodies")
                  (Variable "$body-0")
                  (Variable "$body-1")
 (Concept "here are the qivalents")
                  (Variable "$body-0-eqv")
                  (Variable "$body-1-eqv"))
      ))
(cog-execute! b6)
```
