### PR TITLE
Use open(...).read() for exec method

### DIFF
--- a/examples/atomspace/python.scm
+++ b/examples/atomspace/python.scm
@@ -13,7 +13,7 @@
 (python-eval "print ('hello! ' + str(2+2))")
 
 ; Use exec(open()) to load python files:
-(python-eval "exec(open('my_py_func.py'))")
+(python-eval "exec(open('my_py_func.py').read())")
 
 ; -------------------------------------------------------------------
 ; It is possible to communicate an AtomSpace from guile to python.


### PR DESCRIPTION
Add read() call for open(...) method to fix exception:
"python-eval" "Python error: exec() arg 1 must be a string, bytes or code object.


Actually it works if I run the python.scm file from the directory where it is placed.
If I call it from different directory I get exception:
 "python-eval" "Python error: [Errno 2] No such file or directory: 'my_py_func.py'.