### PR TITLE
Move recursive evaluation of ExOutLink to the ExOut class

### DIFF
--- a/opencog/atoms/execution/ExecutionOutputLink.cc
+++ b/opencog/atoms/execution/ExecutionOutputLink.cc
@@ -102,6 +102,21 @@ ExecutionOutputLink::ExecutionOutputLink(const Link& l)
 ///
 ValuePtr ExecutionOutputLink::execute(AtomSpace* as, bool silent)
 {
+	ValuePtr vp(execute_once(as, silent));
+	if (not vp->is_atom()) return vp;
+
+	Handle res(HandleCast(vp));
+	while (res->is_executable())
+	{
+		vp = res->execute(as, silent);
+		if (not vp->is_atom()) return vp;
+		res = HandleCast(vp);
+	}
+	return vp;
+}
+
+ValuePtr ExecutionOutputLink::execute_once(AtomSpace* as, bool silent)
+{
 	Handle sn(_outgoing[0]);
 	Handle args(_outgoing[1]);
 	Type snt = sn->get_type();

--- a/opencog/atoms/execution/ExecutionOutputLink.h
+++ b/opencog/atoms/execution/ExecutionOutputLink.h
@@ -41,6 +41,8 @@ private:
 	                           const Handle& args,
 	                           bool silent=false);
 
+	ValuePtr execute_once(AtomSpace* as, bool silent=false);
+
 protected:
 	void check_schema(const Handle& schema) const;
 

--- a/opencog/atoms/execution/Instantiator.cc
+++ b/opencog/atoms/execution/Instantiator.cc
@@ -413,13 +413,8 @@ Handle Instantiator::walk_tree(const Handle& expr, bool silent)
 	if (nameserver().isA(t, EXECUTION_OUTPUT_LINK))
 	{
 		Handle eolh = reduce_exout(expr, silent);
-		while (eolh->is_executable())
-		{
-			ValuePtr vp(eolh->execute(_as, silent));
-			eolh = HandleCast(vp);
-			if (not vp->is_atom()) return eolh;
-		}
-		return eolh;
+		// if (not eolh->is_executable()) return eolh;
+		return HandleCast(eolh->execute(_as, silent));
 	}
 
 	// Handle DeleteLink's before general FunctionLink's; they
@@ -597,13 +592,8 @@ ValuePtr Instantiator::instantiate(const Handle& expr,
 	if (nameserver().isA(t, EXECUTION_OUTPUT_LINK))
 	{
 		Handle eolh = reduce_exout(expr, silent);
-		while (eolh->is_executable())
-		{
-			ValuePtr vp(eolh->execute(_as, silent));
-			if (not vp->is_atom()) return vp;
-			eolh = HandleCast(vp);
-		}
-		return eolh;
+		if (not eolh->is_executable()) return eolh;
+		return eolh->execute(_as, silent);
 	}
 
 	// The thread-links are ambiguously executable/evaluatable.

--- a/opencog/atoms/execution/Instantiator.cc
+++ b/opencog/atoms/execution/Instantiator.cc
@@ -310,6 +310,9 @@ Handle Instantiator::walk_tree(const Handle& expr, bool silent)
 		// Step two: beta-reduce.
 		Handle red(HandleCast(ppp->execute(_as, silent)));
 
+		// TODO -- Maybe the PutLink should also do everything below,
+		// itself? i.e. we should not have to do the below for it,
+		// right? The right answer is somewhat ... hazy.
 		if (nullptr == red)
 			return red;
 
@@ -409,14 +412,6 @@ Handle Instantiator::walk_tree(const Handle& expr, bool silent)
 		return expr;
 	}
 
-	// ExecutionOutputLinks
-	if (nameserver().isA(t, EXECUTION_OUTPUT_LINK))
-	{
-		Handle eolh = reduce_exout(expr, silent);
-		// if (not eolh->is_executable()) return eolh;
-		return HandleCast(eolh->execute(_as, silent));
-	}
-
 	// Handle DeleteLink's before general FunctionLink's; they
 	// work differently.
 	if (DELETE_LINK == t)
@@ -430,6 +425,13 @@ Handle Instantiator::walk_tree(const Handle& expr, bool silent)
 				_as->remove_atom(h, true);
 		}
 		return Handle::UNDEFINED;
+	}
+
+	// ExecutionOutputLinks
+	if (nameserver().isA(t, EXECUTION_OUTPUT_LINK))
+	{
+		Handle eolh = reduce_exout(expr, silent);
+		return HandleCast(eolh->execute(_as, silent));
 	}
 
 	// Fire any other function links, not handled above.


### PR DESCRIPTION
Instead of having someone else do work on behalf of ExOutLink, let ExOutLink do the work itself.