### PR TITLE
Fix crashing hangover from #2073

### DIFF
--- a/tests/cython/backwardchainer/test_bc.py
+++ b/tests/cython/backwardchainer/test_bc.py
@@ -67,11 +67,14 @@ class BCTest(TestCase):
                                   InheritanceLink(VariableNode("$who"), C),
                                   TypedVariableLink(VariableNode("$who"), TypeNode("ConceptNode")))
 
+        scheme_eval(self.atomspace, '(gc)')
         print ("test_bc_deduction: post backchain ctor")
         chainer.do_chain()
         print ("test_bc_deduction: post chaining")
+        scheme_eval(self.atomspace, '(gc)')
         results = chainer.get_results()
         print ("test_bc_deduction: post results")
+        scheme_eval(self.atomspace, '(gc)')
         resultAC = None
         for result in results.get_out():
             if result.get_out()[0].name == "A":


### PR DESCRIPTION
This fixes a left-over issue from #2073 - When evaluating scheme code from python, we temporarily use python's atomspace. This can result in he use-count for guile's default atomspace to (temporarily) go to zero. If it just happens to get garage collected at just that precise moment, then .. its gone. The main patch is at line 368, to prevent the use-count from dropping to zero.