### PR TITLE
Copy an Move assignment ctors

### DIFF
--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -149,6 +149,11 @@ protected:
         _atom_space(nullptr)
     {}
 
+    Atom& operator=(const Atom& other) // copy assignment operator
+        { return *this; }
+    Atom& operator=(Atom&& other) // move assignment operator
+        { return *this; }
+
     // The incoming set is not tracked by the garbage collector;
     // this is required, in order to avoid cyclic references.
     // That is, we use weak pointers here, not strong ones.

--- a/opencog/atoms/base/Handle.h
+++ b/opencog/atoms/base/Handle.h
@@ -78,13 +78,26 @@ public:
     static const ContentHash INVALID_HASH = std::numeric_limits<size_t>::max();
     static const Handle UNDEFINED;
 
+    // Copy constructor
     explicit Handle(const AtomPtr& atom) : AtomPtr(atom) {}
+
+    // Move constructor
+    explicit Handle(AtomPtr&& atom) : AtomPtr(atom) {}
+
     explicit Handle() {}
+
     ~Handle() {}
 
     ContentHash value(void) const;
 
+    // Copy assign operator
     inline Handle& operator=(const AtomPtr& a) {
+        this->AtomPtr::operator=(a);
+        return *this;
+    }
+
+    // Move assign operator
+    inline Handle& operator=(AtomPtr&& a) {
         this->AtomPtr::operator=(a);
         return *this;
     }
@@ -98,17 +111,18 @@ public:
         return get();
     }
 
-    // Allows expressions like "if(h)..." to work when h has a non-null pointer.
+    // Allows expressions like "if(h)..." to work
+    // when h has a non-null pointer.
     explicit inline operator bool() const noexcept {
         if (get()) return true;
         return false;
     }
 
     inline bool operator==(std::nullptr_t) const noexcept {
-        return get() == 0x0;
+        return get() == nullptr;
     }
     inline bool operator!=(std::nullptr_t) const noexcept {
-        return get() != 0x0;
+        return get() != nullptr;
     }
     inline bool operator==(const Atom* ap) const noexcept {
         return get() == ap;


### PR DESCRIPTION
Provide explicit copy and move assignment constructors.  

I'm assuming this might provide some mild performance benefits, but have not checked.