### PR TITLE
Make it easier for the compiler to inline.

### DIFF
--- a/opencog/atoms/pattern/PatternTerm.cc
+++ b/opencog/atoms/pattern/PatternTerm.cc
@@ -5,21 +5,7 @@
  * All Rights Reserved
  *
  * Created by Nil Geisweiller Oct 2016
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License v3 as
- * published by the Free Software Foundation and including the exceptions
- * at http://opencog.org/wiki/Licenses
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program; if not, write to:
- * Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 #include "PatternTerm.h"
@@ -64,21 +50,6 @@ void PatternTerm::addOutgoingTerm(const PatternTermPtr& ptm)
 	_outgoing.push_back(ptm);
 }
 
-const Handle& PatternTerm::getHandle() const
-{
-	return _handle;
-}
-
-const Handle& PatternTerm::getQuote() const
-{
-	return _quote;
-}
-
-PatternTermPtr PatternTerm::getParent()
-{
-	return _parent;
-}
-
 PatternTermSeq PatternTerm::getOutgoingSet() const
 {
 	PatternTermSeq oset;
@@ -90,31 +61,6 @@ PatternTermSeq PatternTerm::getOutgoingSet() const
 	}
 
 	return oset;
-}
-
-Arity PatternTerm::getArity() const
-{
-	return _outgoing.size();
-}
-
-Quotation& PatternTerm::getQuotation()
-{
-	return _quotation;
-}
-
-const Quotation& PatternTerm::getQuotation() const
-{
-	return _quotation;
-}
-
-bool PatternTerm::isQuoted() const
-{
-	return _quotation.is_quoted();
-}
-
-bool PatternTerm::hasAnyBoundVariable() const
-{
-	return _has_any_bound_var;
 }
 
 PatternTermPtr PatternTerm::getOutgoingTerm(Arity pos) const

--- a/opencog/atoms/pattern/PatternTerm.h
+++ b/opencog/atoms/pattern/PatternTerm.h
@@ -137,11 +137,13 @@ using namespace opencog;
 namespace std {
 
 /**
- * We need to overload standard comparison operator for PatternTerm pointers.
- * Now we do not care much about complexity of this comparison. The cases of
- * queries having repeated atoms that are deep should be very rare. So we just
- * traverse up towards root node. Typically we compare only the first level
- * handles on this path.
+ * Overload the standard comparison operator for PatternTerm pointers.
+ * This uses content-baed compare for individual atoms, and then moving
+ * up the term inclusion path, if the atoms are identical. Thus, this
+ * is almost the same as `std::less<Handle>` but not quite.
+ *
+ * This is performance-sensitive; it is used during pattern matching
+ * to walk over permutations of unordered links.
  */
 template<>
 struct less<PatternTermPtr>

--- a/opencog/atoms/pattern/PatternTerm.h
+++ b/opencog/atoms/pattern/PatternTerm.h
@@ -5,21 +5,7 @@
  * All Rights Reserved
  *
  * Created by Jacek Świergocki <jswiergo@gmail.com> July 2015
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License v3 as
- * published by the Free Software Foundation and including the exceptions
- * at http://opencog.org/wiki/Licenses
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program; if not, write to:
- * Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 #ifndef _OPENCOG_PATTERN_TERM_H
@@ -111,21 +97,21 @@ public:
 
 	void addOutgoingTerm(const PatternTermPtr& ptm);
 
-	const Handle& getHandle() const;
+	const Handle& getHandle() const noexcept { return _handle; }
 
-	const Handle& getQuote() const;
+	const Handle& getQuote() const noexcept { return _quote; }
 
-	PatternTermPtr getParent();
+	PatternTermPtr getParent() const noexcept { return _parent; }
 
 	PatternTermSeq getOutgoingSet() const;
 
-	Arity getArity() const;
+	Arity getArity() const { return _outgoing.size(); }
 
-	Quotation& getQuotation();
-	const Quotation& getQuotation() const;
-	bool isQuoted() const;
+	Quotation& getQuotation() { return _quotation; };
+	const Quotation& getQuotation() const noexcept { return _quotation; }
+	bool isQuoted() const { return _quotation.is_quoted(); }
 
-	bool hasAnyBoundVariable() const;
+	bool hasAnyBoundVariable() const noexcept { return _has_any_bound_var; }
 
 	PatternTermPtr getOutgoingTerm(Arity pos) const;
 


### PR DESCRIPTION
Move simple returns into the header file.