### PR TITLE
Fix rewriting ImplicationScope wrapped in ExecutionOutputLink

### DIFF
--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -278,6 +278,25 @@ Handle FreeVariables::substitute_scoped(const Handle& term,
 		{
 			// Make a copy... this is what's computationally expensive.
 			IndexMap hidden_map = index_map;
+
+			// Remove from hidden_map all non variables in case they
+			// contain hidden variables.
+			for (auto it = hidden_map.begin(); it != hidden_map.end();)
+			{
+				if (it->first->get_type() != VARIABLE_NODE)
+				{
+					// TODO: we could additionally check whether the
+					// non-variable contains a variable from vees, thus
+					// allowing more subtree subtitution to take place
+					// which might be faster.
+					it = hidden_map.erase(it);
+				}
+				else
+				{
+					++it;
+				}
+			}
+
 			// Remove the alpha-hidden variables.
 			for (const Handle& v : vees.varseq)
 			{

--- a/opencog/query/InitiateSearchCB.cc
+++ b/opencog/query/InitiateSearchCB.cc
@@ -940,7 +940,7 @@ std::string InitiateSearchCB::to_string(const std::string& indent) const
 		unsigned i = 0;
 		for (const Choice& ch : _choices) {
 			ss << indent_p << "choice[" << i << "]:" << std::endl
-			   << indent_pp << "clause = " << ch.clause;
+			   << indent_pp << "clause = " << ch.clause << std::endl;
 			ss << indent_pp << "best_start:" << std::endl
 			   << oc_to_string(ch.best_start, indent_ppp) << std::endl;
 			ss << indent_pp << "start_term:" << std::endl

--- a/tests/query/ExecutionOutputUTest.cxxtest
+++ b/tests/query/ExecutionOutputUTest.cxxtest
@@ -69,6 +69,7 @@ public:
 	void test_value(void);
 	void test_recursion(void);
 	void test_lambda(void);
+	void test_implication_scope(void);
 };
 
 #define an as.add_node
@@ -430,6 +431,34 @@ void ExecutionOutputUTest::test_lambda(void)
 	                      al(EVALUATION_LINK,
 	                         an(PREDICATE_NODE, "P"),
 	                         an(CONCEPT_NODE, "A"))));
+
+	logger().debug() << "result = " << oc_to_string(result);
+	logger().debug() << "expect = " << oc_to_string(expect);
+
+	TS_ASSERT_EQUALS(expect, result);
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+// Test not touching a closed ImplicationScope in argument of the
+// ExecutionOutputLink, the rewriting term of a BindLink.
+void ExecutionOutputUTest::test_implication_scope(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	eval.eval("(load-from-path \"tests/query/exec-implication-scope.scm\")");
+	Handle bl = eval.eval_h("bl");
+
+	Instantiator inst(&as);
+	Handle result = HandleCast(inst.execute(bl));
+	Handle expect = al(SET_LINK,
+	                   al(IMPLICATION_SCOPE_LINK,
+	                      al(EVALUATION_LINK,
+	                         an(PREDICATE_NODE, "P"),
+	                         an(VARIABLE_NODE, "$X")),
+	                      al(EVALUATION_LINK,
+	                         an(PREDICATE_NODE, "Q"),
+	                         an(VARIABLE_NODE, "$X"))));
 
 	logger().debug() << "result = " << oc_to_string(result);
 	logger().debug() << "expect = " << oc_to_string(expect);

--- a/tests/query/exec-implication-scope.scm
+++ b/tests/query/exec-implication-scope.scm
@@ -1,0 +1,21 @@
+(define (dummy x) x)
+
+(Evaluation
+   (Predicate "P")
+   (Concept "A"))
+
+(define bl
+(Bind
+   (Present
+      (Evaluation
+         (Predicate "P")
+         (Variable "$X")))
+   (ExecutionOutput
+      (GroundedSchema "scm: dummy")
+      (ImplicationScope
+         (Evaluation
+            (Predicate "P")
+            (Variable "$X"))
+         (Evaluation
+            (Predicate "Q")
+            (Variable "$X"))))))


### PR DESCRIPTION
Fix issue #2225