### PR TITLE
Bug-fix unordered-search corruption.

### DIFF
--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1436,11 +1436,8 @@ bool PatternMatchEngine::explore_single_branch(const PatternTermPtr& ptm,
 	DO_LOG({LAZY_LOG_FINE << "Pattern term=" << ptm->getHandle()->to_string()
 	              << " solved by " << hg->to_string() << ", move up";})
 
-	// XXX should not do perm_push every time... only selectively.
-	// But when? This is very confusing ...
-	perm_push();
+	// Continue onwards to the rest of the pattern.
 	bool found = do_term_up(ptm, hg, clause_root);
-	perm_pop();
 
 	solution_pop();
 	return found;


### PR DESCRIPTION
This appears to be at the root cause of the failure provided in https://github.com/opencog/atomspace/pull/2357#issuecomment-552384576 