### PR TITLE
Correctly handle AbsentLinks that bridge across components.

### DIFF
--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -95,8 +95,8 @@ void PatternLink::common_init(void)
 	}
 
 	// Split the non-virtual clauses into connected components
-	get_connected_components(_varlist.varset, _fixed,
-	                         _components, _component_vars);
+	get_bridged_components(_varlist.varset, _fixed, _pat.optionals,
+	                       _components, _component_vars);
 	_num_comps = _components.size();
 
 	// Make sure every variable is in some component.

--- a/opencog/atoms/pattern/PatternUtils.h
+++ b/opencog/atoms/pattern/PatternUtils.h
@@ -53,6 +53,12 @@ void get_connected_components(const HandleSet& vars,
                               HandleSeqSeq& compset,
                               HandleSetSeq& compvars);
 
+void get_bridged_components(const HandleSet& vars,
+                            const HandleSeq& clauses,
+                            const HandleSeq& opts,
+                            HandleSeqSeq& compset,
+                            HandleSetSeq& compvars);
+
 } // namespace opencog
 
 #endif // _OPENCOG_PATTERN_UTILS_H

--- a/opencog/query/DefaultPatternMatchCB.cc
+++ b/opencog/query/DefaultPatternMatchCB.cc
@@ -518,17 +518,49 @@ bool DefaultPatternMatchCB::clause_match(const Handle& ptrn,
  * AbsentLink: a match is possible only if the indicated clauses
  * are absent!
  *
- * We do "accept" self-groundings: as these are not actually
- * clauses that are present -- its merely the pattern finding itself.
+ * To recap:
+ *   If ground is found, return false;
+ *   If no ground is found, return true.
  */
 bool DefaultPatternMatchCB::optional_clause_match(const Handle& ptrn,
                                                   const Handle& grnd,
                                                   const HandleMap& term_gnds)
 {
-	if (nullptr == grnd) return true; // XXX can this ever happen?
-	if (not is_self_ground(ptrn, grnd, term_gnds, _vars->varset))
-		_optionals_present = true;
-	return false;
+	// If any grounding at all was found, reject it.
+	if (grnd)
+	{
+		if (not is_self_ground(ptrn, grnd, term_gnds, _vars->varset))
+			_optionals_present = true;
+		return false;
+	}
+
+	// No grounding was found directly, but that may be because
+	// this is a virtual-optional clause. That is, this clause
+	// might be bridging across two disconnected components;
+	// some of the component combinations may have a grounding,
+	// while others do not.  So we have to check.
+	Handle gopt;
+	try
+	{
+		gopt = HandleCast(_instor->instantiate(ptrn, term_gnds, true));
+	}
+	catch (const SilentException& ex)
+	{
+		// The instantiation above can throw an exception if the
+		// it is ill-formed. If so, assume the opt clause is absent.
+		_instor->reset_halt();
+		return true;
+	}
+
+	// If the result is a self-match, we don't mind.
+	// Its only bad if something else got built.
+	if (gopt == ptrn) return true;
+
+	// If the grounding we just built can be found in the atomspace,
+	// then we must reject it.
+	if (_as->get_atom(gopt)) return false;
+
+	return true;
 }
 
 /* ======================================================== */

--- a/opencog/query/PatternLinkRuntime.cc
+++ b/opencog/query/PatternLinkRuntime.cc
@@ -138,7 +138,7 @@ class PMCGroundings : public PatternMatchCallback
  */
 static bool recursive_virtual(PatternMatchCallback& cb,
             const HandleSeq& virtuals,
-            const HandleSeq& negations, // currently ignored
+            const HandleSeq& optionals,
             const HandleMap& var_gnds,
             const HandleMap& term_gnds,
             // copies, NOT references!
@@ -193,6 +193,13 @@ static bool recursive_virtual(PatternMatchCallback& cb,
 			if (not match) return false;
 		}
 
+		Handle empty;
+		for (const Handle& opt: optionals)
+		{
+			bool match = cb.optional_clause_match(opt, empty, var_gnds);
+			if (not match) return false;
+		}
+
 		// Yay! We found one! We now have a fully and completely grounded
 		// pattern! See what the callback thinks of it.
 		return cb.grounding(var_gnds, term_gnds);
@@ -229,7 +236,7 @@ static bool recursive_virtual(PatternMatchCallback& cb,
 		rvg.insert(cand_vg.begin(), cand_vg.end());
 		rpg.insert(cand_pg.begin(), cand_pg.end());
 
-		bool accept = recursive_virtual(cb, virtuals, negations, rvg, rpg,
+		bool accept = recursive_virtual(cb, virtuals, optionals, rvg, rpg,
 		                                comp_var_gnds, comp_term_gnds);
 
 		// Halt recursion immediately if match is accepted.
@@ -407,9 +414,8 @@ bool PatternLink::satisfy(PatternMatchCallback& pmcb) const
 #endif
 	HandleMap empty_vg;
 	HandleMap empty_pg;
-	HandleSeq optionals; // currently ignored
 	pmcb.set_pattern(_varlist, _pat);
-	return recursive_virtual(pmcb, _virtual, optionals,
+	return recursive_virtual(pmcb, _virtual, _pat.optionals,
 	                         empty_vg, empty_pg,
 	                         comp_var_gnds, comp_term_gnds);
 }

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1696,7 +1696,7 @@ bool PatternMatchEngine::do_next_clause(void)
 		       (is_optional(curr_root)))
 		{
 			Handle undef(Handle::UNDEFINED);
-			bool match = _pmc.optional_clause_match(joiner, undef, var_grounding);
+			bool match = _pmc.optional_clause_match(curr_root, undef, var_grounding);
 			DO_LOG({logger().fine("Exhausted search for optional clause, cb=%d", match);})
 			if (not match) {
 				clause_stacks_pop();

--- a/tests/query/AbsentUTest.cxxtest
+++ b/tests/query/AbsentUTest.cxxtest
@@ -63,6 +63,7 @@ public:
 	void test_connect_not_exist(void);
 	void test_discon_exist(void);
 	void test_discon_not_exist(void);
+	void test_bridges(void);
 };
 
 void AbsentUTest::tearDown(void)
@@ -291,6 +292,24 @@ void AbsentUTest::test_discon_not_exist(void)
 	Handle soln = eval->eval_h("soln");
 
 	TSM_ASSERT_EQUALS("Wrong number of solutions", getarity(rtn), 1);
+	TS_ASSERT_EQUALS(rtn, soln);
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+// Test absent links that beidge across disconnected components.
+// This is for bug #1596
+void AbsentUTest::test_bridges(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	eval->eval("(load-from-path \"tests/query/absent-pets.scm\")");
+
+	Handle rtn = eval->eval_h("(cog-execute! pet-keepers)");
+
+	Handle soln = eval->eval_h("expected-result");
+
+	TSM_ASSERT_EQUALS("Wrong number of solutions", getarity(rtn), 3);
 	TS_ASSERT_EQUALS(rtn, soln);
 
 	logger().debug("END TEST: %s", __FUNCTION__);

--- a/tests/query/absent-disconn1.scm
+++ b/tests/query/absent-disconn1.scm
@@ -1,3 +1,6 @@
+
+(use-modules (opencog) (opencog exec))
+
 (define soln (SetLink))
 
 (ListLink (ConceptNode "A") (ConceptNode "B"))

--- a/tests/query/absent-pets.scm
+++ b/tests/query/absent-pets.scm
@@ -1,0 +1,58 @@
+
+(use-modules (opencog) (opencog exec))
+
+; Unit test for Issue #1596
+;
+; Initial data
+(Inheritance (Concept "American") (Concept "person"))
+(Inheritance (Concept "German") (Concept "person"))
+(Inheritance (Concept "cat") (Concept "pet"))
+(Inheritance (Concept "dog") (Concept "pet"))
+
+(Evaluation (Predicate "keep-pet")
+   (List (Concept "German") (Concept "dog")))
+
+; Find potential, hypothetical pet-keepers.
+(define pet-keepers
+ (let ((kp (Predicate "keep-pet"))
+       (vA (Variable "$A"))        
+       (vX (Variable "$X")) )
+
+  (BindLink
+     (VariableList
+        (TypedVariable vA (Type "ConceptNode"))
+        (TypedVariable vX (Type "ConceptNode")) )
+     (And
+        (Inheritance vA (Concept "person"))
+        (Inheritance vX (Concept "pet"))
+
+        ;; Reject those we know about
+        (Absent (Evaluation kp (List vA vX)))
+     )     
+     (List kp vA vX))))
+
+; This:
+; (cog-execute! pet-keepers)
+; should return German-cat, German-dog and American-dog
+; It must NOT return German-dog.
+
+(define expected-result
+(SetLink
+   (ListLink
+      (PredicateNode "keep-pet")
+      (ConceptNode "German")
+      (ConceptNode "cat")
+   )
+   (ListLink
+      (PredicateNode "keep-pet")
+      (ConceptNode "American")
+      (ConceptNode "cat")
+   )
+   (ListLink
+      (PredicateNode "keep-pet")
+      (ConceptNode "American")
+      (ConceptNode "dog")
+   )
+))
+
+*unspecified*


### PR DESCRIPTION
This is a fix for bug #1596  which used an `AbsentLink` to bridge across two otherwise-disconnected search patterns.  In essence it was trying to find all the different ways two graphs could be bridged.