### PR TITLE
Fix crazy-making permustation sort order

### DIFF
--- a/opencog/atoms/base/Link.h
+++ b/opencog/atoms/base/Link.h
@@ -24,6 +24,7 @@
 #ifndef _OPENCOG_LINK_H
 #define _OPENCOG_LINK_H
 
+#include <functional>
 #include <string>
 
 #include <opencog/util/oc_assert.h>
@@ -252,5 +253,19 @@ Handle createLink( Args&&... args )
 
 /** @}*/
 } // namespace opencog
+
+// Overload std::less to perform a content-based compare of the
+// LinkPtr's. Otherwise, it seems to just use the address returned
+// by LinkPtr::get().
+namespace std {
+template<>
+struct less<opencog::LinkPtr>
+{
+    bool operator()(const opencog::LinkPtr& la, const opencog::LinkPtr& lb) const
+    {
+        return la->operator<(*lb);
+    }
+};
+}
 
 #endif // _OPENCOG_LINK_H

--- a/opencog/atoms/core/FreeLink.cc
+++ b/opencog/atoms/core/FreeLink.cc
@@ -64,7 +64,10 @@ void FreeLink::unorder(void)
 	// e.g. EqualLink and IdenticalLink are unordered,
 	// but don't inherit from the C++ UnorderedLink class.
 	// So we hack around and do it here.
-	std::sort(_outgoing.begin(), _outgoing.end(), handle_less());
+	// Use content_based_handle_less() to avoid variations due
+	// to address-space randomization.
+	std::sort(_outgoing.begin(), _outgoing.end(),
+		content_based_handle_less());
 }
 
 void FreeLink::init(void)

--- a/opencog/atoms/core/UnorderedLink.cc
+++ b/opencog/atoms/core/UnorderedLink.cc
@@ -37,8 +37,11 @@ UnorderedLink::UnorderedLink(const HandleSeq& oset, Type t)
 			"Expecting an UnorderedLink, got %s", tname.c_str());
 	}
 
-	// Place into arbitrary, but deterministic order.
-	std::sort(_outgoing.begin(), _outgoing.end(), handle_less());
+	// Place into arbitrary, but deterministic order. We use
+	// content (hash) based less, to avoid variations due to
+	// address-space randomization.
+	std::sort(_outgoing.begin(), _outgoing.end(),
+		content_based_handle_less());
 }
 
 UnorderedLink::UnorderedLink(const HandleSet& oset, Type t)
@@ -57,9 +60,10 @@ UnorderedLink::UnorderedLink(const HandleSet& oset, Type t)
 
 	// Place into arbitrary, but deterministic order.
 	// Actually, this should already be in sorted order, because
-	// HandleSet is already sorted by handle_less(). But it can't
-	// hurt to do it again, to avoid insanity.
-	std::sort(_outgoing.begin(), _outgoing.end(), handle_less());
+	// HandleSet is already sorted by content_based_handle_less().
+	// But it can't hurt to do it again, to avoid insanity.
+	std::sort(_outgoing.begin(), _outgoing.end(),
+		content_based_handle_less());
 }
 
 UnorderedLink::UnorderedLink(const Link& l)

--- a/opencog/atoms/pattern/PatternTerm.cc
+++ b/opencog/atoms/pattern/PatternTerm.cc
@@ -85,7 +85,8 @@ PatternTermSeq PatternTerm::getOutgoingSet() const
 	for (PatternTermWPtr w : _outgoing)
 	{
 		PatternTermPtr s(w.lock());
-		if (s) oset.push_back(s);
+		OC_ASSERT(nullptr != s, "Unexpected corruption of PatternTerm oset!");
+		oset.push_back(s);
 	}
 
 	return oset;
@@ -121,9 +122,7 @@ PatternTermPtr PatternTerm::getOutgoingTerm(Arity pos) const
 	// Checks for a valid position
 	if (pos < getArity()) {
 		PatternTermPtr s(_outgoing[pos].lock());
-		if (not s)
-			throw RuntimeException(TRACE_INFO,
-			                       "expired outgoing set index %d", pos);
+		OC_ASSERT(nullptr != s, "Unexpected missing PatternTerm oset entry!");
 		return s;
 	} else {
 		throw RuntimeException(TRACE_INFO,

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -608,7 +608,8 @@ take_next_step:
 		solution_pop();
 		if (logger().is_fine_enabled())
 			_perm_count[Unorder(ptm, hg)] ++;
-	} while (std::next_permutation(mutation.begin(), mutation.end()));
+	} while (std::next_permutation(mutation.begin(), mutation.end(),
+	         std::less<PatternTermPtr>()));
 
 	// If we are here, we've explored all the possibilities already
 	DO_LOG({LAZY_LOG_FINE << "Exhausted all permutations of term="
@@ -647,7 +648,9 @@ PatternMatchEngine::curr_perm(const PatternTermPtr& ptm,
 		DO_LOG({LAZY_LOG_FINE << "tree_comp FRESH START unordered term="
 		              << ptm->to_string();})
 		Permutation perm = ptm->getOutgoingSet();
-		sort(perm.begin(), perm.end());
+		// Sort into explict std::less<PatternTermPtr>() order, as
+		// otherwise std::next_permutation() will miss some perms.
+		sort(perm.begin(), perm.end(), std::less<PatternTermPtr>());
 		_perm_take_step = false;
 		return perm;
 	}

--- a/tests/query/UnorderedUTest.cxxtest
+++ b/tests/query/UnorderedUTest.cxxtest
@@ -58,11 +58,16 @@ class UnorderedUTest :  public CxxTest::TestSuite
 
 		~UnorderedUTest()
 		{
+			logger().info("Completed running UnorderedUTest");
+
 			// erase the log file if no assertions failed
 			if (!CxxTest::TestTracker::tracker().suiteFailed())
 				std::remove(logger().get_filename().c_str());
 			else
+			{
+				logger().info("UnorderedUTest failed!");
 				logger().flush();
+			}
 		}
 
 		void setUp(void);

--- a/tests/query/UnorderedUTest.cxxtest
+++ b/tests/query/UnorderedUTest.cxxtest
@@ -3,21 +3,7 @@
  *
  * Copyright (C) 2009, 2011, 2014 Linas Vepstas <linasvepstas@gmail.com>
  * All Rights Reserved
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License v3 as
- * published by the Free Software Foundation and including the exceptions
- * at http://opencog.org/wiki/Licenses
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program; if not, write to:
- * Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 #include <opencog/guile/SchemeEval.h>
@@ -50,6 +36,7 @@ class UnorderedUTest :  public CxxTest::TestSuite
 		UnorderedUTest(void)
 		{
 			logger().set_level(Logger::DEBUG);
+			// logger().set_level(Logger::FINE);
 			// logger().set_print_to_stdout_flag(true);
 			logger().set_timestamp_flag(false);
 			// logger().set_sync_flag(true);

--- a/tests/query/UnorderedUTest.cxxtest
+++ b/tests/query/UnorderedUTest.cxxtest
@@ -50,8 +50,9 @@ class UnorderedUTest :  public CxxTest::TestSuite
 		UnorderedUTest(void)
 		{
 			logger().set_level(Logger::DEBUG);
-			logger().set_print_to_stdout_flag(true);
+			// logger().set_print_to_stdout_flag(true);
 			logger().set_timestamp_flag(false);
+			// logger().set_sync_flag(true);
 #include "test-types.cc"
 		}
 
@@ -60,6 +61,8 @@ class UnorderedUTest :  public CxxTest::TestSuite
 			// erase the log file if no assertions failed
 			if (!CxxTest::TestTracker::tracker().suiteFailed())
 				std::remove(logger().get_filename().c_str());
+			else
+				logger().flush();
 		}
 
 		void setUp(void);

--- a/tests/query/UnorderedUTest.cxxtest
+++ b/tests/query/UnorderedUTest.cxxtest
@@ -255,6 +255,8 @@ void UnorderedUTest::test_embed(void)
 	Handle result = eval->eval_h("(cog-execute! embedded-set)");
 
 	logger().debug("embedded result is %s\n", SchemeSmob::to_string(result).c_str());
+	if (2 != getarity(result))
+		logger().info("Error: unexpected number of solutions\n");
 	TSM_ASSERT_EQUALS("wrong number of solutions found", 2, getarity(result));
 	TSM_ASSERT_EQUALS("Incorrect result", result, expected);
 


### PR DESCRIPTION
Fix bug #2371 and tighten up some other problem areas:
* `std::next_permutation()` will skip some permutations if the initial list is not sorted
* Both `std::sort()` AND `std::next_permuation()` must use the SAME std::less<> to sort!
* Avoid address-based sort order; use content-based sort order only.

The original bug was that a mixture of content-based and address-based sorting was used.  This lead to intermittent bugs, whenever certain address-space randomizations placed atoms in different locations.
Apparently, some linux version use different randomizations than others, leading to either frequent failures, or extremely rare failures.

So far, one hour of testing, 12K test iterations, zero failures.