### PR TITLE
better variable naming

### DIFF
--- a/opencog/cython/PythonEval.cc
+++ b/opencog/cython/PythonEval.cc
@@ -382,7 +382,7 @@ static bool try_to_load_modules(const char ** config_paths)
 
 static bool already_initialized = false;
 static bool initialized_outside_opencog = false;
-static bool was_initialized_by_us = false;
+static bool was_finalized_by_us = false;
 static void *_dlso = nullptr;
 
 void opencog::global_python_initialize()
@@ -392,7 +392,7 @@ void opencog::global_python_initialize()
 
     // https://docs.python.org/3/c-api/init.html#c.Py_FinalizeEx
     // Some extensions may not work properly if their initialization routine is called more than once; this can happen if an application calls Py_Initialize() and Py_FinalizeEx() more than once.
-    if (was_initialized_by_us)
+    if (was_finalized_by_us)
         throw std::runtime_error("reinitialization is not supported by python");
 
     already_initialized = true;
@@ -429,7 +429,6 @@ void opencog::global_python_initialize()
     {
         // We are doing the initialization.
         initialized_outside_opencog = false;
-        was_initialized_by_us = true;
 
         // Initialize Python (InitThreads grabs GIL implicitly)
         Py_InitializeEx(NO_SIGNAL_HANDLERS);
@@ -480,6 +479,7 @@ void opencog::global_python_finalize()
         PyGILState_Ensure(); // yes this is needed, see bug #671
         Py_Finalize();
         if (_dlso) dlclose(_dlso);
+        was_finalized_by_us = true;
     }
 
     // No longer initialized.


### PR DESCRIPTION
rename confusing variable name was_initialized_by_us to was_finalized_by_us. 
see https://github.com/opencog/atomspace/pull/2361