### PR TITLE
 Provide a method to return all elements in a matrix 

### DIFF
--- a/opencog/matrix/README.md
+++ b/opencog/matrix/README.md
@@ -100,36 +100,36 @@ method that returns the count, given the pair.
 
 FAQ
 ---
-Q: Why isn't this in C++?  Surely, numerical computations would be
+**Q:** Why isn't this in C++?  Surely, numerical computations would be
    a lot faster in C++, right?
 
-A: Yes, probably. But its a lot easier to write scheme code than
+**A:** Yes, probably. But its a lot easier to write scheme code than
    it is to write C++ code, and so prototyping in scheme just made
    more sense. It was just-plain simpler, faster, easier (for me).
    You are invited to take the lessons learned, and re-implement
    in C++.
 
-Q: What were the lessons learned?
+**Q:** What were the lessons learned?
 
-A: The number #1 most important lesson is that the filter object
+**A:** The number #1 most important lesson is that the filter object
    is the most important object: it controls what data you want
    to keep, and what data you want to discard, and it needs to
    run "underneath", as a foundation to everything else.
 
-Q: Really, C++ is sooo fast...
+**Q:** Really, C++ is sooo fast...
 
-A: Yes, but since the data is stored in values associated with
+**A:** Yes, but since the data is stored in values associated with
    atoms in the atomspace, adding numbers together is NOT the
    bottleneck. Accessing Atom Values *is* the bottleneck. Finding
    a good performance optimization for the atom values framework
    is a lot harder.
 
-Q: Why don't you just export all your data to SciPy or to Gnu R, or to
+**Q:** Why don't you just export all your data to SciPy or to Gnu R, or to
    Octave, or MatLab, for that matter, and just do your data analytics
    there?  That way, you don't need to re-implement all these basic
    statistical algorithms!
 
-A: That sounds nice, but frankly, it's too much work for me. Maybe you
+**A:** That sounds nice, but frankly, it's too much work for me. Maybe you
    can do this.  Seriously, its just a lot easier (for me) to create
    and use the code here, than to struggle mightily with those packages.
 
@@ -150,11 +150,11 @@ A: That sounds nice, but frankly, it's too much work for me. Maybe you
    the RAM needed to export all of these different cut and filtered
    datasets?  Maybe you can, its just not trivial.
 
-Q: But if I did want to do it for Gnu R, how could I do it?
+**Q:** But if I did want to do it for Gnu R, how could I do it?
 
-A: You would use Rcpp at http://dirk.eddelbuettel.com/code/rcpp.html
+**A:** You would use Rcpp at http://dirk.eddelbuettel.com/code/rcpp.html
    Quote:
-   The Rcpp package provides C++ classes that greatly facilitate
+   *The Rcpp package provides C++ classes that greatly facilitate
    interfacing C or C++ code in R packages using the .Call() interface
    provided by R. Rcpp provides matching C++ classes for a large
    number of basic R data types. Hence, a package author can keep his
@@ -163,11 +163,11 @@ A: You would use Rcpp at http://dirk.eddelbuettel.com/code/rcpp.html
    structures can be accessed as easily at the C++ level, and used in
    the normal manner. The mapping of data types works in both
    directions. It is as straightforward to pass data from R to C++,
-   as it is it return data from C++ to R.
+   as it is it return data from C++ to R.*
 
-Q: Any other design issues?
+**Q:** Any other design issues?
 
-A: Yes. As currently structured, all of these classes assume that your
+**A:** Yes. As currently structured, all of these classes assume that your
    data is readily available in RAM. They will not work correctly, if
    your dataset is too big to fit into RAM.  At the time of this
    writing, a single atom takes about 1.5KBytes or so, so a dataset

--- a/opencog/matrix/README.md
+++ b/opencog/matrix/README.md
@@ -64,6 +64,22 @@ be described in terms of it's adjacency matrix. This directory provides
 tools to work with a graph from the point of view of its being an
 adjacency matrix.
 
+Thus, generically, a "matrix" in the AtomSpace is simply a collection of
+Atoms, all of the same kind and general structure, with some
+identifiable sub-part, called "the rows", or the "left atoms", and some
+other identifiable sub-part, called "the columns", or the "right atoms".
+As long as one can easily identify all of the Atoms that belong to the
+collection, and one can identify two distinct sub-parts, one has
+everything one needs to identify pairs `(left, right)` aka
+`(row, column)` aka `(x,y)`.  To get a matrix, one needs one more thing:
+a Value, some Value, any Value, holding a floating-point number for each
+pair. This number is called `N(x,y)`. This number can represent any
+numeric data at all.  In the prototypical usage, this number is an
+observation count obtained by sensory data flowing in from the outside
+world. It dosn't have to be - the matrix toolset provided here is
+generic, intended to be useful for any AtomSpace data that meets the
+requirement of having a numeric value attached to a collection of pairs.
+
 The tools implemented here include:
 
  * Row and column subtotals (i.e. "marginals").

--- a/opencog/matrix/compute-mi.scm
+++ b/opencog/matrix/compute-mi.scm
@@ -385,6 +385,22 @@
   the left and right wild-card values. The primary utility of this
   class is that it prints a progress report. Its really just a fancy
   wrapper around store-atom, which does the actual work.
+
+  The provided methods are:
+  'store-left-marginals - Store all of the left (row) marginal atoms,
+       and all of the values attached to them. This also stores the
+       wild-wild atom as well.
+
+  'store-right-marginals - Store all of the right (column) marginal
+       atoms, and all of the values attached to them. This also stores
+       the wild-wild atom as well.
+
+  'store-wildcards - Store both left and right marginals.
+
+  'store-all-elts - Store all non-marginal matrix entries (and the
+       attached values, of course).
+
+  'store-pairs - Store the provided list of Atoms.
 "
 	(define start-time (current-time))
 	(define (elapsed-secs)
@@ -443,12 +459,13 @@
 			(store-left-wildcards)
 			(store-right-wildcards))
 
-		; Store all the pairs. These must be provided as a list to us,
-		; because, at this time, we don't have an effective way of working
-		; with the non-zero elements.  Maybe a better solution will become
-		; clear over time...
+		; Store the list of given pairs.
 		(define (store-pairs all-pairs)
 			(store-list (lambda (x) x) all-pairs 100000 "pairs"))
+
+		; Store all elements in the matrix.
+		(define (store-all-elts)
+			(store-pairs (star-obj 'get-all-elts)))
 
 		; ------------------
 		; Methods on this class.
@@ -457,6 +474,7 @@
 				((store-left-marginals) (store-left-wildcards))
 				((store-right-marginals)(store-right-wildcards))
 				((store-wildcards)      (store-all-wildcards))
+				((store-all-elts)       (store-all-elts))
 				((store-pairs)          (apply store-pairs args))
 				(else                   (apply llobj (cons message args))))
 		))

--- a/opencog/matrix/compute-mi.scm
+++ b/opencog/matrix/compute-mi.scm
@@ -596,7 +596,7 @@
 	(display "Done computing and saving -log P(x,*) and P(*,y)\n")
 
 	; Now, the individual pair mi's
-	(display "Going to do individual pair MI\n")
+	(display "Going to compute and store individual pair MI\n")
 	(elapsed-secs)
 	(let* ((num-prs (batch-mi-obj 'cache-pair-mi
 				(lambda (atom-list) (for-each store-atom atom-list)))))

--- a/opencog/matrix/filter.scm
+++ b/opencog/matrix/filter.scm
@@ -158,6 +158,9 @@
 			(define stats-atom (get-item-pair L-ATOM R-ATOM))
 			(if (null? stats-atom) 0 (LLOBJ 'get-count stats-atom)))
 
+		(define (get-all-elts)
+			(filter PAIR-PRED (LLOBJ 'get-all-elts)))
+
 		; ---------------
 		(define (get-name)
 			(string-append (LLOBJ 'name) " " ID-STR))
@@ -176,6 +179,7 @@
 				((right-stars)      cache-right-stars)
 				((left-duals)       cache-left-duals)
 				((right-duals)      cache-right-duals)
+				((get-all-elts)     get-all-elts)
 				(else               (LLOBJ 'provides meth))))
 
 		; -------------
@@ -195,6 +199,7 @@
 				((get-pair)         (apply get-item-pair args))
 				((get-count)        (apply get-count args))
 				((get-pair-count)   (apply get-pair-count args))
+				((get-all-elts)     (get-all-elts))
 				((provides)         (apply provides args))
 				((filters?)         RENAME)
 				; Pass through some selected methods

--- a/opencog/matrix/filter.scm
+++ b/opencog/matrix/filter.scm
@@ -45,6 +45,22 @@
   add-generic-filter LLOBJ - Modify LLOBJ so that only the columns and
   rows and individual entries that satisfy the predicates are retained.
 
+  This provides the same methods as the `add-pair-stars` object; it is
+  a replacement of that object, for all practical purposes. Thus, given
+  some matrix, this object provides a way of accessing a smaller,
+  lower-dimensional version of that matrix, by knocking out rows,
+  columns and individual entries.
+
+  Note, however, that the full-sized matrix will typically have
+  marginals associated with it (such as totals over columns and rows)
+  and that those marginals will typically become invalid for the
+  smaller matrix (because totals over columns and rows for the smaller
+  matrix are necessarily different). This filter does NOT attempt to
+  recompute those marginals!  It is up  to the user to track these!
+  The ID-STR can be used to give this submatrix a unique name, and
+  therefore can be used as a tag, when recomputing marginals for the
+  smaller matrix.
+
   The LEFT-BASIS-PRED and RIGHT-BASIS-PRED should be functions that
   accept atoms in the left and right basis, and return #t if they
   should be kept. If these predicates return #f, that row or column

--- a/opencog/matrix/object-api.scm
+++ b/opencog/matrix/object-api.scm
@@ -237,6 +237,11 @@
 
   'right-stars ROW - Likewise, but returns the set (ROW, *).
 
+  'get-all-elts - Return a list of all elements in the matrix.
+      Caution: this may be very large, and thus take a long time to
+      compute.  The result is not cached, so if you call this a second
+      time, this list will be recomputed from scratch!
+
   Note that for (define STARS (add-pair-stars LLOBJ))
   the list returned by
     (map (lambda (COL) (LLOBJ 'get-pair ROW COL)) (STARS 'right-duals ROW))

--- a/opencog/matrix/object-api.scm
+++ b/opencog/matrix/object-api.scm
@@ -480,6 +480,24 @@
 			(atomic-box-set! dual-r-miss '()))
 
 		;-------------------------------------------
+		; Perform a query to find all (non-marginal) matrix entries
+		; in the matrix. Return a list of them.
+		(define (get-all-pairs)
+			(define uleft (uniquely-named-variable))
+			(define uright (uniquely-named-variable))
+			(define term (LLOBJ 'make-pair uleft uright))
+			(define setlnk (cog-execute! (Bind
+				(VariableList
+					(TypedVariable uleft (Type (symbol->string left-type)))
+					(TypedVariable uright (Type (symbol->string right-type))))
+				term term)))
+			(define all-pairs (cog-outgoing-set setlnk))
+			(cog-extract setlnk)
+			(cog-extract-recursive uleft)
+			(cog-extract-recursive uright)
+			all-pairs)
+
+		;-------------------------------------------
 
 		; Provide default methods, but only if the low-level object
 		; does not already provide them. In practice, this is used in
@@ -495,6 +513,7 @@
 				(f-right-stars (overload 'right-stars get-right-stars))
 				(f-left-duals (overload 'left-duals get-left-duals))
 				(f-right-duals (overload 'right-duals get-right-duals))
+				(f-get-all-elts (overload 'get-all-elts get-all-pairs))
 				(f-clobber (overload 'clobber clobber)))
 
 			;-------------------------------------------
@@ -513,6 +532,7 @@
 					((right-stars)      f-right-stars)
 					((left-duals)       f-left-duals)
 					((right-duals)      f-right-duals)
+					((get-all-elts)     f-get-all-elts)
 					((clobber)          f-clobber)
 					(else               (LLOBJ 'provides meth))))
 
@@ -528,6 +548,7 @@
 					((right-stars)      (apply f-right-stars args))
 					((left-duals)       (apply f-left-duals args))
 					((right-duals)      (apply f-right-duals args))
+					((get-all-elts)     (f-get-all-elts))
 					((clobber)          (f-clobber))
 					((provides)         (apply provides args))
 					(else               (apply LLOBJ (cons message args))))


### PR DESCRIPTION
This extends the matrix API with a fairly basic method that had not been needed until now :-)

Recall that a "matrix" in the atomspace is simply a collection of atoms, all of the same kind, all having two sub-parts: a left subpart (aka "the rows") and a right sub-part (aka "the columns").