### PR TITLE
Mass removal of copy constructors

### DIFF
--- a/opencog/atoms/base/Link.cc
+++ b/opencog/atoms/base/Link.cc
@@ -54,6 +54,23 @@ void Link::init(const HandleSeq& outgoingVector)
     _outgoing = outgoingVector;
 }
 
+void Link::init(const HandleSeq&& outgoingVector)
+{
+    if (not nameserver().isA(_type, LINK)) {
+        throw InvalidParamException(TRACE_INFO,
+            "Link ctor: Atom type is not a Link: '%d' %s.",
+            _type, nameserver().getTypeName(_type).c_str());
+    }
+
+    // Yes, people actually send us bad data.
+    for (const Handle& h: outgoingVector)
+        if (nullptr == h)
+            throw InvalidParamException(TRACE_INFO,
+                "Link ctor: invalid outgoing set!");
+
+    _outgoing = std::move(outgoingVector);
+}
+
 Link::~Link()
 {
     DPRINTF("Deleting link:\n%s\n", this->to_string().c_str());

--- a/opencog/atoms/base/Link.h
+++ b/opencog/atoms/base/Link.h
@@ -51,6 +51,7 @@ class Link : public Atom
 
 private:
     void init(const HandleSeq&);
+    void init(const HandleSeq&&);
 
 protected:
     //! Array holding actual outgoing set of the link.
@@ -71,6 +72,12 @@ public:
      * @param Link truthvalue.
      */
     Link(const HandleSeq& oset, Type t=LINK)
+        : Atom(t)
+    {
+        init(oset);
+    }
+
+    Link(HandleSeq&& oset, Type t=LINK)
         : Atom(t)
     {
         init(oset);
@@ -173,7 +180,7 @@ public:
      */
     virtual Handle getOutgoingAtom(Arity pos) const
     {
-        return _outgoig.at(pos);
+        return _outgoing.at(pos);
     }
 
     //! Invoke the callback on each atom in the outgoing set of

--- a/opencog/atoms/base/Link.h
+++ b/opencog/atoms/base/Link.h
@@ -132,15 +132,8 @@ public:
         init(oset);
     }
 
-    /**
-     * Copy constructor, does NOT copy atomspace membership,
-     * or any of the values or truth values.
-     */
-    Link(const Link &l)
-        : Atom(l.get_type())
-    {
-        init(l.getOutgoingSet());
-    }
+    Link(const Link&) = delete;
+    Link& operator=(const Link&) = delete;
 
     /**
      * Destructor for this class.

--- a/opencog/atoms/base/Link.h
+++ b/opencog/atoms/base/Link.h
@@ -149,7 +149,7 @@ public:
 
     virtual size_t size() const {
         size_t size = 1;
-        for (const Handle&h : _outgoing)
+        for (const Handle& h : _outgoing)
             size += h->size();
         return size;
     }
@@ -173,12 +173,7 @@ public:
      */
     virtual Handle getOutgoingAtom(Arity pos) const
     {
-        // Checks for a valid position
-        if (pos < _outgoing.size()) {
-            return Handle(AtomCast(_outgoing[pos]));
-        } else {
-            throw RuntimeException(TRACE_INFO, "invalid outgoing set index %d", pos);
-        }
+        return _outgoig.at(pos);
     }
 
     //! Invoke the callback on each atom in the outgoing set of

--- a/opencog/atoms/base/Node.cc
+++ b/opencog/atoms/base/Node.cc
@@ -21,11 +21,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <stdio.h>
-
-#include <opencog/util/Logger.h>
 #include <opencog/atoms/atom_types/NameServer.h>
-#include <opencog/atoms/base/Link.h>
 
 #include "Node.h"
 
@@ -40,6 +36,17 @@ void Node::init(const std::string& cname)
             _type, nameserver().getTypeName(_type).c_str());
     }
     _name = cname;
+}
+
+void Node::init(const std::string&& cname)
+{
+    if (not nameserver().isA(_type, NODE))
+    {
+        throw InvalidParamException(TRACE_INFO,
+            "Node - Invalid node type '%d' %s.",
+            _type, nameserver().getTypeName(_type).c_str());
+    }
+    _name = std::move(cname);
 }
 
 /// Return a universally-unique string for each distinct node.

--- a/opencog/atoms/base/Node.h
+++ b/opencog/atoms/base/Node.h
@@ -69,15 +69,8 @@ public:
         init(s);
     }
 
-    /**
-     * Copy constructor, does not copy atomspace membership,
-     * or any of the values/truthvalues.
-     */
-    Node(const Node &n)
-        : Atom(n.get_type())
-    {
-        init(n._name);
-    }
+    Node(const Node&) = delete;
+    Node& operator=(const Node&) = delete;
 
     virtual bool is_node() const { return true; }
     virtual bool is_link() const { return false; }

--- a/opencog/atoms/base/Node.h
+++ b/opencog/atoms/base/Node.h
@@ -45,6 +45,7 @@ protected:
     // properties
     std::string _name;
     void init(const std::string&);
+    void init(const std::string&&);
 
     virtual ContentHash compute_hash() const;
 
@@ -57,6 +58,12 @@ public:
      *                  the node.  Use empty string for unamed node.
      */
     Node(Type t, const std::string& s)
+        : Atom(t)
+    {
+        init(s);
+    }
+
+    Node(Type t, const std::string&& s)
         : Atom(t)
     {
         init(s);

--- a/opencog/atoms/core/ArityLink.cc
+++ b/opencog/atoms/core/ArityLink.cc
@@ -38,19 +38,6 @@ ArityLink::ArityLink(const HandleSeq& oset, Type t)
 	}
 }
 
-ArityLink::ArityLink(const Link &l)
-	: FunctionLink(l)
-{
-	// Type must be as expected
-	Type tscope = l.get_type();
-	if (not nameserver().isA(tscope, ARITY_LINK))
-	{
-		const std::string& tname = nameserver().getTypeName(tscope);
-		throw InvalidParamException(TRACE_INFO,
-			"Expecting an ArityLink, got %s", tname.c_str());
-	}
-}
-
 // ---------------------------------------------------------------
 
 /// Return the Arity, as a NumberNode.  Contrast this with

--- a/opencog/atoms/core/ArityLink.h
+++ b/opencog/atoms/core/ArityLink.h
@@ -48,7 +48,8 @@ class ArityLink : public FunctionLink
 {
 public:
 	ArityLink(const HandleSeq&, Type = ARITY_LINK);
-	ArityLink(const Link &l);
+	ArityLink(const ArityLink&) = delete;
+	ArityLink& operator=(const ArityLink&) = delete;
 
 	// Return a pointer to the atom being specified.
 	virtual ValuePtr execute(AtomSpace*, bool);

--- a/opencog/atoms/core/CondLink.h
+++ b/opencog/atoms/core/CondLink.h
@@ -40,6 +40,8 @@ protected:
 
 public:
 	CondLink(const HandleSeq&, Type=COND_LINK);
+	CondLink(const CondLink&) = delete;
+	CondLink& operator=(const CondLink&) = delete;
 
 	virtual ValuePtr execute(AtomSpace*, bool);
 

--- a/opencog/atoms/core/DefineLink.cc
+++ b/opencog/atoms/core/DefineLink.cc
@@ -66,12 +66,6 @@ DefineLink::DefineLink(const Handle& name, const Handle& defn)
 	init();
 }
 
-DefineLink::DefineLink(const Link &l)
-	: UniqueLink(l)
-{
-	init();
-}
-
 /**
  * Get the definition associated with the alias.
  * This will be the second atom of some DefineLink, where

--- a/opencog/atoms/core/DefineLink.h
+++ b/opencog/atoms/core/DefineLink.h
@@ -66,9 +66,11 @@ public:
 
 	DefineLink(const Handle& alias, const Handle& body);
 
-	DefineLink(const Link &l);
-	Handle get_alias(void) const { return _outgoing[0]; }
-	Handle get_definition(void) const { return _outgoing[1]; }
+	DefineLink(const DefineLink&) = delete;
+	DefineLink& operator=(const DefineLink&) = delete;
+
+	Handle get_alias(void) const { return _outgoing.at(0); }
+	Handle get_definition(void) const { return _outgoing.at(1); }
 
 	/**
 	 * Given a Handle pointing to <name> in

--- a/opencog/atoms/core/DeleteLink.cc
+++ b/opencog/atoms/core/DeleteLink.cc
@@ -75,21 +75,6 @@ DeleteLink::DeleteLink(const HandleSeq& oset, Type type)
 	init();
 }
 
-DeleteLink::DeleteLink(const Link &l)
-	: FreeLink(l)
-{
-	// Type must be as expected
-	Type tscope = l.get_type();
-	if (not nameserver().isA(tscope, DELETE_LINK))
-	{
-		const std::string& tname = nameserver().getTypeName(tscope);
-		throw InvalidParamException(TRACE_INFO,
-			"Expecting a DeleteLink, got %s", tname.c_str());
-	}
-
-	init();
-}
-
 DEFINE_LINK_FACTORY(DeleteLink, DELETE_LINK)
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/core/DeleteLink.h
+++ b/opencog/atoms/core/DeleteLink.h
@@ -48,7 +48,8 @@ protected:
 public:
 	DeleteLink(const HandleSeq&, Type=DELETE_LINK);
 
-	DeleteLink(const Link&);
+	DeleteLink(const DeleteLink&) = delete;
+	DeleteLink& operator=(const DeleteLink&) = delete;
 
 	static Handle factory(const Handle&);
 };

--- a/opencog/atoms/core/FreeLink.cc
+++ b/opencog/atoms/core/FreeLink.cc
@@ -37,18 +37,6 @@ FreeLink::FreeLink(const HandleSeq& oset, Type t)
 	init();
 }
 
-FreeLink::FreeLink(const Link& l)
-    : Link(l)
-{
-	Type tscope = l.get_type();
-	if (not nameserver().isA(tscope, FREE_LINK))
-		throw InvalidParamException(TRACE_INFO, "Expecting a FreeLink");
-
-	// Derived classes have thier own init routines.
-	if (FREE_LINK != tscope) return;
-	init();
-}
-
 /* ================================================================= */
 
 void FreeLink::init(void)

--- a/opencog/atoms/core/FreeLink.h
+++ b/opencog/atoms/core/FreeLink.h
@@ -46,7 +46,8 @@ protected:
 
 public:
 	FreeLink(const HandleSeq& oset, Type=FREE_LINK);
-	FreeLink(const Link& l);
+	FreeLink(const FreeLink&) = delete;
+	FreeLink& operator=(const FreeLink&) = delete;
 	virtual ~FreeLink() {}
 
 	const FreeVariables& get_vars() const

--- a/opencog/atoms/core/FunctionLink.cc
+++ b/opencog/atoms/core/FunctionLink.cc
@@ -44,13 +44,6 @@ FunctionLink::FunctionLink(const HandleSeq& oset, Type t)
 	init();
 }
 
-FunctionLink::FunctionLink(const Link& l)
-    : FreeLink(l)
-{
-	check_type(l.get_type());
-	init();
-}
-
 DEFINE_LINK_FACTORY(FunctionLink, FUNCTION_LINK);
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/core/FunctionLink.h
+++ b/opencog/atoms/core/FunctionLink.h
@@ -70,7 +70,8 @@ public:
 	// Sadly, need to make this public, else the factory code fails.
 	FunctionLink(const HandleSeq& oset, Type = FUNCTION_LINK);
 
-	FunctionLink(const Link& l);
+	FunctionLink(const FunctionLink&) = delete;
+	FunctionLink& operator=(const FunctionLink&) = delete;
 	virtual ~FunctionLink() {}
 
 	virtual bool is_executable(void) const { return true; }

--- a/opencog/atoms/core/ImplicationScopeLink.cc
+++ b/opencog/atoms/core/ImplicationScopeLink.cc
@@ -36,20 +36,6 @@ ImplicationScopeLink::ImplicationScopeLink(const HandleSeq& hseq, Type t)
 	init();
 }
 
-ImplicationScopeLink::ImplicationScopeLink(const Link &l)
-	: ScopeLink(l)
-{
-	Type t = l.get_type();
-	if (not nameserver().isA(t, IMPLICATION_SCOPE_LINK))
-	{
-		const std::string& tname = nameserver().getTypeName(t);
-		throw InvalidParamException(TRACE_INFO,
-			"Expecting a ImplicationScopeLink, got %s", tname.c_str());
-	}
-
-	init();
-}
-
 void ImplicationScopeLink::extract_variables(const HandleSeq& oset)
 {
 	size_t sz = _outgoing.size();

--- a/opencog/atoms/core/ImplicationScopeLink.h
+++ b/opencog/atoms/core/ImplicationScopeLink.h
@@ -55,7 +55,8 @@ protected:
 	Handle _implicand;
 public:
 	ImplicationScopeLink(const HandleSeq&, Type = IMPLICATION_SCOPE_LINK);
-	ImplicationScopeLink(const Link &);
+	ImplicationScopeLink(const ImplicationScopeLink &) = delete;
+	ImplicationScopeLink& operator=(const ImplicationScopeLink &) = delete;
 
 	static Handle factory(const Handle&);
 };

--- a/opencog/atoms/core/LambdaLink.cc
+++ b/opencog/atoms/core/LambdaLink.cc
@@ -43,19 +43,6 @@ LambdaLink::LambdaLink(const HandleSeq& oset, Type t)
 	}
 }
 
-LambdaLink::LambdaLink(const Link &l)
-	: PrenexLink(l)
-{
-	// Type must be as expected
-	Type tscope = l.get_type();
-	if (not nameserver().isA(tscope, LAMBDA_LINK))
-	{
-		const std::string& tname = nameserver().getTypeName(tscope);
-		throw SyntaxException(TRACE_INFO,
-			"Expecting a LambdaLink, got %s", tname.c_str());
-	}
-}
-
 DEFINE_LINK_FACTORY(LambdaLink, LAMBDA_LINK)
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/core/LambdaLink.h
+++ b/opencog/atoms/core/LambdaLink.h
@@ -55,7 +55,8 @@ class LambdaLink : public PrenexLink
 public:
 	LambdaLink(const HandleSeq&, Type=LAMBDA_LINK);
 	LambdaLink(const Handle& varcdecls, const Handle& body);
-	LambdaLink(const Link &l);
+	LambdaLink(const LambdaLink &) = delete;
+	LambdaLink& operator=(const LambdaLink &) = delete;
 
 	static Handle factory(const Handle&);
 };

--- a/opencog/atoms/core/NumberNode.cc
+++ b/opencog/atoms/core/NumberNode.cc
@@ -84,16 +84,6 @@ NumberNode::NumberNode(const std::string& s)
 	_name = vector_to_plain(_value);
 }
 
-NumberNode::NumberNode(Node &n)
-	: Node(n)
-{
-	OC_ASSERT(nameserver().isA(_type, NUMBER_NODE),
-		"Bad NumberNode constructor!");
-
-	_value = to_vector(n.get_name());
-	_name = vector_to_plain(_value);
-}
-
 NumberNode::NumberNode(const std::vector<double>& vec)
 	: Node(NUMBER_NODE, "")
 {

--- a/opencog/atoms/core/NumberNode.h
+++ b/opencog/atoms/core/NumberNode.h
@@ -62,8 +62,8 @@ public:
 		: Node(NUMBER_NODE, double_to_string(vvv))
 	{ _value.push_back(vvv); }
 
-	// TODO Should be a move assignment...
-	NumberNode(Node &);
+	NumberNode(NumberNode&) = delete;
+	NumberNode& operator=(const NumberNode&) = delete;
 
 	static std::vector<double> to_vector(const std::string&);
 	static std::string vector_to_json(const std::vector<double>&);

--- a/opencog/atoms/core/PrenexLink.cc
+++ b/opencog/atoms/core/PrenexLink.cc
@@ -54,13 +54,6 @@ PrenexLink::PrenexLink(const HandleSeq& oset, Type t)
 	init();
 }
 
-PrenexLink::PrenexLink(const Link &l)
-	: RewriteLink(l)
-{
-	if (skip_init(l.get_type())) return;
-	init();
-}
-
 /* ================================================================= */
 
 /// Re-assemble into prenex form.

--- a/opencog/atoms/core/PrenexLink.h
+++ b/opencog/atoms/core/PrenexLink.h
@@ -49,7 +49,8 @@ protected:
 public:
 	PrenexLink(const HandleSeq&, Type=PRENEX_LINK);
 	PrenexLink(const Handle& varcdecls, const Handle& body);
-	PrenexLink(const Link &l);
+	PrenexLink(const PrenexLink &) = delete;
+	PrenexLink& operator=(const PrenexLink &) = delete;
 
 	virtual Handle beta_reduce(const HandleSeq& seq) const;
 	virtual Handle beta_reduce(const HandleMap& vm) const;

--- a/opencog/atoms/core/PresentLink.cc
+++ b/opencog/atoms/core/PresentLink.cc
@@ -69,23 +69,6 @@ PresentLink::PresentLink(const HandleSeq& oset, Type t)
 	init();
 }
 
-PresentLink::PresentLink(const Link& l)
-	: UnorderedLink(l)
-{
-	// Type must be as expected
-	Type tscope = l.get_type();
-	if (not nameserver().isA(tscope, PRESENT_LINK))
-	{
-		const std::string& tname = nameserver().getTypeName(tscope);
-		throw InvalidParamException(TRACE_INFO,
-			"Expecting an PresentLink, got %s", tname.c_str());
-	}
-
-	// We have to call init here, because the input link l might
-	// not have gone through a PresentLink constructor before.
-	init();
-}
-
 // ---------------------------------------------------------------
 
 DEFINE_LINK_FACTORY(PresentLink, PRESENT_LINK)

--- a/opencog/atoms/core/PresentLink.h
+++ b/opencog/atoms/core/PresentLink.h
@@ -61,7 +61,8 @@ class PresentLink : public UnorderedLink
 	void init(void);
 public:
 	PresentLink(const HandleSeq&, Type=PRESENT_LINK);
-	PresentLink(const Link &l);
+	PresentLink(const PresentLink &) = delete;
+	PresentLink& operator=(const PresentLink &) = delete;
 
 	static Handle factory(const Handle&);
 };

--- a/opencog/atoms/core/PutLink.cc
+++ b/opencog/atoms/core/PutLink.cc
@@ -34,12 +34,6 @@ PutLink::PutLink(const HandleSeq& oset, Type t)
 	init();
 }
 
-PutLink::PutLink(const Link& l)
-    : PrenexLink(l)
-{
-	init();
-}
-
 /* ================================================================= */
 
 /// PutLink expects a very strict format: an arity-2 link, with

--- a/opencog/atoms/core/PutLink.h
+++ b/opencog/atoms/core/PutLink.h
@@ -83,7 +83,8 @@ protected:
 
 public:
 	PutLink(const HandleSeq& oset, Type=PUT_LINK);
-	PutLink(const Link& l);
+	PutLink(const PutLink&) = delete;
+	PutLink& operator=(const PutLink&) = delete;
 	virtual ~PutLink() {}
 
 	// PutLink arguments may be the second or the third outgoing-set elt.

--- a/opencog/atoms/core/RandomChoice.cc
+++ b/opencog/atoms/core/RandomChoice.cc
@@ -42,19 +42,6 @@ RandomChoiceLink::RandomChoiceLink(const HandleSeq& oset, Type t)
 	}
 }
 
-RandomChoiceLink::RandomChoiceLink(const Link &l)
-	: FunctionLink(l)
-{
-	// Type must be as expected
-	Type tscope = l.get_type();
-	if (not nameserver().isA(tscope, RANDOM_CHOICE_LINK))
-	{
-		const std::string& tname = nameserver().getTypeName(tscope);
-		throw InvalidParamException(TRACE_INFO,
-			"Expecting an RandomChoiceLink, got %s", tname.c_str());
-	}
-}
-
 // ---------------------------------------------------------------
 
 /// When executed, this will randomly select and return an atom

--- a/opencog/atoms/core/RandomChoice.h
+++ b/opencog/atoms/core/RandomChoice.h
@@ -63,7 +63,8 @@ class RandomChoiceLink : public FunctionLink
 {
 public:
 	RandomChoiceLink(const HandleSeq&, Type=RANDOM_CHOICE_LINK);
-	RandomChoiceLink(const Link &l);
+	RandomChoiceLink(const RandomChoiceLink&) = delete;
+	RandomChoiceLink& operator=(const RandomChoiceLink&) = delete;
 
 	// Return a pointer to the atom being specified.
 	virtual ValuePtr execute(AtomSpace*, bool);

--- a/opencog/atoms/core/RandomNumber.cc
+++ b/opencog/atoms/core/RandomNumber.cc
@@ -54,12 +54,6 @@ RandomNumberLink::RandomNumberLink(const HandleSeq& oset, Type t)
 	init();
 }
 
-RandomNumberLink::RandomNumberLink(const Link &l)
-	: FunctionLink(l)
-{
-	init();
-}
-
 // ---------------------------------------------------------------
 
 static double get_dbl(AtomSpace* as, bool silent, const Handle& h)

--- a/opencog/atoms/core/RandomNumber.h
+++ b/opencog/atoms/core/RandomNumber.h
@@ -49,7 +49,8 @@ protected:
 
 public:
 	RandomNumberLink(const HandleSeq&, Type=RANDOM_NUMBER_LINK);
-	RandomNumberLink(const Link &l);
+	RandomNumberLink(const RandomNumberLink&) = delete;
+	RandomNumberLink& operator=(const RandomNumberLink&) = delete;
 
 	// Return a pointer to the atom being specified.
 	virtual ValuePtr execute(AtomSpace*, bool);

--- a/opencog/atoms/core/RewriteLink.cc
+++ b/opencog/atoms/core/RewriteLink.cc
@@ -56,13 +56,6 @@ RewriteLink::RewriteLink(const HandleSeq& oset, Type t)
 	init();
 }
 
-RewriteLink::RewriteLink(const Link &l)
-	: ScopeLink(l), _silent(false)
-{
-	if (skip_init(l.get_type())) return;
-	init();
-}
-
 /* ================================================================= */
 
 inline Handle append_rand_str(const Handle& var)

--- a/opencog/atoms/core/RewriteLink.h
+++ b/opencog/atoms/core/RewriteLink.h
@@ -115,7 +115,8 @@ protected:
 public:
 	RewriteLink(const HandleSeq&, Type=REWRITE_LINK);
 	RewriteLink(const Handle& varcdecls, const Handle& body);
-	RewriteLink(const Link &l);
+	RewriteLink(const RewriteLink &) = delete;
+	RewriteLink& operator=(const RewriteLink &) = delete;
 
 	void make_silent(bool s) { _silent = s; }
 

--- a/opencog/atoms/core/ScopeLink.cc
+++ b/opencog/atoms/core/ScopeLink.cc
@@ -76,13 +76,6 @@ ScopeLink::ScopeLink(const HandleSeq& oset, Type t)
 	init();
 }
 
-ScopeLink::ScopeLink(const Link &l)
-	: Link(l)
-{
-	if (skip_init(l.get_type())) return;
-	init();
-}
-
 /* ================================================================= */
 ///
 /// Find and unpack variable declarations, if any; otherwise, just

--- a/opencog/atoms/core/ScopeLink.h
+++ b/opencog/atoms/core/ScopeLink.h
@@ -72,7 +72,8 @@ protected:
 public:
 	ScopeLink(const HandleSeq&, Type=SCOPE_LINK);
 	ScopeLink(const Handle& varcdecls, const Handle& body);
-	ScopeLink(const Link &l);
+	ScopeLink(const ScopeLink&) = delete;
+	ScopeLink& operator=(const ScopeLink&) = delete;
 
 	// Return the list of variables we are holding.
 	const Variables& get_variables(void) const { return _variables; }

--- a/opencog/atoms/core/SleepLink.cc
+++ b/opencog/atoms/core/SleepLink.cc
@@ -52,19 +52,6 @@ SleepLink::SleepLink(const HandleSeq& oset, Type t)
 			"Expecting a NumberNode or something that returns a NumberNode");
 }
 
-SleepLink::SleepLink(const Link &l)
-	: FunctionLink(l)
-{
-	// Type must be as expected
-	Type tscope = l.get_type();
-	if (not nameserver().isA(tscope, SLEEP_LINK))
-	{
-		const std::string& tname = nameserver().getTypeName(tscope);
-		throw InvalidParamException(TRACE_INFO,
-			"Expecting an SleepLink, got %s", tname.c_str());
-	}
-}
-
 // ---------------------------------------------------------------
 
 /// Return number of seconds left to sleep.

--- a/opencog/atoms/core/SleepLink.h
+++ b/opencog/atoms/core/SleepLink.h
@@ -39,7 +39,8 @@ class SleepLink : public FunctionLink
 {
 public:
 	SleepLink(const HandleSeq&, Type=SLEEP_LINK);
-	SleepLink(const Link &l);
+	SleepLink(const SleepLink &) = delete;
+	SleepLink& operator=(const SleepLink &) = delete;
 
 	// Return number of seconds left to sleep.
 	virtual ValuePtr execute(AtomSpace*, bool);

--- a/opencog/atoms/core/StateLink.cc
+++ b/opencog/atoms/core/StateLink.cc
@@ -48,12 +48,6 @@ StateLink::StateLink(const Handle& name, const Handle& defn)
 	init();
 }
 
-StateLink::StateLink(const Link &l)
-	: UniqueLink(l)
-{
-	init();
-}
-
 /**
  * Get the state associated with the alias.
  * This will be the second atom of some StateLink, where

--- a/opencog/atoms/core/StateLink.h
+++ b/opencog/atoms/core/StateLink.h
@@ -51,7 +51,8 @@ public:
 	StateLink(const HandleSeq&, Type=STATE_LINK);
 	StateLink(const Handle& alias, const Handle& body);
 
-	StateLink(const Link&);
+	StateLink(const StateLink&) = delete;
+	StateLink& operator=(const StateLink&) = delete;
 	Handle get_alias(void) const { return _outgoing[0]; }
 	Handle get_state(void) const { return _outgoing[1]; }
 

--- a/opencog/atoms/core/TimeLink.cc
+++ b/opencog/atoms/core/TimeLink.cc
@@ -44,19 +44,6 @@ TimeLink::TimeLink(const HandleSeq& oset, Type t)
 			"TimeLink does not expect any arguments");
 }
 
-TimeLink::TimeLink(const Link &l)
-	: FunctionLink(l)
-{
-	// Type must be as expected
-	Type tscope = l.get_type();
-	if (not nameserver().isA(tscope, TIME_LINK))
-	{
-		const std::string& tname = nameserver().getTypeName(tscope);
-		throw InvalidParamException(TRACE_INFO,
-			"Expecting an TimeLink, got %s", tname.c_str());
-	}
-}
-
 // ---------------------------------------------------------------
 
 ValuePtr TimeLink::execute(AtomSpace* as, bool silent)

--- a/opencog/atoms/core/TimeLink.h
+++ b/opencog/atoms/core/TimeLink.h
@@ -38,7 +38,8 @@ class TimeLink : public FunctionLink
 {
 public:
 	TimeLink(const HandleSeq&, Type=TIME_LINK);
-	TimeLink(const Link&);
+	TimeLink(const TimeLink&) = delete;
+	TimeLink& operator=(const TimeLink&) = delete;
 
 	// Return a pointer to the atom being specified.
 	virtual ValuePtr execute(AtomSpace*, bool);

--- a/opencog/atoms/core/TruthValueOfLink.cc
+++ b/opencog/atoms/core/TruthValueOfLink.cc
@@ -37,19 +37,6 @@ TruthValueOfLink::TruthValueOfLink(const HandleSeq& oset, Type t)
 	}
 }
 
-TruthValueOfLink::TruthValueOfLink(const Link &l)
-	: ValueOfLink(l)
-{
-	// Type must be as expected
-	Type tscope = l.get_type();
-	if (not nameserver().isA(tscope, TRUTH_VALUE_OF_LINK))
-	{
-		const std::string& tname = nameserver().getTypeName(tscope);
-		throw InvalidParamException(TRACE_INFO,
-			"Expecting an TruthValueOfLink, got %s", tname.c_str());
-	}
-}
-
 // ---------------------------------------------------------------
 
 /// When executed, this will return the TruthValue
@@ -85,19 +72,6 @@ StrengthOfLink::StrengthOfLink(const HandleSeq& oset, Type t)
 	if (not nameserver().isA(t, STRENGTH_OF_LINK))
 	{
 		const std::string& tname = nameserver().getTypeName(t);
-		throw InvalidParamException(TRACE_INFO,
-			"Expecting an StrengthOfLink, got %s", tname.c_str());
-	}
-}
-
-StrengthOfLink::StrengthOfLink(const Link &l)
-	: ValueOfLink(l)
-{
-	// Type must be as expected
-	Type tscope = l.get_type();
-	if (not nameserver().isA(tscope, STRENGTH_OF_LINK))
-	{
-		const std::string& tname = nameserver().getTypeName(tscope);
 		throw InvalidParamException(TRACE_INFO,
 			"Expecting an StrengthOfLink, got %s", tname.c_str());
 	}
@@ -147,19 +121,6 @@ ConfidenceOfLink::ConfidenceOfLink(const HandleSeq& oset, Type t)
 	if (not nameserver().isA(t, CONFIDENCE_OF_LINK))
 	{
 		const std::string& tname = nameserver().getTypeName(t);
-		throw InvalidParamException(TRACE_INFO,
-			"Expecting an ConfidenceOfLink, got %s", tname.c_str());
-	}
-}
-
-ConfidenceOfLink::ConfidenceOfLink(const Link &l)
-	: ValueOfLink(l)
-{
-	// Type must be as expected
-	Type tscope = l.get_type();
-	if (not nameserver().isA(tscope, CONFIDENCE_OF_LINK))
-	{
-		const std::string& tname = nameserver().getTypeName(tscope);
 		throw InvalidParamException(TRACE_INFO,
 			"Expecting an ConfidenceOfLink, got %s", tname.c_str());
 	}

--- a/opencog/atoms/core/TruthValueOfLink.h
+++ b/opencog/atoms/core/TruthValueOfLink.h
@@ -37,7 +37,8 @@ class TruthValueOfLink : public ValueOfLink
 {
 public:
 	TruthValueOfLink(const HandleSeq&, Type=TRUTH_VALUE_OF_LINK);
-	TruthValueOfLink(const Link &l);
+	TruthValueOfLink(const TruthValueOfLink &) = delete;
+	TruthValueOfLink operator=(const TruthValueOfLink &) = delete;
 
 	// Return a pointer to the extracted value.
 	virtual ValuePtr execute(AtomSpace*, bool);
@@ -62,7 +63,8 @@ class StrengthOfLink : public ValueOfLink
 {
 public:
 	StrengthOfLink(const HandleSeq&, Type=STRENGTH_OF_LINK);
-	StrengthOfLink(const Link &l);
+	StrengthOfLink(const StrengthOfLink&) = delete;
+	StrengthOfLink& operator=(const StrengthOfLink&) = delete;
 
 	// Return a pointer to the extracted value.
 	virtual ValuePtr execute(AtomSpace*, bool);
@@ -87,7 +89,8 @@ class ConfidenceOfLink : public ValueOfLink
 {
 public:
 	ConfidenceOfLink(const HandleSeq&, Type=CONFIDENCE_OF_LINK);
-	ConfidenceOfLink(const Link &l);
+	ConfidenceOfLink(const ConfidenceOfLink&) = delete;
+	ConfidenceOfLink operator=(const ConfidenceOfLink&) = delete;
 
 	// Return a pointer to the extracted value.
 	virtual ValuePtr execute(AtomSpace*, bool);

--- a/opencog/atoms/core/TypeNode.h
+++ b/opencog/atoms/core/TypeNode.h
@@ -74,21 +74,8 @@ public:
 		  _kind(t)
 	{}
 
-	TypeNode(Node &n)
-		: Node(n),
-		  _kind(nameserver().getType(n.get_name()))
-	{
-		OC_ASSERT(nameserver().isA(n.get_type(), TYPE_NODE),
-			"Bad TypeNode constructor!");
-
-		if (DEFINED_TYPE_NODE != _type and NOTYPE == _kind)
-			throw InvalidParamException(TRACE_INFO,
-				"Not a valid typename: '%s'", n.get_name().c_str());
-
-		if (DEFINED_TYPE_NODE == _type and NOTYPE != _kind)
-			throw InvalidParamException(TRACE_INFO,
-				"Redefinition of a built-in typename: '%s'", n.get_name().c_str());
-	}
+	TypeNode(TypeNode&) = delete;
+	TypeNode& operator=(const TypeNode&) = delete;
 
 	static void validate(const std::string& str)
 	{

--- a/opencog/atoms/core/TypedAtomLink.cc
+++ b/opencog/atoms/core/TypedAtomLink.cc
@@ -69,12 +69,6 @@ TypedAtomLink::TypedAtomLink(const Handle& name, const Handle& defn)
 	init();
 }
 
-TypedAtomLink::TypedAtomLink(const Link &l)
-	: UniqueLink(l)
-{
-	init();
-}
-
 /**
  * Get the type description associated with the alias.
  * This will be the second atom of some TypedAtomLink, where

--- a/opencog/atoms/core/TypedAtomLink.h
+++ b/opencog/atoms/core/TypedAtomLink.h
@@ -53,9 +53,11 @@ public:
 	TypedAtomLink(const HandleSeq&, Type=TYPED_ATOM_LINK);
 	TypedAtomLink(const Handle& alias, const Handle& body);
 
-	TypedAtomLink(const Link &l);
-	Handle get_atom(void) const { return _outgoing[0]; }
-	Handle get_type(void) const { return _outgoing[1]; }
+	TypedAtomLink(const TypedAtomLink&) = delete;
+	TypedAtomLink& operator=(const TypedAtomLink&) = delete;
+
+	Handle get_atom(void) const { return _outgoing.at(0); }
+	Handle get_type(void) const { return _outgoing.at(1); }
 
 	/**
 	 * Given a Handle pointing to <atom> in

--- a/opencog/atoms/core/UniqueLink.cc
+++ b/opencog/atoms/core/UniqueLink.cc
@@ -80,23 +80,6 @@ UniqueLink::UniqueLink(const Handle& name, const Handle& defn)
 	init(true);
 }
 
-UniqueLink::UniqueLink(const Link &l)
-	: FreeLink(l)
-{
-	// Type must be as expected
-	Type type = l.get_type();
-	if (not nameserver().isA(type, UNIQUE_LINK))
-	{
-		const std::string& tname = nameserver().getTypeName(type);
-		throw InvalidParamException(TRACE_INFO,
-			"Expecting a UniqueLink, got %s", tname.c_str());
-	}
-
-	// Derived types have thier own initialization
-	if (UNIQUE_LINK != type) return;
-	init(true);
-}
-
 /// Get the unique link for this alias.
 Handle UniqueLink::get_unique(const Handle& alias, Type type,
                               bool allow_open)

--- a/opencog/atoms/core/UniqueLink.h
+++ b/opencog/atoms/core/UniqueLink.h
@@ -53,9 +53,10 @@ public:
 	UniqueLink(const HandleSeq&, Type=UNIQUE_LINK);
 	UniqueLink(const Handle& alias, const Handle& body);
 
-	UniqueLink(const Link &l);
+	UniqueLink(const UniqueLink&) = delete;
+	UniqueLink& operator=(const UniqueLink&) = delete;
 
-	Handle get_alias(void) const { return _outgoing[0]; }
+	Handle get_alias(void) const { return _outgoing.at(0); }
 
 	static Handle factory(const Handle&);
 };

--- a/opencog/atoms/core/UnorderedLink.cc
+++ b/opencog/atoms/core/UnorderedLink.cc
@@ -66,25 +66,6 @@ UnorderedLink::UnorderedLink(const HandleSet& oset, Type t)
 		content_based_handle_less());
 }
 
-UnorderedLink::UnorderedLink(const Link& l)
-	: Link(l)
-{
-	// Type must be as expected
-	Type tscope = l.get_type();
-	if (not nameserver().isA(tscope, UNORDERED_LINK))
-	{
-		const std::string& tname = nameserver().getTypeName(tscope);
-		throw InvalidParamException(TRACE_INFO,
-			"Expecting an UnorderedLink, got %s", tname.c_str());
-	}
-
-	// Place into arbitrary, but deterministic order.
-	// We have to do this here,  because the input link l might not
-	// have ever gone through an UnorderedLink constructor before.
-	std::sort(_outgoing.begin(), _outgoing.end(),
-		content_based_handle_less());
-}
-
 // ---------------------------------------------------------------
 
 DEFINE_LINK_FACTORY(UnorderedLink, UNORDERED_LINK)

--- a/opencog/atoms/core/UnorderedLink.h
+++ b/opencog/atoms/core/UnorderedLink.h
@@ -54,7 +54,8 @@ class UnorderedLink : public Link
 public:
 	UnorderedLink(const HandleSeq&, Type=UNORDERED_LINK);
 	UnorderedLink(const HandleSet&, Type=UNORDERED_LINK);
-	UnorderedLink(const Link &l);
+	UnorderedLink(const UnorderedLink&) = delete;
+	UnorderedLink& operator=(const UnorderedLink&) = delete;
 
 	virtual bool is_unordered_link() const { return true; }
 

--- a/opencog/atoms/core/ValueOfLink.cc
+++ b/opencog/atoms/core/ValueOfLink.cc
@@ -38,19 +38,6 @@ ValueOfLink::ValueOfLink(const HandleSeq& oset, Type t)
 	}
 }
 
-ValueOfLink::ValueOfLink(const Link &l)
-	: FunctionLink(l)
-{
-	// Type must be as expected
-	Type tscope = l.get_type();
-	if (not nameserver().isA(tscope, VALUE_OF_LINK))
-	{
-		const std::string& tname = nameserver().getTypeName(tscope);
-		throw InvalidParamException(TRACE_INFO,
-			"Expecting an ValueOfLink, got %s", tname.c_str());
-	}
-}
-
 // ---------------------------------------------------------------
 
 /// When executed, this will return the value at the indicated key.

--- a/opencog/atoms/core/ValueOfLink.h
+++ b/opencog/atoms/core/ValueOfLink.h
@@ -38,7 +38,8 @@ class ValueOfLink : public FunctionLink
 {
 public:
 	ValueOfLink(const HandleSeq&, Type=VALUE_OF_LINK);
-	ValueOfLink(const Link &l);
+	ValueOfLink(const ValueOfLink&) = delete;
+	ValueOfLink& operator=(const ValueOfLink&) = delete;
 
 	// Return a pointer to the atom being specified.
 	virtual ValuePtr execute(AtomSpace*, bool);

--- a/opencog/atoms/core/VariableList.cc
+++ b/opencog/atoms/core/VariableList.cc
@@ -59,12 +59,6 @@ VariableList::VariableList(const HandleSeq& oset, Type t)
 	throw_if_not_variable_list(t);
 }
 
-VariableList::VariableList(const Link &l)
-	: Link(l), _variables(l.get_handle(), true)
-{
-	throw_if_not_variable_list(l.get_type());
-}
-
 /* ================================================================= */
 
 std::string opencog::oc_to_string(const VariableListPtr& vlp,

--- a/opencog/atoms/core/VariableList.h
+++ b/opencog/atoms/core/VariableList.h
@@ -56,7 +56,8 @@ protected:
 public:
 	VariableList(const HandleSeq& vardecls, Type=VARIABLE_LIST);
 	VariableList(const Handle& hvardecls);
-	VariableList(const Link&);
+	VariableList(const VariableList&) = delete;
+	VariableList& operator=(const VariableList&) = delete;
 
 	// Return the list of variables we are holding.
 	const Variables& get_variables(void) const { return _variables; }

--- a/opencog/atoms/core/VariableSet.cc
+++ b/opencog/atoms/core/VariableSet.cc
@@ -58,12 +58,6 @@ VariableSet::VariableSet(const Handle& vardecl)
 {
 }
 
-VariableSet::VariableSet(const Link &l)
-	: UnorderedLink(l), _variables(l.get_handle())
-{
-	throw_if_not_variable_set(l.get_type());
-}
-
 std::string opencog::oc_to_string(const VariableSetPtr& vsp,
                                   const std::string& indent)
 {

--- a/opencog/atoms/core/VariableSet.h
+++ b/opencog/atoms/core/VariableSet.h
@@ -47,7 +47,8 @@ protected:
 public:
 	VariableSet(const HandleSeq& vardecls, Type=VARIABLE_SET);
 	VariableSet(const Handle& hvardecls);
-	VariableSet(const Link&);
+	VariableSet(const VariableSet&) = delete;
+	VariableSet& operator=(const VariableSet&) = delete;
 
 	// Return the list of variables we are holding.
 	const Variables& get_variables(void) const { return _variables; }

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -74,15 +74,6 @@ EvaluationLink::EvaluationLink(const Handle& schema, const Handle& args)
 	}
 }
 
-EvaluationLink::EvaluationLink(const Link& l)
-    : FreeLink(l)
-{
-	Type tscope = l.get_type();
-	if (EVALUATION_LINK != tscope)
-		throw RuntimeException(TRACE_INFO,
-		    "Expecting an EvaluationLink");
-}
-
 /// We get exceptions in two differet ways: (a) due to user error,
 /// in which case we need to report the error to the user, and
 /// (b) occasionally expected errors, which might occur during normal

--- a/opencog/atoms/execution/EvaluationLink.h
+++ b/opencog/atoms/execution/EvaluationLink.h
@@ -23,7 +23,8 @@ class EvaluationLink : public FreeLink
 public:
 	EvaluationLink(const HandleSeq&, Type=EVALUATION_LINK);
 	EvaluationLink(const Handle& schema, const Handle& args);
-	EvaluationLink(const Link& l);
+	EvaluationLink(const EvaluationLink&) = delete;
+	EvaluationLink& operator=(const EvaluationLink&) = delete;
 
 	TruthValuePtr evaluate(AtomSpace* as, bool silent) {
 		return do_evaluate(as, get_handle());

--- a/opencog/atoms/execution/ExecutionOutputLink.cc
+++ b/opencog/atoms/execution/ExecutionOutputLink.cc
@@ -75,17 +75,6 @@ ExecutionOutputLink::ExecutionOutputLink(const Handle& schema,
 	check_schema(schema);
 }
 
-ExecutionOutputLink::ExecutionOutputLink(const Link& l)
-	: FunctionLink(l)
-{
-	Type tscope = l.get_type();
-	if (EXECUTION_OUTPUT_LINK != tscope)
-		throw SyntaxException(TRACE_INFO,
-		                      "Expection an ExecutionOutputLink!");
-
-	check_schema(l.getOutgoingAtom(0));
-}
-
 /// execute -- execute the function defined in an ExecutionOutputLink
 ///
 /// Each ExecutionOutputLink should have the form:

--- a/opencog/atoms/execution/ExecutionOutputLink.h
+++ b/opencog/atoms/execution/ExecutionOutputLink.h
@@ -49,7 +49,8 @@ protected:
 public:
 	ExecutionOutputLink(const HandleSeq&, Type=EXECUTION_OUTPUT_LINK);
 	ExecutionOutputLink(const Handle& schema, const Handle& args);
-	ExecutionOutputLink(const Link& l);
+	ExecutionOutputLink(const ExecutionOutputLink&) = delete;
+	ExecutionOutputLink& operator=(const ExecutionOutputLink&) = delete;
 
 	virtual bool is_executable() const { return true; }
 	virtual ValuePtr execute(AtomSpace* as, bool silent=false);

--- a/opencog/atoms/execution/MapLink.cc
+++ b/opencog/atoms/execution/MapLink.cc
@@ -124,23 +124,6 @@ MapLink::MapLink(const HandleSeq& oset, Type t)
 	init();
 }
 
-MapLink::MapLink(const Link &l)
-	: FunctionLink(l)
-{
-	// Type must be as expected
-	Type tmap = l.get_type();
-	if (not nameserver().isA(tmap, MAP_LINK))
-	{
-		const std::string& tname = nameserver().getTypeName(tmap);
-		throw SyntaxException(TRACE_INFO,
-			"Expecting a MapLink, got %s", tname.c_str());
-	}
-
-	// Derived types have a different initialization sequence.
-	if (MAP_LINK != tmap) return;
-	init();
-}
-
 // ===============================================================
 
 /// Recursive tree-compare-and-extract grounding values.

--- a/opencog/atoms/execution/MapLink.h
+++ b/opencog/atoms/execution/MapLink.h
@@ -65,7 +65,8 @@ protected:
 public:
 	MapLink(const HandleSeq&, Type=MAP_LINK);
 	MapLink(const Handle& pattern, const Handle& term);
-	MapLink(const Link &l);
+	MapLink(const MapLink&) = delete;
+	MapLink operator=(const MapLink&) = delete;
 
 	// Align the pattern and the term side-by-side, and extract the
 	// values that match up with the variables.  If the term is not of

--- a/opencog/atoms/pattern/BindLink.cc
+++ b/opencog/atoms/pattern/BindLink.cc
@@ -60,12 +60,6 @@ BindLink::BindLink(const HandleSeq& hseq, Type t)
 	init();
 }
 
-BindLink::BindLink(const Link &l)
-	: QueryLink(l)
-{
-	init();
-}
-
 /* ================================================================= */
 /* ================================================================= */
 

--- a/opencog/atoms/pattern/BindLink.h
+++ b/opencog/atoms/pattern/BindLink.h
@@ -38,7 +38,8 @@ public:
 	BindLink(const HandleSeq&, Type=BIND_LINK);
 	BindLink(const Handle& vardecl, const Handle& body, const Handle& rewrite);
 	BindLink(const Handle& body, const Handle& rewrite);
-	explicit BindLink(const Link &l);
+	BindLink(const BindLink&) = delete;
+	BindLink& operator=(const BindLink&) = delete;
 
 	virtual bool is_executable() const { return true; }
 	virtual ValuePtr execute(AtomSpace*, bool silent=false);

--- a/opencog/atoms/pattern/DualLink.cc
+++ b/opencog/atoms/pattern/DualLink.cc
@@ -68,12 +68,6 @@ DualLink::DualLink(const HandleSeq& hseq, Type t)
 	init();
 }
 
-DualLink::DualLink(const Link &l)
-	: PatternLink(l)
-{
-	init();
-}
-
 ValuePtr DualLink::execute(AtomSpace* as, bool silent)
 {
 	if (nullptr == as) as = _atom_space;

--- a/opencog/atoms/pattern/DualLink.h
+++ b/opencog/atoms/pattern/DualLink.h
@@ -35,7 +35,8 @@ protected:
 	void init(void);
 public:
 	DualLink(const HandleSeq&, Type=DUAL_LINK);
-	DualLink(const Link &l);
+	DualLink(const DualLink&) = delete;
+	DualLink& operator=(const DualLink&) = delete;
 
 	virtual bool is_executable() const { return true; }
 	virtual ValuePtr execute(AtomSpace*, bool silent=false);

--- a/opencog/atoms/pattern/GetLink.cc
+++ b/opencog/atoms/pattern/GetLink.cc
@@ -46,12 +46,6 @@ GetLink::GetLink(const HandleSeq& hseq, Type t)
 	init();
 }
 
-GetLink::GetLink(const Link &l)
-	: PatternLink(l)
-{
-	init();
-}
-
 /* ================================================================= */
 
 HandleSet GetLink::do_execute(AtomSpace* as, bool silent)

--- a/opencog/atoms/pattern/GetLink.h
+++ b/opencog/atoms/pattern/GetLink.h
@@ -37,7 +37,8 @@ protected:
 
 public:
 	GetLink(const HandleSeq&, Type=GET_LINK);
-	explicit GetLink(const Link &l);
+	GetLink(const GetLink&) = delete;
+	GetLink operator=(const GetLink&) = delete;
 
 	virtual bool is_executable() const { return true; }
 	virtual ValuePtr execute(AtomSpace*, bool silent=false);

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -291,24 +291,6 @@ PatternLink::PatternLink(const HandleSeq& hseq, Type t)
 	init();
 }
 
-PatternLink::PatternLink(const Link& l)
-	: PrenexLink(l)
-{
-	// Type must be as expected
-	Type tscope = l.get_type();
-	if (not nameserver().isA(tscope, PATTERN_LINK))
-	{
-		const std::string& tname = nameserver().getTypeName(tscope);
-		throw InvalidParamException(TRACE_INFO,
-			"Expecting a PatternLink, got %s", tname.c_str());
-	}
-
-	// QueryLink, BindLink use a different initialization sequence.
-	if (nameserver().isA(tscope, QUERY_LINK)) return;
-	if (DUAL_LINK == tscope) return;
-	init();
-}
-
 /* ================================================================= */
 
 /// Make a note of any clauses that must be present (or absent)

--- a/opencog/atoms/pattern/PatternLink.h
+++ b/opencog/atoms/pattern/PatternLink.h
@@ -139,7 +139,8 @@ public:
 	PatternLink(const Handle& body);
 	PatternLink(const Handle& varcdecls, const Handle& body);
 	PatternLink(const Variables&, const Handle&);
-	PatternLink(const Link&);
+	PatternLink(const PatternLink&) = delete;
+	PatternLink& operator=(const PatternLink&) = delete;
 
 	// Used only to set up multi-component links.
 	// DO NOT call this! (unless you are the component handler).

--- a/opencog/atoms/pattern/QueryLink.cc
+++ b/opencog/atoms/pattern/QueryLink.cc
@@ -65,12 +65,6 @@ QueryLink::QueryLink(const HandleSeq& hseq, Type t)
 	init();
 }
 
-QueryLink::QueryLink(const Link &l)
-	: PatternLink(l)
-{
-	init();
-}
-
 /* ================================================================= */
 ///
 /// Find and unpack variable declarations, if any; otherwise, just

--- a/opencog/atoms/pattern/QueryLink.h
+++ b/opencog/atoms/pattern/QueryLink.h
@@ -48,7 +48,8 @@ public:
 	QueryLink(const HandleSeq&, Type=QUERY_LINK);
 	QueryLink(const Handle& vardecl, const Handle& body, const Handle& rewrite);
 	QueryLink(const Handle& body, const Handle& rewrite);
-	explicit QueryLink(const Link &l);
+	QueryLink(const QueryLink&) = delete;
+	QueryLink& operator=(const QueryLink&) = delete;
 
 	const Handle& get_implicand(void) { return _implicand; }
 

--- a/opencog/atoms/pattern/SatisfactionLink.cc
+++ b/opencog/atoms/pattern/SatisfactionLink.cc
@@ -46,12 +46,6 @@ SatisfactionLink::SatisfactionLink(const HandleSeq& hseq, Type t)
 	init();
 }
 
-SatisfactionLink::SatisfactionLink(const Link &l)
-	: PatternLink(l)
-{
-	init();
-}
-
 TruthValuePtr SatisfactionLink::evaluate(AtomSpace* as, bool silent)
 {
 	if (nullptr == as) as = _atom_space;

--- a/opencog/atoms/pattern/SatisfactionLink.h
+++ b/opencog/atoms/pattern/SatisfactionLink.h
@@ -35,7 +35,8 @@ protected:
 	void init(void);
 public:
 	SatisfactionLink(const HandleSeq&, Type=SATISFACTION_LINK);
-	SatisfactionLink(const Link &l);
+	SatisfactionLink(const SatisfactionLink&) = delete;
+	SatisfactionLink& operator=(const SatisfactionLink&) = delete;
 
 	virtual bool is_evaluatable() const { return true; }
 	virtual TruthValuePtr evaluate(AtomSpace*, bool);

--- a/opencog/atoms/reduct/ArithmeticLink.cc
+++ b/opencog/atoms/reduct/ArithmeticLink.cc
@@ -36,12 +36,6 @@ ArithmeticLink::ArithmeticLink(const HandleSeq& oset, Type t)
 	init();
 }
 
-ArithmeticLink::ArithmeticLink(const Link& l)
-    : FoldLink(l)
-{
-	init();
-}
-
 void ArithmeticLink::init(void)
 {
 	Type tscope = get_type();

--- a/opencog/atoms/reduct/ArithmeticLink.h
+++ b/opencog/atoms/reduct/ArithmeticLink.h
@@ -55,7 +55,8 @@ protected:
 
 public:
 	ArithmeticLink(const HandleSeq& oset, Type=ARITHMETIC_LINK);
-	ArithmeticLink(const Link& l);
+	ArithmeticLink(const ArithmeticLink&) = delete;
+	ArithmeticLink& operator=(const ArithmeticLink&) = delete;
 
 	virtual ValuePtr delta_reduce(AtomSpace*, bool) const;
 	virtual ValuePtr execute(AtomSpace*, bool);

--- a/opencog/atoms/reduct/DivideLink.cc
+++ b/opencog/atoms/reduct/DivideLink.cc
@@ -25,12 +25,6 @@ DivideLink::DivideLink(const Handle& a, const Handle& b)
 	init();
 }
 
-DivideLink::DivideLink(const Link& l)
-    : TimesLink(l)
-{
-	init();
-}
-
 void DivideLink::init(void)
 {
 	Type tscope = get_type();

--- a/opencog/atoms/reduct/DivideLink.h
+++ b/opencog/atoms/reduct/DivideLink.h
@@ -29,7 +29,8 @@ protected:
 public:
 	DivideLink(const Handle& a, const Handle& b);
 	DivideLink(const HandleSeq& oset, Type=DIVIDE_LINK);
-	DivideLink(const Link& l);
+	DivideLink(const DivideLink&) = delete;
+	DivideLink& operator=(const DivideLink&) = delete;
 
 	static Handle factory(const Handle&);
 };

--- a/opencog/atoms/reduct/FoldLink.cc
+++ b/opencog/atoms/reduct/FoldLink.cc
@@ -35,12 +35,6 @@ FoldLink::FoldLink(const HandleSeq& oset, Type t)
 	init();
 }
 
-FoldLink::FoldLink(const Link& l)
-    : FunctionLink(l)
-{
-	init();
-}
-
 void FoldLink::init(void)
 {
 	Type tscope = get_type();

--- a/opencog/atoms/reduct/FoldLink.h
+++ b/opencog/atoms/reduct/FoldLink.h
@@ -50,7 +50,8 @@ protected:
 
 public:
 	FoldLink(const HandleSeq&, Type=FOLD_LINK);
-	FoldLink(const Link& l);
+	FoldLink(const FoldLink&) = delete;
+	FoldLink& operator=(const FoldLink&) = delete;
 
 	// Should probably be renamed to execute() ...
    virtual ValuePtr delta_reduce(AtomSpace*, bool) const;

--- a/opencog/atoms/reduct/MinusLink.cc
+++ b/opencog/atoms/reduct/MinusLink.cc
@@ -26,12 +26,6 @@ MinusLink::MinusLink(const Handle& a, const Handle& b)
 	init();
 }
 
-MinusLink::MinusLink(const Link& l)
-    : PlusLink(l)
-{
-	init();
-}
-
 void MinusLink::init(void)
 {
 	Type tscope = get_type();

--- a/opencog/atoms/reduct/MinusLink.h
+++ b/opencog/atoms/reduct/MinusLink.h
@@ -29,7 +29,8 @@ protected:
 public:
 	MinusLink(const Handle& a, const Handle& b);
 	MinusLink(const HandleSeq&, Type=MINUS_LINK);
-	MinusLink(const Link&);
+	MinusLink(const MinusLink&) = delete;
+	MinusLink& operator=(const MinusLink&) = delete;
 
 	static Handle factory(const Handle&);
 };

--- a/opencog/atoms/reduct/PlusLink.cc
+++ b/opencog/atoms/reduct/PlusLink.cc
@@ -29,12 +29,6 @@ PlusLink::PlusLink(const Handle& a, const Handle& b)
 	init();
 }
 
-PlusLink::PlusLink(const Link& l)
-    : ArithmeticLink(l)
-{
-	init();
-}
-
 void PlusLink::init(void)
 {
 	if (nullptr == zero) zero = createNumberNode(0);

--- a/opencog/atoms/reduct/PlusLink.h
+++ b/opencog/atoms/reduct/PlusLink.h
@@ -32,7 +32,8 @@ protected:
 public:
 	PlusLink(const Handle& a, const Handle& b);
 	PlusLink(const HandleSeq&, Type=PLUS_LINK);
-	PlusLink(const Link&);
+	PlusLink(const PlusLink&) = delete;
+	PlusLink& operator=(const PlusLink&) = delete;
 
 	static Handle factory(const Handle&);
 };

--- a/opencog/atoms/reduct/TimesLink.cc
+++ b/opencog/atoms/reduct/TimesLink.cc
@@ -28,12 +28,6 @@ TimesLink::TimesLink(const Handle& a, const Handle& b)
 	init();
 }
 
-TimesLink::TimesLink(const Link& l)
-    : ArithmeticLink(l)
-{
-	init();
-}
-
 void TimesLink::init(void)
 {
 	if (nullptr == one) one = createNumberNode(1);

--- a/opencog/atoms/reduct/TimesLink.h
+++ b/opencog/atoms/reduct/TimesLink.h
@@ -32,7 +32,8 @@ protected:
 public:
 	TimesLink(const HandleSeq&, Type=TIMES_LINK);
 	TimesLink(const Handle& a, const Handle& b);
-	TimesLink(const Link&);
+	TimesLink(const TimesLink&) = delete;
+	TimesLink& operator=(const TimesLink&) = delete;
 
 	static Handle factory(const Handle&);
 };

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -310,7 +310,7 @@ Handle AtomTable::add(AtomPtr atom, bool async, bool force)
         }
     }
     else if (atom->getAtomTable())
-        atom = createNode(*NodeCast(atom));
+        atom = createNode(atom->get_type(), atom->get_name());
 
     atom->copyValues(orig);
     atom->install();

--- a/tests/query/ExecutionOutputUTest.cxxtest
+++ b/tests/query/ExecutionOutputUTest.cxxtest
@@ -233,7 +233,7 @@ void ExecutionOutputUTest::test_varsub(void)
 	      ),
 	   an(VARIABLE_NODE, "$action")
 	);
-	BindLinkPtr situation(createBindLink(*LinkCast(situ)));
+	BindLinkPtr situation(createBindLink(situ->getOutgoingSet()));
 
 	Handle pred =
 	al(BIND_LINK,
@@ -243,7 +243,7 @@ void ExecutionOutputUTest::test_varsub(void)
 	      ),
 	   an(VARIABLE_NODE, "$action")
 	);
-	BindLinkPtr predicament(createBindLink(*LinkCast(pred)));
+	BindLinkPtr predicament(createBindLink(pred->getOutgoingSet()));
 
 	// Now perform the search.
 	DefaultImplicator simpl(&as);


### PR DESCRIPTION
They seem to not be needed; I don't think they were ever needed.

This lays some groundwork for a later pull req that implements move constructors.