### PR TITLE
Verify that StateLink+Get works correctly.

### DIFF
--- a/tests/atoms/StateLinkUTest.cxxtest
+++ b/tests/atoms/StateLinkUTest.cxxtest
@@ -49,6 +49,7 @@ public:
 	void test_getting();
 	void test_putting();
 	void test_list();
+	void test_scope();
 };
 
 #define N _as.add_node
@@ -370,6 +371,71 @@ void StateLinkUTest::test_list()
 	TS_ASSERT_EQUALS(0, bananna->getIncomingSetSize());
 	TS_ASSERT_EQUALS(fruit, link->getOutgoingAtom(0));
 	TS_ASSERT_EQUALS(apple, link->getOutgoingAtom(1));
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// Test correct scoping of GetLink (issue #1576)
+void StateLinkUTest::test_scope()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+	Instantiator inst(&_as);
+
+	// Initial data
+	L(STATE_LINK, N(ANCHOR_NODE, "rule"),
+		L(IMPLICATION_LINK,
+			L(EVALUATION_LINK,
+				N(PREDICATE_NODE, "predurnatural"),
+				L(LIST_LINK, N(VARIABLE_NODE, "$foo"))),
+			N(CONCEPT_NODE, "golem")));
+
+	// This should NOT find the above!
+	Handle free_get =
+		L(GET_LINK,
+			L(TYPED_VARIABLE_LINK,
+				N(VARIABLE_NODE, "$x"), N(TYPE_NODE, "ImplicationLink")),
+			L(STATE_LINK, N(ANCHOR_NODE, "rule"), N(VARIABLE_NODE, "$x")));
+
+	Handle gotten = HandleCast(inst.execute(free_get));
+	printf("Free Got %s\n", gotten->to_string().c_str());
+
+	Handle empty_set = L(SET_LINK, HandleSeq());
+
+	// The result of the get should be correct.
+	TS_ASSERT_EQUALS(gotten, empty_set);
+
+	// -------------------------------------------
+	// Alternate data
+	Handle scoped =
+	L(IMPLICATION_SCOPE_LINK,
+			L(EVALUATION_LINK,
+				N(PREDICATE_NODE, "predatory"),
+				L(LIST_LINK, N(VARIABLE_NODE, "$foo"))),
+			N(CONCEPT_NODE, "loan shark"));
+	L(STATE_LINK, N(ANCHOR_NODE, "rule"), scoped);
+
+	Handle scoped_get =
+		L(GET_LINK,
+			L(TYPED_VARIABLE_LINK,
+				N(VARIABLE_NODE, "$x"), N(TYPE_NODE, "ImplicationScopeLink")),
+			L(STATE_LINK, N(ANCHOR_NODE, "rule"), N(VARIABLE_NODE, "$x")));
+
+	Handle sgotten = HandleCast(inst.execute(scoped_get));
+	printf("Scoped Got %s\n", sgotten->to_string().c_str());
+
+	Handle scope_set = L(SET_LINK, scoped);
+
+	// The result of the get should be correct.
+	TS_ASSERT_EQUALS(sgotten, scope_set);
+
+	// -------------------------------------------
+	// Repeating the free-var get should still NOT find the above!
+
+	Handle regotten = HandleCast(inst.execute(free_get));
+	printf("Re-Free Got %s\n", regotten->to_string().c_str());
+
+	// The result of the get should be correct.
+	TS_ASSERT_EQUALS(regotten, empty_set);
 
 	logger().info("END TEST: %s", __FUNCTION__);
 }


### PR DESCRIPTION
There is a distinction between free variables and bound variables,
when used with StateLinks and the pattner matcher. This is exposed
in issue #1576. This test tightens testing, to make sure that things
stay that way.