### PR TITLE
Modernize CMake config

### DIFF
--- a/lib/AtomSpaceConfig.cmake.in
+++ b/lib/AtomSpaceConfig.cmake.in
@@ -7,16 +7,19 @@ include("@CMAKE_INSTALL_PREFIX@/lib/cmake/AtomSpace/AtomSpaceTargets.cmake")
 # on execution is omitted in atomspace at build time. It should be set
 # here for proper linking.
 set_property(TARGET execution
-    APPEND PROPERTY IMPORTED_LINK_INTERFACE_LIBRARIES_@build_type@
-    atomspace
+	APPEND PROPERTY INTERFACE_LINK_LIBRARIES
+	atomspace
 )
 
 set_property(TARGET query-engine
-    APPEND PROPERTY IMPORTED_LINK_INTERFACE_LIBRARIES_@build_type@
-    atomspace
+	APPEND PROPERTY INTERFACE_LINK_LIBRARIES
+	lambda
+	atomspace
 )
 
-# These names are used in varius projects e.g. opencog, as-moses, etc.
+# These names are used in various projects e.g. opencog, as-moses, etc.
+# XXX FIXME ... they probably should not be! It would be best if the all
+# of the libs were specified i.e. LINK_LIBRARIES(${ATOMSPACE_LIBRARIES})
 set(ATOMSPACE_LIBRARY atomspace)
 set(ATOMSPACE_atombase_LIBRARY atombase)
 set(ATOMSPACE_atomcore_LIBRARY atomcore)
@@ -35,50 +38,50 @@ set(ATOMSPACE_unify_LIBRARY unify)
 set(ATOMSPACE_value_LIBRARY value)
 
 set(ATOMSPACE_LIBRARIES
-    atom_types
-    value
-    atombase
-    atomcore
-    atomspaceutils
-    truthvalue
-    clearbox
-    lambda
-    persist
-    query-engine
-    execution
-    ruleengine
-    smob
-    atomspace
-    unify
+	atom_types
+	value
+	atombase
+	atomcore
+	atomspaceutils
+	truthvalue
+	clearbox
+	lambda
+	persist
+	query-engine
+	execution
+	ruleengine
+	smob
+	atomspace
+	unify
 )
 
 # Python is optional
 IF (HAVE_CYTHON)
 	set(ATOMSPACE_PythonEval_LIBRARY PythonEval)
 	SET(ATOMSPACE_LIBRARIES
-		${ATOMSPACE_LIBRARIES}
-		${ATOMSPACE_PythonEval_LIBRARY}
+	    ${ATOMSPACE_LIBRARIES}
+	    ${ATOMSPACE_PythonEval_LIBRARY}
 	)
 ENDIF (HAVE_CYTHON)
 
 # persist-sql is optional
 IF (persist-sql)
-    set(ATOMSPACE_persist-sql_LIBRARY persist-sql)
-    SET(ATOMSPACE_LIBRARIES
-        ${ATOMSPACE_LIBRARIES}
-        ${ATOMSPACE_persist-sql_LIBRARY}
-    )
-    SET(HAVE_PERSIST_SQL 1)
-    ADD_DEFINITIONS(-DHAVE_PERSIST_SQL)
+	set(ATOMSPACE_persist-sql_LIBRARY persist-sql)
+	SET(ATOMSPACE_LIBRARIES
+	    ${ATOMSPACE_LIBRARIES}
+	    ${ATOMSPACE_persist-sql_LIBRARY}
+	)
+	SET(HAVE_PERSIST_SQL 1)
+	ADD_DEFINITIONS(-DHAVE_PERSIST_SQL)
 ENDIF (persist-sql)
 
 # zmqatoms is optional
 IF (zmqatoms)
-    set(ATOMSPACE_zmqatoms_LIBRARY zmqatoms)
-    SET(ATOMSPACE_LIBRARIES
-        ${ATOMSPACE_LIBRARIES}
-        ${ATOMSPACE_zmqatoms_LIBRARY}
-    )
+	set(ATOMSPACE_zmqatoms_LIBRARY zmqatoms)
+	SET(ATOMSPACE_LIBRARIES
+	    ${ATOMSPACE_LIBRARIES}
+	    ${ATOMSPACE_zmqatoms_LIBRARY}
+	)
 ENDIF (zmqatoms)
 
 set(ATOMSPACE_DATA_DIR "@CMAKE_INSTALL_PREFIX@/share/opencog")


### PR DESCRIPTION
Should fix opencog/as-moses#47

Also contains whitespace/indentation fixes.