### PR TITLE
Assign _vardecl, _body in case ScopeLink::extract_variables didn't

### DIFF
--- a/opencog/atoms/core/PutLink.cc
+++ b/opencog/atoms/core/PutLink.cc
@@ -98,8 +98,8 @@ void PutLink::init(void)
 	}
 	else
 	{
-		// ScopeLink::extract_variables does assign _vardecl and _body
-		// when variable declaration is unquoted, so we redo it here.
+		// ScopeLink::extract_variables does not assign _vardecl and
+		// _body if variable declaration is unquoted. (Re)do it here.
 		_vardecl = _outgoing[0];
 		_body = _outgoing[1];
 		_arguments = _outgoing[2];

--- a/opencog/atoms/core/PutLink.cc
+++ b/opencog/atoms/core/PutLink.cc
@@ -97,7 +97,13 @@ void PutLink::init(void)
 		_arguments = _outgoing[1];
 	}
 	else
+	{
+		// ScopeLink::extract_variables does assign _vardecl and _body
+		// when variable declaration is unquoted, so we redo it here.
+		_vardecl = _outgoing[0];
+		_body = _outgoing[1];
 		_arguments = _outgoing[2];
+	}
 
 	static_typecheck_arguments();
 }

--- a/tests/atoms/core/PutLinkUTest.cxxtest
+++ b/tests/atoms/core/PutLinkUTest.cxxtest
@@ -99,7 +99,7 @@ public:
 	void test_get_lambda();
 	void test_get_multi();
 	void test_multi_set();
-	void xtest_full_quotation();
+	void test_full_quotation();
 };
 
 #define N _as.add_node
@@ -2241,7 +2241,7 @@ void PutLinkUTest::test_multi_set()
  * unquoted variables. Make just sure that it doesn't crash or throw
  * exception.
  */
-void PutLinkUTest::xtest_full_quotation()
+void PutLinkUTest::test_full_quotation()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 


### PR DESCRIPTION
which can happen when the variable declaration is unquoted.