### PR TITLE
Bug-fix creation of disjuncts

### DIFF
--- a/opencog/sheaf/README.md
+++ b/opencog/sheaf/README.md
@@ -45,7 +45,7 @@ In standard mathematical terminology, the spider-body or jigsaw-label
 is called the "germ". It is meant to evoke the idea of a germinating
 seed, as will become clear below.
 
-Diagramatic illustrations of jig-saw puzzle-pieces can be found here:
+Diagrammatic illustrations of jig-saw puzzle-pieces can be found here:
 
 * Sleator, Temperley, [Parsing English with a Link Grammar](http://www.cs.cmu.edu/afs/cs.cmu.edu/project/link/pub/www/papers/ps/tr91-196.pdf)
 * Bob Coeke, [New Scientist: Quantum Links Let Computers Read](http://www.cs.ox.ac.uk/people/bob.coecke/NewScientist.pdf)
@@ -84,7 +84,7 @@ which is the structure used in many other parts of OpenCog.
 ```
 This `EvaluationLink`, and the `Section...Connector` structure are meant
 to be sort-of, more-or-less equivalent and interchangeable. (In many
-cases, thy can be taken to be equivalent; however, the `Section...
+cases, they can be taken to be equivalent; however, the `Section...
 Connector` structure is more general and can describe more kinds of
 structures more simply than an EvaluationLink can.  This will be made
 clear below).
@@ -163,7 +163,7 @@ vertexes into a common set, the "germ".
 In graph theory, an edge unambiguously connects two vertexes. By
 contrast, the connectors on a section are a bit more ambiguous: they can
 connect to anything else that is legally connectable: the connectors
-must match, must be contractible.  The connectibility of connectors
+must match, must be contractible.  The connectability of connectors
 are given by rules, but those rules are "user-defined" (although they
 usually match connectors to germs and force edge-label agreement).
 

--- a/opencog/sheaf/make-section.scm
+++ b/opencog/sheaf/make-section.scm
@@ -23,10 +23,10 @@
 ;        ConnectorSeq
 ;            Connector
 ;                Atom "B"
-;                Label "A-to-B label"
+;                Label "go-to-B label"
 ;            Connector
 ;                Atom "C"
-;                Label "A-to-C label"
+;                Label "go-to-C label"
 ;
 ; which indicates that A is connected to B and to C; viz, that there are
 ; edges (AB) and (AC).  Note that the ConnectorSeq is independent of the
@@ -35,11 +35,16 @@
 ; the same ConnectorSeq as A. Thus, the ConnectorSeq simplifies the
 ; discovery of subgraph isomorphisms.
 ;
-; The ConnectorSeq is an ordered link; it is presumed that, in the
-; general case, that the order of the connectors matter.
+; In order to handle the general case, the ConnectorSeq is an ordered
+; link; it is presumed that, in the general case, that the order of the
+; connectors matter. (Whether the order matters, or not, depends on the
+; type of graph being considered. For example, for graphs that represent
+; temporal sequences, the order matters.)
 ;
 ; In the above example, the edges carry (optional) edge labels
-; indicating the type of the connector.
+; indicating the type of the connector. For example, the edge labels are
+; handy for indicating temporal order, e.g. whether Atom B came before
+; A or after A.
 ;
 ; In everything that follows, it is assumed that all of the vertexes of
 ; the graph are sequentially ordered, i.e. can be laid out in sequence

--- a/opencog/sheaf/make-section.scm
+++ b/opencog/sheaf/make-section.scm
@@ -35,7 +35,7 @@
 ; the same ConnectorSeq as A. Thus, the ConnectorSeq simplifies the
 ; discovery of subgraph isomorphisms.
 ;
-; The ConnecorSeq is an ordered link; it is presumed that, in the
+; The ConnectorSeq is an ordered link; it is presumed that, in the
 ; general case, that the order of the connectors matter.
 ;
 ; In the above example, the edges carry (optional) edge labels
@@ -79,7 +79,7 @@
 ; the two endpoints. A single connector is then just a direction (to
 ; the left, to the right) plus the vertex atom at the far end.
 ;
-; The section (aka connector set) is then a sequence of conectors; the
+; The section (aka connector set) is then a sequence of connectors; the
 ; number of connectors in the section exactly equal to the degree of
 ; the vertex in the MST parse: the connector set "describes" the parse
 ; tree, locally.
@@ -107,14 +107,14 @@
 
   The WEDGE-LIST is assumed to be a list of weighted edges. The weights
   are ignored.  The vertexes in the graph are assumed to just be the
-  set of vertexes aht appear at the ends of each edge; these are
+  set of vertexes that appear at the ends of each edge; these are
   extracted automatically, below.  XXX FIXME a better API could just
   pass these in...
 
   The returned sections are a list of SectionLinks, one for each vertex.
   The SectionLink will list (in order) a list of ConnectorLink's, with
   each connector implicitly specifying an edge, by specifying the atom
-  at the far end of the edge.  The connectors are lablled with direction
+  at the far end of the edge.  The connectors are labeled with direction
   marks, '+' and '-', indicating whether the far end is to the right or
   the left of the given vertex.
 

--- a/opencog/sheaf/sections.scm
+++ b/opencog/sheaf/sections.scm
@@ -21,8 +21,9 @@
 ; at the center, and a bunch of legs. In the above, the body is the
 ; atom "foo", and "bar" is one of the legs.  Or rather, "bar" is at
 ; the end of one of the legs, so that foo-bar can be though of as an
-; edge connecting two vertexes. Its a labelled edge - the
-; DirNode is the label.  Formally, the body is called the "germ".
+; edge connecting two vertexes (one vertex is the spider-body; the other
+; vertex is the tip of a leg). Its a labelled edge - the DirNode is the
+; label.  Formally, the body (without the legs) is called the "germ".
 ;
 ; The utilities provide various ways of accessing different parts of
 ; the section, given one of the atoms in a section. So, for example:
@@ -30,11 +31,11 @@
 ;
 ; get-germ-connector-seqs - given the germ, return a list of all
 ;      ConnectorSeq's appearing in sections on the germ.  The
-;      connector sequences are in one-to-one correspondance with
+;      connector sequences are in one-to-one correspondence with
 ;      the sections on the germ.
 ;
 ; get-germ-connectors     - given the germ, return a list of all
-;      Connectors that appear in seme section on the germ.
+;      Connectors that appear in some section on the germ.
 ;
 ; get-germ-endpoints      - given the germ, return a list of all
 ;      endpoints (legs or vertexes) on all sections having that germ.
@@ -43,7 +44,7 @@
 ; Conversely, given one of the other parts, find the germs:
 ;
 ; get-conseq-germs        - given a connector sequence, return all
-;       germs that have this connector sequence in thier section.
+;       germs that have this connector sequence in their section.
 ;       There is one connector sequence per section.
 ;
 ; NOTES:
@@ -51,8 +52,8 @@
 ; This is currently implemented in just plain-old scheme, and should
 ; be fine for general use. However, performance could be much improved
 ; by re-implementing these in C++. Basically, these just do a lot of
-; very simple atom access, and thus the overhead of guile is
-; proportionatly greater.
+; very simple atom accesses, and thus the overhead of guile is
+; proportionately greater.
 ; ---------------------------------------------------------------------
 
 (use-modules (srfi srfi-1))
@@ -91,7 +92,7 @@
 ;
 (define-public (get-germ-connector-seqs GERM)
 "
-  get-germ-connector-seqs GERM - return all connector seqeucences
+  get-germ-connector-seqs GERM - return all connector sequences
   that appear in sections on the GERM. There is one connector sequence
   per section.
 
@@ -110,7 +111,7 @@
 (define-public (get-germ-connectors GERM)
 "
   get-germ-connectors GERM - return all connectors that appear in
-  the connector sequences of sections on the GERM.
+  the connector sequences of (all) sections on the GERM.
 
   Assumes that the sections for the germ are already in the atomspace.
   These can be loaded by saying (fetch-incoming-by-type GERM 'Section)
@@ -131,7 +132,7 @@
   Assumes that the sections for the germ are already in the atomspace.
   These can be loaded by saying (fetch-incoming-by-type GERM 'Section)
 "
-	; Walk over all the connectors, extracting the enpoints.
+	; Walk over all the connectors, extracting the endpoints.
 	(delete-dup-atoms
 		(map
 			(lambda (CNCTR) (cog-outgoing-atom CNCTR 0))
@@ -175,10 +176,10 @@
 (define-public (get-connector-sections CNCTR)
 "
   get-connector-sections CONNECTOR - return all sections that have
-  this connector appearing in thier connector sequence.
+  this connector appearing in their connector sequence.
 
   Assumes that all connector sequences and sections are already in
-  the atomspace; if not, use `fetch-connnector-sections` instead.
+  the atomspace; if not, use `fetch-connector-sections` instead.
 "
 	; get-conseq-sections returns a list, so concatenate them.
 	(delete-dup-atoms
@@ -192,10 +193,10 @@
 (define-public (fetch-connector-sections CNCTR)
 "
   fetch-connector-sections CONNECTOR - return all sections that have
-  this connector appearing in thier connector sequence.
+  this connector appearing in their connector sequence.
 
   Fetches sections and connector sequences from storage (does not
-  assume they have been loaded yet). Use 'get-connnector-sections`
+  assume they have been loaded yet). Use 'get-connector-sections`
   if fetching is not needed.
 "
 	(fetch-incoming-by-type CNCTR 'ConnectorSeq)
@@ -210,8 +211,8 @@
 ;
 (define-public (get-endpoint-sections END)
 "
-  get-endpoing-sections ENDPOINT - return all sections that have this
-  endpoint appearing in a connector in thier connector sequences.
+  get-endpoint-sections ENDPOINT - return all sections that have this
+  endpoint appearing in a connector in their connector sequences.
 
   Assumes that all connector sequences and sections are already in
   the atomspace; if not, use `fetch-endpoint-sections` instead.
@@ -227,12 +228,12 @@
 ;
 (define-public (fetch-endpoint-sections END)
 "
-  fetch-endpoing-sections ENDPOINT - return all sections that have this
+  fetch-endpoint-sections ENDPOINT - return all sections that have this
   endpoint appearing in a connector in a connector sequence.
 
   Fetches connectors, connector sequences and sections from storage
   (does not assume they have been loaded yet). Use
-  'get-connnector-sections` if fetching is not needed.
+  'get-connector-sections` if fetching is not needed.
 "
 	(fetch-incoming-by-type END 'Connector)
 	; fetch-connector-sections returns a list, so concatenate them.
@@ -254,13 +255,13 @@
 ;        (map (lambda (SEC) (cog-outgoing-atom SEC 0))
 ;           (get-whatever-sections THING)))
 ;
-; Unclear which implementation might be faster. Thes have not been
+; Unclear which implementation might be faster. These have not been
 ; tuned for performance.
 ;
 (define-public (get-conseq-germs CONSEQ)
 "
   get-conseq-germs CONSEQ - return all germs that have this connector
-  sequence in thier section. There is one connector sequence per section.
+  sequence in their section. There is one connector sequence per section.
 
   Assumes that all sections are already in the atomspace; if not, use
   `fetch-conseq-germs` instead.
@@ -276,7 +277,7 @@
 (define-public (fetch-conseq-germs CONSEQ)
 "
   fetch-conseq-germs CONSEQ - return all germs that have this connector
-  sequence in thier section. There is one connector sequence per section.
+  sequence in their section. There is one connector sequence per section.
 
   Fetches sections from storage (does not assume they have been loaded
   yet). Use 'get-conseq-germs` if fetching is not needed.
@@ -290,10 +291,10 @@
 (define-public (get-connector-germs CNCTR)
 "
   get-connector-germs CONNECTOR - return all germs that have this
-  connector appearing in thier section.
+  connector appearing in their section.
 
   Assumes that all connector sequences and sections are already in
-  the atomspace; if not, use `fetch-connnector-germs` instead.
+  the atomspace; if not, use `fetch-connector-germs` instead.
 "
 	; get-conseq-germs returns a list, so concatenate them.
 	(delete-dup-atoms
@@ -312,10 +313,10 @@
 (define-public (fetch-connector-germs CNCTR)
 "
   fetch-connector-germs CONNECTOR - return all germs that have this
-  connector appearing in thier section.
+  connector appearing in their section.
 
   Fetches sections and connector sequences from storage (does not
-  assume they have been loaded yet). Use 'get-connnector-germs`
+  assume they have been loaded yet). Use 'get-connector-germs`
   if fetching is not needed.
 "
 	(fetch-incoming-by-type CNCTR 'ConnectorSeq)
@@ -330,8 +331,8 @@
 ;
 (define-public (get-endpoint-germs END)
 "
-  get-endpoing-germs ENDPOINT - return all germs that have this
-  endpoint appearing in a connector in thier section.
+  get-endpoint-germs ENDPOINT - return all germs that have this
+  endpoint appearing in a connector in their section.
 
   Assumes that all connector sequences and sections are already in
   the atomspace; if not, use `fetch-endpoint-germs` instead.
@@ -347,8 +348,8 @@
 ;
 (define-public (fetch-endpoint-germs END)
 "
-  fetch-endpoing-germs ENDPOINT - return all germs that have this
-  endpoint appearing in a connector in thier section.
+  fetch-endpoint-germs ENDPOINT - return all germs that have this
+  endpoint appearing in a connector in their section.
 
   Fetches connectors, connector sequences and sections from storage
   (does not assume they have been loaded yet). Use 'get-endpoint-germs`

--- a/opencog/sheaf/vo-graph.scm
+++ b/opencog/sheaf/vo-graph.scm
@@ -19,10 +19,10 @@
 ; the weights.
 ;
 ; Terminology:
-; A "numa" is a numbered atom; it is an ordered vertex. Its an atom,
+; A "numa" is a NUMbered Atom; it is an ordered vertex. Its an atom,
 ;    and an integer number indicating it's ordering.
 ;
-; An "overt" is the same thing as a numa.
+; An "overt" is the same thing as a numa, short for Ordered VERTex.
 ;
 ; A "wedge" is an edge, consisting of an ordered pair of numa's.
 ;     Note that ordering of the vertexes in the edge give that

--- a/opencog/sheaf/vo-graph.scm
+++ b/opencog/sheaf/vo-graph.scm
@@ -20,12 +20,12 @@
 ;
 ; Terminology:
 ; A "numa" is a numbered atom; it is an ordered vertex. Its an atom,
-;    and an intgeger number indicating it's ordering.
+;    and an integer number indicating it's ordering.
 ;
 ; An "overt" is the same thing as a numa.
 ;
 ; A "wedge" is an edge, consisting of an ordered pair of numa's.
-;     Note that ordereing of the vertexes in the edge give that
+;     Note that ordering of the vertexes in the edge give that
 ;     edge an implicit directionality. This need NOT correspond
 ;     to the ordinal numbering of the vertexes. That is, an edge
 ;     can point from right to left or from left to right!
@@ -37,7 +37,7 @@
 ; ---------------------------------------------------------------------
 ; The MST parser returns a list of weighted edges, each edge consisting
 ; of a pair of ordered atoms.
-; The functions below unpack each data strcture.
+; The functions below unpack each data structure.
 ;
 ; Get the score of the link.
 (define-public (wedge-get-score lnk) (cdr lnk))


### PR DESCRIPTION
When a word appeared more than once in a sentence, the corresponding disjuncts were created incorrectly, because the multiple word-instances were confused with each-other. This is fixed here (last commit, b284db9d8afcaf5187b30173550e2fbf251c0278) 

In addition, improved documentation, and many spelling fixes.