### PR TITLE
Fix execution include files destination

### DIFF
--- a/opencog/atoms/execution/CMakeLists.txt
+++ b/opencog/atoms/execution/CMakeLists.txt
@@ -56,5 +56,6 @@ ENDIF (HAVE_GUILE)
 # are fixed, first.
 INSTALL (FILES
 	MapLink.h
-	DESTINATION "include/opencog/atoms/core"
+	LibraryManager.h
+	DESTINATION "include/opencog/atoms/execution"
 )


### PR DESCRIPTION
And add LibraryManager as the URE relies on it for creating ASCII representations of inference trees.