### PR TITLE
Pull StateLink management out of the atomspace 

### DIFF
--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -329,7 +329,8 @@ void Atom::remove_atom(const LinkPtr& a)
 #endif /* INCOMING_SET_SIGNALS */
     Type at = a->get_type();
     auto bucket = _incoming_set->_iset.find(at);
-    bucket->second.erase(a);
+    if (bucket != _incoming_set->_iset.end())
+        bucket->second.erase(a);
 }
 
 /// Remove old, and add new, atomically, so that every user
@@ -361,6 +362,9 @@ void Atom::swap_atom(const LinkPtr& old, const LinkPtr& neu)
     _incoming_set->_addAtomSignal(shared_from_this(), neu);
 #endif /* INCOMING_SET_SIGNALS */
 }
+
+void Atom::install() {}
+void Atom::remove() {}
 
 size_t Atom::getIncomingSetSize() const
 {

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -104,7 +104,8 @@ class Atom
 {
     friend class AtomTable;       // Needs to call MarkedForRemoval()
     friend class AtomSpace;       // Needs to call getAtomTable()
-    friend class DeleteLink;      // Needs to call getAtomTable()
+    friend class Link;            // Needs to call install_atom()
+    friend class StateLink;       // Needs to call swap_atom()
     friend class ProtocolBufferSerializer; // Needs to de/ser-ialize an Atom
 
 protected:
@@ -196,6 +197,8 @@ protected:
     void insert_atom(const LinkPtr&);
     void remove_atom(const LinkPtr&);
     void swap_atom(const LinkPtr&, const LinkPtr&);
+    virtual void install();
+    virtual void remove();
 
     virtual ContentHash compute_hash() const = 0;
 

--- a/opencog/atoms/base/Link.cc
+++ b/opencog/atoms/base/Link.cc
@@ -185,3 +185,21 @@ ContentHash Link::compute_hash() const
 	_content_hash = hsh;
 	return _content_hash;
 }
+
+/// Place `this` into the incoming set of each outgoing atom.
+///
+void Link::install()
+{
+	LinkPtr llc(LinkCast(get_handle()));
+	size_t arity = get_arity();
+	for (size_t i = 0; i < arity; i++)
+		_outgoing[i]->insert_atom(llc);
+}
+
+void Link::remove()
+{
+	LinkPtr lll(LinkCast(get_handle()));
+	size_t arity = get_arity();
+	for (size_t i = 0; i < arity; i++)
+		_outgoing[i]->remove_atom(lll);
+}

--- a/opencog/atoms/base/Link.h
+++ b/opencog/atoms/base/Link.h
@@ -57,6 +57,8 @@ protected:
     //! Should not change during atom lifespan.
     HandleSeq _outgoing;
 
+    virtual void install();
+    virtual void remove();
     virtual ContentHash compute_hash() const;
 
 public:

--- a/opencog/atoms/core/DeleteLink.cc
+++ b/opencog/atoms/core/DeleteLink.cc
@@ -43,12 +43,8 @@ void DeleteLink::setAtomSpace(AtomSpace * as)
 		return;
 	}
 
-	const HandleSeq& oset = _outgoing;
-	for (const Handle& h : oset)
-	{
-		Type t = h->get_type();
+	for (const Handle& h : _outgoing)
 		as->extract_atom(h, true);
-	}
 
 	// The AtomSpace code seems to want this exception, so that
 	// the atom gets deleted from the backingstore too.  But we could

--- a/opencog/atoms/core/DeleteLink.cc
+++ b/opencog/atoms/core/DeleteLink.cc
@@ -47,8 +47,7 @@ void DeleteLink::setAtomSpace(AtomSpace * as)
 	for (const Handle& h : oset)
 	{
 		Type t = h->get_type();
-		if (VARIABLE_NODE != t)
-			as->extract_atom(h, true);
+		as->extract_atom(h, true);
 	}
 
 	// The AtomSpace code seems to want this exception, so that

--- a/opencog/atoms/core/StateLink.cc
+++ b/opencog/atoms/core/StateLink.cc
@@ -98,6 +98,10 @@ void StateLink::install()
 		StateLinkPtr old_state(StateLinkCast(defl));
 		if (not old_state->is_closed()) continue;
 
+		// Make sure we are visible in the atomspace, before the swap.
+		AtomSpace *as = old_state->getAtomSpace();
+		setAtomSpace(as);
+
 		// Atomic update of the incoming set.
 		const LinkPtr& new_state = LinkCast(get_handle());
 		alias->swap_atom(old_state, new_state);
@@ -106,8 +110,6 @@ void StateLink::install()
 		_outgoing[1]->insert_atom(new_state);
 
 		// Remove the old StateLink too. It must be no more.
-		AtomSpace *as = old_state->getAtomSpace();
-		// setAtomSpace(as);
 		as->remove_atom(defl->get_handle(), true);
 		swapped = true;
 	}

--- a/opencog/atoms/core/StateLink.cc
+++ b/opencog/atoms/core/StateLink.cc
@@ -21,6 +21,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <opencog/atomspace/AtomSpace.h>
 #include "StateLink.h"
 
 using namespace opencog;
@@ -71,6 +72,20 @@ Handle StateLink::get_state(const Handle& alias)
 Handle StateLink::get_link(const Handle& alias)
 {
 	return get_unique(alias, STATE_LINK, true);
+}
+
+void StateLink::setAtomSpace(AtomSpace * as)
+{
+	// If the handleset is closed (no free variables), then
+	// only one copy of the atom can exist in the atomspace.
+	if (not is_closed())
+	{
+		Atom::setAtomSpace(as);
+		return;
+	}
+	Handle old_state = get_link(get_alias());
+	as->extract_atom(old_state, true);
+	Atom::setAtomSpace(as);
 }
 
 DEFINE_LINK_FACTORY(StateLink, STATE_LINK);

--- a/opencog/atoms/core/StateLink.h
+++ b/opencog/atoms/core/StateLink.h
@@ -46,7 +46,7 @@ class StateLink : public UniqueLink
 {
 protected:
 	void init();
-	void setAtomSpace(AtomSpace *);
+	virtual void install();
 public:
 	StateLink(const HandleSeq&, Type=STATE_LINK);
 	StateLink(const Handle& alias, const Handle& body);

--- a/opencog/atoms/core/StateLink.h
+++ b/opencog/atoms/core/StateLink.h
@@ -46,6 +46,7 @@ class StateLink : public UniqueLink
 {
 protected:
 	void init();
+	void setAtomSpace(AtomSpace *);
 public:
 	StateLink(const HandleSeq&, Type=STATE_LINK);
 	StateLink(const Handle& alias, const Handle& body);

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -39,8 +39,6 @@
 #include <opencog/atoms/atom_types/NameServer.h>
 #include <opencog/atoms/base/Link.h>
 #include <opencog/atoms/base/Node.h>
-#include <opencog/atoms/core/ScopeLink.h>
-#include <opencog/atoms/core/StateLink.h>
 #include <opencog/util/exceptions.h>
 #include <opencog/util/functional.h>
 #include <opencog/util/Logger.h>
@@ -400,28 +398,6 @@ Handle AtomTable::add(AtomPtr atom, bool async, bool force)
     atom->copyValues(Handle(orig));
 
     if (atom->is_link()) {
-        if (STATE_LINK == atom_type) {
-            // If this is a closed StateLink, (i.e. has no variables)
-            // then make sure that the old state gets removed from the
-            // atomtable. The atomtable must contain no more than one
-            // closed state at a time.  Also: we must be careful to
-            // update the incoming set in an atomic fashion, so that
-            // the pattern matcher never finds two closed StateLinks
-            // for any one given alias.  Any number of non-closed
-            // StateLinks are allowed.
-
-            StateLinkPtr slp(StateLinkCast(atom));
-            if (slp->is_closed()) {
-                try {
-                    Handle alias = slp->get_alias();
-                    Handle old_state = StateLink::get_link(alias);
-                    atom->setAtomSpace(_as);
-                    alias->swap_atom(LinkCast(old_state), slp);
-                    extract(old_state, true);
-                } catch (const InvalidParamException& ex) {}
-            }
-        }
-
         // Build the incoming set of outgoing atom h.
         size_t arity = atom->get_arity();
         LinkPtr llc(LinkCast(atom));


### PR DESCRIPTION
Simplify atomspace implementation by handling StateLink entirely with the StateLink class.