### PR TITLE
Fix present bug (issue #2231)

### DIFF
--- a/opencog/atoms/base/Handle.h
+++ b/opencog/atoms/base/Handle.h
@@ -287,9 +287,6 @@ static inline std::string operator+ (const std::string &lhs, Handle h)
 
 // Debugging helpers see
 // http://wiki.opencog.org/w/Development_standards#Print_OpenCog_Objects
-// The reason indent is not an optional argument with default is
-// because gdb doesn't support that, see
-// http://stackoverflow.com/questions/16734783 for more explanation.
 #define OC_TO_STRING_INDENT "  "
 std::string oc_to_string(const Handle& h,
                          const std::string& indent=empty_string);

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -925,4 +925,31 @@ void PatternLink::debug_log(void) const
 
 DEFINE_LINK_FACTORY(PatternLink, PATTERN_LINK)
 
+std::string PatternLink::to_long_string(const std::string& indent) const
+{
+	std::string indent_p = indent + oc_to_string_indent;
+	std::stringstream ss;
+	ss << to_string(indent);
+	ss << indent << "_pat:" << std::endl
+	   << oc_to_string(_pat, indent_p) << std::endl;
+	ss << indent << "_fixed:" << std::endl
+	   << oc_to_string(_fixed, indent_p) << std::endl;
+	ss << indent << "_num_virts = " << _num_virts << std::endl;
+	ss << indent << "_virtual:" << std::endl
+	   << oc_to_string(_virtual, indent_p) << std::endl;
+	ss << indent << "_num_comps = " << _num_comps << std::endl;
+	ss << indent << "_components:" << std::endl
+	   << oc_to_string(_components, indent_p) << std::endl;
+	ss << indent << "_component_vars:" << std::endl
+	   << oc_to_string(_component_vars, indent_p) << std::endl;
+	ss << indent << "_component_patterns:" << std::endl
+	   << oc_to_string(_component_patterns, indent_p) << std::endl;
+	return ss.str();
+}
+
+std::string oc_to_string(const PatternLink& pl, const std::string& indent)
+{
+	return pl.to_long_string(indent);
+}
+
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/pattern/PatternLink.h
+++ b/opencog/atoms/pattern/PatternLink.h
@@ -171,6 +171,10 @@ public:
 	void debug_log(void) const;
 
 	static Handle factory(const Handle&);
+
+	// For printing not only the link iteself but all the associated
+	// C++ attributes
+	std::string to_long_string(const std::string& indent) const;
 };
 
 static inline PatternLinkPtr PatternLinkCast(const Handle& h)
@@ -179,6 +183,11 @@ static inline PatternLinkPtr PatternLinkCast(AtomPtr a)
 	{ return std::dynamic_pointer_cast<PatternLink>(a); }
 
 #define createPatternLink std::make_shared<PatternLink>
+
+// For gdb, see
+// http://wiki.opencog.org/w/Development_standards#Print_OpenCog_Objects
+std::string oc_to_string(const PatternLink& pl,
+                         const std::string& indent=empty_string);
 
 /** @}*/
 }

--- a/opencog/query/PatternLinkRuntime.cc
+++ b/opencog/query/PatternLinkRuntime.cc
@@ -63,6 +63,9 @@ class PMCGroundings : public PatternMatchCallback
 		bool post_link_match(const Handle& link1, const Handle& link2) {
 			return _cb.post_link_match(link1, link2);
 		}
+		void post_link_mismatch(const Handle& link1, const Handle& link2) {
+			_cb.post_link_mismatch(link1, link2);
+		}
 		bool fuzzy_match(const Handle& h1, const Handle& h2) {
 			return _cb.fuzzy_match(h1, h2);
 		}

--- a/tests/query/PresentUTest.cxxtest
+++ b/tests/query/PresentUTest.cxxtest
@@ -26,11 +26,14 @@
 
 using namespace opencog;
 
+#define al as->add_link
+#define an as->add_node
+
 class PresentUTest: public CxxTest::TestSuite
 {
 private:
-		AtomSpace *as;
-		SchemeEval* eval;
+	AtomSpace *as;
+	SchemeEval* eval;
 
 public:
 	PresentUTest(void)
@@ -58,6 +61,7 @@ public:
 	void tearDown(void);
 
 	void test_literal(void);
+	void test_virtual(void);
 };
 
 void PresentUTest::tearDown(void)
@@ -92,3 +96,26 @@ void PresentUTest::test_literal(void)
 
 	logger().debug("END TEST: %s", __FUNCTION__);
 }
+
+/**
+ * Test PresentLink in conjunction with a virtual link.
+ */
+void PresentUTest::test_virtual(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	eval->eval("(load-from-path \"tests/query/present-virtual.scm\")");
+
+	Handle query = eval->eval_h("query");
+	Handle results = HandleCast(query->execute());
+	Handle expected = al(SET_LINK, an(CONCEPT_NODE, "OK"));
+
+	printf("Expecting: %s\n", expected->to_string().c_str());
+	printf("Got: %s\n", results->to_string().c_str());
+	TS_ASSERT_EQUALS(results, expected);
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+#undef al
+#undef an

--- a/tests/query/present-virtual.scm
+++ b/tests/query/present-virtual.scm
@@ -1,0 +1,65 @@
+;; KB
+
+(EvaluationLink
+  (PredicateNode "P")
+  (LambdaLink
+    (ImplicationLink
+      (VariableNode "$Z")
+      (InheritanceLink
+        (VariableNode "$X")
+        (VariableNode "$Y")
+      )
+    )
+  )
+)
+
+(EvaluationLink
+  (PredicateNode "P")
+  (LambdaLink
+    (ImplicationLink
+      (VariableNode "$X")
+      (VariableNode "$Y")
+    )
+  )
+)
+
+;; Query
+
+(define (dummy x) (stv 1 1))
+
+(define query
+  (BindLink
+    (AndLink
+      (EvaluationLink
+        (GroundedPredicateNode "scm: dummy")
+        (EvaluationLink
+          (PredicateNode "P")
+          (LambdaLink
+            (ImplicationLink
+              (InheritanceLink
+                (VariableNode "$X")
+                (VariableNode "$Y")
+              )
+              (VariableNode "$Z")
+            )
+          )
+        )
+      )
+      (PresentLink
+        (EvaluationLink
+          (PredicateNode "P")
+          (LambdaLink
+            (ImplicationLink
+              (InheritanceLink
+                (VariableNode "$X")
+                (VariableNode "$Y")
+              )
+              (VariableNode "$Z")
+            )
+          )
+        )
+      )
+    )
+    (Concept "OK")
+  )
+)


### PR DESCRIPTION
Fix issue #2231

The fix is in commit https://github.com/opencog/atomspace/commit/867f7b9d242770147ab04e452207ebaa900d6c26

It was caused because `_pat_bound_vars` would be set in `DefaultPatternMatchCB::link_match` but never reset in `DefaultPatternMatchCB::post_link_mismatch` as due to the lack of implementation of `PMCGroundings::post_link_mismatch` the default `PatternMatchCallback::post_link_mismatch` was called instead.