### PR TITLE
Experiments with multi-threading in the matrix code.

### DIFF
--- a/opencog/matrix/bin-count.scm
+++ b/opencog/matrix/bin-count.scm
@@ -1,8 +1,8 @@
 ;
 ; bin-count.scm
 ;
-; Assorted ad-hoc collection of bin-counting tools. This is used to
-; create estimates of distributions.
+; Assorted ad-hoc collection of bin-counting (histogramming) tools.
+; This is used to create estimates of distributions.
 ;
 ; Copyright (c) 2017 Linas Vepstas
 ;
@@ -11,7 +11,7 @@
 
 ; ---------------------------------------------------------------------
 ; ---------------------------------------------------------------------
-; Bin-counting utilities.
+; Bin-counting (histogramming) utilities.
 ;
 ; This must be the 20th time I've implemented bin-counts in my life...
 ;
@@ -19,6 +19,7 @@
          LOWER UPPER)
 "
   bin-count ITEMS NBINS item->value item->count LOWER UPPER
+
   Create a distribution by sorting items into bins, and then
   returning an array showing the number of items in each bin.
 

--- a/opencog/matrix/compute-mi.scm
+++ b/opencog/matrix/compute-mi.scm
@@ -310,8 +310,8 @@
 			(define (atomic-inc ctr)
 				(define old (atomic-box-ref ctr))
 				(define new (+ 1 old))
-				(if (not (= old (atomic-box-compare-and-swap! ctr old new)))
-					(atomic-inc ctr)))
+				(define swp (atomic-box-compare-and-swap! ctr old new))
+				(if (= old swp) new (atomic-inc ctr)))
 
 			(define start-time (current-time))
 			(define (elapsed-secs)

--- a/opencog/matrix/compute-mi.scm
+++ b/opencog/matrix/compute-mi.scm
@@ -114,6 +114,7 @@
 ;
 (use-modules (srfi srfi-1))
 (use-modules (ice-9 atomic))
+(use-modules (ice-9 threads))
 (use-modules (opencog))
 (use-modules (opencog persist))
 

--- a/opencog/matrix/compute-mi.scm
+++ b/opencog/matrix/compute-mi.scm
@@ -618,7 +618,9 @@
 	(display "Going to compute and store individual pair MI\n")
 	(elapsed-secs)
 	(let* ((num-prs (batch-mi-obj 'cache-pair-mi
-			(lambda (atom-list) (maybe-par-for-each store-atom atom-list)))))
+				; Non-parallel version here; it's parallel in the
+				; outer loop, above.
+				(lambda (atom-list) (for-each store-atom atom-list)))))
 
 		; This print triggers as soon as the let* above finishes.
 		(format #t "Done computing ~A pair MI's in ~A secs\n"

--- a/opencog/matrix/compute-mi.scm
+++ b/opencog/matrix/compute-mi.scm
@@ -114,17 +114,8 @@
 ;
 (use-modules (srfi srfi-1))
 (use-modules (ice-9 atomic))
-(use-modules (ice-9 threads))
 (use-modules (opencog))
 (use-modules (opencog persist))
-
-; The guile-2.2 par-for-each implementation sucks, and live-locks
-; for more than about 4-5 threads, and sometimes with less.
-; The guile 2.9.4 par-for-each implemetation actually works; the
-; actual speedup depends on the loop contents.
-(define (maybe-par-for-each F L)
-	(par-for-each F L)
-)
 
 ; ---------------------------------------------------------------------
 ; ---------------------------------------------------------------------
@@ -376,7 +367,10 @@
 					))
 			)
 
-			(maybe-par-for-each right-loop lefties)
+			; This is hog-tied waiting for SQL, running it in parallel
+			; provides no speedup.
+			; (maybe-par-for-each right-loop lefties)
+			(for-each right-loop lefties)
 
 			; Return a count of the number of pairs.
 			(atomic-box-ref cnt-pairs)

--- a/opencog/matrix/compute-mi.scm
+++ b/opencog/matrix/compute-mi.scm
@@ -226,17 +226,19 @@
 						(set! cnt (+ cnt 1)))
 					(wldobj 'right-stars left-item)))
 
-			(maybe-par-for-each right-loop (wldobj 'left-basis))
+			; par-for-each fails massively here in guile-2.9.2
+			(for-each right-loop (wldobj 'left-basis))
 
 			; Return the total.
 			cnt)
 
 		; Compute and cache all of the left-side frequencies.
-		; This computes P(*,y) for all y, in parallel.
+		; This computes P(*,y) for all y.
+		; par-for-each fails here in guile-2.9.2
 		(define (cache-all-left-freqs)
-			(maybe-par-for-each cache-left-freq (wldobj 'right-basis)))
+			(for-each cache-left-freq (wldobj 'right-basis)))
 		(define (cache-all-right-freqs)
-			(maybe-par-for-each cache-right-freq (wldobj 'left-basis)))
+			(for-each cache-right-freq (wldobj 'left-basis)))
 
 		; Methods on this class.
 		(lambda (message . args)

--- a/opencog/matrix/entropy.scm
+++ b/opencog/matrix/entropy.scm
@@ -151,7 +151,7 @@
 		; Loop over all columns.
 		(define (cache-all-left-entropy)
 			(elapsed-secs)
-			(for-each cache-left-entropy (star-obj 'right-basis))
+			(maybe-par-for-each cache-left-entropy (star-obj 'right-basis))
 			(format #t "Finished left entropy subtotals in ~A secs\n"
 				(elapsed-secs))
 		)
@@ -159,7 +159,7 @@
 		; Loop over all rows.
 		(define (cache-all-right-entropy)
 			(elapsed-secs)
-			(for-each cache-right-entropy (star-obj 'left-basis))
+			(maybe-par-for-each cache-right-entropy (star-obj 'left-basis))
 			(format #t "Finished right entropy subtotals in ~A secs\n"
 				(elapsed-secs))
 		)
@@ -167,7 +167,7 @@
 		; Loop over all columns.
 		(define (cache-all-left-mi)
 			(elapsed-secs)
-			(for-each cache-left-mi (star-obj 'right-basis))
+			(maybe-par-for-each cache-left-mi (star-obj 'right-basis))
 			(format #t "Finished left MI subtotals in ~A secs\n"
 				(elapsed-secs))
 		)
@@ -175,7 +175,7 @@
 		; Loop over all rows.
 		(define (cache-all-right-mi)
 			(elapsed-secs)
-			(for-each cache-right-mi (star-obj 'left-basis))
+			(maybe-par-for-each cache-right-mi (star-obj 'left-basis))
 			(format #t "Finished right MI subtotals in ~A secs\n"
 				(elapsed-secs))
 		)

--- a/opencog/matrix/matrix.scm
+++ b/opencog/matrix/matrix.scm
@@ -13,7 +13,8 @@
 ; The guile 2.9.4 par-for-each implemetation actually works; the
 ; actual speedup depends on the loop contents.
 (define (maybe-par-for-each F L)
-	(par-for-each F L)
+	; (par-for-each F L)
+	(for-each F L)
 )
 
 ; ---------------------------------------------------------

--- a/opencog/matrix/matrix.scm
+++ b/opencog/matrix/matrix.scm
@@ -4,7 +4,8 @@
 ;
 (define-module (opencog matrix))
 
-; Configuration
+; ---------------------------------------------------------
+; Common configuration
 (use-modules (ice-9 threads))
 
 ; The guile-2.2 par-for-each implementation sucks, and live-locks
@@ -15,6 +16,7 @@
 	(par-for-each F L)
 )
 
+; ---------------------------------------------------------
 ; The files are loaded in pipeline order.
 ; In general, the later files depend on definitions contained
 ; in the earlier files.

--- a/opencog/matrix/matrix.scm
+++ b/opencog/matrix/matrix.scm
@@ -10,8 +10,13 @@
 
 ; The guile-2.2 par-for-each implementation sucks, and live-locks
 ; for more than about 4-5 threads, and sometimes with less.
-; The guile 2.9.4 par-for-each implemetation actually works; the
-; actual speedup depends on the loop contents.
+; The guile 2.9.4 par-for-each implemetation is mostly not insane;
+; however, it appears to offer no speedup whatsoever over
+; single-threaded operation ... for MI computations. (It does offer
+; perfect 24x speedup on 24 cores for pattern matching... its unclear
+; why it fails to speed up MI computations.)  Disable for now, since
+; none of the matrix code benefits from this.
+; XXX TODO diganose the root cause and report back to guile devels.
 (define (maybe-par-for-each F L)
 	; (par-for-each F L)
 	(for-each F L)

--- a/opencog/matrix/matrix.scm
+++ b/opencog/matrix/matrix.scm
@@ -4,6 +4,17 @@
 ;
 (define-module (opencog matrix))
 
+; Configuration
+(use-modules (ice-9 threads))
+
+; The guile-2.2 par-for-each implementation sucks, and live-locks
+; for more than about 4-5 threads, and sometimes with less.
+; The guile 2.9.4 par-for-each implemetation actually works; the
+; actual speedup depends on the loop contents.
+(define (maybe-par-for-each F L)
+	(par-for-each F L)
+)
+
 ; The files are loaded in pipeline order.
 ; In general, the later files depend on definitions contained
 ; in the earlier files.

--- a/opencog/matrix/support.scm
+++ b/opencog/matrix/support.scm
@@ -442,7 +442,7 @@
 		(define (all-left-marginals)
 			; Loop over each item in the right-basis
 			(elapsed-secs)
-			(for-each set-left-marginals (star-obj 'right-basis))
+			(maybe-par-for-each set-left-marginals (star-obj 'right-basis))
 			(format #t "Finished left norm marginals in ~A secs\n"
 				(elapsed-secs))
 
@@ -458,7 +458,7 @@
 		(define (all-right-marginals)
 			; Loop over each item in the left-basis
 			(elapsed-secs)
-			(for-each set-right-marginals (star-obj 'left-basis))
+			(maybe-par-for-each set-right-marginals (star-obj 'left-basis))
 			(format #t "Finished right norm marginals in ~A secs\n"
 				(elapsed-secs))
 


### PR DESCRIPTION
This pull-req adds some scaffolding for multi-threaded operation in the matrix code.

guile-2.9.2 code gives perfect linear (24x speedup on 24 cores) when running the pattern matcher in parallel.  However, it gives no speedup at all, when running the matrix code multi-threaded. I don't know why. It's a bug. 