### PR TITLE
It's not possible to get a TV unless the atom is in an atomspace

### DIFF
--- a/opencog/atoms/core/TruthValueOfLink.cc
+++ b/opencog/atoms/core/TruthValueOfLink.cc
@@ -65,7 +65,16 @@ ValuePtr TruthValueOfLink::execute(AtomSpace* as, bool silent)
 	if (ah)
 		return ValueCast(ah->getTruthValue());
 
-	return get_handle();
+	if (silent)
+		throw SilentException();
+
+	// If the user asked for a TV not in any atomspace,
+	// what should we do? I dunno, so I'm throwing an error.
+	throw InvalidParamException(TRACE_INFO,
+		"Asked for TruthValue of atom not in any atomspace: %s",
+		this->to_string().c_str());
+
+	return Handle();
 }
 
 // =============================================================
@@ -115,7 +124,16 @@ ValuePtr StrengthOfLink::execute(AtomSpace* as, bool silent)
 		if (ah)
 			strengths.push_back(ah->getTruthValue()->get_mean());
 		else
-			return get_handle();
+		{
+			if (silent)
+				throw SilentException();
+
+			// If the user asked for a TV not in any atomspace,
+			// what should we do? I dunno, so I'm throwing an error.
+			throw InvalidParamException(TRACE_INFO,
+				"Asked for Strength of atom not in any atomspace: %s",
+				this->to_string().c_str());
+		}
 	}
 
 	return createFloatValue(strengths);
@@ -168,7 +186,16 @@ ValuePtr ConfidenceOfLink::execute(AtomSpace* as, bool silent)
 		if (ah)
 			confids.push_back(ah->getTruthValue()->get_confidence());
 		else
-			return get_handle();
+		{
+			if (silent)
+				throw SilentException();
+
+			// If the user asked for a TV not in any atomspace,
+			// what should we do? I dunno, so I'm throwing an error.
+			throw InvalidParamException(TRACE_INFO,
+				"Asked for Confidence of atom not in any atomspace: %s",
+				this->to_string().c_str());
+		}
 	}
 
 	return createFloatValue(confids);

--- a/opencog/atoms/core/TruthValueOfLink.cc
+++ b/opencog/atoms/core/TruthValueOfLink.cc
@@ -21,6 +21,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <opencog/atomspace/AtomSpace.h>
 #include "TruthValueOfLink.h"
 
 using namespace opencog;
@@ -58,7 +59,13 @@ ValuePtr TruthValueOfLink::execute(AtomSpace* as, bool silent)
 	if (1 != ary)
 		throw SyntaxException(TRACE_INFO, "Expecting one atom!");
 
-	return ValueCast(_outgoing[0]->getTruthValue());
+	// We cannot know the TruthValue of the Atom unless we are
+	// working with the unique version that sits in the AtomSpace!
+	Handle ah(as->get_atom(_outgoing[0]));
+	if (ah)
+		return ValueCast(ah->getTruthValue());
+
+	return get_handle();
 }
 
 // =============================================================
@@ -102,7 +109,13 @@ ValuePtr StrengthOfLink::execute(AtomSpace* as, bool silent)
 		if (VARIABLE_NODE == t or GLOB_NODE == t)
 			return get_handle();
 
-		strengths.push_back(h->getTruthValue()->get_mean());
+		// We cannot know the TruthValue of the Atom unless we are
+		// working with the unique version that sits in the AtomSpace!
+		Handle ah(as->get_atom(h));
+		if (ah)
+			strengths.push_back(ah->getTruthValue()->get_mean());
+		else
+			return get_handle();
 	}
 
 	return createFloatValue(strengths);
@@ -149,7 +162,13 @@ ValuePtr ConfidenceOfLink::execute(AtomSpace* as, bool silent)
 		if (VARIABLE_NODE == t or GLOB_NODE == t)
 			return get_handle();
 
-		confids.push_back(h->getTruthValue()->get_confidence());
+		// We cannot know the TruthValue of the Atom unless we are
+		// working with the unique version that sits in the AtomSpace!
+		Handle ah(as->get_atom(h));
+		if (ah)
+			confids.push_back(ah->getTruthValue()->get_confidence());
+		else
+			return get_handle();
 	}
 
 	return createFloatValue(confids);

--- a/opencog/atoms/core/ValueOfLink.cc
+++ b/opencog/atoms/core/ValueOfLink.cc
@@ -69,6 +69,7 @@ ValuePtr ValueOfLink::execute(AtomSpace* as, bool silent)
 		if (pap) return pap;
 	}
 
+	// Hmm. shouldn't this be SilentException?
 	if (silent)
 		throw NotEvaluatableException();
 

--- a/opencog/atoms/core/ValueOfLink.cc
+++ b/opencog/atoms/core/ValueOfLink.cc
@@ -21,6 +21,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <opencog/atomspace/AtomSpace.h>
 #include "FunctionLink.h"
 #include "ValueOfLink.h"
 
@@ -59,8 +60,14 @@ ValuePtr ValueOfLink::execute(AtomSpace* as, bool silent)
 	if (2 != ary)
 		throw SyntaxException(TRACE_INFO, "Expecting two atoms!");
 
-	ValuePtr pap = _outgoing[0]->getValue(_outgoing[1]);
-	if (pap) return pap;
+	// We cannot know the Value of the Atom unless we are
+	// working with the unique version that sits in the AtomSpace!
+	Handle ah(as->get_atom(_outgoing[0]));
+	if (ah)
+	{
+		ValuePtr pap = ah->getValue(_outgoing[1]);
+		if (pap) return pap;
+	}
 
 	if (silent)
 		throw NotEvaluatableException();

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -905,10 +905,10 @@ TruthValuePtr EvaluationLink::do_eval_scratch(AtomSpace* as,
 				continue;
 			}
 
-			if (not nameserver().isA(h->get_type(), FUNCTION_LINK))
-				throw SyntaxException(TRACE_INFO, "Expecting a FunctionLink");
+			if (not  h->is_executable())
+				throw SyntaxException(TRACE_INFO, "Expecting an executable Link");
 
-			ValuePtr v(h->execute());
+			ValuePtr v(h->execute(scratch, silent));
 			FloatValuePtr fv(FloatValueCast(v));
 			nums.push_back(fv->value().at(0));
 		}

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -124,42 +124,43 @@ void throwSyntaxException(bool silent, const char* message...)
 	va_end(args);
 }
 
-/// Pattern matching hack. The pattern matcher returns sets of atoms;
-/// if that set contains a single number, then unwrap it.
-/// See issue #1502 which proposes to eliminate this SetLink hack.
-static NumberNodePtr unwrap_set(Handle h)
+/// Extract a single floating-point double out of an atom, that,
+/// when executed, should yeild a value containing a number.
+/// Viz, either a NumberNode, or a FloatValue.
+static double get_numeric_value(AtomSpace* as, bool silent,
+                                Handle h)
 {
-	if (SET_LINK == h->get_type())
+	Type t = h->get_type();
+	if (DEFINED_SCHEMA_NODE == t)
 	{
-		if (1 != h->get_arity())
-			throw SyntaxException(TRACE_INFO,
-				"Don't know how to do arithmetic with this: %s",
-				h->to_string().c_str());
-		h = h->getOutgoingAtom(0);
+		h = DefineLink::get_definition(h);
+		t = h->get_type();
 	}
 
-	NumberNodePtr na(NumberNodeCast(h));
-	if (nullptr == na)
+	ValuePtr pap(h);
+	if (h->is_executable())
 	{
-		NodePtr np(NodeCast(h));
-		if (np) na = createNumberNode(*np);
+		pap = h->execute(as, silent);
+		t = pap->get_type();
+
+		// Pattern matching hack. The pattern matcher returns sets of
+		// atoms; if that set contains a single number, then unwrap it.
+		// See issue #1502 which proposes to eliminate this SetLink hack.
+		if (SET_LINK == t)
+		{
+			h = HandleCast(pap);
+			if (1 != h->get_arity())
+				throw SyntaxException(TRACE_INFO,
+					"Don't know how to unwrap this: %s",
+					h->to_string().c_str());
+			pap = h->getOutgoingAtom(0);
+			t = pap->get_type();
+		}
 	}
 
-	if (nullptr == na)
-		throw SyntaxException(TRACE_INFO,
-			"Don't know how to compare this: %s",
-			h->to_string().c_str());
-	return na;
-}
-
-/// Extract a single floating-point double out of a value expected to
-/// contain a number.
-static double get_numeric_value(const ValuePtr& pap, bool silent)
-{
-	Type t = pap->get_type();
-	if (NUMBER_NODE == t or SET_LINK == t)
+	if (NUMBER_NODE == t)
 	{
-		NumberNodePtr n(unwrap_set(HandleCast(pap)));
+		NumberNodePtr n(NumberNodeCast(pap));
 		return n->get_value();
 	}
 
@@ -186,12 +187,8 @@ static bool greater(AtomSpace* as, const Handle& h, bool silent)
 		throw SyntaxException(TRACE_INFO,
 		     "GreaterThankLink expects two arguments");
 
-	Instantiator inst(as);
-	ValuePtr pap0(inst.execute(oset[0]));
-	ValuePtr pap1(inst.execute(oset[1]));
-
-	double v0 = get_numeric_value(pap0, silent);
-	double v1 = get_numeric_value(pap1, silent);
+	double v0 = get_numeric_value(as, silent, oset[0]);
+	double v1 = get_numeric_value(as, silent, oset[1]);
 
 	return (v0 > v1);
 }

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -558,8 +558,10 @@ static bool crisp_eval_scratch(AtomSpace* as,
 }
 
 /// Evaluate a formula defined by a PREDICATE_FORMULA_LINK
-static TruthValuePtr eval_formula(const Handle& predform,
-                                  const HandleSeq& cargs)
+static TruthValuePtr eval_formula(AtomSpace* as,
+                                  const Handle& predform,
+                                  const HandleSeq& cargs,
+                                  bool silent)
 {
 	// Collect up two floating point values.
 	std::vector<double> nums;
@@ -597,7 +599,7 @@ static TruthValuePtr eval_formula(const Handle& predform,
 		}
 
 		// Expecting a FunctionLink without variables.
-		ValuePtr v(flh->execute());
+		ValuePtr v(flh->execute(as, silent));
 		FloatValuePtr fv(FloatValueCast(v));
 		nums.push_back(fv->value()[0]);
 	}
@@ -645,7 +647,7 @@ TruthValuePtr do_eval_with_args(AtomSpace* as,
 
 		if (PREDICATE_FORMULA_LINK == dtype)
 		{
-			return eval_formula(defn, cargs);
+			return eval_formula(as, defn, cargs, silent);
 		}
 
 		// If its not a LambdaLink, then I don't know what to do...
@@ -665,7 +667,7 @@ TruthValuePtr do_eval_with_args(AtomSpace* as,
 	// AtomSpace.
 	if (PREDICATE_FORMULA_LINK == pntype)
 	{
-		return eval_formula(pn, cargs);
+		return eval_formula(as, pn, cargs, silent);
 	}
 
 	if (GROUNDED_PREDICATE_NODE != pntype)

--- a/opencog/atoms/reduct/ArithmeticLink.cc
+++ b/opencog/atoms/reduct/ArithmeticLink.cc
@@ -163,15 +163,17 @@ ValuePtr ArithmeticLink::get_value(AtomSpace* as, bool silent, ValuePtr vptr) co
 	{
 		vptr = DefineLink::get_definition(HandleCast(vptr));
 	}
-	while (nameserver().isA(vptr->get_type(), FUNCTION_LINK))
+	while (vptr->is_atom())
 	{
-		ValuePtr red(HandleCast(vptr)->execute(as, silent));
+		Handle h(HandleCast(vptr));
+		if (not h->is_executable()) break;
+
+		ValuePtr red(h->execute(as, silent));
 
 		// It would probably be better to throw a silent exception, here?
 		if (nullptr == red) return vptr;
 		if (*red == *vptr) return vptr;
 		vptr = red;
-
 	}
 
 	// The FunctionLink might be a GetLink, which returns a SetLink

--- a/opencog/atoms/reduct/ArithmeticLink.cc
+++ b/opencog/atoms/reduct/ArithmeticLink.cc
@@ -24,6 +24,7 @@
 
 #include <opencog/atoms/atom_types/atom_types.h>
 #include <opencog/atoms/atom_types/NameServer.h>
+#include <opencog/atoms/core/DefineLink.h>
 #include <opencog/atoms/core/NumberNode.h>
 #include "ArithmeticLink.h"
 
@@ -158,6 +159,10 @@ Handle ArithmeticLink::reorder(void) const
 
 ValuePtr ArithmeticLink::get_value(AtomSpace* as, bool silent, ValuePtr vptr) const
 {
+	if (DEFINED_SCHEMA_NODE == vptr->get_type())
+	{
+		vptr = DefineLink::get_definition(HandleCast(vptr));
+	}
 	while (nameserver().isA(vptr->get_type(), FUNCTION_LINK))
 	{
 		ValuePtr red(HandleCast(vptr)->execute(as, silent));

--- a/opencog/atoms/reduct/ArithmeticLink.cc
+++ b/opencog/atoms/reduct/ArithmeticLink.cc
@@ -83,12 +83,12 @@ void ArithmeticLink::init(void)
 /// ever-more rules to the rule engine to reduce ever-more interesting
 /// algebraic expressions.
 ///
-ValuePtr ArithmeticLink::delta_reduce(void) const
+ValuePtr ArithmeticLink::delta_reduce(AtomSpace* as, bool silent) const
 {
 	Handle road(reorder());
 	ArithmeticLinkPtr alp(ArithmeticLinkCast(road));
 
-	ValuePtr red(alp->FoldLink::delta_reduce());
+	ValuePtr red(alp->FoldLink::delta_reduce(as, silent));
 
 	if (nullptr == red or not red->is_atom()) return red;
 
@@ -185,7 +185,7 @@ ValuePtr ArithmeticLink::get_value(ValuePtr vptr) const
 /// execute() -- Execute the expression
 ValuePtr ArithmeticLink::execute(AtomSpace* as, bool silent)
 {
-	return delta_reduce();
+	return delta_reduce(as, silent);
 }
 
 // ===========================================================

--- a/opencog/atoms/reduct/ArithmeticLink.cc
+++ b/opencog/atoms/reduct/ArithmeticLink.cc
@@ -156,11 +156,11 @@ Handle ArithmeticLink::reorder(void) const
 
 // ===========================================================
 
-ValuePtr ArithmeticLink::get_value(ValuePtr vptr) const
+ValuePtr ArithmeticLink::get_value(AtomSpace* as, bool silent, ValuePtr vptr) const
 {
 	while (nameserver().isA(vptr->get_type(), FUNCTION_LINK))
 	{
-		ValuePtr red(HandleCast(vptr)->execute());
+		ValuePtr red(HandleCast(vptr)->execute(as, silent));
 
 		// It would probably be better to throw a silent exception, here?
 		if (nullptr == red) return vptr;

--- a/opencog/atoms/reduct/ArithmeticLink.h
+++ b/opencog/atoms/reduct/ArithmeticLink.h
@@ -49,7 +49,7 @@ public:
 	ArithmeticLink(const HandleSeq& oset, Type=ARITHMETIC_LINK);
 	ArithmeticLink(const Link& l);
 
-	virtual ValuePtr delta_reduce(void) const;
+	virtual ValuePtr delta_reduce(AtomSpace*, bool) const;
 	virtual ValuePtr execute(AtomSpace*, bool);
 	virtual ValuePtr execute(void) { return execute(_atom_space, false); }
 };

--- a/opencog/atoms/reduct/ArithmeticLink.h
+++ b/opencog/atoms/reduct/ArithmeticLink.h
@@ -43,7 +43,7 @@ protected:
 	virtual Handle reorder(void) const;
 	bool _commutative;
 
-	ValuePtr get_value(ValuePtr) const;
+	ValuePtr get_value(AtomSpace*, bool, ValuePtr) const;
 
 public:
 	ArithmeticLink(const HandleSeq& oset, Type=ARITHMETIC_LINK);

--- a/opencog/atoms/reduct/DivideLink.cc
+++ b/opencog/atoms/reduct/DivideLink.cc
@@ -64,13 +64,14 @@ static inline double get_double(const ValuePtr& pap)
 }
 
 // No ExpLink or PowLink and so kons is very simple
-ValuePtr DivideLink::kons(const ValuePtr& fi, const ValuePtr& fj) const
+ValuePtr DivideLink::kons(AtomSpace* as, bool silent,
+                          const ValuePtr& fi, const ValuePtr& fj) const
 {
 	// Try to yank out values, if possible.
-	ValuePtr vi(get_value(fi));
+	ValuePtr vi(get_value(as, silent, fi));
 	Type vitype = vi->get_type();
 
-	ValuePtr vj(get_value(fj));
+	ValuePtr vj(get_value(as, silent, fj));
 	Type vjtype = vj->get_type();
 
 	// Are they numbers?

--- a/opencog/atoms/reduct/DivideLink.h
+++ b/opencog/atoms/reduct/DivideLink.h
@@ -39,7 +39,7 @@ class DivideLink : public TimesLink
 protected:
 	void init(void);
 
-	ValuePtr kons(const ValuePtr&, const ValuePtr&) const;
+	ValuePtr kons(AtomSpace*, bool, const ValuePtr&, const ValuePtr&) const;
 public:
 	DivideLink(const Handle& a, const Handle& b);
 	DivideLink(const HandleSeq& oset, Type=DIVIDE_LINK);

--- a/opencog/atoms/reduct/FoldLink.cc
+++ b/opencog/atoms/reduct/FoldLink.cc
@@ -85,7 +85,7 @@ ValuePtr FoldLink::delta_reduce(AtomSpace* as, bool silent) const
 		// Performance ... maybe it is faster to call the nameserver
 		// instead?
 		// if (nameserver().isA(h->get_type(), FUNCTION_LINK))
-		if (h->is_atom() and h->is_executable())
+		if (h->is_executable())
 		{
 			expr = kons(as, silent, h->execute(as, silent), expr);
 		}

--- a/opencog/atoms/reduct/FoldLink.cc
+++ b/opencog/atoms/reduct/FoldLink.cc
@@ -59,7 +59,7 @@ void FoldLink::init(void)
 /// Actually, what is implemete here is not pure delta-reduction.
 /// If the arguments to Fold are executale, then they are executed
 /// first, and only then is the delta-reduction performed.
-ValuePtr FoldLink::delta_reduce(void) const
+ValuePtr FoldLink::delta_reduce(AtomSpace* as, bool silent) const
 {
 	ValuePtr expr = knil;
 
@@ -87,11 +87,11 @@ ValuePtr FoldLink::delta_reduce(void) const
 		// if (nameserver().isA(h->get_type(), FUNCTION_LINK))
 		if (h->is_atom() and h->is_executable())
 		{
-			expr = kons(h->execute(), expr);
+			expr = kons(as, silent, h->execute(as, silent), expr);
 		}
 		else
 		{
-			expr = kons(h, expr);
+			expr = kons(as, silent, h, expr);
 		}
 	}
 

--- a/opencog/atoms/reduct/FoldLink.h
+++ b/opencog/atoms/reduct/FoldLink.h
@@ -43,7 +43,8 @@ class FoldLink : public FunctionLink
 {
 protected:
 	ValuePtr knil;
-	virtual ValuePtr kons(const ValuePtr&, const ValuePtr&) const = 0;
+	virtual ValuePtr kons(AtomSpace*, bool,
+	                      const ValuePtr&, const ValuePtr&) const = 0;
 
 	void init(void);
 
@@ -51,7 +52,8 @@ public:
 	FoldLink(const HandleSeq&, Type=FOLD_LINK);
 	FoldLink(const Link& l);
 
-   virtual ValuePtr delta_reduce(void) const;
+	// Should probably be renamed to execute() ...
+   virtual ValuePtr delta_reduce(AtomSpace*, bool) const;
 };
 
 static inline FoldLinkPtr FoldLinkCast(const Handle& h)

--- a/opencog/atoms/reduct/MinusLink.cc
+++ b/opencog/atoms/reduct/MinusLink.cc
@@ -65,13 +65,14 @@ static inline double get_double(const ValuePtr& pap)
 	return NumberNodeCast(pap)->get_value();
 }
 
-ValuePtr MinusLink::kons(const ValuePtr& fi, const ValuePtr& fj) const
+ValuePtr MinusLink::kons(AtomSpace* as, bool silent,
+                         const ValuePtr& fi, const ValuePtr& fj) const
 {
 	// Try to yank out values, if possible.
-	ValuePtr vi(get_value(fi));
+	ValuePtr vi(get_value(as, silent, fi));
 	Type vitype = vi->get_type();
 
-	ValuePtr vj(get_value(fj));
+	ValuePtr vj(get_value(as, silent, fj));
 	Type vjtype = vj->get_type();
 
 	// Are they numbers?

--- a/opencog/atoms/reduct/MinusLink.h
+++ b/opencog/atoms/reduct/MinusLink.h
@@ -39,7 +39,7 @@ class MinusLink : public PlusLink
 protected:
 	void init(void);
 
-	ValuePtr kons(const ValuePtr&, const ValuePtr&) const;
+	ValuePtr kons(AtomSpace*, bool, const ValuePtr&, const ValuePtr&) const;
 public:
 	MinusLink(const Handle& a, const Handle& b);
 	MinusLink(const HandleSeq&, Type=MINUS_LINK);

--- a/opencog/atoms/reduct/PlusLink.cc
+++ b/opencog/atoms/reduct/PlusLink.cc
@@ -68,7 +68,8 @@ static inline double get_double(const ValuePtr& pap)
 	return NumberNodeCast(pap)->get_value();
 }
 
-ValuePtr PlusLink::kons(const ValuePtr& fi, const ValuePtr& fj) const
+ValuePtr PlusLink::kons(AtomSpace* as, bool silent,
+                        const ValuePtr& fi, const ValuePtr& fj) const
 {
 	// Try to yank out values, if possible.
 	ValuePtr vi(get_value(fi));
@@ -117,7 +118,7 @@ ValuePtr PlusLink::kons(const ValuePtr& fi, const ValuePtr& fj) const
 		}
 		Handle foo(createLink(seq, PLUS_LINK));
 		PlusLinkPtr ap = PlusLinkCast(foo);
-		return ap->delta_reduce();
+		return ap->delta_reduce(as, silent);
 	}
 
 	// Is fi identical to fj? If so, then replace by 2*fi
@@ -198,7 +199,7 @@ ValuePtr PlusLink::kons(const ValuePtr& fi, const ValuePtr& fj) const
 			// a_plus is now (a+1) or (a+b) as described above.
 			Handle foo(createLink(rest, PLUS_LINK));
 			PlusLinkPtr ap = PlusLinkCast(foo);
-			ValuePtr a_plus(ap->delta_reduce());
+			ValuePtr a_plus(ap->delta_reduce(as, silent));
 
 			return createTimesLink(exx, HandleCast(a_plus));
 		}

--- a/opencog/atoms/reduct/PlusLink.cc
+++ b/opencog/atoms/reduct/PlusLink.cc
@@ -72,10 +72,10 @@ ValuePtr PlusLink::kons(AtomSpace* as, bool silent,
                         const ValuePtr& fi, const ValuePtr& fj) const
 {
 	// Try to yank out values, if possible.
-	ValuePtr vi(get_value(fi));
+	ValuePtr vi(get_value(as, silent, fi));
 	Type vitype = vi->get_type();
 
-	ValuePtr vj(get_value(fj));
+	ValuePtr vj(get_value(as, silent, fj));
 	Type vjtype = vj->get_type();
 
 	// Are they numbers?
@@ -126,7 +126,7 @@ ValuePtr PlusLink::kons(AtomSpace* as, bool silent,
 	if (hvi and content_eq(hvi, HandleCast(vj)))
 	{
 		Handle two(createNumberNode("2"));
-		return createTimesLink(hvi, two) -> execute();
+		return createTimesLink(hvi, two) -> execute(as, silent);
 	}
 
 	// Swap order, to make the Minus handling below easier.

--- a/opencog/atoms/reduct/PlusLink.h
+++ b/opencog/atoms/reduct/PlusLink.h
@@ -38,7 +38,8 @@ class PlusLink : public ArithmeticLink
 {
 protected:
 	static Handle zero;
-	virtual ValuePtr kons(const ValuePtr&, const ValuePtr&) const;
+	virtual ValuePtr kons(AtomSpace*, bool,
+	                      const ValuePtr&, const ValuePtr&) const;
 
 	void init(void);
 

--- a/opencog/atoms/reduct/TimesLink.cc
+++ b/opencog/atoms/reduct/TimesLink.cc
@@ -69,7 +69,8 @@ static inline double get_double(const ValuePtr& pap)
 /// Because there is no ExpLink or PowLink that can handle repeated
 /// products, or any distributive property, kons is very simple for
 /// the TimesLink.
-ValuePtr TimesLink::kons(const ValuePtr& fi, const ValuePtr& fj) const
+ValuePtr TimesLink::kons(AtomSpace* as, bool silent,
+                         const ValuePtr& fi, const ValuePtr& fj) const
 {
 	// Try to yank out values, if possible.
 	ValuePtr vi(get_value(fi));
@@ -106,7 +107,7 @@ ValuePtr TimesLink::kons(const ValuePtr& fi, const ValuePtr& fj) const
 		}
 		Handle foo(createLink(seq, TIMES_LINK));
 		TimesLinkPtr ap = TimesLinkCast(foo);
-		return ap->delta_reduce();
+		return ap->delta_reduce(as, silent);
 	}
 
 	// Are they both numbers?

--- a/opencog/atoms/reduct/TimesLink.cc
+++ b/opencog/atoms/reduct/TimesLink.cc
@@ -73,10 +73,10 @@ ValuePtr TimesLink::kons(AtomSpace* as, bool silent,
                          const ValuePtr& fi, const ValuePtr& fj) const
 {
 	// Try to yank out values, if possible.
-	ValuePtr vi(get_value(fi));
+	ValuePtr vi(get_value(as, silent, fi));
 	Type vitype = vi->get_type();
 
-	ValuePtr vj(get_value(fj));
+	ValuePtr vj(get_value(as, silent, fj));
 	Type vjtype = vj->get_type();
 
 	// Is either one a TimesLink? If so, then flatten.

--- a/opencog/atoms/reduct/TimesLink.h
+++ b/opencog/atoms/reduct/TimesLink.h
@@ -38,7 +38,8 @@ class TimesLink : public ArithmeticLink
 {
 protected:
 	static Handle one;
-	ValuePtr kons(const ValuePtr&, const ValuePtr&) const;
+	ValuePtr kons(AtomSpace*, bool,
+	              const ValuePtr&, const ValuePtr&) const;
 
 	void init(void);
 

--- a/tests/atoms/FormulaUTest.cxxtest
+++ b/tests/atoms/FormulaUTest.cxxtest
@@ -55,6 +55,7 @@ public:
 	void test_evalform();
 	void test_putlink();
 	void test_define();
+	void test_lambda();
 };
 
 #define MAXERR 1.0e-12
@@ -288,6 +289,33 @@ void FormulaUTest::test_define()
 	fvp = FloatValueCast(ValueCast(tvp));
 	TS_ASSERT_LESS_THAN(fabs(fvp->value()[0] - 0.96), MAXERR);
 	TS_ASSERT_LESS_THAN(fabs(fvp->value()[1] - 0.9604), MAXERR);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void FormulaUTest::test_lambda()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	TruthValuePtr tvp = _eval.eval_tv("(cog-evaluate! (its-one atom-a atom-b))");
+	printf("TV for iab=%s\n", tvp->to_string().c_str());
+	TS_ASSERT_EQUALS(tvp->get_type(), SIMPLE_TRUTH_VALUE);
+	TS_ASSERT_EQUALS(tvp, TruthValue::TRUE_TV());
+
+	tvp = _eval.eval_tv("(cog-evaluate! (its-one atom-b atom-c))");
+	printf("TV for ibc=%s\n", tvp->to_string().c_str());
+	TS_ASSERT_EQUALS(tvp->get_type(), SIMPLE_TRUTH_VALUE);
+	TS_ASSERT_EQUALS(tvp, TruthValue::FALSE_TV());
+
+	tvp = _eval.eval_tv("(cog-evaluate! (its-conf atom-a atom-b))");
+	printf("TV for iab=%s\n", tvp->to_string().c_str());
+	TS_ASSERT_EQUALS(tvp->get_type(), SIMPLE_TRUTH_VALUE);
+	TS_ASSERT_EQUALS(tvp, TruthValue::TRUE_TV());
+
+	tvp = _eval.eval_tv("(cog-evaluate! (its-conf atom-b atom-c))");
+	printf("TV for ibc=%s\n", tvp->to_string().c_str());
+	TS_ASSERT_EQUALS(tvp->get_type(), SIMPLE_TRUTH_VALUE);
+	TS_ASSERT_EQUALS(tvp, TruthValue::FALSE_TV());
 
 	logger().info("END TEST: %s", __FUNCTION__);
 }

--- a/tests/atoms/FormulaUTest.cxxtest
+++ b/tests/atoms/FormulaUTest.cxxtest
@@ -67,7 +67,7 @@ void FormulaUTest::test_strength_of()
 	_eval.eval("(Concept \"B\" (stv 0.6 0.9))");
 
 	ValuePtr sof = _eval.eval_v("(cog-execute! (StrengthOf (Concept \"A\")))");
-	printf("Get strenght_of=%s\n", sof->to_string().c_str());
+	printf("Get strength_of=%s\n", sof->to_string().c_str());
 	TS_ASSERT_EQUALS(sof->get_type(), FLOAT_VALUE);
 	FloatValuePtr fvp = FloatValueCast(sof);
 	TS_ASSERT_LESS_THAN(fabs(fvp->value()[0] - 0.8), MAXERR);

--- a/tests/atoms/formulas.scm
+++ b/tests/atoms/formulas.scm
@@ -117,3 +117,55 @@
 		(List
 			(Concept "A")
 			(Concept "B"))))
+
+; --------------------------------------------------
+
+(define atom-a (Concept "A" (stv 0.8 1.0)))
+(define atom-b (Concept "B" (stv 0.6 0.9)))
+(define atom-c (Concept "C"))
+
+(define key (Predicate "key"))
+
+(define iab (Inheritance atom-a atom-b (stv 0.8 0.8)))
+(define ibc (Inheritance atom-b atom-c (stv 0.3 0.3)))
+
+(cog-set-value! iab key (FloatValue 1 2 3))
+(cog-set-value! ibc key (FloatValue 4 5 6))
+
+; The InheritanceLink is not necessarily in any atomspace.
+(Define
+	(DefinedPredicate "its-about-one")
+	(Lambda
+		(VariableList (Variable "$x") (Variable "$y"))
+		(SequentialAnd
+			(GreaterThan
+				(ValueOf (Inheritance (Variable "$x") (Variable "$y"))  key)
+				(Number 0.99))
+			(GreaterThan
+				(Number 1.01)
+				(ValueOf (Inheritance (Variable "$x") (Variable "$y")) key))
+		)))
+
+; Expect (its-one atom-a atom-b) to be true,
+; and (its-one atom-b atom-c) to be false.
+(define (its-one a b)
+	(Evaluation (DefinedPredicate "its-about-one") (List a b)))
+
+(Define
+	(DefinedPredicate "mostly-confident")
+	(Lambda
+		(VariableList (Variable "$x") (Variable "$y"))
+		(SequentialAnd
+			(GreaterThan
+				(ConfidenceOf (Inheritance (Variable "$x") (Variable "$y")))
+				(Number 0.75))
+			(GreaterThan
+				(Number 0.85)
+				(ConfidenceOf (Inheritance (Variable "$x") (Variable "$y"))))
+		)))
+
+; Expect (its-conf atom-a atom-b) to be true,
+; and (its-conf atom-b atom-c) to be false.
+(define (its-conf a b)
+	(Evaluation (DefinedPredicate "mostly-confident") (List a b)))
+

--- a/tests/cython/README.md
+++ b/tests/cython/README.md
@@ -13,7 +13,7 @@ apt-get install python-nose
 You may need to set up the PYTHON path:
 export PYTHONPATH=${PROJECT_BINARY_DIR}/opencog/cython
 or, if installed:
-export PYTHONPATH=/usr/local/lib/python3.5/dist-packages/opencog:${PYTHON}
+export PYTHONPATH=/usr/local/lib/python3/dist-packages/opencog:${PYTHON}
 
 For example:
 export PYTHONPATH=build/opencog/cython

--- a/tests/cython/atomspace/test_do_execute.py
+++ b/tests/cython/atomspace/test_do_execute.py
@@ -22,7 +22,7 @@ class DoExecuteTest(unittest.TestCase):
 
         value_of_link = ValueOfLink(atom, key)
 
-        value = execute_atom(atomspace, value_of_link)
+        value = execute_atom(self.atomspace, value_of_link)
         self.assertEqual(FloatValue([1, 2, 3]), value)
         self.assertEqual([1, 2, 3], value.to_list())
 


### PR DESCRIPTION
If an atom is not in an atomspace, we don't really know what TV it is supposed to have.
This fixes issue #2214  - the TruthValueOf, StrengthOf and ConfidenceOf links weren't
working correctly.