### PR TITLE
 Bug-fix for #2284  - failed EqualLink

### DIFF
--- a/opencog/atoms/core/FindUtils.cc
+++ b/opencog/atoms/core/FindUtils.cc
@@ -179,6 +179,21 @@ bool is_unscoped_in_tree(const Handle& tree, const Handle& atom)
 	return false;
 }
 
+bool is_constant_in_tree(const Handle& tree, const Handle& atom)
+{
+	// Base cases
+	if (content_eq(tree, atom)) return true;
+	if (not tree->is_link()) return false;
+
+	if (if tree->is_executable()) return false;
+
+	// Recursive case
+	for (const Handle& h : tree->getOutgoingSet())
+		if (is_constant_in_tree(h, atom))
+			return true;
+	return false;
+}
+
 bool is_unquoted_unscoped_in_tree(const Handle& tree, const Handle& atom)
 {
 	return is_unquoted_in_tree(tree, atom) and is_unscoped_in_tree(tree, atom);

--- a/opencog/atoms/core/FindUtils.cc
+++ b/opencog/atoms/core/FindUtils.cc
@@ -264,6 +264,20 @@ bool any_unquoted_unscoped_in_tree(const Handle& tree,
 	return false;
 }
 
+bool any_free_in_tree(const Handle& tree,
+                      const HandleSet& atoms)
+{
+	// XXX FIXME: this is subtley broken: the place where it occurs
+	// unquoted might be inside an executable term; the place where
+	// it occurs outside an executable term might be quoted...
+	for (const Handle& n: atoms)
+		if (is_unquoted_in_tree(tree, n) and
+		    is_unscoped_in_tree(tree, n) and
+		    is_constant_in_tree(tree,n))
+			return true;
+	return false;
+}
+
 unsigned int num_unquoted_in_tree(const Handle& tree,
                                   const HandleSet& atoms)
 {
@@ -279,9 +293,7 @@ bool is_atom_in_any_tree(const HandleSeq& trees,
                          const Handle& atom)
 {
 	for (const Handle& tree: trees)
-	{
 		if (is_atom_in_tree(tree, atom)) return true;
-	}
 	return false;
 }
 
@@ -289,9 +301,7 @@ bool is_unquoted_in_any_tree(const HandleSeq& trees,
                              const Handle& atom)
 {
 	for (const Handle& tree: trees)
-	{
 		if (is_unquoted_in_tree(tree, atom)) return true;
-	}
 	return false;
 }
 

--- a/opencog/atoms/core/FindUtils.cc
+++ b/opencog/atoms/core/FindUtils.cc
@@ -221,7 +221,7 @@ bool is_free_in_tree(const Handle& tree, const Handle& atom)
 	// The atom may occur in two distinct places in a tree: in
 	// one place, it is scoped, and in another, its in an executable
 	// term. We have to reject both, and not one-at-a-time.
-	auto unsco_and_const = [](const Handle& tr, const Handle& ato)
+	auto scoped_or_executable = [](const Handle& tr, const Handle& ato)
 	{
 		// Halt recursion if the term is executable.
 		if (tr->is_executable()) return true;
@@ -237,7 +237,7 @@ bool is_free_in_tree(const Handle& tree, const Handle& atom)
 		return false;
 	};
 	return is_unquoted_in_tree(tree, atom) and
-	       is_found_in_tree(tree, atom, unsco_and_const);
+	       is_found_in_tree(tree, atom, scoped_or_executable);
 }
 
 bool is_unquoted_unscoped_in_any_tree(const HandleSeq& hs,

--- a/opencog/atoms/core/FindUtils.cc
+++ b/opencog/atoms/core/FindUtils.cc
@@ -165,8 +165,9 @@ bool is_unscoped_in_tree(const Handle& tree, const Handle& atom)
 	// Base cases
 	if (content_eq(tree, atom)) return true;
 	if (not tree->is_link()) return false;
-	ScopeLinkPtr stree(ScopeLinkCast(tree));
-	if (nullptr != stree) {
+	if (nameserver().isA(tree->get_type(), SCOPE_LINK))
+	{
+		ScopeLinkPtr stree(ScopeLinkCast(tree));
 		const HandleSet& varset = stree->get_variables().varset;
 		if (varset.find(atom) != varset.cend())
 			return false;
@@ -185,7 +186,8 @@ bool is_constant_in_tree(const Handle& tree, const Handle& atom)
 	if (content_eq(tree, atom)) return true;
 	if (not tree->is_link()) return false;
 
-	if (if tree->is_executable()) return false;
+	// Halt recursion if the term is executable.
+	if (tree->is_executable()) return false;
 
 	// Recursive case
 	for (const Handle& h : tree->getOutgoingSet())
@@ -316,8 +318,9 @@ HandleSet get_free_variables(const Handle& h, Quotation quotation)
 	HandleSet results = get_free_variables(h->getOutgoingSet(), quotation);
 	// If the link was a scope link then remove the scoped
 	// variables from the free variables found.
-	ScopeLinkPtr sh(ScopeLinkCast(h));
-	if (nullptr != sh) {
+	if (nameserver().isA(h->get_type(), SCOPE_LINK))
+	{
+		ScopeLinkPtr sh(ScopeLinkCast(h));
 		const HandleSet& varset = sh->get_variables().varset;
 		for (auto& v : varset)
 			results.erase(v);

--- a/opencog/atoms/core/FindUtils.cc
+++ b/opencog/atoms/core/FindUtils.cc
@@ -203,7 +203,9 @@ bool is_unquoted_unscoped_in_tree(const Handle& tree, const Handle& atom)
 
 bool is_free_in_tree(const Handle& tree, const Handle& atom)
 {
-	return is_unquoted_unscoped_in_tree(tree, atom);
+	return is_unquoted_in_tree(tree, atom) and
+	       is_unscoped_in_tree(tree, atom) and
+	       is_constant_in_tree(tree, atom);
 }
 
 bool is_unquoted_unscoped_in_any_tree(const HandleSeq& hs,
@@ -215,9 +217,12 @@ bool is_unquoted_unscoped_in_any_tree(const HandleSeq& hs,
 	return false;
 }
 
-bool is_free_in_any_tree(const HandleSeq& hs, const Handle& atom)
+bool is_free_in_any_tree(const HandleSeq& hs, const Handle& v)
 {
-	return is_unquoted_unscoped_in_any_tree(hs, atom);
+	for (const Handle& h : hs)
+		if (is_free_in_tree(h, v))
+			return true;
+	return false;
 }
 
 bool any_atom_in_tree(const Handle& tree, const HandleSet& atoms)
@@ -232,9 +237,7 @@ bool any_atom_in_tree(const Handle& tree, const HandleSet& atoms)
 bool any_unquoted_in_tree(const Handle& tree, const HandleSet& atoms)
 {
 	for (const Handle& n: atoms)
-	{
 		if (is_unquoted_in_tree(tree, n)) return true;
-	}
 	return false;
 }
 
@@ -242,6 +245,13 @@ bool any_unscoped_in_tree(const Handle& tree, const HandleSet& atoms)
 {
 	for (const Handle& n: atoms)
 		if (is_unscoped_in_tree(tree, n)) return true;
+	return false;
+}
+
+bool any_constant_in_tree(const Handle& tree, const HandleSet& atoms)
+{
+	for (const Handle& n: atoms)
+		if (is_constant_in_tree(tree, n)) return true;
 	return false;
 }
 

--- a/opencog/atoms/core/FindUtils.cc
+++ b/opencog/atoms/core/FindUtils.cc
@@ -224,7 +224,7 @@ bool is_free_in_tree(const Handle& tree, const Handle& atom)
 	auto unsco_and_const = [](const Handle& tr, const Handle& ato)
 	{
 		// Halt recursion if the term is executable.
-		if (tr->is_executable()) return false;
+		if (tr->is_executable()) return true;
 
 		// Halt rescursion if scoped.
 		if (nameserver().isA(tr->get_type(), SCOPE_LINK))
@@ -232,9 +232,9 @@ bool is_free_in_tree(const Handle& tree, const Handle& atom)
 			ScopeLinkPtr stree(ScopeLinkCast(tr));
 			const HandleSet& varset = stree->get_variables().varset;
 			if (varset.find(ato) != varset.cend())
-				return false;
+				return true;
 		}
-		return true;
+		return false;
 	};
 	return is_unquoted_in_tree(tree, atom) and
 	       is_found_in_tree(tree, atom, unsco_and_const);

--- a/opencog/atoms/core/FindUtils.h
+++ b/opencog/atoms/core/FindUtils.h
@@ -208,7 +208,7 @@ bool is_constant_in_tree(const Handle& tree, const Handle& atom);
 bool is_unquoted_unscoped_in_tree(const Handle& tree, const Handle& atom);
 
 /**
- * Shorter name for is_unquoted_unscoped_in_tree
+ * True if is_unquoted, is_unscoped and is_constant_in_tree
 */
 bool is_free_in_tree(const Handle& tree, const Handle& atom);
 
@@ -220,7 +220,8 @@ bool is_unquoted_unscoped_in_any_tree(const HandleSeq& trees,
                                       const Handle& atom);
 
 /**
- * Shorter name for is_unquoted_unscoped_in_any_tree
+ * Return true if the atom (variable) occurs unquoted and
+ * unscoped and constant somewhere in any of the trees.
 */
 bool is_free_in_any_tree(const HandleSeq& hs, const Handle& atom);
 
@@ -246,6 +247,13 @@ bool any_unquoted_in_tree(const Handle& tree,
  * somewhere in the tree.
  */
 bool any_unscoped_in_tree(const Handle& tree,
+                          const HandleSet& atoms);
+
+/**
+ * Return true if any of the atoms (variables) occur
+ * somewhere in the tree, outside of an executable term.
+ */
+bool any_constant_in_tree(const Handle& tree,
                           const HandleSet& atoms);
 
 /**

--- a/opencog/atoms/core/FindUtils.h
+++ b/opencog/atoms/core/FindUtils.h
@@ -264,6 +264,13 @@ bool any_unquoted_unscoped_in_tree(const Handle& tree,
                                    const HandleSet& atoms);
 
 /**
+ * Return true if any of the atoms (variables) occur unquoted and
+ * unscoped and outside of an executable term, somewhere in the tree.
+ */
+bool any_free_in_tree(const Handle& tree,
+                      const HandleSet& atoms);
+
+/**
  * Return how many of the indicated atoms occur somewhere in
  * the tree (that is, in the tree spanned by the outgoing set.)
  * But ONLY if they are not quoted!  This is intended to be used to

--- a/opencog/atoms/core/FindUtils.h
+++ b/opencog/atoms/core/FindUtils.h
@@ -127,6 +127,16 @@ private:
 bool is_atom_in_tree(const Handle& tree, const Handle& atom);
 
 /**
+ * Return true if the indicated atom occurs somewhere in the tree
+ * (viz, the tree recursively spanned by the outgoing set of the handle)
+ * The search of some is terminated if the predicate `reject` returns
+ * true. (That is, rejected subtrees are not searched, so that the
+ * rejected subtree is a search-failure).
+ */
+bool is_found_in_tree(const Handle& tree, const Handle& atom,
+           bool (*reject)(const Handle& tree, const Handle& atom));
+
+/**
  * Return true if the indicated atom occurs quoted somewhere in the
  * tree.  That is, it returns true only if the atom is inside a
  * QuoteLink.

--- a/opencog/atoms/core/FindUtils.h
+++ b/opencog/atoms/core/FindUtils.h
@@ -196,6 +196,12 @@ int max_quotation_level(const Handle& tree,
 bool is_unscoped_in_tree(const Handle& tree, const Handle& atom);
 
 /**
+ * Return true if the atom (variable) occurs in a non-executable
+ * term somewhere in the tree.
+ */
+bool is_constant_in_tree(const Handle& tree, const Handle& atom);
+
+/**
  * Return true if the atom (variable) occurs both unquoted and
  * unscoped somewhere in the tree.
 */

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -685,14 +685,14 @@ bool PatternLink::add_dummies()
 		    IDENTICAL_LINK == tt)
 		{
 			const Handle& left = t->getOutgoingAtom(0);
-			if (any_unquoted_in_tree(left, _varlist.varset))
+			if (any_unquoted_unscoped_in_tree(left, _varlist.varset))
 			{
 				_pat.mandatory.emplace_back(left);
 				_fixed.emplace_back(left);
 			}
 
 			const Handle& right = t->getOutgoingAtom(1);
-			if (any_unquoted_in_tree(right, _varlist.varset))
+			if (any_unquoted_unscoped_in_tree(right, _varlist.varset))
 			{
 				_pat.mandatory.emplace_back(right);
 				_fixed.emplace_back(right);

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -685,14 +685,14 @@ bool PatternLink::add_dummies()
 		    IDENTICAL_LINK == tt)
 		{
 			const Handle& left = t->getOutgoingAtom(0);
-			if (any_unquoted_unscoped_in_tree(left, _varlist.varset))
+			if (any_free_in_tree(left, _varlist.varset))
 			{
 				_pat.mandatory.emplace_back(left);
 				_fixed.emplace_back(left);
 			}
 
 			const Handle& right = t->getOutgoingAtom(1);
-			if (any_unquoted_unscoped_in_tree(right, _varlist.varset))
+			if (any_free_in_tree(right, _varlist.varset))
 			{
 				_pat.mandatory.emplace_back(right);
 				_fixed.emplace_back(right);

--- a/tests/query/BuggyEqualUTest.cxxtest
+++ b/tests/query/BuggyEqualUTest.cxxtest
@@ -20,6 +20,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <opencog/atoms/core/NumberNode.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/guile/SchemeEval.h>
 #include <opencog/util/Logger.h>
@@ -61,6 +62,7 @@ class BuggyEqual :  public CxxTest::TestSuite
 
 		void test_bugeq(void);
 		void test_bugalt(void);
+		void test_arithmetic(void);
 };
 
 void BuggyEqual::setUp(void)
@@ -86,6 +88,7 @@ void BuggyEqual::test_bugeq(void)
 
 	logger().debug("END TEST: %s", __FUNCTION__);
 }
+
 /*
  * NotLink causing weird trouble.
  */
@@ -98,6 +101,30 @@ void BuggyEqual::test_bugalt(void)
 	Handle alt = eval->eval_h("(cog-execute! pln-alt)");
 	printf("Alt results:\n%s\n", alt->to_short_string().c_str());
 	TSM_ASSERT_EQUALS("wrong number of solutions found", 4, getarity(alt));
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+/*
+ * Failed arithmetic search
+ */
+void BuggyEqual::test_arithmetic(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	eval->eval("(load-from-path \"tests/query/buggy-equal-arithmetic.scm\")");
+
+	Handle sixset = eval->eval_h("(cog-execute! arithmetic-search)");
+	printf("Arithmetic results:\n%s\n", sixset->to_short_string().c_str());
+	TSM_ASSERT_EQUALS("wrong number of solutions", 1, getarity(sixset));
+
+	Handle six = sixset->getOutgoingAtom(0);
+	TSM_ASSERT_EQUALS("Expected number node!", NUMBER_NODE, six->get_type());
+
+	NumberNodePtr nn(NumberNodeCast(six));
+	double dsix = nn->get_value();
+	TS_ASSERT_LESS_THAN_EQUALS(5.99999, dsix);
+	TS_ASSERT_LESS_THAN_EQUALS(dsix, 6.00001);
 
 	logger().debug("END TEST: %s", __FUNCTION__);
 }

--- a/tests/query/buggy-equal-arithmetic.scm
+++ b/tests/query/buggy-equal-arithmetic.scm
@@ -1,0 +1,19 @@
+;
+; buggy-equal-arithmetic.scm
+;
+; Unit test for github bug report opencog/atomspace#2284
+;
+(use-modules (opencog) (opencog exec))
+
+(Number 1)
+(Number 2)
+(Number 3)
+(Number 4)
+(Number 5)
+(Number 6)
+
+;; Exepcted result of running below is (Number 6)
+(define arithmetic-search
+	(GetLink
+		(TypedVariable (Variable "$X1") (Type 'NumberNode)) 
+		(Equal (Plus (Variable "$X1") (Number 5)) (Number 11))))


### PR DESCRIPTION
Search pattern was being set up incorrectly, looking for a grounding inside of an 
executable term, which, by definition, will not be groundable. This, exclude executable
terms from the list of groundable constant terms.