### PR TITLE
Add method to fetch error string to generic evaluator API

### DIFF
--- a/opencog/cython/PythonEval.cc
+++ b/opencog/cython/PythonEval.cc
@@ -678,7 +678,7 @@ void PythonEval::throw_on_error()
 {
     if (not PyErr_Occurred()) return;
 
-    std::string errorString = build_python_error_message(NO_FUNCTION_NAME);
+    _error_string = build_python_error_message(NO_FUNCTION_NAME);
     PyErr_Clear();
 
     // Clear the evaluator state; else future input is garbaged up.
@@ -690,7 +690,7 @@ void PythonEval::throw_on_error()
 
     // If there was an error, throw an exception so the user knows the
     // script had a problem.
-    throw RuntimeException(TRACE_INFO, "%s", errorString.c_str());
+    throw RuntimeException(TRACE_INFO, "%s", _error_string.c_str());
 }
 
 /**

--- a/opencog/eval/GenericEval.h
+++ b/opencog/eval/GenericEval.h
@@ -40,6 +40,7 @@ class GenericEval
 {
 	protected:
 		std::string _input_line;
+		std::string _error_string;
 		bool _pending_input;
 		bool _caught_error;
 
@@ -65,6 +66,7 @@ class GenericEval
 		virtual void clear_pending()
 		{
 			_input_line = "";
+			_error_string = "";
 			_pending_input = false;
 			_caught_error = false;
 		}
@@ -75,6 +77,14 @@ class GenericEval
 		virtual bool eval_error(void)
 		{
 			return _caught_error;
+		}
+
+		/**
+		 * Return the error string, if any.
+		 */
+		virtual std::string get_error_string(void)
+		{
+			return _error_string;
 		}
 
 		/**

--- a/opencog/guile/SchemeEval.cc
+++ b/opencog/guile/SchemeEval.cc
@@ -61,8 +61,8 @@ void SchemeEval::init(void)
 	_eval_thread = SCM_EOL;
 
 	// User error and crash management
-	_error_string = SCM_EOL;
-	_error_string = scm_gc_protect_object(_error_string);
+	_scm_error_string = SCM_EOL;
+	_scm_error_string = scm_gc_protect_object(_scm_error_string);
 
 	_captured_stack = SCM_BOOL_F;
 	_captured_stack = scm_gc_protect_object(_captured_stack);
@@ -192,7 +192,7 @@ void SchemeEval::finish(void)
 		scm_gc_unprotect_object(_pipe);
 	}
 
-	scm_gc_unprotect_object(_error_string);
+	scm_gc_unprotect_object(_scm_error_string);
 	scm_gc_unprotect_object(_captured_stack);
 
 	// Force garbage collection
@@ -218,8 +218,8 @@ void SchemeEval::set_captured_stack(SCM newstack)
 
 void SchemeEval::set_error_string(SCM newerror)
 {
-	SCM olderror = _error_string;
-	_error_string = scm_gc_protect_object(newerror);
+	SCM olderror = _scm_error_string;
+	_scm_error_string = scm_gc_protect_object(newerror);
 	scm_gc_unprotect_object(olderror);
 }
 
@@ -720,30 +720,27 @@ std::string SchemeEval::do_poll_result()
 
 	if (_caught_error)
 	{
-		std::string rv = poll_port();
+		_error_string = poll_port();
 
-		char * str = scm_to_utf8_string(_error_string);
-		rv += str;
+		char * str = scm_to_utf8_string(_scm_error_string);
+		_error_string += str;
 		free(str);
 		set_error_string(SCM_EOL);
 		set_captured_stack(SCM_BOOL_F);
 
-		rv += "\n";
-		return rv;
+		_error_string += "\n";
+		return _error_string;
 	}
-	else
-	{
-		// First, we get the contents of the output port,
-		// and pass that on.
-		std::string rv = poll_port();
 
-		// Next, we append the "interpreter" output
-		rv += prt(tmp_rc);
-		rv += "\n";
-		scm_remember_upto_here_1(tmp_rc);
-		return rv;
-	}
-	return "#<Error: Unreachable statement reached>";
+	// First, we get the contents of the output port,
+	// and pass that on.
+	std::string rv = poll_port();
+
+	// Next, we append the "interpreter" output
+	rv += prt(tmp_rc);
+	rv += "\n";
+	scm_remember_upto_here_1(tmp_rc);
+	return rv;
 }
 
 /* ============================================================== */
@@ -796,7 +793,7 @@ SCM SchemeEval::do_scm_eval(SCM sexpr, SCM (*evo)(void *))
 
 	if (_caught_error)
 	{
-		char * str = scm_to_utf8_string(_error_string);
+		char * str = scm_to_utf8_string(_scm_error_string);
 		// Don't blank out the error string yet.... we need it later.
 		// (probably because someone called cog-bind with an
 		// ExecutionOutputLink in it with a bad scheme schema node.)

--- a/opencog/guile/SchemeEval.h
+++ b/opencog/guile/SchemeEval.h
@@ -119,7 +119,7 @@ class SchemeEval : public GenericEval
 		static void * c_wrap_apply_v(void *);
 
 		// Exception and error handling stuff
-		SCM _error_string;
+		SCM _scm_error_string;
 		std::string _error_msg;
 		SCM _captured_stack;
 		void set_error_string(SCM);


### PR DESCRIPTION
This is needed by the cogserver, to properly report errors.