### PR TITLE
Use the opencog module when defining submodules

### DIFF
--- a/opencog/scm/opencog/dist-gearman.scm
+++ b/opencog/scm/opencog/dist-gearman.scm
@@ -1,9 +1,9 @@
 ;
-; OpenCog Pattern matcher module
+; OpenCog Gearman module
 ;
-
 (define-module (opencog dist-gearman))
 
+(use-modules (opencog))
 (use-modules (opencog as-config))
 (load-extension (string-append opencog-ext-path-dist-gearman "libdist-gearman") "opencog_dist_init")
 

--- a/opencog/scm/opencog/exec.scm
+++ b/opencog/scm/opencog/exec.scm
@@ -1,9 +1,9 @@
 ;
 ; OpenCog Execution module
 ;
-
 (define-module (opencog exec))
 
+(use-modules (opencog))
 (use-modules (opencog as-config))
 (load-extension (string-append opencog-ext-path-exec "libexec") "opencog_exec_init")
 

--- a/opencog/scm/opencog/extension.scm
+++ b/opencog/scm/opencog/extension.scm
@@ -3,6 +3,6 @@
 ;
 ; This simply gives scope to the wrapper code in guile/SchemePrimitive.cc
 ;
-
 (define-module (opencog extension))
 
+(use-modules (opencog))

--- a/opencog/scm/opencog/logger.scm
+++ b/opencog/scm/opencog/logger.scm
@@ -7,7 +7,6 @@
 (define-module (opencog logger))
 
 (use-modules (opencog))
-
 (use-modules (opencog as-config))
 (load-extension (string-append opencog-ext-path-logger "liblogger") "opencog_logger_init")
 

--- a/opencog/scm/opencog/persist-zmq.scm
+++ b/opencog/scm/opencog/persist-zmq.scm
@@ -1,8 +1,8 @@
 ;
 ; OpenCog ZeroMQ Persistence module
 ;
-
 (define-module (opencog persist-zmq))
 
+(use-modules (opencog))
 (use-modules (opencog as-config))
 (load-extension (string-append opencog-ext-path-persist-zmq "libpersist-zmq") "opencog_persist_zmq_init")

--- a/opencog/scm/opencog/python.scm
+++ b/opencog/scm/opencog/python.scm
@@ -1,9 +1,9 @@
 ;
 ; Python wrapper.  Allows python snippets to be executed from scheme.
 ;
-
 (define-module (opencog python))
 
+(use-modules (opencog))
 (use-modules (opencog as-config))
 (load-extension (string-append opencog-ext-path-python-scm "libPythonSCM")
 	"opencog_python_init")

--- a/opencog/scm/opencog/query.scm
+++ b/opencog/scm/opencog/query.scm
@@ -4,6 +4,7 @@
 
 (define-module (opencog query))
 
+(use-modules (opencog))
 (use-modules (opencog exec))
 
 (define-public (cog-bind handle)

--- a/opencog/scm/opencog/test-runner.scm
+++ b/opencog/scm/opencog/test-runner.scm
@@ -3,6 +3,8 @@
   #:re-export (test-begin test-assert test-end)
   #:export (opencog-test-runner))
 
+(use-modules (opencog))
+
 (define (opencog-test-runner)
 "
   opencog-test-runner


### PR DESCRIPTION
Failure to do so will leave the guile subsystem uninitialised.
See pull req #2385 for an example.