### PR TITLE
atomspace destruction general cleanup.

### DIFF
--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -141,9 +141,6 @@ protected:
      * directly.  Only derived classes (Node, Link) can call this.
      *
      * @param The type of the atom.
-     * @param Outgoing set of the atom, that is, the set of atoms this
-     * atom references. It must be an empty vector if the atom is a node.
-     * @param The truthValue of the atom.
      */
     Atom(Type t)
       : Value(t),

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -123,7 +123,8 @@ AtomTable::~AtomTable()
     if (_environ) _environ->_num_nested--;
     if (0 != _num_nested)
         throw opencog::RuntimeException(TRACE_INFO,
-                "AtomTable - deleteing atomtable with subtables!");
+           "AtomTable - deleteing atomtable %lu which has subtables!",
+           _uuid);
 }
 
 void AtomTable::ready_transient(AtomTable* parent, AtomSpace* holder)

--- a/opencog/guile/SchemeEval.cc
+++ b/opencog/guile/SchemeEval.cc
@@ -552,7 +552,8 @@ void SchemeEval::do_eval(const std::string &expr)
 {
 	per_thread_init();
 
-	// Set global _atomspace variable in the execution environment.
+	// Set the execution environment atomspace (i.e. for this thread)
+	// to the evaluator _atomspace variable.
 	AtomSpace* saved_as = nullptr;
 	if (_atomspace)
 	{
@@ -763,7 +764,7 @@ SCM SchemeEval::do_scm_eval(SCM sexpr, SCM (*evo)(void *))
 {
 	per_thread_init();
 
-	// Set global atomspace variable in the execution environment.
+	// Set per-thread atomspace variable in the execution environment.
 	AtomSpace* saved_as = NULL;
 	if (_atomspace)
 	{

--- a/opencog/guile/SchemeEval.cc
+++ b/opencog/guile/SchemeEval.cc
@@ -1116,12 +1116,6 @@ static void return_to_pool(SchemeEval* ev)
 /// Use thread-local storage (TLS) in order to avoid repeatedly
 /// creating and destroying the evaluator.
 ///
-/// This will throw an error if used recursively.  Viz, if the
-/// evaluator evaluates something that causes another evaluator
-/// to be needed for this thread (e.g. an ExecutionOutputLink),
-/// then this very same evaluator would be re-entered, corrupting
-/// its own internal state.  If that happened, the result would be
-/// a hard-to-find & fix bug. So instead, we throw.
 SchemeEval* SchemeEval::get_evaluator(AtomSpace* as)
 {
 	static thread_local std::map<AtomSpace*,SchemeEval*> issued;
@@ -1156,13 +1150,6 @@ SchemeEval* SchemeEval::get_evaluator(AtomSpace* as)
 	evaluator->_atomspace = as;
 	issued[as] = evaluator;
 	return evaluator;
-
-#if 0
-	if (evaluator->recursing())
-		throw RuntimeException(TRACE_INFO,
-			"Evaluator thread singleton used recursively!");
-#endif
-
 }
 
 /* ============================================================== */

--- a/opencog/scm/opencog/base/utilities.scm
+++ b/opencog/scm/opencog/base/utilities.scm
@@ -983,7 +983,7 @@
     See cog-push-atomspace for an explanation.
 "
 	(begin
-		(if (null-list? cog-atomspace-stack)
+		(if (null-list? (fluid-ref cog-atomspace-stack))
 			(throw 'badpop "More pops than pushes!"))
 
 		; guile gc will eventually garbage-collect this atomspace.

--- a/opencog/scm/opencog/base/utilities.scm
+++ b/opencog/scm/opencog/base/utilities.scm
@@ -986,14 +986,19 @@
 		(if (null-list? (fluid-ref cog-atomspace-stack))
 			(throw 'badpop "More pops than pushes!"))
 
-		; guile gc will eventually garbage-collect this atomspace.
-		; However, gc might not run for a while; in the meanwhile,
-		; we do all the cruft it contained to be gone. So just
-		; brute-force clear it.
+		; guile gc will eventually garbage-collect this atomspace,
+		; which should clear it. But ... brute-force clear it now,
+		; anyway. Just because...
 		(cog-atomspace-clear)
 		(cog-set-atomspace! (car (fluid-ref cog-atomspace-stack)))
 		(fluid-set! cog-atomspace-stack
 			(cdr (fluid-ref cog-atomspace-stack)))
+
+		; Try to force garbage-collection of the atomspace. The goal
+		; here is to avoid out-of-order gc, where a parent atomspace
+		; in the stack is gc'ed before a child, leading to an assert
+		; in AtomTable.cc about child atomspaces.
+		(gc)
 	))
 
 ; ---------------------------------------------------------------------

--- a/opencog/scm/opencog/base/utilities.scm
+++ b/opencog/scm/opencog/base/utilities.scm
@@ -986,9 +986,11 @@
 		(if (null-list? (fluid-ref cog-atomspace-stack))
 			(throw 'badpop "More pops than pushes!"))
 
-		; guile gc will eventually garbage-collect this atomspace,
-		; which should clear it. But ... brute-force clear it now,
-		; anyway. Just because...
+		; Guile gc should eventually garbage-collect this atomspace,
+		; which will clear it. But ... even when brute-forcing the
+		; gc to run (as done below), the atomspace seems to hang
+		; around anyway, undeleted. So we brute-force clear it now,
+		; so that at least the atoms do not chew up RAM.
 		(cog-atomspace-clear)
 		(cog-set-atomspace! (car (fluid-ref cog-atomspace-stack)))
 		(fluid-set! cog-atomspace-stack

--- a/opencog/scm/opencog/base/utilities.scm
+++ b/opencog/scm/opencog/base/utilities.scm
@@ -961,7 +961,7 @@
 
 ; ---------------------------------------------------------------------
 
-(define-public cog-atomspace-stack '())
+(define-public cog-atomspace-stack (make-fluid '()))
 (define-public (cog-push-atomspace)
 "
  cog-push-atomspace -- Create a temporary atomspace.
@@ -971,7 +971,8 @@
     after popping, all of the atoms placed into it will also be
     deleted (unless they are refered to in some way).
 "
-	(set! cog-atomspace-stack (cons (cog-atomspace) cog-atomspace-stack))
+	(fluid-set! cog-atomspace-stack
+		(cons (cog-atomspace) (fluid-ref cog-atomspace-stack)))
 	(cog-set-atomspace! (cog-new-atomspace (cog-atomspace))))
 
 ; ---------------------------------------------------------------------
@@ -990,8 +991,9 @@
 		; we do all the cruft it contained to be gone. So just
 		; brute-force clear it.
 		(cog-atomspace-clear)
-		(cog-set-atomspace! (car cog-atomspace-stack))
-		(set! cog-atomspace-stack (cdr cog-atomspace-stack))
+		(cog-set-atomspace! (car (fluid-ref cog-atomspace-stack)))
+		(fluid-set! cog-atomspace-stack
+			(cdr (fluid-ref cog-atomspace-stack)))
 	))
 
 ; ---------------------------------------------------------------------


### PR DESCRIPTION
Mostly remove dead code, avoid multiple copies of the same code.
Also make the guile atomspace stack be per-thread.  (Why? Atomspaces are already per-thread. This at least makes it consistent)