### PR TITLE
Bug fix for #2298

### DIFF
--- a/examples/atomspace/property.scm
+++ b/examples/atomspace/property.scm
@@ -54,6 +54,7 @@
 	(Lambda
 		(VariableList (Variable "$atom") (Variable "$property"))
 		(Get
+			(Variable "$n")
 			(State (List (Variable "$atom") (Variable "$property"))
 				(Variable "$n"))
 			)))

--- a/opencog/atoms/execution/Instantiator.cc
+++ b/opencog/atoms/execution/Instantiator.cc
@@ -116,7 +116,7 @@ Handle Instantiator::reduce_exout(const Handle& expr, bool silent)
 	Handle sn(eolp->get_schema());
 	Handle args(eolp->get_args());
 
-        if (not _vmap->empty())
+	if (not _vmap->empty())
 		sn = beta_reduce(sn, *_vmap);
 
 	// If its a DSN, obtain the correct body for it.

--- a/tests/query/ExecutionOutputUTest.cxxtest
+++ b/tests/query/ExecutionOutputUTest.cxxtest
@@ -69,6 +69,7 @@ public:
 	void test_value(void);
 	void test_recursion(void);
 	void test_lambda(void);
+	void test_lambda_get(void);
 	void test_implication_scope(void);
 	void test_variable_schema(void);
 };
@@ -432,6 +433,26 @@ void ExecutionOutputUTest::test_lambda(void)
 	                      al(EVALUATION_LINK,
 	                         an(PREDICATE_NODE, "P"),
 	                         an(CONCEPT_NODE, "A"))));
+
+	logger().debug() << "result = " << oc_to_string(result);
+	logger().debug() << "expect = " << oc_to_string(expect);
+
+	TS_ASSERT_EQUALS(expect, result);
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+// This tests one of the demo examples that users are told to run.
+void ExecutionOutputUTest::test_lambda_get(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	eval.eval("(load-from-path \"tests/query/exec-lambda-get.scm\")");
+	Handle exo = eval.eval_h("exo");
+
+	Instantiator inst(&as);
+	Handle result = HandleCast(inst.execute(exo));
+	Handle expect = al(SET_LINK, an(NUMBER_NODE, "0.6"));
 
 	logger().debug() << "result = " << oc_to_string(result);
 	logger().debug() << "expect = " << oc_to_string(expect);

--- a/tests/query/exec-lambda-get.scm
+++ b/tests/query/exec-lambda-get.scm
@@ -1,0 +1,57 @@
+;
+; execu-lambda-get.scm -- copy of demo `property.scm`
+;                      -- Designing Atoms with properties.
+;
+; Many knowledge representation systems want to view the world in
+; terms of objects that have properties on them. This can already
+; be done quite easily with EvaluationLinks and Predicates.
+; But what if one wants a strict guarantee that there is only one
+; property of a given name, and then change it time to time?
+;
+; The StateLink can be used to set "state" in the atomspace; see
+; the `state.scm` file for a example.  States can be thought of as
+; "key-value" pairs in the atomspace; for a give key, there can only
+; ever be one value. Keys and values can be any atoms whatever. By
+; using a key that combines an atom with a property name, one can
+; implement a "property" on that atom.
+;
+; This example shows how to set properties, and three different ways
+; of getting a named property on a atom.
+
+(use-modules (opencog) (opencog exec))
+
+; The StateLink associates a property to a atom. In this case, the
+; property is a number. The "key" is just a list, combining the atom
+; and the property name.
+(State (List (Concept "asdf") (Predicate "truthiness"))
+	(Number 0.5))
+
+(State (List (Concept "qwerty") (Predicate "truthiness"))
+	(Number 0.5))
+
+; Changing a property is easy: this bumps up the value to 0.6
+(State (List (Concept "qwerty") (Predicate "truthiness"))
+	(Number 0.6))
+
+; The getter cane be abstracted away, so that the use of the StateLink
+; is hidden from view.  Below, the DefineLink is used to define a schema
+; called "get property", which takes two arguments: an atom name, and
+; the property.  When executed, the schema returns the property value.
+(DefineLink
+	(DefinedSchema "get property")
+	(Lambda
+		(VariableList (Variable "$atom") (Variable "$property"))
+		(Get
+			(Variable "$n")
+			(State (List (Variable "$atom") (Variable "$property"))
+				(Variable "$n"))
+			)))
+
+; Call the schema defined above.  It should return 0.6 as the value.
+(define exo
+	(ExecutionOutput
+		(DefinedSchema "get property")
+		(List (Concept "qwerty") (Predicate "truthiness"))
+	))
+
+; --------


### PR DESCRIPTION
The demo code was written in an older style, with an ambiguous collection of bound vars.
It used to work, but with recent changes making bound var handling more strict, it started to fail.
So -- fix the example.

Also add unit test to make sure it stays fixed ....