### PR TITLE
Change Persistance API to provide a generic bulk load/store

### DIFF
--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -263,6 +263,24 @@ public:
     }
 
     /**
+     * Use the backing store to load entire AtomSpace.
+     */
+    void load_atomspace(void) {
+        if (nullptr == _backing_store)
+            throw RuntimeException(TRACE_INFO, "No backing store");
+        _backing_store->loadAtomSpace(_atom_table);
+    }
+
+    /**
+     * Use the backing store to store entire AtomSpace.
+     */
+    void store_atomspace(void) {
+        if (nullptr == _backing_store)
+            throw RuntimeException(TRACE_INFO, "No backing store");
+        _backing_store->storeAtomSpace(_atom_table);
+    }
+
+    /**
      * Use the backing store to load the entire incoming set of the
      * atom.
      * If the flag is true, then the load is done recursively.

--- a/opencog/atomspace/BackingStore.h
+++ b/opencog/atomspace/BackingStore.h
@@ -75,9 +75,9 @@ class BackingStore
 		virtual void getIncomingByType(AtomTable&, const Handle&, Type) = 0;
 
 		/**
-		 * Put all atoms having a value for the key into the atomtable.
-		 * If the bool flag is set, then all values on the atom are
-		 * fetched.
+		 * Get all atoms which have a value set for the given key.
+		 * If the bool flag is set, then all values on those atom are
+		 * fetched; otherwise, only that particular key is updated.
 		 */
 		virtual void getValuations(AtomTable&, const Handle&, bool) = 0;
 

--- a/opencog/atomspace/BackingStore.h
+++ b/opencog/atomspace/BackingStore.h
@@ -108,6 +108,16 @@ class BackingStore
 		virtual void loadType(AtomTable&, Type) = 0;
 
 		/**
+		 * Load *all* atoms.
+		 */
+		virtual void loadAtomSpace(AtomTable&) = 0;
+
+		/**
+		 * Store *all* atoms.
+		 */
+		virtual void storeAtomSpace(const AtomTable&) = 0;
+
+		/**
 		 * Read-write synchronization barrier.
 		 * All writes will be completed before this routine returns.
 		 * This allows the backend to implement asynchronous writes,

--- a/opencog/persist/guile/PersistSCM.cc
+++ b/opencog/persist/guile/PersistSCM.cc
@@ -81,6 +81,13 @@ Handle PersistSCM::fetch_incoming_by_type(Handle h, Type t)
 	return h;
 }
 
+// XXX FIXME -- it appear that this was never exposed in scheme,
+// and so there are no users anywhere for this, which means that
+// there are no users for `as->fetch_valuations()` either, which
+// means it can be removed.  It's not hard to implement in SQL,
+// but does pose an implementation difficulty for IPFS. Since this
+// appears to be unused, then it really should be eliminate.
+// ... someday. In a later pull req, I guess.
 void PersistSCM::fetch_valuations(Handle key, bool get_all_values)
 {
 	AtomSpace *as = SchemeSmob::ss_get_env_as("fetch-valuations");

--- a/opencog/persist/guile/PersistSCM.cc
+++ b/opencog/persist/guile/PersistSCM.cc
@@ -49,6 +49,10 @@ void PersistSCM::init(void)
 	             &PersistSCM::store_atom, this, "persist");
 	define_scheme_primitive("load-atoms-of-type",
 	             &PersistSCM::load_type, this, "persist");
+	define_scheme_primitive("load-atomspace",
+	             &PersistSCM::load_atomspace, this, "persist");
+	define_scheme_primitive("store-atomspace",
+	             &PersistSCM::store_atomspace, this, "persist");
 	define_scheme_primitive("barrier",
 	             &PersistSCM::barrier, this, "persist");
 }
@@ -98,6 +102,18 @@ void PersistSCM::load_type(Type t)
 {
 	AtomSpace *as = SchemeSmob::ss_get_env_as("load-atoms-of-type");
 	as->fetch_all_atoms_of_type(t);
+}
+
+void PersistSCM::load_atomspace(void)
+{
+	AtomSpace *as = SchemeSmob::ss_get_env_as("load-atomspace");
+	as->load_atomspace();
+}
+
+void PersistSCM::store_atomspace(void)
+{
+	AtomSpace *as = SchemeSmob::ss_get_env_as("store-atomspace");
+	as->store_atomspace();
 }
 
 void PersistSCM::barrier(void)

--- a/opencog/persist/guile/PersistSCM.h
+++ b/opencog/persist/guile/PersistSCM.h
@@ -45,6 +45,8 @@ private:
 	void fetch_valuations(Handle, bool);
 	Handle store_atom(Handle);
 	void load_type(Type);
+	void load_atomspace(void);
+	void store_atomspace(void);
 	void barrier(void);
 
 public:

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.h
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.h
@@ -264,10 +264,8 @@ class SQLAtomStorage : public BackingStore
 		void flushStoreQueue();
 
 		// Large-scale loads and saves
-		void loadAtomSpace(AtomSpace*);
-		void storeAtomSpace(AtomSpace*);
-		void load(AtomTable &); // Load entire contents of DB
-		void store(const AtomTable &); // Store entire contents of AtomTable
+		void loadAtomSpace(AtomTable &); // Load entire contents of DB
+		void storeAtomSpace(const AtomTable &); // Store entire contents of AtomTable
 
 		// Debugging and performance monitoring
 		void print_stats(void);

--- a/opencog/persist/sql/multi-driver/SQLBulk.cc
+++ b/opencog/persist/sql/multi-driver/SQLBulk.cc
@@ -142,7 +142,7 @@ int SQLAtomStorage::getMaxObservedHeight(void)
 	return rp.intval;
 }
 
-void SQLAtomStorage::load(AtomTable &table)
+void SQLAtomStorage::loadAtomSpace(AtomTable &table)
 {
 	rethrow();
 	UUID max_nrec = getMaxObservedUUID();
@@ -261,7 +261,7 @@ void SQLAtomStorage::loadType(AtomTable &table, Type atom_type)
 }
 
 /// Store all of the atoms in the atom table.
-void SQLAtomStorage::store(const AtomTable &table)
+void SQLAtomStorage::storeAtomSpace(const AtomTable &table)
 {
 	rethrow();
 
@@ -306,16 +306,6 @@ void SQLAtomStorage::store(const AtomTable &table)
 	double rate = ((double) _store_count) / secs;
 	printf("\tFinished storing %lu atoms total, in %d seconds (%d per second)\n",
 		(unsigned long) _store_count, (int) secs, (int) rate);
-}
-
-void SQLAtomStorage::storeAtomSpace(AtomSpace* atomspace)
-{
-	store(atomspace->get_atomtable());
-}
-
-void SQLAtomStorage::loadAtomSpace(AtomSpace* atomspace)
-{
-	load(atomspace->get_atomtable());
 }
 
 /* ============================= END OF FILE ================= */

--- a/opencog/persist/sql/multi-driver/SQLPersistSCM.cc
+++ b/opencog/persist/sql/multi-driver/SQLPersistSCM.cc
@@ -63,8 +63,6 @@ void SQLPersistSCM::init(void)
 {
     define_scheme_primitive("sql-open", &SQLPersistSCM::do_open, this, "persist-sql");
     define_scheme_primitive("sql-close", &SQLPersistSCM::do_close, this, "persist-sql");
-    define_scheme_primitive("sql-load", &SQLPersistSCM::do_load, this, "persist-sql");
-    define_scheme_primitive("sql-store", &SQLPersistSCM::do_store, this, "persist-sql");
     define_scheme_primitive("sql-stats", &SQLPersistSCM::do_stats, this, "persist-sql");
     define_scheme_primitive("sql-clear-cache", &SQLPersistSCM::do_clear_cache, this, "persist-sql");
     define_scheme_primitive("sql-clear-stats", &SQLPersistSCM::do_clear_stats, this, "persist-sql");
@@ -128,25 +126,6 @@ void SQLPersistSCM::do_close(void)
     // Only then actually call the dtor.
     backing->unregisterWith(_as);
     delete backing;
-}
-
-void SQLPersistSCM::do_load(void)
-{
-    if (nullptr == _backing)
-        throw RuntimeException(TRACE_INFO,
-            "sql-load: Error: Database not open");
-
-    _backing->loadAtomSpace(_as);
-}
-
-
-void SQLPersistSCM::do_store(void)
-{
-    if (nullptr == _backing)
-        throw RuntimeException(TRACE_INFO,
-            "sql-store: Error: Database not open");
-
-    _backing->storeAtomSpace(_as);
 }
 
 void SQLPersistSCM::do_stats(void)

--- a/opencog/persist/sql/multi-driver/SQLPersistSCM.h
+++ b/opencog/persist/sql/multi-driver/SQLPersistSCM.h
@@ -55,8 +55,6 @@ public:
 
     void do_open(const std::string&);
     void do_close(void);
-    void do_load(void);
-    void do_store(void);
 
     void do_stats(void);
     void do_clear_cache(void);

--- a/opencog/scm/opencog/persist-sql.scm
+++ b/opencog/scm/opencog/persist-sql.scm
@@ -9,8 +9,8 @@
 (use-modules (opencog as-config))
 (load-extension (string-append opencog-ext-path-persist-sql "libpersist-sql") "opencog_persist_sql_init")
 
-(export sql-clear-cache sql-clear-stats sql-close sql-load sql-open
-	sql-store sql-stats sql-set-hilo-watermarks! sql-set-stall-writers!)
+(export sql-clear-cache sql-clear-stats sql-close sql-open
+	sql-stats sql-set-hilo-watermarks! sql-set-stall-writers!)
 
 (set-procedure-property! sql-clear-cache 'documentation
 "
@@ -79,15 +79,6 @@
     queues. If the flag is set, then the writers will 'stall', i.e.
     avoid doing any actual stores until the writeback queues have
     at least the low-watermark pending writes in them.
-")
-
-(set-procedure-property! sql-store 'documentation
-"
- sql-store - Store all atoms in the atomspace to the database.
-    This will dump the ENTIRE contents of the atomspace to the databse.
-    Depending on the size of the database, this can potentially take a
-    lot of time.  During normal operation, a bulk-save is rarely
-    required, as individual atoms can always be stored, one at a time.
 ")
 
 (set-procedure-property! sql-stats 'documentation

--- a/opencog/scm/opencog/persist-sql.scm
+++ b/opencog/scm/opencog/persist-sql.scm
@@ -37,15 +37,6 @@
     no longer be stored to or fetched from the database.
 ")
 
-(set-procedure-property! sql-load 'documentation
-"
- sql-load - load all atoms in the database.
-    This will cause ALL of the atoms in the open database to be loaded
-    into the atomspace. This can be a very time-consuming operation.
-    In normal operation, it is rarely necessary to load all atoms;
-    atoms can always be fetched and stored one at a time, on demand.
-")
-
 (set-procedure-property! sql-open 'documentation
 "
  sql-open URL - Open a connection to a database
@@ -106,3 +97,19 @@
     to the stdout of the server. These statistics can be quite arcane
     and are useful primarily to the developers of the database backend.
 ")
+
+(define-public (sql-load)
+"
+ sql-load - load all atoms in the database.
+    Deprecated; use `load-atomspace` instead.
+"
+	(load-atomspace)
+)
+
+(define-public (sql-store)
+"
+ sql-store - store all atoms in the database.
+    Deprecated; use `store-atomspace` instead.
+"
+	(store-atomspace)
+)

--- a/opencog/scm/opencog/persist-sql.scm
+++ b/opencog/scm/opencog/persist-sql.scm
@@ -4,8 +4,8 @@
 
 (define-module (opencog persist-sql))
 
-
 (use-modules (opencog))
+(use-modules (opencog persist))
 (use-modules (opencog as-config))
 (load-extension (string-append opencog-ext-path-persist-sql "libpersist-sql") "opencog_persist_sql_init")
 

--- a/opencog/scm/opencog/persist.scm
+++ b/opencog/scm/opencog/persist.scm
@@ -11,7 +11,7 @@
 
 ; This avoids complaints, when the docs are set, below.
 (export fetch-atom fetch-incoming-set fetch-incoming-by-type
-store-atom load-atoms-of-type barrier)
+store-atom load-atoms-of-type barrier load-atomspace store-atomspace)
 
 ;; -----------------------------------------------------
 ;;
@@ -65,6 +65,24 @@ store-atom load-atoms-of-type barrier)
     does not mean that the data was actually written to disk. It merely
     means that the atomspace, as a client of the database, has given
     them to the database.
+")
+
+(set-procedure-property! load-atomspace 'documentation
+"
+ load-atomspace - load all atoms in the database.
+    This will cause ALL of the atoms in the open database to be loaded
+    into the atomspace. This can be a very time-consuming operation.
+    In normal operation, it is rarely necessary to load all atoms;
+    atoms can always be fetched and stored one at a time, on demand.
+")
+
+(set-procedure-property! store-atomspace 'documentation
+"
+ store-atomspace - Store all atoms in the atomspace to the database.
+    This will dump the ENTIRE contents of the atomspace to the databse.
+    Depending on the size of the database, this can potentially take a
+    lot of time.  During normal operation, a bulk-save is rarely
+    required, as individual atoms can always be stored, one at a time.
 ")
 
 ;

--- a/tests/persist/sql/multi-driver/BasicSaveUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/BasicSaveUTest.cxxtest
@@ -463,7 +463,7 @@ void BasicSaveUTest::do_test_table()
     add_to_table(idx++, table1, "DD-dd-wow ");
     add_to_table(idx++, table1, "EE-ee-wow ");
 
-    store->store(*table1);
+    store->storeAtomSpace(*table1);
     // table1->print();
     delete store;
     delete table1;
@@ -474,7 +474,7 @@ void BasicSaveUTest::do_test_table()
 
     AtomTable *table2 = new AtomTable();
 
-    store->load(*table2);
+    store->loadAtomSpace(*table2);
     // table2->print();
 
     idx = 0;

--- a/tests/persist/sql/multi-driver/DeleteUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/DeleteUTest.cxxtest
@@ -508,7 +508,7 @@ void DeleteUTest::do_test_remove(void)
         check_space(i, _as, "verify-add");
 
     /* Push all atoms out to the SQL DB */
-    _pm->do_store();
+    _as->store_atomspace();
 
     printf("Initial Atomspace size=%lu expect=%d\n", _as->get_size(), 7*idx);
     TSM_ASSERT("Initial unexpected atomspace size",
@@ -618,7 +618,7 @@ void DeleteUTest::do_test_recurse(void)
         check_space(i, _as, "verify-add");
 
     /* Push all atoms out to the SQL DB */
-    _pm->do_store();
+    _as->store_atomspace();
 
     /* Perform recursive extract of some nodes.
      * This should result in thier being removed from the atomspace,

--- a/tests/persist/sql/multi-driver/FetchUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/FetchUTest.cxxtest
@@ -226,7 +226,7 @@ void FetchUTest::test_stuff(void)
 	eval->eval(sql_open);
 	eval->eval(R"((cog-set-tv! (Concept "AAA") (stv 0.1 0.11)))");
 	eval->eval(R"((cog-set-tv! (Concept "BBB") (stv 0.2 0.22)))");
-	eval->eval("(sql-store)");
+	eval->eval("(store-atomspace)");
 	eval->eval("(sql-close)");
 
 	delete _as;
@@ -255,7 +255,7 @@ void FetchUTest::test_stuff(void)
 
 	// Saving everything should not crash.  It should, however,
 	// change the TV on (Concept "BBB") back to DEFAULT_TV.
-	eval->eval("(sql-store)");
+	eval->eval("(store-atomspace)");
 	eval->eval("(sql-close)");
 
 	delete _as;
@@ -294,7 +294,7 @@ void FetchUTest::test_readonly(void)
 	eval->eval(R"((cog-set-tv! (Concept "AAA") (stv 0.1 0.11)))");
 	eval->eval(R"((cog-set-tv! (Concept "BBB") (stv 0.2 0.22)))");
 	eval->eval(R"((List (Concept "AAA") (Concept "BBB")))");
-	eval->eval("(sql-store)");
+	eval->eval("(store-atomspace)");
 	eval->eval("(sql-close)");
 
 	delete _as;

--- a/tests/persist/sql/multi-driver/PersistUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/PersistUTest.cxxtest
@@ -421,7 +421,7 @@ void PersistUTest::do_test_atomspace(void)
         check_space(i, _as, "verify-add");
 
     /* Push all atoms out to the SQL DB */
-    _pm->do_store();
+    _as->store_atomspace();
 
     /* Extract atoms from the AtomSpace. This does not delete them from
      * the SQL storage, though; to do that, they must be deleted, not


### PR DESCRIPTION
It seems reasonable to assume that all persistence backends will provide a generic bulk save/restore.  So provide this. This will reduce the overall amount of duplicated code in different backends.