### PR TITLE
Assume FreeLinks are always ordered links.

### DIFF
--- a/opencog/atoms/core/FreeLink.cc
+++ b/opencog/atoms/core/FreeLink.cc
@@ -32,8 +32,6 @@ FreeLink::FreeLink(const HandleSeq& oset, Type t)
 	if (not nameserver().isA(t, FREE_LINK))
 		throw InvalidParamException(TRACE_INFO, "Expecting a FreeLink");
 
-	unorder();
-
 	// Derived classes have thier own init routines.
 	if (FREE_LINK != t) return;
 	init();
@@ -46,8 +44,6 @@ FreeLink::FreeLink(const Link& l)
 	if (not nameserver().isA(tscope, FREE_LINK))
 		throw InvalidParamException(TRACE_INFO, "Expecting a FreeLink");
 
-	unorder();
-
 	// Derived classes have thier own init routines.
 	if (FREE_LINK != tscope) return;
 	init();
@@ -55,25 +51,9 @@ FreeLink::FreeLink(const Link& l)
 
 /* ================================================================= */
 
-void FreeLink::unorder(void)
-{
-	if (not is_unordered_link()) return;
-
-	// Place into arbitrary, but deterministic order.
-	// We have to do this here,  because some links,
-	// e.g. EqualLink and IdenticalLink are unordered,
-	// but don't inherit from the C++ UnorderedLink class.
-	// So we hack around and do it here.
-	// Use content_based_handle_less() to avoid variations due
-	// to address-space randomization.
-	std::sort(_outgoing.begin(), _outgoing.end(),
-		content_based_handle_less());
-}
-
 void FreeLink::init(void)
 {
-	bool ordered = not is_unordered_link();
-	_vars.find_variables(_outgoing, ordered);
+	_vars.find_variables(_outgoing, true);
 }
 
 DEFINE_LINK_FACTORY(FreeLink, FREE_LINK);

--- a/opencog/atoms/core/FreeLink.h
+++ b/opencog/atoms/core/FreeLink.h
@@ -42,8 +42,6 @@ class FreeLink : public Link
 {
 protected:
 	FreeVariables _vars;
-
-	void unorder(void);
 	void init(void);
 
 public:


### PR DESCRIPTION
This reverts commit e3c26feac825de54db8461484df446583a49dd77
which added this code, with minimal explanation as to what the
actual problem was.

The current problem is that the C++ code comment mentions
EqualLink and IdenticalLink, both of which *are* unordered,
but neither of which are FreeLinks.  Grepping through the
atom type definitions, I found no free, unordered link types.
(for the spacetime, attention and agi-bio).