### PR TITLE
Remove nuisance function that was prone to abuse.

### DIFF
--- a/examples/pattern-matcher/markov-chain.scm
+++ b/examples/pattern-matcher/markov-chain.scm
@@ -215,14 +215,13 @@
 
 ;;; Get the probability on atom. The probability is assumed to be stored
 ;;; in the "mean" component of a SimpleTruthValue.
-(define (get-prob atom)
-	(assoc-ref (cog-tv->alist (cog-tv atom)) 'mean))
+(define (get-prob atom) (cog-mean atom))
 
 ;;; Return true if the TV on the atom is the default TV.
 ;;; For our purposes, we treat it as the default if the confidence is
 ;;; below 0.5 (since we later set confidence to 1.0)
 (define (is-default-tv? atom)
-	(not (< 0.5 (assoc-ref (cog-tv->alist (cog-tv atom)) 'confidence))))
+	(not (< 0.5 (cog-confidence atom))))
 
 ;;; Set a probability value on the atom.
 (define (set-prob atom value)

--- a/opencog/guile/README
+++ b/opencog/guile/README
@@ -460,14 +460,6 @@ interface.
          guile> (cog-tv x)
          (stv 0.9 0.8)
 
-=== cog-tv->alist ===
-      Convert a truth value to an association list (alist).
-
-      Example:
-         guile> (define x (cog-new-stv 0.7 0.9))
-         guile> (cog-tv->alist x)
-         ((mean . 0.699999988079071) (confidence . 0.899999976158142))
-
 === cog-get-types ===
       Return a list of all of the atom types in the system.
 

--- a/opencog/scm/opencog/base/tv.scm
+++ b/opencog/scm/opencog/base/tv.scm
@@ -160,44 +160,6 @@
 
 ; ===================================================================
 
-(define-public (cog-tv->alist TV)
-"
- cog-tv->alist TV
-    Convert the truth value TV to an association list (alist).
-
-    Example:
-       guile> (define x (cog-new-stv 0.7 0.9))
-       guile> (cog-tv->alist x)
-       ((mean . 0.7) (confidence . 0.9))
-"
-	(define vl (cog-value->list TV))
-	(case (cog-type TV)
-		((SimpleTruthValue)
-			(list (cons 'mean (car vl)) (cons 'confidence (cadr vl))))
-
-		((CountTruthValue)
-			(list (cons 'mean (car vl)) (cons 'confidence (cadr vl))
-				(cons 'count (caddr vl))))
-
-		((IndefiniteTruthValue)
-			(list (cons 'lower (car vl)) (cons 'upper (cadr vl))
-				(cons 'confidence-level (caddr vl))))
-
-		((EvidenceCountTruthValue)
-			(list (cons 'positive-count (car vl)) (cons 'count (cadr vl))))
-
-		((FuzzyTruthValue)
-			(list (cons 'mean (car vl)) (cons 'confidence (cadr vl))))
-
-		((ProbabilisticTruthValue)
-			(list (cons 'mean (car vl)) (cons 'confidence (cadr vl))
-				(cons 'count (caddr vl))))
-
-		(else '())
-	)
-)
-
-; -----------------------------------------------------------------------
 (define-public (tv-positive-count TV)
 "
   Return the floating-point positive count of a EvidenceCountTruthValue.

--- a/tests/scm/SCMExecutionOutputUTest.cxxtest
+++ b/tests/scm/SCMExecutionOutputUTest.cxxtest
@@ -221,8 +221,6 @@ void SCMExecutionOutputUTest::test_recursive(void)
 		"(define (make-queen x)"
 		"   (InheritanceLink x (ConceptNode \"queen\")))"
 		"(define (stv mean conf) (cog-new-stv mean conf))"
-		"(define (tv-mean tv) (assoc-ref (cog-tv->alist tv) 'mean))"
-		"(define (tv-conf tv) (assoc-ref (cog-tv->alist tv) 'confidence))"
 	);
 	CHKEV(eval);
 
@@ -231,8 +229,8 @@ void SCMExecutionOutputUTest::test_recursive(void)
 	eval->eval(
 		"(define (royal-incr atom cnt)"
 		"   (cog-set-tv! atom"
-		"       (stv (+ (tv-mean (cog-tv atom)) cnt)"
-		"           (tv-conf (cog-tv atom)))))"
+		"       (stv (+ (cog-mean atom) cnt)"
+		"           (cog-confidence atom))))"
 	);
 	CHKEV(eval);
 
@@ -242,7 +240,7 @@ void SCMExecutionOutputUTest::test_recursive(void)
 	// That is, 0.9/0.1 = 9.
 	eval->eval(
 		"(define (royalize x)"
-		"   (if (> (tv-mean (cog-tv x)) 0.9)"
+		"   (if (> (cog-mean x) 0.9)"
 		"      (make-king x)"
 		"      (royalize (royal-incr x 0.1))))"
 	);
@@ -257,7 +255,7 @@ void SCMExecutionOutputUTest::test_recursive(void)
 	// ExecutionOutputLink::do_execute() onto the stack.
 	eval->eval(
 		"(define (promote x)"
-		"   (if (> (tv-mean (cog-tv x)) 0.9)"
+		"   (if (> (cog-mean x) 0.9)"
 		"      (make-queen x)"
 		"      (exe-royalize (royal-incr x 0.01))))"
 	);


### PR DESCRIPTION
This function is old, was supported for compatibility,
and was misunderstood/mis-used.