### PR TITLE
Move common code to a single method

### DIFF
--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1253,8 +1253,6 @@ bool PatternMatchEngine::explore_upglob_branches(const PatternTermPtr& ptm,
 	              << "It's grounding " << hg->to_string()
 	              << " has " << sz << " branches";})
 
-	size_t gstate_size = SIZE_MAX;
-
 	// Move up the solution graph, looking for a match.
 	bool found = false;
 	for (size_t i = 0; i < sz; i++)

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1299,22 +1299,21 @@ bool PatternMatchEngine::explore_glob_branches(const PatternTermPtr& ptm,
                                                const Handle& clause_root)
 {
 	// Check if the pattern has globs in it, and record the glob_state.
-	// Do this *before* exploring the term.
+	// Do this *before* starting exploration.
 	bool has_glob = (0 < _pat->globby_holders.count(ptm->getHandle()));
 	size_t gstate_size = _glob_state.size();
 
-	bool found = explore_link_branches(ptm, hg, clause_root);
-	if (found) return true;
-
-	// If no solution was found, and there are globs, then there may
-	// still be another way to ground the glob differently, to this
-	// same candidate clause. So try that, and do it until exhausted.
-	while (not found and has_glob and _glob_state.size() > gstate_size)
+	// If no solution is found, and there are globs, then there may
+	// be other ways to ground the glob differently.  So keep trying,
+	// until all possibilities are exhausted.
+	do
 	{
+		if (explore_link_branches(ptm, hg, clause_root))
+			return true;
 		DO_LOG({logger().fine("Globby clause not grounded; try again");})
-		found = explore_link_branches(ptm, hg, clause_root);
-		if (found) return true;
 	}
+	while (has_glob and _glob_state.size() > gstate_size);
+
 	return false;
 }
 

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1268,22 +1268,10 @@ bool PatternMatchEngine::explore_upglob_branches(const PatternTermPtr& ptm,
 		// their state will be recorded in _glob_state, so that one can,
 		// if needed, resume and try to ground those globs again in a
 		// different way (e.g. backtracking from another branchpoint).
-		// If there are no more possible ways to ground them, they
-		// will be removed from glob_state. So simply by comparing the
-		// _glob_state size before and after seems to be an OK way to
-		// quickly check if we can move on to the next one or not.
 		std::map<GlobPair, GlobState> saved_glob_state;
 		saved_glob_state = _glob_state;
-		gstate_size = _glob_state.size();
 
-		found = explore_link_branches(ptm, Handle(iset[i]), clause_root);
-
-		// If there may be another way to ground it differently to the same
-		// candidate, do it until exhausted.
-		while (not found and _glob_state.size() > gstate_size)
-		{
-			found = explore_link_branches(ptm, Handle(iset[i]), clause_root);
-		}
+		found = explore_glob_branches(ptm, Handle(iset[i]), clause_root);
 
 		// Restore the saved state, for the next go-around.
 		_glob_state = saved_glob_state;
@@ -1306,6 +1294,11 @@ bool PatternMatchEngine::explore_glob_branches(const PatternTermPtr& ptm,
 	// If no solution is found, and there are globs, then there may
 	// be other ways to ground the glob differently.  So keep trying,
 	// until all possibilities are exhausted.
+	//
+	// Once there are no more possible ways to ground globby terms,
+	// they are removed from glob_state. So simply by comparing the
+	// _glob_state size before and after seems to be an OK way to
+	// quickly check if we can move on to the next one or not.
 	do
 	{
 		if (explore_link_branches(ptm, hg, clause_root))

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1282,6 +1282,11 @@ bool PatternMatchEngine::explore_upglob_branches(const PatternTermPtr& ptm,
 	return found;
 }
 
+/// explore_glob_branches -- explore glob grounding alternatives
+///
+/// Please see the docs for `explore_link_branches` for the general
+/// idea. In this particular method, all possible alternatives for
+/// grounding glob nodes are explored.
 bool PatternMatchEngine::explore_glob_branches(const PatternTermPtr& ptm,
                                                const Handle& hg,
                                                const Handle& clause_root)

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -248,6 +248,8 @@ private:
 	                         const Handle&);
 	bool explore_upglob_branches(const PatternTermPtr&, const Handle&,
 	                         const Handle&);
+	bool explore_glob_branches(const PatternTermPtr&, const Handle&,
+	                           const Handle&);
 	bool explore_link_branches(const PatternTermPtr&, const Handle&,
 	                           const Handle&);
 	bool explore_choice_branches(const PatternTermPtr&, const Handle&,


### PR DESCRIPTION
The same exploration loop occurs in two places in the code.
Move it to it's own method.  There are no functional changes
as a result of this; its only a refactoring of the code.