### PR TITLE
Return correct atom class in Atom outgoing and incoming sets in Python API

### DIFF
--- a/opencog/cython/opencog/atom.pyx
+++ b/opencog/cython/opencog/atom.pyx
@@ -73,9 +73,7 @@ cdef class Atom(Value):
             deref((<Atom>key).handle))
         if value.get() == NULL:
             return None
-        return create_value_by_type(value.get().get_type(),
-                                    PtrHolder.create(<shared_ptr[void]&>value),
-                                    self.atomspace)
+        return create_python_value_from_c_value(value, self.atomspace)
 
     def get_out(self):
         cdef cAtom* atom_ptr = self.handle.atom_ptr()

--- a/opencog/cython/opencog/atomspace.pxd
+++ b/opencog/cython/opencog/atomspace.pxd
@@ -199,6 +199,8 @@ cdef class AtomSpace:
     cdef object parent_atomspace
 
 
+cdef create_python_value_from_c_value(cValuePtr& value, AtomSpace atomspace)
+
 # FloatValue
 cdef extern from "opencog/atoms/value/FloatValue.h" namespace "opencog":
     cdef cppclass cFloatValue "opencog::FloatValue":

--- a/opencog/cython/opencog/atomspace_details.pyx
+++ b/opencog/cython/opencog/atomspace_details.pyx
@@ -18,9 +18,7 @@ cdef convert_handle_seq_to_python_list(vector[cHandle] handles, AtomSpace atomsp
     handle_iter = handles.begin()
     while handle_iter != handles.end():
         handle = deref(handle_iter)
-        value = create_value_by_type(handle.get().get_type(),
-                                    PtrHolder.create(<shared_ptr[void]&>handle),
-                                    atomspace)
+        value = create_python_value_from_c_value(<cValuePtr&>handle, atomspace)
         result.append(value)
         inc(handle_iter)
     return result

--- a/opencog/cython/opencog/atomspace_details.pyx
+++ b/opencog/cython/opencog/atomspace_details.pyx
@@ -18,7 +18,10 @@ cdef convert_handle_seq_to_python_list(vector[cHandle] handles, AtomSpace atomsp
     handle_iter = handles.begin()
     while handle_iter != handles.end():
         handle = deref(handle_iter)
-        result.append(Atom.createAtom(handle, atomspace))
+        value = create_value_by_type(handle.get().get_type(),
+                                    PtrHolder.create(<shared_ptr[void]&>handle),
+                                    atomspace)
+        result.append(value)
         inc(handle_iter)
     return result
 

--- a/opencog/cython/opencog/bindlink.pyx
+++ b/opencog/cython/opencog/bindlink.pyx
@@ -3,16 +3,15 @@ from opencog.atomspace cimport cAtomSpace, cTruthValue
 from opencog.atomspace cimport tv_ptr, strength_t, count_t, shared_ptr
 from opencog.atomspace cimport handle_cast
 from cython.operator cimport dereference as deref
+from opencog.atomspace cimport create_python_value_from_c_value
 
-from opencog.atomspace import is_a, types, create_value_by_type
+from opencog.atomspace import is_a, types
 
 def execute_atom(AtomSpace atomspace, Atom atom):
     if atom == None: raise ValueError("execute_atom atom is: None")
     cdef cValuePtr c_value_ptr = c_execute_atom(atomspace.atomspace,
                                            deref(atom.handle))
-    type = deref(c_value_ptr).get_type()
-    cdef PtrHolder ptr_holder = PtrHolder.create(<shared_ptr[void]&>c_value_ptr)
-    return create_value_by_type(type, ptr_holder, atomspace)
+    return create_python_value_from_c_value(c_value_ptr, atomspace)
 
 
 

--- a/opencog/cython/opencog/nameserver.pyx
+++ b/opencog/cython/opencog/nameserver.pyx
@@ -74,11 +74,15 @@ cdef create_python_value_from_c_value(cValuePtr& value, AtomSpace atomspace):
 
     thismodule = sys.modules[__name__]
     clazz = getattr(thismodule, type_name, None)
-    if clazz is not None:
-        return clazz(ptr_holder = ptr_holder)
-
     cdef cValue *c_ptr = value.get()
+    if clazz is not None:
+        if c_ptr.is_atom():
+            return clazz(ptr_holder = ptr_holder, atomspace = atomspace)
+        else:
+            return clazz(ptr_holder = ptr_holder)
+
     if c_ptr.is_atom() and atomspace is not None:
-        return Atom(ptr_holder, atomspace)
+        return Atom(ptr_holder = ptr_holder, atomspace = atomspace)
 
     raise TypeError("Python API for " + type_name + " is not implemented yet")
+

--- a/tests/cython/atomspace/test_atom.py
+++ b/tests/cython/atomspace/test_atom.py
@@ -1,3 +1,4 @@
+import unittest
 from unittest import TestCase
 
 from opencog.atomspace import AtomSpace, Atom
@@ -24,4 +25,23 @@ class AtomTest(TestCase):
         value = FloatValue([1.0, 2.0, 3.0])
         atom.set_value(key, value)
         self.assertEqual(value.__class__, atom.get_value(key).__class__)
+
+    def test_get_out(self):
+        atom = ListLink('list', ConceptNode('a'), ConceptNode('b'))
+
+        out = atom.out
+
+        self.assertEqual(out, [ConceptNode('a'), ConceptNode('b')])
+
+    def test_get_input(self):
+        atom = ConceptNode('node')
+        a = ListLink(atom, ConceptNode('x'))
+        b = ListLink(atom, ConceptNode('y'))
+
+        incoming = atom.incoming
+
+        self.assertEqual(set(incoming), set([a, b]))
+
+if __name__ == '__main__':
+    unittest.main()
 


### PR DESCRIPTION
What is done:
- add unit test to check that `Atom.out` and `Atom.incoming` work properly
- call `create_value_by_type` to return correct `Atom` class from `Atom.out`
- rename `create_value_by_type` to `create_python_value_from_c_value` and simplify signature