### PR TITLE
Streamline atomtable insertion code

### DIFF
--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -358,11 +358,6 @@ Handle AtomTable::add(AtomPtr atom, bool async, bool force)
         }
         atom = createLink(closet, atom->get_type());
     }
-
-    // Clone, if we haven't done so already. We MUST maintain our own
-    // private copy of the atom, because each atom instance keeps a pointer to
-    // the atomspace. This pointer is used to get UUID, send signals, implement
-    // getAtomSpace() and getAtomTable() methods.
     else if (atom->is_node())
         atom = createNode(*NodeCast(atom));
     else

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -337,7 +337,6 @@ Handle AtomTable::add(AtomPtr atom, bool async, bool force)
         return atom->get_handle();
 
     AtomPtr orig(atom);
-    Type atom_type = atom->get_type();
 
     // If this atom is in some other atomspace or not in any atomspace,
     // then we need to clone it. We cannot insert it into this atomtable
@@ -357,23 +356,18 @@ Handle AtomTable::add(AtomPtr atom, bool async, bool force)
             if (nullptr == h.operator->()) return Handle::UNDEFINED;
             closet.emplace_back(add(h, async));
         }
-        atom = createLink(closet, atom_type);
+        atom = createLink(closet, atom->get_type());
     }
 
     // Clone, if we haven't done so already. We MUST maintain our own
     // private copy of the atom, because each atom instance keeps a pointer to
     // the atomspace. This pointer is used to get UUID, send signals, implement
     // getAtomSpace() and getAtomTable() methods.
-    else if (atom == orig)
-    {
-        if (atom->is_node())
-            atom = createNode(*NodeCast(atom));
-        else if (atom->is_link())
-            atom = createLink(*LinkCast(atom));
-        else
-            throw RuntimeException(TRACE_INFO,
-               "AtomTable - expecting an Atom!");
-    }
+    else if (atom->is_node())
+        atom = createNode(*NodeCast(atom));
+    else
+        throw RuntimeException(TRACE_INFO,
+           "AtomTable - expecting an Atom!");
 
     // Lock before checking to see if this kind of atom is already in
     // the atomspace.  Lock, to prevent two different threads from

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -348,11 +348,11 @@ Handle AtomTable::add(AtomPtr atom, bool async, bool force)
         }
         atom = createLink(closet, atom->get_type());
     }
-    else if (atom->is_node())
-        atom = createNode(*NodeCast(atom));
     else
-        throw RuntimeException(TRACE_INFO,
-           "AtomTable - expecting an Atom!");
+        atom = createNode(*NodeCast(atom));
+
+    // Force computation of hash external to the locked section.
+    ContentHash hash = atom->get_hash();
 
     // Lock before checking to see if this kind of atom is already in
     // the atomspace.  Lock, to prevent two different threads from
@@ -385,7 +385,7 @@ Handle AtomTable::add(AtomPtr atom, bool async, bool force)
     _size_by_type[atom->_type] ++;
 
     Handle h(atom->get_handle());
-    _atom_store.insert({atom->get_hash(), h});
+    _atom_store.insert({hash, h});
 
 #ifdef CHECK_ATOM_HASH_COLLISION
     auto its = _atom_store.equal_range(atom->get_hash());

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -259,16 +259,6 @@ Handle AtomTable::getHandle(Type t, const HandleSeq& seq) const
 
 Handle AtomTable::getLinkHandle(const AtomPtr& a) const
 {
-    // Make sure all the atoms in the outgoing set are in the atomspace.
-    // If any are not, then reject the whole mess. XXX Why? So what?
-    // If the hash-checking, below, is good, then everything should be
-    // just fine. XXX Except BackwardChainerUTest fails myseriously,
-    // when we skip this test. Not sure why. Strange. XXX FIXME.
-    for (const Handle& ho : a->getOutgoingSet()) {
-        Handle rh(getHandle(ho));
-        if (not rh) return rh;
-    }
-
     // Start searching to see if we have this atom.
     ContentHash ch = a->get_hash();
 
@@ -336,7 +326,7 @@ Handle AtomTable::add(AtomPtr atom, bool async, bool force)
     if (not force and in_environ(atom))
         return atom->get_handle();
 
-    AtomPtr orig(atom);
+    Handle orig(atom);
 
     // If this atom is in some other atomspace or not in any atomspace,
     // then we need to clone it. We cannot insert it into this atomtable
@@ -384,7 +374,7 @@ Handle AtomTable::add(AtomPtr atom, bool async, bool force)
         if (hcheck and hcheck->getAtomSpace() == _as) return hcheck;
     }
 
-    atom->copyValues(Handle(orig));
+    atom->copyValues(orig);
     atom->install();
     atom->keep_incoming_set();
     atom->setAtomSpace(_as);

--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -201,13 +201,12 @@ public:
      * @return The handle of the desired atom if found.
      */
     Handle getHandle(Type, const std::string&) const;
-    Handle getNodeHandle(const AtomPtr&) const;
     Handle getHandle(Type, const HandleSeq&) const;
-    Handle getLinkHandle(const AtomPtr&) const;
     Handle getHandle(const AtomPtr&) const;
     Handle getHandle(const Handle& h) const {
         AtomPtr a(h); return getHandle(a);
     }
+    Handle lookupHandle(const AtomPtr&) const;
 
     /**
      * Returns the set of atoms of a given type (subclasses optionally).


### PR DESCRIPTION
Mostly, this just eliminates a block of duplicated code and some branches that go with it.