### PR TITLE
Temporarily disable the cogserver unit test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,13 +224,13 @@ jobs:
 #      - run:
 #          name: Run tests
 #          command: cd build && make test ARGS="$MAKEFLAGS"
+#      - run:
+#          name: Print test log
+#          command: cat build/tests/Testing/Temporary/LastTest.log
+#          when: always
       - run:
           name: Install CogServer
           command: cd build && make install && ldconfig
-      - run:
-          name: Print test log
-          command: cat build/tests/Testing/Temporary/LastTest.log
-          when: always
       - persist_to_workspace:
           root: /ws/
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,9 +217,13 @@ jobs:
       - run:
           name: Build tests
           command: cd build && make tests
-      - run:
-          name: Run tests
-          command: cd build && make test ARGS="$MAKEFLAGS"
+#
+# Disable, until https://github.com/opencog/cogserver/issues/5
+# is fixed. The failing ShellUTest makes circleci report false
+# negatives.
+#      - run:
+#          name: Run tests
+#          command: cd build && make test ARGS="$MAKEFLAGS"
       - run:
           name: Install CogServer
           command: cd build && make install && ldconfig
@@ -373,13 +377,9 @@ workflows:
   build-test-package:
     jobs:
       - atomspace
-#
-# Disable, until https://github.com/opencog/cogserver/issues/5
-# is fixed. The failing ShellUTest makes circleci report false
-# negatives.
-#      - cogserver:
-#          requires:
-#            - atomspace
+      - cogserver:
+          requires:
+            - atomspace
       - ure:
           requires:
             - atomspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,9 +373,13 @@ workflows:
   build-test-package:
     jobs:
       - atomspace
-      - cogserver:
-          requires:
-            - atomspace
+#
+# Disable, until https://github.com/opencog/cogserver/issues/5
+# is fixed. The failing ShellUTest makes circleci report false
+# negatives.
+#      - cogserver:
+#          requires:
+#            - atomspace
       - ure:
           requires:
             - atomspace


### PR DESCRIPTION
Disable, until https://github.com/opencog/cogserver/issues/5
is fixed. The failing ShellUTest makes circleci report false
negatives.