### PR TITLE
Localize use of PatternMatchEngine

### DIFF
--- a/opencog/query/InitiateSearchCB.cc
+++ b/opencog/query/InitiateSearchCB.cc
@@ -440,55 +440,55 @@ bool InitiateSearchCB::search_loop(PatternMatchEngine *pme,
  *    but this has no effect on the thoroughness of the search.  The search
  *    will proceed by exploring the entire incoming-set for this node.
  *
- *    This is ideal, when the node_match() callback accepts a match only
+ *    This is ideal, when the `node_match()` callback accepts a match only
  *    when the pattern and suggested nodes are identical (i.e. are
- *    exactly the same atom).  If the node_match() callback is willing to
- *    accept a broader range of node matches, then other possible
+ *    exactly the same atom).  If the `node_match()` callback is willing
+ *    to accept a broader range of node matches, then other possible
  *    solutions might be missed. Just how to fix this depends sharpely
- *    on what node_match() is willing to accept as a match.
+ *    on what `node_match()` is willing to accept as a match.
  *
  *    Anyway, this seems like a very reasonable limitation: if you
- *    really want a lenient node_match(), then use variables instead.
- *    Don't overload node-match with something weird, and you should be
- *    OK.  Otherwise, you'll have to implement your own initiate_search()
- *    callback.
+ *    really want a lenient `node_match()`, then use variables instead.
+ *    Don't overload `node_match` with something weird, and you should
+ *    be OK.  Otherwise, you'll have to implement your own
+ *    `initiate_search()` callback.
  *
  * 2) If the clauses consist entirely of variables, i.e. if there is not
  *    even one single non-variable node in the pattern, then a search is
  *    driven by looking for all links that are of the same type as one
  *    of the links in one of the clauses.
  *
- *    If the link_match() callback is willing to accept a broader range
+ *    If the `link_match()` callback is willing to accept a broader range
  *    of types, then this search method may fail to find some possible
  *    patterns.
  *
- *    Lets start by noting that this situation is very rare: most
- *    patterns will not consist entirely if Links and VariableNodes.
+ *    Let's start by noting that this situation is very rare: most
+ *    patterns will not consist entirely of `Links` and `VariableNodes`.
  *    Almost surely, most reasonable people will have at least one
  *    non-variable node in the pattern. So the disucssion below almost
  *    surely does not apply.
  *
  *    But if you really want this, there are several possible remedies.
- *    One is to modify the link_type_search() callback to try each
+ *    One is to modify the `link_type_search()` callback to try each
  *    possible link type that is considered to be equivalent by
- *    link_match(). Another alternative is to just leave the
- *    link_match() callback alone, and use variables for links, instead.
+ *    `link_match()`. Another alternative is to just leave the
+ *    `link_match()` callback alone, and use variables for links, instead.
  *    This is probably the best strategy, because then the fairly
  *    standard reasoning can be used when thinking about the problem.
- *    Of course, you can always write your own initiate_search() callback.
+ *    Of course, you can always write your own `initiate_search()` callback.
  *
  * If the constraint 1) can be met, (which is always the case for
  * "standard, canonical" searches, then the pattern match should be
  * quite rapid.  Incoming sets tend to be small; in addition, the
- * implemnentation here picks the smallest, "tinnest" incoming set to
+ * implemnentation here picks the smallest, "thinnest" incoming set to
  * explore.
  *
- * The default implementation of node_match() and link_match() in this
+ * The default implementation of `node_match()` and `link_match()` in this
  * class does satisfy both 1) and 2), so this algo will work correctly,
  * if these two methods are not overloaded with more callbacks that are
  * lenient about matching.
  *
- * If you overload node_match(), and do so in a way that breaks
+ * If you overload `node_match()`, and do so in a way that breaks
  * assumption 1), then you will scratch your head, thinking
  * "why did my search fail to find this obvious solution?" The answer
  * will be for you to create a new search algo, in a new class, that
@@ -498,7 +498,8 @@ bool InitiateSearchCB::search_loop(PatternMatchEngine *pme,
  */
 bool InitiateSearchCB::initiate_search(PatternMatchEngine *pme)
 {
-	jit_analyze(pme);
+	jit_analyze();
+	pme->set_pattern(*_variables, *_pattern);
 
 	DO_LOG({logger().fine("Attempt to use node-neighbor search");})
 	if (setup_neighbor_search())
@@ -828,7 +829,7 @@ bool InitiateSearchCB::setup_no_search(void)
  * earlier, because the definitions for them might not have been
  * present, or may have changed since the pattern was initially created.
  */
-void InitiateSearchCB::jit_analyze(PatternMatchEngine* pme)
+void InitiateSearchCB::jit_analyze(void)
 {
 	// If there are no definitions, there is nothing to do.
 	if (0 == _pattern->defined_terms.size())
@@ -889,7 +890,6 @@ void InitiateSearchCB::jit_analyze(PatternMatchEngine* pme)
 
 	_dynamic = &_pattern->evaluatable_terms;
 
-	pme->set_pattern(*_variables, *_pattern);
 	set_pattern(*_variables, *_pattern);
 	DO_LOG({logger().fine("JIT expanded!");
 	_pl->debug_log();})

--- a/opencog/query/InitiateSearchCB.cc
+++ b/opencog/query/InitiateSearchCB.cc
@@ -513,7 +513,9 @@ bool InitiateSearchCB::initiate_search(PatternMatchEngine *pme)
 	// method.
 	DO_LOG({logger().fine("Cannot use link-type search, use variable-type search");})
 	_search_fail = false;
-	found = variable_search(pme);
+	bool setup = setup_variable_search();
+	if (setup)
+		found = search_loop(pme, "zzzzzzzzzzz variable_search zzzzzzzzzzz");
 	return found;
 }
 
@@ -797,10 +799,9 @@ bool InitiateSearchCB::setup_variable_search(void)
 	return true;
 }
 
-bool InitiateSearchCB::variable_search(PatternMatchEngine *pme)
+bool InitiateSearchCB::search_loop(PatternMatchEngine *pme,
+                                   const std::string dbg_banner)
 {
-	if (not setup_variable_search()) return false;
-
 	DO_LOG({LAZY_LOG_FINE << "Search-set size: "
 	            << _search_set.size() << " atoms";})
 
@@ -809,9 +810,9 @@ bool InitiateSearchCB::variable_search(PatternMatchEngine *pme)
 #endif
 	for (const Handle& h : _search_set)
 	{
-		DO_LOG({LAZY_LOG_FINE << "zzzzzzzzzzz variable_search zzzzzzzzzzz\n"
-		                      << "Loop candidate (" << ++i << "/" << hsz << "):\n"
-		                      << h->to_string();})
+		DO_LOG({LAZY_LOG_FINE << dbg_banner
+		             << "\nLoop candidate (" << ++i << "/" << hsz << "):\n"
+		             << h->to_string();})
 		bool found = pme->explore_neighborhood(_root, _starter_term, h);
 		if (found) return true;
 	}

--- a/opencog/query/InitiateSearchCB.cc
+++ b/opencog/query/InitiateSearchCB.cc
@@ -501,7 +501,8 @@ bool InitiateSearchCB::initiate_search(PatternMatchEngine *pme)
 	// types that occur in the atomspace.
 	DO_LOG({logger().fine("Cannot use no-var search, use link-type search");})
 	_search_fail = false;
-	found = link_type_search(pme);
+	if (setup_link_type_search())
+		found = search_loop(pme, "yyyyyyyyyy link_type_search yyyyyyyyyy");
 	if (found) return true;
 	if (not _search_fail) return false;
 
@@ -513,8 +514,7 @@ bool InitiateSearchCB::initiate_search(PatternMatchEngine *pme)
 	// method.
 	DO_LOG({logger().fine("Cannot use link-type search, use variable-type search");})
 	_search_fail = false;
-	bool setup = setup_variable_search();
-	if (setup)
+	if (setup_variable_search())
 		found = search_loop(pme, "zzzzzzzzzzz variable_search zzzzzzzzzzz");
 	return found;
 }
@@ -561,7 +561,7 @@ void InitiateSearchCB::find_rarest(const Handle& clause,
  * type which has the smallest number of atoms of that type in the
  * AtomSpace.
  */
-bool InitiateSearchCB::link_type_search(PatternMatchEngine *pme)
+bool InitiateSearchCB::setup_link_type_search()
 {
 	const HandleSeq& clauses = _pattern->mandatory;
 
@@ -603,20 +603,8 @@ bool InitiateSearchCB::link_type_search(PatternMatchEngine *pme)
 	Type ptype = _starter_term->get_type();
 
 	HandleSeq handle_set;
-	_as->get_handles_by_type(handle_set, ptype);
-
-#ifdef DEBUG
-	size_t i = 0, hsz = handle_set.size();
-#endif
-	for (const Handle& h : handle_set)
-	{
-		DO_LOG({LAZY_LOG_FINE << "yyyyyyyyyy link_type_search yyyyyyyyyy\n"
-		                      << "Loop candidate (" << ++i << "/" << hsz << "):\n"
-		                      << h->to_string();})
-		bool found = pme->explore_neighborhood(_root, _starter_term, h);
-		if (found) return true;
-	}
-	return false;
+	_as->get_handles_by_type(_search_set, ptype);
+	return true;
 }
 
 /* ======================================================== */

--- a/opencog/query/InitiateSearchCB.cc
+++ b/opencog/query/InitiateSearchCB.cc
@@ -630,7 +630,7 @@ bool InitiateSearchCB::link_type_search(PatternMatchEngine *pme)
  * variables, then you probably don't want to use this method, either;
  * you should create something more clever.
  */
-bool InitiateSearchCB::variable_search(PatternMatchEngine *pme)
+bool InitiateSearchCB::setup_variable_search(void)
 {
 	const HandleSeq& clauses = _pattern->mandatory;
 
@@ -788,19 +788,26 @@ bool InitiateSearchCB::variable_search(PatternMatchEngine *pme)
 		}
 	}
 
-	HandleSeq handle_set;
 	if (ptypes.empty())
-		_as->get_handles_by_type(handle_set, ATOM, true);
+		_as->get_handles_by_type(_search_set, ATOM, true);
 	else
 		for (Type ptype : ptypes)
-			_as->get_handles_by_type(handle_set, ptype);
+			_as->get_handles_by_type(_search_set, ptype);
 
-	DO_LOG({LAZY_LOG_FINE << "Atomspace reported " << handle_set.size() << " atoms";})
+	return true;
+}
+
+bool InitiateSearchCB::variable_search(PatternMatchEngine *pme)
+{
+	if (not setup_variable_search()) return false;
+
+	DO_LOG({LAZY_LOG_FINE << "Search-set size: "
+	            << _search_set.size() << " atoms";})
 
 #ifdef DEBUG
-	size_t i = 0, hsz = handle_set.size();
+	size_t i = 0, hsz = _search_set.size();
 #endif
-	for (const Handle& h : handle_set)
+	for (const Handle& h : _search_set)
 	{
 		DO_LOG({LAZY_LOG_FINE << "zzzzzzzzzzz variable_search zzzzzzzzzzz\n"
 		                      << "Loop candidate (" << ++i << "/" << hsz << "):\n"

--- a/opencog/query/InitiateSearchCB.cc
+++ b/opencog/query/InitiateSearchCB.cc
@@ -280,7 +280,7 @@ Handle InitiateSearchCB::find_thinnest(const HandleSeq& clauses,
  * if the search was not performed, due to a failure to find a sutiable
  * starting point.
  */
-bool InitiateSearchCB::neighbor_search(PatternMatchEngine *pme)
+bool InitiateSearchCB::neighbor_search(PatternMatchEngine* pme)
 {
 	// If there are no non-constant clauses, abort; will use
 	// no_search() instead.
@@ -365,18 +365,13 @@ bool InitiateSearchCB::neighbor_search(PatternMatchEngine *pme)
 		// get_incoming_set(), so that, e.g. it gets sorted by attentional
 		// focus in the AttentionalFocusCB class...
 		IncomingSet iset = get_incoming_set(best_start);
-		size_t sz = iset.size();
-		for (size_t i = 0; i < sz; i++)
-		{
-			Handle h(iset[i]);
-			DO_LOG({LAZY_LOG_FINE << "xxxxxxxxxx neighbor_search xxxxxxxxxx\n"
-			              << "Loop candidate (" << i+1 << "/" << sz << "):\n"
-			              << h->to_string();})
-			bool found = pme->explore_neighborhood(_root, _starter_term, h);
+		_search_set.clear();
+		for (const auto& lptr: iset)
+			_search_set.emplace_back(HandleCast(lptr));
 
-			// Terminate search if satisfied.
-			if (found) return true;
-		}
+		bool found = search_loop(pme, "xxxxxxxxxx neighbor_search xxxxxxxxxx");
+		// Terminate search if satisfied.
+		if (found) return true;
 	}
 
 	// If we are here, we have searched the entire neighborhood, and

--- a/opencog/query/InitiateSearchCB.cc
+++ b/opencog/query/InitiateSearchCB.cc
@@ -495,11 +495,8 @@ bool InitiateSearchCB::initiate_search(PatternMatchEngine *pme)
 	// the LoopUTest), and so instead, we search based on the link
 	// types that occur in the atomspace.
 	DO_LOG({logger().fine("Cannot use no-var search, use link-type search");})
-	_search_fail = false;
 	if (setup_link_type_search())
-		found = search_loop(pme, "yyyyyyyyyy link_type_search yyyyyyyyyy");
-	if (found) return true;
-	if (not _search_fail) return false;
+		return search_loop(pme, "yyyyyyyyyy link_type_search yyyyyyyyyy");
 
 	// The URE Reasoning case: if we found nothing, then there are no
 	// links!  Ergo, every clause must be a lone variable, all by
@@ -508,10 +505,10 @@ bool InitiateSearchCB::initiate_search(PatternMatchEngine *pme)
 	// and that's all. We deal with this in the variable_search()
 	// method.
 	DO_LOG({logger().fine("Cannot use link-type search, use variable-type search");})
-	_search_fail = false;
 	if (setup_variable_search())
-		found = search_loop(pme, "zzzzzzzzzzz variable_search zzzzzzzzzzz");
-	return found;
+		return search_loop(pme, "zzzzzzzzzzz variable_search zzzzzzzzzzz");
+
+	return false;
 }
 
 /* ======================================================== */
@@ -584,10 +581,7 @@ bool InitiateSearchCB::setup_link_type_search()
 	// and that's all. We deal with this in the variable_search()
 	// method.
 	if (nullptr == _root)
-	{
-		_search_fail = true;
 		return false;
-	}
 
 	DO_LOG({LAZY_LOG_FINE << "Start clause is: " << std::endl
 	                      << _root->to_string();})
@@ -740,13 +734,10 @@ bool InitiateSearchCB::setup_variable_search(void)
 #endif
 		}
 
+		// There are no clauses. This is kind-of weird, but it can happen
+		// if all clauses are optional.
 		if (0 == clauses.size())
-		{
-			// This is kind-of weird, but it can happen if all clauses
-			// are optional.
-			_search_fail = true;
 			return false;
-		}
 
 		// The pattern body might be of the form
 		// (And (Present (Variable "$x")) (Evaluation ...))

--- a/opencog/query/InitiateSearchCB.cc
+++ b/opencog/query/InitiateSearchCB.cc
@@ -484,10 +484,8 @@ bool InitiateSearchCB::initiate_search(PatternMatchEngine *pme)
 	// we want to quickly rule out this case before moving to more
 	// complex searches, below.
 	DO_LOG({logger().fine("Cannot use node-neighbor search, use no-var search");})
-	_search_fail = false;
-	found = no_search(pme);
-	if (found) return true;
-	if (not _search_fail) return false;
+	if (setup_no_search())
+		return pme->explore_constant_evaluatables(_pattern->mandatory);
 
 	// If we are here, then we could not find a clause at which to
 	// start, which can happen if the clauses consist entirely of
@@ -806,16 +804,9 @@ bool InitiateSearchCB::search_loop(PatternMatchEngine *pme,
  * inefficient to use the pattern matcher for this, so if you want it
  * to run fast, re-work the below to not use the PME.
  */
-bool InitiateSearchCB::no_search(PatternMatchEngine *pme)
+bool InitiateSearchCB::setup_no_search(void)
 {
-	if (0 < _variables->varset.size())
-	{
-		_search_fail = true;
-		return false;
-	}
-
-	// Evaluate all evaluatable clauses
-	return pme->explore_constant_evaluatables(_pattern->mandatory);
+	return (0 == _variables->varset.size());
 }
 
 /* ======================================================== */

--- a/opencog/query/InitiateSearchCB.h
+++ b/opencog/query/InitiateSearchCB.h
@@ -91,12 +91,11 @@ protected:
 	virtual void find_rarest(const Handle&, Handle&, size_t&,
 	                         Quotation quotation=Quotation());
 
+	bool neighbor_search(PatternMatchEngine *);
 	bool setup_link_type_search(void);
 	bool setup_variable_search(void);
 
 	bool _search_fail;
-	bool neighbor_search(PatternMatchEngine *);
-	bool link_type_search(PatternMatchEngine *);
 	bool no_search(PatternMatchEngine *);
 
 	bool search_loop(PatternMatchEngine *, const std::string);

--- a/opencog/query/InitiateSearchCB.h
+++ b/opencog/query/InitiateSearchCB.h
@@ -91,12 +91,11 @@ protected:
 	virtual void find_rarest(const Handle&, Handle&, size_t&,
 	                         Quotation quotation=Quotation());
 
+	bool _search_fail;
 	bool neighbor_search(PatternMatchEngine *);
+	bool setup_no_search(void);
 	bool setup_link_type_search(void);
 	bool setup_variable_search(void);
-
-	bool _search_fail;
-	bool no_search(PatternMatchEngine *);
 
 	bool search_loop(PatternMatchEngine *, const std::string);
 	AtomSpace *_as;

--- a/opencog/query/InitiateSearchCB.h
+++ b/opencog/query/InitiateSearchCB.h
@@ -67,7 +67,7 @@ protected:
 	const HandleSet* _dynamic;
 
 	PatternLinkPtr _pl;
-	void jit_analyze(PatternMatchEngine *);
+	void jit_analyze(void);
 
 	Handle _root;
 	Handle _starter_term;

--- a/opencog/query/InitiateSearchCB.h
+++ b/opencog/query/InitiateSearchCB.h
@@ -71,6 +71,7 @@ protected:
 
 	Handle _root;
 	Handle _starter_term;
+	HandleSeq _search_set;
 
 	struct Choice
 	{
@@ -90,11 +91,13 @@ protected:
 	virtual void find_rarest(const Handle&, Handle&, size_t&,
 	                         Quotation quotation=Quotation());
 
+	bool setup_variable_search(void);
+
 	bool _search_fail;
-	virtual bool neighbor_search(PatternMatchEngine *);
-	virtual bool link_type_search(PatternMatchEngine *);
-	virtual bool variable_search(PatternMatchEngine *);
-	virtual bool no_search(PatternMatchEngine *);
+	bool neighbor_search(PatternMatchEngine *);
+	bool link_type_search(PatternMatchEngine *);
+	bool variable_search(PatternMatchEngine *);
+	bool no_search(PatternMatchEngine *);
 
 	AtomSpace *_as;
 };

--- a/opencog/query/InitiateSearchCB.h
+++ b/opencog/query/InitiateSearchCB.h
@@ -91,6 +91,7 @@ protected:
 	virtual void find_rarest(const Handle&, Handle&, size_t&,
 	                         Quotation quotation=Quotation());
 
+	bool setup_link_type_search(void);
 	bool setup_variable_search(void);
 
 	bool _search_fail;

--- a/opencog/query/InitiateSearchCB.h
+++ b/opencog/query/InitiateSearchCB.h
@@ -75,11 +75,11 @@ protected:
 
 	struct Choice
 	{
-		size_t clause;
+		Handle clause;
 		Handle best_start;
 		Handle start_term;
 	};
-	size_t _curr_clause;
+	Handle _curr_clause;
 	std::vector<Choice> _choices;
 
 	virtual Handle find_starter(const Handle&, size_t&, Handle&, size_t&);
@@ -87,16 +87,16 @@ protected:
 	                                      size_t&);
 	virtual Handle find_thinnest(const HandleSeq&,
 	                             const HandleSet&,
-	                             Handle&, size_t&);
+	                             Handle&, Handle&);
 	virtual void find_rarest(const Handle&, Handle&, size_t&,
 	                         Quotation quotation=Quotation());
 
-	bool _search_fail;
-	bool neighbor_search(PatternMatchEngine *);
+	bool setup_neighbor_search(void);
 	bool setup_no_search(void);
 	bool setup_link_type_search(void);
 	bool setup_variable_search(void);
 
+	bool choice_loop(PatternMatchEngine *, const std::string);
 	bool search_loop(PatternMatchEngine *, const std::string);
 	AtomSpace *_as;
 };

--- a/opencog/query/InitiateSearchCB.h
+++ b/opencog/query/InitiateSearchCB.h
@@ -96,9 +96,9 @@ protected:
 	bool _search_fail;
 	bool neighbor_search(PatternMatchEngine *);
 	bool link_type_search(PatternMatchEngine *);
-	bool variable_search(PatternMatchEngine *);
 	bool no_search(PatternMatchEngine *);
 
+	bool search_loop(PatternMatchEngine *, const std::string);
 	AtomSpace *_as;
 };
 


### PR DESCRIPTION
Due to historical design reasons, the PatternMatchEngine had invasively invaded
too many corners of the code. As a result, efforts to parallelize the pattern matcher,
such as #2316 got complicated and off-track. This pull req is part one of a series to
isolate it down to one small area, which will make parallelization much easier to
accomplish.