### PR TITLE
streamline atomspace clearing

### DIFF
--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -186,7 +186,15 @@ void AtomTable::clear_all_atoms()
 
 void AtomTable::clear()
 {
-#ifdef SLOW_BUT_BCAREFUL_CLEAR
+#define FAST_CLEAR 1
+#ifdef FAST_CLEAR
+    // Always do the fast clear.
+    clear_all_atoms();
+#else
+    // This is a stunningly inefficient way to clear the atomtable!
+    // This will take minutes on any decent-sized atomspace!
+    // However, due to the code in extract(), it does a lot of error
+    // checking.
     if (_transient)
     {
         // Do the fast clear since we're a transient atom table.
@@ -198,8 +206,6 @@ void AtomTable::clear()
 
         getHandleSetByType(allNodes, NODE, true, false);
 
-        // XXX FIXME TODO This is a stunningly inefficient way to clear the
-        // atomtable! This will take minutes on any decent-sized atomspace!
         for (Handle h: allNodes) extract(h, true);
 
         allNodes.clear();
@@ -214,10 +220,6 @@ void AtomTable::clear()
         OC_ASSERT(_num_nodes == 0);
         OC_ASSERT(_num_links == 0);
     }
-#else
-
-    // Always do the fast clear.
-    clear_all_atoms();
 #endif
 }
 

--- a/opencog/atomspace/FixedIntegerIndex.cc
+++ b/opencog/atomspace/FixedIntegerIndex.cc
@@ -31,6 +31,11 @@ size_t FixedIntegerIndex::size(void) const
 	return cnt;
 }
 
+void FixedIntegerIndex::clear(void)
+{
+	for (auto& s : idx) s.clear();
+}
+
 bool FixedIntegerIndex::contains_duplicate() const
 {
 	for (const AtomSet& atoms : idx)

--- a/opencog/atomspace/FixedIntegerIndex.h
+++ b/opencog/atomspace/FixedIntegerIndex.h
@@ -91,6 +91,8 @@ public:
 
 	size_t size(void) const;
 
+	void clear(void);
+
 	// Return true if there exists some index containing duplicated
 	// atoms (equal by content). Used for testing.
 	bool contains_duplicate() const;


### PR DESCRIPTION
There is no particular reason to always perform slow atomspace clearing. Sure, it does some consistency checks, but they always pass, anyway.