### PR TITLE
Replace painfully-slow report by a fast version

### DIFF
--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -350,6 +350,7 @@ void SchemeSmob::register_procs()
 	register_proc("cog-type->int",         1, 0, 0, C(ss_get_type));
 	register_proc("cog-get-subtypes",      1, 0, 0, C(ss_get_subtypes));
 	register_proc("cog-subtype?",          2, 0, 0, C(ss_subtype_p));
+	register_proc("cog-count-atoms",       1, 0, 0, C(ss_count));
 
 	// Iterators
 	register_proc("cog-map-type",          2, 0, 0, C(ss_map_type));

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -132,6 +132,7 @@ private:
 	static SCM ss_get_type(SCM);
 	static SCM ss_get_subtypes(SCM);
 	static SCM ss_subtype_p(SCM, SCM);
+	static SCM ss_count(SCM);
 
 	// Truth values
 	static SCM ss_tv_get_mean(SCM);

--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -422,6 +422,17 @@ SCM SchemeSmob::ss_subtype_p (SCM stype, SCM schild)
 	return SCM_BOOL_F;
 }
 
+/**
+ * Return a count of the number of atoms of the indicated type
+ */
+SCM SchemeSmob::ss_count (SCM stype)
+{
+	Type t = verify_type(stype, "cog-count-atoms");
+	AtomSpace* as = ss_get_env_as("cog-set-tv!");
+	size_t cnt = as->get_num_atoms_of_type(t);
+	return scm_from_size_t(cnt);
+}
+
 SCM SchemeSmob::ss_get_free_variables(SCM satom)
 {
 	Handle h = verify_handle(satom, "cog-free-variables");

--- a/opencog/scm/opencog/base/core-docs.scm
+++ b/opencog/scm/opencog/base/core-docs.scm
@@ -756,6 +756,18 @@
   See also: cog-get-atoms TYPE - returns a list of atoms of TYPE.
 ")
 
+(set-procedure-property! cog-count-atoms 'documentation
+"
+  cog-count-atoms -- Count of the number of atoms of given type
+
+  cog-count-atoms ATOM-TYPE
+  Return a count of the number of atoms of the given type `ATOM-TYPE`.
+
+  Example usage:
+     (display (cog-count-atoms 'ConceptNode))
+  will display a count of all atoms of type 'ConceptNode
+")
+
 (set-procedure-property! cog-atomspace 'documentation
 "
  cog-atomspace

--- a/opencog/scm/opencog/base/utilities.scm
+++ b/opencog/scm/opencog/base/utilities.scm
@@ -18,7 +18,6 @@
 ; -- cog-get-atoms -- Return a list of all atoms of type 'atom-type'
 ; -- cog-get-all-roots -- Return the list of all root atoms.
 ; -- cog-prt-atomspace -- Prints all atoms in the atomspace
-; -- cog-count-atoms -- Count of the number of atoms of given type.
 ; -- cog-report-counts -- Return an association list of counts.
 ; -- cog-get-root -- Return all hypergraph roots containing 'atom'
 ; -- cog-get-trunk -- Return all hypergraphs containing `ATOM`.
@@ -270,28 +269,6 @@
   (define (cons-roots x) (set! roots (cons x roots)))
   (traverse-roots cons-roots)
   roots
-)
-
-; -----------------------------------------------------------------------
-(define-public (cog-count-atoms atom-type)
-"
-  cog-count-atoms -- Count of the number of atoms of given type
-
-  cog-count-atoms atom-type
-  Return a count of the number of atoms of the given type 'atom-type'
-
-  Example usage:
-  (display (cog-count-atoms 'ConceptNode))
-  will display a count of all atoms of type 'ConceptNode
-"
-	(let ((cnt 0))
-		(define (inc atom)
-			(set! cnt (+ cnt 1))
-			#f
-		)
-		(cog-map-type inc atom-type)
-		cnt
-	)
 )
 
 ; -----------------------------------------------------------------------


### PR DESCRIPTION
The old version actually tried to count atoms. That doesn't work very well, when the count gets big.