### PR TITLE
split PyEval initialization and setting default atomspace

### DIFF
--- a/opencog/cython/opencog/type_constructors.pyx
+++ b/opencog/cython/opencog/type_constructors.pyx
@@ -7,18 +7,38 @@
 # This imports all the python wrappers for atom creation.
 #
 
+import warnings
 from opencog.atomspace import (createFloatValue, createLinkValue,
                                 createStringValue, createTruthValue)
 from opencog.atomspace import AtomSpace, types
 
 atomspace = None
 def set_type_ctor_atomspace(new_atomspace):
+    warnings.warn('set_type_ctor_atomspace is deprecated, use set_default_atomspace instead',
+            DeprecationWarning)
+    return set_default_atomspace(new_atomspace)
+
+def get_type_ctor_atomspace():
+    warnings.warn('get_type_ctor_atomspace is deprecated, use get_default_atomspace instead',
+            DeprecationWarning)
+    return get_default_atomspace()
+
+
+def set_default_atomspace(new_atomspace):
+    """
+    Set default atomspace for all threads
+    """
     global atomspace
     atomspace = new_atomspace
 
-def get_type_ctor_atomspace():
+
+def get_default_atomspace():
+    """
+    Get default atomspace
+    """
     global atomspace
     return atomspace
+
 
 include "opencog/atoms/atom_types/core_types.pyx"
 

--- a/opencog/cython/opencog/utilities.pyx
+++ b/opencog/cython/opencog/utilities.pyx
@@ -1,43 +1,54 @@
 from contextlib import contextmanager
 from opencog.atomspace cimport AtomSpace
 from opencog.atomspace import create_child_atomspace
-from opencog.type_constructors import get_type_ctor_atomspace, set_type_ctor_atomspace
+from opencog.type_constructors import get_default_atomspace, set_default_atomspace
+import warnings
+
 
 # Avoid recursive intialization
 is_initialized = False
 
-def initialize_opencog(AtomSpace atomspace):
 
+def initialize_opencog(AtomSpace atomspace=None):
+    """
+    Set default atomspace(deprecated feature) and
+    create python evaluator singleton object.
+
+    Calling this function should not be needed. Use set_default_atomspace to set default atomspace.
+    Python evaluator will be created on first evaluation.
+    """
+    if atomspace is not None:
+        warnings.warn("setting default atomspace with initialize_opencog is deprecated,\
+                use set_default_atomspace instead", DeprecationWarning)
+        set_default_atomspace(atomspace)
     # Avoid recursive intialization
     global is_initialized
     if is_initialized:
-        set_type_ctor_atomspace(atomspace)
         return
     is_initialized = True
-
     c_initialize_python()
-    set_type_ctor_atomspace(atomspace)
+
 
 def finalize_opencog():
     global is_initialized
     if is_initialized:
-        set_type_ctor_atomspace(None)
+        set_default_atomspace(None)
         c_finalize_python()
-
     is_initialized = False
 
 
 @contextmanager
 def tmp_atomspace():
     """
-    Context manager, to create child atomspace from current default 
+    Context manager, to create child atomspace from current default
     """
-    parent_atomspace = get_type_ctor_atomspace()
+    parent_atomspace = get_default_atomspace()
     if parent_atomspace is None:
         raise RuntimeError("Default atomspace is None")
     atomspace = create_child_atomspace(parent_atomspace)
-    initialize_opencog(atomspace)
+    set_default_atomspace(atomspace)
     try:
         yield atomspace
     finally:
-        initialize_opencog(parent_atomspace)
+        set_default_atomspace(parent_atomspace)
+

--- a/tests/cython/bindlink/test_bindlink.py
+++ b/tests/cython/bindlink/test_bindlink.py
@@ -5,7 +5,6 @@ from opencog.atomspace import AtomSpace, TruthValue, Atom, types
 from opencog.bindlink import execute_atom, evaluate_atom
 
 from opencog.type_constructors import *
-from opencog.utilities import initialize_opencog, finalize_opencog
 
 from test_functions import green_count, red_count
 import test_functions
@@ -27,8 +26,7 @@ class BindlinkTest(unittest.TestCase):
         self.atomspace.clear()
 
         # Initialize Python
-        initialize_opencog(self.atomspace)
-        set_type_ctor_atomspace(self.atomspace)
+        set_default_atomspace(self.atomspace)
 
         # Define several animals and something of a different type as well
         InheritanceLink( ConceptNode("Frog"),       ConceptNode("animal"))


### PR DESCRIPTION
better names for setting and getting default atomspace:

set_default_atomspace and get_default_atomspace, also allow to call initialize_opencog without atomspace

fix for issue https://github.com/opencog/atomspace/issues/2391