### PR TITLE
 Remove the clone() method from TruthValues

### DIFF
--- a/opencog/atoms/truthvalue/CountTruthValue.h
+++ b/opencog/atoms/truthvalue/CountTruthValue.h
@@ -85,11 +85,6 @@ public:
         return std::static_pointer_cast<const TruthValue>(
             std::make_shared<const CountTruthValue>(v));
     }
-
-    TruthValuePtr clone() const
-    {
-        return std::make_shared<CountTruthValue>(*this);
-    }
 };
 
 static inline CountTruthValuePtr CountTruthValueCast(const TruthValuePtr& tv)

--- a/opencog/atoms/truthvalue/EvidenceCountTruthValue.h
+++ b/opencog/atoms/truthvalue/EvidenceCountTruthValue.h
@@ -104,11 +104,6 @@ public:
 		return std::static_pointer_cast<const TruthValue>(
 			std::make_shared<const EvidenceCountTruthValue>(pap));
 	}
-
-	TruthValuePtr clone() const
-	{
-		return std::make_shared<EvidenceCountTruthValue>(*this);
-	}
 };
 
 template<typename ... Type>

--- a/opencog/atoms/truthvalue/FuzzyTruthValue.h
+++ b/opencog/atoms/truthvalue/FuzzyTruthValue.h
@@ -104,11 +104,6 @@ public:
         return std::static_pointer_cast<const TruthValue>(
             std::make_shared<const FuzzyTruthValue>(pap));
     }
-
-    TruthValuePtr clone() const
-    {
-        return std::make_shared<FuzzyTruthValue>(*this);
-    }
 };
 
 /** @}*/

--- a/opencog/atoms/truthvalue/IndefiniteTruthValue.h
+++ b/opencog/atoms/truthvalue/IndefiniteTruthValue.h
@@ -161,11 +161,6 @@ public:
             std::make_shared<const IndefiniteTruthValue>(v));
     }
 
-    TruthValuePtr clone() const
-    {
-        return std::make_shared<IndefiniteTruthValue>(*this);
-    }
-
     static confidence_t DEFAULT_CONFIDENCE_LEVEL;
     static strength_t diffError;
     static strength_t s; //Nil : not that sure s should be strength_t

--- a/opencog/atoms/truthvalue/IndefiniteTruthValue.h
+++ b/opencog/atoms/truthvalue/IndefiniteTruthValue.h
@@ -124,7 +124,7 @@ public:
     std::string to_string(const std::string&) const;
 
     // clone method
-    static IndefiniteTruthValuePtr createITV(TruthValuePtr tv)
+    static IndefiniteTruthValuePtr createITV(const TruthValuePtr& tv)
     {
         if (tv->get_type() != INDEFINITE_TRUTH_VALUE)
             throw RuntimeException(TRACE_INFO, "Cannot clone non-indefinite TV");
@@ -132,7 +132,7 @@ public:
             static_cast<const IndefiniteTruthValue&>(*tv));
     }
 
-    static TruthValuePtr createTV(TruthValuePtr tv)
+    static TruthValuePtr createTV(const TruthValuePtr& tv)
     {
         return std::static_pointer_cast<const TruthValue>(createITV(tv));
     }

--- a/opencog/atoms/truthvalue/ProbabilisticTruthValue.h
+++ b/opencog/atoms/truthvalue/ProbabilisticTruthValue.h
@@ -79,11 +79,6 @@ public:
         return std::static_pointer_cast<const TruthValue>(
             std::make_shared<const ProbabilisticTruthValue>(pap));
     }
-
-    TruthValuePtr clone() const
-    {
-        return std::make_shared<const ProbabilisticTruthValue>(*this);
-    }
 };
 
 /** @}*/

--- a/opencog/atoms/truthvalue/SimpleTruthValue.h
+++ b/opencog/atoms/truthvalue/SimpleTruthValue.h
@@ -95,11 +95,6 @@ public:
         return std::static_pointer_cast<const TruthValue>(
             std::make_shared<const SimpleTruthValue>(pap));
     }
-
-    TruthValuePtr clone() const
-    {
-        return std::make_shared<const SimpleTruthValue>(*this);
-    }
 };
 
 template<typename ... Type>

--- a/opencog/atoms/truthvalue/TruthValue.h
+++ b/opencog/atoms/truthvalue/TruthValue.h
@@ -147,8 +147,6 @@ public:
 	virtual confidence_t get_confidence()  const = 0;
 	virtual count_t get_count()  const = 0;
 
-	virtual TruthValuePtr clone() const  = 0;
-
 	/**
 	 * Merge this TV object with the given TV object argument.
 	 * It always returns a new TV object with the result of the merge,

--- a/tests/atoms/truthvalue/IndefiniteTruthValueUTest.cxxtest
+++ b/tests/atoms/truthvalue/IndefiniteTruthValueUTest.cxxtest
@@ -379,46 +379,6 @@ public:
         }
     }
 
-    void testClone() {
-        for (int i = 0; i < NUM_TVS; i++) {
-            TruthValuePtr clon = tvs[i]->clone();
-            IndefiniteTruthValuePtr clonedTv = IndefiniteTVCast(clon);
-            TS_ASSERT(fabs(clonedTv->getL()  - ls[i]) <= FLOAT_ACCEPTABLE_ERROR);
-            TS_ASSERT(fabs(clonedTv->getU()  - us[i]) <= FLOAT_ACCEPTABLE_ERROR);
-            TS_ASSERT(fabs(clonedTv->getConfidenceLevel()  - IndefiniteTruthValue::DEFAULT_CONFIDENCE_LEVEL) <= FLOAT_ACCEPTABLE_ERROR);
-            //compute diff using a method provided with the UTest
-            strength_t computedDiff = computeDiff(clonedTv->getL(), clonedTv->getU(),
-                                             default_k, clonedTv->getConfidenceLevel());
-            TS_ASSERT(isApproxEq(clonedTv->getDiff(), computedDiff, DIFF_ACCEPTABLE_ERROR));
-            TS_ASSERT(clonedTv->isSymmetric());
-            TS_ASSERT(fabs(clonedTv->get_mean() - means[i]) <= ERROR_THRESHOLD);
-            count_t expectedCount = count(ls[i], us[i]);
-            confidence_t expectedConfidence = confidence(ls[i], us[i]);
-            TS_ASSERT(fabs(clonedTv->get_count() - expectedCount) <= ERROR_THRESHOLD);
-            TS_ASSERT(fabs(clonedTv->get_confidence() - expectedConfidence) <= ERROR_THRESHOLD);
-        }
-        // Changes all attributes and check if clone still works fine.
-        tvs[0]->setL(ls[1]);
-        tvs[0]->setU(us[1]);
-        tvs[0]->setConfidenceLevel(IndefiniteTruthValue::DEFAULT_CONFIDENCE_LEVEL + 0.1f);
-        tvs[0]->setDiff(0.1f);
-        //tvs[0]->setSymmetric(false); Cannot call this yet because it thows an exception (asymmetric indefinite tv is not implemented)
-        tvs[0]->setMean(means[1]);
-        TruthValuePtr clon = tvs[0]->clone();
-        IndefiniteTruthValuePtr clonedTv = IndefiniteTVCast(clon);
-        TS_ASSERT(fabs(clonedTv->getL()  - ls[1]) <= FLOAT_ACCEPTABLE_ERROR);
-        TS_ASSERT(fabs(clonedTv->getU()  - us[1]) <= FLOAT_ACCEPTABLE_ERROR);
-        TS_ASSERT(fabs(clonedTv->getConfidenceLevel() - (IndefiniteTruthValue::DEFAULT_CONFIDENCE_LEVEL + 0.1f)) <= ERROR_THRESHOLD);
-        TS_ASSERT(fabs(clonedTv->getDiff() - 0.1f) <= ERROR_THRESHOLD);
-        //TS_ASSERT(!clonedTv->isSymmetric());
-        TS_ASSERT(clonedTv->isSymmetric());
-        TS_ASSERT(fabs(clonedTv->get_mean() - means[1]) <= ERROR_THRESHOLD);
-        count_t expectedCount = count(ls[1], us[1]);
-        confidence_t expectedConfidence = confidence(ls[1], us[1]);
-        TS_ASSERT(fabs(clonedTv->get_count() - expectedCount) <= ERROR_THRESHOLD);
-        TS_ASSERT(fabs(clonedTv->get_confidence() - expectedConfidence) <= ERROR_THRESHOLD);
-    }
-
     void testSetAndGetFirstOrderDistribution() {
         for (unsigned int i = 0; i < NUM_TVS; i++) {
             IndefiniteTruthValue* tv = tvs[i];

--- a/tests/atoms/truthvalue/SimpleTruthValueUTest.cxxtest
+++ b/tests/atoms/truthvalue/SimpleTruthValueUTest.cxxtest
@@ -104,15 +104,6 @@ public:
         }
     }
 
-    void testClone() {
-        for (int i = 0; i < NUM_TVS; i++) {
-            TruthValuePtr clonedTv = tvs[i]->clone();
-            TS_ASSERT(fabs(clonedTv->get_mean()  - means[i]) <= FLOAT_ACCEPTABLE_ERROR);
-            TS_ASSERT(fabs(clonedTv->get_count()  - counts[i]) <= FLOAT_ACCEPTABLE_ERROR);
-            TS_ASSERT(clonedTv->get_confidence() - confidences[i] < FLOAT_ACCEPTABLE_ERROR);
-        }
-    }
-
     void testGetType() {
         for (int i = 0; i < NUM_TVS; i++) {
             TS_ASSERT(tvs[i]->get_type() == SIMPLE_TRUTH_VALUE);


### PR DESCRIPTION
Nuisance method that no one uses for anything. Continuing to carry it forward is a cognitive overload for users/implementors who don't realize that it's not needed.