### PR TITLE
Make clean split between crisp-TV atoms, and others.

### DIFF
--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -457,7 +457,7 @@ static bool crisp_eval_scratch(AtomSpace* as,
 	{
 		TruthValuePtr tv(EvaluationLink::do_eval_scratch(as,
 		      evelnk->getOutgoingAtom(0), scratch, silent));
-		return 0.5 < tv->get_mean();
+		return tv->get_mean() < 0.5;
 	}
 	else if (AND_LINK == t)
 	{
@@ -491,7 +491,7 @@ static bool crisp_eval_scratch(AtomSpace* as,
 		bool is_trec = is_tail_rec(evelnk, oset[arity-1]);
 		if (is_trec) arity--;
 
-		// Loop at least once. If tail-recurive, loop forever.
+		// Loop at least once. If tail-recursive, loop forever.
 		do
 		{
 			for (size_t i=0; i<arity; i++)
@@ -592,6 +592,8 @@ static bool crisp_eval_scratch(AtomSpace* as,
 	throwSyntaxException(silent,
 		"Either incorrect or not implemented yet. Cannot evaluate %s",
 		evelnk->to_string().c_str());
+
+	return false;
 }
 
 TruthValuePtr EvaluationLink::do_eval_scratch(AtomSpace* as,

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -455,18 +455,15 @@ static bool crisp_eval_scratch(AtomSpace* as,
 	// Crisp-binary-valued Boolean Logical connectives
 	if (NOT_LINK == t)
 	{
-		TruthValuePtr tv(EvaluationLink::do_eval_scratch(as,
-		      evelnk->getOutgoingAtom(0), scratch, silent));
-		return tv->get_mean() < 0.5;
+		return not crisp_eval_scratch(as,
+		      evelnk->getOutgoingAtom(0), scratch, silent);
 	}
 	else if (AND_LINK == t)
 	{
 		for (const Handle& h : evelnk->getOutgoingSet())
 		{
-			TruthValuePtr tv(EvaluationLink::do_eval_scratch(as,
-			          h, scratch, silent));
-			if (tv->get_mean() < 0.5)
-				return false;
+			bool tv = crisp_eval_scratch(as, h, scratch, silent);
+			if (not tv) return false;
 		}
 		return true;
 	}
@@ -474,10 +471,8 @@ static bool crisp_eval_scratch(AtomSpace* as,
 	{
 		for (const Handle& h : evelnk->getOutgoingSet())
 		{
-			TruthValuePtr tv(EvaluationLink::do_eval_scratch(as,
-			               h, scratch, silent));
-			if (0.5 < tv->get_mean())
-				return true;
+			bool tv = crisp_eval_scratch(as, h, scratch, silent);
+			if (tv) return true;
 		}
 		return false;
 	}

--- a/opencog/atoms/execution/EvaluationLink.h
+++ b/opencog/atoms/execution/EvaluationLink.h
@@ -50,10 +50,6 @@ public:
 	                                     const Handle&,
 	                                     AtomSpace* scratch,
 	                                     bool silent=false);
-	static TruthValuePtr do_eval_with_args(AtomSpace*,
-	                                       const Handle& schema,
-	                                       const HandleSeq& args,
-	                                       bool silent=false);
 
 	static Handle factory(const Handle&);
 };


### PR DESCRIPTION
Some evaluatable atoms have a very natural crisp, binary true/false interpretation: the logical constants TrueLink, FalseLink, and the logical connectives NotLink, AndLink, OrLink, and a handful of others. Separate these out during evaluation from the mish-mash of others that might have probabilistic or fuzzy interpretations.

This is a code-cleanup exercise. It makes the code simpler, easier, faster. It will simplify future maintenance and future design changes.  There's no actual functional change, here.