### PR TITLE
create empty variable list when replacing variables

### DIFF
--- a/opencog/scm/opencog/base/apply.scm
+++ b/opencog/scm/opencog/base/apply.scm
@@ -22,6 +22,7 @@
 (define-public (substitute-var bindings body)
   (let ((body_type (cog-type body)))
     (cond ; recursive case
+          ((cog-subtype? 'VariableList body_type) (VariableList))
           ((cog-subtype? 'Link body_type)
            (apply cog-new-link
                   (cons body_type


### PR DESCRIPTION
in substitute-var utility function return empty VariableList, since VariableList with replaced variables is not valid 