### PR TITLE
Fix unification of clauses with GlobNodes in them.

### DIFF
--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1203,8 +1203,10 @@ bool PatternMatchEngine::explore_up_branches(const PatternTermPtr& ptm,
 	// Move up the solution graph, looking for a match.
 	IncomingSet iset = _pmc.get_incoming_set(hg);
 	size_t sz = iset.size();
-	DO_LOG({LAZY_LOG_FINE << "Looking upward for term=" << ptm->to_string()
-	              << " have " << sz << " branches";})
+	DO_LOG({LAZY_LOG_FINE << "Looking upward for term = "
+	              << ptm->getHandle()->to_string()
+	              << "It's grounding " << hg->to_string()
+	              << " has " << sz << " branches";})
 
 	// Check if the pattern has globs in it.
 	bool has_glob = (0 < _pat->globby_holders.count(ptm->getHandle()));
@@ -1458,8 +1460,14 @@ bool PatternMatchEngine::do_term_up(const PatternTermPtr& ptm,
 	// find its parent in the clause. For an evaluatable term, we find
 	// the parent evaluatable in the clause, which may be many steps
 	// higher.
+#if 1
 	DO_LOG({LAZY_LOG_FINE << "Term = " << ptm->to_string()
-	              << " of clause UUID = " << clause_root.value()
+	              << " of clause hash = " << clause_root.value()
+	              << " has ground, move upwards";})
+#endif
+
+	DO_LOG({LAZY_LOG_FINE << "Term = " << ptm->getHandle()->to_string()
+	              << " of clause = " << clause_root->to_string()
 	              << " has ground, move upwards";})
 
 	if (0 < _pat->in_evaluatable.count(hp))

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -229,6 +229,10 @@ private:
 	                           const Handle&);
 	bool explore_up_branches(const PatternTermPtr&, const Handle&,
 	                         const Handle&);
+	bool explore_upvar_branches(const PatternTermPtr&, const Handle&,
+	                         const Handle&);
+	bool explore_upglob_branches(const PatternTermPtr&, const Handle&,
+	                         const Handle&);
 	bool explore_link_branches(const PatternTermPtr&, const Handle&,
 	                           const Handle&);
 	bool explore_choice_branches(const PatternTermPtr&, const Handle&,

--- a/tests/query/GlobUTest.cxxtest
+++ b/tests/query/GlobUTest.cxxtest
@@ -677,6 +677,7 @@ void GlobUTest::test_pivot(void)
  */
 void GlobUTest::test_multi_pivot(void)
 {
+#if 0
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
 	eval->eval("(load-from-path \"tests/query/glob-multi-pivot.scm\")");
@@ -694,4 +695,5 @@ void GlobUTest::test_multi_pivot(void)
 
 	// ----
 	logger().debug("END TEST: %s", __FUNCTION__);
+#endif
 }

--- a/tests/query/GlobUTest.cxxtest
+++ b/tests/query/GlobUTest.cxxtest
@@ -686,6 +686,14 @@ void GlobUTest::test_multi_pivot(void)
 		"		(ConceptNode \"blah\")))"
 	);
 
+	Handle chesponse = eval->eval_h(
+		"(SetLink"
+		"	(ListLink"
+		"		(ConceptNode \"class-3\")"
+		"		(ListLink"
+		"			(ConceptNode \"blah\"))))"
+	);
+
 	Handle plain = eval->eval_h("(cog-execute! glob-unify-plain)");
 	printf("unify-plain got %s\n", plain->to_string().c_str());
 	TS_ASSERT_EQUALS(1, plain->get_arity());
@@ -696,13 +704,20 @@ void GlobUTest::test_multi_pivot(void)
 	TS_ASSERT_EQUALS(1, tall->get_arity());
 	TS_ASSERT_EQUALS(tall, response);
 
-#if 0
 	Handle pivot = eval->eval_h("(cog-execute! glob-multi-pivot)");
 	printf("multi-pivot got %s\n", pivot->to_string().c_str());
 	TS_ASSERT_EQUALS(1, pivot->get_arity());
-
 	TS_ASSERT_EQUALS(pivot, response);
-#endif
+
+	Handle chase = eval->eval_h("(cog-execute! glob-chase-pivot)");
+	printf("chase-pivot got %s\n", chase->to_string().c_str());
+	TS_ASSERT_EQUALS(1, chase->get_arity());
+	TS_ASSERT_EQUALS(chase, chesponse);
+
+	Handle mhase = eval->eval_h("(cog-execute! glob-chase-multi-pivot)");
+	printf("multi-chase got %s\n", mhase->to_string().c_str());
+	TS_ASSERT_EQUALS(1, mhase->get_arity());
+	TS_ASSERT_EQUALS(mhase, chesponse);
 
 	// ----
 	logger().debug("END TEST: %s", __FUNCTION__);

--- a/tests/query/GlobUTest.cxxtest
+++ b/tests/query/GlobUTest.cxxtest
@@ -75,6 +75,7 @@ public:
 	void test_gnest(void);
 	void test_partition(void);
 	void test_pivot(void);
+	void test_multi_pivot(void);
 };
 
 void GlobUTest::tearDown(void)
@@ -657,6 +658,31 @@ void GlobUTest::test_pivot(void)
 
 	Handle pivot = eval->eval_h("(cog-execute! glob-pivot)");
 	printf("pivot got %s\n", pivot->to_string().c_str());
+	TS_ASSERT_EQUALS(1, pivot->get_arity());
+
+	Handle response = eval->eval_h(
+		"(SetLink"
+		"	(ListLink"
+		"		(ConceptNode \"blah\")))"
+	);
+	TS_ASSERT_EQUALS(pivot, response);
+
+	// ----
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+/*
+ * Test pivoting around multiple common GlobNodes.
+ * Same as above, but trickier.
+ */
+void GlobUTest::test_multi_pivot(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	eval->eval("(load-from-path \"tests/query/glob-multi-pivot.scm\")");
+
+	Handle pivot = eval->eval_h("(cog-execute! glob-multi-pivot)");
+	printf("multi-pivot got %s\n", pivot->to_string().c_str());
 	TS_ASSERT_EQUALS(1, pivot->get_arity());
 
 	Handle response = eval->eval_h(

--- a/tests/query/GlobUTest.cxxtest
+++ b/tests/query/GlobUTest.cxxtest
@@ -677,23 +677,33 @@ void GlobUTest::test_pivot(void)
  */
 void GlobUTest::test_multi_pivot(void)
 {
-#if 0
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
 	eval->eval("(load-from-path \"tests/query/glob-multi-pivot.scm\")");
-
-	Handle pivot = eval->eval_h("(cog-execute! glob-multi-pivot)");
-	printf("multi-pivot got %s\n", pivot->to_string().c_str());
-	TS_ASSERT_EQUALS(1, pivot->get_arity());
-
 	Handle response = eval->eval_h(
 		"(SetLink"
 		"	(ListLink"
 		"		(ConceptNode \"blah\")))"
 	);
+
+	Handle plain = eval->eval_h("(cog-execute! glob-unify-plain)");
+	printf("unify-plain got %s\n", plain->to_string().c_str());
+	TS_ASSERT_EQUALS(1, plain->get_arity());
+	TS_ASSERT_EQUALS(plain, response);
+
+	Handle tall = eval->eval_h("(cog-execute! glob-unify-tall)");
+	printf("unify-tall got %s\n", tall->to_string().c_str());
+	TS_ASSERT_EQUALS(1, tall->get_arity());
+	TS_ASSERT_EQUALS(tall, response);
+
+#if 0
+	Handle pivot = eval->eval_h("(cog-execute! glob-multi-pivot)");
+	printf("multi-pivot got %s\n", pivot->to_string().c_str());
+	TS_ASSERT_EQUALS(1, pivot->get_arity());
+
 	TS_ASSERT_EQUALS(pivot, response);
+#endif
 
 	// ----
 	logger().debug("END TEST: %s", __FUNCTION__);
-#endif
 }

--- a/tests/query/glob-multi-pivot.scm
+++ b/tests/query/glob-multi-pivot.scm
@@ -69,6 +69,36 @@
 )
 
 ; ---------------------------------------------
+
+(define glob-chase-pivot
+	(GetLink
+		(VariableList
+			(Variable "$cls")
+			(TypedVariableLink
+				(GlobNode "$G")
+				(TypeSetLink
+					(TypeNode "ConceptNode")
+					(IntervalLink (NumberNode 1) (NumberNode -1))
+				)
+			)
+		)
+		(AndLink
+			(EvaluationLink
+				(PredicateNode "pred-1")
+				(ListLink (GlobNode "$G")))
+
+			(EvaluationLink
+				(PredicateNode "pred-2")
+				(ListLink (GlobNode "$G")))
+
+			(MemberLink
+				(GlobNode "$G")
+				(Variable "$cls"))
+		)
+	)
+)
+
+; ---------------------------------------------
 (define glob-multi-pivot
 	(GetLink
 		(TypedVariableLink
@@ -99,7 +129,7 @@
 )
 
 ; ---------------------------------------------
-(define glob-chase-pivot
+(define glob-chase-multi-pivot
 	(GetLink
 		(VariableList
 			(Variable "$cls")

--- a/tests/query/glob-multi-pivot.scm
+++ b/tests/query/glob-multi-pivot.scm
@@ -25,6 +25,50 @@
 	(ConceptNode "class-3"))
 
 ; ---------------------------------------------
+
+(define glob-unify-plain
+	(GetLink
+		(TypedVariableLink
+			(GlobNode "$G")
+			(TypeSetLink
+				(TypeNode "ConceptNode")
+				(IntervalLink (NumberNode 1) (NumberNode -1))
+			)
+		)
+		(AndLink
+			(EvaluationLink
+				(PredicateNode "pred-1")
+				(ListLink (GlobNode "$G")))
+
+			(MemberLink
+				(GlobNode "$G")
+				(ConceptNode "class-3"))
+		)
+	)
+)
+
+(define glob-unify-tall
+	(GetLink
+		(TypedVariableLink
+			(GlobNode "$G")
+			(TypeSetLink
+				(TypeNode "ConceptNode")
+				(IntervalLink (NumberNode 1) (NumberNode -1))
+			)
+		)
+		(AndLink
+			(EvaluationLink
+				(PredicateNode "pred-1")
+				(ListLink (GlobNode "$G")))
+
+			(MemberLink
+				(OrderedLink (GlobNode "$G"))
+				(ConceptNode "class-1"))
+		)
+	)
+)
+
+; ---------------------------------------------
 (define glob-multi-pivot
 	(GetLink
 		(TypedVariableLink

--- a/tests/query/glob-multi-pivot.scm
+++ b/tests/query/glob-multi-pivot.scm
@@ -20,6 +20,11 @@
 	(OrderedLink (ConceptNode "blah"))
 	(ConceptNode "class-2"))
 
+(MemberLink
+	(ConceptNode "blah")
+	(ConceptNode "class-3"))
+
+; ---------------------------------------------
 (define glob-multi-pivot
 	(GetLink
 		(TypedVariableLink
@@ -45,6 +50,39 @@
 			(MemberLink
 				(OrderedLink (GlobNode "$G"))
 				(ConceptNode "class-2"))
+		)
+	)
+)
+
+; ---------------------------------------------
+(define glob-chase-pivot
+	(GetLink
+		(VariableList
+			(Variable "$cls")
+			(TypedVariableLink
+				(GlobNode "$G")
+				(TypeSetLink
+					(TypeNode "ConceptNode")
+					(IntervalLink (NumberNode 1) (NumberNode -1))
+				)
+			)
+		)
+		(AndLink
+			(EvaluationLink
+				(PredicateNode "pred-1")
+				(ListLink (GlobNode "$G")))
+
+			(EvaluationLink
+				(PredicateNode "pred-2")
+				(ListLink (GlobNode "$G")))
+
+			(MemberLink
+				(OrderedLink (GlobNode "$G"))
+				(ConceptNode "class-1"))
+
+			(MemberLink
+				(GlobNode "$G")
+				(Variable "$cls"))
 		)
 	)
 )

--- a/tests/query/glob-multi-pivot.scm
+++ b/tests/query/glob-multi-pivot.scm
@@ -1,0 +1,50 @@
+
+; multi-pivot version of glob-pivot.scm
+; 
+;
+(use-modules (opencog) (opencog exec))
+
+(EvaluationLink
+	(PredicateNode "pred-1")
+	(ListLink (ConceptNode "blah")))
+
+(EvaluationLink
+	(PredicateNode "pred-2")
+	(ListLink (ConceptNode "blah")))
+
+(MemberLink
+	(OrderedLink (ConceptNode "blah"))
+	(ConceptNode "class-1"))
+
+(MemberLink
+	(OrderedLink (ConceptNode "blah"))
+	(ConceptNode "class-2"))
+
+(define glob-multi-pivot
+	(GetLink
+		(TypedVariableLink
+			(GlobNode "$G")
+			(TypeSetLink
+				(TypeNode "ConceptNode")
+				(IntervalLink (NumberNode 1) (NumberNode -1))
+			)
+		)
+		(AndLink
+			(EvaluationLink
+				(PredicateNode "pred-1")
+				(ListLink (GlobNode "$G")))
+
+			(EvaluationLink
+				(PredicateNode "pred-2")
+				(ListLink (GlobNode "$G")))
+
+			(MemberLink
+				(OrderedLink (GlobNode "$G"))
+				(ConceptNode "class-1"))
+
+			(MemberLink
+				(OrderedLink (GlobNode "$G"))
+				(ConceptNode "class-2"))
+		)
+	)
+)

--- a/tests/query/glob-pivot.scm
+++ b/tests/query/glob-pivot.scm
@@ -4,43 +4,43 @@
 (use-modules (opencog) (opencog exec))
 
 (EvaluationLink
-    (PredicateNode "pred-1")
-    (ListLink
-        (ConceptNode "blah")
-    )
+	(PredicateNode "pred-1")
+	(ListLink
+		(ConceptNode "blah")
+	)
 )
 (EvaluationLink
-    (PredicateNode "pred-2")
-    (ListLink
-        (ConceptNode "blah")
-    )
+	(PredicateNode "pred-2")
+	(ListLink
+		(ConceptNode "blah")
+	)
 )
 
 (define glob-pivot
-    (GetLink
-        (TypedVariableLink
-            (GlobNode "$G")
-            (TypeSetLink
-                (TypeNode "ConceptNode")
-                (IntervalLink
-                    (NumberNode 1)
-                    (NumberNode -1)
-                )
-            )
-        )
-        (AndLink
-            (EvaluationLink
-                (PredicateNode "pred-1")
-                (ListLink
-                    (GlobNode "$G")
-                )
-            )
-            (EvaluationLink
-                (PredicateNode "pred-2")
-                (ListLink
-                    (GlobNode "$G")
-                )
-            )
-        )
-    )
+	(GetLink
+		(TypedVariableLink
+			(GlobNode "$G")
+			(TypeSetLink
+				(TypeNode "ConceptNode")
+				(IntervalLink
+					(NumberNode 1)
+					(NumberNode -1)
+				)
+			)
+		)
+		(AndLink
+			(EvaluationLink
+				(PredicateNode "pred-1")
+				(ListLink
+					(GlobNode "$G")
+				)
+			)
+			(EvaluationLink
+				(PredicateNode "pred-2")
+				(ListLink
+					(GlobNode "$G")
+				)
+			)
+		)
+	)
 )


### PR DESCRIPTION
Apparently, in all of the prior work on GlobNodes, no one attempted to unify
multiple clauses containing the same GlobNode. Bug #2167 was the first to
expose this lack. After fixing that, it became apparent that some additional
fixes were needed, as more general test cases exposed more issues. 
I think this patch finally fixes all of them, but I did not try anything truly wild
or complex; just the next batch of "basic support".
