### PR TITLE
Implement AlwaysLink (for-all link in pattern matcher)

### DIFF
--- a/examples/pattern-matcher/README.md
+++ b/examples/pattern-matcher/README.md
@@ -107,8 +107,9 @@ pattern matcher implements a form of "intuitionistic logic", or
 "constructivist logic" under the covers. Perhaps not a surprise: these
 are the logics of theorem-proving, in general.)
 
-* `presence.scm`     -- Testing for the presence of an Atom.
-* `absent.scm`       -- Using the AbsentLink.
+* `presence.scm`     -- Testing for presence of an Atom ("there-exists").
+* `absent.scm`       -- Using the AbsentLink ("there-does-not-exist").
+* `always.scm`       -- Testing if a clause always holds ("for-all").
 * `value-of.scm`     -- Looking for high or low TruthValues.
 * `query.scm`        -- Running queries in parallel.
 

--- a/examples/pattern-matcher/always.scm
+++ b/examples/pattern-matcher/always.scm
@@ -43,7 +43,7 @@
 	(Bind
 		(VariableList
 			(TypedVariable (Variable "basket") (Type 'ConceptNode))
-			(TypedVariable (Variable "ball") (Type 'ConceptNode))
+			(TypedVariable (Variable "ball")   (Type 'ConceptNode))
 		)
 		(And
 			; Look at every basket ...
@@ -55,7 +55,7 @@
 			; Always means that *every* ball in the basket MUST
 			; be red! Any single failure to satisfy this invalidates
 			; the entire search.
-			(Always (Evaluation (Predicate "is red")  (Variable "ball")))
+			(Always (Evaluation (Predicate "is red") (Variable "ball")))
 		)
 
 		; Report the basket which has only red balls in it.

--- a/examples/pattern-matcher/always.scm
+++ b/examples/pattern-matcher/always.scm
@@ -1,0 +1,65 @@
+;
+; always.scm -- Demo illustrating AlwaysLink ("for-all")
+;
+; The most basic kinds of pattern searches are to see if some
+; particular pattern can be found. These are "exists" searches;
+; does the pattern exist?  Sometimes one wants to have "for-all"
+; searches: does **every** instance of the pattern **always**
+; satisfy some predicate or term? Such searches can be implemented
+; with the AlwaysLink.
+;
+; In this example, there are three baskets holding balls. Some
+; hold balls of several different colors, some hold only balls
+; that are all of the same color. The example sets up these baskets,
+; and then issues a query to find the basket that holds only red
+; balls, and no others.
+;
+(use-modules (opencog) (opencog exec))
+
+; Three baskets holding balls
+(Inheritance (Concept "reds basket")        (Concept "basket"))
+(Inheritance (Concept "reds&greens basket") (Concept "basket"))
+(Inheritance (Concept "yellows basket")     (Concept "basket"))
+
+; Balls placed into baskets
+(Member (Concept "red ball")      (Concept "reds basket"))
+(Member (Concept "red ball too")  (Concept "reds basket"))
+(Member (Concept "red ball also") (Concept "reds basket"))
+(Member (Concept "red ball")      (Concept "reds&greens basket"))
+(Member (Concept "red ball too")  (Concept "reds&greens basket"))
+(Member (Concept "green ball")    (Concept "reds&greens basket"))
+(Member (Concept "yellow ball")   (Concept "yellows basket"))
+
+; Predicate that tests the colors of the balls
+(Evaluation (Predicate "is red") (Concept "red ball"))
+(Evaluation (Predicate "is red") (Concept "red ball too"))
+(Evaluation (Predicate "is red") (Concept "red ball also"))
+
+(Evaluation (Predicate "is green")  (Concept "green ball"))
+(Evaluation (Predicate "is yellow") (Concept "yellow ball"))
+
+; The search that we will perform.
+(define get-baskets-with-only-red-balls
+	(Bind
+		(VariableList
+			(TypedVariable (Variable "basket") (Type 'ConceptNode))
+			(TypedVariable (Variable "ball") (Type 'ConceptNode))
+		)
+		(And
+			; Look at every basket ...
+			(Inheritance (Variable "basket") (Concept "basket"))
+
+			; Look at the balls in the basket ...
+			(Member (Variable "ball") (Variable "basket"))
+
+			; Always means that *every* ball in the basket MUST
+			; be red! Any single failure to satisfy this invalidates
+			; the entire search.
+			(Always (Evaluation (Predicate "is red")  (Variable "ball")))
+		)
+
+		; Report the basket which has only red balls in it.
+		(Variable "basket"))
+)
+
+(cog-execute! get-baskets-with-only-red-balls)

--- a/opencog/atoms/atom_types/atom_types.script
+++ b/opencog/atoms/atom_types/atom_types.script
@@ -198,6 +198,17 @@ PRESENT_LINK <- SET_LINK,CRISP_OUTPUT_LINK
 // PresentLink is used to accomplish this.
 ABSENT_LINK <- PRESENT_LINK
 
+// The other adjoint.
+// Exists == left adjoint to the pullback functor of a relation.
+//           where PresentLink is `Exists` for the pattern matcher.
+// ForAll == right adjoint to the pullback functor of a relation.
+//           We invent AlwaysLink, since `ForAll` is already taken
+//           up by PLN.
+// This is used in the pattern matcher, to implement an "always the
+// case" condition during matching. It's a kind-of `ForAll`, just like
+// Present is a kind-of `ThereExists`.
+ALWAYS_LINK <- PRESENT_LINK
+
 // Performance scripting links.
 // ParallelLink launches multiple threads, but does not wait for any of
 // them to return.  JoinLink launches multiple threads, and waits for
@@ -704,9 +715,18 @@ INTENSIONAL_SIMILARITY_LINK <- SIMILARITY_LINK
 // Should these inherit from ReWriteLink or PrenexLink instead ???
 // I think PLN uses these; otherwise they are not yet properly defined.
 //
+// Lojban uses ExistsLink, but incorrectly (it is unaware that Exists
+// is scoped!)
+//
 // Exists == left adjoint to the pullback functor of a relation.
+//           Note that PRESENT_LINK below is the unscoped variant
+//           of this, used in the pattern matcher.
 // ForAll == right adjoint to the pullback functor of a relation.
-// XXX Currently not implemented (viz don't work with virtual links).
+//           Note that ALWAYS_LINK below is the unscoped variant
+//           of this, used in the pattern matcher.
+//
+// XXX These are currently not implemented (viz they don't actually
+// work as virtual links).
 FORALL_LINK <- SCOPE_LINK,CRISP_OUTPUT_LINK "ForAllLink"
 EXISTS_LINK <- SCOPE_LINK,CRISP_OUTPUT_LINK
 

--- a/opencog/atoms/pattern/Pattern.h
+++ b/opencog/atoms/pattern/Pattern.h
@@ -93,6 +93,10 @@ struct Pattern
 	/// grounded, they might be rejected (depending on the callback).
 	HandleSeq optionals;    // Optional clauses
 
+	/// The always (for-all) clauses have to always be the same way.
+	/// Any grounding failure at all invalidates all other groundings.
+	HandleSeq always;       // ForAll clauses
+
 	/// Black-box clauses. These are clauses that contain GPN's. These
 	/// have to drop into scheme or python to get evaluated, which means
 	/// that they will be slow.  So, we leave these for last, so that the

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -354,10 +354,9 @@ bool PatternLink::record_literal(const Handle& h, bool reverse)
 	if (not reverse and ALWAYS_LINK == typ)
 	    // or (reverse and NEVER_LINK == typ))
 	{
-		for (const Handle& inv: h->getOutgoingSet())
+		for (const Handle& ah: h->getOutgoingSet())
 		{
-			_pat.always.emplace_back(inv);
-			_pat.quoted_clauses.emplace_back(inv);
+			_pat.always.emplace_back(ah);
 		}
 		return true;
 	}
@@ -761,8 +760,6 @@ void PatternLink::make_connectivity_map(const HandleSeq& component)
 	for (const Handle& h : _pat.mandatory)
 		make_map_recursive(h, h);
 	for (const Handle& h : _pat.optionals)
-		make_map_recursive(h, h);
-	for (const Handle& h : _pat.always)
 		make_map_recursive(h, h);
 
 	// Save some minor amount of space by erasing those atoms that

--- a/opencog/query/DefaultPatternMatchCB.cc
+++ b/opencog/query/DefaultPatternMatchCB.cc
@@ -565,6 +565,23 @@ bool DefaultPatternMatchCB::optional_clause_match(const Handle& ptrn,
 
 /* ======================================================== */
 
+/* There must always be a grounding! Always! If there ever
+ * wasn't one, then we fail forever-more.
+ */
+bool DefaultPatternMatchCB::always_clause_match(const Handle& ptrn,
+                                                const Handle& grnd,
+                                                const HandleMap& term_gnds)
+{
+printf("duuude always ! state=%d grnd=%d\n", _forall_state,
+grnd!=nullptr);
+	// No grounding at all was found, reject it.
+	if (not grnd) _forall_state = false;
+
+	return _forall_state;
+}
+
+/* ======================================================== */
+
 IncomingSet DefaultPatternMatchCB::get_incoming_set(const Handle& h)
 {
 	return h->getIncomingSet(_as);

--- a/opencog/query/DefaultPatternMatchCB.cc
+++ b/opencog/query/DefaultPatternMatchCB.cc
@@ -565,19 +565,39 @@ bool DefaultPatternMatchCB::optional_clause_match(const Handle& ptrn,
 
 /* ======================================================== */
 
-/* There must always be a grounding! Always! If there ever
- * wasn't one, then we fail forever-more.
+/* This implements AlwaysLink (the non-scoped vesion of ForAllLink
+ * used by the pattern matcher.) The AlwaysLink must always be
+ * satsifed, every time it is called, from the begining of the
+ * search to the end.  The AlwaysLinks is satsified whenever
+ * ptrn==grnd, and otherwise, if fails. That is, if ptrn==nullptr
+ * then there is some grounding of (all of) the other clauses of
+ * the pattern, with AlwaysLink failing to be satisfied. Reject
+ * this case, now and forever. (viz, this is stateful.)
  */
 bool DefaultPatternMatchCB::always_clause_match(const Handle& ptrn,
                                                 const Handle& grnd,
                                                 const HandleMap& term_gnds)
 {
-printf("duuude always ! state=%d grnd=%d\n", _forall_state,
-grnd!=nullptr);
-	// No grounding at all was found, reject it.
+	// No grounding was found, reject it.
 	if (not grnd) _forall_state = false;
 
+	// If we failed once, we will always fail.
 	return _forall_state;
+}
+
+void DefaultPatternMatchCB::push(void)
+{
+	_stack_depth++;
+}
+
+void DefaultPatternMatchCB::pop(void)
+{
+	_stack_depth--;
+
+	// Reset the for-all state at the very start of a new search.
+	// If might be more elegant if iniate_search told us when
+	// it was starting again, but whatever. This works for now.
+	if (0 == _stack_depth) _forall_state = true;
 }
 
 /* ======================================================== */

--- a/opencog/query/DefaultPatternMatchCB.h
+++ b/opencog/query/DefaultPatternMatchCB.h
@@ -69,12 +69,16 @@ class DefaultPatternMatchCB : public virtual PatternMatchCallback
 
 		virtual bool clause_match(const Handle&, const Handle&,
 		                          const HandleMap&);
-		/**
-		 * Typically called for AbsentLink
-		 */
+
+		/** Called for AbsentLink */
 		virtual bool optional_clause_match(const Handle& pattrn,
 		                                   const Handle& grnd,
 		                                   const HandleMap&);
+
+		/** Called for AlawaysLink */
+		virtual bool always_clause_match(const Handle& pattrn,
+		                                 const Handle& grnd,
+		                                 const HandleMap&);
 
 		virtual IncomingSet get_incoming_set(const Handle&);
 
@@ -132,6 +136,7 @@ class DefaultPatternMatchCB : public virtual PatternMatchCallback
 		bool eval_sentence(const Handle& pat, const HandleMap& gnds);
 
 		bool _optionals_present = false;
+		bool _forall_state = true;
 		AtomSpace* _as;
 };
 

--- a/opencog/query/DefaultPatternMatchCB.h
+++ b/opencog/query/DefaultPatternMatchCB.h
@@ -80,6 +80,9 @@ class DefaultPatternMatchCB : public virtual PatternMatchCallback
 		                                 const Handle& grnd,
 		                                 const HandleMap&);
 
+		virtual void push(void);
+		virtual void pop(void);
+
 		virtual IncomingSet get_incoming_set(const Handle&);
 
 		/**
@@ -137,6 +140,7 @@ class DefaultPatternMatchCB : public virtual PatternMatchCallback
 
 		bool _optionals_present = false;
 		bool _forall_state = true;
+		size_t _stack_depth = 0;
 		AtomSpace* _as;
 };
 

--- a/opencog/query/PatternLinkRuntime.cc
+++ b/opencog/query/PatternLinkRuntime.cc
@@ -86,6 +86,12 @@ class PMCGroundings : public PatternMatchCallback
 		{
 			return _cb.optional_clause_match(pattrn, grnd, term_gnds);
 		}
+		bool always_clause_match(const Handle& pattrn,
+		                           const Handle& grnd,
+		                           const HandleMap& term_gnds)
+		{
+			return _cb.always_clause_match(pattrn, grnd, term_gnds);
+		}
 		IncomingSet get_incoming_set(const Handle& h) {
 			return _cb.get_incoming_set(h);
 		}

--- a/opencog/query/PatternMatchCallback.h
+++ b/opencog/query/PatternMatchCallback.h
@@ -256,6 +256,27 @@ class PatternMatchCallback
 		                                   const HandleMap& term_gnds) = 0;
 
 		/**
+		 * Called when the search for a top-level for-all clause
+		 * has been completed. The clause may or may not have been
+		 * grounded as a result of the search. If it has been grounded,
+		 * then grnd will be non-null.
+		 *
+		 * Return false to terminate further searches from this point
+		 * on; the result of termination will be backtracking to search
+		 * for other possible groundings of the required clauses.
+		 * Return true to examine the next for-all clause (if any).
+		 *
+		 * Note that all required clauses will have been grounded,
+		 * and all optional clauses will have been examined before
+		 * the for-all clauses are tested. This guarantees that the
+		 * groundings for all variables are "final", and this is a
+		 * last-chance test.
+		 */
+		virtual bool always_clause_match(const Handle& pattrn,
+		                                 const Handle& grnd,
+		                                 const HandleMap& term_gnds) = 0;
+
+		/**
 		 * Called when a complete grounding for all clauses is found.
 		 * Should return false to search for more solutions; or return
 		 * true to terminate search.  (Just as in all the other callbacks,

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1784,7 +1784,7 @@ void PatternMatchEngine::get_next_untried_clause(void)
 	}
 
 	// If there are no optional clauses, we are done.
-	if (_pat->optionals.empty())
+	if (_pat->optionals.empty() and _pat->always.empty())
 	{
 		// There are no more ungrounded clauses to consider. We are done.
 		next_clause = Handle::UNDEFINED;
@@ -1801,6 +1801,24 @@ void PatternMatchEngine::get_next_untried_clause(void)
 		{
 			if (get_next_thinnest_clause(true, true, true)) return;
 		}
+	}
+
+	// Now loop over all for-all clauses.
+	// I think that all variables will be grounded at this point, right?
+	for (const Handle& root : _pat->always)
+	{
+		if (issued.end() != issued.find(root)) continue;
+		issued.insert(root);
+		next_clause = root;
+		for (const Handle &v : _varlist->varset)
+		{
+			if (is_free_in_tree(root, v))
+			{
+				next_joint = v;
+				return;
+			}
+		}
+		throw RuntimeException(TRACE_INFO, "BUG! Somethings wrong!!");
 	}
 
 	// If we are here, there are no more unsolved clauses to consider.

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1621,6 +1621,13 @@ bool PatternMatchEngine::clause_accept(const Handle& clause_root,
 		DO_LOG({logger().fine("optional clause match callback match=%d", match);})
 	}
 	else
+	if (is_always(clause_root))
+	{
+		clause_accepted = true;
+		match = _pmc.always_clause_match(clause_root, hg, var_grounding);
+		DO_LOG({logger().fine("for-all clause match callback match=%d", match);})
+	}
+	else
 	{
 		match = _pmc.clause_match(clause_root, hg, var_grounding);
 		DO_LOG({logger().fine("clause match callback match=%d", match);})

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1816,7 +1816,6 @@ void PatternMatchEngine::get_next_untried_clause(void)
 			if (is_free_in_tree(root, v))
 			{
 				next_joint = v;
-printf("duuude now doing the forall!\n");
 				return;
 			}
 		}
@@ -2209,7 +2208,8 @@ bool PatternMatchEngine::explore_clause(const Handle& term,
 			found = explore_term_branches(term, grnd, clause);
 		}
 
-		// Report the failure to the callback.
+		// AlwaysLink clauses must always be satisfied. Report the
+		// failure to satisfy to the callback.
 		if (is_always(clause))
 		{
 			Handle empty;

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -63,6 +63,10 @@ private:
 		const HandleSeq& o(_pat->optionals);
 		return o.end() != std::find(o.begin(), o.end(), h); }
 
+	bool is_always(const Handle& h) {
+		const HandleSeq& o(_pat->always);
+		return o.end() != std::find(o.begin(), o.end(), h); }
+
 	bool is_evaluatable(const Handle& h) {
 		return (_pat->evaluatable_holders.count(h) != 0); }
 

--- a/tests/query/AlwaysUTest.cxxtest
+++ b/tests/query/AlwaysUTest.cxxtest
@@ -1,0 +1,90 @@
+/*
+ * tests/query/AlwaysUTest.cxxtest
+ *
+ * Copyright (C) 2019 Linas Vepstas
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/guile/SchemeEval.h>
+#include <opencog/atomspace/AtomSpace.h>
+#include <opencog/util/Logger.h>
+#include "imply.h"
+
+using namespace opencog;
+
+class AlwaysUTest: public CxxTest::TestSuite
+{
+private:
+	AtomSpace *as;
+	SchemeEval* eval;
+
+public:
+	AlwaysUTest(void)
+	{
+		logger().set_level(Logger::DEBUG);
+		logger().set_print_to_stdout_flag(true);
+
+		as = new AtomSpace();
+		eval = new SchemeEval(as);
+		eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+
+	}
+
+	~AlwaysUTest()
+	{
+		delete as;
+		// Erase the log file if no assertions failed.
+		if (!CxxTest::TestTracker::tracker().suiteFailed())
+			std::remove(logger().get_filename().c_str());
+	}
+
+	void setUp(void);
+	void tearDown(void);
+
+	void test_basic(void);
+};
+
+void AlwaysUTest::tearDown(void)
+{
+}
+
+void AlwaysUTest::setUp(void)
+{
+}
+
+#define getarity(hand) hand->get_arity()
+
+/*
+ * Basic AlwaysLink unit test. The simplest test possible.
+ */
+void AlwaysUTest::test_basic(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	eval->eval("(load-from-path \"tests/query/always.scm\")");
+
+	Handle red_set = eval->eval_h("(cog-execute! baskets-with-red-balls-only)");
+	printf("Expecting red basket, got %s", red_set->to_string().c_str());
+
+	TS_ASSERT_EQUALS(1, getarity(red_set));
+
+	Handle redbask = as->add_node(CONCEPT_NODE, "reds basket");
+	TS_ASSERT_EQUALS(redbask, red_set->getOutgoingAtom(0));
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}

--- a/tests/query/AlwaysUTest.cxxtest
+++ b/tests/query/AlwaysUTest.cxxtest
@@ -86,5 +86,12 @@ void AlwaysUTest::test_basic(void)
 	Handle redbask = as->add_node(CONCEPT_NODE, "reds basket");
 	TS_ASSERT_EQUALS(redbask, red_set->getOutgoingAtom(0));
 
+	// ----------------
+	Handle red_n_yell = eval->eval_h("(cog-execute! baskets-with-same-color)");
+	printf("Expecting red and yellow, got %s", red_n_yell>to_string().c_str());
+
+	// XXX FIXME (Always (Equals ...)) has not been implemented yet!
+	// TS_ASSERT_EQUALS(2, getarity(red_n_yell));
+
 	logger().debug("END TEST: %s", __FUNCTION__);
 }

--- a/tests/query/AlwaysUTest.cxxtest
+++ b/tests/query/AlwaysUTest.cxxtest
@@ -88,7 +88,7 @@ void AlwaysUTest::test_basic(void)
 
 	// ----------------
 	Handle red_n_yell = eval->eval_h("(cog-execute! baskets-with-same-color)");
-	printf("Expecting red and yellow, got %s", red_n_yell>to_string().c_str());
+	printf("Expecting red and yellow, got %s", red_n_yell->to_string().c_str());
 
 	// XXX FIXME (Always (Equals ...)) has not been implemented yet!
 	// TS_ASSERT_EQUALS(2, getarity(red_n_yell));

--- a/tests/query/CMakeLists.txt
+++ b/tests/query/CMakeLists.txt
@@ -78,6 +78,7 @@ IF (HAVE_GUILE)
 	ADD_CXXTEST(FiniteStateMachineUTest)
 	ADD_CXXTEST(AbsentUTest)
 	ADD_CXXTEST(PresentUTest)
+	ADD_CXXTEST(AlwaysUTest)
 	ADD_CXXTEST(ScopeUTest)
 	ADD_CXXTEST(NestedPutUTest)
 

--- a/tests/query/always.scm
+++ b/tests/query/always.scm
@@ -1,0 +1,51 @@
+;
+; always.scm
+;
+; Basic unit test for AlwaysLink
+; This is (soon will be) example code.
+; Invented after discussions at opencog/atomspace#2203
+;
+
+(use-modules (opencog) (opencog exec))
+
+; Three baskets holding balls
+(Inheritance (Concept "reds basket") (Concept "basket"))
+(Inheritance (Concept "reds&greens basket") (Concept "basket"))
+(Inheritance (Concept "yellows basket") (Concept "basket"))
+
+; Balls placed into baskets
+(Member (Concept "red ball") (Concept "reds basket"))
+(Member (Concept "red ball too") (Concept "reds basket"))
+(Member (Concept "red ball also") (Concept "reds basket"))
+(Member (Concept "red ball") (Concept "reds&greens basket"))
+(Member (Concept "red ball too") (Concept "reds&greens basket"))
+(Member (Concept "green ball") (Concept "reds&greens basket"))
+(Member (Concept "yellow ball") (Concept "yellows basket"))
+
+; Colors of the balls
+(Evaluation (Predicate "is red") (Concept "red ball"))
+(Evaluation (Predicate "is red") (Concept "red ball too"))
+(Evaluation (Predicate "is red") (Concept "red ball also"))
+
+(Evaluation (Predicate "is green") (Concept "green ball"))
+(Evaluation (Predicate "is yellow") (Concept "yellow ball"))
+
+(define baskets-with-red-balls-only
+	(Bind
+		(VariableList
+			(TypedVariable (Variable "basket") (Type 'ConceptNode))
+			(TypedVariable (Variable "ball") (Type 'ConceptNode))
+		)
+		(And
+			(Inheritance (Variable "basket") (Concept "basket"))
+			(Member (Variable "ball") (Variable "basket"))
+
+			; Always means that *every* ball in the basket MUST
+			; be red! Failure to satisfy this invalidates the
+			; search.
+			(Always (Evaluation (Predicate "is red")  (Variable "ball")))
+		)
+
+		; Report the basket which has only red balls in it.
+		(Variable "basket"))
+)

--- a/tests/query/always.scm
+++ b/tests/query/always.scm
@@ -21,6 +21,7 @@
 (Member (Concept "red ball too") (Concept "reds&greens basket"))
 (Member (Concept "green ball") (Concept "reds&greens basket"))
 (Member (Concept "yellow ball") (Concept "yellows basket"))
+(Member (Concept "ochre ball") (Concept "yellows basket"))
 
 ; Colors of the balls
 (Evaluation (Predicate "is red") (Concept "red ball"))
@@ -29,6 +30,7 @@
 
 (Evaluation (Predicate "is green") (Concept "green ball"))
 (Evaluation (Predicate "is yellow") (Concept "yellow ball"))
+(Evaluation (Predicate "is yellow") (Concept "ochre ball"))
 
 (define baskets-with-red-balls-only
 	(Bind
@@ -48,4 +50,24 @@
 
 		; Report the basket which has only red balls in it.
 		(Variable "basket"))
+)
+
+(define baskets-with-same-color
+(Bind
+	(VariableList
+		(TypedVariable (Variable "basket")      (Type 'ConceptNode))
+		(TypedVariable (Variable "one ball")    (Type 'ConceptNode))
+		(TypedVariable (Variable "other ball")  (Type 'ConceptNode))
+		(TypedVariable (Variable "one color")   (Type 'PredicateNode))
+		(TypedVariable (Variable "other color") (Type 'PredicateNode))
+	)
+	(And
+		(Inheritance (Variable "basket")      (Concept "basket"))
+		(Member (Variable "one ball")         (Variable "basket"))
+		(Member (Variable "other ball")       (Variable "basket"))
+		(Evaluation (Variable "one color")    (Variable "one ball"))
+		(Evaluation (Variable "other color")  (Variable "other ball"))
+		(Always (Equal (Variable "one color") (Variable "other color")))
+	)
+	(Variable "basket"))
 )


### PR DESCRIPTION
Per discussions in #2203 -- The `PresentLink` in the pattern matcher is a 
kind of `ThereExistsLink` but custom tailored so it can be used with the 
patten matcher. So of course, we need something analogous to a `ForAllLink`. 
Since that name is already taken by PLN, for a kind of ScopeLink, it seemed 
easier to just introduce the `AlwaysLink`. It is not clear if a `NeverLink` is needed.
(because "not always" is "sometimes")

This is just the most basic, bare-bones implementation. More complex uses are
probably buggy. 