### PR TITLE
Propely handle variable scheme in ExecutionOutput

### DIFF
--- a/opencog/atoms/execution/Instantiator.cc
+++ b/opencog/atoms/execution/Instantiator.cc
@@ -116,6 +116,9 @@ Handle Instantiator::reduce_exout(const Handle& expr, bool silent)
 	Handle sn(eolp->get_schema());
 	Handle args(eolp->get_args());
 
+        if (not _vmap->empty())
+		sn = beta_reduce(sn, *_vmap);
+
 	// If its a DSN, obtain the correct body for it.
 	if (DEFINED_SCHEMA_NODE == sn->get_type())
 		sn = DefineLink::get_definition(sn);

--- a/tests/query/ExecutionOutputUTest.cxxtest
+++ b/tests/query/ExecutionOutputUTest.cxxtest
@@ -70,6 +70,7 @@ public:
 	void test_recursion(void);
 	void test_lambda(void);
 	void test_implication_scope(void);
+	void test_variable_schema(void);
 };
 
 #define an as.add_node
@@ -466,4 +467,55 @@ void ExecutionOutputUTest::test_implication_scope(void)
 	TS_ASSERT_EQUALS(expect, result);
 
 	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+void ExecutionOutputUTest::test_variable_schema(void)
+{
+	al(DEFINE_LINK,
+		an(DEFINED_SCHEMA_NODE, "sum"),
+		al(LAMBDA_LINK,
+			al(VARIABLE_LIST,
+				an(VARIABLE_NODE, "x"),
+				an(VARIABLE_NODE, "y")),
+			al(PLUS_LINK,
+				an(VARIABLE_NODE, "x"),
+				an(VARIABLE_NODE, "y"))
+		));
+
+	al(DEFINE_LINK,
+		an(DEFINED_SCHEMA_NODE, "mul"),
+		al(LAMBDA_LINK,
+			al(VARIABLE_LIST,
+				an(VARIABLE_NODE, "x"),
+				an(VARIABLE_NODE, "y")),
+			al(TIMES_LINK,
+				an(VARIABLE_NODE, "x"),
+				an(VARIABLE_NODE, "y"))
+		));
+
+	al(INHERITANCE_LINK,
+		an(DEFINED_SCHEMA_NODE, "mul"),
+		an(CONCEPT_NODE, "current-schema")
+	);
+
+
+	Handle get_link =
+	al(BIND_LINK,
+		al(TYPED_VARIABLE_LINK,
+			an(VARIABLE_NODE, "$SCHEMA"), an(TYPE_NODE, "DefinedSchemaNode")),
+		al(AND_LINK,
+			al(INHERITANCE_LINK,
+				an(VARIABLE_NODE, "$SCHEMA"),
+				an(CONCEPT_NODE, "current-schema")
+		    )
+		),
+		al(EXECUTION_OUTPUT_LINK,
+			an(VARIABLE_NODE, "$SCHEMA"),
+			al(LIST_LINK, an(NUMBER_NODE, "6"), an(NUMBER_NODE, "7"))
+		)
+	);
+	Instantiator inst(&as);
+
+	ValuePtr result = inst.execute(get_link);
+	TS_ASSERT_EQUALS(result, al(SET_LINK, an(NUMBER_NODE, "42")));
 }


### PR DESCRIPTION
The following BindLink does not work if ExecutionOutputLink uses variable for schema.
For example:
```
(use-modules
 (opencog)
 (opencog exec))

(Define
 (DefinedSchema "mul")
 (Lambda
  (VariableList
   (Variable "x")
   (Variable "y"))
  (Times
   (Variable "x")
   (Variable "y"))))

(Define
 (DefinedSchema "sum")
 (Lambda
  (VariableList
   (Variable "x")
   (Variable "y"))
  (Plus
   (Variable "x")
   (Variable "y"))))

(Inheritance
 (DefinedSchema "mul")
 (Concept "current-schema"))

(define call-curent-schema
 (Bind
  (TypedVariable (Variable "$SCHEMA") (Type "DefinedSchemaNode"))
  (Inheritance
   (Variable "$SCHEMA")
   (Concept "current-schema"))
  (ExecutionOutput
   (Variable "$SCHEMA")
   (List
    (Number "6")
    (Number "7"))))
)

(display
 (cog-execute! call-curent-schema))
```
The expected result is: `(SetLink  (NumberNode "42.000000"))` - "mul" DefinedSchema is found.
The current result is `Segmentation fault (core dumped)`.

The fix calls `beta_reduce(...)` for ExecutionOutputLink schema in `Instantiator::reduce_exout(...)` method. 