### PR TITLE
use c++ api in cython atom.__hash__ method

### DIFF
--- a/opencog/cython/opencog/atom.pyx
+++ b/opencog/cython/opencog/atom.pyx
@@ -151,8 +151,4 @@ cdef class Atom(Value):
             return -1
 
     def __hash__(self):
-        cdef cAtom* atom_ptr = self.handle.atom_ptr()
-        if atom_ptr == NULL:
-            raise RuntimeError("hash called on null pointer")
-        cdef ContentHash h = deref(atom_ptr).get_hash()
-        return PyLong_FromLongLong(h)
+        return PyLong_FromLongLong(self.get_c_handle().get().get_hash())

--- a/opencog/cython/opencog/atom.pyx
+++ b/opencog/cython/opencog/atom.pyx
@@ -1,4 +1,4 @@
-from cpython cimport PyLong_FromSize_t
+from cpython cimport PyLong_FromLongLong
 
 # Atom wrapper object
 cdef class Atom(Value):
@@ -155,4 +155,4 @@ cdef class Atom(Value):
         if atom_ptr == NULL:
             raise RuntimeError("hash called on null pointer")
         cdef ContentHash h = deref(atom_ptr).get_hash()
-        return PyLong_FromSize_t(h)
+        return PyLong_FromLongLong(h)

--- a/opencog/cython/opencog/atom.pyx
+++ b/opencog/cython/opencog/atom.pyx
@@ -1,3 +1,5 @@
+from cpython cimport PyLong_FromLongLong
+
 # Atom wrapper object
 cdef class Atom(Value):
 
@@ -148,8 +150,9 @@ cdef class Atom(Value):
         else:
             return -1
 
-    def __hash__(a1):
-        # Use the address of the atom in memory as the hash.
-        # This should be globally unique, because the atomspace
-        # does not allow more than one, ever.
-        return hash(PyLong_FromVoidPtr(a1.handle.atom_ptr()))
+    def __hash__(self):
+        cdef cAtom* atom_ptr = self.handle.atom_ptr()
+        if atom_ptr == NULL:
+            raise RuntimeError("hash called on null pointer")
+        cdef ContentHash h = deref(atom_ptr).get_hash()
+        return PyLong_FromLongLong(h)

--- a/opencog/cython/opencog/atom.pyx
+++ b/opencog/cython/opencog/atom.pyx
@@ -1,4 +1,4 @@
-from cpython cimport PyLong_FromLongLong
+from cpython cimport PyLong_FromSize_t
 
 # Atom wrapper object
 cdef class Atom(Value):
@@ -155,4 +155,4 @@ cdef class Atom(Value):
         if atom_ptr == NULL:
             raise RuntimeError("hash called on null pointer")
         cdef ContentHash h = deref(atom_ptr).get_hash()
-        return PyLong_FromLongLong(h)
+        return PyLong_FromSize_t(h)

--- a/opencog/cython/opencog/atomspace.pxd
+++ b/opencog/cython/opencog/atomspace.pxd
@@ -102,6 +102,9 @@ cdef class TruthValue(Value):
     cdef cTruthValue* _ptr(self)
     cdef tv_ptr* _tvptr(self)
 
+# ContentHash
+
+ctypedef size_t ContentHash;
 
 # Atom
 cdef extern from "opencog/atoms/base/Link.h" namespace "opencog":
@@ -123,6 +126,7 @@ cdef extern from "opencog/atoms/base/Atom.h" namespace "opencog":
         # Conditionally-valid methods. Not defined for all atoms.
         string get_name()
         vector[cHandle] getOutgoingSet()
+        ContentHash get_hash()
 
     cdef cHandle handle_cast "HandleCast" (cValuePtr) except +
 


### PR DESCRIPTION
before this fix hash(atom) would return different hashes for the same atoms in different atomspaces.