### PR TITLE
More CMake voodoo

### DIFF
--- a/opencog/atoms/atom_types/CMakeLists.txt
+++ b/opencog/atoms/atom_types/CMakeLists.txt
@@ -10,6 +10,11 @@ ADD_CUSTOM_TARGET(opencog_atom_types DEPENDS atom_types.h
 	atom_types.definitions atom_types.inheritance core_types.scm
 	core_types.pyx)
 
+# The goal of SET_SOURCE_FILE_PROPERTIES is to guarantee that the
+# creation of `atom_types.h` is finished BEFORE the compilation of
+# `NameServer.cc` starts.
+SET_SOURCE_FILES_PROPERTIES(atom_types.h PROPERTIES GENERATED TRUE)
+
 # The atom_types.h file is written to the build directory
 INCLUDE_DIRECTORIES(${CMAKE_BINARY_DIR})
 
@@ -19,6 +24,8 @@ ADD_LIBRARY (atom_types
 	)
 
 # Without this, parallel make will race and crap up the generated files.
+# Actually, that's not true ... even with this, compilation of other
+# units might start before the generation has finished.  Ugh.
 ADD_DEPENDENCIES(atom_types opencog_atom_types)
 
 TARGET_LINK_LIBRARIES(atom_types

--- a/opencog/atoms/atom_types/CMakeLists.txt
+++ b/opencog/atoms/atom_types/CMakeLists.txt
@@ -12,8 +12,12 @@ ADD_CUSTOM_TARGET(opencog_atom_types DEPENDS atom_types.h
 
 # The goal of SET_SOURCE_FILE_PROPERTIES is to guarantee that the
 # creation of `atom_types.h` is finished BEFORE the compilation of
-# `NameServer.cc` starts.
+# `NameServer.cc` starts. Similar concerns apply to the use of the
+# pyx file, as well as the two C files (definitions, inheritance).
 SET_SOURCE_FILES_PROPERTIES(atom_types.h PROPERTIES GENERATED TRUE)
+SET_SOURCE_FILES_PROPERTIES(atom_types.definitions PROPERTIES GENERATED TRUE)
+SET_SOURCE_FILES_PROPERTIES(atom_types.inheritance PROPERTIES GENERATED TRUE)
+SET_SOURCE_FILES_PROPERTIES(core_types.pyx PROPERTIES GENERATED TRUE)
 
 # The atom_types.h file is written to the build directory
 INCLUDE_DIRECTORIES(${CMAKE_BINARY_DIR})


### PR DESCRIPTION
Another attempt to fix issue opencog/opencog-nix#54

The root cause is that the build of `NameServer.o` starts
before the generation of `atom_types.h` has finished.