### PR TITLE
Place build paths before the install path in Python sys.path

### DIFF
--- a/opencog/cython/PythonEval.cc
+++ b/opencog/cython/PythonEval.cc
@@ -222,7 +222,7 @@ static bool try_to_load_modules(const char ** config_paths)
             PyObject* pyModulePath = PyUnicode_DecodeUTF8(
                   config_paths[i], strlen(config_paths[i]), "strict");
 #endif
-            PyList_Append(pySysPath, pyModulePath);
+            PyList_Insert(pySysPath, (Py_ssize_t) 0, pyModulePath);
             Py_DECREF(pyModulePath);
         }
     }

--- a/opencog/cython/PythonEval.cc
+++ b/opencog/cython/PythonEval.cc
@@ -208,6 +208,7 @@ static bool try_to_load_modules(const char ** config_paths)
 {
     PyObject* pySysPath = PySys_GetObject((char*)"path");
 
+    Py_ssize_t pos_idx = 0;
     // Add default OpenCog module directories to the Python interpreter's path.
     for (int i = 0; config_paths[i] != NULL; ++i)
     {
@@ -222,8 +223,9 @@ static bool try_to_load_modules(const char ** config_paths)
             PyObject* pyModulePath = PyUnicode_DecodeUTF8(
                   config_paths[i], strlen(config_paths[i]), "strict");
 #endif
-            PyList_Insert(pySysPath, (Py_ssize_t) 0, pyModulePath);
+            PyList_Insert(pySysPath, pos_idx, pyModulePath);
             Py_DECREF(pyModulePath);
+            pos_idx += 1;
         }
     }
 

--- a/opencog/cython/PythonEval.cc
+++ b/opencog/cython/PythonEval.cc
@@ -102,7 +102,6 @@ static const char* DEFAULT_PYTHON_MODULE_PATHS[] =
 static const char* PROJECT_PYTHON_MODULE_PATHS[] =
 {
     PROJECT_BINARY_DIR"/opencog/cython", // bindings
-    PROJECT_SOURCE_DIR"/opencog/python", // opencog modules written in python
     PROJECT_SOURCE_DIR"/tests/cython",   // for testing
     NULL
 };


### PR DESCRIPTION
This will likely be causing people confusion and weird failures while testing.

The way it worked before this PR, is it used installed modules for testing in preference to the build dir. This is clearly wrong.