### PR TITLE
Isolation of the PatternMatchEngine, part two

### DIFF
--- a/opencog/query/DefaultPatternMatchCB.h
+++ b/opencog/query/DefaultPatternMatchCB.h
@@ -30,7 +30,6 @@
 #include <opencog/atoms/execution/Instantiator.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/query/PatternMatchCallback.h>
-#include <opencog/query/PatternMatchEngine.h>
 
 namespace opencog {
 

--- a/opencog/query/InitiateSearchCB.cc
+++ b/opencog/query/InitiateSearchCB.cc
@@ -496,14 +496,15 @@ bool InitiateSearchCB::search_loop(PatternMatchEngine *pme,
  * probably *not* be modified, since it is quite efficient for the
  * "standard, canonical" case.
  */
-bool InitiateSearchCB::initiate_search(PatternMatchEngine *pme)
+bool InitiateSearchCB::initiate_search(PatternMatchCallback& pmc)
 {
 	jit_analyze();
-	pme->set_pattern(*_variables, *_pattern);
+	PatternMatchEngine pme(pmc);
+	pme.set_pattern(*_variables, *_pattern);
 
 	DO_LOG({logger().fine("Attempt to use node-neighbor search");})
 	if (setup_neighbor_search())
-		return choice_loop(pme, "xxxxxxxxxx neighbor_search xxxxxxxxxx");
+		return choice_loop(&pme, "xxxxxxxxxx neighbor_search xxxxxxxxxx");
 
 	// If we are here, then we could not find a clause at which to
 	// start, which can happen if the clauses hold no variables, and
@@ -512,7 +513,7 @@ bool InitiateSearchCB::initiate_search(PatternMatchEngine *pme)
 	// complex searches, below.
 	DO_LOG({logger().fine("Cannot use node-neighbor search, use no-var search");})
 	if (setup_no_search())
-		return pme->explore_constant_evaluatables(_pattern->mandatory);
+		return pme.explore_constant_evaluatables(_pattern->mandatory);
 
 	// If we are here, then we could not find a clause at which to
 	// start, which can happen if the clauses consist entirely of
@@ -521,7 +522,7 @@ bool InitiateSearchCB::initiate_search(PatternMatchEngine *pme)
 	// types that occur in the atomspace.
 	DO_LOG({logger().fine("Cannot use no-var search, use link-type search");})
 	if (setup_link_type_search())
-		return search_loop(pme, "yyyyyyyyyy link_type_search yyyyyyyyyy");
+		return search_loop(&pme, "yyyyyyyyyy link_type_search yyyyyyyyyy");
 
 	// The URE Reasoning case: if we found nothing, then there are no
 	// links!  Ergo, every clause must be a lone variable, all by
@@ -531,7 +532,7 @@ bool InitiateSearchCB::initiate_search(PatternMatchEngine *pme)
 	// method.
 	DO_LOG({logger().fine("Cannot use link-type search, use variable-type search");})
 	if (setup_variable_search())
-		return search_loop(pme, "zzzzzzzzzzz variable_search zzzzzzzzzzz");
+		return search_loop(&pme, "zzzzzzzzzzz variable_search zzzzzzzzzzz");
 
 	return false;
 }

--- a/opencog/query/InitiateSearchCB.h
+++ b/opencog/query/InitiateSearchCB.h
@@ -30,7 +30,6 @@
 #include <opencog/atoms/core/Quotation.h>
 #include <opencog/atoms/pattern/PatternLink.h>
 #include <opencog/query/PatternMatchCallback.h>
-#include <opencog/query/PatternMatchEngine.h>
 
 namespace opencog {
 
@@ -96,8 +95,8 @@ protected:
 	bool setup_link_type_search(void);
 	bool setup_variable_search(void);
 
-	bool choice_loop(PatternMatchEngine *, const std::string);
-	bool search_loop(PatternMatchEngine *, const std::string);
+	bool choice_loop(PatternMatchCallback&, const std::string);
+	bool search_loop(PatternMatchCallback&, const std::string);
 	AtomSpace *_as;
 };
 

--- a/opencog/query/InitiateSearchCB.h
+++ b/opencog/query/InitiateSearchCB.h
@@ -54,7 +54,7 @@ public:
 	 * in order to drive a reasonably-fast search.
 	 */
 	virtual void set_pattern(const Variables&, const Pattern&);
-	virtual bool initiate_search(PatternMatchEngine *);
+	virtual bool initiate_search(PatternMatchCallback&);
 
 	std::string to_string(const std::string& indent=empty_string) const;
 

--- a/opencog/query/PatternLinkRuntime.cc
+++ b/opencog/query/PatternLinkRuntime.cc
@@ -28,8 +28,8 @@
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/atoms/pattern/PatternUtils.h>
 
-// #include "PatternMatchEngine.h"
 #include <opencog/query/DefaultPatternMatchCB.h>
+#include <opencog/query/PatternMatchEngine.h>
 
 using namespace opencog;
 
@@ -103,9 +103,9 @@ class PMCGroundings : public PatternMatchCallback
 			_cb.set_pattern(vars, pat);
 		}
 
-		bool initiate_search(PatternMatchEngine* pme)
+		bool initiate_search(PatternMatchCallback& pmcb)
 		{
-			return _cb.initiate_search(pme);
+			return _cb.initiate_search(pmcb);
 		}
 
 		bool search_finished(bool done)
@@ -325,13 +325,10 @@ bool PatternLink::satisfy(PatternMatchCallback& pmcb) const
 	// in a direct fashion.
 	if (_num_comps <= 1)
 	{
-		PatternMatchEngine pme(pmcb);
-
 		debug_log();
 
-		pme.set_pattern(_variables, _pat);
 		pmcb.set_pattern(_variables, _pat);
-		bool found = pmcb.initiate_search(&pme);
+		bool found = pmcb.initiate_search(pmcb);
 
 #ifdef DEBUG
 		logger().fine("================= Done with Search =================");

--- a/opencog/query/PatternLinkRuntime.cc
+++ b/opencog/query/PatternLinkRuntime.cc
@@ -380,7 +380,7 @@ bool PatternLink::satisfy(PatternMatchCallback& pmcb) const
 #endif
 
 		PatternLinkPtr clp(PatternLinkCast(_component_patterns.at(i)));
-		Pattern pat = clp->get_pattern();
+		const Pattern& pat(clp->get_pattern());
 		bool is_pure_optional = false;
 		if (pat.mandatory.size() == 0 and pat.optionals.size() > 0)
 			is_pure_optional = true;

--- a/opencog/query/PatternMatchCallback.h
+++ b/opencog/query/PatternMatchCallback.h
@@ -33,7 +33,6 @@
 #include <opencog/atoms/pattern/PatternTerm.h> // for pattern context
 
 namespace opencog {
-class PatternMatchEngine;
 
 /**
  * Callback interface, used to implement specifics of hypergraph
@@ -337,7 +336,7 @@ class PatternMatchCallback
 		 * values on all the other callbacks; it summarizes (passes
 		 * through) the return values of all the others.
 		 */
-		virtual bool initiate_search(PatternMatchEngine *) = 0;
+		virtual bool initiate_search(PatternMatchCallback&) = 0;
 
 		/**
 		 * Called when the search has completed. In principle, this is not

--- a/opencog/query/Recognizer.cc
+++ b/opencog/query/Recognizer.cc
@@ -22,6 +22,7 @@
  */
 
 #include <opencog/atoms/core/FindUtils.h>
+#include <opencog/query/PatternMatchEngine.h>
 #include "Recognizer.h"
 
 using namespace opencog;
@@ -70,15 +71,18 @@ bool Recognizer::do_search(PatternMatchEngine* pme, const Handle& top)
 	return false;
 }
 
-bool Recognizer::initiate_search(PatternMatchEngine* pme)
+bool Recognizer::initiate_search(PatternMatchCallback& pmc)
 {
+	PatternMatchEngine pme(pmc);
+	pme.set_pattern(*_vars, *_pattern);
+
 	const HandleSeq& clauses = _pattern->mandatory;
 
 	_cnt = 0;
 	for (const Handle& h: clauses)
 	{
 		_root = h;
-		bool found = do_search(pme, h);
+		bool found = do_search(&pme, h);
 		if (found) return true;
 	}
 	return false;

--- a/opencog/query/Recognizer.h
+++ b/opencog/query/Recognizer.h
@@ -24,10 +24,10 @@
 #ifndef _OPENCOG_RECOGNIZER_H
 #define _OPENCOG_RECOGNIZER_H
 
-#include <opencog/atoms/pattern/PatternLink.h>
 #include <opencog/query/DefaultPatternMatchCB.h>
 
 namespace opencog {
+class PatternMatchEngine;
 
 /**
  * Pattern recognition is the dual of pattern matching.
@@ -76,7 +76,7 @@ class Recognizer :
 			DefaultPatternMatchCB::set_pattern(vars, pat);
 		}
 
-		virtual bool initiate_search(PatternMatchEngine*);
+		virtual bool initiate_search(PatternMatchCallback&);
 		virtual bool node_match(const Handle&, const Handle&);
 		virtual bool link_match(const PatternTermPtr&, const Handle&);
 		virtual bool fuzzy_match(const Handle&, const Handle&);

--- a/opencog/query/Recognizer.h
+++ b/opencog/query/Recognizer.h
@@ -27,7 +27,6 @@
 #include <opencog/query/DefaultPatternMatchCB.h>
 
 namespace opencog {
-class PatternMatchEngine;
 
 /**
  * Pattern recognition is the dual of pattern matching.
@@ -57,7 +56,7 @@ class Recognizer :
 		Handle _root;
 		Handle _starter_term;
 		size_t _cnt;
-		bool do_search(PatternMatchEngine*, const Handle&);
+		bool do_search(PatternMatchCallback&, const Handle&);
 		bool loose_match(const Handle&, const Handle&);
 
 	public:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,7 +21,7 @@ IF (CXXTEST_FOUND)
 	ADD_SUBDIRECTORY (atomspaceutils)
 
 	# Persistence is for saving/restoring atomspace to disk.
-	ADD_SUBDIRECTORY (persist)
+	# ADD_SUBDIRECTORY (persist)
 
 	# guile provides scheme bindings for the atomspace.
 	ADD_SUBDIRECTORY (scm)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,7 +21,7 @@ IF (CXXTEST_FOUND)
 	ADD_SUBDIRECTORY (atomspaceutils)
 
 	# Persistence is for saving/restoring atomspace to disk.
-	# ADD_SUBDIRECTORY (persist)
+	ADD_SUBDIRECTORY (persist)
 
 	# guile provides scheme bindings for the atomspace.
 	ADD_SUBDIRECTORY (scm)

--- a/tests/query/BindTVUTest.cxxtest
+++ b/tests/query/BindTVUTest.cxxtest
@@ -40,11 +40,11 @@ public:
 	BindTVUTest(void)
 	{
 		logger().set_level(Logger::DEBUG);
+		logger().set_timestamp_flag(false);
 		logger().set_print_to_stdout_flag(true);
 
 		as = new AtomSpace();
 		eval = new SchemeEval(as);
-		eval->eval("(use-modules (opencog exec))");
 		eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
 	}
 

--- a/tests/query/bind-tv.scm
+++ b/tests/query/bind-tv.scm
@@ -1,5 +1,6 @@
-;; Definitions
+(use-modules (opencog) (opencog exec))
 
+;; Definitions
 (define (sp x)
 "
   Return (stv 0.55 0.55) and store it into its own call, that is
@@ -11,20 +12,23 @@
   (let* ((tv (stv 0.55 0.55))
          (gp (GroundedPredicate "scm:sp"))
          (ev (Evaluation gp x)))
-  (cog-set-tv! ev tv)
-  tv))
+    (cog-set-tv! ev tv)
+    tv))
 
 (define GP (GroundedPredicate "scm:sp"))
 (define A (Concept "A"))
 (define B (Concept "B"))
-(define X (Variable "$X"))
 (define E (Evaluation GP A))
 
+(define X (Variable "$X"))
 ;; Facts
 
 (Inheritance A B)
 
 ;; Query
+;; Note that this is a strange query -- the variable X never appears
+;; in the EvaluationLink, and so this splits up as two disjoint queries
+;; having nothing to do with each-other.
 
 (define query
   (BindLink


### PR DESCRIPTION
Remaining steps of the isolation of the PatternMatchEngine to the
only users that actually need to use it.  This sharply narrows the users
of the engine, vs. the engine itself, so that they are nearly two distinct
components.