### PR TITLE
check arg type in python's atom factory method

### DIFF
--- a/opencog/cython/opencog/atomspace_details.pyx
+++ b/opencog/cython/opencog/atomspace_details.pyx
@@ -125,6 +125,8 @@ cdef class AtomSpace:
         for atom in outgoing:
             if isinstance(atom, Atom):
                 handle_vector.push_back(deref((<Atom>(atom)).handle))
+            else:
+                raise TypeError("outgoing set should contain atoms, got {0} instead".format(type(atom)))
         cdef cHandle result
         result = self.atomspace.add_link(t, handle_vector)
         if result == result.UNDEFINED: return None

--- a/tests/cython/atomspace/test_atom.py
+++ b/tests/cython/atomspace/test_atom.py
@@ -47,8 +47,11 @@ class AtomTest(TestCase):
         self.assertIn(key, keys)
 
     def test_get_out(self):
-        atom = ListLink('list', ConceptNode('a'), ConceptNode('b'))
 
+        with self.assertRaises(TypeError):
+            atom = ListLink('list', ConceptNode('a'), ConceptNode('b'))
+
+        atom = ListLink(ConceptNode('a'), ConceptNode('b'))
         out = atom.out
 
         self.assertEqual(out, [ConceptNode('a'), ConceptNode('b')])


### PR DESCRIPTION
raise error on type of argument to atom constructor in python
fix for issue https://github.com/opencog/atomspace/issues/2302