### PR TITLE
Improve efficiency of search by narrowing.

### DIFF
--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -317,7 +317,7 @@ public:
     //! That is, this call returns the incoming set as it was at the
     //! time of the call; any deletions that occur afterwards (possibly
     //! in other threads) will not be reflected in the returned set.
-    IncomingSet getIncomingSet(AtomSpace* as=nullptr) const;
+    IncomingSet getIncomingSet(AtomSpace* = nullptr) const;
 
     //! Place incoming set into STL container of Handles.
     //! Example usage:
@@ -384,10 +384,10 @@ public:
     }
 
     /** Functional version of getIncomingSetByType.  */
-    IncomingSet getIncomingSetByType(Type type) const;
+    IncomingSet getIncomingSetByType(Type, AtomSpace* = nullptr) const;
 
     /** Return the size of the incoming set, for the given type. */
-    size_t getIncomingSetSizeByType(Type type) const;
+    size_t getIncomingSetSizeByType(Type type, AtomSpace* = nullptr) const;
 
     /** Returns a string representation of the node. */
     virtual std::string to_string(const std::string& indent) const = 0;

--- a/opencog/query/DefaultPatternMatchCB.cc
+++ b/opencog/query/DefaultPatternMatchCB.cc
@@ -583,9 +583,9 @@ bool DefaultPatternMatchCB::always_clause_match(const Handle& ptrn,
 
 /* ======================================================== */
 
-IncomingSet DefaultPatternMatchCB::get_incoming_set(const Handle& h)
+IncomingSet DefaultPatternMatchCB::get_incoming_set(const Handle& h, Type t)
 {
-	return h->getIncomingSet(_as);
+	return h->getIncomingSetByType(t, _as);
 }
 
 /* ======================================================== */

--- a/opencog/query/DefaultPatternMatchCB.h
+++ b/opencog/query/DefaultPatternMatchCB.h
@@ -79,7 +79,7 @@ class DefaultPatternMatchCB : public virtual PatternMatchCallback
 		                                 const Handle& grnd,
 		                                 const GroundingMap&);
 
-		virtual IncomingSet get_incoming_set(const Handle&);
+		virtual IncomingSet get_incoming_set(const Handle&, Type);
 
 		/**
 		 * Called when a virtual link is encountered. Returns false

--- a/opencog/query/InitiateSearchCB.cc
+++ b/opencog/query/InitiateSearchCB.cc
@@ -371,9 +371,9 @@ bool InitiateSearchCB::choice_loop(PatternMatchCallback& pmc,
 		DO_LOG({LAZY_LOG_FINE << "Root clause is: " <<  _root->to_string();})
 
 		// This should be calling the over-loaded virtual method
-		// get_incoming_set(), so that, e.g. it gets sorted by attentional
-		// focus in the AttentionalFocusCB class...
-		IncomingSet iset = get_incoming_set(best_start);
+		// get_incoming_set(), so that, e.g. it gets sorted by
+		// attentional focus in the AttentionalFocusCB class...
+		IncomingSet iset = get_incoming_set(best_start, _starter_term->get_type());
 		_search_set.clear();
 		for (const auto& lptr: iset)
 			_search_set.emplace_back(HandleCast(lptr));

--- a/opencog/query/PatternLinkRuntime.cc
+++ b/opencog/query/PatternLinkRuntime.cc
@@ -92,8 +92,8 @@ class PMCGroundings : public PatternMatchCallback
 		{
 			return _cb.always_clause_match(pattrn, grnd, term_gnds);
 		}
-		IncomingSet get_incoming_set(const Handle& h) {
-			return _cb.get_incoming_set(h);
+		IncomingSet get_incoming_set(const Handle& h, Type t) {
+			return _cb.get_incoming_set(h, t);
 		}
 		void push(void) { _cb.push(); }
 		void pop(void) { _cb.pop(); }

--- a/opencog/query/PatternMatchCallback.h
+++ b/opencog/query/PatternMatchCallback.h
@@ -300,9 +300,9 @@ class PatternMatchCallback
 		 * is smaller than the full incoming set (for example, by
 		 * returning only those atoms with a high av-sti).
 		 */
-		virtual IncomingSet get_incoming_set(const Handle& h)
+		virtual IncomingSet get_incoming_set(const Handle& h, Type t)
 		{
-			return h->getIncomingSet();
+			return h->getIncomingSetByType(t);
 		}
 
 		/**

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1285,7 +1285,8 @@ bool PatternMatchEngine::explore_upvar_branches(const PatternTermPtr& ptm,
                                                 const Handle& clause)
 {
 	// Move up the solution graph, looking for a match.
-	IncomingSet iset = _pmc.get_incoming_set(hg);
+	Type t = ptm->getHandle()->get_type();
+	IncomingSet iset = _pmc.get_incoming_set(hg, t);
 	size_t sz = iset.size();
 	DO_LOG({LAZY_LOG_FINE << "Looking upward at term = "
 	                      << ptm->getHandle()->to_string() << std::endl
@@ -1321,14 +1322,15 @@ bool PatternMatchEngine::explore_upvar_branches(const PatternTermPtr& ptm,
 /// inconoming, just as above, and also loop over differrent glob
 /// grounding possibilities.
 bool PatternMatchEngine::explore_upglob_branches(const PatternTermPtr& ptm,
-                                             const Handle& hg,
-                                             const Handle& clause_root)
+                                                 const Handle& hg,
+                                                 const Handle& clause_root)
 {
+	Type t = ptm->getHandle()->get_type();
 	IncomingSet iset;
 	if (nullptr == hg->getAtomSpace())
-		iset = _pmc.get_incoming_set(hg->getOutgoingAtom(0));
+		iset = _pmc.get_incoming_set(hg->getOutgoingAtom(0), t);
 	else
-		iset = _pmc.get_incoming_set(hg);
+		iset = _pmc.get_incoming_set(hg, t);
 
 	size_t sz = iset.size();
 	DO_LOG({LAZY_LOG_FINE << "Looking globby upward for term = "

--- a/opencog/query/Recognizer.cc
+++ b/opencog/query/Recognizer.cc
@@ -56,7 +56,8 @@ bool Recognizer::do_search(PatternMatchCallback& pmc, const Handle& top)
 	PatternMatchEngine pme(pmc);
 	pme.set_pattern(*_vars, *_pattern);
 
-	IncomingSet iset = get_incoming_set(top);
+	// IncomingSet iset = get_incoming_set(top);
+	IncomingSet iset = top->getIncomingSet(_as);
 	size_t sz = iset.size();
 	for (size_t i = 0; i < sz; i++)
 	{


### PR DESCRIPTION
The pattern match will clearly fail if the link types are
 mismatched; so don't even bother to even begin a search
 in this case. Since this is a callback, advanced users can
 over-ride.

Note that opencog/attention#12 updates the API there.