### PR TITLE
Assorted Python bug-fixes.

### DIFF
--- a/opencog/cython/PythonEval.cc
+++ b/opencog/cython/PythonEval.cc
@@ -1452,6 +1452,7 @@ void PythonEval::begin_eval()
     _caught_error = false;
     _pending_input = false;
     _result = "";
+    _capture_stdout = "";
 }
 
 void PythonEval::eval_expr(const std::string& partial_expr)
@@ -1558,10 +1559,8 @@ void PythonEval::eval_expr_line(const std::string& partial_expr)
     while (0 < nr)
     {
        buf[nr] = 0;
-       if (1 < nr or 0 != buf[0])
-       {
-          _result += buf;
-       }
+       if (1 < nr or 0 != buf[0]) _capture_stdout += buf;
+
        nr = read(pipefd[0], buf, sizeof(buf)-1);
     }
 
@@ -1604,7 +1603,7 @@ std::string PythonEval::poll_result()
         _wait_done.wait(lck, evdone);
     }
 
-    std::string r = _result;
+    std::string r = _capture_stdout + _result;
 
     // Add the missing newline
     if (0 < _result.size()) r += "\n";
@@ -1613,6 +1612,7 @@ std::string PythonEval::poll_result()
     if (_caught_error and 0 < _result.size()) r += _error_string + "\n";
 
     _result.clear();
+    _capture_stdout.clear();
     return r;
 }
 

--- a/opencog/cython/PythonEval.cc
+++ b/opencog/cython/PythonEval.cc
@@ -1567,8 +1567,14 @@ std::string PythonEval::poll_result()
     }
 
     std::string r = _result;
+
+    // Add the missing newline
+    if (0 < _result.size()) r += "\n";
+
+    // Report the error string too, but only the first time.
+    if (_caught_error and 0 < _result.size()) r += _error_string + "\n";
+
     _result.clear();
-    if (_caught_error) r += _error_string;
     return r;
 }
 

--- a/opencog/cython/PythonEval.cc
+++ b/opencog/cython/PythonEval.cc
@@ -1542,6 +1542,7 @@ void PythonEval::eval_expr_line(const std::string& partial_expr)
 
 wait_for_more:
     _caught_error = false;
+    _error_string = "";
     _pending_input = true;
     // Add this expression to our evaluation buffer.
     _input_line += part;
@@ -1567,6 +1568,7 @@ std::string PythonEval::poll_result()
 
     std::string r = _result;
     _result.clear();
+    if (_caught_error) r += _error_string;
     return r;
 }
 

--- a/opencog/cython/PythonEval.h
+++ b/opencog/cython/PythonEval.h
@@ -133,7 +133,7 @@ class PythonEval : public GenericEval
         std::string _result;
         int _paren_count;
         void eval_expr_line(const std::string&);
-        void throw_on_error();
+        bool check_for_error();
 
     public:
         PythonEval(AtomSpace*);

--- a/opencog/cython/PythonEval.h
+++ b/opencog/cython/PythonEval.h
@@ -131,6 +131,7 @@ class PythonEval : public GenericEval
         std::map <std::string, PyObject*> _modules;
 
         std::string _result;
+        std::string _capture_stdout;
         int _paren_count;
         void eval_expr_line(const std::string&);
         bool check_for_error();

--- a/tests/scm/scm-python.scm
+++ b/tests/scm/scm-python.scm
@@ -12,6 +12,6 @@
 (define rc (python-eval "print ('Hello world\\n', 2+2)"))
 
 ; Python print returns 'None'
-(test-assert "python-eval is borken" (string=? rc "None"))
+(test-assert "python-eval is borken" (string=? rc "Hello world\n 4\nNone\n"))
 
 (test-end t)


### PR DESCRIPTION
So, apparently no one ever used python with the cogserver before...

* This fixes a hard-crash of the cogserver, when using python.
* This also captures stdout and passes the results back to cogserver
   i.e. so that `print ("hello world")` actually works