### PR TITLE
Explore all permutations of an unordered link

### DIFF
--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1166,9 +1166,28 @@ bool PatternMatchEngine::explore_term_branches(const Handle& term,
 		// If no solution was found, and there are globs, then there may
 		// still be another way to ground the glob differently, to this
 		// same candidate clause. So try that, and do it until exhausted.
-		while (not found and has_glob and _glob_state.size() > gstate_size)
+		//
+		// If no solution was found, and there are unordered links, then
+		// there may be alternate permuations of the unordered link that
+		// might satisfy this clause. So try those, until exhausted.
+		//
+		// This should work even if there are mixtures of globs and
+		// unordered links, even if there are more than one of each,
+		// even if they're nested at various depths; the stacks should
+		// take care of the managing the flags.
+		while (not found and
+		       (_have_more or (has_glob and _glob_state.size() > gstate_size)))
 		{
-			DO_LOG({logger().fine("Globby clause not grounded; try again");})
+			if (_have_more)
+			{
+				_have_more = false;
+				_take_step = true;
+				DO_LOG({logger().fine("Permutable clause not grounded; try again");})
+			}
+			else
+			{
+				DO_LOG({logger().fine("Globby clause not grounded; try again");})
+			}
 			found = explore_link_branches(ptm, hg, clause_root);
 			if (found) return true;
 		}

--- a/tests/query/UnorderedUTest.cxxtest
+++ b/tests/query/UnorderedUTest.cxxtest
@@ -69,6 +69,7 @@ class UnorderedUTest :  public CxxTest::TestSuite
 		void test_un1(void);
 		void test_un2(void);
 		void test_exhaust(void);
+		void test_embed(void);
 };
 
 /*
@@ -225,6 +226,27 @@ void UnorderedUTest::test_exhaust(void)
 
 	logger().debug("exhaust-eq-6 result is %s\n", SchemeSmob::to_string(result).c_str());
 	TSM_ASSERT_EQUALS("wrong number of solutions found", 6, getarity(result));
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+void UnorderedUTest::test_embed(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	SchemeEval* eval = new SchemeEval(as);
+	eval->eval("(load-from-path \"tests/query/unordered-embed.scm\")");
+	Handle expected = eval->eval_h("expect-embedded-set");
+
+	// Make sure the scheme file actually loaded!
+	TSM_ASSERT("Failed to load test data", expected);
+
+	// Result should be a SetLink w/ two solutions
+	Handle result = eval->eval_h("(cog-execute! embedded-set)");
+
+	logger().debug("embedded result is %s\n", SchemeSmob::to_string(result).c_str());
+	TSM_ASSERT_EQUALS("wrong number of solutions found", 2, getarity(result));
+	TSM_ASSERT_EQUALS("Incorrect result", result, expected);
 
 	logger().debug("END TEST: %s", __FUNCTION__);
 }

--- a/tests/query/unordered-embed.scm
+++ b/tests/query/unordered-embed.scm
@@ -1,0 +1,14 @@
+(use-modules (opencog) (opencog exec))
+
+(List (Concept "A") (Set (Predicate "P") (Predicate "Q")))
+
+(define embedded-set
+	(Bind
+		(Present (List (Variable "$C") (Set (Variable "$X") (Variable "$Y"))))
+		(Implication (Variable "$X") (Variable "$Y"))))
+
+; The expected answer from above.
+(define expect-embedded-set
+	(Set
+		(Implication (Predicate "P") (Predicate "Q"))
+		(Implication (Predicate "Q") (Predicate "P"))))


### PR DESCRIPTION
This fixes issue #2346 and passes all unit tests, for me.
There are, however, more complex cases which are not handled.
This includes multiple SetLinks encourntered during search.