### PR TITLE
Every submodule must first load it's parent.

### DIFF
--- a/opencog/scm/opencog/logger.scm
+++ b/opencog/scm/opencog/logger.scm
@@ -6,6 +6,8 @@
 
 (define-module (opencog logger))
 
+(use-modules (opencog))
+
 (use-modules (opencog as-config))
 (load-extension (string-append opencog-ext-path-logger "liblogger") "opencog_logger_init")
 


### PR DESCRIPTION
Before this change, the following crashed:
```
(use-modules (opencog logger))
(use-modules (opencog))
(cog-logger-set-timestamp! #f)
```