### PR TITLE
Inf&nan number support

### DIFF
--- a/opencog/atoms/core/NumberNode.cc
+++ b/opencog/atoms/core/NumberNode.cc
@@ -47,17 +47,14 @@ std::vector<double> NumberNode::to_vector(const std::string& str)
 	std::vector<double> vec;
 
 	size_t pos = 0;
-	size_t len = str.size();
-	while (true)
-	{
-		pos = str.find_first_of("+-0123456789.", pos);
-		if (pos == std::string::npos) return vec;
-		size_t last;
-		vec.emplace_back(std::stod(str.substr(pos), &last));
-		if (pos == std::string::npos) return vec;
-		pos += last;
-		if (len <= pos) return vec;
+	size_t in = 0;
+	// first condition in the loop will trim str.
+	while ((in = str.find_first_not_of(" \t\r\n", in)) != std::string::npos
+	       and (pos = str.find_first_of(' ', in)) != std::string::npos) {
+		vec.emplace_back(std::stod(str.substr(in, pos - in)));
+		in = pos + 1;
 	}
+	if (in != std::string::npos) vec.emplace_back(std::stod(str.substr(in)));
 	return vec;
 }
 

--- a/opencog/atoms/core/NumberNode.h
+++ b/opencog/atoms/core/NumberNode.h
@@ -23,6 +23,7 @@
 #ifndef _OPENCOG_NUMBER_NODE_H
 #define _OPENCOG_NUMBER_NODE_H
 
+#include <boost/lexical_cast.hpp>
 #include <opencog/atoms/base/Node.h>
 #include <opencog/atoms/value/FloatValue.h>
 
@@ -54,7 +55,7 @@ private:
 	// the European comma as a decimal separator blows up the code.
 	static std::string double_to_string(double x)
 	{
-		std::string vs(std::to_string(x));
+		std::string vs = boost::lexical_cast<std::string>(x);
 		std::size_t found = vs.find(',');
 		if (std::string::npos != found)
 			vs[found] = '.';

--- a/tests/atoms/reduct/ReductUTest.cxxtest
+++ b/tests/atoms/reduct/ReductUTest.cxxtest
@@ -58,6 +58,8 @@ public:
 	void tearDown(void);
 
 	void test_arithmetic(void);
+	void test_arithmetic_inf(void);
+	void test_arithmetic_nan(void);
 	void test_setlink(void);
 	void test_minus(void);
 	void test_plus_minus(void);
@@ -213,6 +215,64 @@ void ReductUTest::test_arithmetic(void)
 
 	// ---------
 	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+/*
+ * Test Plus inf.
+ */
+void ReductUTest::test_arithmetic_inf(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	// ---------
+	Handle inf = eval->eval_h(
+			"(cog-execute! (PlusLink (NumberNode 0) (NumberNode \"inf\")))"
+	);
+	printf("expecting res: %s\n", inf->to_short_string().c_str());
+
+	Handle einf = eval->eval_h("(NumberNode \"inf\")");
+	TS_ASSERT_EQUALS(inf, einf)
+
+	// ---------
+	Handle pninf4 = eval->eval_h(
+			"(cog-execute! "
+			"   (PlusLink"
+			"      (NumberNode \"inf 0 3.0\")"
+			"      (NumberNode \"inf -inf 1.0\")))"
+	);
+	printf("expecting res: %s\n", pninf4->to_short_string().c_str());
+
+	Handle epninf4 = eval->eval_h("(NumberNode \"inf -inf 4.0\")");
+	TS_ASSERT_EQUALS(pninf4, epninf4)
+}
+
+/*
+ * Test Plus nan.
+ */
+void ReductUTest::test_arithmetic_nan(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	// ---------
+	Handle nan = eval->eval_h(
+			"(cog-execute! (PlusLink (NumberNode 0) (NumberNode \"nan\")))"
+	);
+	printf("expecting nan: %s\n", nan->to_short_string().c_str());
+
+	Handle enan = eval->eval_h("(NumberNode \"nan\")");
+	TS_ASSERT_EQUALS(nan, enan)
+
+	// ---------
+	Handle nn4 = eval->eval_h(
+			"(cog-execute! "
+			"   (PlusLink"
+			"      (NumberNode \"nan nan 3.0\")"
+			"      (NumberNode \"inf -inf 1.0\")))"
+	);
+	printf("expecting nn4: %s\n", nn4->to_short_string().c_str());
+
+	Handle enn4 = eval->eval_h("(NumberNode \"nan nan 4.0\")");
+	TS_ASSERT_EQUALS(nn4, enn4)
 }
 
 // Test SetLink, which the pattern matcher gives to us.


### PR DESCRIPTION
NOTE: commit c8fe151 replaces the existing std::to_string by boost::lexical_cast I had to change this because apparently std::to_string fails when creating an infinity NumberNode on at least some systems, which I couldn't find any pattern on. The problem doesn't rise when tried from the atomspace, but the same code i:e (NumberNode "-inf") would fail from asmoses.

If it is due to build configuration I couldn't find it. If any one has any idea on that or think boost::lexical_cast could rise a problem I didn't see, I will be glad to proceed to fix the configuration error rather than this PR.