### PR TITLE
Rename LibraryManager::lang_lib_fun by LibraryManager::parse_schema

### DIFF
--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -763,9 +763,9 @@ TruthValuePtr do_eval_with_args(AtomSpace* as,
 	// Generic shared-library foreign-function interface.
 	// Currently used only by the Haskell bindings.
 	//
-	// Extract the language, library and function
+	// Extract the language, library and function from schema
 	std::string lang, lib, fun;
-	LibraryManager::lang_lib_fun(schema, lang, lib, fun);
+	LibraryManager::parse_schema(schema, lang, lib, fun);
 	if (lang == "lib")
 	{
 		void* sym = LibraryManager::getFunc(lib,fun);

--- a/opencog/atoms/execution/ExecutionOutputLink.cc
+++ b/opencog/atoms/execution/ExecutionOutputLink.cc
@@ -167,7 +167,7 @@ ValuePtr ExecutionOutputLink::do_execute(AtomSpace* as,
 
 	// Extract the language, library and function
 	std::string lang, lib, fun;
-	LibraryManager::lang_lib_fun(schema, lang, lib, fun);
+	LibraryManager::parse_schema(schema, lang, lib, fun);
 
 	ValuePtr result;
 

--- a/opencog/atoms/execution/LibraryManager.cc
+++ b/opencog/atoms/execution/LibraryManager.cc
@@ -71,7 +71,7 @@ void* LibraryManager::getFunc(std::string libName, std::string funcName)
 	return sym;
 }
 
-void LibraryManager::lang_lib_fun(const std::string& schema,
+void LibraryManager::parse_schema(const std::string& schema,
                                   std::string& lang,
                                   std::string& lib,
                                   std::string& fun)

--- a/opencog/atoms/execution/LibraryManager.h
+++ b/opencog/atoms/execution/LibraryManager.h
@@ -34,13 +34,14 @@ private:
 public:
 	static void* getFunc(std::string libName,std::string funcName);
 	static void setLocalFunc(std::string libName, std::string funcName, void* func);
+
 	/**
 	 * Given a grounded schema name like "py: foo", extract
 	 * 1. the language, like "py"
 	 * 2. the library, like "" if there is none
 	 * 3. the function, like "foo"
 	 */
-	static void lang_lib_fun(const std::string& schema,
+	static void parse_schema(const std::string& schema,
 	                         std::string& lang,
 	                         std::string& lib,
 	                         std::string& fun);

--- a/opencog/ure/backwardchainer/BIT.cc
+++ b/opencog/ure/backwardchainer/BIT.cc
@@ -704,7 +704,7 @@ std::string AndBIT::line_separator(const std::string& up_aa,
 
 	// Get formula string
 	std::string lang, lib, fun;
-	LibraryManager::lang_lib_fun(gsn->get_name(), lang, lib, fun);
+	LibraryManager::parse_schema(gsn->get_name(), lang, lib, fun);
 	std::string formula_str = fun.substr(0, line_sep_size - 2);
 	size_t formula_str_size = formula_str.size();
 


### PR DESCRIPTION
Such function is actually not used by `LibraryManager` it can probably be moved away from it (as long as it is accessible by the URE that's all I care). But it's no big deal for now I guess.