### PR TITLE
Remove dead code

### DIFF
--- a/opencog/atomspace/AtomSpace.cc
+++ b/opencog/atomspace/AtomSpace.cc
@@ -407,18 +407,6 @@ Handle AtomSpace::fetch_incoming_by_type(Handle h, Type t)
     return h;
 }
 
-void AtomSpace::fetch_valuations(Handle key, bool get_all_values)
-{
-    if (nullptr == _backing_store)
-        throw RuntimeException(TRACE_INFO, "No backing store");
-
-    key = get_atom(key);
-    if (nullptr == key) return;
-
-    // Get everything from the backing store.
-    _backing_store->getValuations(_atom_table, key, get_all_values);
-}
-
 bool AtomSpace::remove_atom(Handle h, bool recursive)
 {
     // Removal of atoms from read-only databases is not allowed.

--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -302,18 +302,6 @@ public:
     Handle fetch_incoming_by_type(Handle, Type);
 
     /**
-     * Use the backing store to load all atoms that have a value
-     * set for the indicated key.  This is typically used to load
-     * up a slice of a dataset: viz, to avoid loading any other atoms.
-     *
-     * If the boolean flag is set to true, then all values on the
-     * atom are fetched; otherwise, only that one value is fetched.
-     * This can save a lot of RAM, if the atoms have a lot of misc.
-     * values attached to them.
-     */
-    void fetch_valuations(Handle, bool=false);
-
-    /**
      * Recursively store the atom to the backing store.
      * I.e. if the atom is a link, then store all of the atoms
      * in its outgoing set as well, recursively.

--- a/opencog/atomspace/BackingStore.h
+++ b/opencog/atomspace/BackingStore.h
@@ -75,13 +75,6 @@ class BackingStore
 		virtual void getIncomingByType(AtomTable&, const Handle&, Type) = 0;
 
 		/**
-		 * Get all atoms which have a value set for the given key.
-		 * If the bool flag is set, then all values on those atom are
-		 * fetched; otherwise, only that particular key is updated.
-		 */
-		virtual void getValuations(AtomTable&, const Handle&, bool) = 0;
-
-		/**
 		 * Recursively store the atom and anything in it's outgoing set.
 		 * If the atom is already in storage, this will update it's
 		 * truth value, etc. If the `synchronous` flag is set, this

--- a/opencog/persist/guile/PersistSCM.cc
+++ b/opencog/persist/guile/PersistSCM.cc
@@ -81,19 +81,6 @@ Handle PersistSCM::fetch_incoming_by_type(Handle h, Type t)
 	return h;
 }
 
-// XXX FIXME -- it appear that this was never exposed in scheme,
-// and so there are no users anywhere for this, which means that
-// there are no users for `as->fetch_valuations()` either, which
-// means it can be removed.  It's not hard to implement in SQL,
-// but does pose an implementation difficulty for IPFS. Since this
-// appears to be unused, then it really should be eliminate.
-// ... someday. In a later pull req, I guess.
-void PersistSCM::fetch_valuations(Handle key, bool get_all_values)
-{
-	AtomSpace *as = SchemeSmob::ss_get_env_as("fetch-valuations");
-	as->fetch_valuations(key, get_all_values);
-}
-
 /**
  * Store the single atom to the backing store hanging off the
  * atom-space.

--- a/opencog/persist/guile/PersistSCM.h
+++ b/opencog/persist/guile/PersistSCM.h
@@ -42,7 +42,6 @@ private:
 	Handle fetch_atom(Handle);
 	Handle fetch_incoming_set(Handle);
 	Handle fetch_incoming_by_type(Handle, Type);
-	void fetch_valuations(Handle, bool);
 	Handle store_atom(Handle);
 	void load_type(Type);
 	void load_atomspace(void);

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.h
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.h
@@ -256,7 +256,6 @@ class SQLAtomStorage : public BackingStore
 		Handle getLink(Type, const HandleSeq&);
 		void getIncomingSet(AtomTable&, const Handle&);
 		void getIncomingByType(AtomTable&, const Handle&, Type t);
-		void getValuations(AtomTable&, const Handle&, bool get_all);
 		void storeAtom(const Handle&, bool synchronous = false);
 		void removeAtom(const Handle&, bool recursive);
 		void loadType(AtomTable&, Type);

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.h
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.h
@@ -150,7 +150,6 @@ class SQLAtomStorage : public BackingStore
 		std::mutex _valuation_mutex;
 		void storeValuation(const ValuationPtr&);
 		void storeValuation(const Handle&, const Handle&, const ValuePtr&);
-		ValuePtr getValuation(const Handle&, const Handle&);
 		void deleteValuation(const Handle&, const Handle&);
 		void deleteValuation(Response&, UUID, UUID);
 		void deleteAllValuations(Response&, UUID);

--- a/opencog/persist/sql/multi-driver/SQLResponse.h
+++ b/opencog/persist/sql/multi-driver/SQLResponse.h
@@ -87,7 +87,6 @@ class SQLAtomStorage::Response
 		    fltval(0),
 		    strval(nullptr),
 		    lnkval(nullptr),
-		    get_all_values(false),
 		    intval(0)
 		{}
 
@@ -352,40 +351,6 @@ class SQLAtomStorage::Response
 
 			ValuePtr pap = store->doUnpackValue(*this);
 			atom->setValue(hkey, pap);
-			return false;
-		}
-
-		// Valuations --------------------------------------------
-		// Get the values first, and then get the atom they are attached
-		// to. This is backwards from everything up above.
-		Handle katom;
-		bool get_all_values;
-		bool get_valuations_cb(void)
-		{
-			rs->foreach_column(&Response::get_value_column_cb, this);
-
-			// Do we know this atom yet? If not, go get it.
-			// Note: it is very likely we do NOT yet have this atom!
-			Handle h(store->_tlbuf.getAtom(uuid));
-			if (nullptr == h)
-			{
-				PseudoPtr pu(store->petAtom(uuid));
-				h = store->get_recursive_if_not_exists(pu);
-				h = table->add(h, false);
-				store->_tlbuf.addAtom(h, uuid);
-			}
-
-			// If user wanted all the values, then go get them.
-			if (get_all_values)
-			{
-				store->get_atom_values(h);
-				return false;
-			}
-
-			// Otherwise, just get this one and only value.
-			ValuePtr pap = store->doUnpackValue(*this);
-			h->setValue(katom, pap);
-
 			return false;
 		}
 

--- a/opencog/persist/sql/multi-driver/SQLValues.cc
+++ b/opencog/persist/sql/multi-driver/SQLValues.cc
@@ -317,21 +317,6 @@ ValuePtr SQLAtomStorage::getValue(VUID vuid)
 	return doGetValue(buff);
 }
 
-/// Return a value, given by the key-atom pair.
-/// If the value type is a link, then the full recursive
-/// fetch is performed.
-ValuePtr SQLAtomStorage::getValuation(const Handle& key,
-                                      const Handle& atom)
-{
-	char buff[BUFSZ];
-	snprintf(buff, BUFSZ,
-		"SELECT * FROM Valuations WHERE key = %lu AND atom = %lu;",
-		get_uuid(key),
-		get_uuid(atom));
-
-	return doGetValue(buff);
-}
-
 /// Return a value, given by indicated query buffer.
 /// If the value type is a link, then the full recursive
 /// fetch is performed.

--- a/opencog/persist/sql/multi-driver/SQLValues.cc
+++ b/opencog/persist/sql/multi-driver/SQLValues.cc
@@ -491,30 +491,4 @@ void SQLAtomStorage::get_atom_values(Handle& atom)
 	rp.atom = nullptr;
 }
 
-/* ================================================================ */
-
-void SQLAtomStorage::getValuations(AtomTable& table,
-                                   const Handle& key, bool get_all_values)
-{
-	rethrow();
-
-	// If the uuid of the key is not known, the key does not exist
-	// in the database; therefore, there are no values. Just return.
-	UUID kuid = check_uuid(key);
-	if (TLB::INVALID_UUID == kuid) return;
-
-	char buff[BUFSZ];
-	snprintf(buff, BUFSZ,
-		"SELECT * FROM Valuations WHERE key=%lu;", kuid);
-
-	Response rp(conn_pool);
-	rp.store = this;
-	rp.table = &table;
-	rp.katom = key;
-	rp.get_all_values = get_all_values;
-	rp.exec(buff);
-	rp.rs->foreach_row(&Response::get_valuations_cb, &rp);
-	rp.katom = nullptr;
-}
-
 /* ============================= END OF FILE ================= */

--- a/opencog/persist/zmq/atomspace/ZMQClient.cc
+++ b/opencog/persist/zmq/atomspace/ZMQClient.cc
@@ -175,12 +175,6 @@ void ZMQClient::getIncomingByType(AtomTable& table, const Handle& h, Type t)
 	// TODO: implement
 }
 
-void ZMQClient::getValuations(AtomTable& table,
-                              const Handle& key, bool get_all_values)
-{
-	// TODO: implement
-}
-
 /**
  * Fetch Node from database, with the indicated type and name.
  * If there is no such node, NULL is returned.

--- a/opencog/persist/zmq/atomspace/ZMQClient.h
+++ b/opencog/persist/zmq/atomspace/ZMQClient.h
@@ -88,7 +88,6 @@ class ZMQClient
 		void load(AtomTable &); // Load entire contents of DB
 		void getIncomingSet(AtomTable&, const Handle&);
 		void getIncomingByType(AtomTable&, const Handle&, Type);
-		void getValuations(AtomTable&, const Handle&, bool);
 		void store(const AtomTable &); // Store entire contents of AtomTable
 		void reserve(void);     // reserve range of UUID's
 

--- a/opencog/persist/zmq/atomspace/ZMQPersistSCM.cc
+++ b/opencog/persist/zmq/atomspace/ZMQPersistSCM.cc
@@ -53,7 +53,6 @@ class ZMQBackingStore : public BackingStore
 		virtual void loadType(AtomTable&, Type);
 		virtual void getIncomingSet(AtomTable&, const Handle&);
 		virtual void getIncomingByType(AtomTable&, const Handle&, Type);
-		virtual void getValuations(AtomTable&, const Handle&, bool);
 		virtual void barrier();
 };
 
@@ -93,11 +92,6 @@ void ZMQBackingStore::getIncomingSet(AtomTable& table, const Handle& h)
 void ZMQBackingStore::getIncomingByType(AtomTable& table, const Handle& h, Type t)
 {
 	_store->getIncomingByType(table, h, t);
-}
-
-void ZMQBackingStore::getValuations(AtomTable& table, const Handle& key, bool get_all)
-{
-	_store->getValuations(table, key, get_all);
 }
 
 void ZMQBackingStore::storeAtom(const Handle& h, bool synchronous)

--- a/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
@@ -123,7 +123,6 @@ class ValueSaveUTest :  public CxxTest::TestSuite
         void do_test_load_by_type();
         void do_test_link_by_type();
         void do_test_incoming();
-        void do_test_load_by_key(bool);
 
         void test_odbc_single_atom_save();
         void test_pq_single_atom_save();
@@ -139,12 +138,6 @@ class ValueSaveUTest :  public CxxTest::TestSuite
 
         void test_odbc_incoming();
         void test_pq_incoming();
-
-        void test_odbc_load_by_key();
-        void test_pq_load_by_key();
-
-        void test_odbc_load_all_key();
-        void test_pq_load_all_key();
 };
 
 /*
@@ -252,46 +245,6 @@ void ValueSaveUTest::test_pq_incoming(void)
 #if HAVE_PGSQL_STORAGE
 	uri = mkuri("postgres", dbname, username, passwd);
 	do_test_incoming();
-#endif // HAVE_PGSQL_STORAGE
-	logger().debug("END TEST: %s", __FUNCTION__);
-}
-
-void ValueSaveUTest::test_odbc_load_by_key(void)
-{
-	logger().debug("BEGIN TEST: %s", __FUNCTION__);
-#if HAVE_ODBC_STORAGE
-	uri = mkuri("odbc", dbname, username, passwd);
-	do_test_load_by_key(false);
-#endif
-	logger().debug("END TEST: %s", __FUNCTION__);
-}
-
-void ValueSaveUTest::test_pq_load_by_key(void)
-{
-	logger().debug("BEGIN TEST: %s", __FUNCTION__);
-#if HAVE_PGSQL_STORAGE
-	uri = mkuri("postgres", dbname, username, passwd);
-	do_test_load_by_key(false);
-#endif // HAVE_PGSQL_STORAGE
-	logger().debug("END TEST: %s", __FUNCTION__);
-}
-
-void ValueSaveUTest::test_odbc_load_all_key(void)
-{
-	logger().debug("BEGIN TEST: %s", __FUNCTION__);
-#if HAVE_ODBC_STORAGE
-	uri = mkuri("odbc", dbname, username, passwd);
-	do_test_load_by_key(true);
-#endif
-	logger().debug("END TEST: %s", __FUNCTION__);
-}
-
-void ValueSaveUTest::test_pq_load_all_key(void)
-{
-	logger().debug("BEGIN TEST: %s", __FUNCTION__);
-#if HAVE_PGSQL_STORAGE
-	uri = mkuri("postgres", dbname, username, passwd);
-	do_test_load_by_key(true);
 #endif // HAVE_PGSQL_STORAGE
 	logger().debug("END TEST: %s", __FUNCTION__);
 }
@@ -996,144 +949,6 @@ void ValueSaveUTest::do_test_incoming()
 	gpt = gct->getValue(gkey);
 	gpl = gcl->getValue(gkey);
 	gpv = gcv->getValue(gkey);
-
-	TS_ASSERT(*gpf == *pvf);
-	TS_ASSERT(*gpt == *pvt);
-	TS_ASSERT(*gpl == *pvl);
-	TS_ASSERT(*gpv == *pvv);
-
-	// --------------------
-	store->kill_data();
-	delete as;
-	delete store;
-}
-
-// ============================================================
-
-// Test the fetch_valuations() method in the atomspace.
-// The fetch should restore only certain values, and NOT the
-// truth values.
-void ValueSaveUTest::do_test_load_by_key(bool get_all_values)
-{
-	SQLAtomStorage *store = new SQLAtomStorage(uri);
-	TS_ASSERT(store->connected())
-
-	// Clear out left-over junk, just in case.
-	store->kill_data();
-
-	AtomSpace* as = new AtomSpace();
-	store->registerWith(as);
-
-	Handle key = as->add_node(PREDICATE_NODE, "some pred key");
-	Handle af = as->add_node(CONCEPT_NODE, "float node");
-	Handle at = as->add_node(CONCEPT_NODE, "string node");
-	Handle al = as->add_node(CONCEPT_NODE, "link depth-1 node");
-	Handle av = as->add_node(CONCEPT_NODE, "link depth-2 node");
-
-	// --------------------
-	// Now set some values
-	ValuePtr pvf = createFloatValue(
-		std::vector<double>({1.1098765432109876, 2.1234567890123456e37,
-		                     3.2109876543210987e-250}));
-	af->setValue(key, pvf);
-
-	TruthValuePtr tf(SimpleTruthValue::createTV(0.11, 100));
-	af->setTruthValue(tf);
-
-	// --------------------
-	ValuePtr pvt = createStringValue(
-		std::vector<std::string>({"aaa", "bb bb bb", "ccc ccc ccc"}));
-	at->setValue(key, pvt);
-
-	TruthValuePtr tt(SimpleTruthValue::createTV(0.22, 200));
-	at->setTruthValue(tt);
-
-	// --------------------
-	ValuePtr pvl = createLinkValue(
-		std::vector<ValuePtr>({pvf, pvt}));
-	al->setValue(key, pvl);
-
-	TruthValuePtr tl(SimpleTruthValue::createTV(0.33, 300));
-	al->setTruthValue(tl);
-
-	// --------------------
-	ValuePtr pvv = createLinkValue(
-		std::vector<ValuePtr>({pvl, pvl, pvf, pvt}));
-	av->setValue(key, pvv);
-
-	TruthValuePtr tv(SimpleTruthValue::createTV(0.44, 400));
-	av->setTruthValue(tv);
-
-	// --------------------
-	// Save, and close things down.
-	as->store_atom(af);
-	as->store_atom(at);
-	as->store_atom(al);
-	as->store_atom(av);
-	as->barrier();
-
-	delete as;
-	delete store;
-
-	// --------------------
-	// Start it up again.
-
-	store = new SQLAtomStorage(uri);
-	TS_ASSERT(store->connected())
-
-	as = new AtomSpace();
-	store->registerWith(as);
-
-	// --------------------
-	// Fetch by type. This is what we are testing.
-	Handle gkey = as->add_node(PREDICATE_NODE, "some pred key");
-	as->fetch_valuations(gkey, get_all_values);
-
-	Handle gaf = as->add_node(CONCEPT_NODE, "float node");
-	Handle gat = as->add_node(CONCEPT_NODE, "string node");
-	Handle gal = as->add_node(CONCEPT_NODE, "link depth-1 node");
-	Handle gav = as->add_node(CONCEPT_NODE, "link depth-2 node");
-
-	TS_ASSERT(*gaf == *af);
-	TS_ASSERT(*gat == *at);
-	TS_ASSERT(*gal == *al);
-	TS_ASSERT(*gav == *av);
-
-	TruthValuePtr gtf = gaf->getTruthValue();
-	TruthValuePtr gtt = gat->getTruthValue();
-	TruthValuePtr gtl = gal->getTruthValue();
-	TruthValuePtr gtv = gav->getTruthValue();
-
-	if (get_all_values)
-	{
-		TS_ASSERT(*gtf == *tf);
-		TS_ASSERT(*gtt == *tt);
-		TS_ASSERT(*gtl == *tl);
-		TS_ASSERT(*gtv == *tv);
-	}
-	else
-	{
-		TS_ASSERT(*gtf != *tf);
-		TS_ASSERT(*gtt != *tt);
-		TS_ASSERT(*gtl != *tl);
-		TS_ASSERT(*gtv != *tv);
-
-		// We expect the truth values to be untouched.
-		TS_ASSERT(gtf == TruthValue::DEFAULT_TV());
-		TS_ASSERT(gtt == TruthValue::DEFAULT_TV());
-		TS_ASSERT(gtl == TruthValue::DEFAULT_TV());
-		TS_ASSERT(gtv == TruthValue::DEFAULT_TV());
-	}
-
-	ValuePtr gpf = gaf->getValue(gkey);
-	ValuePtr gpt = gat->getValue(gkey);
-	ValuePtr gpl = gal->getValue(gkey);
-	ValuePtr gpv = gav->getValue(gkey);
-
-	TS_ASSERT(gpf != nullptr);
-	TS_ASSERT(gpt != nullptr);
-	TS_ASSERT(gpl != nullptr);
-	TS_ASSERT(gpv != nullptr);
 
 	TS_ASSERT(*gpf == *pvf);
 	TS_ASSERT(*gpt == *pvt);


### PR DESCRIPTION
A user API was never created for this database-backend code.  So there are no users of it.  And that is a good thing, since having this violates a key design principle that separates Atoms from Values: Values do not have incoming sets.  This dead code created a de facto incoming set in the sql backend that is unsupportable in general. 