### PR TITLE
Restore OpenCogFunctions.cmake for backwards compat.

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,7 +1,8 @@
 INSTALL(FILES
-		OpenCogAtomTypes.cmake
-		OpenCogCython.cmake
-		OpenCogGuile.cmake
-		OpenCogMacros.cmake
-		DESTINATION
-		${DATADIR}/cmake/)
+	OpenCogAtomTypes.cmake
+	OpenCogCython.cmake
+	OpenCogGuile.cmake
+	OpenCogMacros.cmake
+	OpenCogFunctions.cmake
+	DESTINATION
+	${DATADIR}/cmake/)

--- a/cmake/OpenCogFunctions.cmake
+++ b/cmake/OpenCogFunctions.cmake
@@ -1,0 +1,5 @@
+
+# Backwards-compatibility wrapper
+INCLUDE(OpenCogMacros)
+INCLUDE(OpenCogGuile)
+INCLUDE(OpenCogCython)


### PR DESCRIPTION
This fixes the first part of bug #2267 