### PR TITLE
Implement VariableSet

### DIFF
--- a/opencog/atoms/atom_types/atom_types.script
+++ b/opencog/atoms/atom_types/atom_types.script
@@ -235,6 +235,12 @@ VARIABLE_NODE <- NODE
 // A list of variables or variable declarations.
 VARIABLE_LIST <- LIST_LINK
 
+// A set (thus unordered) of variables or variable declarations. This
+// is convenient when combined with a scope link where the order of
+// variables is irrelevant to the semantics of the scope, like a
+// BindLink.
+VARIABLE_SET <- SET_LINK
+
 // A non-greedy globbing variable; matches one or more atoms in a
 // sequence.  XXX TODO - this could be changed to a link, so that
 // it resembles a FUZZY_LINK more closely?  FuzzyLink implements

--- a/opencog/atoms/core/CMakeLists.txt
+++ b/opencog/atoms/core/CMakeLists.txt
@@ -35,6 +35,7 @@ ADD_LIBRARY (atomcore
 	ValueOfLink.cc
 	Variables.cc
 	VariableList.cc
+	VariableSet.cc
 )
 
 # Without this, parallel make will race and crap up the generated files.
@@ -80,5 +81,6 @@ INSTALL (FILES
 	ValueOfLink.h
 	Variables.h
 	VariableList.h
+	VariableSet.h
 	DESTINATION "include/opencog/atoms/core"
 )

--- a/opencog/atoms/core/PrenexLink.cc
+++ b/opencog/atoms/core/PrenexLink.cc
@@ -207,6 +207,13 @@ Handle PrenexLink::beta_reduce(const HandleSeq& seq) const
 	HandleMap issued;
 
 	// First, figure out what the new variables will be.
+	//
+	// TODO: this step could be simplified by using final_variables
+	// instead of final_varlist and modifying collect to process the
+	// whole bound at once, with the help of Variables::extend.
+	// Variables::extend should also be modified to return the mapping
+	// between old and new variables when alpha-conversion is used.
+	// Similar simplications can be applied to all calls of collect.
 	Variables bound = lam->get_variables();
 	for (const Handle& bv: bound.varseq)
 	{

--- a/opencog/atoms/core/PrenexLink.h
+++ b/opencog/atoms/core/PrenexLink.h
@@ -44,7 +44,7 @@ class PrenexLink : public RewriteLink
 {
 protected:
 	void init(void);
-	Handle reassemble(Type, const HandleMap&, const HandleSeq&) const;
+	Handle reassemble(Type, const HandleMap&, const Variables&) const;
 
 public:
 	PrenexLink(const HandleSeq&, Type=PRENEX_LINK);

--- a/opencog/atoms/core/PutLink.cc
+++ b/opencog/atoms/core/PutLink.cc
@@ -159,10 +159,10 @@ void PutLink::static_typecheck_arguments(void)
 		}
 	}
 
-	size_t sz = _varlist.varseq.size();
+	size_t sz = _variables.varseq.size();
 	if (1 == sz)
 	{
-		if (not _varlist.is_type(valley)
+		if (not _variables.is_type(valley)
 		    and SET_LINK != vtype
 		    and PUT_LINK != vtype
 		    and not (nameserver().isA(vtype, SATISFYING_LINK)))
@@ -174,7 +174,7 @@ void PutLink::static_typecheck_arguments(void)
 			{
 				LambdaLinkPtr lam(LambdaLinkCast(valley));
 				const Handle& body = lam->get_body();
-				if (_varlist.is_type(body))
+				if (_variables.is_type(body))
 					return; // everything is OK.
 			}
 
@@ -194,7 +194,7 @@ void PutLink::static_typecheck_arguments(void)
 	{
 		// is_type() verifies that the arity of the vars
 		// and the arguments matches up.
-		if (not _varlist.is_type(valley->getOutgoingSet()))
+		if (not _variables.is_type(valley->getOutgoingSet()))
 		{
 			if (_vardecl)
 				throw SyntaxException(TRACE_INFO,
@@ -237,7 +237,7 @@ void PutLink::static_typecheck_arguments(void)
 				throw InvalidParamException(TRACE_INFO,
 					"PutLink expected argument list!");
 
-			if (not _varlist.is_type(h->getOutgoingSet()))
+			if (not _variables.is_type(h->getOutgoingSet()))
 				throw InvalidParamException(TRACE_INFO,
 					"PutLink bad argument list!");
 		}
@@ -247,7 +247,7 @@ void PutLink::static_typecheck_arguments(void)
 	// If the arity is one, the arguments must obey type constraint.
 	for (const Handle& h : valley->getOutgoingSet())
 	{
-		if (not _varlist.is_type(h))
+		if (not _variables.is_type(h))
 			throw InvalidParamException(TRACE_INFO,
 					"PutLink bad type!");
 	}
@@ -341,7 +341,7 @@ static inline Handle expand(const Handle& arg, bool silent)
 Handle PutLink::do_reduce(void) const
 {
 	Handle bods(_body);
-	Variables vars(_varlist);
+	Variables vars(_variables);
 	PrenexLinkPtr subs(PrenexLinkCast(get_handle()));
 	Handle args(_arguments);
 

--- a/opencog/atoms/core/RewriteLink.cc
+++ b/opencog/atoms/core/RewriteLink.cc
@@ -81,7 +81,7 @@ inline HandleSeq append_rand_str(const HandleSeq& vars)
 
 Handle RewriteLink::alpha_convert() const
 {
-	HandleSeq vars = append_rand_str(_varlist.varseq);
+	HandleSeq vars = append_rand_str(_variables.varseq);
 	return alpha_convert(vars);
 }
 
@@ -90,7 +90,7 @@ Handle RewriteLink::alpha_convert(const HandleSeq& vars) const
 	// Perform alpha conversion
 	HandleSeq hs;
 	for (size_t i = 0; i < get_arity(); ++i)
-		hs.push_back(_varlist.substitute_nocheck(getOutgoingAtom(i), vars, _silent));
+		hs.push_back(_variables.substitute_nocheck(getOutgoingAtom(i), vars, _silent));
 
 	// Create the alpha converted scope link
 	return createLink(hs, get_type());
@@ -99,7 +99,7 @@ Handle RewriteLink::alpha_convert(const HandleSeq& vars) const
 Handle RewriteLink::alpha_convert(const HandleMap& vsmap) const
 {
 	HandleSeq vars;
-	for (const Handle& var : _varlist.varseq) {
+	for (const Handle& var : _variables.varseq) {
 		auto it = vsmap.find(var);
 		vars.push_back(it == vsmap.end() ? append_rand_str(var) : it->second);
 	}

--- a/opencog/atoms/core/ScopeLink.cc
+++ b/opencog/atoms/core/ScopeLink.cc
@@ -32,6 +32,8 @@
 #include <opencog/atoms/core/LambdaLink.h>
 #include <opencog/atoms/core/TypeNode.h>
 #include <opencog/atoms/core/TypeUtils.h>
+#include <opencog/atoms/core/VariableList.h>
+#include <opencog/atoms/core/VariableSet.h>
 
 #include "ScopeLink.h"
 
@@ -105,7 +107,7 @@ void ScopeLink::extract_variables(const HandleSeq& oset)
 	// there are no variable declarations. There are two cases that can
 	// apply here: either the body is a lambda, in which case, we copy
 	// the variables from the lambda; else we extract all free variables.
-	if (VARIABLE_LIST != decls and
+	if (VARIABLE_LIST != decls and VARIABLE_SET != decls and
 	    // A VariableNode could a be valid body, if it has no variable
 	    // declaration, that is if the Scope has only one argument.
 	    (VARIABLE_NODE != decls or oset.size() == 1) and
@@ -143,15 +145,14 @@ void ScopeLink::extract_variables(const HandleSeq& oset)
 
 /* ================================================================= */
 ///
-/// Initialize _variables given a handle of either VariableList or a
-/// variable.
+/// Initialize _variables given a handle representing a variable
+/// declaration.
 ///
-void ScopeLink::init_scoped_variables(const Handle& hvar)
+void ScopeLink::init_scoped_variables(const Handle& vardecl)
 {
-	// Use the VariableList class as a tool to extract the variables
-	// for us.
-	VariableList vl(hvar);
-	_variables = vl.get_variables();
+	_variables = Variables(vardecl);
+	if (vardecl->get_type() == VARIABLE_SET)
+		_variables.canonical_sort(_body);
 }
 
 /* ================================================================= */

--- a/opencog/atoms/core/ScopeLink.cc
+++ b/opencog/atoms/core/ScopeLink.cc
@@ -261,6 +261,9 @@ ContentHash ScopeLink::compute_hash() const
 	}
 	fnv1a_hash(hsh, vth);
 
+	// As to not mix together VariableList and VariableSet
+	fnv1a_hash(hsh, _variables._ordered);
+
 	Arity vardecl_offset = _vardecl != Handle::UNDEFINED;
 	Arity n_scoped_terms = get_arity() - vardecl_offset;
 	UnorderedHandleSet hidden;

--- a/opencog/atoms/core/ScopeLink.h
+++ b/opencog/atoms/core/ScopeLink.h
@@ -57,7 +57,7 @@ protected:
 	Handle _body;
 
 	/// Variables bound in the body.
-	Variables _varlist;
+	Variables _variables;
 
 protected:
 	void init(void);
@@ -75,7 +75,7 @@ public:
 	ScopeLink(const Link &l);
 
 	// Return the list of variables we are holding.
-	const Variables& get_variables(void) const { return _varlist; }
+	const Variables& get_variables(void) const { return _variables; }
 	const Handle& get_vardecl(void) const { return _vardecl; }
 	const Handle& get_body(void) const { return _body; }
 

--- a/opencog/atoms/core/ScopeLink.h
+++ b/opencog/atoms/core/ScopeLink.h
@@ -62,7 +62,7 @@ protected:
 protected:
 	void init(void);
 	void extract_variables(const HandleSeq& oset);
-	void init_scoped_variables(const Handle& hvar);
+	void init_scoped_variables(const Handle& vardecl);
 
 	bool skip_init(Type);
 	ContentHash term_hash(const Handle&, UnorderedHandleSet&,

--- a/opencog/atoms/core/TypeUtils.cc
+++ b/opencog/atoms/core/TypeUtils.cc
@@ -316,7 +316,7 @@ Handle filter_vardecl(const Handle& vardecl, const HandleSeq& hs)
 			return vardecl;
 	}
 
-	else if (VARIABLE_LIST == t)
+	else if (VARIABLE_LIST == t or VARIABLE_SET == t)
 	{
 		HandleSeq subvardecls;
 		HandleSet subvars;      // avoid duplicating variables
@@ -331,7 +331,7 @@ Handle filter_vardecl(const Handle& vardecl, const HandleSeq& hs)
 			return Handle::UNDEFINED;
 		if (subvardecls.size() == 1)
 			return subvardecls[0];
-		return Handle(createVariableList(subvardecls));
+		return Handle(createLink(subvardecls, t));
 	}
 
 	// If we're here we have failed to recognize vardecl as a useful

--- a/opencog/atoms/core/TypeUtils.cc
+++ b/opencog/atoms/core/TypeUtils.cc
@@ -27,6 +27,7 @@
 #include <opencog/atoms/core/TypeNode.h>
 #include <opencog/atoms/core/DefineLink.h>
 #include <opencog/atoms/core/VariableList.h>
+#include <opencog/atoms/core/VariableSet.h>
 
 #include "FindUtils.h"
 
@@ -392,34 +393,22 @@ TypeSet type_intersection(const TypeSet& lhs,
 	return res;
 }
 
-VariableListPtr gen_varlist(const Handle& h)
+VariableSetPtr gen_variable_set(const Handle& h)
 {
 	HandleSet vars = get_free_variables(h);
-	return createVariableList(HandleSeq(vars.begin(), vars.end()));
+	return createVariableSet(HandleSeq(vars.begin(), vars.end()));
 }
 
 Handle gen_vardecl(const Handle& h)
 {
-	return Handle(gen_varlist(h));
-}
-
-VariableListPtr gen_varlist(const Handle& h, const Handle& vardecl)
-{
-	if (not vardecl)
-		return gen_varlist(h);
-
-	Type vardecl_t = vardecl->get_type();
-	if (vardecl_t == VARIABLE_LIST)
-		return VariableListCast(vardecl);
-
-	OC_ASSERT(vardecl_t == VARIABLE_NODE
-	          or vardecl_t == TYPED_VARIABLE_LINK);
-	return createVariableList(vardecl);
+	return Handle(gen_variable_set(h));
 }
 
 Variables gen_variables(const Handle& h, const Handle& vardecl)
 {
-	return gen_varlist(h, vardecl)->get_variables();
+	if (vardecl)
+		return Variables(vardecl);
+	return gen_variable_set(h)->get_variables();
 }
 
 Handle gen_vardecl(const Handle& h, const Handle& vardecl)
@@ -429,13 +418,14 @@ Handle gen_vardecl(const Handle& h, const Handle& vardecl)
 	return vardecl;
 }
 
-Handle gen_vardecl(const HandleSeq& varlist)
+Handle gen_vardecl(const HandleSeq& varlist, bool ordered)
 {
 	Handle vardecl;
 	if (1 == varlist.size())
 		return varlist[0];
 	else
-		return Handle(createVariableList(varlist));
+		return ordered ? Handle(createVariableList(varlist))
+			: Handle(createVariableSet(varlist));
 }
 
 } // ~namespace opencog

--- a/opencog/atoms/core/TypeUtils.h
+++ b/opencog/atoms/core/TypeUtils.h
@@ -35,6 +35,8 @@ namespace opencog
  *  @{
  */
 
+// TODO: most of what is here should be moved to Variables
+
 /**
  * Type checker.  Returns true if `value` is of type `type_spec`.
  * More precisely, returns true if `value` will fit into the type

--- a/opencog/atoms/core/TypeUtils.h
+++ b/opencog/atoms/core/TypeUtils.h
@@ -35,7 +35,7 @@ namespace opencog
  *  @{
  */
 
-// TODO: most of what is here should be moved to Variables
+// TODO: some of what is here could be moved to Variables
 
 /**
  * Type checker.  Returns true if `value` is of type `type_spec`.

--- a/opencog/atoms/core/TypeUtils.h
+++ b/opencog/atoms/core/TypeUtils.h
@@ -27,6 +27,7 @@
 #include <opencog/atoms/base/Handle.h>
 #include <opencog/atoms/atom_types/types.h>
 #include <opencog/atoms/core/VariableList.h>
+#include <opencog/atoms/core/VariableSet.h>
 
 namespace opencog
 {
@@ -183,9 +184,9 @@ TypeSet type_intersection(const TypeSet& lhs,
                           const TypeSet& rhs);
 
 /**
- * Generate a VariableList of the free variables of a given atom h.
+ * Generate a VariableSet of the free variables of a given atom h.
  */
-VariableListPtr gen_varlist(const Handle& h);
+VariableSetPtr gen_variable_set(const Handle& h);
 
 /**
  * Generate a variable declaration of the free variables of a given atom h.
@@ -194,13 +195,8 @@ Handle gen_vardecl(const Handle& h);
 
 /**
  * Given an atom h and its variable declaration vardecl, turn the
- * vardecl into a VariableList if not already, and if undefined,
- * generate a VariableList of the free variables of h.
- */
-VariableListPtr gen_varlist(const Handle& h, const Handle& vardecl);
-
-/**
- * Like above but return Variables instead.
+ * vardecl into a Variables object, and if undefined, generate a
+ * Variables object from the free variables of h.
  */
 Variables gen_variables(const Handle& h, const Handle& vardecl);
 
@@ -213,11 +209,12 @@ Handle gen_vardecl(const Handle& h, const Handle& vardecl);
  * Given a list variables or typed variables, return the
  * corresponding variable declaration.
  *
- * If varlist has only one member return a VariableNode or
- * TypedVariableLink. If varlist is empty, return an empty
- * VariableList.
+ * If varlist has only one element return a VariableNode or
+ * TypedVariableLink. If varlist is empty or has more than one
+ * element, return a VariableList if ordered is true, or a VariableSet
+ * if ordered is false.
  */
-Handle gen_vardecl(const HandleSeq& varlist);
+Handle gen_vardecl(const HandleSeq& varlist, bool ordered=true);
 
 /** @}*/
 }

--- a/opencog/atoms/core/VariableList.cc
+++ b/opencog/atoms/core/VariableList.cc
@@ -51,18 +51,18 @@ VariableList::VariableList(const Handle& vardecl)
 		// typed variable.
 		vardecl->get_type() == VARIABLE_LIST ?
 		vardecl->getOutgoingSet() : HandleSeq({vardecl}),
-		VARIABLE_LIST), _varlist(vardecl)
+		VARIABLE_LIST), _variables(vardecl)
 {
 }
 
 VariableList::VariableList(const HandleSeq& oset, Type t)
-	: Link(oset, t), _varlist(oset, true)
+	: Link(oset, t), _variables(oset, true)
 {
 	throw_if_not_variable_list(t);
 }
 
 VariableList::VariableList(const Link &l)
-	: Link(l), _varlist(l.get_handle())
+	: Link(l), _variables(l.get_handle())
 {
 	throw_if_not_variable_list(l.get_type());
 }

--- a/opencog/atoms/core/VariableList.cc
+++ b/opencog/atoms/core/VariableList.cc
@@ -24,52 +24,21 @@
 #include <math.h>
 
 #include <opencog/atoms/atom_types/NameServer.h>
-#include <opencog/atoms/core/DefineLink.h>
-#include <opencog/atoms/core/NumberNode.h>
 #include <opencog/atoms/core/TypeNode.h>
 
 #include "VariableList.h"
 
 using namespace opencog;
 
-void VariableList::validate_vardecl(const HandleSeq& oset)
+void VariableList::throw_if_not_variable_list(Type t) const
 {
-	for (const Handle& h: oset)
+	if (not nameserver().isA(t, VARIABLE_LIST))
 	{
-		Type t = h->get_type();
-		if (VARIABLE_NODE == t or GLOB_NODE == t)
-		{
-			_varlist.varset.insert(h);    // tree (unordered)
-			_varlist.varseq.emplace_back(h); // vector (ordered)
-		}
-		else if (TYPED_VARIABLE_LINK == t)
-		{
-			get_vartype(h);
-		}
-
-		// Sigh. This UnquoteLink check is a bit of hackery. It can
-		// happen, during pattern-recognition, that we are *searching*
-		// for BindLink's/GetLink's, and need to construct a dummy
-		// variable to match a variable list.  This dummy will be
-		// unquoted first.  Its not unquoting an actual VariableList,
-		// though, its just unquoting a dummy, and so there's nothing
-		// there, its empty, there's nothing to do.  So just pass on
-		// the whole she-bang.  See the `recog.scm` example for a
-		// a real-world example of this happening.
-		else if (UNQUOTE_LINK == t)
-		{
-			return;
-		}
-		else
-		{
-			throw InvalidParamException(TRACE_INFO,
-				"Expected a VariableNode or a TypedVariableLink, got: %s"
-				"\nVariableList is %s",
-					nameserver().getTypeName(t).c_str(),
-					to_string().c_str());
-		}
+		const std::string& tname = nameserver().getTypeName(t);
+		throw InvalidParamException(TRACE_INFO,
+		                            "Expecting a VariableList, got %s",
+		                            tname.c_str());
 	}
-	build_index();
 }
 
 VariableList::VariableList(const Handle& vardecl)
@@ -82,345 +51,23 @@ VariableList::VariableList(const Handle& vardecl)
 		// typed variable.
 		vardecl->get_type() == VARIABLE_LIST ?
 		vardecl->getOutgoingSet() : HandleSeq({vardecl}),
-		VARIABLE_LIST)
+		VARIABLE_LIST), _varlist(vardecl)
 {
-	validate_vardecl(getOutgoingSet());
 }
 
 VariableList::VariableList(const HandleSeq& oset, Type t)
-	: Link(oset, t)
+	: Link(oset, t), _varlist(oset, true)
 {
-	if (not nameserver().isA(t, VARIABLE_LIST))
-	{
-		const std::string& tname = nameserver().getTypeName(t);
-		throw InvalidParamException(TRACE_INFO,
-			"Expecting a VariableList, got %s", tname.c_str());
-	}
-	// derived classes have a different initialization order
-	if (VARIABLE_LIST != t) return;
-	validate_vardecl(oset);
+	throw_if_not_variable_list(t);
 }
 
 VariableList::VariableList(const Link &l)
-	: Link(l)
+	: Link(l), _varlist(l.get_handle())
 {
-	// Type must be as expected
-	Type tscope = l.get_type();
-	if (not nameserver().isA(tscope, VARIABLE_LIST))
-	{
-		const std::string& tname = nameserver().getTypeName(tscope);
-		throw InvalidParamException(TRACE_INFO,
-			"Expecting a VariableList, got %s", tname.c_str());
-	}
-
-	// Dervided types have a different initialization sequence
-	if (VARIABLE_LIST != tscope) return;
-	validate_vardecl(_outgoing);
+	throw_if_not_variable_list(l.get_type());
 }
 
 /* ================================================================= */
-/**
- * Extract the variable type(s) from a TypedVariableLink
- *
- * The call is expecting htypelink to point to one of the two
- * following structures:
- *
- *    TypedVariableLink
- *       VariableNode "$some_var_name"
- *       TypeNode  "ConceptNode"
- *
- * or
- *
- *    TypedVariableLink
- *       VariableNode "$some_var_name"
- *       TypeChoice
- *          TypeNode  "ConceptNode"
- *          TypeNode  "NumberNode"
- *          TypeNode  "WordNode"
- *
- * or possibly types that are SignatureLink's or FuyzzyLink's or
- * polymorphic combinations thereof: e.g. the following is valid:
- *
- *    TypedVariableLink
- *       VariableNode "$some_var_name"
- *       TypeChoice
- *          TypeNode  "ConceptNode"
- *          SignatureLink
- *              InheritanceLink
- *                 PredicateNode "foobar"
- *                 TypeNode  "ListLink"
- *          FuzzyLink
- *              InheritanceLink
- *                 ConceptNode "animal"
- *                 ConceptNode "tiger"
- *
- * In either case, the variable itself is appended to "vset",
- * and the list of allowed types are associated with the variable
- * via the map "typemap".
- */
-void VariableList::get_vartype(const Handle& htypelink)
-{
-	const HandleSeq& oset = htypelink->getOutgoingSet();
-	if (2 != oset.size())
-	{
-		throw InvalidParamException(TRACE_INFO,
-			"TypedVariableLink has wrong size, got %lu", oset.size());
-	}
-
-	Handle varname(oset[0]);
-	Handle vartype(oset[1]);
-
-	Type nt = varname->get_type();
-	Type t = vartype->get_type();
-
-	// Specifying how many atoms can be matched to a GlobNode, if any
-	HandleSeq intervals;
-
-	// If its a defined type, unbundle it.
-	if (DEFINED_TYPE_NODE == t)
-	{
-		vartype = DefineLink::get_definition(vartype);
-		t = vartype->get_type();
-	}
-
-	// For GlobNode, we can specify either the interval or the type, e.g.
-	//
-	// TypedVariableLink
-	//   GlobNode  "$foo"
-	//   IntervalLink
-	//     NumberNode  2
-	//     NumberNode  3
-	//
-	// or both under a TypeSetLink, e.g.
-	//
-	// TypedVariableLink
-	//   GlobNode  "$foo"
-	//   TypeSetLink
-	//     IntervalLink
-	//       NumberNode  2
-	//       NumberNode  3
-	//     TypeNode "ConceptNode"
-	if (GLOB_NODE == nt and TYPE_SET_LINK == t)
-	{
-		for (const Handle& h : vartype->getOutgoingSet())
-		{
-			Type th = h->get_type();
-
-			if (INTERVAL_LINK == th)
-				intervals = h->getOutgoingSet();
-
-			else if (TYPE_NODE == th)
-			{
-				vartype = h;
-				t = th;
-			}
-
-			else throw SyntaxException(TRACE_INFO,
-				"Unexpected contents in TypedSetLink\n"
-				"Expected IntervalLink and TypeNode, got %s",
-				h->to_string().c_str());
-		}
-	}
-
-	// The vartype is either a single type name, or a list of typenames.
-	if (TYPE_NODE == t)
-	{
-		Type vt = TypeNodeCast(vartype)->get_kind();
-		if (vt != ATOM)  // Atom type is same as untyped.
-		{
-			TypeSet ts = {vt};
-			_varlist._simple_typemap.insert({varname, ts});
-		}
-	}
-	else if (TYPE_INH_NODE == t)
-	{
-		Type vt = TypeNodeCast(vartype)->get_kind();
-		TypeSet ts;
-		TypeSet::iterator it = ts.begin();
-		nameserver().getChildren(vt, std::inserter(ts, it));
-		_varlist._simple_typemap.insert({varname, ts});
-	}
-	else if (TYPE_CO_INH_NODE == t)
-	{
-		Type vt = TypeNodeCast(vartype)->get_kind();
-		TypeSet ts;
-		TypeSet::iterator it = ts.begin();
-		nameserver().getChildren(vt, std::inserter(ts, it));
-		_varlist._simple_typemap.insert({varname, ts});
-	}
-	else if (TYPE_CHOICE == t)
-	{
-		TypeSet typeset;
-		HandleSet deepset;
-		HandleSet fuzzset;
-
-		const HandleSeq& tset = vartype->getOutgoingSet();
-		size_t tss = tset.size();
-		for (size_t i=0; i<tss; i++)
-		{
-			Handle ht(tset[i]);
-			Type var_type = ht->get_type();
-			if (TYPE_NODE == var_type)
-			{
-				Type vt = TypeNodeCast(ht)->get_kind();
-				if (ATOM != vt) typeset.insert(vt);
-			}
-			else if (SIGNATURE_LINK == var_type)
-			{
-				const HandleSeq& sig = ht->getOutgoingSet();
-				if (1 != sig.size())
-					throw SyntaxException(TRACE_INFO,
-						"Unexpected contents in SignatureLink\n"
-						"Expected arity==1, got %s", vartype->to_string().c_str());
-
-				deepset.insert(ht);
-			}
-			else if (FUZZY_LINK == var_type)
-			{
-				const HandleSeq& fuz = ht->getOutgoingSet();
-				if (1 != fuz.size())
-					throw SyntaxException(TRACE_INFO,
-						"Unexpected contents in FuzzyLink\n"
-						"Expected arity==1, got %s", vartype->to_string().c_str());
-
-				fuzzset.insert(ht);
-			}
-			else
-			{
-				throw InvalidParamException(TRACE_INFO,
-					"VariableChoice has unexpected content:\n"
-					"Expected TypeNode, got %s",
-					    nameserver().getTypeName(ht->get_type()).c_str());
-			}
-		}
-
-		if (0 < typeset.size())
-			_varlist._simple_typemap.insert({varname, typeset});
-		if (0 < deepset.size())
-			_varlist._deep_typemap.insert({varname, deepset});
-		if (0 < fuzzset.size())
-			_varlist._fuzzy_typemap.insert({varname, fuzzset});
-	}
-	else if (SIGNATURE_LINK == t)
-	{
-		const HandleSeq& tset = vartype->getOutgoingSet();
-		if (1 != tset.size())
-			throw SyntaxException(TRACE_INFO,
-				"Unexpected contents in SignatureLink\n"
-				"Expected arity==1, got %s", vartype->to_string().c_str());
-
-		HandleSet ts;
-		ts.insert(vartype);
-		_varlist._deep_typemap.insert({varname, ts});
-	}
-	else if (FUZZY_LINK == t)
-	{
-		const HandleSeq& tset = vartype->getOutgoingSet();
-		if (1 != tset.size())
-			throw SyntaxException(TRACE_INFO,
-				"Unexpected contents in FuzzyLink\n"
-				"Expected arity==1, got %s", vartype->to_string().c_str());
-
-		HandleSet ts;
-		ts.insert(vartype);
-		_varlist._fuzzy_typemap.insert({varname, ts});
-	}
-	else if (VARIABLE_NODE == t)
-	{
-		// This occurs when the variable type is a variable to be
-		// matched by the pattern matcher. There's nothing to do
-		// except not throwing an exception.
-	}
-	else if (GLOB_NODE == nt and INTERVAL_LINK == t)
-	{
-		intervals = vartype->getOutgoingSet();
-	}
-	else
-	{
-		throw SyntaxException(TRACE_INFO,
-			"Unexpected contents in TypedVariableLink\n"
-			"Expected type specifier (e.g. TypeNode, TypeChoice, etc.), got %s",
-			nameserver().getTypeName(t).c_str());
-	}
-
-	if (0 < intervals.size())
-	{
-		_varlist._glob_intervalmap.insert({varname, std::make_pair(
-			std::round(NumberNodeCast(intervals[0])->get_value()),
-			std::round(NumberNodeCast(intervals[1])->get_value()))});
-	}
-
-	_varlist.varset.insert(varname);
-	_varlist.varseq.emplace_back(varname);
-}
-
-/* ================================================================= */
-/**
- * Validate variable declarations for syntax correctness.
- *
- * This will check to make sure that a set of variable declarations are
- * of a reasonable form. Thus, for example, a structure similar to the
- * below is expected.
- *
- *       VariableList
- *          VariableNode "$var0"
- *          VariableNode "$var1"
- *          TypedVariableLink
- *             VariableNode "$var2"
- *             TypeNode  "ConceptNode"
- *          TypedVariableLink
- *             VariableNode "$var3"
- *             TypeChoice
- *                 TypeNode  "PredicateNode"
- *                 TypeNode  "GroundedPredicateNode"
- *
- * As a side-effect, the variables and type restrictions are unpacked.
- */
-void VariableList::validate_vardecl(const Handle& hdecls)
-{
-	// Expecting the declaration list to be either a single
-	// variable, or a list of variable declarations
-	Type tdecls = hdecls->get_type();
-	if (VARIABLE_NODE == tdecls or GLOB_NODE == tdecls)
-	{
-		_varlist.varset.insert(hdecls);
-		_varlist.varseq.emplace_back(hdecls);
-	}
-	else if (TYPED_VARIABLE_LINK == tdecls)
-	{
-		get_vartype(hdecls);
-	}
-	else if (VARIABLE_LIST == tdecls)
-	{
-		// The list of variable declarations should be .. a list of
-		// variables! Make sure its as expected.
-		const HandleSeq& dset = hdecls->getOutgoingSet();
-		validate_vardecl(dset);
-	}
-	else
-	{
-		throw InvalidParamException(TRACE_INFO,
-			"Expected a VariableList holding variable declarations");
-	}
-	build_index();
-}
-
-/* ================================================================= */
-/**
- * Build the index from variable name, to its ordinal number.
- * The index is needed for variable substitution, i.e. for the
- * substitute method below.  The specific sequence order of the
- * variables is essential for making substitution work.
- */
-void VariableList::build_index(void)
-{
-	if (0 < _varlist.index.size()) return;
-	size_t sz = _varlist.varseq.size();
-	for (size_t i=0; i<sz; i++)
-	{
-		_varlist.index.insert({_varlist.varseq[i], i});
-	}
-}
 
 std::string opencog::oc_to_string(const VariableListPtr& vlp,
                                   const std::string& indent)

--- a/opencog/atoms/core/VariableList.cc
+++ b/opencog/atoms/core/VariableList.cc
@@ -51,7 +51,7 @@ VariableList::VariableList(const Handle& vardecl)
 		// typed variable.
 		vardecl->get_type() == VARIABLE_LIST ?
 		vardecl->getOutgoingSet() : HandleSeq({vardecl}),
-		VARIABLE_LIST), _variables(vardecl)
+		VARIABLE_LIST), _variables(vardecl, true)
 {
 }
 
@@ -62,7 +62,7 @@ VariableList::VariableList(const HandleSeq& oset, Type t)
 }
 
 VariableList::VariableList(const Link &l)
-	: Link(l), _variables(l.get_handle())
+	: Link(l), _variables(l.get_handle(), true)
 {
 	throw_if_not_variable_list(l.get_type());
 }

--- a/opencog/atoms/core/VariableList.h
+++ b/opencog/atoms/core/VariableList.h
@@ -50,16 +50,9 @@ protected:
 	/// Unbundled variables and types for them.
 	Variables _varlist;
 
-	// See VariableList.cc for comments
-	void get_vartype(const Handle&);
-
-	// Validate the variable decls
-	void validate_vardecl(const Handle&);
-	void validate_vardecl(const HandleSeq&);
-
 	VariableList(Type, const HandleSeq&);
 
-	void build_index(void);
+	void throw_if_not_variable_list(Type t) const;
 public:
 	VariableList(const HandleSeq& vardecls, Type=VARIABLE_LIST);
 	VariableList(const Handle& hvardecls);

--- a/opencog/atoms/core/VariableList.h
+++ b/opencog/atoms/core/VariableList.h
@@ -48,7 +48,7 @@ class VariableList : public Link
 {
 protected:
 	/// Unbundled variables and types for them.
-	Variables _varlist;
+	Variables _variables;
 
 	VariableList(Type, const HandleSeq&);
 
@@ -59,29 +59,29 @@ public:
 	VariableList(const Link&);
 
 	// Return the list of variables we are holding.
-	const Variables& get_variables(void) const { return _varlist; }
+	const Variables& get_variables(void) const { return _variables; }
 
 	// Return true if we are holding a single variable, and the handle
 	// given as the argument satisfies the type restrictions (if any).
 	// Else return false.
-	bool is_type(const Handle& h) const { return _varlist.is_type(h); }
+	bool is_type(const Handle& h) const { return _variables.is_type(h); }
 
 	// Return true if we are holding the variable `var`, and `val`
 	// satisfies the type restrictions that apply to `var`.
 	bool is_type(const Handle& var, const Handle& val) const
-		{ return _varlist.is_type(var, val); }
+		{ return _variables.is_type(var, val); }
 
 	// Return true if the sequence is of the same length as the variable
 	// declarations we are holding, and if they satisfy all of the type
 	// restrictions (if any).
-	bool is_type(const HandleSeq& hseq) const { return _varlist.is_type(hseq); }
+	bool is_type(const HandleSeq& hseq) const { return _variables.is_type(hseq); }
 
 	// Given the tree `tree` containing variables in it, create and
 	// return a new tree with the indicated arguments `args` substituted
 	// for the variables. The `args` must pass the typecheck, else an
 	// exception is thrown.
 	Handle substitute(const Handle& tree, const HandleSeq& args) const
-		{ return _varlist.substitute(tree, args); }
+		{ return _variables.substitute(tree, args); }
 
 	static Handle factory(const Handle&);
 };

--- a/opencog/atoms/core/VariableSet.cc
+++ b/opencog/atoms/core/VariableSet.cc
@@ -1,0 +1,73 @@
+/*
+ * VariableSet.cc
+ *
+ * Copyright (C) 2019 SingularityNET Foundation
+ * All Rights Reserved
+ *
+ * Author: Nil Geisweiller <ngeiswei@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the
+ * exceptions at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "VariableSet.h"
+
+using namespace opencog;
+
+void VariableSet::throw_if_not_variable_set(Type t) const
+{
+	if (not nameserver().isA(t, VARIABLE_SET))
+	{
+		const std::string& tname = nameserver().getTypeName(t);
+		throw InvalidParamException(TRACE_INFO,
+			"Expecting a VariableSet, got %s", tname.c_str());
+	}
+}
+
+VariableSet::VariableSet(const HandleSeq& vardecls, Type t)
+	: Link(vardecls, t), _variables(vardecls, false)
+{
+	throw_if_not_variable_set(t);
+}
+
+VariableSet::VariableSet(const Handle& vardecl)
+	: Link(
+		not vardecl ?
+		// If vardecl is undefined then construct an empty variable set
+		HandleSeq({})
+		:
+		// Otherwise vardecl is either a VariableSet, or a naked or
+		// typed variable.
+		vardecl->get_type() == VARIABLE_SET ?
+		vardecl->getOutgoingSet() : HandleSeq({vardecl}),
+		VARIABLE_SET), _variables(vardecl)
+{
+	throw_if_not_variable_set(vardecl->get_type());
+}
+
+VariableSet::VariableSet(const Link &l)
+	: Link(l), _variables(l.get_handle())
+{
+	throw_if_not_variable_set(l.get_type());
+}
+
+std::string opencog::oc_to_string(const VariableSetPtr& vsp,
+                                  const std::string& indent)
+{
+	if (vsp == nullptr)
+		return indent + "nullvariableset\n";
+	else
+		return oc_to_string(vsp->get_handle(), indent);
+}

--- a/opencog/atoms/core/VariableSet.cc
+++ b/opencog/atoms/core/VariableSet.cc
@@ -24,6 +24,8 @@
 
 #include "VariableSet.h"
 
+#include <opencog/atoms/base/ClassServer.h>
+
 using namespace opencog;
 
 void VariableSet::throw_if_not_variable_set(Type t) const
@@ -37,13 +39,13 @@ void VariableSet::throw_if_not_variable_set(Type t) const
 }
 
 VariableSet::VariableSet(const HandleSeq& vardecls, Type t)
-	: Link(vardecls, t), _variables(vardecls, false)
+	: UnorderedLink(vardecls, t), _variables(vardecls, false)
 {
 	throw_if_not_variable_set(t);
 }
 
 VariableSet::VariableSet(const Handle& vardecl)
-	: Link(
+	: UnorderedLink(
 		not vardecl ?
 		// If vardecl is undefined then construct an empty variable set
 		HandleSeq({})
@@ -58,7 +60,7 @@ VariableSet::VariableSet(const Handle& vardecl)
 }
 
 VariableSet::VariableSet(const Link &l)
-	: Link(l), _variables(l.get_handle())
+	: UnorderedLink(l), _variables(l.get_handle())
 {
 	throw_if_not_variable_set(l.get_type());
 }
@@ -71,3 +73,5 @@ std::string opencog::oc_to_string(const VariableSetPtr& vsp,
 	else
 		return oc_to_string(vsp->get_handle(), indent);
 }
+
+DEFINE_LINK_FACTORY(VariableSet, VARIABLE_SET)

--- a/opencog/atoms/core/VariableSet.h
+++ b/opencog/atoms/core/VariableSet.h
@@ -1,0 +1,74 @@
+/*
+ * opencog/atoms/core/VariableList.h
+ *
+ * Copyright (C) 2019 SingularityNET Foundation
+ * All Rights Reserved
+ *
+ * Author: Nil Geisweiller <ngeiswei@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef _OPENCOG_VARIABLE_SET_H
+#define _OPENCOG_VARIABLE_SET_H
+
+#include <opencog/util/empty_string.h>
+#include <opencog/atoms/base/Link.h>
+#include <opencog/atoms/core/Variables.h>
+
+namespace opencog
+{
+/** \addtogroup grp_atomspace
+ *  @{
+ */
+
+class VariableSet : public Link
+{
+protected:
+	/// Unbundled variables and types for them.
+	Variables _variables;
+
+	void throw_if_not_variable_set(Type t) const;
+	
+public:
+	VariableSet(const HandleSeq& vardecls, Type=VARIABLE_SET);
+	VariableSet(const Handle& hvardecls);
+	VariableSet(const Link&);
+
+	// Return the list of variables we are holding.
+	const Variables& get_variables(void) const { return _variables; }
+};
+
+typedef std::shared_ptr<VariableSet> VariableSetPtr;
+static inline VariableSetPtr VariableSetCast(const Handle& h)
+	{ return std::dynamic_pointer_cast<VariableSet>(h); }
+static inline VariableSetPtr VariableSetCast(const AtomPtr& a)
+	{ return std::dynamic_pointer_cast<VariableSet>(a); }
+
+#define createVariableSet std::make_shared<VariableSet>
+
+// Debugging helpers see
+// http://wiki.opencog.org/w/Development_standards#Print_OpenCog_Objects
+// The reason indent is not an optional argument with default is
+// because gdb doesn't support that, see
+// http://stackoverflow.com/questions/16734783 for more explanation.
+std::string oc_to_string(const VariableSetPtr& vsp,
+                         const std::string& indent=empty_string);
+
+/** @}*/
+}
+
+#endif // _OPENCOG_VARIABLE_SET_H

--- a/opencog/atoms/core/VariableSet.h
+++ b/opencog/atoms/core/VariableSet.h
@@ -28,6 +28,7 @@
 #include <opencog/util/empty_string.h>
 #include <opencog/atoms/base/Link.h>
 #include <opencog/atoms/core/Variables.h>
+#include <opencog/atoms/core/UnorderedLink.h>
 
 namespace opencog
 {
@@ -35,7 +36,7 @@ namespace opencog
  *  @{
  */
 
-class VariableSet : public Link
+class VariableSet : public UnorderedLink
 {
 protected:
 	/// Unbundled variables and types for them.
@@ -50,6 +51,8 @@ public:
 
 	// Return the list of variables we are holding.
 	const Variables& get_variables(void) const { return _variables; }
+
+	static Handle factory(const Handle&);
 };
 
 typedef std::shared_ptr<VariableSet> VariableSetPtr;

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -845,8 +845,12 @@ void Variables::validate_vardecl(const Handle& hdecls)
 		return;
 
 	// Expecting the declaration list to be either a single
-	// variable, or a list of variable declarations
+	// variable, a list or a set of variable declarations.
 	Type tdecls = hdecls->get_type();
+
+	// Order matters only if it is a list of variables
+	_ordered = VARIABLE_LIST == tdecls;
+
 	if (VARIABLE_NODE == tdecls or GLOB_NODE == tdecls)
 	{
 		varset.insert(hdecls);
@@ -858,8 +862,6 @@ void Variables::validate_vardecl(const Handle& hdecls)
 	}
 	else if (VARIABLE_LIST == tdecls or VARIABLE_SET == tdecls)
 	{
-		_ordered = VARIABLE_LIST == tdecls;
-
 		// Extract the list of set of variables and make sure its as
 		// expected.
 		const HandleSeq& dset = hdecls->getOutgoingSet();

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -830,6 +830,10 @@ void Variables::get_vartype(const Handle& htypelink)
  */
 void Variables::validate_vardecl(const Handle& hdecls)
 {
+	// If no variable declaration then create the empty variables
+	if (not hdecls)
+		return;
+
 	// Expecting the declaration list to be either a single
 	// variable, or a list of variable declarations
 	Type tdecls = hdecls->get_type();
@@ -858,6 +862,13 @@ void Variables::validate_vardecl(const Handle& hdecls)
 		// variables! Make sure its as expected.
 		const HandleSeq& dset = hdecls->getOutgoingSet();
 		validate_vardecl(dset);
+	}
+	else if (UNQUOTE_LINK == tdecls)
+	{
+		// This indicates that the variable declaration is not in normal
+		// form (i.e. requires beta-reductions to be fully formed), thus
+		// variables inference is aborted for now.
+		return;
 	}
 	else
 	{
@@ -1362,20 +1373,6 @@ void Variables::validate_vardecl(const HandleSeq& oset)
 		else if (TYPED_VARIABLE_LINK == t)
 		{
 			get_vartype(h);
-		}
-
-		// Sigh. This UnquoteLink check is a bit of hackery. It can
-		// happen, during pattern-recognition, that we are *searching*
-		// for BindLink's/GetLink's, and need to construct a dummy
-		// variable to match a variable list.  This dummy will be
-		// unquoted first.  Its not unquoting an actual VariableList,
-		// though, its just unquoting a dummy, and so there's nothing
-		// there, its empty, there's nothing to do.  So just pass on
-		// the whole she-bang.  See the `recog.scm` example for a
-		// a real-world example of this happening.
-		else if (UNQUOTE_LINK == t)
-		{
-			return;
 		}
 		else
 		{

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -33,6 +33,8 @@
 #include <opencog/atoms/core/TypeNode.h>
 #include <opencog/atoms/core/TypeUtils.h>
 #include <opencog/atoms/core/FindUtils.h>
+#include <opencog/atoms/core/DefineLink.h>
+#include <opencog/atoms/core/NumberNode.h>
 
 #include "ScopeLink.h"
 #include "VariableList.h"
@@ -541,6 +543,304 @@ Handle FreeVariables::substitute_scoped(const Handle& term,
 
 /* ================================================================= */
 
+/* ================================================================= */
+/**
+ * Extract the variable type(s) from a TypedVariableLink
+ *
+ * The call is expecting htypelink to point to one of the two
+ * following structures:
+ *
+ *    TypedVariableLink
+ *       VariableNode "$some_var_name"
+ *       TypeNode  "ConceptNode"
+ *
+ * or
+ *
+ *    TypedVariableLink
+ *       VariableNode "$some_var_name"
+ *       TypeChoice
+ *          TypeNode  "ConceptNode"
+ *          TypeNode  "NumberNode"
+ *          TypeNode  "WordNode"
+ *
+ * or possibly types that are SignatureLink's or FuyzzyLink's or
+ * polymorphic combinations thereof: e.g. the following is valid:
+ *
+ *    TypedVariableLink
+ *       VariableNode "$some_var_name"
+ *       TypeChoice
+ *          TypeNode  "ConceptNode"
+ *          SignatureLink
+ *              InheritanceLink
+ *                 PredicateNode "foobar"
+ *                 TypeNode  "ListLink"
+ *          FuzzyLink
+ *              InheritanceLink
+ *                 ConceptNode "animal"
+ *                 ConceptNode "tiger"
+ *
+ * In either case, the variable itself is appended to "vset",
+ * and the list of allowed types are associated with the variable
+ * via the map "typemap".
+ */
+void Variables::get_vartype(const Handle& htypelink)
+{
+	const HandleSeq& oset = htypelink->getOutgoingSet();
+	if (2 != oset.size())
+	{
+		throw InvalidParamException(TRACE_INFO,
+			"TypedVariableLink has wrong size, got %lu", oset.size());
+	}
+
+	Handle varname(oset[0]);
+	Handle vartype(oset[1]);
+
+	Type nt = varname->get_type();
+	Type t = vartype->get_type();
+
+	// Specifying how many atoms can be matched to a GlobNode, if any
+	HandleSeq intervals;
+
+	// If its a defined type, unbundle it.
+	if (DEFINED_TYPE_NODE == t)
+	{
+		vartype = DefineLink::get_definition(vartype);
+		t = vartype->get_type();
+	}
+
+	// For GlobNode, we can specify either the interval or the type, e.g.
+	//
+	// TypedVariableLink
+	//   GlobNode  "$foo"
+	//   IntervalLink
+	//     NumberNode  2
+	//     NumberNode  3
+	//
+	// or both under a TypeSetLink, e.g.
+	//
+	// TypedVariableLink
+	//   GlobNode  "$foo"
+	//   TypeSetLink
+	//     IntervalLink
+	//       NumberNode  2
+	//       NumberNode  3
+	//     TypeNode "ConceptNode"
+	if (GLOB_NODE == nt and TYPE_SET_LINK == t)
+	{
+		for (const Handle& h : vartype->getOutgoingSet())
+		{
+			Type th = h->get_type();
+
+			if (INTERVAL_LINK == th)
+				intervals = h->getOutgoingSet();
+
+			else if (TYPE_NODE == th)
+			{
+				vartype = h;
+				t = th;
+			}
+
+			else throw SyntaxException(TRACE_INFO,
+				"Unexpected contents in TypedSetLink\n"
+				"Expected IntervalLink and TypeNode, got %s",
+				h->to_string().c_str());
+		}
+	}
+
+	// The vartype is either a single type name, or a list of typenames.
+	if (TYPE_NODE == t)
+	{
+		Type vt = TypeNodeCast(vartype)->get_kind();
+		if (vt != ATOM)  // Atom type is same as untyped.
+		{
+			TypeSet ts = {vt};
+			_simple_typemap.insert({varname, ts});
+		}
+	}
+	else if (TYPE_INH_NODE == t)
+	{
+		Type vt = TypeNodeCast(vartype)->get_kind();
+		TypeSet ts;
+		TypeSet::iterator it = ts.begin();
+		nameserver().getChildren(vt, std::inserter(ts, it));
+		_simple_typemap.insert({varname, ts});
+	}
+	else if (TYPE_CO_INH_NODE == t)
+	{
+		Type vt = TypeNodeCast(vartype)->get_kind();
+		TypeSet ts;
+		TypeSet::iterator it = ts.begin();
+		nameserver().getChildren(vt, std::inserter(ts, it));
+		_simple_typemap.insert({varname, ts});
+	}
+	else if (TYPE_CHOICE == t)
+	{
+		TypeSet typeset;
+		HandleSet deepset;
+		HandleSet fuzzset;
+
+		const HandleSeq& tset = vartype->getOutgoingSet();
+		size_t tss = tset.size();
+		for (size_t i=0; i<tss; i++)
+		{
+			Handle ht(tset[i]);
+			Type var_type = ht->get_type();
+			if (TYPE_NODE == var_type)
+			{
+				Type vt = TypeNodeCast(ht)->get_kind();
+				if (ATOM != vt) typeset.insert(vt);
+			}
+			else if (SIGNATURE_LINK == var_type)
+			{
+				const HandleSeq& sig = ht->getOutgoingSet();
+				if (1 != sig.size())
+					throw SyntaxException(TRACE_INFO,
+						"Unexpected contents in SignatureLink\n"
+						"Expected arity==1, got %s", vartype->to_string().c_str());
+
+				deepset.insert(ht);
+			}
+			else if (FUZZY_LINK == var_type)
+			{
+				const HandleSeq& fuz = ht->getOutgoingSet();
+				if (1 != fuz.size())
+					throw SyntaxException(TRACE_INFO,
+						"Unexpected contents in FuzzyLink\n"
+						"Expected arity==1, got %s", vartype->to_string().c_str());
+
+				fuzzset.insert(ht);
+			}
+			else
+			{
+				throw InvalidParamException(TRACE_INFO,
+					"VariableChoice has unexpected content:\n"
+					"Expected TypeNode, got %s",
+					    nameserver().getTypeName(ht->get_type()).c_str());
+			}
+		}
+
+		if (0 < typeset.size())
+			_simple_typemap.insert({varname, typeset});
+		if (0 < deepset.size())
+			_deep_typemap.insert({varname, deepset});
+		if (0 < fuzzset.size())
+			_fuzzy_typemap.insert({varname, fuzzset});
+	}
+	else if (SIGNATURE_LINK == t)
+	{
+		const HandleSeq& tset = vartype->getOutgoingSet();
+		if (1 != tset.size())
+			throw SyntaxException(TRACE_INFO,
+				"Unexpected contents in SignatureLink\n"
+				"Expected arity==1, got %s", vartype->to_string().c_str());
+
+		HandleSet ts;
+		ts.insert(vartype);
+		_deep_typemap.insert({varname, ts});
+	}
+	else if (FUZZY_LINK == t)
+	{
+		const HandleSeq& tset = vartype->getOutgoingSet();
+		if (1 != tset.size())
+			throw SyntaxException(TRACE_INFO,
+				"Unexpected contents in FuzzyLink\n"
+				"Expected arity==1, got %s", vartype->to_string().c_str());
+
+		HandleSet ts;
+		ts.insert(vartype);
+		_fuzzy_typemap.insert({varname, ts});
+	}
+	else if (VARIABLE_NODE == t)
+	{
+		// This occurs when the variable type is a variable to be
+		// matched by the pattern matcher. There's nothing to do
+		// except not throwing an exception.
+	}
+	else if (GLOB_NODE == nt and INTERVAL_LINK == t)
+	{
+		intervals = vartype->getOutgoingSet();
+	}
+	else
+	{
+		throw SyntaxException(TRACE_INFO,
+			"Unexpected contents in TypedVariableLink\n"
+			"Expected type specifier (e.g. TypeNode, TypeChoice, etc.), got %s",
+			nameserver().getTypeName(t).c_str());
+	}
+
+	if (0 < intervals.size())
+	{
+		_glob_intervalmap.insert({varname, std::make_pair(
+			std::round(NumberNodeCast(intervals[0])->get_value()),
+			std::round(NumberNodeCast(intervals[1])->get_value()))});
+	}
+
+	varset.insert(varname);
+	varseq.emplace_back(varname);
+}
+
+/* ================================================================= */
+/**
+ * Validate variable declarations for syntax correctness.
+ *
+ * This will check to make sure that a set of variable declarations are
+ * of a reasonable form. Thus, for example, a structure similar to the
+ * below is expected.
+ *
+ *       VariableList
+ *          VariableNode "$var0"
+ *          VariableNode "$var1"
+ *          TypedVariableLink
+ *             VariableNode "$var2"
+ *             TypeNode  "ConceptNode"
+ *          TypedVariableLink
+ *             VariableNode "$var3"
+ *             TypeChoice
+ *                 TypeNode  "PredicateNode"
+ *                 TypeNode  "GroundedPredicateNode"
+ *
+ * As a side-effect, the variables and type restrictions are unpacked.
+ */
+void Variables::validate_vardecl(const Handle& hdecls)
+{
+	// Expecting the declaration list to be either a single
+	// variable, or a list of variable declarations
+	Type tdecls = hdecls->get_type();
+	if (VARIABLE_NODE == tdecls or GLOB_NODE == tdecls)
+	{
+		varset.insert(hdecls);
+		varseq.emplace_back(hdecls);
+	}
+	else if (TYPED_VARIABLE_LINK == tdecls)
+	{
+		get_vartype(hdecls);
+	}
+	else if (VARIABLE_LIST == tdecls)
+	{
+		// The list of variable declarations should be .. a list of
+		// variables! Make sure its as expected.
+		const HandleSeq& dset = hdecls->getOutgoingSet();
+		validate_vardecl(dset);
+	}
+	else if (VARIABLE_SET == tdecls)
+	{
+		// The variable order does not matter
+		_ordered = false;
+
+		// The set of variable declarations should be .. a set of
+		// variables! Make sure its as expected.
+		const HandleSeq& dset = hdecls->getOutgoingSet();
+		validate_vardecl(dset);
+	}
+	else
+	{
+		throw InvalidParamException(TRACE_INFO,
+			"Expected a VariableList holding variable declarations");
+	}
+}
+
+
+
 bool Variables::is_well_typed() const
 {
 	for (const auto& vt : _simple_typemap)
@@ -1011,13 +1311,43 @@ Handle Variables::get_vardecl() const
 {
 	HandleSeq vars;
 	for (const Handle& var : varseq)
+void Variables::validate_vardecl(const HandleSeq& oset)
+{
+	for (const Handle& h: oset)
 	{
-		vars.emplace_back(get_type_decl(var, var));
-	}
-	if (vars.size() == 1)
-		return vars[0];
+		Type t = h->get_type();
+		if (VARIABLE_NODE == t or GLOB_NODE == t)
+		{
+			varset.insert(h);
+			varseq.emplace_back(h);
+		}
+		else if (TYPED_VARIABLE_LINK == t)
+		{
+			get_vartype(h);
+		}
 
-	return Handle(createVariableList(vars));
+		// Sigh. This UnquoteLink check is a bit of hackery. It can
+		// happen, during pattern-recognition, that we are *searching*
+		// for BindLink's/GetLink's, and need to construct a dummy
+		// variable to match a variable list.  This dummy will be
+		// unquoted first.  Its not unquoting an actual VariableList,
+		// though, its just unquoting a dummy, and so there's nothing
+		// there, its empty, there's nothing to do.  So just pass on
+		// the whole she-bang.  See the `recog.scm` example for a
+		// a real-world example of this happening.
+		else if (UNQUOTE_LINK == t)
+		{
+			return;
+		}
+		else
+		{
+			throw InvalidParamException(TRACE_INFO,
+				"Expected a VariableNode or a TypedVariableLink, got: %s"
+				"\nVariableList is %s",
+					nameserver().getTypeName(t).c_str(),
+					to_string().c_str());
+		}
+	}
 }
 
 std::string Variables::to_string(const std::string& indent) const

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -556,8 +556,13 @@ Handle FreeVariables::substitute_scoped(const Handle& term,
 
 /* ================================================================= */
 
-Variables::Variables(const Handle& vardecl)
-	: _ordered(true)
+Variables::Variables(bool ordered)
+	: _ordered(ordered)
+{
+}
+
+Variables::Variables(const Handle& vardecl, bool ordered)
+	: _ordered(ordered)
 {
 	validate_vardecl(vardecl);
 	init_index();

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -543,6 +543,20 @@ Handle FreeVariables::substitute_scoped(const Handle& term,
 
 /* ================================================================= */
 
+Variables::Variables(const Handle& vardecl)
+	: _ordered(true)
+{
+	validate_vardecl(vardecl);
+	init_index();
+}
+
+Variables::Variables(const HandleSeq& vardecls, bool ordered)
+	: _ordered(ordered)
+{
+	validate_vardecl(vardecls);
+	init_index();
+}
+
 /* ================================================================= */
 /**
  * Extract the variable type(s) from a TypedVariableLink

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -1285,6 +1285,9 @@ void Variables::extend(const Variables& vset)
 			catch(const std::out_of_range&) {}
 		}
 	}
+
+	// If either this or the other are ordered then the result is ordered
+	_ordered = _ordered or vset._ordered;
 }
 
 void Variables::erase(const Handle& var)

--- a/opencog/atoms/core/Variables.h
+++ b/opencog/atoms/core/Variables.h
@@ -102,9 +102,10 @@ struct FreeVariables
 	/// variables are not considered).
 	void find_variables(const Handle& body);
 
-	/// Like above but for outgoing sets. The ordered flag indicates
-	/// whether the outgoing set is associated with an ordered link.
-	void find_variables(const HandleSeq& oset, bool ordered=true);
+	/// Like above but for outgoing sets. The link_ordered flag
+	/// indicates whether the outgoing set is associated with an
+	/// ordered link.
+	void find_variables(const HandleSeq& oset, bool ordered_link=true);
 
 	/// Sort the variables in a canonical order determined by their
 	/// positions in the given body.  In ordered link, the ordered is
@@ -174,7 +175,8 @@ typedef std::map<Handle, std::pair<double, double>> GlobIntervalMap;
 struct Variables : public FreeVariables,
                    public boost::totally_ordered<Variables>
 {
-	// CTors.
+	// CTors. The ordered flag indicates whether we care about the
+	// order of the variables.
 	Variables(bool ordered=true);
 	Variables(const Handle& vardecl, bool ordered=true);
 	Variables(const HandleSeq& vardecls, bool ordered=true);
@@ -295,6 +297,13 @@ struct Variables : public FreeVariables,
 	///
 	/// TODO: support deep and fuzzy typemaps.
 	Handle get_vardecl() const;
+
+	/// Like FreeVariables::find_variables but set _ordered to false,
+	/// on the ground that if such a method is called then no ordered
+	/// was provided by the creator of that scope, and thus order is
+	/// not relevant.
+	void find_variables(const Handle& body);
+	void find_variables(const HandleSeq& oset, bool ordered_link=true);
 
 	// Useful for debugging
 	std::string to_string(const std::string& indent=empty_string) const;

--- a/opencog/atoms/core/Variables.h
+++ b/opencog/atoms/core/Variables.h
@@ -64,7 +64,7 @@ struct FreeVariables
 	typedef std::map<Handle, unsigned int> IndexMap;
 	IndexMap index;
 
-	// CTor, convenient for  unit tests, so far
+	// CTor, mostly convenient for unit tests
 	FreeVariables() {}
 	FreeVariables(const std::initializer_list<Handle>& variables);
 
@@ -174,10 +174,11 @@ typedef std::map<Handle, std::pair<double, double>> GlobIntervalMap;
 struct Variables : public FreeVariables,
                    public boost::totally_ordered<Variables>
 {
-	// CTor, convenient for  unit tests, so far
-	Variables() {}
+	// CTor, mostly convenient for unit tests
+	Variables()
+		: _ordered(true) {}
 	Variables(const std::initializer_list<Handle>& variables)
-		: FreeVariables(variables) {}
+		: FreeVariables(variables), _ordered(true) {}
 
 	// CTor given a variable declaration
 	Variables(const Handle& vardecl);

--- a/opencog/atoms/core/Variables.h
+++ b/opencog/atoms/core/Variables.h
@@ -174,17 +174,16 @@ typedef std::map<Handle, std::pair<double, double>> GlobIntervalMap;
 struct Variables : public FreeVariables,
                    public boost::totally_ordered<Variables>
 {
-	// CTor, mostly convenient for unit tests
-	Variables()
-		: _ordered(true) {}
-	Variables(const std::initializer_list<Handle>& variables)
-		: FreeVariables(variables), _ordered(true) {}
+	// CTors.
+	//
+	// Unordered by default as only VariableList can set such order.
+	Variables(bool ordered=false);
+	Variables(const Handle& vardecl, bool ordered=false);
+	Variables(const HandleSeq& vardecls, bool ordered=false);
 
-	// CTor given a variable declaration
-	Variables(const Handle& vardecl);
-	Variables(const HandleSeq& vardecls, bool ordered=true);
-
-	/// Whether the order matters or not
+	/// Whether the order matters or not. Typically if constructed with
+	/// VariableList then the order matters, if constructed with
+	/// VariableSet then the order does not matter.
 	bool _ordered;
 
 	/// Unbundled variables and type restrictions for them.

--- a/opencog/atoms/core/Variables.h
+++ b/opencog/atoms/core/Variables.h
@@ -170,6 +170,13 @@ struct Variables : public FreeVariables,
 	Variables(const std::initializer_list<Handle>& variables)
 		: FreeVariables(variables) {}
 
+	// CTor given a variable declaration
+	Variables(const Handle& vardecl);
+	Variables(const HandleSeq& vardecls, bool ordered=true);
+
+	/// Whether the order matters or not
+	bool _ordered;
+
 	/// Unbundled variables and type restrictions for them.
 
 	/// _simple_typemap is the (possibly empty) list of restrictions

--- a/opencog/atoms/core/Variables.h
+++ b/opencog/atoms/core/Variables.h
@@ -106,6 +106,15 @@ struct FreeVariables
 	/// whether the outgoing set is associated with an ordered link.
 	void find_variables(const HandleSeq& oset, bool ordered=true);
 
+	/// Sort the variables in a canonical order determined by their
+	/// positions in the given body.  In ordered link, the ordered is
+	/// determined by the outgoing set order (from left to right).  In
+	/// unordered links, the ordered is determined by some arbitrary,
+	/// though semantically consistent fix order.  The order only
+	/// depends on variable names as last resort, when no semantic
+	/// property can be used to break the symmetry.
+	void canonical_sort(const Handle& body);
+
 	/// Convert a variable->argument mapping into a sequence of
 	/// "arguments" that are in the same order as the free variables
 	/// in this class.  If the mapping does not mention a variable,
@@ -277,12 +286,14 @@ struct Variables : public FreeVariables,
 	/// Return just the Variable itself, if its not typed.
 	Handle get_type_decl(const Handle&, const Handle&) const;
 
-	/// This is the inverse function of VariableList(vardecls).get_variable().
+	/// Inverse of Variables(vardecl).get_variable()
 	///
-	/// That is, convert everything in this object into a single
-	/// VariableList, suitable for direct use in a ScopeLink.
+	/// That is, convert Variables object into avariable declaration,
+	/// that is a VariableList, VariableSet, TypedVariableLink,
+	/// VariableNode or GlobNode, suitable for direct use in a
+	/// ScopeLink.
 	///
-	/// If empty then return the empty VariableList.
+	/// If empty then return the empty VariableList or VariableSet.
 	///
 	/// TODO: support deep and fuzzy typemaps.
 	Handle get_vardecl() const;

--- a/opencog/atoms/core/Variables.h
+++ b/opencog/atoms/core/Variables.h
@@ -176,10 +176,11 @@ struct Variables : public FreeVariables,
                    public boost::totally_ordered<Variables>
 {
 	// CTors. The ordered flag indicates whether we care about the
-	// order of the variables.
-	Variables(bool ordered=true);
-	Variables(const Handle& vardecl, bool ordered=true);
-	Variables(const HandleSeq& vardecls, bool ordered=true);
+	// order of the variables. It is false by default and only enabled
+	// if VariableList is used.
+	Variables(bool ordered=false);
+	Variables(const Handle& vardecl, bool ordered=false);
+	Variables(const HandleSeq& vardecls, bool ordered=false);
 
 	/// Whether the order matters or not. Typically if constructed with
 	/// VariableList then the order matters, if constructed with

--- a/opencog/atoms/core/Variables.h
+++ b/opencog/atoms/core/Variables.h
@@ -277,7 +277,8 @@ struct Variables : public FreeVariables,
 	                  const HandleMap& map,
 	                  bool silent=false) const;
 
-	// Extend this variable set by adding in the given variable set.
+	// Extend this by adding in the given variables. If either this or
+	// the other are ordered, then the result is ordered
 	void extend(const Variables&);
 
 	// Erase the given variable, if exist

--- a/opencog/atoms/core/Variables.h
+++ b/opencog/atoms/core/Variables.h
@@ -175,11 +175,9 @@ struct Variables : public FreeVariables,
                    public boost::totally_ordered<Variables>
 {
 	// CTors.
-	//
-	// Unordered by default as only VariableList can set such order.
-	Variables(bool ordered=false);
-	Variables(const Handle& vardecl, bool ordered=false);
-	Variables(const HandleSeq& vardecls, bool ordered=false);
+	Variables(bool ordered=true);
+	Variables(const Handle& vardecl, bool ordered=true);
+	Variables(const HandleSeq& vardecls, bool ordered=true);
 
 	/// Whether the order matters or not. Typically if constructed with
 	/// VariableList then the order matters, if constructed with

--- a/opencog/atoms/core/Variables.h
+++ b/opencog/atoms/core/Variables.h
@@ -186,6 +186,13 @@ struct Variables : public FreeVariables,
 	/// GlobNodes in the pattern.
 	GlobIntervalMap _glob_intervalmap;
 
+	// See VariableList.cc for comments
+	void get_vartype(const Handle&);
+
+	// Validate the variable decls
+	void validate_vardecl(const Handle&);
+	void validate_vardecl(const HandleSeq&);
+
 	/// Return true iff all variables are well typed. For now only
 	/// simple types are supported, specifically if some variable is
 	/// simple typed NOTYPE, then it returns false.

--- a/opencog/atoms/execution/MapLink.cc
+++ b/opencog/atoms/execution/MapLink.cc
@@ -22,6 +22,7 @@
 #include <opencog/atoms/base/ClassServer.h>
 #include <opencog/atoms/core/FindUtils.h>
 #include <opencog/atoms/execution/Instantiator.h>
+#include <opencog/atoms/core/VariableSet.h>
 
 #include "MapLink.h"
 
@@ -48,7 +49,7 @@ void MapLink::init(void)
 		const Handle& body = _outgoing[0];
 		FreeVariables fv;
 		fv.find_variables(body);
-		Handle decl(createVariableList(fv.varseq));
+		Handle decl(createVariableSet(fv.varseq));
 		_pattern = createScopeLink(decl, body);
 	}
 	_mvars = &_pattern->get_variables();

--- a/opencog/atoms/pattern/PatternLink.h
+++ b/opencog/atoms/pattern/PatternLink.h
@@ -154,7 +154,7 @@ public:
 	            const HandleSeq&);
 
 	// Return the list of variables we are holding.
-	const Variables& get_variables(void) const { return _varlist; }
+	const Variables& get_variables(void) const { return _variables; }
 	const Pattern& get_pattern(void) const { return _pat; }
 
 	const HandleSeqSeq& get_components(void) const { return _components; }

--- a/opencog/atoms/pattern/QueryLink.cc
+++ b/opencog/atoms/pattern/QueryLink.cc
@@ -92,7 +92,7 @@ void QueryLink::extract_variables(const HandleSeq& oset)
 	{
 		_body = oset[0];
 		_implicand = oset[1];
-		_variables.find_variables(oset[0]);
+		_variables.find_variables(_body);
 		return;
 	}
 
@@ -103,7 +103,7 @@ void QueryLink::extract_variables(const HandleSeq& oset)
 	_implicand = oset[2];
 
 	// Initialize _variables with the scoped variables
-	init_scoped_variables(oset[0]);
+	init_scoped_variables(_vardecl);
 }
 
 /* ================================================================= */

--- a/opencog/atoms/pattern/QueryLink.cc
+++ b/opencog/atoms/pattern/QueryLink.cc
@@ -92,7 +92,7 @@ void QueryLink::extract_variables(const HandleSeq& oset)
 	{
 		_body = oset[0];
 		_implicand = oset[1];
-		_varlist.find_variables(oset[0]);
+		_variables.find_variables(oset[0]);
 		return;
 	}
 
@@ -102,7 +102,7 @@ void QueryLink::extract_variables(const HandleSeq& oset)
 	_body = oset[1];
 	_implicand = oset[2];
 
-	// Initialize _varlist with the scoped variables
+	// Initialize _variables with the scoped variables
 	init_scoped_variables(oset[0]);
 }
 

--- a/opencog/query/PatternLinkRuntime.cc
+++ b/opencog/query/PatternLinkRuntime.cc
@@ -329,8 +329,8 @@ bool PatternLink::satisfy(PatternMatchCallback& pmcb) const
 
 		debug_log();
 
-		pme.set_pattern(_varlist, _pat);
-		pmcb.set_pattern(_varlist, _pat);
+		pme.set_pattern(_variables, _pat);
+		pmcb.set_pattern(_variables, _pat);
 		bool found = pmcb.initiate_search(&pme);
 
 #ifdef DEBUG
@@ -423,7 +423,7 @@ bool PatternLink::satisfy(PatternMatchCallback& pmcb) const
 #endif
 	HandleMap empty_vg;
 	HandleMap empty_pg;
-	pmcb.set_pattern(_varlist, _pat);
+	pmcb.set_pattern(_variables, _pat);
 	return recursive_virtual(pmcb, _virtual, _pat.optionals,
 	                         empty_vg, empty_pg,
 	                         comp_var_gnds, comp_term_gnds);

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -841,7 +841,7 @@ bool PatternMatchEngine::glob_compare(const PatternTermSeq& osp,
 
 			// If the lower bound of the interval is zero, the glob
 			// can be grounded to nothing.
-			if (_varlist->is_lower_bound(ohp, 0))
+			if (_variables->is_lower_bound(ohp, 0))
 			{
 				// Try again, find another glob that can be grounded
 				// in a different way. (we are probably resuming the
@@ -874,7 +874,7 @@ bool PatternMatchEngine::glob_compare(const PatternTermSeq& osp,
 
 				// Just in case, if the upper bound is zero...
 				// XXX Huh ???
-				if (not _varlist->is_upper_bound(ohp, 1))
+				if (not _variables->is_upper_bound(ohp, 1))
 				{
 					record_match(glob, glob_seq);
 					ip++;
@@ -907,7 +907,7 @@ bool PatternMatchEngine::glob_compare(const PatternTermSeq& osp,
 					}
 
 					// Can't exceed the upper bound.
-					if (not _varlist->is_upper_bound(ohp, glob_seq.size()+1))
+					if (not _variables->is_upper_bound(ohp, glob_seq.size()+1))
 					{
 						jg--;
 						break;
@@ -931,7 +931,7 @@ bool PatternMatchEngine::glob_compare(const PatternTermSeq& osp,
 
 			// Try again if we can't ground enough atoms to satisfy
 			// the lower bound restriction.
-			if (not _varlist->is_lower_bound(ohp, glob_seq.size()))
+			if (not _variables->is_lower_bound(ohp, glob_seq.size()))
 			{
 				backtrack(true);
 				continue;
@@ -1047,7 +1047,7 @@ bool PatternMatchEngine::tree_compare(const PatternTermPtr& ptm,
 	// of the bound variables. If so, then declare a match.
 	if (not ptm->isQuoted())
 	{
-		if (_varlist->varset.end() != _varlist->varset.find(hp))
+		if (_variables->varset.end() != _variables->varset.find(hp))
 			return variable_compare(hp, hg);
 
 		// Report other variables that might be found.
@@ -1836,7 +1836,7 @@ void PatternMatchEngine::get_next_untried_clause(void)
 		if (issued.end() != issued.find(root)) continue;
 		issued.insert(root);
 		next_clause = root;
-		for (const Handle &v : _varlist->varset)
+		for (const Handle &v : _variables->varset)
 		{
 			if (is_free_in_tree(root, v))
 			{
@@ -1964,7 +1964,7 @@ bool PatternMatchEngine::get_next_thinnest_clause(bool search_virtual,
 	// Grounded variables ordered by the size of their grounding incoming set
 	std::multimap<std::size_t, Handle> thick_vars;
 
-	for (const Handle &v : _varlist->varset)
+	for (const Handle &v : _variables->varset)
 	{
 		const auto& gnd = var_grounding.find(v);
 		if (gnd != var_grounding.end())
@@ -2379,7 +2379,7 @@ bool PatternMatchEngine::explore_constant_evaluatables(const HandleSeq& clauses)
 PatternMatchEngine::PatternMatchEngine(PatternMatchCallback& pmcb)
 	: _pmc(pmcb),
 	_nameserver(nameserver()),
-	_varlist(nullptr),
+	_variables(nullptr),
 	_pat(nullptr),
 	clause_accepted(false)
 {
@@ -2401,7 +2401,7 @@ PatternMatchEngine::PatternMatchEngine(PatternMatchCallback& pmcb)
 void PatternMatchEngine::set_pattern(const Variables& v,
                                      const Pattern& p)
 {
-	_varlist = &v;
+	_variables = &v;
 	_pat = &p;
 }
 

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -51,7 +51,7 @@ private:
 	// grounded. The variables are what are being directly grounded.
 
 	// These are pointers; maybe they could be (should be?) references.
-	const Variables* _varlist;
+	const Variables* _variables;
 	const Pattern* _pat;
 
 	bool is_optional(const Handle& h) {

--- a/tests/atoms/AlphaConvertUTest.cxxtest
+++ b/tests/atoms/AlphaConvertUTest.cxxtest
@@ -88,7 +88,7 @@ void AlphaConvertUTest::test_untyped_variable()
 	_asb.clear();
 	Handle hscoz =
 	LB(SCOPE_LINK,
-		LB(VARIABLE_LIST, NB(VARIABLE_NODE, "$Z")),
+		LB(VARIABLE_SET, NB(VARIABLE_NODE, "$Z")),
 		LB(AND_LINK, NB(VARIABLE_NODE, "$Z")));
 
 	// x and z should be equal
@@ -231,7 +231,7 @@ void AlphaConvertUTest::test_atomspace()
 
 	Handle hscoz =
 	LA(SCOPE_LINK,
-		LA(VARIABLE_LIST, NA(VARIABLE_NODE, "$Z")),
+		LA(VARIABLE_SET, NA(VARIABLE_NODE, "$Z")),
 		LA(AND_LINK, NA(VARIABLE_NODE, "$Z")));
 
 	// x and z should be equal

--- a/tests/atoms/AlphaConvertUTest.cxxtest
+++ b/tests/atoms/AlphaConvertUTest.cxxtest
@@ -52,6 +52,7 @@ public:
 	void test_atomspace();
 	void test_bindlink();
 	void test_vardecl_free_scope();
+	void test_variable_set_scope();
 };
 
 #define NA _asa.add_node
@@ -327,6 +328,42 @@ void AlphaConvertUTest::test_vardecl_free_scope()
 
 	// hsco1 and hsco2 should be equal as they are alpha-equivalent.
 	TS_ASSERT(sco1->is_equal(hsco2));
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// Test is_equal for scopes with mixture of VariableList, VariableSet
+// and no variable declarations.
+void AlphaConvertUTest::test_variable_set_scope()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle X = NA(VARIABLE_NODE, "$X");
+	Handle Y = NA(VARIABLE_NODE, "$Y");
+
+	Handle sh1 = LA(SCOPE_LINK,
+	                LA(VARIABLE_SET, X, Y),
+	                LA(LIST_LINK, X, Y));
+	Handle sh2 = LA(SCOPE_LINK,
+	                LA(VARIABLE_LIST, X, Y),
+	                LA(LIST_LINK, X, Y));
+	Handle sh3 = LA(SCOPE_LINK,
+	                LA(VARIABLE_LIST, Y, X),
+	                LA(LIST_LINK, X, Y));
+	Handle sh4 = LA(SCOPE_LINK,
+	                LA(LIST_LINK, X, Y));
+
+	ScopeLinkPtr sc1 = ScopeLinkCast(sh1);
+	ScopeLinkPtr sc2 = ScopeLinkCast(sh2);
+	ScopeLinkPtr sc3 = ScopeLinkCast(sh3);
+	ScopeLinkPtr sc4 = ScopeLinkCast(sh4);
+
+	TS_ASSERT(not sc1->is_equal(sh2));
+	TS_ASSERT(not sc1->is_equal(sh3));
+	TS_ASSERT(sc1->is_equal(sh4));
+	TS_ASSERT(not sc2->is_equal(sh3));
+	TS_ASSERT(not sc2->is_equal(sh4));
+	TS_ASSERT(not sc3->is_equal(sh4));
 
 	logger().info("END TEST: %s", __FUNCTION__);
 }

--- a/tests/atoms/core/CMakeLists.txt
+++ b/tests/atoms/core/CMakeLists.txt
@@ -25,5 +25,7 @@ ADD_CXXTEST(CheckersUTest)
 
 ADD_CXXTEST(FindUtilsUTest)
 
+ADD_CXXTEST(TypeUtilsUTest)
+
 ADD_CXXTEST(VariablesUTest)
 TARGET_LINK_LIBRARIES(VariablesUTest atomspace)

--- a/tests/atoms/core/PutLinkUTest.cxxtest
+++ b/tests/atoms/core/PutLinkUTest.cxxtest
@@ -2,7 +2,7 @@
  * tests/atoms/PutLinkUTest.cxxtest
  *
  * Copyright (C) 2015,2017 Linas Vepstas
- * Copyright (C) 2016 Nil Geiswieller
+ * Copyright (C) 2016 Nil Geisweiller
  * All Rights Reserved
  *
  * This program is free software; you can redistribute it and/or modify
@@ -538,9 +538,6 @@ void PutLinkUTest::test_compose()
 
 	Handle expected_putted =
 		L(LAMBDA_LINK,
-			L(VARIABLE_LIST,
-				N(VARIABLE_NODE, "$x"),
-				N(VARIABLE_NODE, "$y")),
 			L(EVALUATION_LINK,
 				N(PREDICATE_NODE, "P"),
 				L(INHERITANCE_LINK,

--- a/tests/atoms/core/ScopeLinkUTest.cxxtest
+++ b/tests/atoms/core/ScopeLinkUTest.cxxtest
@@ -41,7 +41,7 @@ class ScopeLinkUTest :  public CxxTest::TestSuite
 private:
 	AtomSpace _as;
 	SchemeEval _eval;
-	Handle X, Y, S, T, P, Q, CT;
+	Handle X, Y, Z, S, T, P, Q, CT;
 
 public:
 	ScopeLinkUTest() : _eval(&_as)
@@ -50,6 +50,7 @@ public:
 
 		X = an(VARIABLE_NODE, "$X");
 		Y = an(VARIABLE_NODE, "$Y");
+		Z = an(VARIABLE_NODE, "$Z");
 		S = an(VARIABLE_NODE, "$S");
 		T = an(VARIABLE_NODE, "$T");
 		P = an(PREDICATE_NODE, "P");
@@ -72,6 +73,9 @@ public:
 	void test_get_variables_1();
 	void test_get_variables_2();
 	void test_get_variables_3();
+	void test_get_variables_4();
+	void test_get_variables_5();
+	void test_get_variables_6();
 };
 
 void ScopeLinkUTest::test_content_less()
@@ -290,6 +294,95 @@ void ScopeLinkUTest::test_get_variables_3()
 	printf("Excepted %s\n", oc_to_string(exp).c_str());
 
 	TS_ASSERT_EQUALS(got, exp);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void ScopeLinkUTest::test_get_variables_4()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Test that default variables in scope link are sorted according
+	// to canonical order defined in VarScraper
+	Handle body = al(INHERITANCE_LINK, X, al(AND_LINK, Y, Z));
+	Handle sch = al(SCOPE_LINK, body);
+
+	ScopeLinkPtr sc = ScopeLinkCast(sch);
+
+	auto got = sc->get_variables().varseq;
+	Variables expvar;
+	expvar.find_variables(body);
+
+	printf("Got %s\n", oc_to_string(got).c_str());
+	printf("Excepted %s\n", oc_to_string(expvar.varseq).c_str());
+
+	TS_ASSERT_EQUALS(got, expvar.varseq);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void ScopeLinkUTest::test_get_variables_5()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Test that variables in scope link provided with VariableSet are
+	// sorted according to canonical order defined in VarScraper. We
+	// provide a mixture of typed and untyped variables to make sure it
+	// covers these cases.
+	Handle vardecl = al(VARIABLE_SET,
+	                    al(TYPED_VARIABLE_LINK, X, CT),
+	                    Y,
+	                    al(TYPED_VARIABLE_LINK, Z, CT));
+	Handle body = al(INHERITANCE_LINK, X, al(AND_LINK, Y, Z));
+	Handle sch = al(SCOPE_LINK, vardecl, body);
+
+	ScopeLinkPtr sc = ScopeLinkCast(sch);
+
+	// Test that variables are in canonical order
+	const Variables& result = sc->get_variables();
+	Variables expect;
+	expect.find_variables(body);
+
+	printf("Got %s\n", oc_to_string(result.varseq).c_str());
+	printf("Excepted %s\n", oc_to_string(expect.varseq).c_str());
+
+	TS_ASSERT_EQUALS(result.varseq, expect.varseq);
+
+	// Test that the inferred variable declaration corresponds to the
+	// scope one
+	Handle re_vardecl = result.get_vardecl();
+	Handle sc_vardecl = sc->get_vardecl();
+
+	printf("Got vardecl %s\n", oc_to_string(re_vardecl).c_str());
+	printf("Excepted vardecl %s\n", oc_to_string(sc_vardecl).c_str());	
+
+	TS_ASSERT(content_eq(re_vardecl, sc_vardecl));
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void ScopeLinkUTest::test_get_variables_6()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Like above but Z is not in the variable declaration thus treated
+	// as constant.
+	Handle vardecl = al(VARIABLE_SET,
+	                    al(TYPED_VARIABLE_LINK, X, CT),
+	                    al(TYPED_VARIABLE_LINK, Y, CT));
+	Handle body = al(INHERITANCE_LINK, X, al(AND_LINK, Y, Z));
+	Handle sch = al(SCOPE_LINK, vardecl, body);
+
+	ScopeLinkPtr sc = ScopeLinkCast(sch);
+
+	HandleSeq result = sc->get_variables().varseq;
+	HandleSeq expect{X, Y};
+
+	printf("Got %s\n", oc_to_string(result).c_str());
+	printf("Excepted %s\n", oc_to_string(expect).c_str());
+
+	// Test that variables are in canonical order
+	TS_ASSERT_EQUALS(result, expect);
 
 	logger().info("END TEST: %s", __FUNCTION__);
 }

--- a/tests/atoms/core/TypeUtilsUTest.cxxtest
+++ b/tests/atoms/core/TypeUtilsUTest.cxxtest
@@ -1,0 +1,86 @@
+/*
+ * tests/atoms/core/TypeUtilsUTest.cxxtest
+ *
+ * Copyright (C) 2019 SingularityNET Foundation
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/util/Logger.h>
+#include <opencog/atoms/core/TypeUtils.h>
+#include <opencog/atomspace/AtomSpace.h>
+#include <cxxtest/TestSuite.h>
+
+using namespace opencog;
+
+#define al as.add_link
+#define an as.add_node
+
+class FindUtilsUTest :  public CxxTest::TestSuite
+{
+private:
+	AtomSpace as;
+	Handle X, Y, P;
+
+public:
+	FindUtilsUTest()
+	{
+		logger().set_level(Logger::INFO);
+		logger().set_print_to_stdout_flag(true);
+	}
+
+	void setUp();
+
+	void test_filter_vardecl_1();
+	void test_filter_vardecl_2();
+};
+
+void FindUtilsUTest::setUp(void)
+{
+	X = an(VARIABLE_NODE, "$X");
+	Y = an(VARIABLE_NODE, "$Y");
+	P = an(PREDICATE_NODE, "P");
+}
+
+void FindUtilsUTest::test_filter_vardecl_1()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle vardecl = al(VARIABLE_LIST, X, Y);
+	Handle body = al(IMPLICATION_LINK, X, P);
+
+	Handle result = filter_vardecl(vardecl, body);
+	Handle except = X;
+
+	TS_ASSERT_EQUALS(result, except);
+}
+
+void FindUtilsUTest::test_filter_vardecl_2()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle vardecl = al(VARIABLE_SET, X, Y);
+	Handle body = al(IMPLICATION_LINK, X, P);
+
+	Handle result = filter_vardecl(vardecl, body);
+	Handle except = X;
+
+	TS_ASSERT_EQUALS(result, except);
+}
+
+#undef al
+#undef an

--- a/tests/atoms/core/VariablesUTest.cxxtest
+++ b/tests/atoms/core/VariablesUTest.cxxtest
@@ -57,7 +57,8 @@ public:
 		CNT = an(TYPE_NODE, "ConceptNode");
 	}
 
-	void test_extend();
+	void test_extend_1();
+	void test_extend_2();
 	void test_find_variables_ordered_1();
 	void test_find_variables_ordered_2();
 	void test_find_variables_ordered_3();
@@ -73,7 +74,34 @@ public:
 	void test_find_variables_mixed_5();
 };
 
-void VariablesUTest::test_extend()
+void VariablesUTest::test_extend_1()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle
+		vardecl1 = X,
+		vardecl2 = al(VARIABLE_LIST,
+		              al(TYPED_VARIABLE_LINK, X, PNT),
+		              al(TYPED_VARIABLE_LINK, Y, CNT)),
+		expect = al(VARIABLE_LIST,
+		            al(TYPED_VARIABLE_LINK, X, PNT),
+		            al(TYPED_VARIABLE_LINK, Y, CNT));
+
+	VariableList vl1(vardecl1), vl2(vardecl2);
+
+	Variables v1(vl1.get_variables()), v2(vl2.get_variables());
+
+	v1.extend(v2);
+
+	Handle result = _as.add_atom(v1.get_vardecl());
+
+	logger().debug() << "expect = " << oc_to_string(expect);
+	logger().debug() << "result = " << oc_to_string(result);
+
+	TS_ASSERT_EQUALS(result, expect);
+}
+
+void VariablesUTest::test_extend_2()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 

--- a/tests/query/BindVariableSetUTest.cxxtest
+++ b/tests/query/BindVariableSetUTest.cxxtest
@@ -1,0 +1,107 @@
+/*
+ * tests/query/BindVariableSetUTest.cxxtest
+ *
+ * Copyright (C) 2019 SingularityNET Foundation
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <thread>
+
+#include <opencog/atoms/pattern/BindLink.h>
+#include <opencog/atomspace/AtomSpace.h>
+#include <opencog/util/Logger.h>
+#include <cxxtest/TestSuite.h>
+
+using namespace opencog;
+
+#define al _as.add_link
+#define an _as.add_node
+
+class BindVariableSetUTest: public CxxTest::TestSuite
+{
+private:
+	AtomSpace _as;
+
+	Handle X, Y, Z, A, B, C;
+	
+public:
+	BindVariableSetUTest(void)
+	{
+		logger().set_level(Logger::DEBUG);
+		logger().set_print_to_stdout_flag(true);
+		logger().set_timestamp_flag(false);
+	}
+
+	~BindVariableSetUTest()
+	{
+		// Erase the log file if no assertions failed.
+		if (!CxxTest::TestTracker::tracker().suiteFailed())
+				std::remove(logger().get_filename().c_str());
+	}
+
+	void setUp(void);
+	void tearDown(void);
+
+	void test_no_type(void);
+};
+
+void BindVariableSetUTest::tearDown(void)
+{
+	_as.clear();
+}
+
+void BindVariableSetUTest::setUp(void)
+{
+	X = an(VARIABLE_NODE, "$X");
+	Y = an(VARIABLE_NODE, "$Y");
+	Z = an(VARIABLE_NODE, "$Z");
+	A = an(CONCEPT_NODE, "A");
+	B = an(CONCEPT_NODE, "B");
+	C = an(CONCEPT_NODE, "C");
+}
+
+/**
+ * Test simple bind link with variable declaration of variable set
+ * without type constraints.
+ */
+void BindVariableSetUTest::test_no_type(void)
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// KB
+	Handle kb = al(INHERITANCE_LINK, A, al(AND_LINK, B, C));
+	
+	// Query
+	// Handle vardecl = al(VARIABLE_SET, X, Y, Z);
+	Handle body = al(PRESENT_LINK, al(INHERITANCE_LINK, X, al(AND_LINK, Y, Z)));
+	Handle rewrite = al(LIST_LINK, X, Y, Z);
+	Handle query = al(BIND_LINK, body, rewrite);
+
+	Handle result = HandleCast(query->execute(&_as));
+	Handle expect = al(SET_LINK,
+	                   al(LIST_LINK, A, B, C)); // ,
+	                   // al(LIST_LINK, A, C, B));
+
+	logger().debug() << "result = " << oc_to_string(result);
+	logger().debug() << "expect = " << oc_to_string(expect);
+
+	TS_ASSERT_EQUALS(result, expect);
+}
+
+#undef al
+#undef an

--- a/tests/query/BindVariableSetUTest.cxxtest
+++ b/tests/query/BindVariableSetUTest.cxxtest
@@ -94,8 +94,8 @@ void BindVariableSetUTest::test_no_type(void)
 
 	Handle result = HandleCast(query->execute(&_as));
 	Handle expect = al(SET_LINK,
-	                   al(LIST_LINK, A, B, C)); // ,
-	                   // al(LIST_LINK, A, C, B));
+	                   al(LIST_LINK, A, B, C),
+	                   al(LIST_LINK, A, C, B));
 
 	logger().debug() << "result = " << oc_to_string(result);
 	logger().debug() << "expect = " << oc_to_string(expect);

--- a/tests/query/CMakeLists.txt
+++ b/tests/query/CMakeLists.txt
@@ -32,6 +32,9 @@ ADD_CXXTEST(Boolean2NotUTest)
 ADD_CXXTEST(ConstantClausesUTest)
 ADD_CXXTEST(PermutationsUTest)
 
+# Unit tests for queries using VariableSet as variable declaration
+ADD_CXXTEST(BindVariableSetUTest)
+
 # These are NOT in alphabetical order; they are in order of
 # simpler to more complex.  Later test cases assume features
 # that are tested in earlier test cases.  DO NOT reorder this


### PR DESCRIPTION
Addresses issue https://github.com/opencog/atomspace/issues/2325

I'm happy with the PR. However, there a slight change in the definition of alpha-equivalence of scopes to note. Precisely, assuming that `<body>` contains a single free variable `$X`, then the following equivalences hold

```
Scope
  <body>
```

is equivalent to

```
Scope
  Variable "$X"
  <body>
```

is equivalent to

```
Scope
  VariableSet
    Variable "$X"
  <body>
```

That is because a scope without variable declaration produces by default a `VariableSet` over the free variables of that scope. So for instance

```
Scope
  Inheritance
    Variable "$X"
    Variable "$Y"
```

is equivalent to

```
Scope
  VariableSet
    Variable "$X"
    Variable "$Y"
  Inheritance
    Variable "$X"
    Variable "$Y"
```

Such convention has been chosen on the ground that if no variable declaration is provided, then the user shouldn't care about the order since that one is arbitrary (though fixed according to the semantics of the variables in the body), so a `VariableSet` should be used, not a `VariableList`.

`VariableList` can of course be used when the variable declaration is provided.

You also should note that, as of that PR, the follow equivalence does NOT hold.

```
Scope
  VariableList
    Variable "$X"
  <body>
```

is NOT equivalent to

```
Scope
  VariableSet
    Variable "$X"
  <body>
```

while it could, since there is only one variable, order is irrelevant to the semantics of the scope.

This could be corrected in the future if we so desire.

Wikipage still need to be updated (which I'll likely do tomorrow). Meanwhile, your feedback is welcome. 