### PR TITLE
Fix removal of constant clauses

### DIFF
--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -58,7 +58,7 @@ void PatternLink::common_init(void)
 	    _pat.quoted_clauses.begin(), _pat.quoted_clauses.end());
 	validate_variables(_varlist.varset, all_clauses);
 
-	remove_constants(_varlist.varset, _pat, _components, _component_patterns);
+	remove_constants(_varlist.varset, _pat);
 
 	// Locate the black-box and clear-box clauses.
 	_fixed = _pat.quoted_clauses;

--- a/opencog/atoms/pattern/PatternUtils.cc
+++ b/opencog/atoms/pattern/PatternUtils.cc
@@ -74,10 +74,17 @@ bool remove_constants(const HandleSet& vars, Pattern& pat)
 
 		i = pat.mandatory.erase(i);
 
+		// Remove the clause from quoted_clauses.
+		auto qc = std::find(pat.quoted_clauses.begin(),
+		                   pat.quoted_clauses.end(), clause);
+		if (qc != pat.quoted_clauses.end())
+			pat.quoted_clauses.erase(qc);
+
 		// Remove the clause from unquoted_clauses.
-		auto c = std::find(pat.unquoted_clauses.begin(), pat.unquoted_clauses.end(), clause);
-		if (c != pat.unquoted_clauses.end())
-			pat.unquoted_clauses.erase(c);
+		auto uc = std::find(pat.unquoted_clauses.begin(),
+		                   pat.unquoted_clauses.end(), clause);
+		if (uc != pat.unquoted_clauses.end())
+			pat.unquoted_clauses.erase(uc);
 
 		modified = true;
 	}

--- a/opencog/atoms/pattern/PatternUtils.cc
+++ b/opencog/atoms/pattern/PatternUtils.cc
@@ -57,10 +57,7 @@ namespace opencog {
  *
  * Returns true if the list of clauses was modified, else returns false.
  */
-bool remove_constants(const HandleSet& vars,
-                      Pattern& pat,
-                      HandleSeqSeq& components,
-                      HandleSeq& component_patterns)
+bool remove_constants(const HandleSet& vars, Pattern& pat)
 {
 	bool modified = false;
 
@@ -77,21 +74,7 @@ bool remove_constants(const HandleSet& vars,
 
 		i = pat.mandatory.erase(i);
 
-		// remove the clause from components and component_patterns
-		auto j = std::find(components.begin(), components.end(),
-		                   HandleSeq{clause});
-		if (j != components.end())
-		{
-			components.erase(j);
-			if (not component_patterns.empty())
-			{
-				auto cpj = std::next(component_patterns.begin(),
-				                     std::distance(components.begin(), j));
-				component_patterns.erase(cpj);
-			}
-		}
-
-		// remove the clause from unquoted_clauses.
+		// Remove the clause from unquoted_clauses.
 		auto c = std::find(pat.unquoted_clauses.begin(), pat.unquoted_clauses.end(), clause);
 		if (c != pat.unquoted_clauses.end())
 			pat.unquoted_clauses.erase(c);

--- a/opencog/atoms/pattern/PatternUtils.h
+++ b/opencog/atoms/pattern/PatternUtils.h
@@ -39,10 +39,7 @@ namespace opencog {
 
 // Make sure that variables can be found in the clauses.
 // See C file for description
-bool remove_constants(const HandleSet& vars,
-                      Pattern& pat,
-                      HandleSeqSeq& components,
-                      HandleSeq& component_patterns);
+bool remove_constants(const HandleSet& vars, Pattern& pat);
 
 // Return true iff the clause is constant.
 bool is_constant(const HandleSet& vars, const Handle& clause);


### PR DESCRIPTION
This is an alternate fix to #2231, and effectively hides the fix in #2233 at least for the indicated unit test.