### PR TITLE
Workaround for distutils bug in Ubuntu/Debian's Python3 versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,7 +275,7 @@ IF(HAVE_PY_INTERP)
 		# Find python destination dir for python bindings
 		# because it may differ on each operating system.
 		EXECUTE_PROCESS(
-			COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import *;print(get_python_lib(True, False, '${CMAKE_INSTALL_PREFIX}'))"
+			COMMAND ${PYTHON_EXECUTABLE} "${PROJECT_SOURCE_DIR}/scripts/get_python_lib.py" "${CMAKE_INSTALL_PREFIX}"
 			OUTPUT_VARIABLE PYTHON_DEST
 		)
 

--- a/scripts/get_python_lib.py
+++ b/scripts/get_python_lib.py
@@ -1,0 +1,24 @@
+import sys
+import sysconfig
+import site
+
+if __name__ == '__main__':
+    # This is a hack due to the distutils in debian/ubuntu's python3 being misconfigured
+    # see discussion https://github.com/opencog/atomspace/issues/1782
+    #
+    # If the bug is fixed, this script could be replaced by:
+    #
+    # from distutils.sysconfig import get_python_lib; print(get_python_lib(plat_specific=True, prefix=prefix))
+    
+    prefix = sys.argv[1]
+
+    # use sites if the prefix is recognized and the sites module is available
+    # (virtualenv is missing getsitepackages())
+    if hasattr(site, 'getsitepackages'):
+        paths = [p for p in site.getsitepackages() if p.startswith(prefix)]
+        if len(paths) == 1:
+            print(paths[0])
+            exit(0)
+    
+    # use sysconfig platlib as the fall back
+    print(sysconfig.get_paths()['platlib'])

--- a/scripts/get_python_lib.py
+++ b/scripts/get_python_lib.py
@@ -6,9 +6,11 @@ if __name__ == '__main__':
     # This is a hack due to the distutils in debian/ubuntu's python3 being misconfigured
     # see discussion https://github.com/opencog/atomspace/issues/1782
     #
-    # If the bug is fixed, this script could be replaced by:
+    # If the bug is fixed, most of this script could be replaced by:
     #
     # from distutils.sysconfig import get_python_lib; print(get_python_lib(plat_specific=True, prefix=prefix))
+    #
+    # However, using this would not respect a python virtual environments, so in a way this is better!
     
     prefix = sys.argv[1]
 


### PR DESCRIPTION
This will probably mean a lot of `PYTHONPATH` munging can be avoided, as a result there may be docs and cmake test config that need to be cleaned up.

Fixes #1782 

Should be merged with the OpenCog PR to avoid confusion - I'll link it to this one.