### PR TITLE
Print Traceback in Python code during error

### DIFF
--- a/opencog/cython/PyIncludeWrapper.h
+++ b/opencog/cython/PyIncludeWrapper.h
@@ -11,6 +11,8 @@
 #undef _XOPEN_SOURCE
 #endif
 #include <Python.h>
+// Include header for Python traceback forward declaration
+#include <frameobject.h>
 #ifdef _GNU_SOURCE
 #pragma pop_macro("_POSIX_C_SOURCE")
 #pragma pop_macro("_XOPEN_SOURCE")

--- a/opencog/cython/PythonEval.cc
+++ b/opencog/cython/PythonEval.cc
@@ -643,14 +643,29 @@ std::string PythonEval::build_python_error_message(
     // Print the traceback, too, if it is provided.
     if (pyTraceback)
     {
-        PyObject* pyTBString = PyObject_Str(pyTraceback);
 #if PY_MAJOR_VERSION == 2
+        PyObject* pyTBString = PyObject_Str(pyTraceback);
         char* tb = PyBytes_AsString(pyTBString);
-#else
-        const char* tb = PyUnicode_AsUTF8(pyTBString);
-#endif
         errorStringStream << "\nTraceback: " << tb;
         Py_DECREF(pyTBString);
+#else
+        errorStringStream << "\nTraceback (most recent call last):\n";
+
+        PyTracebackObject* pyTracebackObject = (PyTracebackObject*)pyTraceback;
+
+        while (pyTracebackObject != NULL) {
+
+            int line_number = pyTracebackObject-> tb_lineno;
+            const char* filename = PyUnicode_AsUTF8(pyTracebackObject->tb_frame->f_code->co_filename);
+            const char* code_name = PyUnicode_AsUTF8(pyTracebackObject->tb_frame->f_code->co_name);
+
+            errorStringStream << "File \"" << filename <<"\", ";
+            errorStringStream << "line " << line_number <<", ";
+            errorStringStream << "in " << code_name <<"\n";
+
+            pyTracebackObject = pyTracebackObject -> tb_next;
+        }
+#endif
     }
 
     // Cleanup the references. NOTE: The traceback can be NULL even

--- a/opencog/cython/PythonEval.cc
+++ b/opencog/cython/PythonEval.cc
@@ -626,7 +626,7 @@ std::string PythonEval::build_python_error_message(
     errorStringStream << "Python error";
 
     if (function_name != NO_FUNCTION_NAME)
-        errorStringStream << " in" << function_name;
+        errorStringStream << " in " << function_name;
 
     PyObject* pyErrorString = PyObject_Str(pyError);
 #if PY_MAJOR_VERSION == 2


### PR DESCRIPTION
The fix prints Python traceback with file name, line number and code name during error.

For example, running the code below gives output:
```python
from opencog.type_constructors import *
from opencog.utilities import initialize_opencog
from opencog.bindlink import execute_atom

# Initialize AtomSpace
atomspace = AtomSpace()
initialize_opencog(atomspace)


def pow(node_a, node_b):
    return NumberNode(str(node_a.name ** node_b.name))


execution_output_link = ExecutionOutputLink(
    GroundedSchemaNode("py: pow"),
    ListLink(
        NumberNode("2"),
        NumberNode("5")
    ))

execute_atom(atomspace, execution_output_link)
```

Output:
```text
Traceback (most recent call last):
  File "samples/links/python/sample_execution_output_link.py", line 21, in <module>
    execute_atom(atomspace, execution_output_link)
  File "bindlink.pyx", line 9, in opencog.bindlink.execute_atom
RuntimeError: Python error inpow: unsupported operand type(s) for ** or pow(): 'str' and 'str'.
Traceback (most recent call last):
File "samples/links/python/sample_execution_output_link.py", line 11, in pow
 (stellarspot/atomspace/opencog/cython/PythonEval.cc:947)
```