### PR TITLE
Handle the case where And, Or or Not are used as logical connectors

### DIFF
--- a/opencog/atoms/core/RewriteLink.cc
+++ b/opencog/atoms/core/RewriteLink.cc
@@ -434,7 +434,7 @@ Handle RewriteLink::consume_quotations(const Variables& variables,
 	                       (t == PUT_LINK or
 	                        nameserver().isA(t, FUNCTION_LINK) or
 	                        nameserver().isA(t, EVALUATION_LINK) or
-	                        (t == AND_LINK and clause_root) or
+	                        (is_logical_connector(t) and clause_root) or
 	                        is_scope_bound_to_ancestor(variables, h)));
 
 	// Propagate the need for quotation down
@@ -506,6 +506,11 @@ bool RewriteLink::is_bound_to_ancestor(const Variables& variables,
 		}
 	}
 	return false;
+}
+
+bool RewriteLink::is_logical_connector(Type t)
+{
+	return t == AND_LINK or t == OR_LINK or t == NOT_LINK;
 }
 
 /* ================================================================= */

--- a/opencog/atoms/core/RewriteLink.h
+++ b/opencog/atoms/core/RewriteLink.h
@@ -103,6 +103,13 @@ protected:
 	 */
 	static bool is_scope_bound_to_ancestor(const Variables& variables, const Handle& h);
 
+	/**
+	 * Return true if the type if the type is AND_LINK, OR_LINK or
+	 * NOT_LINK, as when used at the root of the pattern body these
+	 * links act as logical connectors.
+	 */
+	static bool is_logical_connector(Type);
+
 public:
 	RewriteLink(const HandleSeq&, Type=REWRITE_LINK);
 	RewriteLink(const Handle& varcdecls, const Handle& body);

--- a/tests/atoms/RewriteLinkUTest.cxxtest
+++ b/tests/atoms/RewriteLinkUTest.cxxtest
@@ -78,6 +78,7 @@ public:
 	void test_consume_quotations_2();
 	void test_consume_quotations_3();
 	void test_consume_quotations_4();
+	void test_consume_quotations_5();
 };
 
 #define NA _asa.add_node
@@ -332,6 +333,29 @@ void RewriteLinkUTest::test_consume_quotations_4()
 	// gpn is evaluatable
 	Handle result = RewriteLink::consume_quotations(vardecl, quoted_clauses, true),
 		expected = _eval.eval_h("consumed-quoted-grounded-predicate-argument");
+
+	std::cout << "result = " << oc_to_string(result);
+	std::cout << "expected = " << oc_to_string(expected);
+
+	TS_ASSERT(content_eq(result, expected));
+}
+
+void RewriteLinkUTest::test_consume_quotations_5()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	std::string rs = _eval.eval("(load-from-path \"tests/atoms/quotations.scm\")");
+	logger().debug() << "rs = " << rs;
+
+	// Test simple RewriteLink
+	Handle vardecl = al(VARIABLE_LIST),
+		quoted_clause = _eval.eval_h("quoted-not-X");
+
+	// LocalQuoteLink should not be removed because NotLink is
+	// interpreted as a logical connector by the pattern matcher in
+	// that context.
+	Handle result = RewriteLink::consume_quotations(vardecl, quoted_clause, true),
+		expected = quoted_clause;
 
 	std::cout << "result = " << oc_to_string(result);
 	std::cout << "expected = " << oc_to_string(expected);

--- a/tests/atoms/quotations.scm
+++ b/tests/atoms/quotations.scm
@@ -169,3 +169,11 @@
     )
   )
 )
+
+(define quoted-not-X
+  (LocalQuoteLink
+    (NotLink
+      (VariableNode "$X")
+    )
+  )
+)


### PR DESCRIPTION
LocalQuote at the root of the pattern body should not be consumed when
wrapping logical connectors And, Or or Not, otherwise the semantics of
the pattern is modified.