### PR TITLE
Execute PutLink arguments

### DIFF
--- a/opencog/atoms/execution/Instantiator.cc
+++ b/opencog/atoms/execution/Instantiator.cc
@@ -310,18 +310,6 @@ Handle Instantiator::walk_tree(const Handle& expr, bool silent)
 		Handle hexpr(beta_reduce(expr, *_vmap));
 		PutLinkPtr ppp(PutLinkCast(hexpr));
 
-		Handle pargs = ppp->get_arguments();
-		Handle gargs = walk_tree(pargs, silent);
-		if (gargs != pargs)
-		{
-			HandleSeq groset;
-			if (ppp->get_vardecl())
-				groset.emplace_back(ppp->get_vardecl());
-			groset.emplace_back(ppp->get_body());
-			groset.emplace_back(gargs);
-			ppp = createPutLink(groset);
-		}
-
 		// Step two: beta-reduce.
 		Handle red(HandleCast(ppp->execute(_as, silent)));
 

--- a/opencog/atoms/execution/Instantiator.cc
+++ b/opencog/atoms/execution/Instantiator.cc
@@ -310,6 +310,18 @@ Handle Instantiator::walk_tree(const Handle& expr, bool silent)
 		Handle hexpr(beta_reduce(expr, *_vmap));
 		PutLinkPtr ppp(PutLinkCast(hexpr));
 
+		Handle pargs = ppp->get_arguments();
+		Handle gargs = walk_tree(pargs, silent);
+		if (gargs != pargs)
+		{
+			HandleSeq groset;
+			if (ppp->get_vardecl())
+				groset.emplace_back(ppp->get_vardecl());
+			groset.emplace_back(ppp->get_body());
+			groset.emplace_back(gargs);
+			ppp = createPutLink(groset);
+		}
+
 		// Step two: beta-reduce.
 		Handle red(HandleCast(ppp->execute(_as, silent)));
 

--- a/tests/atoms/PutLinkUTest.cxxtest
+++ b/tests/atoms/PutLinkUTest.cxxtest
@@ -96,6 +96,7 @@ public:
 	void test_quoted_eval();
 	void test_quoted_lambda();
 	void test_arguments_execution();
+	void test_arguments_execution_with_lambda();
 };
 
 #define N _as.add_node
@@ -2106,6 +2107,58 @@ void PutLinkUTest::test_arguments_execution()
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
 	std::string rs = _eval.eval("(load-from-path \"tests/atoms/put-execute-arguments.scm\")");
+	logger().debug() << "rs = " << rs;
+
+	Instantiator inst(&_as);
+	Handle put = _eval.eval_h("put-execute-arguments"),
+		result = HandleCast(inst.execute(put)),
+		expected = _eval.eval_h("expected-put-execute-arguments");
+
+	logger().debug() << "result = " << oc_to_string(result);
+	logger().debug() << "expected = " << oc_to_string(expected);
+
+	TS_ASSERT_EQUALS(result, expected);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+/**
+ *
+ * Test
+ *
+ * (Inheritance (Concept "B") (Concept "Parent"))
+ * (Inheritance (Concept "C") (Concept "Parent"))
+ *
+ *  (PutLink
+ *  (LambdaLink
+ *   (VariableNode "x")
+ *   (EvaluationLink
+ *    (PredicateNode "relation")
+ *    (ListLink
+ *    (VariableNode "x")
+ *     (VariableNode "A"))))
+ *  (GetLink
+ *   (Inheritance (Variable "$X") (Concept "Parent"))))
+ *
+ * which should return
+ *
+ *  (SetLink
+ *  (EvaluationLink
+ *   (PredicateNode "relation")
+ *   (ListLink
+ *   (ConceptNode "B")
+ *  (VariableNode "A")))
+ *  (EvaluationLink
+ *   (PredicateNode "relation")
+ *   (ListLink
+ *    (ConceptNode "C")
+ *    (VariableNode "A"))))
+*/
+void PutLinkUTest::test_arguments_execution_with_lambda()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	std::string rs = _eval.eval("(load-from-path \"tests/atoms/put-execute-arguments-with-lambda.scm\")");
 	logger().debug() << "rs = " << rs;
 
 	Instantiator inst(&_as);

--- a/tests/atoms/PutLinkUTest.cxxtest
+++ b/tests/atoms/PutLinkUTest.cxxtest
@@ -95,6 +95,7 @@ public:
 	void test_quoted_exec();
 	void test_quoted_eval();
 	void test_quoted_lambda();
+	void test_arguments_execution();
 };
 
 #define N _as.add_node
@@ -2059,6 +2060,58 @@ void PutLinkUTest::test_quoted_lambda()
 	Handle put = _eval.eval_h("put-quoted-conjuction-lambda"),
 		result = HandleCast(inst.execute(put)),
 		expected = _eval.eval_h("put-quoted-conjuction-lambda-result");
+
+	logger().debug() << "result = " << oc_to_string(result);
+	logger().debug() << "expected = " << oc_to_string(expected);
+
+	TS_ASSERT_EQUALS(result, expected);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+/**
+ *
+ * Test
+ *
+ * (Inheritance (Concept "B") (Concept "Parent"))
+ * (Inheritance (Concept "C") (Concept "Parent"))
+ *
+ *  (PutLink
+ *  (LambdaLink
+ *   (VariableNode "x")
+ *   (EvaluationLink
+ *    (PredicateNode "relation")
+ *    (ListLink
+ *    (VariableNode "x")
+ *     (VariableNode "A"))))
+ *  (GetLink
+ *   (Inheritance (Variable "$X") (Concept "Parent"))))
+ *
+ * which should return
+ *
+ *  (SetLink
+ *  (EvaluationLink
+ *   (PredicateNode "relation")
+ *   (ListLink
+ *   (ConceptNode "B")
+ *  (VariableNode "A")))
+ *  (EvaluationLink
+ *   (PredicateNode "relation")
+ *   (ListLink
+ *    (ConceptNode "C")
+ *    (VariableNode "A"))))
+*/
+void PutLinkUTest::test_arguments_execution()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	std::string rs = _eval.eval("(load-from-path \"tests/atoms/put-execute-arguments.scm\")");
+	logger().debug() << "rs = " << rs;
+
+	Instantiator inst(&_as);
+	Handle put = _eval.eval_h("put-execute-arguments"),
+		result = HandleCast(inst.execute(put)),
+		expected = _eval.eval_h("expected-put-execute-arguments");
 
 	logger().debug() << "result = " << oc_to_string(result);
 	logger().debug() << "expected = " << oc_to_string(expected);

--- a/tests/atoms/put-execute-arguments-with-lambda.scm
+++ b/tests/atoms/put-execute-arguments-with-lambda.scm
@@ -3,11 +3,13 @@
 
 (define put-execute-arguments
  (PutLink
+  (LambdaLink
+   (VariableNode "x")
    (EvaluationLink
     (PredicateNode "relation")
     (ListLink
      (VariableNode "x")
-     (ConceptNode "A")))
+     (ConceptNode "A"))))
   (GetLink
    (Inheritance (Variable "$X") (Concept "Parent")))))
 

--- a/tests/atoms/put-execute-arguments.scm
+++ b/tests/atoms/put-execute-arguments.scm
@@ -1,0 +1,27 @@
+(Inheritance (Concept "B") (Concept "Parent"))
+(Inheritance (Concept "C") (Concept "Parent"))
+
+(define put-execute-arguments
+ (PutLink
+  (LambdaLink
+   (VariableNode "x")
+   (EvaluationLink
+    (PredicateNode "relation")
+    (ListLink
+     (VariableNode "x")
+     (VariableNode "A"))))
+  (GetLink
+   (Inheritance (Variable "$X") (Concept "Parent")))))
+
+(define expected-put-execute-arguments
+ (SetLink
+  (EvaluationLink
+   (PredicateNode "relation")
+   (ListLink
+    (ConceptNode "B")
+    (VariableNode "A")))
+  (EvaluationLink
+   (PredicateNode "relation")
+   (ListLink
+    (ConceptNode "C")
+    (VariableNode "A")))))


### PR DESCRIPTION
The sample below does not work as expected because arguments of the PutLink first are used in LambdaLink and then executed:
```
(Inheritance (Concept "B") (Concept "Parent"))
(Inheritance (Concept "C") (Concept "Parent"))

(define put-link
 (PutLink
  (LambdaLink
   (VariableNode "x")
   (EvaluationLink
    (PredicateNode "relatives")
    (ListLink
     (VariableNode "x")
     (VariableNode "A"))))
  (GetLink
   (Inheritance (Variable "$X") (Concept "Parent")))))

(display
 (cog-execute! put-link))
```

Output is:
```
(SetLink
)
```

Expected result is:
```
(SetLink
   (EvaluationLink
      (PredicateNode "relatives")
      (ListLink
         (ConceptNode "B")
         (VariableNode "A")
      )
   )
   (EvaluationLink
      (PredicateNode "relatives")
      (ListLink
         (ConceptNode "C")
         (VariableNode "A")
      )
   )
)
```

The pull request #2195 removed the eager execution of PutLink where arguments were executed before the beta-reduction.
The `EvaluationLink::do_eval_scratch()`  https://github.com/opencog/atomspace/blob/23d6f03635c169110cf90883890ea89cfb9190cb/opencog/atoms/execution/EvaluationLink.cc#L873  method has comments:
```
		// Evalating a PutLink requires three steps:
		// (1) execute the arguments, first,
		// (2) beta reduce (put arguments into body)
		// (3) evaluate the resulting body.
```

The proposed fix returns the code to `Instantiator::walk_tree()` which executes PutLink arguments before beta-reduce.
