### PR TITLE
Feature/python execute atom return valueptr

### DIFF
--- a/opencog/cython/opencog/BindlinkStub.cc
+++ b/opencog/cython/opencog/BindlinkStub.cc
@@ -8,11 +8,9 @@
 
 using namespace opencog;
 
-// XXX FIXME -- signature should be
-// ValuePtr opencog::do_execute(AtomSpace* atomspace, Handle h)
-Handle opencog::do_execute(AtomSpace* atomspace, Handle h)
+ValuePtr opencog::do_execute(AtomSpace* atomspace, Handle h)
 {
 	Instantiator inst(atomspace);
 	ValuePtr pap(inst.execute(h));
-	return HandleCast(pap);
+	return pap;
 }

--- a/opencog/cython/opencog/BindlinkStub.h
+++ b/opencog/cython/opencog/BindlinkStub.h
@@ -26,7 +26,7 @@
 
 namespace opencog {
 
-Handle do_execute(AtomSpace*, Handle);
+ValuePtr do_execute(AtomSpace*, Handle);
 
 } // namespace opencog
 

--- a/opencog/cython/opencog/atomspace.pxd
+++ b/opencog/cython/opencog/atomspace.pxd
@@ -122,6 +122,7 @@ cdef extern from "opencog/atoms/base/Atom.h" namespace "opencog":
         string get_name()
         vector[cHandle] getOutgoingSet()
 
+    cdef cHandle handle_cast "HandleCast" (cValuePtr) except +
 
 # Handle
 cdef extern from "opencog/atoms/base/Handle.h" namespace "opencog":

--- a/opencog/cython/opencog/bindlink.pxd
+++ b/opencog/cython/opencog/bindlink.pxd
@@ -1,4 +1,4 @@
-from opencog.atomspace cimport cHandle, tv_ptr, cAtomSpace
+from opencog.atomspace cimport cValuePtr, cHandle, tv_ptr, cAtomSpace
 
 ctypedef size_t cSize
 
@@ -6,4 +6,4 @@ cdef extern from "opencog/atoms/execution/EvaluationLink.h" namespace "opencog":
     tv_ptr c_evaluate_atom "opencog::EvaluationLink::do_evaluate"(cAtomSpace*, cHandle)
 
 cdef extern from "opencog/cython/opencog/BindlinkStub.h" namespace "opencog":
-    cdef cHandle c_execute_atom "do_execute"(cAtomSpace*, cHandle) except +
+    cdef cValuePtr c_execute_atom "do_execute"(cAtomSpace*, cHandle) except +

--- a/opencog/cython/opencog/bindlink.pyx
+++ b/opencog/cython/opencog/bindlink.pyx
@@ -1,12 +1,14 @@
 from opencog.atomspace cimport Atom, AtomSpace, TruthValue
 from opencog.atomspace cimport cHandle, cAtomSpace, cTruthValue
 from opencog.atomspace cimport tv_ptr, strength_t, count_t
+from opencog.atomspace cimport handle_cast
 from cython.operator cimport dereference as deref
 
 def execute_atom(AtomSpace atomspace, Atom atom):
     if atom == None: raise ValueError("execute_atom atom is: None")
-    cdef cHandle c_result = c_execute_atom(atomspace.atomspace,
+    cdef cValuePtr c_value_ptr = c_execute_atom(atomspace.atomspace,
                                            deref(atom.handle))
+    cdef cHandle c_result = handle_cast(c_value_ptr)
     return Atom.createAtom(c_result, atomspace)
 
 def evaluate_atom(AtomSpace atomspace, Atom atom):

--- a/tests/cython/atomspace/test_do_execute.py
+++ b/tests/cython/atomspace/test_do_execute.py
@@ -1,0 +1,39 @@
+import unittest
+
+from opencog.type_constructors import *
+from opencog.bindlink import execute_atom
+from opencog.utilities import initialize_opencog, finalize_opencog
+
+
+class DoExecuteTest(unittest.TestCase):
+
+    def setUp(self):
+        self.atomspace = AtomSpace()
+        initialize_opencog(self.atomspace)
+
+    def tearDown(self):
+        finalize_opencog()
+        del self.atomspace
+
+    def test_do_execute(self):
+        (DefineLink(
+            DefinedSchemaNode('add'),
+            LambdaLink(
+                VariableList(
+                    VariableNode('$X'),
+                    VariableNode('$Y')),
+                PlusLink(
+                    VariableNode('$X'),
+                    VariableNode('$Y')))))
+
+        res = execute_atom(self.atomspace,
+                           ExecutionOutputLink(
+                               DefinedSchemaNode('add'),
+                               ListLink(
+                                   NumberNode("3"),
+                                   NumberNode("4"))))
+        self.assertEqual(NumberNode("7"), res)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
These are initial changes for the request #2094 
* a unit test is added
* `execute_atom` returns a ValuePtr

Packages renaming will be addressed in a separate fix.