### PR TITLE
Add green ball unit test for the URE

### DIFF
--- a/tests/rule-engine/backwardchainer/BackwardChainerUTest.cxxtest
+++ b/tests/rule-engine/backwardchainer/BackwardChainerUTest.cxxtest
@@ -52,9 +52,12 @@ public:
 	void test_conditional_partial_instantiation();
 	void test_impossible_criminal();
 	void test_criminal();
-	// TODO: re-enable the following tests
-	void test_induction();
-	void test_focus_set();
+	// TODO: re-enable when GlobNode is supported
+	void xtest_green_balls();
+	// TODO: re-enable when meta rule is supported
+	void xtest_induction();
+	// TODO: re-enable when focus set is supported (if ever)
+	void xtest_focus_set();
 };
 
 BackwardChainerUTest::BackwardChainerUTest() : _eval(&_as)
@@ -619,7 +622,34 @@ void BackwardChainerUTest::test_criminal()
 	logger().debug("END TEST: %s", __FUNCTION__);
 }
 
-void BackwardChainerUTest::test_induction()
+void BackwardChainerUTest::xtest_green_balls()
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	load_from_path("green-balls-kb.scm");
+	load_from_path("green-balls-rb.scm");
+	load_from_path("green-balls-targets.scm");
+	randGen().seed(0);
+
+	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfig::top_rbs_name);
+
+	Handle target = _eval.eval_h("target-known-evidence");
+
+	BackwardChainer bc(_as, top_rbs, target);
+	// See green-balls-rb.scm to change the number of iterations and
+	// other parameters
+	bc.do_chain();
+
+	Handle results = bc.get_results(),
+		top_result = results->getOutgoingAtom(0);
+
+	logger().debug() << "results = " << oc_to_string(results);
+
+	TS_ASSERT_LESS_THAN(0.9, top_result->getTruthValue()->get_mean());
+	TS_ASSERT_LESS_THAN(0.9, top_result->getTruthValue()->get_confidence());
+}
+
+void BackwardChainerUTest::xtest_induction()
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
@@ -640,16 +670,15 @@ void BackwardChainerUTest::test_induction()
 	bc.do_chain();
 
 	// TODO: fixme, for that we need to support BIT expansion over meta rule
-	// TS_ASSERT_DELTA(target->getTruthValue()->get_mean(), 1, 1e-10);
+	TS_ASSERT_DELTA(target->getTruthValue()->get_mean(), 1, 1e-10);
 	// TODO: determine the expected confidence, which depends on the
 	// number of instances the induction is based on
-	// TS_ASSERT_DELTA(target->getTruthValue()->get_confidence(), 1, 1e-10);
-	TS_ASSERT(true);
+	TS_ASSERT_DELTA(target->getTruthValue()->get_confidence(), 1, 1e-10);
 
 	logger().debug("END TEST: %s", __FUNCTION__);
 }
 
-void BackwardChainerUTest::test_focus_set()
+void BackwardChainerUTest::xtest_focus_set()
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
@@ -701,8 +730,7 @@ void BackwardChainerUTest::test_focus_set()
 		expected = al(SET_LINK, soln1);
 
 	// Re-enable when focus set is supported
-	TS_ASSERT(true);
-	// TS_ASSERT_EQUALS(results, expected);
+	TS_ASSERT_EQUALS(results, expected);
 
 	logger().debug("END TEST: %s", __FUNCTION__);
 }

--- a/tests/rule-engine/backwardchainer/scm/green-balls-kb.scm
+++ b/tests/rule-engine/backwardchainer/scm/green-balls-kb.scm
@@ -1,0 +1,33 @@
+;; We have 3 balls, 2 explicitly green, and one implicitely green
+;; since it absorbs only red and blue.
+;;
+;; We want to prove that all balls are green in a backward way, which
+;; requires to infer that the third ball is in fact green.
+
+;; Balls
+(define B1 (Concept "B1"))
+(define B2 (Concept "B2"))
+(define B3 (Concept "B3"))
+
+;; Classes
+(define ball (Concept "ball"))
+(define green (Concept "green"))
+(define red_blue_absorb (Concept "red_blue_absorb"))
+
+;; B1 to B3 are balls
+(Inheritance (stv 1 1) B1 ball)
+(Inheritance (stv 1 1) B2 ball)
+(Inheritance (stv 1 1) B3 ball)
+
+;; B1 and B2 are explicitely green
+(Inheritance (stv 1 1) B1 green)
+(Inheritance (stv 1 1) B2 green)
+
+;; B3 only absorbs red and blue
+(Inheritance (stv 1 1) B3 red_blue_absorb)
+
+;; Whatever only absorbs red and blue is green
+(ImplicationScope (stv 1 1)
+  (TypedVariable X (Type "ConceptNode"))
+  (Inheritance X red_blue_absorb)
+  (Inheritance X green))

--- a/tests/rule-engine/backwardchainer/scm/green-balls-rb.scm
+++ b/tests/rule-engine/backwardchainer/scm/green-balls-rb.scm
@@ -1,0 +1,3 @@
+;; Rule base of the green balls unit test
+
+

--- a/tests/rule-engine/backwardchainer/scm/green-balls-targets.scm
+++ b/tests/rule-engine/backwardchainer/scm/green-balls-targets.scm
@@ -1,0 +1,107 @@
+;; To express that all balls are green based on a collection of facts
+;; we introduce a predicate
+;;
+;; Predicate "based-on-evidence"
+;;
+;; Which we use as follows
+;;
+;; Evaluation (stv 1 3/800)
+;;   Predicate "based-on-evidence"
+;;   List
+;;     ImplicationScope
+;;       TypedVariable
+;;         X
+;;         Type "ConceptNode"
+;;       Inheritance
+;;         X
+;;         ball
+;;       Inheritance
+;;         X
+;;         green
+;;     Set
+;;       List
+;;         Inheritance B1 ball
+;;         Inheritance B1 green
+;;       List
+;;         Inheritance B2 ball
+;;         Inheritance B2 green
+;;       List
+;;         Inheritance B3 ball
+;;         Inheritance B3 green
+
+;; Variable
+(define X (Variable "$X"))
+(define E (Variable "$E"))
+(define G (Glob "$G"))
+
+;; Balls
+(define B1 (Concept "B1"))
+(define B2 (Concept "B2"))
+(define B3 (Concept "B3"))
+
+;; Classes
+(define ball (Concept "ball"))
+(define green (Concept "green"))
+
+;; Define target with all evidence already stated
+(define target-known-evidence
+  (Evaluation
+    (Predicate "based-on-evidence")
+    (List
+      ;; Implication scope
+      (ImplicationScope
+        (TypedVariable
+          X
+          (Type "ConceptNode"))
+        (Inheritance X ball)
+        (Inheritance X green))
+      ;; Evidence
+      (Set
+        (List
+          (Inheritance B1 ball)
+          (Inheritance B1 green))
+        (List
+          (Inheritance B2 ball)
+          (Inheritance B2 green))
+        (List
+          (Inheritance B3 ball)
+          (Inheritance B3 green))))))
+
+;; Define target with all evidence unknown
+(define target-unknown-evidence
+  (Evaluation
+    (Predicate "based-on-evidence")
+    (List
+      ;; Implication scope
+      (ImplicationScope
+        (TypedVariable
+          X
+          (Type "ConceptNode"))
+        (Inheritance X ball)
+        (Inheritance X green))
+      ;; Evidence
+      E)))
+
+(define vardecl-unknown-evidence
+  (TypedVariable
+    E
+    (Type "SetLink")))
+
+;; Define target with all evidence unknown, using Glob
+(define target-unknown-evidence-with-glob
+  (Evaluation
+    (Predicate "based-on-evidence")
+    (List
+      ;; Implication scope
+      (ImplicationScope
+        (TypedVariable
+          X
+          (Type "ConceptNode"))
+        (Inheritance X ball)
+        (Inheritance X green))
+      ;; Evidence
+      (Set G))))
+
+;; TODO: the type of G should be further specified, such the number of
+;; elements, or possible range, as well as possible the type of each
+;; element, e.g. List, once the backward chainer supports deep types.

--- a/tests/rule-engine/rules/evidence-based-conditional-direct-evaluation.scm
+++ b/tests/rule-engine/rules/evidence-based-conditional-direct-evaluation.scm
@@ -1,0 +1,41 @@
+;; Evidence Based Conditional Direct Evaluation rule
+;;
+;; This is a form a conditional direct evaluation but keep track of
+;; the evidence used to make the evaluation.
+;;
+;; Evaluation
+;;   Predicate "based-on-evidence"
+;;   List
+;;     ImplicationScope
+;;       X
+;;       P[X]
+;;       Q[X]
+;;     Set ES
+;; P[T]
+;; Q[T]     // such that T is not in ES
+;; |-
+;; Evaluation
+;;   Predicate "based-on-evidence"
+;;   List
+;;     ImplicationScope
+;;       X
+;;       P[X]
+;;       Q[X]
+;;     Set ES T
+;;
+;; where P[X] and Q[X] are some expression where X appears. ES is a
+;; glob node representing the terms used to construct or retrieve the
+;; evidence of the implication scope in the premise, and E is the new
+;; term of evidence.
+
+;; TODO: resume once GlobNode is supported
+
+(define evidence-based-conditional-direct-evaluation-implication-scope-rule
+  ;; (let* ((X (Variable "$X"))
+  ;;        (PX (
+  ;; (Bind
+)
+
+(define (evidence-based-conditional-direct-evaluation-implication-scope-formula
+         conclusion . premises)
+)


### PR DESCRIPTION
Inspired from Alexander Scherbatiy network flow problem. A piece of
evidence is required to be built (such that a green is ball given that
it only absorbs red and blue) which requires the direct evaluation
rule to keep track of each piece of evidence in order to back-infer
the missing piece of evidence.

It requires GlobNode to be supported (or at least it would simplify
the rule) so I'm postponing its completion till GlobNode is supported.