### PR TITLE
Check for mal-formed links, before they bite later on.

### DIFF
--- a/opencog/atoms/base/Link.cc
+++ b/opencog/atoms/base/Link.cc
@@ -47,6 +47,12 @@ void Link::init(const HandleSeq& outgoingVector)
             _type, nameserver().getTypeName(_type).c_str());
     }
 
+    // Yes, people actually send us bad data.
+    for (const Handle& h: outgoingVector)
+        if (nullptr == h)
+            throw InvalidParamException(TRACE_INFO,
+                "Link ctor: invalid outgoing set!");
+
     _outgoing = outgoingVector;
 }
 


### PR DESCRIPTION
OpenPsi was sending us junk, leading to mystery crashes.