### PR TITLE
Use value_pop() instead of pop().

### DIFF
--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
@@ -169,7 +169,7 @@ SQLAtomStorage::~SQLAtomStorage()
 
 	while (not conn_pool.is_empty())
 	{
-		LLConnection* db_conn = conn_pool.pop();
+		LLConnection* db_conn = conn_pool.value_pop();
 		delete db_conn;
 	}
 
@@ -187,7 +187,7 @@ SQLAtomStorage::~SQLAtomStorage()
 bool SQLAtomStorage::connected(void)
 {
 	// This will leak a resource, if db_conn->connected() ever throws.
-	LLConnection* db_conn = conn_pool.pop();
+	LLConnection* db_conn = conn_pool.value_pop();
 	bool have_connection = db_conn->connected();
 	conn_pool.push(db_conn);
 	return have_connection;

--- a/opencog/persist/sql/multi-driver/SQLResponse.h
+++ b/opencog/persist/sql/multi-driver/SQLResponse.h
@@ -108,13 +108,13 @@ class SQLAtomStorage::Response
 			// block, waiting for a connection to be returned to the pool.
 			// Thus, the size of the pool regulates how many outstanding
 			// SQL requests can be pending in parallel.
-			if (nullptr == _conn) _conn = _pool.pop();
+			if (nullptr == _conn) _conn = _pool.value_pop();
 			rs = _conn->exec(buff, false);
 		}
 		void try_exec(const char * buff)
 		{
 			if (rs) rs->release();
-			if (nullptr == _conn) _conn = _pool.pop();
+			if (nullptr == _conn) _conn = _pool.value_pop();
 			rs = _conn->exec(buff, true);
 		}
 		void exec(const std::string& str)


### PR DESCRIPTION
The problem with pop() is that there's a C++ method overloading
clash; the signatures have different return values.