### PR TITLE
Add cog-get-all-roots in base utilities

### DIFF
--- a/opencog/scm/opencog/base/utilities.scm
+++ b/opencog/scm/opencog/base/utilities.scm
@@ -333,6 +333,13 @@
 
 ; -----------------------------------------------------------------------
 (define-public (cog-get-all-roots)
+"
+  cog-get-all-roots -- Return the list of all root atoms.
+
+  cog-get-all-roots
+  Return the list of all root atoms, that is atoms with
+  no incoming set.
+"
   (define roots '())
   (define (cons-roots x) (set! roots (cons x roots)))
   (traverse-roots cons-roots)

--- a/opencog/scm/opencog/base/utilities.scm
+++ b/opencog/scm/opencog/base/utilities.scm
@@ -332,6 +332,14 @@
 )
 
 ; -----------------------------------------------------------------------
+(define-public (cog-get-all-roots)
+  (define roots '())
+  (define (cons-roots x) (set! roots (cons x roots)))
+  (traverse-roots cons-roots)
+  roots
+)
+
+; -----------------------------------------------------------------------
 (define-public (cog-count-atoms atom-type)
 "
   cog-count-atoms -- Count of the number of atoms of given type
@@ -1260,6 +1268,7 @@
 'cog-report-counts
 'cog-get-root
 'cog-get-all-nodes
+'cog-get-all-roots
 'cog-get-partner
 'cog-pred-get-partner
 'cog-filter

--- a/opencog/scm/opencog/base/utilities.scm
+++ b/opencog/scm/opencog/base/utilities.scm
@@ -18,6 +18,7 @@
 ; -- clear -- extract all atoms in the atomspace.
 ; -- count-all -- Return the total number of atoms in the atomspace.
 ; -- cog-get-atoms -- Return a list of all atoms of type 'atom-type'
+; -- cog-get-all-roots -- Return the list of all root atoms.
 ; -- cog-prt-atomspace -- Prints all atoms in the atomspace
 ; -- cog-count-atoms -- Count of the number of atoms of given type.
 ; -- cog-report-counts -- Return an association list of counts.


### PR DESCRIPTION
I found this to be useful to the pattern miner, maybe it can be useful outside of it.