### PR TITLE
Add std::less<AtomPtr>; remove dead code

### DIFF
--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -448,9 +448,24 @@ std::string oc_to_string(const IncomingSet& iset,
 /** @}*/
 } // namespace opencog
 
-// Overloading operator<< for Incoming Set 
 namespace std {
-    
+
+/// Overload std::less to perform a content-based compare of the
+/// AtomPtr's. Otherwise, it seems to just use the address returned
+/// by `AtomPtr::get()`. The core problem is that sometimes, were were
+/// expecting that `std::less<Handle>` was going to be used, and it
+/// wasn't, resulting in an address-space compare. This should halt
+/// that misbehavior. See issue #2371 for details.
+template<>
+struct less<opencog::AtomPtr>
+{
+    bool operator()(const opencog::AtomPtr& ata, const opencog::AtomPtr& atb) const
+    {
+        return ata->operator<(*atb);
+    }
+};
+
+// Overloading operator<< for Incoming Set
 ostream& operator<<(ostream&, const opencog::IncomingSet&);
 
 }

--- a/opencog/atoms/base/Handle.h
+++ b/opencog/atoms/base/Handle.h
@@ -171,14 +171,6 @@ bool content_eq(const opencog::Handle& lh,
 //! Boost needs this function to be called by exactly this name.
 std::size_t hash_value(Handle const&);
 
-struct handle_less
-{
-   bool operator()(const Handle& hl, const Handle& hr) const
-   {
-       return hl.operator<(hr);
-   }
-};
-
 //! a pair of Handles
 typedef std::pair<Handle, Handle> HandlePair;
 

--- a/opencog/atoms/base/Handle.h
+++ b/opencog/atoms/base/Handle.h
@@ -375,22 +375,6 @@ ostream& operator<<(ostream&, const opencog::HandleSeq&);
 ostream& operator<<(ostream&, const opencog::HandleSet&);
 ostream& operator<<(ostream&, const opencog::UnorderedHandleSet&);
 
-#ifdef THIS_USED_TO_WORK_GREAT_BUT_IS_BROKEN_IN_GCC472
-// The below used to work, but broke in gcc-4.7.2. The reason it
-// broke is that it fails to typedef result_type and argument_type,
-// which ... somehow used to work automagically?? It doesn't any more.
-// I have no clue why gcc-4.7.2 broke this, and neither does google or
-// stackoverflow.
-
-template<>
-inline std::size_t
-std::hash<opencog::Handle>::operator()(const opencog::Handle& h) const
-{
-    return hash_value(h);
-}
-
-#else
-
 // This works for me, per note immediately above.
 template<>
 struct hash<opencog::Handle>
@@ -445,8 +429,6 @@ struct equal_to<opencog::HandlePair>
                eq.operator()(lhp.second, rhp.second);
     }
 };
-
-#endif // THIS_USED_TO_WORK_GREAT_BUT_IS_BROKEN_IN_GCC472
 
 } // ~namespace std
 

--- a/opencog/atoms/base/Link.h
+++ b/opencog/atoms/base/Link.h
@@ -254,9 +254,9 @@ Handle createLink( Args&&... args )
 /** @}*/
 } // namespace opencog
 
-// Overload std::less to perform a content-based compare of the
-// LinkPtr's. Otherwise, it seems to just use the address returned
-// by LinkPtr::get().
+/// Overload std::less to perform a content-based compare of the
+/// LinkPtr's. Otherwise, it seems to just use the address returned
+/// by LinkPtr::get().
 namespace std {
 template<>
 struct less<opencog::LinkPtr>

--- a/opencog/atoms/core/UnorderedLink.cc
+++ b/opencog/atoms/core/UnorderedLink.cc
@@ -81,7 +81,8 @@ UnorderedLink::UnorderedLink(const Link& l)
 	// Place into arbitrary, but deterministic order.
 	// We have to do this here,  because the input link l might not
 	// have ever gone through an UnorderedLink constructor before.
-	std::sort(_outgoing.begin(), _outgoing.end(), handle_less());
+	std::sort(_outgoing.begin(), _outgoing.end(),
+		content_based_handle_less());
 }
 
 // ---------------------------------------------------------------


### PR DESCRIPTION
Apparently, there are situations where `std::less<shared_ptr<Atom>>` gets used,
whereas the coder mght have expected `std::less>Handle>` to get used. This is
an attempt to solve that problem.  Some dead code gets removed, too.