### PR TITLE
Disable multithreading in circleci for atomspace utests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
           command: cd build && make -j2 tests
       - run:
           name: Run tests
-          command: cd build && make -j2 test ARGS=-j2
+          command: cd build && make -j2 test
       - run:
           name: Install AtomSpace
           command: cd build && make -j2 install && ldconfig


### PR DESCRIPTION
This cause utests using persistent storage to occasionally fail.