### PR TITLE
Remove global atomspace variable from PythonEval

### DIFF
--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -740,7 +740,7 @@ TruthValuePtr do_eval_with_args(AtomSpace* as,
 
 		// Be sure to specify the atomspace in which to work!
 		PythonEval &applier = PythonEval::instance();
-		return applier.apply_tv(as, schema.substr(pos), args);
+		return applier.apply_tv(schema.substr(pos), args);
 #else
 		throw RuntimeException(TRACE_INFO,
 			"This binary does not have python support in it; "

--- a/opencog/atoms/execution/ExecutionOutputLink.cc
+++ b/opencog/atoms/execution/ExecutionOutputLink.cc
@@ -187,11 +187,11 @@ ValuePtr ExecutionOutputLink::do_execute(AtomSpace* as,
 	else if (lang == "py")
 	{
 #ifdef HAVE_CYTHON
-		// Get a reference to the python evaluator. 
+		// Get a reference to the python evaluator.
 		// Be sure to specify the atomspace in which the
 		// evaluation is to be performed.
 		PythonEval &applier = PythonEval::instance();
-		result = applier.apply(as, fun, args);
+		result = applier.apply(fun, args);
 #else
 		throw RuntimeException(TRACE_INFO,
 		                       "Cannot evaluate python GroundedSchemaNode!");

--- a/opencog/atoms/execution/ExecutionOutputLink.cc
+++ b/opencog/atoms/execution/ExecutionOutputLink.cc
@@ -188,8 +188,6 @@ ValuePtr ExecutionOutputLink::do_execute(AtomSpace* as,
 	{
 #ifdef HAVE_CYTHON
 		// Get a reference to the python evaluator.
-		// Be sure to specify the atomspace in which the
-		// evaluation is to be performed.
 		PythonEval &applier = PythonEval::instance();
 		result = applier.apply(fun, args);
 #else

--- a/opencog/cython/PythonEval.cc
+++ b/opencog/cython/PythonEval.cc
@@ -78,18 +78,14 @@ const char* NO_FUNCTION_NAME = "";
  */
 PythonEval* PythonEval::singletonInstance = NULL;
 
-PythonEval::PythonEval(AtomSpace* atomspace)
+PythonEval::PythonEval()
 {
     // Check that this is the first and only PythonEval object.
     if (singletonInstance) {
         throw RuntimeException(TRACE_INFO,
             "Can't create more than one PythonEval singleton instance!");
     }
-
-    // Remember our atomspace.
-    _atomspace = atomspace;
     _paren_count = 0;
-
     // Initialize Python objects and imports.
     //
     // Strange but true: one can use the atomspace, and put atoms
@@ -128,12 +124,12 @@ PythonEval::~PythonEval()
 /**
 * Use a singleton instance to avoid initializing python interpreter twice.
 */
-void PythonEval::create_singleton_instance(AtomSpace* atomspace)
+void PythonEval::create_singleton_instance()
 {
     if (singletonInstance) return;
 
     // Create the single instance of a PythonEval object.
-    singletonInstance = new PythonEval(atomspace);
+    singletonInstance = new PythonEval();
 }
 
 void PythonEval::delete_singleton_instance()
@@ -145,51 +141,11 @@ void PythonEval::delete_singleton_instance()
     singletonInstance = NULL;
 }
 
-PythonEval& PythonEval::instance(AtomSpace* atomspace)
+PythonEval& PythonEval::instance()
 {
     // Make sure we have a singleton.
     if (!singletonInstance)
-        create_singleton_instance(atomspace);
-
-    // Make sure the atom space is the same as the one in the singleton.
-    if (atomspace and singletonInstance->_atomspace != atomspace) {
-
-#define CHECK_SINGLETON
-#ifdef CHECK_SINGLETON
-        if (nullptr != singletonInstance->_atomspace)
-        {
-            // Someone is trying to initialize the Python interpreter on a
-            // different AtomSpace.  Because of the singleton design of the
-            // the CosgServer+AtomSpace, there is no easy way to support this...
-            // logger().error() will print a stack tace to tell use who
-            // is doing this.
-            logger().error("PythonEval: ",
-                "Trying to re-initialize python interpreter with different\n"
-                "AtomSpace ptr! Current ptr=%p uuid=%d "
-                "New ptr=%p uuid=%d\n",
-                singletonInstance->_atomspace,
-                singletonInstance->_atomspace->get_uuid(),
-                atomspace, atomspace?atomspace->get_uuid():0);
-
-            throw RuntimeException(TRACE_INFO,
-                "Trying to re-initialize python interpreter with different\n"
-                "AtomSpace ptr! Current ptr=%p New ptr=%p\n",
-                singletonInstance->_atomspace, atomspace);
-        }
-#else
-        // We need to be able to call the python interpreter with
-        // different atomspaces; for example, we need to use temporary
-        // atomspaces when evaluating virtual links.  So, just set it
-        // here.  Hopefully the user will set it back, after using the
-        // temp atomspace.   Cleary, this is not thread-safe, and will
-        // bust with multiple threads. But the whole singleton-instance
-        // design is fundamentally flawed, so there is not much we can
-        // do about it until someone takes the time to fix this class
-        // to allow multiple instances.
-        //
-        singletonInstance->_atomspace = atomspace;
-#endif
-    }
+        create_singleton_instance();
     return *singletonInstance;
 }
 
@@ -508,28 +464,6 @@ void PythonEval::initialize_python_objects_and_imports(void)
     Py_INCREF(_pyRootModule);
     PyModule_AddStringConstant(_pyRootModule, "__file__", "");
 
-#define SET_ATOMSPACE_IN_MODULE
-#ifdef SET_ATOMSPACE_IN_MODULE
-    // This seems like a really bad idea ... why would we do this?
-    // Add ATOMSPACE to __main__ module.
-    PyObject* pyRootDictionary = PyModule_GetDict(_pyRootModule);
-    PyObject* pyAtomSpaceObject = this->atomspace_py_object(_atomspace);
-
-    // Sometimes the atomspace cannot be found, viz null pointer.
-    // I don't know why.
-    if (pyAtomSpaceObject)
-    {
-        PyDict_SetItemString(pyRootDictionary, "ATOMSPACE", pyAtomSpaceObject);
-        Py_DECREF(pyAtomSpaceObject);
-    }
-
-    // PyModule_GetDict returns a borrowed reference, so don't do this:
-    // Py_DECREF(pyRootDictionary);
-#endif // SET_ATOMSPACE_IN_MODULE
-
-    if (nullptr == _atomspace)
-        logger().warn("Python evaluator initialized with null atomspace!");
-
     // These are needed for calling Python/C API functions, define
     // them once here so we can reuse them.
     _pyGlobal = PyDict_New();
@@ -658,23 +592,6 @@ void PythonEval::import_module(const boost::filesystem::path &file,
         logger().warn() << "Couldn't import '" << moduleName << "' module";
         return;
     }
-
-#ifdef SET_ATOMSPACE_IN_MODULE
-    // This seems like a really bad idea ... why would we do this?
-    PyObject* pyModuleDictionary = PyModule_GetDict(pyModule);
-
-    // Add the ATOMSPACE object to this module
-    PyObject* pyAtomSpaceObject = this->atomspace_py_object(_atomspace);
-    PyDict_SetItemString(pyModuleDictionary, "ATOMSPACE",
-            pyAtomSpaceObject);
-
-    // This decrement is needed because PyDict_SetItemString does
-    // not "steal" the reference, unlike PyList_SetItem.
-    Py_DECREF(pyAtomSpaceObject);
-    if (nullptr == _atomspace)
-        logger().warn("Python module initialized with null atomspace!");
-#endif // SET_ATOMSPACE_IN_MODULE
-
     // We need to increment the pyModule reference because
     // PyModule_AddObject "steals" it and we're keeping a copy
     // in our modules list.
@@ -1030,7 +947,6 @@ PyObject* PythonEval::call_user_function(const std::string& moduleFunction,
     // Create the Python tuple for the function call with python
     // atoms for each of the atoms in the link arguments.
     PyObject* pyArguments = PyTuple_New(actualArgumentCount);
-    PyObject* pyAtomSpace = this->atomspace_py_object(_atomspace);
     const HandleSeq& argumentHandles = arguments->getOutgoingSet();
     int tupleItem = 0;
     for (const Handle& h: argumentHandles)
@@ -1045,7 +961,6 @@ PyObject* PythonEval::call_user_function(const std::string& moduleFunction,
 
         ++tupleItem;
     }
-    Py_DECREF(pyAtomSpace);
 
     // Execute the user function and store its return value.
     PyObject* pyReturnValue = PyObject_CallObject(pyUserFunc, pyArguments);
@@ -1077,10 +992,9 @@ PyObject* PythonEval::call_user_function(const std::string& moduleFunction,
     return pyReturnValue;
 }
 
-Handle PythonEval::apply(AtomSpace* as, const std::string& func, Handle varargs)
+Handle PythonEval::apply(const std::string& func, Handle varargs)
 {
     std::lock_guard<std::recursive_mutex> lck(_mtx);
-    RAII raii(this, as);
 
     // Get the atom object returned by this user function.
     PyObject* pyReturnAtom = this->call_user_function(func, varargs);
@@ -1130,12 +1044,12 @@ Handle PythonEval::apply(AtomSpace* as, const std::string& func, Handle varargs)
  * Apply the user function to the arguments passed in varargs and
  * return the extracted truth value.
  */
-TruthValuePtr PythonEval::apply_tv(AtomSpace *as,
+TruthValuePtr PythonEval::apply_tv(
                                    const std::string& func,
                                    Handle varargs)
 {
     std::lock_guard<std::recursive_mutex> lck(_mtx);
-    RAII raii(this, as);
+
 
     // Get the python truth value object returned by this user function.
     PyObject *pyTruthValue = call_user_function(func, varargs);
@@ -1194,7 +1108,6 @@ void PythonEval::apply_as(const std::string& moduleFunction,
                           AtomSpace* as_argument)
 {
     std::lock_guard<std::recursive_mutex> lck(_mtx);
-
     PyObject *pyModule, *pyObject, *pyUserFunc;
     PyObject *pyDict;
     std::string functionName;

--- a/opencog/cython/PythonEval.h
+++ b/opencog/cython/PythonEval.h
@@ -97,17 +97,6 @@ class PythonEval : public GenericEval
         // Single-threded design.
         static PythonEval* singletonInstance;
 
-        AtomSpace* _atomspace;
-        // Resource Acquisition is Allocation, for the current AtomSpace.
-        // If anything throws an exception, then dtor runs and restores
-        // the old atomspace.
-        struct RAII {
-            RAII(PythonEval* pev, AtomSpace* as) : _pev(pev)
-               { _save_as = pev->_atomspace; pev->_atomspace = as; }
-            ~RAII() {_pev->_atomspace = _save_as; }
-            AtomSpace* _save_as;
-            PythonEval* _pev;
-        };
 
         // Single, global mutex for serializing access to the atomspace.
         // The singleton-instance design of this class forces us to
@@ -143,13 +132,13 @@ class PythonEval : public GenericEval
         bool check_for_error();
 
     public:
-        PythonEval(AtomSpace*);
+        PythonEval();
         ~PythonEval();
 
         /**
          * Create the singleton instance with the supplied atomspace.
          */
-        static void create_singleton_instance(AtomSpace*);
+        static void create_singleton_instance();
 
         /**
          * Delete the singleton instance.
@@ -159,7 +148,7 @@ class PythonEval : public GenericEval
         /**
          * Get a reference to the singleton instance.
          */
-        static PythonEval & instance(AtomSpace* atomspace = NULL);
+        static PythonEval & instance();
 
         // The async-output interface.
         virtual void begin_eval(void);
@@ -178,13 +167,13 @@ class PythonEval : public GenericEval
          * Calls the Python function passed in `func`, passing it
          * the `varargs` as an argument, and returning a Handle.
          */
-        Handle apply(AtomSpace*, const std::string& func, Handle varargs);
+        Handle apply(const std::string& func, Handle varargs);
 
         /**
          * Calls the Python function passed in `func`, passing it
          * the `varargs` as an argument, returning a TruthValuePtr.
          */
-        TruthValuePtr apply_tv(AtomSpace*, const std::string& func, Handle varargs);
+        TruthValuePtr apply_tv(const std::string& func, Handle varargs);
 
         /**
          * Calls the Python function passed in `func`, passing it

--- a/opencog/cython/PythonSCM.cc
+++ b/opencog/cython/PythonSCM.cc
@@ -98,12 +98,17 @@ void* PythonSCM::init_in_guile(void* self)
 	scm_c_define_module("opencog python", init_in_module, self);
 	scm_c_use_module("opencog python");
 	PythonEval& pev = PythonEval::instance();
+  	// Make sure that guile and python are using the same atomspace.
+	// This will avoid assorted confusion.
+	AtomSpace* as = SchemeSmob::ss_get_env_as("python-eval");
 
 	// This feels hacky, I guess, but I cannot figure out any other
 	// way of telling python which atomspace it is supposed to use
 	// by default.
 	pev.eval("from opencog.atomspace import AtomSpace");
 	pev.eval("from opencog.type_constructors import set_type_ctor_atomspace");
+	pev.eval("set_type_ctor_atomspace(AtomSpace(" +
+            std::to_string((uint64_t) as) + "))\n");
 
 	return NULL;
 }

--- a/opencog/cython/PythonSCM.cc
+++ b/opencog/cython/PythonSCM.cc
@@ -97,21 +97,13 @@ void* PythonSCM::init_in_guile(void* self)
 {
 	scm_c_define_module("opencog python", init_in_module, self);
 	scm_c_use_module("opencog python");
-
-	// Make sure that guile and python are using the same atomspace.
-	// This will avoid assorted confusion.
-	AtomSpace* as = SchemeSmob::ss_get_env_as("python-eval");
-	PythonEval& pev = PythonEval::instance(as);
+	PythonEval& pev = PythonEval::instance();
 
 	// This feels hacky, I guess, but I cannot figure out any other
 	// way of telling python which atomspace it is supposed to use
 	// by default.
 	pev.eval("from opencog.atomspace import AtomSpace");
 	pev.eval("from opencog.type_constructors import set_type_ctor_atomspace");
-	char buf[301];
-	snprintf(buf, 300, "set_type_ctor_atomspace(AtomSpace(%ld))\n",
-		(uint64_t) as);
-	pev.eval(buf);
 
 	return NULL;
 }

--- a/opencog/cython/opencog/Utilities.cc
+++ b/opencog/cython/opencog/Utilities.cc
@@ -9,7 +9,7 @@
 
 using namespace opencog;
 
-void opencog::initialize_python(AtomSpace* atomSpace)
+void opencog::initialize_python()
 {
     // Initialize Python.
     logger().debug("initialize_opencog - initializing Python");
@@ -18,7 +18,7 @@ void opencog::initialize_python(AtomSpace* atomSpace)
     // Tell the python evaluator to create its singleton instance
     // with our atomspace.
     logger().debug("initialize_opencog - creating PythonEval singleton instance");
-    PythonEval::create_singleton_instance(atomSpace);
+    PythonEval::create_singleton_instance();
 }
 
 void opencog::finalize_python()

--- a/opencog/cython/opencog/Utilities.h
+++ b/opencog/cython/opencog/Utilities.h
@@ -26,7 +26,7 @@
 
 namespace opencog {
 
-void initialize_python(AtomSpace*);
+void initialize_python();
 void finalize_python();
 
 } // namespace opencog

--- a/opencog/cython/opencog/utilities.pxd
+++ b/opencog/cython/opencog/utilities.pxd
@@ -6,5 +6,5 @@ cdef extern from "opencog/cython/opencog/Utilities.h" namespace "opencog":
     #   initialize_python(AtomSpace*);
     #   void finalize_python();
     #
-    cdef void c_initialize_python "opencog::initialize_python" (cAtomSpace*)
+    cdef void c_initialize_python "opencog::initialize_python" ()
     cdef void c_finalize_python "opencog::finalize_python" ()

--- a/opencog/cython/opencog/utilities.pyx
+++ b/opencog/cython/opencog/utilities.pyx
@@ -15,7 +15,7 @@ def initialize_opencog(AtomSpace atomspace):
         return
     is_initialized = True
 
-    c_initialize_python(atomspace.atomspace)
+    c_initialize_python()
     set_type_ctor_atomspace(atomspace)
 
 def finalize_opencog():

--- a/tests/cython/PythonEvalUTest.cxxtest
+++ b/tests/cython/PythonEvalUTest.cxxtest
@@ -136,45 +136,27 @@ public:
     {
         logger().debug("[PythonEvalUTest] testPythonEvalSingletonCreationDeletion()");
 
-        AtomSpace* atomSpace = NULL;
 
         // Tell the python evaluator to create its singleton instance.
-        PythonEval::create_singleton_instance(NULL);
+        PythonEval::create_singleton_instance();
 
         // Delete the singleton instance of the PythonEval.
         PythonEval::delete_singleton_instance();
 
-
-        // Create an atomspace.
-        atomSpace = new AtomSpace();
-
-        // Tell the python evaluator to create its singleton instance
-        // with this atomspace.
-        PythonEval::create_singleton_instance(atomSpace);
+        PythonEval::create_singleton_instance();
 
         // Delete the singleton instance of the PythonEval.
         PythonEval::delete_singleton_instance();
 
-        // Delete the atomspace.
-        delete atomSpace;
-        atomSpace = NULL;
 
         // Initialize Python.
         global_python_initialize();
 
-        // Create an atomspace.
-        atomSpace = new AtomSpace();
-
-        // Tell the python evaluator to create its singleton instance
-        // with this atomspace.
-        PythonEval::create_singleton_instance(atomSpace);
+        // Repeat the process
+        PythonEval::create_singleton_instance();
 
         // Delete the singleton instance of the PythonEval.
         PythonEval::delete_singleton_instance();
-
-        // Delete the atomspace.
-        delete atomSpace;
-        atomSpace = NULL;
 
         logger().debug("[PythonEvalUTest] testPythonEvalSingletonCreationDeletion() DONE");
     }
@@ -182,35 +164,31 @@ public:
     void testPythonEvalEvalExpr()
     {
         logger().debug("[PythonEvalUTest] testPythonEvalEvalExpr()");
-
-        // Create an atomspace and singleton instance to use it.
-        AtomSpace* atomSpace = new AtomSpace();
-        PythonEval::create_singleton_instance(atomSpace);
+        PythonEval::create_singleton_instance();
         PythonEval* evaluator = &PythonEval::instance();
 
         // Check that our atom space global is visible and can add a node.
         evaluator->clear_pending();
         evaluator->eval_expr("from opencog.atomspace import *");
+        evaluator->eval_expr("ATOMSPACE = AtomSpace()");
         evaluator->eval_expr("ATOMSPACE.add_node(types.ConceptNode,'test')");
         evaluator->eval_expr("print ('Total atoms = ', ATOMSPACE.size(), '\\n')");
 
-        // Delete the singleton instance and atomspace.
+        // Delete the singleton instance.
         PythonEval::delete_singleton_instance();
-        delete atomSpace;
-        atomSpace = NULL;
         logger().debug("[PythonEvalUTest] testPythonEvalEvalExpr() DONE");
     }
 
     void testApplyAndApplyTV()
     {
-        AtomSpace *as = new AtomSpace();
-        PythonEval::create_singleton_instance(as);
+        PythonEval::create_singleton_instance();
         PythonEval* python = &PythonEval::instance();
 
         // Define python functions for use by scheme.
-        python->eval(
-            "from opencog.atomspace import types, Atom, TruthValue\n"
+        std::string eval_res = python->eval(
+            "from opencog.atomspace import vsfvkdfjnv Atom, TruthValue\n"
             "def add_link(atom1, atom2):\n"
+            "    ATOMSPACE = atom1.atomspace\n"
             "    link = ATOMSPACE.add_link(types.ListLink, [atom1, atom2])\n"
             "    print ('add_link(',atom1,',',atom2,') = ', link)\n"
             "    return link\n\n"
@@ -219,8 +197,10 @@ public:
             "    print ('return_truth TruthValue(0.75, 100.0)')\n"
             "    return TruthValue(0.75, 100.0)\n\n"
             );
+        std::cout << "eval_res:" << std::endl << eval_res << std::endl;
 
 #ifdef HAVE_GUILE
+        AtomSpace * as = new AtomSpace();
         // Create a scheme evaluator to trigger cog-evaluate and cog-execute.
         SchemeEval* scheme = new SchemeEval(as);
 
@@ -256,14 +236,14 @@ public:
                 );
         error = scheme->eval_error();
         scheme->clear_pending();
+        delete as;
         TSM_ASSERT("Failed cog-evaluate!", !error);
 #endif // HAVE_GUILE
     }
 
     void testCodeBlockWithNewline()
     {
-        AtomSpace *as = new AtomSpace();
-        PythonEval::create_singleton_instance(as);
+        PythonEval::create_singleton_instance();
         PythonEval* python = &PythonEval::instance();
 
         // Define python functions with newline within the code block

--- a/tests/cython/PythonEvalUTest.cxxtest
+++ b/tests/cython/PythonEvalUTest.cxxtest
@@ -184,9 +184,12 @@ public:
         PythonEval::create_singleton_instance();
         PythonEval* python = &PythonEval::instance();
 
+        TS_ASSERT_THROWS(std::string eval_res = python->eval(
+                    "from opencog.atomspace import vsfvkdfjnv\n"), RuntimeException);
+
         // Define python functions for use by scheme.
         std::string eval_res = python->eval(
-            "from opencog.atomspace import vsfvkdfjnv Atom, TruthValue\n"
+            "from opencog.atomspace import Atom, TruthValue\n"
             "def add_link(atom1, atom2):\n"
             "    ATOMSPACE = atom1.atomspace\n"
             "    link = ATOMSPACE.add_link(types.ListLink, [atom1, atom2])\n"

--- a/tests/cython/PythonUtilitiesUTest.cxxtest
+++ b/tests/cython/PythonUtilitiesUTest.cxxtest
@@ -33,28 +33,17 @@ public:
 
     void testOpencogInitializationFinalization() {
 
-        // Create an atomspace.
-        AtomSpace* atomSpace = new AtomSpace();
-
         // Initialize Python.
-        initialize_python(atomSpace);
+        initialize_python();
 
         // Stop Python.
         finalize_python();
-
-        // Delete the atom space.
-        delete atomSpace;
 
         // Do it again.
 
-        // Create a atomspace.
-        atomSpace = new AtomSpace();
-
         // Stop Python.
         finalize_python();
 
-        // Delete the atom space.
-        delete atomSpace;
    }
 
 

--- a/tests/cython/atomspace/test_atom.py
+++ b/tests/cython/atomspace/test_atom.py
@@ -2,6 +2,8 @@ import unittest
 from unittest import TestCase
 
 from opencog.atomspace import AtomSpace, Atom, TruthValue
+from opencog.bindlink import execute_atom
+
 from opencog.atomspace import types, is_a, get_type, get_type_name, create_child_atomspace
 
 from opencog.type_constructors import *
@@ -70,6 +72,36 @@ class AtomTest(TestCase):
         error_str = "key should be an instance of Atom, got {0} instead".format(str)
         with self.assertRaisesRegex(TypeError, error_str):
             string_node.set_value("bad key", StringValue("Hello, World!"))
+
+    def test_grounded_cond(self):
+        grounded_cond = CondLink(
+                    EvaluationLink (
+                        GroundedPredicateNode ("py:grounded_cond1"),
+                        ListLink ()),
+                    NumberNode('1'),
+                        EvaluationLink(
+                            GroundedPredicateNode("py:grounded_cond2"),
+                            ListLink()),
+                    NumberNode('2'))
+        result = execute_atom(self.space, grounded_cond)
+        baz = NumberNode("2")
+        print("got %s", result)
+        print("expected %s\n", baz)
+        self.assertTrue(result == baz)
+
+
+def grounded_cond1(*args):
+    print(args)
+    return TruthValue(0, 0)
+
+def grounded_cond2(*args):
+    print(args)
+    return TruthValue(1, 1)
+
+import __main__
+
+__main__.grounded_cond1 = grounded_cond1
+__main__.grounded_cond2 = grounded_cond2
 
 
 if __name__ == '__main__':

--- a/tests/cython/bindlink/test_bindlink.py
+++ b/tests/cython/bindlink/test_bindlink.py
@@ -8,6 +8,7 @@ from opencog.type_constructors import *
 from opencog.utilities import initialize_opencog, finalize_opencog
 
 from test_functions import green_count, red_count
+import test_functions
 
 __author__ = 'Curtis Faith'
 

--- a/tests/cython/bindlink/test_functions.py
+++ b/tests/cython/bindlink/test_functions.py
@@ -1,18 +1,20 @@
-# 
+#
 # Test Functions
 
 from opencog.atomspace import types, Atom, TruthValue
 from opencog.type_constructors import *
 
+
 def print_arguments(argOne, argTwo):
     print ("argOne = ", argOne)
     print ("argTwo = ", argTwo)
-    atom = ATOMSPACE.add_link(types.ListLink, [argOne, argTwo])
+    atomspace = argOne.atomspace
+    atom = atomspace.add_link(types.ListLink, [argOne, argTwo])
     print ("atom = ", atom)
     return atom
 
 def add_link(atom_one, atom_two):
-    link_atom = ATOMSPACE.add_link(types.ListLink, [atom_one, atom_two])
+    link_atom = atom_one.atomspace.add_link(types.ListLink, [atom_one, atom_two])
     return link_atom
 
 def bogus_tv(atom_one, atom_two):

--- a/tests/scm/scm-python-arity.scm
+++ b/tests/scm/scm-python-arity.scm
@@ -19,7 +19,7 @@ from opencog.type_constructors import atomspace
 
 # Twiddle some atoms in the atomspace
 def foo(atom_a, atom_b) :
-    global atomspace
+    atomspace = atom_a.atomspace
     TV = TruthValue(0.2, 0.69)
     atomspace.add_node(types.ConceptNode, 'Apple', TV)
     atomspace.add_link(types.InheritanceLink, [atom_a, atom_b])

--- a/tests/scm/scm-python-arity.scm
+++ b/tests/scm/scm-python-arity.scm
@@ -15,7 +15,7 @@
 ; Define a python func returning a TV
 (python-eval "
 from opencog.atomspace import AtomSpace, TruthValue, types
-from opencog.type_constructors import atomspace
+
 
 # Twiddle some atoms in the atomspace
 def foo(atom_a, atom_b) :

--- a/tests/scm/scm-python-shared-atomspace.scm
+++ b/tests/scm/scm-python-shared-atomspace.scm
@@ -19,9 +19,10 @@
 from opencog.atomspace import AtomSpace, TruthValue, types
 from opencog.type_constructors import atomspace
 
+
 # Twiddle some atoms in the atomspace
 def foo(atom_a, atom_b):
-    global atomspace
+    atomspace = atom_a.atomspace
     TV = TruthValue(0.2, 0.69)
     atomspace.add_node(types.ConceptNode, 'Apple', TV)
     atomspace.add_link(types.InheritanceLink, [atom_a, atom_b])

--- a/tests/scm/scm-python-shared-atomspace.scm
+++ b/tests/scm/scm-python-shared-atomspace.scm
@@ -17,17 +17,18 @@
 ; Define a python func returning a TV
 (python-eval "
 from opencog.atomspace import AtomSpace, TruthValue, types
-from opencog.type_constructors import atomspace
+from opencog.utilities import get_type_ctor_atomspace
 
 
 # Twiddle some atoms in the atomspace
 def foo(atom_a, atom_b):
-    atomspace = atom_a.atomspace
+    atomspace = get_type_ctor_atomspace()
     TV = TruthValue(0.2, 0.69)
     atomspace.add_node(types.ConceptNode, 'Apple', TV)
     atomspace.add_link(types.InheritanceLink, [atom_a, atom_b])
     return TruthValue(0.42, 0.24)
 ")
+
 
 ; Call the python func defined above.
 (cog-evaluate!


### PR DESCRIPTION
Atomspace set by initialize_opencog wasn't used anywhere, except by tests.

This PR implements some changes from discussion in this issue https://github.com/opencog/atomspace/issues/2391