### PR TITLE
Add support for std::unordered_map<Handle, Handle>

### DIFF
--- a/opencog/atoms/base/Handle.cc
+++ b/opencog/atoms/base/Handle.cc
@@ -233,6 +233,21 @@ std::string oc_to_string(const HandleMap& hmap, const std::string& indent)
 	return ss.str();
 }
 
+std::string oc_to_string(const UnorderedHandleMap& hmap, const std::string& indent)
+{
+	std::stringstream ss;
+	ss << indent << "size = " << hmap.size();
+	int i = 0;
+	for (const auto& p : hmap) {
+		ss << std::endl << indent << "key[" << i << "]:" << std::endl
+		   << oc_to_string(p.first, indent + OC_TO_STRING_INDENT) << std::endl
+		   << indent << "value[" << i << "]:" << std::endl
+		   << oc_to_string(p.second, indent + OC_TO_STRING_INDENT);
+		i++;
+	}
+	return ss.str();
+}
+
 std::string oc_to_string(const HandleMap::value_type& hmv, const std::string& indent)
 {
 	std::stringstream ss;
@@ -379,6 +394,10 @@ ostream& operator<<(ostream& out, const opencog::HandleSeq& hs)
 ostream& operator<<(ostream& out, const opencog::HandleSet& ohs)
 {
 	return out << oc_to_string(ohs);
+}
+ostream& operator<<(ostream& out, const opencog::UnorderedHandleMap& hm)
+{
+	return out << oc_to_string(hm);
 }
 ostream& operator<<(ostream& out, const opencog::UnorderedHandleSet& uhs)
 {

--- a/opencog/atoms/base/Handle.h
+++ b/opencog/atoms/base/Handle.h
@@ -35,6 +35,7 @@
 #include <string>
 #include <sstream>
 #include <set>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -199,6 +200,9 @@ typedef std::unordered_set<Handle> UnorderedHandleSet;
 //! an ordered map from Handle to Handle
 typedef std::map<Handle, Handle> HandleMap;
 
+//! a hash table. Usually has faster insertion.
+typedef std::unordered_map<Handle, Handle> UnorderedHandleMap;
+
 //! an ordered map from Handle to Handle set
 typedef std::map<Handle, HandleSet> HandleMultimap;
 
@@ -314,6 +318,8 @@ std::string oc_to_string(const HandleMap& hm,
                          const std::string& indent=empty_string);
 std::string oc_to_string(const HandleMap::value_type& hmv,
                          const std::string& indent=empty_string);
+std::string oc_to_string(const UnorderedHandleMap& hm,
+                         const std::string& indent=empty_string);
 std::string oc_to_string(const HandleMultimap& hmm,
                          const std::string& indent=empty_string);
 std::string oc_to_string(const HandleMapSeq& hms,
@@ -366,6 +372,7 @@ ostream& operator<<(ostream&, const opencog::HandleMap&);
 ostream& operator<<(ostream&, const opencog::HandleSeq&);
 ostream& operator<<(ostream&, const opencog::HandleSet&);
 ostream& operator<<(ostream&, const opencog::UnorderedHandleSet&);
+ostream& operator<<(ostream&, const opencog::UnorderedHandleMap&);
 
 // This works for me, per note immediately above.
 template<>

--- a/opencog/atoms/base/Handle.h
+++ b/opencog/atoms/base/Handle.h
@@ -224,7 +224,15 @@ typedef Counter<Handle, double> HandleCounter;
 //! a map from handle to unsigned
 typedef Counter<Handle, unsigned> HandleUCounter;
 
-typedef UnorderedHandleMap GroundingMap;
+// A map of variables to thier groundings.  Everyone working with
+// groundings uses this type; changing the type here allows easy
+// comparisons of performance for these two mapping styles.
+// At this time (Dec 2019; gcc-8.3.0) there seems to be no difference
+// in performance in the pattern matcher as a result of using the
+// unordered aka std::_Hashtable variant vs the std::_Rb_tree variant.
+// (as measured with the `guile -l nano-en.scm` benchmark.)
+typedef HandleMap GroundingMap;
+// typedef UnorderedHandleMap GroundingMap;
 typedef std::vector<GroundingMap> GroundingMapSeq;
 typedef std::vector<GroundingMapSeq> GroundingMapSeqSeq;
 

--- a/opencog/atoms/base/Handle.h
+++ b/opencog/atoms/base/Handle.h
@@ -224,6 +224,10 @@ typedef Counter<Handle, double> HandleCounter;
 //! a map from handle to unsigned
 typedef Counter<Handle, unsigned> HandleUCounter;
 
+typedef UnorderedHandleMap GroundingMap;
+typedef std::vector<GroundingMap> GroundingMapSeq;
+typedef std::vector<GroundingMapSeq> GroundingMapSeqSeq;
+
 //! a handle iterator
 typedef std::iterator<std::forward_iterator_tag, Handle> HandleIterator;
 

--- a/opencog/atoms/execution/Instantiator.cc
+++ b/opencog/atoms/execution/Instantiator.cc
@@ -42,7 +42,7 @@ Instantiator::Instantiator(AtomSpace* as)
 /// member of the pair is the variable; the second is the value that
 /// should be used as its replacement.  (Note that "variables" do not
 /// have to actually be VariableNode's; they can be any atom.)
-static Handle beta_reduce(const Handle& expr, const HandleMap& vmap)
+static Handle beta_reduce(const Handle& expr, const GroundingMap& vmap)
 {
 	// Format conversion. FreeVariables::substitute_nocheck() performs
 	// beta-reduction correctly, so we just use that. But we have to
@@ -274,7 +274,7 @@ Handle Instantiator::walk_tree(const Handle& expr, bool silent)
 		// If we are here, we found a free variable (or glob?). Look
 		// it up. Return a grounding if it has one, otherwise return
 		// the variable itself.
-		HandleMap::const_iterator it = _vmap->find(expr);
+		GroundingMap::const_iterator it = _vmap->find(expr);
 		if (_vmap->end() == it) return expr;
 
 		// Not so fast, pardner. VariableNodes can be grounded by
@@ -544,7 +544,7 @@ bool Instantiator::not_self_match(Type t)
  * added to the atomspace, and its handle is returned.
  */
 ValuePtr Instantiator::instantiate(const Handle& expr,
-                                   const HandleMap &vars,
+                                   const GroundingMap &vars,
                                    bool silent)
 {
 	// throw, not assert, because this is a user error ...
@@ -659,7 +659,7 @@ ValuePtr Instantiator::execute(const Handle& expr, bool silent)
 
 	// XXX FIXME, since the variable map is empty, maybe we can do
 	// something more efficient, here?
-	ValuePtr vp(instantiate(expr, HandleMap(), silent));
+	ValuePtr vp(instantiate(expr, GroundingMap(), silent));
 
 	return vp;
 }

--- a/opencog/atoms/execution/Instantiator.h
+++ b/opencog/atoms/execution/Instantiator.h
@@ -45,7 +45,7 @@ class Instantiator
 {
 private:
 	AtomSpace *_as;
-	const HandleMap *_vmap;
+	const GroundingMap *_vmap;
 	bool _halt;
 
 	/**
@@ -135,7 +135,7 @@ public:
 	}
 
 	ValuePtr instantiate(const Handle& expr,
-	                     const HandleMap& vars,
+	                     const GroundingMap& vars,
 	                     bool silent=false);
 
 	ValuePtr execute(const Handle& expr, bool silent=false);

--- a/opencog/atoms/execution/MapLink.cc
+++ b/opencog/atoms/execution/MapLink.cc
@@ -161,7 +161,7 @@ MapLink::MapLink(const Link &l)
 ///
 bool MapLink::extract(const Handle& termpat,
                       const Handle& ground,
-                      HandleMap& valmap,
+                      GroundingMap& valmap,
                       Quotation quotation) const
 {
 	if (termpat == ground) return true;
@@ -326,10 +326,10 @@ Handle MapLink::rewrite_one(const Handle& cterm, AtomSpace* scratch) const
 	// Execute the ground, including consuming its quotation as part of
 	// the MapLink semantics
 	Instantiator inst(scratch);
-	Handle term(HandleCast(inst.instantiate(cterm, HandleMap())));
+	Handle term(HandleCast(inst.instantiate(cterm, GroundingMap())));
 
 	// Extract values for variables.
-	HandleMap valmap;
+	GroundingMap valmap;
 	if (not extract(_pattern->get_body(), term, valmap))
 		return Handle::UNDEFINED;
 

--- a/opencog/atoms/execution/MapLink.h
+++ b/opencog/atoms/execution/MapLink.h
@@ -57,7 +57,7 @@ protected:
 
 	MapLink(Type, const Handle&);
 
-	bool extract(const Handle&, const Handle&, HandleMap&,
+	bool extract(const Handle&, const Handle&, GroundingMap&,
 	             Quotation quotation=Quotation()) const;
 
 	Handle rewrite_one(const Handle&, AtomSpace*) const;

--- a/opencog/query/DefaultPatternMatchCB.cc
+++ b/opencog/query/DefaultPatternMatchCB.cc
@@ -350,7 +350,7 @@ void DefaultPatternMatchCB::post_link_mismatch(const Handle& lpat,
 /// nested ChoiceLinks. So, sadly, this code is fairly complex. :-(
 bool DefaultPatternMatchCB::is_self_ground(const Handle& ptrn,
                                            const Handle& grnd,
-                                           const HandleMap& term_gnds,
+                                           const GroundingMap& term_gnds,
                                            const HandleSet& varset,
                                            Quotation quotation)
 {
@@ -466,7 +466,7 @@ bool DefaultPatternMatchCB::is_self_ground(const Handle& ptrn,
  */
 bool DefaultPatternMatchCB::clause_match(const Handle& ptrn,
                                          const Handle& grnd,
-                                         const HandleMap& term_gnds)
+                                         const GroundingMap& term_gnds)
 {
 	// Is the pattern same as the ground?
 	// if (ptrn == grnd) return false;
@@ -524,7 +524,7 @@ bool DefaultPatternMatchCB::clause_match(const Handle& ptrn,
  */
 bool DefaultPatternMatchCB::optional_clause_match(const Handle& ptrn,
                                                   const Handle& grnd,
-                                                  const HandleMap& term_gnds)
+                                                  const GroundingMap& term_gnds)
 {
 	// If any grounding at all was found, reject it.
 	if (grnd)
@@ -576,7 +576,7 @@ bool DefaultPatternMatchCB::optional_clause_match(const Handle& ptrn,
  */
 bool DefaultPatternMatchCB::always_clause_match(const Handle& ptrn,
                                                 const Handle& grnd,
-                                                const HandleMap& term_gnds)
+                                                const GroundingMap& term_gnds)
 {
 	return grnd != nullptr;
 }
@@ -596,7 +596,7 @@ IncomingSet DefaultPatternMatchCB::get_incoming_set(const Handle& h)
 // beta-reduction with the groundings, followed by proper evaluation.
 
 bool DefaultPatternMatchCB::eval_term(const Handle& virt,
-                                      const HandleMap& gnds)
+                                      const GroundingMap& gnds)
 {
 	// Evaluation of the link requires working with an atomspace
 	// of some sort, so that the atoms can be communicated to scheme or
@@ -744,7 +744,7 @@ bool DefaultPatternMatchCB::eval_term(const Handle& virt,
  * variables to values.
  */
 bool DefaultPatternMatchCB::eval_sentence(const Handle& top,
-                                          const HandleMap& gnds)
+                                          const GroundingMap& gnds)
 {
 	DO_LOG({LAZY_LOG_FINE << "Enter eval_sentence CB with top=" << std::endl
 	              << top->to_short_string() << std::endl

--- a/opencog/query/DefaultPatternMatchCB.h
+++ b/opencog/query/DefaultPatternMatchCB.h
@@ -67,17 +67,17 @@ class DefaultPatternMatchCB : public virtual PatternMatchCallback
 		virtual void post_link_mismatch(const Handle&, const Handle&);
 
 		virtual bool clause_match(const Handle&, const Handle&,
-		                          const HandleMap&);
+		                          const GroundingMap&);
 
 		/** Called for AbsentLink */
 		virtual bool optional_clause_match(const Handle& pattrn,
 		                                   const Handle& grnd,
-		                                   const HandleMap&);
+		                                   const GroundingMap&);
 
 		/** Called for AlawaysLink */
 		virtual bool always_clause_match(const Handle& pattrn,
 		                                 const Handle& grnd,
-		                                 const HandleMap&);
+		                                 const GroundingMap&);
 
 		virtual IncomingSet get_incoming_set(const Handle&);
 
@@ -85,7 +85,7 @@ class DefaultPatternMatchCB : public virtual PatternMatchCallback
 		 * Called when a virtual link is encountered. Returns false
 		 * to reject the match.
 		 */
-		virtual bool evaluate_sentence(const Handle& pat, const HandleMap& gnds)
+		virtual bool evaluate_sentence(const Handle& pat, const GroundingMap& gnds)
 		{ return eval_sentence(pat, gnds); }
 
 		virtual const TypeSet& get_connectives(void)
@@ -107,7 +107,7 @@ class DefaultPatternMatchCB : public virtual PatternMatchCallback
 		Handle _pattern_body;
 
 		bool is_self_ground(const Handle&, const Handle&,
-		                    const HandleMap&, const HandleSet&,
+		                    const GroundingMap&, const HandleSet&,
 		                    Quotation quotation=Quotation());
 
 		// Variables that should be ignored, because they are bound
@@ -131,8 +131,8 @@ class DefaultPatternMatchCB : public virtual PatternMatchCallback
 
 		// Crisp-logic evaluation of evaluatable terms
 		TypeSet _connectives;
-		bool eval_term(const Handle& pat, const HandleMap& gnds);
-		bool eval_sentence(const Handle& pat, const HandleMap& gnds);
+		bool eval_term(const Handle& pat, const GroundingMap& gnds);
+		bool eval_sentence(const Handle& pat, const GroundingMap& gnds);
 
 		bool _optionals_present = false;
 		AtomSpace* _as;

--- a/opencog/query/Implicator.cc
+++ b/opencog/query/Implicator.cc
@@ -38,8 +38,8 @@ using namespace opencog;
  * to continue hunting for more, we return `false` here. We want to
  * find all possible groundings.)
  */
-bool Implicator::grounding(const HandleMap &var_soln,
-                           const HandleMap &term_soln)
+bool Implicator::grounding(const GroundingMap &var_soln,
+                           const GroundingMap &term_soln)
 {
 	// PatternMatchEngine::print_solution(var_soln, term_soln);
 

--- a/opencog/query/Implicator.h
+++ b/opencog/query/Implicator.h
@@ -66,8 +66,8 @@ class Implicator :
 		Handle implicand;
 		size_t max_results;
 
-		virtual bool grounding(const HandleMap &var_soln,
-		                       const HandleMap &term_soln);
+		virtual bool grounding(const GroundingMap &var_soln,
+		                       const GroundingMap &term_soln);
 
 		virtual const ValueSet& get_result_set() const
 		{ return _result_set; }

--- a/opencog/query/InitiateSearchCB.cc
+++ b/opencog/query/InitiateSearchCB.cc
@@ -831,7 +831,7 @@ void InitiateSearchCB::jit_analyze(void)
 	while (0 < _pattern->defined_terms.size())
 	{
 		Variables vset;
-		HandleMap defnmap;
+		GroundingMap defnmap;
 		for (const Handle& name : _pattern->defined_terms)
 		{
 			Handle defn = DefineLink::get_definition(name);

--- a/opencog/query/PatternLinkRuntime.cc
+++ b/opencog/query/PatternLinkRuntime.cc
@@ -70,25 +70,25 @@ class PMCGroundings : public PatternMatchCallback
 			return _cb.fuzzy_match(h1, h2);
 		}
 		bool evaluate_sentence(const Handle& link_h,
-		                       const HandleMap &gnds)
+		                       const GroundingMap &gnds)
 		{
 			return _cb.evaluate_sentence(link_h,gnds);
 		}
 		bool clause_match(const Handle& pattrn_link_h,
 		                  const Handle& grnd_link_h,
-		                  const HandleMap& term_gnds)
+		                  const GroundingMap& term_gnds)
 		{
 			return _cb.clause_match(pattrn_link_h, grnd_link_h, term_gnds);
 		}
 		bool optional_clause_match(const Handle& pattrn,
 		                           const Handle& grnd,
-		                           const HandleMap& term_gnds)
+		                           const GroundingMap& term_gnds)
 		{
 			return _cb.optional_clause_match(pattrn, grnd, term_gnds);
 		}
 		bool always_clause_match(const Handle& pattrn,
 		                           const Handle& grnd,
-		                           const HandleMap& term_gnds)
+		                           const GroundingMap& term_gnds)
 		{
 			return _cb.always_clause_match(pattrn, grnd, term_gnds);
 		}
@@ -115,16 +115,16 @@ class PMCGroundings : public PatternMatchCallback
 
 		// This one we don't pass through. Instead, we collect the
 		// groundings.
-		bool grounding(const HandleMap &var_soln,
-		               const HandleMap &term_soln)
+		bool grounding(const GroundingMap &var_soln,
+		               const GroundingMap &term_soln)
 		{
 			_term_groundings.push_back(term_soln);
 			_var_groundings.push_back(var_soln);
 			return false;
 		}
 
-		HandleMapSeq _term_groundings;
-		HandleMapSeq _var_groundings;
+		GroundingMapSeq _term_groundings;
+		GroundingMapSeq _var_groundings;
 };
 
 /**
@@ -148,11 +148,11 @@ class PMCGroundings : public PatternMatchCallback
 static bool recursive_virtual(PatternMatchCallback& cb,
             const HandleSeq& virtuals,
             const HandleSeq& optionals,
-            const HandleMap& var_gnds,
-            const HandleMap& term_gnds,
+            const GroundingMap& var_gnds,
+            const GroundingMap& term_gnds,
             // copies, NOT references!
-            HandleMapSeqSeq comp_var_gnds,
-            HandleMapSeqSeq comp_term_gnds)
+            GroundingMapSeqSeq comp_var_gnds,
+            GroundingMapSeqSeq comp_term_gnds)
 {
 	// If we are done with the recursive step, then we have one of the
 	// many combinatoric possibilities in the var_gnds and term_gnds
@@ -226,9 +226,9 @@ static bool recursive_virtual(PatternMatchCallback& cb,
 	// vg and vp will be the collection of all of the different possible
 	// groundings for one of the components (well, its for component m,
 	// in the above notation.) So the loop below tries every possibility.
-	HandleMapSeq vg = comp_var_gnds.back();
+	GroundingMapSeq vg = comp_var_gnds.back();
 	comp_var_gnds.pop_back();
-	HandleMapSeq pg = comp_term_gnds.back();
+	GroundingMapSeq pg = comp_term_gnds.back();
 	comp_term_gnds.pop_back();
 
 	size_t ngnds = vg.size();
@@ -237,11 +237,11 @@ static bool recursive_virtual(PatternMatchCallback& cb,
 		// Given a set of groundings, tack on those for this component,
 		// and recurse, with one less component. We need to make a copy,
 		// of course.
-		HandleMap rvg(var_gnds);
-		HandleMap rpg(term_gnds);
+		GroundingMap rvg(var_gnds);
+		GroundingMap rpg(term_gnds);
 
-		const HandleMap& cand_vg(vg[i]);
-		const HandleMap& cand_pg(pg[i]);
+		const GroundingMap& cand_vg(vg[i]);
+		const GroundingMap& cand_pg(pg[i]);
 		rvg.insert(cand_vg.begin(), cand_vg.end());
 		rpg.insert(cand_pg.begin(), cand_pg.end());
 
@@ -366,8 +366,8 @@ bool PatternLink::satisfy(PatternMatchCallback& pmcb) const
 	}
 #endif
 
-	HandleMapSeqSeq comp_term_gnds;
-	HandleMapSeqSeq comp_var_gnds;
+	GroundingMapSeqSeq comp_term_gnds;
+	GroundingMapSeqSeq comp_var_gnds;
 
 	for (size_t i = 0; i < _num_comps; i++)
 	{
@@ -418,8 +418,8 @@ bool PatternLink::satisfy(PatternMatchCallback& pmcb) const
 	              << "num comp=" << comp_var_gnds.size()
 	              << " num virts=" << _virtual.size();
 #endif
-	HandleMap empty_vg;
-	HandleMap empty_pg;
+	GroundingMap empty_vg;
+	GroundingMap empty_pg;
 	pmcb.set_pattern(_variables, _pat);
 	return recursive_virtual(pmcb, _virtual, _pat.optionals,
 	                         empty_vg, empty_pg,

--- a/opencog/query/PatternMatchCallback.h
+++ b/opencog/query/PatternMatchCallback.h
@@ -209,7 +209,7 @@ class PatternMatchCallback
 		 * grounding, and forces a backtrack.
 		 */
 		virtual bool evaluate_sentence(const Handle& eval,
-		                               const HandleMap& gnds) = 0;
+		                               const GroundingMap& gnds) = 0;
 
 		/**
 		 * Called when a top-level clause has been fully grounded.
@@ -229,7 +229,7 @@ class PatternMatchCallback
 		 */
 		virtual bool clause_match(const Handle& pattrn_link_h,
 		                          const Handle& grnd_link_h,
-		                          const HandleMap& term_gnds)
+		                          const GroundingMap& term_gnds)
 		{
 			// Reject templates grounded by themselves.
 			if (pattrn_link_h == grnd_link_h) return false;
@@ -252,7 +252,7 @@ class PatternMatchCallback
 		 */
 		virtual bool optional_clause_match(const Handle& pattrn,
 		                                   const Handle& grnd,
-		                                   const HandleMap& term_gnds) = 0;
+		                                   const GroundingMap& term_gnds) = 0;
 
 		/**
 		 * Called when the search for a top-level for-all clause
@@ -273,7 +273,7 @@ class PatternMatchCallback
 		 */
 		virtual bool always_clause_match(const Handle& pattrn,
 		                                 const Handle& grnd,
-		                                 const HandleMap& term_gnds) = 0;
+		                                 const GroundingMap& term_gnds) = 0;
 
 		/**
 		 * Called when a complete grounding for all clauses is found.
@@ -288,8 +288,8 @@ class PatternMatchCallback
 		 * the same result.  This can happen, for example, if there are
 		 * mutiple ways for the pattern to match up to the result.
 		 */
-		virtual bool grounding(const HandleMap &var_soln,
-		                       const HandleMap &term_soln) = 0;
+		virtual bool grounding(const GroundingMap &var_soln,
+		                       const GroundingMap &term_soln) = 0;
 
 		/**
 		 * Called whenever the incoming set of an atom is to be explored.

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -2296,8 +2296,8 @@ void PatternMatchEngine::solution_drop(void)
 /// Pass the grounding that was found out to the callback.
 /// ... unless there is an Always clasue, in which case we
 /// save them up until we've looked at all of them.
-bool PatternMatchEngine::report_grounding(const HandleMap &var_soln,
-                                          const HandleMap &term_soln)
+bool PatternMatchEngine::report_grounding(const GroundingMap &var_soln,
+                                          const GroundingMap &term_soln)
 {
 	// If there is no for-all clause (no AlwaysLink clause)
 	// then report groundings as they are found.
@@ -2520,13 +2520,13 @@ bool PatternMatchEngine::explore_constant_evaluatables(const HandleSeq& clauses)
 	bool found = true;
 	for (const Handle& clause : clauses) {
 		if (is_in(clause, _pat->evaluatable_holders)) {
-			found = _pmc.evaluate_sentence(clause, HandleMap());
+			found = _pmc.evaluate_sentence(clause, GroundingMap());
 			if (not found)
 				break;
 		}
 	}
 	if (found)
-		report_grounding(HandleMap(), HandleMap());
+		report_grounding(GroundingMap(), GroundingMap());
 
 	return found;
 }
@@ -2570,8 +2570,8 @@ void PatternMatchEngine::set_pattern(const Variables& v,
 
 #ifdef DEBUG
 void PatternMatchEngine::print_solution(
-	const HandleMap &vars,
-	const HandleMap &clauses)
+	const GroundingMap &vars,
+	const GroundingMap &clauses)
 {
 	Logger::Level save = logger().get_level();
 	logger().set_level("fine");
@@ -2584,8 +2584,8 @@ void PatternMatchEngine::print_solution(
 }
 
 void PatternMatchEngine::log_solution(
-	const HandleMap &vars,
-	const HandleMap &clauses)
+	const GroundingMap &vars,
+	const GroundingMap &clauses)
 {
 	if (!logger().is_fine_enabled())
 		return;
@@ -2623,7 +2623,7 @@ void PatternMatchEngine::log_solution(
 
 	// Print out the full binding to all of the clauses.
 	logger().fine() << "Groundings for " << clauses.size() << " clauses:";
-	HandleMap::const_iterator m;
+	GroundingMap::const_iterator m;
 	int i = 0;
 	for (m = clauses.begin(); m != clauses.end(); ++m, ++i)
 	{
@@ -2652,8 +2652,8 @@ void PatternMatchEngine::log_term(const HandleSet &vars,
 }
 #else
 
-void PatternMatchEngine::log_solution(const HandleMap &vars,
-                                      const HandleMap &clauses) {}
+void PatternMatchEngine::log_solution(const GroundingMap &vars,
+                                      const GroundingMap &clauses) {}
 
 void PatternMatchEngine::log_term(const HandleSet &vars,
                                   const HandleSeq &clauses) {}

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -486,7 +486,7 @@ bool PatternMatchEngine::unorder_compare(const PatternTermPtr& ptm,
 			// Each glob comparison steps the glob state forwards.
 			// Each different permutation has to start with the
 			// same glob state as before. So save and restore state.
-			std::map<PatternTermSeq, GlobState> saved_glob_state = _glob_state;
+			auto saved_glob_state = _glob_state;
 			match = glob_compare(mutation, osg);
 			_glob_state = saved_glob_state;
 		}
@@ -1349,8 +1349,7 @@ bool PatternMatchEngine::explore_upglob_branches(const PatternTermPtr& ptm,
 		// their state will be recorded in _glob_state, so that one can,
 		// if needed, resume and try to ground those globs again in a
 		// different way (e.g. backtracking from another branchpoint).
-		std::map<PatternTermSeq, GlobState> saved_glob_state;
-		saved_glob_state = _glob_state;
+		auto saved_glob_state = _glob_state;
 
 		found = explore_glob_branches(ptm, Handle(iset[i]), clause_root);
 

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -171,7 +171,10 @@ private:
 	typedef std::map<PatternTermPtr, size_t> GlobGrd;
 	typedef std::pair<GlobGrd, GlobPosStack> GlobState;
 
-	std::map<PatternTermSeq, GlobState> _glob_state;
+	// Looking for performance differences between these two...
+	// ... but there does not seem to be any ...!?
+	// std::map<PatternTermSeq, GlobState> _glob_state;
+	std::unordered_map<PatternTermSeq, GlobState> _glob_state;
 
 	// --------------------------------------------
 	// Methods and state that select the next clause to be grounded.

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -27,7 +27,6 @@
 #include <map>
 #include <set>
 #include <stack>
-#include <unordered_map>
 #include <vector>
 
 #include <opencog/atoms/atom_types/NameServer.h>
@@ -171,10 +170,12 @@ private:
 	typedef std::map<PatternTermPtr, size_t> GlobGrd;
 	typedef std::pair<GlobGrd, GlobPosStack> GlobState;
 
-	// Looking for performance differences between these two...
-	// ... but there does not seem to be any ...!?
-	// std::map<PatternTermSeq, GlobState> _glob_state;
-	std::unordered_map<PatternTermSeq, GlobState> _glob_state;
+	// GlobState can be defined as either std::map (aka std::_Rb_tree)
+	// or as std::unordered_map (aka std::_Hashtable). I looked for a
+	// performance difference between these two, but could not find one,
+	// at least with the `guile -l nano-en.scm` benchmark.
+	std::map<PatternTermSeq, GlobState> _glob_state;
+	// std::unordered_map<PatternTermSeq, GlobState> _glob_state;
 
 	// --------------------------------------------
 	// Methods and state that select the next clause to be grounded.

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -90,9 +90,9 @@ private:
 	// Map of current groundings of variables to their grounds
 	// Also contains grounds of subclauses (not sure why, this seems
 	// to be needed)
-	HandleMap var_grounding;
+	GroundingMap var_grounding;
 	// Map of clauses to their current groundings
-	HandleMap clause_grounding;
+	GroundingMap clause_grounding;
 
 	// Insert association between pattern ptm and its grounding hg into
 	// var_grounding.
@@ -168,7 +168,7 @@ private:
 	typedef std::stack<GlobPos> GlobPosStack;
 
 	// Record how many atoms have been grounded to the globs
-	typedef std::unordered_map<PatternTermPtr, size_t> GlobGrd;
+	typedef std::map<PatternTermPtr, size_t> GlobGrd;
 	typedef std::pair<GlobGrd, GlobPosStack> GlobState;
 
 	// Looking for performance differences between these two...
@@ -202,9 +202,8 @@ private:
 	void solution_drop(void);
 
 	// Stacks containing partial groundings.
-	typedef HandleMap SolnMap;
-	std::stack<SolnMap> var_solutn_stack;
-	std::stack<SolnMap> _clause_solutn_stack;
+	std::stack<GroundingMap> var_solutn_stack;
+	std::stack<GroundingMap> _clause_solutn_stack;
 
 	std::stack<IssuedSet> issued_stack;
 	std::stack<ChoiceState> choice_stack;
@@ -218,15 +217,14 @@ private:
 	// -------------------------------------------
 	// Methods that run when all clauses have been grounded.
 
-	typedef HandleMap GrndMap;
-	std::vector<GrndMap> _var_ground_cache;
-	std::vector<GrndMap> _term_ground_cache;
+	std::vector<GroundingMap> _var_ground_cache;
+	std::vector<GroundingMap> _term_ground_cache;
 	bool _forall_state = true;
 	bool _did_check_forall;
 
 	// Report a fully grounded pattern to the callback.
-	bool report_grounding(const HandleMap &var_soln,
-	                      const HandleMap &term_soln);
+	bool report_grounding(const GroundingMap &var_soln,
+	                      const GroundingMap &term_soln);
 	bool report_forall(void);
 
 	// -------------------------------------------
@@ -294,10 +292,10 @@ public:
 	bool explore_constant_evaluatables(const HandleSeq& clauses);
 
 	// Handy-dandy utilities
-	static void print_solution(const HandleMap &vars,
-	                           const HandleMap &clauses);
-	static void log_solution(const HandleMap &vars,
-	                         const HandleMap &clauses);
+	static void print_solution(const GroundingMap &vars,
+	                           const GroundingMap &clauses);
+	static void log_solution(const GroundingMap &vars,
+	                         const GroundingMap &clauses);
 
 	static void log_term(const HandleSet &vars,
 	                     const HandleSeq &clauses);

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -168,7 +168,7 @@ private:
 	typedef std::stack<GlobPos> GlobPosStack;
 
 	// Record how many atoms have been grounded to the globs
-	typedef std::map<PatternTermPtr, size_t> GlobGrd;
+	typedef std::unordered_map<PatternTermPtr, size_t> GlobGrd;
 	typedef std::pair<GlobGrd, GlobPosStack> GlobState;
 
 	// Looking for performance differences between these two...

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -174,6 +174,7 @@ private:
 	// or as std::unordered_map (aka std::_Hashtable). I looked for a
 	// performance difference between these two, but could not find one,
 	// at least with the `guile -l nano-en.scm` benchmark.
+	// (As of Dec 2019, using gcc-8.3.0 and glibc-2.28)
 	std::map<PatternTermSeq, GlobState> _glob_state;
 	// std::unordered_map<PatternTermSeq, GlobState> _glob_state;
 

--- a/opencog/query/Recognizer.cc
+++ b/opencog/query/Recognizer.cc
@@ -233,8 +233,8 @@ bool Recognizer::fuzzy_match(const Handle& npat_h, const Handle& nsoln_h)
 	return true;
 }
 
-bool Recognizer::grounding(const HandleMap& var_soln,
-                           const HandleMap& term_soln)
+bool Recognizer::grounding(const GroundingMap& var_soln,
+                           const GroundingMap& term_soln)
 {
 	Handle rule = term_soln.at(_root);
 

--- a/opencog/query/Recognizer.h
+++ b/opencog/query/Recognizer.h
@@ -79,8 +79,8 @@ class Recognizer :
 		virtual bool node_match(const Handle&, const Handle&);
 		virtual bool link_match(const PatternTermPtr&, const Handle&);
 		virtual bool fuzzy_match(const Handle&, const Handle&);
-		virtual bool grounding(const HandleMap &var_soln,
-		                       const HandleMap &term_soln);
+		virtual bool grounding(const GroundingMap &var_soln,
+		                       const GroundingMap &term_soln);
 };
 
 } // namespace opencog

--- a/opencog/query/Satisfier.cc
+++ b/opencog/query/Satisfier.cc
@@ -29,8 +29,8 @@
 
 using namespace opencog;
 
-bool Satisfier::grounding(const HandleMap &var_soln,
-                          const HandleMap &term_soln)
+bool Satisfier::grounding(const GroundingMap &var_soln,
+                          const GroundingMap &term_soln)
 {
 	// PatternMatchEngine::print_solution(var_soln, term_soln);
 	_result = TruthValue::TRUE_TV();
@@ -97,7 +97,7 @@ bool Satisfier::search_finished(bool done)
 	if (SEQUENTIAL_AND_LINK != btype and SEQUENTIAL_OR_LINK != btype)
 		return done;
 
-	HandleMap empty;
+	GroundingMap empty;
 	bool rc = eval_sentence(_pattern_body, empty);
 	if (rc)
 		_result = TruthValue::TRUE_TV();
@@ -107,8 +107,8 @@ bool Satisfier::search_finished(bool done)
 
 // ===========================================================
 
-bool SatisfyingSet::grounding(const HandleMap &var_soln,
-                              const HandleMap &term_soln)
+bool SatisfyingSet::grounding(const GroundingMap &var_soln,
+                              const GroundingMap &term_soln)
 {
 	// PatternMatchEngine::log_solution(var_soln, term_soln);
 

--- a/opencog/query/Satisfier.h
+++ b/opencog/query/Satisfier.h
@@ -72,8 +72,8 @@ class Satisfier :
 		// groundings, this will usually return false, so the
 		// patternMatchEngine can keep looking for ever more
 		// groundings.
-		virtual bool grounding(const HandleMap &var_soln,
-		                       const HandleMap &term_soln);
+		virtual bool grounding(const GroundingMap &var_soln,
+		                       const GroundingMap &term_soln);
 
 		// Final pass, if no grounding was found.
 		virtual bool search_finished(bool);
@@ -117,8 +117,8 @@ class SatisfyingSet :
 		// groundings, this will usually return false, so the
 		// patternMatchEngine can keep looking for ever more
 		// groundings.
-		virtual bool grounding(const HandleMap &var_soln,
-		                       const HandleMap &term_soln);
+		virtual bool grounding(const GroundingMap &var_soln,
+		                       const GroundingMap &term_soln);
 };
 
 }; // namespace opencog

--- a/opencog/query/Substitutor.h
+++ b/opencog/query/Substitutor.h
@@ -50,9 +50,9 @@ private:
 
 	// Placing vmap first allows the compiler to optimize the stack
 	// frame. That is, expr changes each time, but vmap does not.
-	static Handle walk_tree(const HandleMap &vmap, const Handle& expr)
+	static Handle walk_tree(const GroundingMap &vmap, const Handle& expr)
 	{
-		HandleMap::const_iterator it = vmap.find(expr);
+		GroundingMap::const_iterator it = vmap.find(expr);
 		if (vmap.end() != it )
 			return it->second;
 
@@ -85,7 +85,7 @@ public:
 	 * @return      a new atom with sub-atoms replaced
 	 */
 	static Handle substitute(const Handle& expr,
-	                         const HandleMap &vars)
+	                         const GroundingMap &vars)
 	{
 		// throw, not assert, because this is a user error ...
 		if (nullptr == expr)


### PR DESCRIPTION
Add support for `std::unordered_map<Handle, Handle>`
The goal here is to be able to perform simple head-to-head  performance
comparisons between that and `std::map<Handle, Handle>` versions of the
pattern matcher. After a few hours of messing around, I was unable to find
any differences.  Both of these show up with about 18% CPU usage in `perf`
but I'm guessing the CPU usage there is dominated by incrementing/decrementing
the smart-pointer counts in 
`std::__shared_ptr<opencog::Atom, (__gnu_cxx::_Lock_policy)2>::__shared_ptr`
when `solution_push()` is called. 