### PR TITLE
Reorganize flow of control through the pattern matcher.

### DIFF
--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1416,7 +1416,7 @@ bool PatternMatchEngine::explore_link_branches(const PatternTermPtr& ptm,
                                                const Handle& clause_root)
 {
 	// Look for a match, at least once.
-	if (explore_choice_branches(ptm, hg, clause_root))
+	if (explore_dispatch(ptm, hg, clause_root))
 		return true;
 
 	// If its not an unordered link, then it will not have
@@ -1434,12 +1434,26 @@ bool PatternMatchEngine::explore_link_branches(const PatternTermPtr& ptm,
 		_perm_have_more = false;
 
 		// If the pattern was satisfied, then we are done for good.
-		if (explore_choice_branches(ptm, hg, clause_root))
+		if (explore_dispatch(ptm, hg, clause_root))
 			return true;
 	}
 	DO_LOG({logger().fine("No more unordered permutations");})
 
 	return false;
+}
+
+bool PatternMatchEngine::explore_dispatch(const PatternTermPtr& ptm,
+                                          const Handle& hg,
+                                          const Handle& clause_root)
+{
+	const Handle& hp = ptm->getHandle();
+
+	// Iterate over different possible choices.
+	if (CHOICE_LINK == hp->get_type())
+	{
+		return explore_choice_branches(ptm, hg, clause_root);
+	}
+	return explore_single_branch(ptm, hg, clause_root);
 }
 
 /// See explore_link_branches() for a general explanation. This method
@@ -1449,11 +1463,6 @@ bool PatternMatchEngine::explore_choice_branches(const PatternTermPtr& ptm,
                                                  const Handle& hg,
                                                  const Handle& clause_root)
 {
-	const Handle& hp = ptm->getHandle();
-	// If its not a choice link, then don't try to iterate.
-	if (CHOICE_LINK != hp->get_type())
-		return explore_single_branch(ptm, hg, clause_root);
-
 	DO_LOG({logger().fine("Begin choice branchpoint iteration loop");})
 	do {
 		// XXX This `need_choice_push` thing is probably wrong; it probably

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1415,28 +1415,30 @@ bool PatternMatchEngine::explore_link_branches(const PatternTermPtr& ptm,
                                                const Handle& hg,
                                                const Handle& clause_root)
 {
-	// Look for a match, at least once.
-	if (explore_dispatch(ptm, hg, clause_root))
-		return true;
-
 	// If its not an unordered link, then it will not have
 	// permuations, and so there is nothing more to do.
 	if (not _nameserver.isA(ptm->getHandle()->get_type(), UNORDERED_LINK))
-		return false;
-
-	while (have_perm(ptm, hg) and _perm_latest_wrap != ptm)
 	{
+		return explore_dispatch(ptm, hg, clause_root);
+	}
+
+	do
+	{
+		// If the pattern was satisfied, then we are done for good.
+		if (explore_dispatch(ptm, hg, clause_root))
+			return true;
+
 		DO_LOG({logger().fine("Step to next permutation");})
 
 		// If we are here, there was no match.
 		// On the next go-around, take a step.
 		_perm_take_step = true;
 		_perm_have_more = false;
-
-		// If the pattern was satisfied, then we are done for good.
-		if (explore_dispatch(ptm, hg, clause_root))
-			return true;
 	}
+	while (have_perm(ptm, hg) and _perm_latest_wrap != ptm);
+
+	_perm_take_step = false;
+	_perm_have_more = false;
 	DO_LOG({logger().fine("No more unordered permutations");})
 
 	return false;

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1188,46 +1188,55 @@ bool PatternMatchEngine::explore_term_branches(const Handle& term,
 	for (const PatternTermPtr &ptm : pl->second)
 	{
 		DO_LOG({LAZY_LOG_FINE << "Begin exploring term: " << ptm->to_string();})
-		if (explore_var_branches(ptm, hg, clause_root))
+		if (explore_odometer(ptm, hg, clause_root))
 			return true;
-
-		// If no solution was found, and there are unordered links, then
-		// there may be alternate permuations of the unordered link that
-		// might satisfy this clause. So try those, until exhausted.
-		// Note that these unordered links might be buried deeply;
-		// that is why we iterate over them here.
-		if (_perm_first_term)
-		{
-			_perm_have_odometer = true;
-			DO_LOG({LAZY_LOG_FINE << "First odometer term: "
-			                      << _perm_first_term->to_string();})
-		}
-		if (_perm_latest_term != _perm_first_term)
-		{
-			DO_LOG({LAZY_LOG_FINE << "Last odometer term: "
-			                      << _perm_latest_term->to_string();})
-		}
-
-		while (_perm_have_more)
-		{
-			_perm_have_more = false;
-			_perm_take_step = true;
-
-			DO_LOG({LAZY_LOG_FINE << "Continue exploring term: "
-			                      << ptm->to_string();})
-			if (explore_var_branches(ptm, hg, clause_root))
-			{
-				return true;
-			}
-			if (_perm_latest_wrap and _perm_latest_wrap == _perm_latest_term)
-			{
-				DO_LOG({LAZY_LOG_FINE << "Terminate Odometer: "
-				                      << _perm_latest_term->to_string();})
-				return false;
-			}
-		}
 		DO_LOG({LAZY_LOG_FINE << "Finished exploring term: "
 		                      << ptm->to_string();})
+	}
+	return false;
+}
+
+bool PatternMatchEngine::explore_odometer(const PatternTermPtr& ptm,
+                                          const Handle& hg,
+                                          const Handle& clause_root)
+{
+	if (explore_var_branches(ptm, hg, clause_root))
+		return true;
+
+	// If no solution was found, and there are unordered links, then
+	// there may be alternate permuations of the unordered link that
+	// might satisfy this clause. So try those, until exhausted.
+	// Note that these unordered links might be buried deeply;
+	// that is why we iterate over them here.
+	if (_perm_first_term)
+	{
+		_perm_have_odometer = true;
+		DO_LOG({LAZY_LOG_FINE << "First odometer term: "
+		                      << _perm_first_term->to_string();})
+	}
+	if (_perm_latest_term != _perm_first_term)
+	{
+		DO_LOG({LAZY_LOG_FINE << "Last odometer term: "
+		                      << _perm_latest_term->to_string();})
+	}
+
+	while (_perm_have_more)
+	{
+		_perm_have_more = false;
+		_perm_take_step = true;
+
+		DO_LOG({LAZY_LOG_FINE << "Continue exploring term: "
+		                      << ptm->to_string();})
+		if (explore_var_branches(ptm, hg, clause_root))
+		{
+			return true;
+		}
+		if (_perm_latest_wrap and _perm_latest_wrap == _perm_latest_term)
+		{
+			DO_LOG({LAZY_LOG_FINE << "Terminate Odometer: "
+			                      << _perm_latest_term->to_string();})
+			return false;
+		}
 	}
 	_perm_have_odometer = false;
 	return false;

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1344,6 +1344,9 @@ bool PatternMatchEngine::explore_glob_branches(const PatternTermPtr& ptm,
 	// quickly check if we can move on to the next one or not.
 	do
 	{
+		// It's not clear if the odometer can play nice with
+		// globby terms. Anyway, no unit test mixs these two.
+		// So, for now, we ignore it.
 		// if (explore_odometer(ptm, hg, clause_root))
 		if (explore_type_branches(ptm, hg, clause_root))
 			return true;
@@ -1354,6 +1357,15 @@ bool PatternMatchEngine::explore_glob_branches(const PatternTermPtr& ptm,
 	return false;
 }
 
+// explore_odometer - explore multiple unordered links at once.
+//
+// The core issue adressed here is that there may be lots of
+// UnorderedLinks below us, and we have to explore all of them.
+// So this tries to advance all of them.
+// XXX The design here is deeply flawed. Its just barely enough
+// to pass the current unit tests, but clearly fails on more
+// complex cases. See issue opencog/atomspace#2388
+// A redesign is needed.
 bool PatternMatchEngine::explore_odometer(const PatternTermPtr& ptm,
                                           const Handle& hg,
                                           const Handle& clause_root)

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1469,13 +1469,16 @@ bool PatternMatchEngine::explore_dispatch(const PatternTermPtr& ptm,
 	return explore_single_branch(ptm, hg, clause_root);
 }
 
-/// See explore_unordered_branches() for a general explanation. This method
-/// handles the ChoiceLink branch alternatives only.  It assumes
-/// that the caller had handled the unordered-link alternative branches.
+/// See explore_unordered_branches() for a general explanation.
+/// This method handles the ChoiceLink branch alternatives only.
+/// This method is never called, currently.
 bool PatternMatchEngine::explore_choice_branches(const PatternTermPtr& ptm,
                                                  const Handle& hg,
                                                  const Handle& clause_root)
 {
+	throw RuntimeException(TRACE_INFO,
+		"This is not implemented or just wrong or something!!");
+
 	DO_LOG({logger().fine("Begin choice branchpoint iteration loop");})
 	do {
 		// XXX This `need_choice_push` thing is probably wrong; it probably
@@ -1483,7 +1486,7 @@ bool PatternMatchEngine::explore_choice_branches(const PatternTermPtr& ptm,
 		// However, currently, no test case trips this up. so .. OK.
 		// Whatever. This still probably needs fixing.
 		if (_need_choice_push) choice_stack.push(_choice_state);
-		bool match = explore_glob_branches(ptm, hg, clause_root);
+		bool match = explore_single_branch(ptm, hg, clause_root);
 		if (_need_choice_push) POPSTK(choice_stack, _choice_state);
 		_need_choice_push = false;
 

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1355,9 +1355,13 @@ bool PatternMatchEngine::explore_glob_branches(const PatternTermPtr& ptm,
                                                const Handle& hg,
                                                const Handle& clause_root)
 {
-	// Check if the pattern has globs in it, and record the glob_state.
-	// Do this *before* starting exploration.
+	// Check if the pattern has globs in it,
 	bool has_glob = (0 < _pat->globby_holders.count(ptm->getHandle()));
+
+	if (not has_glob)
+		return explore_dispatch(ptm, hg, clause_root);
+
+	// Record the glob_state *before* starting exploration.
 	size_t gstate_size = _glob_state.size();
 
 	// If no solution is found, and there are globs, then there may
@@ -1372,10 +1376,9 @@ bool PatternMatchEngine::explore_glob_branches(const PatternTermPtr& ptm,
 	{
 		if (explore_dispatch(ptm, hg, clause_root))
 			return true;
-		if (has_glob)
-			DO_LOG({logger().fine("Globby clause not grounded; try again");})
+		DO_LOG({logger().fine("Globby clause not grounded; try again");})
 	}
-	while (has_glob and _glob_state.size() > gstate_size);
+	while (_glob_state.size() > gstate_size);
 
 	return false;
 }

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1249,7 +1249,7 @@ bool PatternMatchEngine::explore_term_branches(const Handle& term,
 /// one branch, we backtrack to here, and try another branch. When
 /// backtracking, all state must be popped and pushed again, to enter
 /// the new branch. We don't pushd & pop here, we push-n-pop in the
-/// explore_link_branches() method.
+/// explore_unordered_branches() method.
 ///
 /// This method is part of a recursive chain that only terminates
 /// when a grounding for *the entire pattern* was found (and the
@@ -1348,7 +1348,7 @@ bool PatternMatchEngine::explore_upglob_branches(const PatternTermPtr& ptm,
 
 /// explore_glob_branches -- explore glob grounding alternatives
 ///
-/// Please see the docs for `explore_link_branches` for the general
+/// Please see the docs for `explore_unordered_branches` for the general
 /// idea. In this particular method, all possible alternatives for
 /// grounding glob nodes are explored.
 bool PatternMatchEngine::explore_glob_branches(const PatternTermPtr& ptm,
@@ -1380,7 +1380,7 @@ bool PatternMatchEngine::explore_glob_branches(const PatternTermPtr& ptm,
 	return false;
 }
 
-/// explore_link_branches -- explore UnorderedLink alternatives.
+/// explore_unordered_branches -- explore UnorderedLink alternatives.
 ///
 /// Every UnorderedLink of arity N presents N-factorial different
 /// grounding possbilities, corresponding to different permutations
@@ -1395,7 +1395,7 @@ bool PatternMatchEngine::explore_glob_branches(const PatternTermPtr& ptm,
 /// nothing, then the next branch is explored, until exhaustion of the
 /// possibilities.  Upon exhaustion, it returns to the caller.
 ///
-bool PatternMatchEngine::explore_link_branches(const PatternTermPtr& ptm,
+bool PatternMatchEngine::explore_unordered_branches(const PatternTermPtr& ptm,
                                                const Handle& hg,
                                                const Handle& clause_root)
 {
@@ -1460,13 +1460,13 @@ bool PatternMatchEngine::explore_dispatch(const PatternTermPtr& ptm,
 	// Unordered links have permutations to explore.
 	if (_nameserver.isA(ptype, UNORDERED_LINK))
 	{
-		return explore_link_branches(ptm, hg, clause_root);
+		return explore_unordered_branches(ptm, hg, clause_root);
 	}
 
 	return explore_single_branch(ptm, hg, clause_root);
 }
 
-/// See explore_link_branches() for a general explanation. This method
+/// See explore_unordered_branches() for a general explanation. This method
 /// handles the ChoiceLink branch alternatives only.  It assumes
 /// that the caller had handled the unordered-link alternative branches.
 bool PatternMatchEngine::explore_choice_branches(const PatternTermPtr& ptm,

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -253,7 +253,11 @@ private:
 	                         const Handle&);
 	bool explore_upglob_branches(const PatternTermPtr&, const Handle&,
 	                         const Handle&);
+	bool explore_var_branches(const PatternTermPtr&, const Handle&,
+	                          const Handle&);
 	bool explore_glob_branches(const PatternTermPtr&, const Handle&,
+	                           const Handle&);
+	bool explore_type_branches(const PatternTermPtr&, const Handle&,
 	                           const Handle&);
 	bool explore_unordered_branches(const PatternTermPtr&, const Handle&,
 	                                const Handle&);
@@ -261,8 +265,6 @@ private:
 	                             const Handle&);
 	bool explore_single_branch(const PatternTermPtr&, const Handle&,
 	                           const Handle&);
-	bool explore_dispatch(const PatternTermPtr&, const Handle&,
-	                      const Handle&);
 	bool do_term_up(const PatternTermPtr&, const Handle&,
 	                const Handle&);
 	bool clause_accept(const Handle&, const Handle&);

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -259,6 +259,8 @@ private:
 	                           const Handle&);
 	bool explore_type_branches(const PatternTermPtr&, const Handle&,
 	                           const Handle&);
+	bool explore_odometer(const PatternTermPtr&, const Handle&,
+	                      const Handle&);
 	bool explore_unordered_branches(const PatternTermPtr&, const Handle&,
 	                                const Handle&);
 	bool explore_choice_branches(const PatternTermPtr&, const Handle&,

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -255,8 +255,8 @@ private:
 	                         const Handle&);
 	bool explore_glob_branches(const PatternTermPtr&, const Handle&,
 	                           const Handle&);
-	bool explore_link_branches(const PatternTermPtr&, const Handle&,
-	                           const Handle&);
+	bool explore_unordered_branches(const PatternTermPtr&, const Handle&,
+	                                const Handle&);
 	bool explore_choice_branches(const PatternTermPtr&, const Handle&,
 	                             const Handle&);
 	bool explore_single_branch(const PatternTermPtr&, const Handle&,

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -243,8 +243,8 @@ private:
 	// -------------------------------------------
 	// Upwards-walking and grounding of a single clause.
 	// See PatternMatchEngine.cc for descriptions
-	bool explore_clause(const Handle&, const Handle&, const Handle&);
 	bool explore_redex(const Handle&, const Handle&, const Handle&);
+	bool explore_clause(const Handle&, const Handle&, const Handle&);
 	bool explore_term_branches(const Handle&, const Handle&,
 	                           const Handle&);
 	bool explore_up_branches(const PatternTermPtr&, const Handle&,
@@ -261,6 +261,8 @@ private:
 	                             const Handle&);
 	bool explore_single_branch(const PatternTermPtr&, const Handle&,
 	                           const Handle&);
+	bool explore_dispatch(const PatternTermPtr&, const Handle&,
+	                      const Handle&);
 	bool do_term_up(const PatternTermPtr&, const Handle&,
 	                const Handle&);
 	bool clause_accept(const Handle&, const Handle&);

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -139,6 +139,7 @@ private:
 	bool _perm_have_more;
 	bool _perm_reset;
 	bool _perm_have_odometer;
+	PatternTermPtr _perm_first_term;
 	PatternTermPtr _perm_latest_term;
 	PatternTermPtr _perm_latest_wrap;
 	std::map<Unorder, int> _perm_count;

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -253,8 +253,6 @@ private:
 	                         const Handle&);
 	bool explore_upglob_branches(const PatternTermPtr&, const Handle&,
 	                         const Handle&);
-	bool explore_var_branches(const PatternTermPtr&, const Handle&,
-	                          const Handle&);
 	bool explore_glob_branches(const PatternTermPtr&, const Handle&,
 	                           const Handle&);
 	bool explore_type_branches(const PatternTermPtr&, const Handle&,

--- a/tests/query/unordered-odo-couple.scm
+++ b/tests/query/unordered-odo-couple.scm
@@ -25,8 +25,11 @@
 			(Variable "$U") (Variable "$V") (Variable "$W")
 			(Variable "$X") (Variable "$Y"))))
 
+; (cog-execute! couple-dim-two)
+
 ; ----------------------------------------------------
 ; Like above, but 2! * 1! * 2! = 4 permutations
+
 (List (Concept "C")
 	(Set (Predicate "P") (Predicate "Q") (Predicate "R"))
 	(Set (Predicate "R") (Predicate "S") (Predicate "T"))
@@ -43,8 +46,11 @@
 			(Variable "$D") (Variable "$E") (Variable "$F")
 			(Variable "$G"))))
 
+; (cog-execute! couple-dim-three)
+
 ; ----------------------------------------------------
 ; Like above, but 2*1*1*2 = 4 permutations
+
 (List (Concept "D")
 	(Set (Predicate "P") (Predicate "Q") (Predicate "R"))
 	(Set (Predicate "R") (Predicate "S") (Predicate "T"))
@@ -62,3 +68,7 @@
 			(Variable "$A") (Variable "$B") (Variable "$C")
 			(Variable "$D") (Variable "$E") (Variable "$F")
 			(Variable "$G") (Variable "$H") (Variable "$J"))))
+
+; (cog-execute! couple-dim-four)
+
+; ----------------------------------------------------


### PR DESCRIPTION
It had gotten a big spaghetti-codeified. The reorganization here might make it a bit
more readable/understandable.  There are no functional changes, and miniscule 
positive impacts on performance.