### PR TITLE
Remove unused argument; rename to more accurate name.

### DIFF
--- a/opencog/atoms/pattern/Pattern.cc
+++ b/opencog/atoms/pattern/Pattern.cc
@@ -29,9 +29,6 @@ std::string Pattern::to_string(const std::string& indent) const
 	if (not clauses.empty())
 		ss << indent << "clauses:" << std::endl
 		   << oc_to_string(clauses, indent + OC_TO_STRING_INDENT);
-	if (not constants.empty())
-		ss << indent << "constants:" << std::endl
-		   << oc_to_string(constants, indent + OC_TO_STRING_INDENT);
 	if (not mandatory.empty())
 		ss << indent << "mandatory:" << std::endl
 		   << oc_to_string(mandatory, indent + OC_TO_STRING_INDENT);

--- a/opencog/atoms/pattern/Pattern.h
+++ b/opencog/atoms/pattern/Pattern.h
@@ -83,9 +83,6 @@ struct Pattern
 	/// The actual clauses. Set by unbundle_clauses().
 	HandleSeq        clauses;
 
-	/// The removed constant clauses. Set by unbundle_clauses().
-	HandleSeq        constants;
-
 	/// The cnf_clauses are the clauses, but with the AbsentLink removed.
 	/// This simplifies graph discovery, so that when they are found,
 	/// they can be rejected (e.g. are not absent).

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -58,15 +58,6 @@ void PatternLink::common_init(void)
 	// Locate the black-box and clear-box clauses.
 	unbundle_virtual(_varlist.varset, _pat.cnf_clauses,
 	                 _fixed, _virtual, _pat.black);
-
-	// Same as above but for constant clauses. The fixed clauses (non
-	// virtual because with less than 2 variables) are pushed into a
-	// dummy container, constant_fixed as they are not useful for
-	// subsequent component analysis.
-	HandleSeq constant_fixed;
-	unbundle_virtual(_varlist.varset, _pat.constants,
-	                 constant_fixed, _virtual, _pat.black);
-
 	_num_virts = _virtual.size();
 
 	add_dummies();

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -51,8 +51,8 @@ void PatternLink::common_init(void)
 		return;
 	}
 
-	remove_constants(_varlist.varset, _pat, _components, _component_patterns);
 	validate_variables(_varlist.varset, _pat.clauses);
+	remove_constants(_varlist.varset, _pat, _components, _component_patterns);
 	extract_optionals(_varlist.varset, _pat.clauses);
 
 	// Locate the black-box and clear-box clauses.
@@ -927,34 +927,6 @@ void PatternLink::check_connectivity(const HandleSeqSeq& components)
 		cnt++;
 	}
 	throw InvalidParamException(TRACE_INFO, ss.str().c_str());
-}
-
-/* ================================================================= */
-
-void PatternLink::remove_constant_clauses(void)
-{
-	// Remove clauses that don't alter the search. Any clause that
-	// fails to contain a variable, or fails to be evaluatable, will
-	// not affect the search in any way, because it is trivially
-	// satisfiable (and is always satisfied). Thus, its pointless
-	// to try to match them; they will always match.
-	bool bogus = remove_constants(_varlist.varset, _pat, _components,
-	                              _component_patterns);
-	if (bogus)
-	{
-		if (logger().is_debug_enabled())
-		{
-			logger().debug("%s: Constant clauses removed from pattern %s",
-			           __FUNCTION__, to_string().c_str());
-			for (const Handle& h: _pat.constants)
-			{
-				logger().debug("%s: Removed %s",
-				          __FUNCTION__, h->to_string().c_str());
-			}
-		}
-		_num_comps = _components.size();
-		make_connectivity_map(_pat.cnf_clauses);
-	}
 }
 
 /* ================================================================= */

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -52,7 +52,7 @@ void PatternLink::common_init(void)
 	}
 
 	remove_constants(_varlist.varset, _pat, _components, _component_patterns);
-	validate_clauses(_varlist.varset, _pat.clauses, _pat.constants);
+	validate_variables(_varlist.varset, _pat.clauses);
 	extract_optionals(_varlist.varset, _pat.clauses);
 
 	// Locate the black-box and clear-box clauses.
@@ -115,7 +115,6 @@ void PatternLink::common_init(void)
 		// a minor performance boost during clause traversal.
 		// Gurk. This does not work currently; the evaluatables have been
 		// stripped out of the component. I think this is a bug ...
-		// Is this related to the other XXX for validate_clauses??
 		// _pat.cnf_clauses = _components[0];
 	   make_connectivity_map(_pat.cnf_clauses);
 	}
@@ -466,9 +465,8 @@ void PatternLink::locate_globs(HandleSeq& clauses)
  * to programmer error. Quoted variables are constants, and so don't
  * count.
  */
-void PatternLink::validate_clauses(HandleSet& vars,
-                                   HandleSeq& clauses,
-                                   HandleSeq& constants)
+void PatternLink::validate_variables(HandleSet& vars,
+                                     const HandleSeq& clauses)
 
 {
 	for (const Handle& v : vars)

--- a/opencog/atoms/pattern/PatternLink.h
+++ b/opencog/atoms/pattern/PatternLink.h
@@ -99,9 +99,8 @@ protected:
 
 	void locate_defines(HandleSeq& clauses);
 	void locate_globs(HandleSeq& clauses);
-	void validate_clauses(HandleSet& vars,
-	                      HandleSeq& clauses,
-	                      HandleSeq& constants);
+	void validate_variables(HandleSet& vars,
+	                        const HandleSeq& clauses);
 
 	void extract_optionals(const HandleSet &vars,
 	                       const HandleSeq &component);

--- a/opencog/atoms/pattern/PatternLink.h
+++ b/opencog/atoms/pattern/PatternLink.h
@@ -167,8 +167,6 @@ public:
 	const HandleSeq& get_fixed(void) const { return _fixed; }
 	const HandleSeq& get_virtual(void) const { return _virtual; }
 
-	void remove_constant_clauses(void);
-
 	bool satisfy(PatternMatchCallback&) const;
 
 	void debug_log(void) const;

--- a/opencog/atoms/pattern/PatternUtils.cc
+++ b/opencog/atoms/pattern/PatternUtils.cc
@@ -30,25 +30,24 @@ using namespace opencog;
 namespace opencog {
 
 /**
- * Remove constant clauses from the list of clauses if they are in
- * the queried atomspace.
- *
- * Make sure that every clause contains at least one variable;
- * if not, remove the clause from the list of clauses.
+ * Remove constant clauses from the list of clauses. Every clause
+ * should contain at least one variable, or it should be evaluatable.
+ * If does not, or is not, remove the clause from the list of clauses.
  *
  * The core idea is that pattern matching against a constant expression
  * "doesn't make sense" -- the constant expression will always match to
  * itself and is thus "trivial".  In principle, the programmer should
  * never include constants in the list of clauses ... but, due to
  * programmer error, this can happen, and will lead to failures during
- * pattern matching. Thus, the routine below can be used to validate
- * the input.
+ * pattern matching. Thus, the routine below can be used to clean up
+ * the pattern-matcher input.
  *
  * Terms that contain GroundedSchema or GroundedPredicate nodes can
- * have side-effects, and are thus not really constants. They must be
- * evaluated during the pattern search. Terms that contain
- * DefinedPredicate or DefinedSchema nodes are simply not known until
- * runtime evaluation/execution.
+ * have side-effects, and are thus are not constants, even if they
+ * don't contain any variables. They must be kept around, and must be
+ * evaluated during the pattern search.  The definitions of
+ * DefinedPredicate or DefinedSchema nodes cannot be accessed until
+ * runtime evaluation/execution, so these too must be kept.
  *
  * The match for EvaluatableLink's is meant to solve the problem of
  * evaluating (SatisfactionLink (AndLink (TrueLink))) vs. evaluating

--- a/opencog/atoms/pattern/PatternUtils.cc
+++ b/opencog/atoms/pattern/PatternUtils.cc
@@ -20,8 +20,6 @@
  * Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-#include <boost/range/algorithm/find.hpp>
-
 #include <opencog/atoms/core/FindUtils.h>
 #include "PatternUtils.h"
 
@@ -80,7 +78,8 @@ bool remove_constants(const HandleSet& vars,
 		i = pat.clauses.erase(i);
 
 		// remove the clause from components and component_patterns
-		auto j = boost::find(components, HandleSeq{clause});
+		auto j = std::find(components.begin(), components.end(),
+		                   HandleSeq{clause});
 		if (j != components.end())
 		{
 			components.erase(j);
@@ -93,12 +92,12 @@ bool remove_constants(const HandleSet& vars,
 		}
 
 		// remove the clause from _pattern_mandatory.
-		auto m = boost::find(pat.mandatory, clause);
+		auto m = std::find(pat.mandatory.begin(), pat.mandatory.end(), clause);
 		if (m != pat.mandatory.end())
 			pat.mandatory.erase(m);
 
 		// remove the clause from _cnf_clauses.
-		auto c = boost::find(pat.cnf_clauses, clause);
+		auto c = std::find(pat.cnf_clauses.begin(), pat.cnf_clauses.end(), clause);
 		if (c != pat.cnf_clauses.end())
 			pat.cnf_clauses.erase(c);
 

--- a/opencog/atoms/pattern/PatternUtils.cc
+++ b/opencog/atoms/pattern/PatternUtils.cc
@@ -77,7 +77,6 @@ bool remove_constants(const HandleSet& vars,
 			++i; continue;
 		}
 
-		pat.constants.emplace_back(clause);
 		i = pat.clauses.erase(i);
 
 		// remove the clause from components and component_patterns


### PR DESCRIPTION
Someone changed this function long ago, but did not clean up
the arguments when they did so. Clean up now.