### PR TITLE
Explore all permutations of an unordered link

### DIFF
--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1163,8 +1163,23 @@ bool PatternMatchEngine::explore_term_branches(const Handle& term,
 
 	for (const PatternTermPtr &ptm : pl->second)
 	{
+		DO_LOG({LAZY_LOG_FINE << "Begin exploring term: " << ptm->to_string();})
 		if (explore_glob_branches(ptm, hg, clause_root))
 			return true;
+
+		// If no solution was found, and there are unordered links, then
+		// there may be alternate permuations of the unordered link that
+		// might satisfy this clause. So try those, until exhausted.
+		// Note that these unordered links might be buried deeply;
+		// that is why we iterate over them here.
+		while (_have_more)
+		{
+			_have_more = false;
+			_take_step = true;
+
+			if (explore_glob_branches(ptm, hg, clause_root))
+				return true;
+		}
 	}
 	return false;
 }
@@ -1306,7 +1321,8 @@ bool PatternMatchEngine::explore_glob_branches(const PatternTermPtr& ptm,
 	{
 		if (explore_link_branches(ptm, hg, clause_root))
 			return true;
-		DO_LOG({logger().fine("Globby clause not grounded; try again");})
+		if (has_glob)
+			DO_LOG({logger().fine("Globby clause not grounded; try again");})
 	}
 	while (has_glob and _glob_state.size() > gstate_size);
 
@@ -1393,7 +1409,7 @@ bool PatternMatchEngine::explore_choice_branches(const PatternTermPtr& ptm,
 		// However, currently, no test case trips this up. so .. OK.
 		// Whatever. This still probably needs fixing.
 		if (_need_choice_push) choice_stack.push(_choice_state);
-		bool match = explore_single_branch(ptm, hg, clause_root);
+		bool match = explore_glob_branches(ptm, hg, clause_root);
 		if (_need_choice_push) POPSTK(choice_stack, _choice_state);
 		_need_choice_push = false;
 

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1177,9 +1177,11 @@ bool PatternMatchEngine::explore_term_branches(const Handle& term,
 			_have_more = false;
 			_take_step = true;
 
+			DO_LOG({LAZY_LOG_FINE << "Continue exploring term: " << ptm->to_string();})
 			if (explore_glob_branches(ptm, hg, clause_root))
 				return true;
 		}
+		DO_LOG({LAZY_LOG_FINE << "Finished exploring term: " << ptm->to_string();})
 	}
 	return false;
 }

--- a/tests/query/PermutationsUTest.cxxtest
+++ b/tests/query/PermutationsUTest.cxxtest
@@ -93,14 +93,13 @@ void PermutationsUTest::test_bind(void)
 
 	Handle result = HandleCast(query->execute(&_as));
 	Handle expect = al(SET_LINK,
-	                   al(LIST_LINK, A, B, C),
-	                   al(LIST_LINK, A, C, B));
+	                   al(ORDERED_LINK, A, B, C),
+	                   al(ORDERED_LINK, A, C, B));
 
 	logger().debug() << "result = " << oc_to_string(result);
 	logger().debug() << "expect = " << oc_to_string(expect);
 
-	// TODO: re-enable the test once it passes
-	// TS_ASSERT_EQUALS(result, expect);
+	TS_ASSERT_EQUALS(result, expect);
 	TS_ASSERT(true);
 }
 

--- a/tests/query/PermutationsUTest.cxxtest
+++ b/tests/query/PermutationsUTest.cxxtest
@@ -78,6 +78,8 @@ void PermutationsUTest::setUp(void)
 /**
  * Test bind link with a clause containing unordered links to make
  * sure that the results consider all permutations of outgoings.
+ * See also `unordered-embed.scm` for additional variations of this
+ * same bugfix.
  */
 void PermutationsUTest::test_bind(void)
 {

--- a/tests/query/UnorderedUTest.cxxtest
+++ b/tests/query/UnorderedUTest.cxxtest
@@ -69,7 +69,7 @@ class UnorderedUTest :  public CxxTest::TestSuite
 		void test_un1(void);
 		void test_un2(void);
 		void test_exhaust(void);
-		void xtest_embed(void);
+		void test_embed(void);
 };
 
 /*
@@ -230,7 +230,7 @@ void UnorderedUTest::test_exhaust(void)
 	logger().debug("END TEST: %s", __FUNCTION__);
 }
 
-void UnorderedUTest::xtest_embed(void)
+void UnorderedUTest::test_embed(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 

--- a/tests/query/UnorderedUTest.cxxtest
+++ b/tests/query/UnorderedUTest.cxxtest
@@ -71,6 +71,7 @@ class UnorderedUTest :  public CxxTest::TestSuite
 		void test_exhaust(void);
 		void test_embed(void);
 		void xtest_cube(void);
+		void test_arcane(void);
 };
 
 /*
@@ -283,6 +284,25 @@ void UnorderedUTest::xtest_cube(void)
 	logger().debug("cube result is %s\n", SchemeSmob::to_string(result).c_str());
 	TSM_ASSERT_EQUALS("wrong number of solutions found", 8, getarity(result));
 	TSM_ASSERT_EQUALS("Incorrect result", result, expected);
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+// A simple bug that triggers an in loop; however, very complicated
+// arcane inputs are needed to trigger the bug. See #2357 and #2360
+// for details.
+void UnorderedUTest::test_arcane(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	SchemeEval* eval = new SchemeEval(as);
+	eval->eval("(load-from-path \"tests/query/unordered-arcane.scm\")");
+
+	// Result should be a SetLink w/ one solutions
+	Handle result = eval->eval_h("(cog-execute! query)");
+
+	logger().debug("embedded result is %s\n", SchemeSmob::to_string(result).c_str());
+	TSM_ASSERT_EQUALS("wrong number of solutions found", 1, getarity(result));
 
 	logger().debug("END TEST: %s", __FUNCTION__);
 }

--- a/tests/query/unordered-arcane.scm
+++ b/tests/query/unordered-arcane.scm
@@ -1,0 +1,46 @@
+;
+; Test for infinite loop caused in #2357 fixed in #2360
+; The stuff in here is kind of crazy, but all if it is needed
+; to provoke the bug.
+
+(use-modules (opencog) (opencog exec) (opencog logger))
+; (cog-logger-set-level! "fine")
+; (cog-logger-set-stdout! #t)
+
+; Target graph to be found
+(ListLink
+	(OrderedLink (VariableList (VariableNode "$W"))
+		(PresentLink
+			(InheritanceLink (VariableNode "$W") (Concept "A"))
+			(InheritanceLink (Concept "A") (Concept "B"))))
+	(NumberNode "5.000000"))
+
+; This is never matched, but needs to be present to trigger
+; several explores in `do_term_up()`
+(AndLink
+	(InheritanceLink (VariableNode "$W") (Concept "A"))
+	(InheritanceLink (Concept "A") (Concept "B")))
+
+; Query to run.
+; The Quote...Unquote is needed to trigger the bug; removing
+; the quotes hides the bug.  Note that in the original bug report,
+; the OrderedLink was a LambdaLink.
+(define query
+	(GetLink (PresentLink
+
+		; Matches the target graph
+		(ListLink (QuoteLink
+			(OrderedLink (UnquoteLink (VariableNode "$f-vardecl"))
+				(PresentLink (UnquoteLink (VariableNode "$cnj-bodies-1"))
+					(UnquoteLink (VariableNode "$cnj-bodies-0")))))
+			(VariableNode "$ms-0"))
+
+		; Also matches the target graph
+		(ListLink (QuoteLink
+			(OrderedLink (UnquoteLink (VariableNode "$f-vardecl"))
+				(PresentLink (UnquoteLink (VariableNode "$cnj-bodies-1"))
+					(UnquoteLink (VariableNode "$cnj-bodies-0")))))
+			(VariableNode "$ms-1")))))
+
+; Run the query.
+; (cog-execute! query)

--- a/tests/query/unordered-arcane.scm
+++ b/tests/query/unordered-arcane.scm
@@ -9,7 +9,7 @@
 
 ; Target graph to be found
 (ListLink
-	(OrderedLink (VariableList (VariableNode "$W"))
+	(LambdaLink (VariableList (VariableNode "$W"))
 		(PresentLink
 			(InheritanceLink (VariableNode "$W") (Concept "A"))
 			(InheritanceLink (Concept "A") (Concept "B"))))
@@ -24,20 +24,21 @@
 ; Query to run.
 ; The Quote...Unquote is needed to trigger the bug; removing
 ; the quotes hides the bug.  Note that in the original bug report,
-; the OrderedLink was a LambdaLink.
+; the OrderedLink was a LambdaLink. OK, I put it back to Lambda.
+; If testing w/o the quotes, users Ordered...
 (define query
 	(GetLink (PresentLink
 
 		; Matches the target graph
 		(ListLink (QuoteLink
-			(OrderedLink (UnquoteLink (VariableNode "$f-vardecl"))
+			(LambdaLink (UnquoteLink (VariableNode "$f-vardecl"))
 				(PresentLink (UnquoteLink (VariableNode "$cnj-bodies-1"))
 					(UnquoteLink (VariableNode "$cnj-bodies-0")))))
 			(VariableNode "$ms-0"))
 
 		; Also matches the target graph
 		(ListLink (QuoteLink
-			(OrderedLink (UnquoteLink (VariableNode "$f-vardecl"))
+			(LambdaLink (UnquoteLink (VariableNode "$f-vardecl"))
 				(PresentLink (UnquoteLink (VariableNode "$cnj-bodies-1"))
 					(UnquoteLink (VariableNode "$cnj-bodies-0")))))
 			(VariableNode "$ms-1")))))


### PR DESCRIPTION
This fixes issue #2346 and passes all unit tests, for me.
There are, however, more complex cases which are not handled.
This includes multiple SetLinks encourntered during search.