### PR TITLE
cython context manager to create temporary atomspaces

### DIFF
--- a/opencog/cython/opencog/atomspace_details.pyx
+++ b/opencog/cython/opencog/atomspace_details.pyx
@@ -249,3 +249,5 @@ def create_child_atomspace(object atomspace):
     cdef AtomSpace result = AtomSpace_factory(child)
     result.owns_atomspace = True
     return result
+
+

--- a/opencog/cython/opencog/atomspace_details.pyx
+++ b/opencog/cython/opencog/atomspace_details.pyx
@@ -172,10 +172,7 @@ cdef class AtomSpace:
     # Methods to make the atomspace act more like a standard Python container
     def __contains__(self, atom):
         """ Custom checker to see if object is in AtomSpace """
-        if isinstance(atom, Atom):
-            return self.is_valid(atom)
-        else:
-            return False
+        return is_in_atomspace(self.atomspace, deref((<Atom>(atom)).handle))
 
     # Maybe this should be called __repr__ ???
     def __str__(self):

--- a/opencog/cython/opencog/type_constructors.pyx
+++ b/opencog/cython/opencog/type_constructors.pyx
@@ -16,6 +16,10 @@ def set_type_ctor_atomspace(new_atomspace):
     global atomspace
     atomspace = new_atomspace
 
+def get_type_ctor_atomspace():
+    global atomspace
+    return atomspace
+
 include "opencog/atoms/atom_types/core_types.pyx"
 
 def FloatValue(arg):

--- a/opencog/cython/opencog/utilities.pyx
+++ b/opencog/cython/opencog/utilities.pyx
@@ -1,5 +1,7 @@
+from contextlib import contextmanager
 from opencog.atomspace cimport AtomSpace
-from opencog.type_constructors import set_type_ctor_atomspace
+from opencog.atomspace import create_child_atomspace
+from opencog.type_constructors import get_type_ctor_atomspace, set_type_ctor_atomspace
 
 # Avoid recursive intialization
 is_initialized = False
@@ -23,3 +25,19 @@ def finalize_opencog():
         c_finalize_python()
 
     is_initialized = False
+
+
+@contextmanager
+def tmp_atomspace():
+    """
+    Context manager, to create child atomspace from current default 
+    """
+    parent_atomspace = get_type_ctor_atomspace()
+    if parent_atomspace is None:
+        raise RuntimeError("Default atomspace is None")
+    atomspace = create_child_atomspace(parent_atomspace)
+    initialize_opencog(atomspace)
+    try:
+        yield atomspace
+    finally:
+        initialize_opencog(parent_atomspace)

--- a/tests/cython/atomspace/test_atomspace.py
+++ b/tests/cython/atomspace/test_atomspace.py
@@ -4,7 +4,7 @@ from opencog.atomspace import AtomSpace, TruthValue, Atom
 from opencog.atomspace import types, is_a, get_type, get_type_name, create_child_atomspace
 
 from opencog.type_constructors import *
-from opencog.utilities import initialize_opencog, finalize_opencog
+from opencog.utilities import initialize_opencog, finalize_opencog, tmp_atomspace
 
 from time import sleep
 
@@ -197,6 +197,17 @@ class AtomSpaceTest(TestCase):
         self.assertTrue(a3 in self.space)
 
         self.assertEquals(len(self.space), 3)
+
+    def test_context_mgr_tmp(self):
+        a = ConceptNode('a')
+        return
+        with tmp_atomspace() as tmp_as:
+             b = ConceptNode('b')
+             self.assertTrue(a in self.space)
+             self.assertFalse(b in self.space)
+        c = ConceptNode('c')
+        self.assertTrue(c in self.space)
+        self.assertFalse(c in tmp_as)
 
 class AtomTest(TestCase):
 

--- a/tests/cython/atomspace/test_atomspace.py
+++ b/tests/cython/atomspace/test_atomspace.py
@@ -200,14 +200,15 @@ class AtomSpaceTest(TestCase):
 
     def test_context_mgr_tmp(self):
         a = ConceptNode('a')
-        return
         with tmp_atomspace() as tmp_as:
              b = ConceptNode('b')
              self.assertTrue(a in self.space)
+             # verify that current default atomspace is tmp_as
              self.assertFalse(b in self.space)
         c = ConceptNode('c')
+        # verify that current default atomspace is self.space
         self.assertTrue(c in self.space)
-        self.assertFalse(c in tmp_as)
+
 
 class AtomTest(TestCase):
 


### PR DESCRIPTION
cython method to create temporary atomspaces from current default one

fix \_\_contains\_\_ method for cython atomspace wrapper