### PR TITLE
Allow new Values to be declared after Atoms have been declared

### DIFF
--- a/opencog/atoms/atom_types/NameServer.cc
+++ b/opencog/atoms/atom_types/NameServer.cc
@@ -44,7 +44,7 @@ using namespace opencog;
 
 NameServer::NameServer(void)
 {
-	nTypes = 1;
+	nTypes = MAX_NUM_VALUE + 1;
 	nValues = 1;
 	_maxDepth = 0;
 	_tmod = 0;
@@ -123,15 +123,13 @@ Type NameServer::declType(const Type parent, const std::string& name)
     }
 
     std::unique_lock<std::mutex> l(type_mutex);
-    // Assign type code and increment type counter.
-    type = nTypes++;
 
+    // Assign type code and increment type counter.
     if (0 == ATOM or parent < ATOM)
     {
         if (0 == ATOM and 0 == name.compare("Atom"))
         {
             type = MAX_NUM_VALUE;
-            nTypes = MAX_NUM_VALUE + 1;
         }
         else
         {
@@ -142,6 +140,10 @@ Type NameServer::declType(const Type parent, const std::string& name)
                     MAX_NUM_VALUE);
             type = nValues++;
         }
+    }
+    else
+    {
+        type = nTypes++;
     }
 
     // Resize inheritanceMap container.

--- a/opencog/atoms/atom_types/NameServer.cc
+++ b/opencog/atoms/atom_types/NameServer.cc
@@ -210,6 +210,12 @@ bool NameServer::isDefined(const std::string& typeName) const
     return name2CodeMap.find(typeName) != name2CodeMap.end();
 }
 
+bool NameServer::isDefined(Type t) const
+{
+    std::lock_guard<std::mutex> l(type_mutex);
+    return (1 <= t and t < nValues) or (ATOM <= t and t < nTypes);
+}
+
 Type NameServer::getType(const std::string& typeName) const
 {
     std::lock_guard<std::mutex> l(type_mutex);

--- a/opencog/atoms/atom_types/NameServer.h
+++ b/opencog/atoms/atom_types/NameServer.h
@@ -245,6 +245,7 @@ public:
      * Returns whether a class with name 'typeName' is defined.
      */
     bool isDefined(const std::string& typeName) const;
+    bool isDefined(Type) const;
 
     /**
      * Returns the type of a given class.

--- a/opencog/atoms/atom_types/NameServer.h
+++ b/opencog/atoms/atom_types/NameServer.h
@@ -73,6 +73,7 @@ private:
     mutable int _tmod;
 
     Type nTypes;
+    Type nValues;
     Type _maxDepth;
 
     std::vector< std::vector<bool> > inheritanceMap;

--- a/opencog/atoms/atom_types/atom_types.script
+++ b/opencog/atoms/atom_types/atom_types.script
@@ -44,9 +44,6 @@ FUZZY_TRUTH_VALUE          <- TRUTH_VALUE
 PROBABILISTIC_TRUTH_VALUE  <- TRUTH_VALUE
 EVIDENCE_COUNT_TRUTH_VALUE <- TRUTH_VALUE
 
-// The AttentionValue
-ATTENTION_VALUE <- FLOAT_VALUE
-
 // ===========================================================
 // A base class for time-varying (floating-point) values.
 // XXX TODO we need other base classes for other kinds of varying values.

--- a/opencog/atoms/base/ClassServer.cc
+++ b/opencog/atoms/base/ClassServer.cc
@@ -90,6 +90,7 @@ void ClassServer::splice(std::vector<T>& methods, Type t, T fact)
 	// declared.
 	for (Type chi=t; chi < _nameServer.getNumberOfClasses(); chi++)
 	{
+		if (not _nameServer.isDefined(t)) continue;
 		if (_nameServer.isAncestor(t, chi) and
 		    (nullptr == methods[chi] or
 		     ok_to_clobber.end() != ok_to_clobber.find(methods[chi])))

--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -332,10 +332,13 @@ SCM SchemeSmob::ss_get_types (void)
 	Type t = nameserver().getNumberOfClasses();
 	while (1) {
 		t--;
-		const std::string &tname = nameserver().getTypeName(t);
-		SCM str = scm_from_utf8_string(tname.c_str());
-		SCM sym = scm_string_to_symbol(str);
-		list = scm_cons(sym, list);
+		if (nameserver().isDefined(t))
+		{
+			const std::string &tname = nameserver().getTypeName(t);
+			SCM str = scm_from_utf8_string(tname.c_str());
+			SCM sym = scm_string_to_symbol(str);
+			list = scm_cons(sym, list);
+		}
 		if (0 == t) break;
 	}
 

--- a/opencog/persist/sql/multi-driver/SQLTypeMap.cc
+++ b/opencog/persist/sql/multi-driver/SQLTypeMap.cc
@@ -73,7 +73,7 @@ void SQLAtomStorage::setup_typemap(void)
 	// stored.  So we start by loading a map from SQL (if its there).
 	//
 	// Be careful to initialize the typemap with invalid types,
-	// in case there are unexpected holes in the map!
+	// in case there are (unexpected) holes in the map!
 	for (int i=0; i< TYPEMAP_SZ; i++)
 	{
 		loading_typemap[i] = NOTYPE;
@@ -95,6 +95,8 @@ void SQLAtomStorage::setup_typemap(void)
 		/* If this typename is not yet known, record it */
 		if (-1 == sqid)
 		{
+			if (not nameserver().isDefined(t)) continue;
+
 			const char * tname = nameserver().getTypeName(t).c_str();
 
 			// Let the sql id be the same as the current type number,

--- a/tests/atoms/atom_types/NameServerUTest.cxxtest
+++ b/tests/atoms/atom_types/NameServerUTest.cxxtest
@@ -84,25 +84,26 @@ public:
 
         nameserver().beginTypeDecls("classy test types");
         Type CS_UTEST_NODE   = nameserver().declType(NODE, "CsUtestNode");
+        Type CS_UTEST_LINK   = nameserver().declType(LIST_LINK, "CsUtestLink");
+        Type CS_UTEST_NODE_2 = nameserver().declType(NODE, "CsUtestNode");
+        Type CS_UTEST_LINK_2 = nameserver().declType(UNORDERED_LINK, "CsUtestLink");
+        nameserver().endTypeDecls();
+
+        TS_ASSERT(nameserver().getNumberOfClasses() == (unsigned int)(ntypes+2));
         TS_ASSERT(CS_UTEST_NODE   == ntypes);
-        TS_ASSERT(nameserver().getNumberOfClasses() == (unsigned int)(ntypes+1));
         TS_ASSERT( nameserver().isA(CS_UTEST_NODE, NODE));
         TS_ASSERT(!nameserver().isA(CS_UTEST_NODE, NUMBER_NODE));
         TS_ASSERT(!nameserver().isA(CS_UTEST_NODE, LINK));
 
-        Type CS_UTEST_LINK   = nameserver().declType(LIST_LINK, "CsUtestLink");
         TS_ASSERT(CS_UTEST_LINK   == (ntypes + 1));
-        TS_ASSERT(nameserver().getNumberOfClasses() == (unsigned int)(ntypes+2));
         TS_ASSERT( nameserver().isA(CS_UTEST_LINK, LINK));
         TS_ASSERT( nameserver().isA(CS_UTEST_LINK, ORDERED_LINK));
         TS_ASSERT( nameserver().isA(CS_UTEST_LINK, LIST_LINK));
-        TS_ASSERT(!nameserver().isA(CS_UTEST_LINK, UNORDERED_LINK));
+        TS_ASSERT( nameserver().isA(CS_UTEST_LINK, UNORDERED_LINK));
         TS_ASSERT(!nameserver().isA(CS_UTEST_LINK, NODE));
         TS_ASSERT(!nameserver().isA(CS_UTEST_LINK, NUMBER_NODE));
 
-        Type CS_UTEST_NODE_2 = nameserver().declType(NODE, "CsUtestNode");
         TS_ASSERT(CS_UTEST_NODE_2 == ntypes);
-        TS_ASSERT(nameserver().getNumberOfClasses() == (unsigned int)(ntypes+2));
         TS_ASSERT( nameserver().isA(CS_UTEST_NODE_2, NODE));
         TS_ASSERT(!nameserver().isA(CS_UTEST_NODE_2, NUMBER_NODE));
         TS_ASSERT(!nameserver().isA(CS_UTEST_NODE_2, LINK));
@@ -110,9 +111,7 @@ public:
         TS_ASSERT(!nameserver().isA(CS_UTEST_NODE, NUMBER_NODE));
         TS_ASSERT(!nameserver().isA(CS_UTEST_NODE, LINK));
 
-        Type CS_UTEST_LINK_2 = nameserver().declType(UNORDERED_LINK, "CsUtestLink");
         TS_ASSERT(CS_UTEST_LINK_2 == (ntypes + 1));
-        TS_ASSERT(nameserver().getNumberOfClasses() == (unsigned int)(ntypes+2));
         TS_ASSERT( nameserver().isA(CS_UTEST_LINK_2, LINK));
         TS_ASSERT( nameserver().isA(CS_UTEST_LINK_2, ORDERED_LINK));
         TS_ASSERT( nameserver().isA(CS_UTEST_LINK_2, LIST_LINK));
@@ -126,10 +125,15 @@ public:
         TS_ASSERT(!nameserver().isA(CS_UTEST_LINK,   NODE));
         TS_ASSERT(!nameserver().isA(CS_UTEST_LINK,   NUMBER_NODE));
 
-        nameserver().endTypeDecls();
-
         bool is_init = nameserver().beginTypeDecls("classy test types");
         TS_ASSERT(is_init);
+
+        nameserver().beginTypeDecls("classy values");
+        Type CS_UTEST_VALUE = nameserver().declType(VALUE, "CsUtestValue");
+        Type CS_UTEST_FVALUE = nameserver().declType(FLOAT_VALUE, "CsUtestFloatValue");
+        nameserver().endTypeDecls();
+
+        TS_ASSERT(nameserver().getNumberOfClasses() == (unsigned int)(ntypes+2));
     }
 
     void testIteratorMethods()

--- a/tests/atoms/atom_types/NameServerUTest.cxxtest
+++ b/tests/atoms/atom_types/NameServerUTest.cxxtest
@@ -45,9 +45,15 @@ public:
     {
         Type numClasses = nameserver().getNumberOfClasses();
         for (Type t = 0; t < numClasses; t++) {
+            if (not nameserver().isDefined(t)) continue;
             TS_ASSERT(nameserver().isA(t, t));
-            if (t > ATOM) TS_ASSERT(nameserver().isA(t, NODE)
-                              or nameserver().isA(t, LINK));
+            if (t > ATOM) {
+                TS_ASSERT(nameserver().isA(t, NODE)
+                          or nameserver().isA(t, LINK));
+            }
+            else {
+                TS_ASSERT(nameserver().isA(t, VALUE));
+            }
         }
 
         TS_ASSERT( nameserver().isA(NODE, ATOM));

--- a/tests/atoms/atom_types/NameServerUTest.cxxtest
+++ b/tests/atoms/atom_types/NameServerUTest.cxxtest
@@ -92,6 +92,8 @@ public:
         TS_ASSERT(nameserver().getNumberOfClasses() == (unsigned int)(ntypes+2));
         TS_ASSERT(CS_UTEST_NODE   == ntypes);
         TS_ASSERT( nameserver().isA(CS_UTEST_NODE, NODE));
+        TS_ASSERT(!nameserver().isA(CS_UTEST_NODE, FLOAT_VALUE));
+        TS_ASSERT(!nameserver().isA(CS_UTEST_NODE, TRUTH_VALUE));
         TS_ASSERT(!nameserver().isA(CS_UTEST_NODE, NUMBER_NODE));
         TS_ASSERT(!nameserver().isA(CS_UTEST_NODE, LINK));
 
@@ -100,6 +102,8 @@ public:
         TS_ASSERT( nameserver().isA(CS_UTEST_LINK, ORDERED_LINK));
         TS_ASSERT( nameserver().isA(CS_UTEST_LINK, LIST_LINK));
         TS_ASSERT( nameserver().isA(CS_UTEST_LINK, UNORDERED_LINK));
+        TS_ASSERT(!nameserver().isA(CS_UTEST_LINK, FLOAT_VALUE));
+        TS_ASSERT(!nameserver().isA(CS_UTEST_LINK, TRUTH_VALUE));
         TS_ASSERT(!nameserver().isA(CS_UTEST_LINK, NODE));
         TS_ASSERT(!nameserver().isA(CS_UTEST_LINK, NUMBER_NODE));
 
@@ -128,12 +132,33 @@ public:
         bool is_init = nameserver().beginTypeDecls("classy test types");
         TS_ASSERT(is_init);
 
+        // ================================================
+        // Test addition of new Value types,
+        // AFTER addition of new Atom types.
+        // The new Values should fit into place.
+
         nameserver().beginTypeDecls("classy values");
         Type CS_UTEST_VALUE = nameserver().declType(VALUE, "CsUtestValue");
         Type CS_UTEST_FVALUE = nameserver().declType(FLOAT_VALUE, "CsUtestFloatValue");
         nameserver().endTypeDecls();
 
+        TS_ASSERT( nameserver().isA(CS_UTEST_VALUE,   VALUE));
+        TS_ASSERT(!nameserver().isA(CS_UTEST_VALUE,   FLOAT_VALUE));
+        TS_ASSERT(!nameserver().isA(CS_UTEST_VALUE,   TRUTH_VALUE));
+        TS_ASSERT(!nameserver().isA(CS_UTEST_VALUE,   ATOM));
+
+        TS_ASSERT( nameserver().isA(CS_UTEST_FVALUE,  VALUE));
+        TS_ASSERT( nameserver().isA(CS_UTEST_FVALUE,  FLOAT_VALUE));
+        TS_ASSERT(!nameserver().isA(CS_UTEST_VALUE,   TRUTH_VALUE));
+        TS_ASSERT(!nameserver().isA(CS_UTEST_FVALUE,  ATOM));
+
+        // Total number of types is unchanged from before.
         TS_ASSERT(nameserver().getNumberOfClasses() == (unsigned int)(ntypes+2));
+
+        // Numerical hierarchy is obeyed: all values have
+        // numeric codes that are less than Atom.
+        TS_ASSERT(CS_UTEST_VALUE < ATOM);
+        TS_ASSERT(CS_UTEST_FVALUE < ATOM);
     }
 
     void testIteratorMethods()


### PR DESCRIPTION
This fixes a blocker issue for #2190 ... it needed to be done a while ago, anyway, for octomap, and for attention values.