### PR TITLE
Provide an `sql-create` function to simplify DB management

### DIFF
--- a/opencog/persist/sql/README.md
+++ b/opencog/persist/sql/README.md
@@ -599,6 +599,9 @@ minimization of complexity. If you need complex database management,
 then you need a database managemenet system. This guile module is
 not a replacement for a full DBMS, nor could it ever be.
 
+Skip ahead to the section [Using the System](#using-the-system)
+below for more info.
+
 User setup
 ----------
 (Optional)  The above is sufficient for most simple use-cases. The unit
@@ -839,21 +842,24 @@ $ guile
 scheme@(guile-user)> (use-modules (opencog))
 scheme@(guile-user)> (use-modules (opencog persist) (opencog persist-sql))
 ```
-Open a database with `sql-open`:
+Create a database with `sql-create`:
 ```
-scheme@(guile-user)> (sql-open "postgres:///opencog_test?user=opencog_tester")
-Reserving UUID up to 3
+scheme@(guile-user)> (sql-create "postgres:///foo")
+```
+and then open it with `sql-open`:
+```
+scheme@(guile-user)> (sql-open "postgres:///foo")
 ```
 There are other, alternate forms for the URI. See the [postgres
 documentation](https://www.postgresql.org/docs/9.6/static/libpq-connect.html)
 for details.
 ```
-> (sql-open "odbc://opencog_tester:cheese/opencog_test")
-> (sql-open "postgres://opencog_tester@localhost/opencog_test")
-> (sql-open "postgres://opencog_tester:cheese@localhost/opencog_test")
-> (sql-open "postgres:///opencog_test?user=opencog_tester")
-> (sql-open "postgres:///opencog_test?user=opencog_tester&host=localhost")
-> (sql-open "postgres:///opencog_test?user=opencog_tester&password=cheese")
+> (sql-open "odbc://atomspace_user:cheese/foo")
+> (sql-open "postgres://atomspace_user@localhost/foo")
+> (sql-open "postgres://atomspace_user:cheese@localhost/foo")
+> (sql-open "postgres:///foo?user=atomspace_user")
+> (sql-open "postgres:///foo?user=atomspace_user&host=localhost")
+> (sql-open "postgres:///foo?user=atomspace_user&password=cheese")
 ```
 
 Save an atom with `store-atom`:
@@ -865,8 +871,18 @@ scheme@(guile-user)> (store-atom x)
 Other useful scheme functions: `fetch-atom` and `fetch-incoming-set`.
 A debugging print: `sql-stats`
 
-Bulk load and restore: `sql-load` `sql-store` `sql-close`
+Bulk load and restore: `sql-load` `sql-store` `sql-close`.
 
+View the list of supported functions with the `,apropos` guile shell
+command:
+```
+   scheme> ,a sql
+   scheme> ,a fetch
+```
+Specific documentation cane be viewed with the `,describe` command:
+```
+   scheme> ,d sql-open
+```
 
 Bulk Save and Restore
 ---------------------

--- a/opencog/persist/sql/README.md
+++ b/opencog/persist/sql/README.md
@@ -301,6 +301,9 @@ C-language bindings to the Postgres client library.
 
 Optional ODBC drivers
 ---------------------
+The use of the ODBC driver is discouraged; so, unless you really need it
+or really like it, you should skip this step.
+
 Optionally, download and install UnixODBC devel packages.  Do NOT use
 IODBC, it fails to support UTF-8!  It's also buggy when more than a few
 100K atoms need to be fetched.
@@ -328,6 +331,7 @@ simply won't work with MySQL, because of a lack of array support.
 Same holds true for SQLite.  Sorry. There is some work in the
 code-base to support these other databases, but the work-arounds for
 the missing features are kind-of complicated, and likely to be slow.
+(The above statements were accurate in 2012; things may have changed.)
 
 Be sure to install the Postgres server and the Postgres client.
 
@@ -528,6 +532,62 @@ have to create an explicit database user login, as explained below;
 otherwise, creating a user is optional.
 
 
+Does it work now?
+-----------------
+If the above steps were properly carried out, then the system is ready
+to be used. A simple "sniff test" can verify this.  At the shell prompt,
+start `guile`, and then try the following:
+```
+   $ guile
+   scheme> (use-modules (opencog))
+   scheme> (use-modules (opencog persist) (opencog persist-sql))
+   scheme> (sql-create "postgres:///foo")
+   scheme> (sql-open "postgres:///foo")
+   scheme> (Concept "this is a test" (stv 0.4 0.6))
+   scheme> (store-atom (Concept "this is a test"))
+   scheme> (sql-stats)
+   scheme> (sql-close)
+```
+
+The above should work without any errors. If not, double-check your
+configuration. You can verify that the truth value was stored by
+fetching the Atom; alll associated values will be fetched:
+
+```
+   $ guile
+   scheme> (use-modules (opencog))
+   scheme> (use-modules (opencog persist) (opencog persist-sql))
+   scheme> (sql-open "postgres:///foo")
+   scheme> (fetch-atom (Concept "this is a test"))
+   scheme> (sql-close)
+```
+
+Other useful scheme operations include bulk load/store, such as
+`store-atomspace`, `load-atomspace` and `load-atoms-of-type`.
+
+Even more handy are operations that fetch only a small portion
+of the atomspace: `fetch-incoming-set`, `fetch-incoming-by-type`,
+`load-referers` and `store-referers`.
+
+You can be reminded of these by saying
+```
+   scheme> ,a sql
+   scheme> ,a fetch
+```
+and get specific documentation on each:
+```
+   scheme> ,d sql-open
+```
+which will, for example, remind you of the supported URL formats:
+```
+   postgres:///DBNAME
+   postgres://USER@HOST/DBNAME
+   postgres://USER:PASSWORD@HOST/DBNAME
+   postgres:///DBNAME?user=USER
+   postgres:///DBNAME?user=USER&host=HOST
+   postgres:///DBNAME?user=USER&password=PASS
+```
+
 User setup
 ----------
 (Optional)  You can continue without creating a database user, if you
@@ -593,8 +653,8 @@ Be sure to reload or restart the postgres server after the above change:
    service postgresql reload
 ```
 
-Table initialization
---------------------
+Manual table initialization
+---------------------------
 Next, you need to populate the database with OpenCog-specific tables.
 Navigate to the atomspace folder you cloned from GitHub:
 

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
@@ -47,9 +47,10 @@ using namespace opencog;
 /* ================================================================ */
 // Constructors
 
-void SQLAtomStorage::init(const char * uri)
+void SQLAtomStorage::open(std::string uris)
 {
-	_uri = uri;
+	_uri = uris;
+	const char * uri = uris.c_str();
 
 	bool use_libpq = (0 == strncmp(uri, "postgres", 8));
 	bool use_odbc = (0 == strncmp(uri, "odbc", 4));
@@ -149,15 +150,13 @@ void SQLAtomStorage::init(const char * uri)
 	table_id_cache.insert(1);
 }
 
-SQLAtomStorage::SQLAtomStorage(std::string uri) :
+SQLAtomStorage::SQLAtomStorage(void) :
 	_tlbuf(&_uuid_manager),
 	_uuid_manager("uuid_pool"),
 	_vuid_manager("vuid_pool"),
 	_write_queue(this, &SQLAtomStorage::vdo_store_atom, NUM_WB_QUEUES),
 	_async_write_queue_exception(nullptr)
 {
-	init(uri.c_str());
-
 	// Use a bigger buffer than the default. Assuming that the hardware
 	// can do 1K atom stores/sec or better, this gives a backlog of
 	// unwritten stuff less than a second long, which seems like an OK

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
@@ -297,6 +297,28 @@ void SQLAtomStorage::rename_tables(void)
 	rp.exec("ALTER TABLE TypeCodes RENAME TO TypeCodes_Backup;");
 }
 
+void SQLAtomStorage::create_database(std::string uri)
+{
+	// Gack. Yuck. Ouch. Wrong. But whatever. Parse the URI
+	// and extract a database name from it. This completely
+	// ignores any usernames or passwords in the URI, and is
+	// likely to screw up if there is some hostname in there.
+	// Any way ... extract the database name.
+	if ('/' != uri[0] or strncmp(uri.c_str(), "postgres:///", 12))
+		throw IOException(TRACE_INFO, "Unknown URI '%s'\n", uri.c_str());
+
+	size_t pos = uri.find_first_of("?@:&");
+	if (pos != uri.npos)
+		throw IOException(TRACE_INFO, "Unsupported URI '%s'\n", uri.c_str());
+
+	std::string dbname(uri);
+	if (0 == strncmp(uri.c_str(), "postgres:///", 12))
+		dbname = uri.substr(12);
+
+	Response rp(conn_pool);
+	rp.exec("CREATE DATABASE " + dbname + ";");
+}
+
 void SQLAtomStorage::create_tables(void)
 {
 	Response rp(conn_pool);

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
@@ -268,9 +268,9 @@ void SQLAtomStorage::create_tables(void)
 {
 	Response rp(conn_pool);
 
-	// See the file "atom.sql" for detailed documentation as to the
+	// See the file `atom.sql` for detailed documentation as to the
 	// structure of the SQL tables. The code below is kept in sync,
-	// manually, with the contents of atom.sql.
+	// manually, with the contents of `atom.sql`.
 	rp.exec("CREATE TABLE Spaces ("
 	              "space     BIGINT PRIMARY KEY,"
 	              "parent    BIGINT);");
@@ -287,6 +287,8 @@ void SQLAtomStorage::create_tables(void)
 	            "outgoing BIGINT[],"
 	            "UNIQUE (type, name),"
 	            "UNIQUE (type, outgoing));");
+
+	rp.exec("CREATE INDEX incoming_idx on Atoms USING GIN(outgoing);");
 
 	rp.exec("CREATE TABLE Valuations ("
 	            "key BIGINT REFERENCES Atoms(uuid),"
@@ -309,6 +311,9 @@ void SQLAtomStorage::create_tables(void)
 	rp.exec("CREATE TABLE TypeCodes ("
 	            "type SMALLINT UNIQUE,"
 	            "typename TEXT UNIQUE);");
+
+	rp.exec("CREATE SEQUENCE uuid_pool START WITH 1 INCREMENT BY 400;");
+	rp.exec("CREATE SEQUENCE vuid_pool START WITH 1 INCREMENT BY 400;");
 
 	type_map_was_loaded = false;
 }

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
@@ -189,7 +189,8 @@ void SQLAtomStorage::open(std::string uri)
 	// _initial_conn_pool_size += NUM_WB_QUEUES;
 // #define NUM_OMP_THREADS 8
 
-	enlarge_conn_pool(NUM_OMP_THREADS - 1);
+	// minus 2 because we had a +2 in connect();
+	enlarge_conn_pool(NUM_OMP_THREADS - 2);
 
 	if (!connected()) return;
 
@@ -322,7 +323,8 @@ void SQLAtomStorage::create_database(std::string uri)
 	// not, then libpq will deliver an error.
 	connect(server);
 	if (!connected())
-		throw IOException(TRACE_INFO, "Error: cannot connect to '%s'", server.c_str());
+		throw IOException(TRACE_INFO, "Error: cannot connect to '%s'",
+		                  server.c_str());
 
 	{
 		Response rp(conn_pool);

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.cc
@@ -141,7 +141,7 @@ void SQLAtomStorage::connect(std::string uris)
 		throw IOException(TRACE_INFO, "Unknown URI '%s'\n", uri);
 
 	if (0 == _initial_conn_pool_size)
-		enlarge_conn_pool(NUM_WB_QUEUES + 1);
+		enlarge_conn_pool(NUM_WB_QUEUES + 2);
 
 	if (!connected()) return;
 
@@ -211,6 +211,8 @@ void SQLAtomStorage::open(std::string uri)
  */
 bool SQLAtomStorage::connected(void)
 {
+	if (0 == _initial_conn_pool_size) return false;
+
 	// This will leak a resource, if db_conn->connected() ever throws.
 	LLConnection* db_conn = conn_pool.value_pop();
 	bool have_connection = db_conn->connected();
@@ -289,21 +291,27 @@ void SQLAtomStorage::rename_tables(void)
 
 void SQLAtomStorage::create_database(std::string uri)
 {
+	if (!connected())
+		throw IOException(TRACE_INFO, "Error: no connection to db server!");
+
 	// Gack. Yuck. Ouch. Wrong. But whatever. Parse the URI
 	// and extract a database name from it. This completely
 	// ignores any usernames or passwords in the URI, and is
 	// likely to screw up if there is some hostname in there.
 	// Any way ... extract the database name.
-	if ('/' != uri[0] or strncmp(uri.c_str(), "postgres:///", 12))
+	if (strncmp(uri.c_str(), "postgres:///", 12) and
+	    uri.npos != uri.find_first_of("/?@:&"))
+	{
 		throw IOException(TRACE_INFO, "Unknown URI '%s'\n", uri.c_str());
-
-	size_t pos = uri.find_first_of("?@:&");
-	if (pos != uri.npos)
-		throw IOException(TRACE_INFO, "Unsupported URI '%s'\n", uri.c_str());
+	}
 
 	std::string dbname(uri);
 	if (0 == strncmp(uri.c_str(), "postgres:///", 12))
 		dbname = uri.substr(12);
+
+	size_t pos = dbname.find_first_of("?@:&");
+	if (pos != dbname.npos)
+		throw IOException(TRACE_INFO, "Unsupported URI '%s'\n", uri.c_str());
 
 	Response rp(conn_pool);
 	rp.exec("CREATE DATABASE " + dbname + ";");

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.h
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.h
@@ -236,6 +236,7 @@ class SQLAtomStorage : public BackingStore
 		SQLAtomStorage& operator=(const SQLAtomStorage&) = delete; // disable assignment
 		virtual ~SQLAtomStorage();
 		void open(std::string uri);
+		void connect(std::string uri);
 		bool connected(void); // connection to DB is alive
 
 		void create_tables(void); // initialize the database

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.h
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.h
@@ -62,6 +62,7 @@ class SQLAtomStorage : public BackingStore
 		concurrent_stack<LLConnection*> conn_pool;
 		int _initial_conn_pool_size;
 		void enlarge_conn_pool(int);
+		void close_conn_pool(void);
 
 		// Utility for handling responses (on stack).
 		class Response;
@@ -126,6 +127,7 @@ class SQLAtomStorage : public BackingStore
 		// --------------------------
 		// Table management
 		void rename_tables(void);
+		void create_tables(void);
 
 		// --------------------------
 		// Values
@@ -243,7 +245,6 @@ class SQLAtomStorage : public BackingStore
 		bool connected(void); // connection to DB is alive
 
 		void create_database(std::string uri); // create the database
-		void create_tables(void);   // initialize the database
 		void kill_data(void);       // destroy DB contents
 		void clear_cache(void);     // clear out the TLB.
 

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.h
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.h
@@ -61,11 +61,14 @@ class SQLAtomStorage : public BackingStore
 		// Pool of shared connections
 		concurrent_stack<LLConnection*> conn_pool;
 		int _initial_conn_pool_size;
+		void enlarge_conn_pool(int);
 
 		// Utility for handling responses (on stack).
 		class Response;
 
 		std::string _uri;
+		bool _use_libpq;
+		bool _use_odbc;
 		int _server_version;
 		void get_server_version(void);
 

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.h
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.h
@@ -239,9 +239,10 @@ class SQLAtomStorage : public BackingStore
 		void connect(std::string uri);
 		bool connected(void); // connection to DB is alive
 
-		void create_tables(void); // initialize the database
-		void kill_data(void);     // destroy DB contents
-		void clear_cache(void);   // clear out the TLB.
+		void create_database(std::string uri); // create the database
+		void create_tables(void);   // initialize the database
+		void kill_data(void);       // destroy DB contents
+		void clear_cache(void);     // clear out the TLB.
 
 		void registerWith(AtomSpace*);
 		void unregisterWith(AtomSpace*);

--- a/opencog/persist/sql/multi-driver/SQLAtomStorage.h
+++ b/opencog/persist/sql/multi-driver/SQLAtomStorage.h
@@ -65,7 +65,6 @@ class SQLAtomStorage : public BackingStore
 		// Utility for handling responses (on stack).
 		class Response;
 
-		void init(const char *);
 		std::string _uri;
 		int _server_version;
 		void get_server_version(void);
@@ -124,7 +123,6 @@ class SQLAtomStorage : public BackingStore
 		// --------------------------
 		// Table management
 		void rename_tables(void);
-		void create_tables(void);
 
 		// --------------------------
 		// Values
@@ -233,14 +231,16 @@ class SQLAtomStorage : public BackingStore
 		void rethrow(void);
 
 	public:
-		SQLAtomStorage(std::string uri);
+		SQLAtomStorage(void);
 		SQLAtomStorage(const SQLAtomStorage&) = delete; // disable copying
 		SQLAtomStorage& operator=(const SQLAtomStorage&) = delete; // disable assignment
 		virtual ~SQLAtomStorage();
+		void open(std::string uri);
 		bool connected(void); // connection to DB is alive
 
-		void kill_data(void); // destroy DB contents
-		void clear_cache(void); // clear out the TLB.
+		void create_tables(void); // initialize the database
+		void kill_data(void);     // destroy DB contents
+		void clear_cache(void);   // clear out the TLB.
 
 		void registerWith(AtomSpace*);
 		void unregisterWith(AtomSpace*);
@@ -260,7 +260,7 @@ class SQLAtomStorage : public BackingStore
 
 		// Large-scale loads and saves
 		void loadAtomSpace(AtomTable &); // Load entire contents of DB
-		void storeAtomSpace(const AtomTable &); // Store entire contents of AtomTable
+		void storeAtomSpace(const AtomTable &); // Store all of AtomTable
 
 		// Debugging and performance monitoring
 		void print_stats(void);

--- a/opencog/persist/sql/multi-driver/SQLPersistSCM.cc
+++ b/opencog/persist/sql/multi-driver/SQLPersistSCM.cc
@@ -78,8 +78,6 @@ SQLPersistSCM::~SQLPersistSCM()
 
 void SQLPersistSCM::do_create(const std::string& uri)
 {
-// xxxx this is borken.
-    // Use the postgres driver.
     SQLAtomStorage *store = new SQLAtomStorage();
     if (!store)
         throw RuntimeException(TRACE_INFO,
@@ -92,6 +90,9 @@ void SQLPersistSCM::do_create(const std::string& uri)
             "sql-open: Error: Unable to connect to the database");
     }
 
+    // Use the postgres driver.
+    store->connect("postgres://");
+    store->create_database(uri);
     store->create_tables();
 
     delete store;
@@ -116,7 +117,6 @@ void SQLPersistSCM::do_open(const std::string& uri)
         throw RuntimeException(TRACE_INFO,
              "sql-open: Error: Atomspace connected to another storage backend!");
 
-    // Use the postgres driver.
     SQLAtomStorage *store = new SQLAtomStorage();
     if (!store)
         throw RuntimeException(TRACE_INFO,

--- a/opencog/persist/sql/multi-driver/SQLPersistSCM.cc
+++ b/opencog/persist/sql/multi-driver/SQLPersistSCM.cc
@@ -61,6 +61,7 @@ void SQLPersistSCM::init_in_module(void* data)
 
 void SQLPersistSCM::init(void)
 {
+    define_scheme_primitive("sql-create", &SQLPersistSCM::do_create, this, "persist-sql");
     define_scheme_primitive("sql-open", &SQLPersistSCM::do_open, this, "persist-sql");
     define_scheme_primitive("sql-close", &SQLPersistSCM::do_close, this, "persist-sql");
     define_scheme_primitive("sql-stats", &SQLPersistSCM::do_stats, this, "persist-sql");
@@ -73,6 +74,27 @@ void SQLPersistSCM::init(void)
 SQLPersistSCM::~SQLPersistSCM()
 {
     if (_backing) delete _backing;
+}
+
+void SQLPersistSCM::do_create(const std::string& uri)
+{
+// xxxx this is borken.
+    // Use the postgres driver.
+    SQLAtomStorage *store = new SQLAtomStorage(uri);
+    if (!store)
+        throw RuntimeException(TRACE_INFO,
+            "sql-open: Error: Unable to open the database");
+
+    if (!store->connected())
+    {
+        delete store;
+        throw RuntimeException(TRACE_INFO,
+            "sql-open: Error: Unable to connect to the database");
+    }
+
+    store->create_tables();
+
+    delete store;
 }
 
 void SQLPersistSCM::do_open(const std::string& uri)

--- a/opencog/persist/sql/multi-driver/SQLPersistSCM.cc
+++ b/opencog/persist/sql/multi-driver/SQLPersistSCM.cc
@@ -78,21 +78,8 @@ SQLPersistSCM::~SQLPersistSCM()
 
 void SQLPersistSCM::do_create(const std::string& uri)
 {
-    SQLAtomStorage *store = new SQLAtomStorage();
-
-    // Use the postgres driver.
-    store->connect("postgres://");
-
-    if (!store->connected())
-    {
-        delete store;
-        throw RuntimeException(TRACE_INFO,
-            "sql-open: Error: Unable to connect to the database");
-    }
-
+    SQLAtomStorage* store = new SQLAtomStorage();
     store->create_database(uri);
-    store->create_tables();
-
     delete store;
 }
 

--- a/opencog/persist/sql/multi-driver/SQLPersistSCM.cc
+++ b/opencog/persist/sql/multi-driver/SQLPersistSCM.cc
@@ -79,9 +79,9 @@ SQLPersistSCM::~SQLPersistSCM()
 void SQLPersistSCM::do_create(const std::string& uri)
 {
     SQLAtomStorage *store = new SQLAtomStorage();
-    if (!store)
-        throw RuntimeException(TRACE_INFO,
-            "sql-open: Error: Unable to open the database");
+
+    // Use the postgres driver.
+    store->connect("postgres://");
 
     if (!store->connected())
     {
@@ -90,8 +90,6 @@ void SQLPersistSCM::do_create(const std::string& uri)
             "sql-open: Error: Unable to connect to the database");
     }
 
-    // Use the postgres driver.
-    store->connect("postgres://");
     store->create_database(uri);
     store->create_tables();
 
@@ -118,10 +116,6 @@ void SQLPersistSCM::do_open(const std::string& uri)
              "sql-open: Error: Atomspace connected to another storage backend!");
 
     SQLAtomStorage *store = new SQLAtomStorage();
-    if (!store)
-        throw RuntimeException(TRACE_INFO,
-            "sql-open: Error: Unable to open the database");
-
     store->open(uri);
     if (!store->connected())
     {

--- a/opencog/persist/sql/multi-driver/SQLPersistSCM.cc
+++ b/opencog/persist/sql/multi-driver/SQLPersistSCM.cc
@@ -80,7 +80,7 @@ void SQLPersistSCM::do_create(const std::string& uri)
 {
 // xxxx this is borken.
     // Use the postgres driver.
-    SQLAtomStorage *store = new SQLAtomStorage(uri);
+    SQLAtomStorage *store = new SQLAtomStorage();
     if (!store)
         throw RuntimeException(TRACE_INFO,
             "sql-open: Error: Unable to open the database");
@@ -115,12 +115,14 @@ void SQLPersistSCM::do_open(const std::string& uri)
     if (_as->isAttachedToBackingStore())
         throw RuntimeException(TRACE_INFO,
              "sql-open: Error: Atomspace connected to another storage backend!");
+
     // Use the postgres driver.
-    SQLAtomStorage *store = new SQLAtomStorage(uri);
+    SQLAtomStorage *store = new SQLAtomStorage();
     if (!store)
         throw RuntimeException(TRACE_INFO,
             "sql-open: Error: Unable to open the database");
 
+    store->open(uri);
     if (!store->connected())
     {
         delete store;

--- a/opencog/persist/sql/multi-driver/SQLPersistSCM.h
+++ b/opencog/persist/sql/multi-driver/SQLPersistSCM.h
@@ -53,6 +53,7 @@ public:
     SQLPersistSCM(AtomSpace*);
     ~SQLPersistSCM();
 
+    void do_create(const std::string&);
     void do_open(const std::string&);
     void do_close(void);
 

--- a/opencog/scm/opencog/persist-sql.scm
+++ b/opencog/scm/opencog/persist-sql.scm
@@ -9,7 +9,7 @@
 (use-modules (opencog as-config))
 (load-extension (string-append opencog-ext-path-persist-sql "libpersist-sql") "opencog_persist_sql_init")
 
-(export sql-clear-cache sql-clear-stats sql-close sql-open
+(export sql-clear-cache sql-clear-stats sql-close sql-create sql-open
 	sql-stats sql-set-hilo-watermarks! sql-set-stall-writers!)
 
 (set-procedure-property! sql-clear-cache 'documentation

--- a/opencog/scm/opencog/persist-sql.scm
+++ b/opencog/scm/opencog/persist-sql.scm
@@ -37,15 +37,35 @@
     no longer be stored to or fetched from the database.
 ")
 
+(set-procedure-property! sql-create 'documentation
+"
+ sql-create URL - Create and initialize a new database,
+    Create the database encoded in the URL, and initialize it for
+    holding AtomSpace data. This assumes that the user has database
+    creation priviledges; otherwise an error will be thrown.
+
+    Currently, the ONLY supported URL formats are:
+       postgres:///DBNAME
+       postgres://USER@HOST/DBNAME
+       postgres://USER:PASSWORD@HOST/DBNAME
+
+  For example, to create the database \"foo\", just say:
+     (sql-create \"postgres:///foo\")
+  To then use it, you have to open it:
+     (sql-open \"postgres:///foo\")
+  To delete it, you must say \"dropdb foo\" at the shell (bash) prompt.
+")
+
 (set-procedure-property! sql-open 'documentation
 "
- sql-open URL - Open a connection to a database
+ sql-open URL - Open a connection to a database.
     Open a connection to the database encoded in the URL. All
     appropriate database credentials must be supplied in the URL,
     including the username and password, if required.
 
     The URL must be on one of these formats:
        odbc://USER:PASSWORD/DBNAME
+       postgres:///DBNAME
        postgres://USER@HOST/DBNAME
        postgres://USER:PASSWORD@HOST/DBNAME
        postgres:///DBNAME?user=USER

--- a/tests/persist/sql/multi-driver/BasicSaveUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/BasicSaveUTest.cxxtest
@@ -254,7 +254,8 @@ static void atomCompare(AtomPtr a, AtomPtr b, const char* where)
  */
 void BasicSaveUTest::single_atom_save_restore(std::string id)
 {
-    SQLAtomStorage *store = new SQLAtomStorage(uri);
+    SQLAtomStorage *store = new SQLAtomStorage();
+    store->open(uri);
     if (!store->connected())
     {
         logger().debug("single_atom_save_restore: cannot connect to db");
@@ -380,7 +381,8 @@ void BasicSaveUTest::do_test_single_atom(void)
 {
     logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    astore = new SQLAtomStorage(uri);
+    astore = new SQLAtomStorage();
+    astore->open(uri);
     if (!astore->connected())
     {
         logger().info("setUp: cannot connect to database");
@@ -407,7 +409,8 @@ void BasicSaveUTest::do_test_fresh_atom(void)
 {
     logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    SQLAtomStorage *store = new SQLAtomStorage(uri);
+    SQLAtomStorage *store = new SQLAtomStorage();
+    store->open(uri);
     if (!store->connected())
     {
         logger().debug("single_atom_save_restore: cannot connect to db");
@@ -448,7 +451,8 @@ void BasicSaveUTest::do_test_table()
 {
     logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-    SQLAtomStorage *store = new SQLAtomStorage(uri);
+    SQLAtomStorage *store = new SQLAtomStorage();
+    store->open(uri);
     if (!store->connected())
     {
         logger().debug("test_table: cannot connect to db");
@@ -469,7 +473,8 @@ void BasicSaveUTest::do_test_table()
     delete table1;
 
     // Reopen connection, and load the atom table.
-    store = new SQLAtomStorage(uri);
+    store = new SQLAtomStorage();
+    store->open(uri);
     TSM_ASSERT("Not connected to database", store->connected());
 
     AtomTable *table2 = new AtomTable();

--- a/tests/persist/sql/multi-driver/DeleteUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/DeleteUTest.cxxtest
@@ -169,7 +169,8 @@ void DeleteUTest::kill_data(void)
 #if HAVE_PGSQL_STORAGE
     if ("" == uri) uri = mkuri("postgres", dbname, username, passwd);
 #endif
-    SQLAtomStorage* astore = new SQLAtomStorage(uri);
+    SQLAtomStorage* astore = new SQLAtomStorage();
+    astore->open(uri);
     if (!astore->connected())
     {
         logger().info("setUp: SQLAtomStorage cannot connect to database");

--- a/tests/persist/sql/multi-driver/FetchUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/FetchUTest.cxxtest
@@ -150,7 +150,8 @@ void FetchUTest::tearDown(void)
 
 void FetchUTest::kill_data(void)
 {
-	SQLAtomStorage* astore = new SQLAtomStorage(uri);
+	SQLAtomStorage* astore = new SQLAtomStorage();
+	astore->open(uri);
 	if (!astore->connected())
 	{
 		logger().info("setUp: SQLAtomStorage cannot connect to database");

--- a/tests/persist/sql/multi-driver/LargeFlatUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/LargeFlatUTest.cxxtest
@@ -150,7 +150,8 @@ void LargeFlatUTest::kill_data(void)
 #if HAVE_PGSQL_STORAGE
 	if ("" == uri) uri = mkuri("postgres", dbname, username, passwd);
 #endif
-	SQLAtomStorage* astore = new SQLAtomStorage(uri);
+	SQLAtomStorage* astore = new SQLAtomStorage();
+	astore->open(uri);
 	if (!astore->connected())
 	{
 		logger().info("setUp: SQLAtomStorage cannot connect to database");

--- a/tests/persist/sql/multi-driver/LargeZipfUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/LargeZipfUTest.cxxtest
@@ -138,7 +138,8 @@ void LargeZipfTest::kill_data(void)
 #if HAVE_PGSQL_STORAGE
 	if ("" == uri) uri = mkuri("postgres", dbname, username, passwd);
 #endif
-	SQLAtomStorage* astore = new SQLAtomStorage(uri);
+	SQLAtomStorage* astore = new SQLAtomStorage();
+	astore->open(uri);
 	if (!astore->connected())
 	{
 		logger().info("setUp: SQLAtomStorage cannot connect to database");

--- a/tests/persist/sql/multi-driver/MultiPersistUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/MultiPersistUTest.cxxtest
@@ -205,7 +205,8 @@ void MultiPersistUTest::tearDown(void)
 
 void MultiPersistUTest::kill_data(void)
 {
-    SQLAtomStorage* astore = new SQLAtomStorage(uri);
+    SQLAtomStorage* astore = new SQLAtomStorage();
+    astore->open(uri);
     if (!astore->connected())
     {
         logger().info("setUp: SQLAtomStorage cannot connect to database");

--- a/tests/persist/sql/multi-driver/MultiUserUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/MultiUserUTest.cxxtest
@@ -234,7 +234,8 @@ void MultiUserUTest::tearDown(void)
 
 void MultiUserUTest::kill_data(void)
 {
-    SQLAtomStorage* astore = new SQLAtomStorage(uri);
+    SQLAtomStorage* astore = new SQLAtomStorage();
+    astore->open(uri);
     if (!astore->connected())
     {
         logger().info("setUp: SQLAtomStorage cannot connect to database");

--- a/tests/persist/sql/multi-driver/PersistUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/PersistUTest.cxxtest
@@ -159,7 +159,8 @@ void PersistUTest::kill_data(void)
 #if HAVE_PGSQL_STORAGE
     if ("" == uri) uri = mkuri("postgres", dbname, username, passwd);
 #endif
-    SQLAtomStorage* astore = new SQLAtomStorage(uri);
+    SQLAtomStorage* astore = new SQLAtomStorage();
+    astore->open(uri);
     if (!astore->connected())
     {
         logger().info("setUp: SQLAtomStorage cannot connect to database");

--- a/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
@@ -257,7 +257,8 @@ void ValueSaveUTest::test_pq_incoming(void)
  */
 void ValueSaveUTest::do_test_single_atom_save()
 {
-	SQLAtomStorage *store = new SQLAtomStorage(uri);
+	SQLAtomStorage *store = new SQLAtomStorage();
+	store->open(uri);
 	TS_ASSERT(store->connected())
 
 	// Clear out left-over junk, just in case.
@@ -328,7 +329,8 @@ void ValueSaveUTest::check_one(ValuePtr pap, bool fetchkey)
 
 	// ------
 	// First, save the value
-	SQLAtomStorage *store = new SQLAtomStorage(uri);
+	SQLAtomStorage *store = new SQLAtomStorage();
+	store->open(uri);
 	TS_ASSERT(store->connected())
 
 	AtomSpace* as = new AtomSpace();
@@ -351,7 +353,8 @@ void ValueSaveUTest::check_one(ValuePtr pap, bool fetchkey)
 
 	// ---------------------------------
 	// Now, fetch the value and compare.
-	store = new SQLAtomStorage(uri);
+	store = new SQLAtomStorage();
+	store->open(uri);
 	TS_ASSERT(store->connected())
 
 	as = new AtomSpace();
@@ -375,7 +378,8 @@ void ValueSaveUTest::check_one(ValuePtr pap, bool fetchkey)
 
 void ValueSaveUTest::do_test_save_restore(bool fkey)
 {
-	SQLAtomStorage *store = new SQLAtomStorage(uri);
+	SQLAtomStorage *store = new SQLAtomStorage();
+	store->open(uri);
 	TS_ASSERT(store->connected())
 
 	// Clear out left-over junk, just in case.
@@ -432,7 +436,8 @@ void ValueSaveUTest::do_test_save_restore(bool fkey)
 // as well.  This tests the fetching of nodes.
 void ValueSaveUTest::do_test_load_by_type()
 {
-	SQLAtomStorage *store = new SQLAtomStorage(uri);
+	SQLAtomStorage *store = new SQLAtomStorage();
+	store->open(uri);
 	TS_ASSERT(store->connected())
 
 	// Clear out left-over junk, just in case.
@@ -495,7 +500,8 @@ void ValueSaveUTest::do_test_load_by_type()
 	// --------------------
 	// Start it up again.
 
-	store = new SQLAtomStorage(uri);
+	store = new SQLAtomStorage();
+	store->open(uri);
 	TS_ASSERT(store->connected())
 
 	as = new AtomSpace();
@@ -551,7 +557,8 @@ void ValueSaveUTest::do_test_load_by_type()
 // be fetched.
 void ValueSaveUTest::do_test_link_by_type()
 {
-	SQLAtomStorage *store = new SQLAtomStorage(uri);
+	SQLAtomStorage *store = new SQLAtomStorage();
+	store->open(uri);
 	TS_ASSERT(store->connected())
 
 	// Clear out left-over junk, just in case.
@@ -642,7 +649,8 @@ void ValueSaveUTest::do_test_link_by_type()
 	// --------------------
 	// Start it up again.
 
-	store = new SQLAtomStorage(uri);
+	store = new SQLAtomStorage();
+	store->open(uri);
 	TS_ASSERT(store->connected())
 
 	as = new AtomSpace();
@@ -758,7 +766,8 @@ void ValueSaveUTest::do_test_link_by_type()
 // as well, but only on the incoming set!
 void ValueSaveUTest::do_test_incoming()
 {
-	SQLAtomStorage *store = new SQLAtomStorage(uri);
+	SQLAtomStorage *store = new SQLAtomStorage();
+	store->open(uri);
 	TS_ASSERT(store->connected())
 
 	// Clear out left-over junk, just in case.
@@ -849,7 +858,8 @@ void ValueSaveUTest::do_test_incoming()
 	// --------------------
 	// Start it up again.
 
-	store = new SQLAtomStorage(uri);
+	store = new SQLAtomStorage();
+	store->open(uri);
 	TS_ASSERT(store->connected())
 
 	as = new AtomSpace();


### PR DESCRIPTION
It's a pain in the neck to manage AtomSpace databases from the command-line.
This should simplify things a little bit.