### PR TITLE
Add missing cmake include

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,7 @@ ENDIF (GUILE_FOUND AND GMP_LIBRARY AND GMP_INCLUDE_DIR)
 
 # ----------------------------------------------------------
 # secure_getenv
+INCLUDE(CheckSymbolExists)
 CHECK_SYMBOL_EXISTS(secure_getenv "stdlib.h" HAVE_SECURE_GETENV)
 IF (HAVE_SECURE_GETENV)
 	ADD_DEFINITIONS(-DHAVE_SECURE_GETENV)


### PR DESCRIPTION
This was needed to build on my system, Termux on Android, cmake 3.15.2 .