### PR TITLE
Remove `using opencog` from header.

### DIFF
--- a/opencog/atoms/pattern/PatternTerm.h
+++ b/opencog/atoms/pattern/PatternTerm.h
@@ -131,8 +131,6 @@ std::string oc_to_string(const PatternTermPtr& pt,
 
 } // namespace opencog
 
-using namespace opencog;
-
 namespace std {
 
 /**
@@ -145,12 +143,12 @@ namespace std {
  * to walk over permutations of unordered links.
  */
 template<>
-struct less<PatternTermPtr>
+struct less<opencog::PatternTermPtr>
 {
-	bool operator()(const PatternTermPtr& lhs, const PatternTermPtr& rhs) const
+	bool operator()(const opencog::PatternTermPtr& lhs, const opencog::PatternTermPtr& rhs) const
 	{
-		const Handle& lHandle = lhs->getHandle();
-		const Handle& rHandle = rhs->getHandle();
+		const opencog::Handle& lHandle = lhs->getHandle();
+		const opencog::Handle& rHandle = rhs->getHandle();
 		if (lHandle == rHandle)
 		{
 			if (not lHandle) return false;


### PR DESCRIPTION
`using namespace opencog` in header exports all `opencog` namespace into global namespace.