### PR TITLE
Remove decade-old cruft.

### DIFF
--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -402,7 +402,7 @@ IncomingSet Atom::getIncomingSet(AtomSpace* as) const
             for (const WinkPtr& w : bucket.second)
             {
                 LinkPtr l(w.lock());
-                if (l and atab->in_environ(l))
+                if (l and atab->in_environ(l->get_handle()))
                     iset.emplace_back(l);
             }
         }
@@ -440,7 +440,7 @@ IncomingSet Atom::getIncomingSetByType(Type type, AtomSpace* as) const
         for (const WinkPtr& w : bucket->second)
         {
             LinkPtr l(w.lock());
-            if (l and atab->in_environ(l))
+            if (l and atab->in_environ(l->get_handle()))
                 result.emplace_back(l);
         }
         return result;
@@ -469,7 +469,7 @@ size_t Atom::getIncomingSetSizeByType(Type type, AtomSpace* as) const
         for (const WinkPtr& w : bucket->second)
         {
             LinkPtr l(w.lock());
-            if (l and atab->in_environ(l)) cnt++;
+            if (l and atab->in_environ(l->get_handle())) cnt++;
         }
         return cnt;
     }

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -104,6 +104,7 @@ class Atom
 {
     friend class AtomTable;       // Needs to call MarkedForRemoval()
     friend class AtomSpace;       // Needs to call getAtomTable()
+    friend class TypeIndex;       // Needs to clear _atom_space
     friend class Link;            // Needs to call install_atom()
     friend class StateLink;       // Needs to call swap_atom()
     friend class SQLAtomStorage;  // Needs to call getAtomTable()

--- a/opencog/atomspace/AtomSpace.cc
+++ b/opencog/atomspace/AtomSpace.cc
@@ -294,7 +294,7 @@ void AtomSpace::unregisterBackingStore(BackingStore *bs)
 
 // ====================================================================
 
-Handle AtomSpace::add_atom(const Handle& h, bool async)
+Handle AtomSpace::add_atom(const Handle& h)
 {
     // Cannot add atoms to a read-only atomspace. But if it's already
     // in the atomspace, return it.
@@ -303,7 +303,7 @@ Handle AtomSpace::add_atom(const Handle& h, bool async)
     // If it is a DeleteLink, then the addition will fail. Deal with it.
     Handle rh;
     try {
-        rh = _atom_table.add(h, async);
+        rh = _atom_table.add(h);
     }
     catch (const DeleteException& ex) {
         // Atom deletion has not been implemented in the backing store
@@ -314,14 +314,13 @@ Handle AtomSpace::add_atom(const Handle& h, bool async)
     return rh;
 }
 
-Handle AtomSpace::add_node(Type t, const string& name,
-                           bool async)
+Handle AtomSpace::add_node(Type t, const string& name)
 {
     // Cannot add atoms to a read-only atomspace. But if it's already
     // in the atomspace, return it.
     if (_read_only) return _atom_table.getHandle(t, name);
 
-    return _atom_table.add(createNode(t, name), async);
+    return _atom_table.add(createNode(t, name));
 }
 
 Handle AtomSpace::get_node(Type t, const string& name)
@@ -329,7 +328,7 @@ Handle AtomSpace::get_node(Type t, const string& name)
     return _atom_table.getHandle(t, name);
 }
 
-Handle AtomSpace::add_link(Type t, const HandleSeq& outgoing, bool async)
+Handle AtomSpace::add_link(Type t, const HandleSeq& outgoing)
 {
     // Cannot add atoms to a read-only atomspace. But if it's already
     // in the atomspace, return it.
@@ -338,7 +337,7 @@ Handle AtomSpace::add_link(Type t, const HandleSeq& outgoing, bool async)
     // If it is a DeleteLink, then the addition will fail. Deal with it.
     Handle rh;
     try {
-        rh = _atom_table.add(createLink(outgoing, t), async);
+        rh = _atom_table.add(createLink(outgoing, t));
     }
     catch (const DeleteException& ex) {
         if (_backing_store) {
@@ -390,12 +389,12 @@ Handle AtomSpace::fetch_atom(const Handle& h)
     // If we found it, add it to the atomspace -- even when the
     // atomspace is marked read-only; the atomspace is acting as
     // a cache for the backingstore.
-    if (hv) return _atom_table.add(hv, false);
+    if (hv) return _atom_table.add(hv);
 
     // If it is not found, then it cannot be added.
     if (_read_only) return Handle::UNDEFINED;
 
-    return _atom_table.add(h, false);
+    return _atom_table.add(h);
 }
 
 Handle AtomSpace::fetch_incoming_set(Handle h, bool recursive)
@@ -464,7 +463,7 @@ Handle AtomSpace::set_value(const Handle& h,
     if (nullptr == has or has->_read_only) {
         if (has != this and not _read_only) {
             // Copy the atom into this atomspace
-            Handle copy(_atom_table.add(h, false, true));
+            Handle copy(_atom_table.add(h, true));
             copy->setValue(key, value);
             return copy;
         }
@@ -495,7 +494,7 @@ Handle AtomSpace::set_truthvalue(const Handle& h, const TruthValuePtr& tvp)
     if (nullptr == has or has->_read_only) {
         if (has != this and not _read_only) {
             // Copy the atom into this atomspace
-            Handle copy(_atom_table.add(h, false, true));
+            Handle copy(_atom_table.add(h, true));
             copy->setTruthValue(tvp);
             return copy;
         }

--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -139,12 +139,11 @@ public:
 
     /**
      * Add an atom to the Atom Table.  If the atom already exists
-     * then new truth value is ignored, and the existing atom is
-     * returned.
+     * then that is returned.
      */
-    Handle add_atom(const Handle&, bool async=false);
-    Handle add_atom(AtomPtr a, bool async=false)
-        { return add_atom(a->get_handle(), async); }
+    Handle add_atom(const Handle&);
+    Handle add_atom(AtomPtr a)
+        { return add_atom(a->get_handle()); }
 
     /**
      * Add a node to the Atom Table.  If the atom already exists
@@ -153,7 +152,7 @@ public:
      * \param t     Type of the node
      * \param name  Name of the node
      */
-    Handle add_node(Type t, const std::string& name="", bool async=false);
+    Handle add_node(Type t, const std::string& name="");
 
     /**
      * Add a link to the Atom Table. If the atom already exists, then
@@ -163,7 +162,7 @@ public:
      * @param outgoing  a const reference to a HandleSeq containing
      *                  the outgoing set of the link
      */
-    Handle add_link(Type t, const HandleSeq& outgoing, bool async=false);
+    Handle add_link(Type t, const HandleSeq& outgoing);
 
     inline Handle add_link(Type t)
     {

--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -142,7 +142,7 @@ public:
      * then that is returned.
      */
     Handle add_atom(const Handle&);
-    Handle add_atom(AtomPtr a)
+    Handle add_atom(const AtomPtr& a)
         { return add_atom(a->get_handle()); }
 
     /**
@@ -317,8 +317,8 @@ public:
      * the AtomSpace is not connected to a backend, there is no
      * difference between remove and extract.
      *
-     * The atom itself remains valid as long as there are Handles or
-     * AtomPtr's that reference it; the RAM associated with the atom is
+     * The atom itself remains valid as long as there are Handles
+     * that reference it; the RAM associated with the atom is
      * freed only when the last reference goes away.
      *
      * @param h The Handle of the atom to be removed.
@@ -337,8 +337,8 @@ public:
 
     /**
      * Removes an atom from the atomspace, and any attached storage.
-     * The atom remains valid as long as there are Handles or AtomPtr's
-     * that reference it; it is deleted only when the last reference
+     * The atom remains valid as long as there are Handles that
+     * reference it; it is deleted only when the last reference
      * goes away.
      *
      * @param h The Handle of the atom to be removed.
@@ -524,7 +524,7 @@ public:
     {
         return _atom_table.atomAddedSignal();
     }
-    AtomPtrSignal& atomRemovedSignal()
+    AtomSignal& atomRemovedSignal()
     {
         return _atom_table.atomRemovedSignal();
     }

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -364,8 +364,7 @@ void AtomTable::put_atom_into_index(const AtomPtr& atom)
           "AtomTable - transient should not index atoms!");
 
     std::unique_lock<std::recursive_mutex> lck(_mtx);
-    Atom* pat = atom.operator->();
-    typeIndex.insertAtom(pat);
+    typeIndex.insertAtom(atom->get_handle());
 
     // We can now unlock, since we are done. In particular, the signals
     // need to run unlocked, since they may result in more atom table
@@ -562,8 +561,7 @@ AtomPtrSet AtomTable::extract(Handle& handle, bool recursive)
         }
     }
 
-    Atom* pat = atom.operator->();
-    typeIndex.removeAtom(pat);
+    typeIndex.removeAtom(handle);
 
     // Remove atom from other incoming sets.
     atom->remove();

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -227,8 +227,6 @@ Handle AtomTable::add(const Handle& orig, bool force)
     // Force computation of hash external to the locked section.
     orig->get_hash();
 
-    Handle atom(orig);
-
     // Lock before checking to see if this kind of atom is already in
     // the atomspace.  Lock, to prevent two different threads from
     // trying to add exactly the same atom.
@@ -256,6 +254,7 @@ Handle AtomTable::add(const Handle& orig, bool force)
     // avoiding running the factories a second time. This is, however,
     // potentially buggy, if the user is sneaky and hands us an Atom
     // that should have gone through a factory, but did not.
+    Handle atom(orig);
     if (atom->is_link()) {
         bool need_copy = false;
         if (atom->getAtomTable())
@@ -283,7 +282,7 @@ Handle AtomTable::add(const Handle& orig, bool force)
     else if (atom->getAtomTable())
         atom = createNode(atom->get_type(), atom->get_name());
 
-    atom->copyValues(orig);
+    if (atom != orig) atom->copyValues(orig);
     atom->install();
     atom->keep_incoming_set();
     atom->setAtomSpace(_as);

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -237,7 +237,7 @@ static void prt_diag(AtomPtr atom, size_t i, size_t arity, const HandleSeq& ogs)
 }
 #endif
 
-Handle AtomTable::add(AtomPtr atom, bool async, bool force)
+Handle AtomTable::add(AtomPtr atom, bool force)
 {
     // Can be null, if its a Value
     if (nullptr == atom) return Handle::UNDEFINED;
@@ -295,7 +295,7 @@ Handle AtomTable::add(AtomPtr atom, bool async, bool force)
                 // operator->() will be null if its a Value that is
                 // not an atom.
                 if (nullptr == h.operator->()) return Handle::UNDEFINED;
-                closet.emplace_back(add(h, async));
+                closet.emplace_back(add(h));
             }
             atom = createLink(closet, atom->get_type());
         } else {

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -310,7 +310,7 @@ size_t AtomTable::getNumAtomsOfType(Type type, bool subclass) const
     if (subclass)
     {
         // Also count subclasses of this type, if need be.
-        Type ntypes = nameserver().getNumberOfClasses();
+        Type ntypes = _nameserver.getNumberOfClasses();
         for (Type t = ATOM; t<ntypes; t++)
         {
             if (t != type and _nameserver.isA(t, type))

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -152,8 +152,7 @@ Handle AtomTable::getHandle(Type t, const HandleSeq& seq) const
 }
 
 /// Find an equivalent atom that is exactly the same as the arg. If
-/// such an atom is in the table, it is returned, else the return
-/// is the bad handle.
+/// such an atom is in the table, it is returned, else return nullptr.
 Handle AtomTable::lookupHandle(const Handle& a) const
 {
     if (nullptr == a) return Handle::UNDEFINED;

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -325,7 +325,7 @@ size_t AtomTable::getNumAtomsOfType(Type type, bool subclass) const
         Type ntypes = nameserver().getNumberOfClasses();
         for (Type t = ATOM; t<ntypes; t++)
         {
-            if (t != type and _nameserver.isA(type, t))
+            if (t != type and _nameserver.isA(t, type))
                 result += typeIndex.size(t);
         }
     }

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -215,19 +215,19 @@ static void prt_diag(Handle atom, size_t i, size_t arity, const HandleSeq& ogs)
 }
 #endif
 
-Handle AtomTable::add(Handle atom, bool force)
+Handle AtomTable::add(const Handle& orig, bool force)
 {
     // Can be null, if its a Value
-    if (nullptr == atom) return Handle::UNDEFINED;
+    if (nullptr == orig) return Handle::UNDEFINED;
 
     // Is the atom already in this table, or one of its environments?
-    if (not force and in_environ(atom))
-        return atom;
+    if (not force and in_environ(orig))
+        return orig;
 
     // Force computation of hash external to the locked section.
-    atom->get_hash();
+    orig->get_hash();
 
-    Handle orig(atom);
+    Handle atom(orig);
 
     // Lock before checking to see if this kind of atom is already in
     // the atomspace.  Lock, to prevent two different threads from

--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -92,11 +92,8 @@ private:
     std::unordered_multimap<ContentHash, Handle> _atom_store;
 
     //!@{
-    //! Index for quick retrieval of certain kinds of atoms.
+    //! Index of atoms.
     TypeIndex typeIndex;
-
-    async_caller<AtomTable, AtomPtr> _index_queue;
-    void put_atom_into_index(const AtomPtr&);
     //!@}
 
     /**

--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -88,13 +88,8 @@ private:
     // Cached count of the number of atoms of each type.
     std::vector<size_t> _size_by_type;
 
-    // Index of all the atoms in the table, addressible by thier hash.
-    std::unordered_multimap<ContentHash, Handle> _atom_store;
-
-    //!@{
     //! Index of atoms.
     TypeIndex typeIndex;
-    //!@}
 
     /**
      * signal connection used to find out about atom type additions in the

--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -326,7 +326,7 @@ public:
      * @param The new atom to be added.
      * @return The handle of the newly added atom.
      */
-    Handle add(Handle, bool force=false);
+    Handle add(const Handle&, bool force=false);
 
     /**
      * Read-write synchronization barrier fence.  When called, this

--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -69,8 +69,6 @@ class AtomTable
     friend class ::AtomSpaceUTest;
 
 private:
-    NameServer& _nameserver;
-
     // Single, global mutex for locking the indexes.
     // Its recursive because we need to lock twice during atom insertion
     // and removal: we need to keep the indexes stable while we search
@@ -80,22 +78,6 @@ private:
     //! Index of atoms.
     TypeIndex typeIndex;
 
-    /**
-     * signal connection used to find out about atom type additions in the
-     * NameServer
-     */
-    int addedTypeConnection;
-
-    /** Handler of the 'type added' signal from NameServer */
-    void typeAdded(Type);
-
-    /** Provided signals */
-    AtomSignal _addAtomSignal;
-    AtomSignal _removeAtomSignal;
-
-    /** Signal emitted when the TV changes. */
-    TVCHSigl _TVChangedSignal;
-
     /// Parent environment for this table.  Null if top-level.
     /// This allows atomspaces to be nested; atoms in this atomspace
     /// can reference those in the parent environment.
@@ -104,11 +86,24 @@ private:
     /// of this atomtable, and so need to have its UUID to sync up.
     AtomTable* _environ;
     std::atomic_int _num_nested;
-    UUID _uuid;
 
     // The AtomSpace that is holding us (if any).
     AtomSpace* _as;
     bool _transient;
+
+    UUID _uuid;
+
+    /** Find out about atom type additions in the NameServer. */
+    NameServer& _nameserver;
+    int addedTypeConnection;
+    void typeAdded(Type);
+
+    /** Provided signals */
+    AtomSignal _addAtomSignal;
+    AtomSignal _removeAtomSignal;
+
+    /** Signal emitted when the TV changes. */
+    TVCHSigl _TVChangedSignal;
 
     /**
      * Drop copy constructor and equals operator to

--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -50,10 +50,7 @@ namespace opencog
  *  @{
  */
 
-typedef std::set<AtomPtr> AtomPtrSet;
-
 typedef SigSlot<const Handle&> AtomSignal;
-typedef SigSlot<const AtomPtr&> AtomPtrSignal;
 typedef SigSlot<const Handle&,
                 const TruthValuePtr&,
                 const TruthValuePtr&> TVCHSigl;
@@ -102,7 +99,7 @@ private:
 
     /** Provided signals */
     AtomSignal _addAtomSignal;
-    AtomPtrSignal _removeAtomSignal;
+    AtomSignal _removeAtomSignal;
 
     /** Signal emitted when the TV changes. */
     TVCHSigl _TVChangedSignal;
@@ -163,7 +160,7 @@ public:
      * shared libraries. Yes, this is kind-of hacky, but its the
      * simplest fix for just right now.
      */
-    bool in_environ(const AtomPtr& atom) const
+    bool in_environ(const Handle& atom) const
     {
         if (nullptr == atom) return false;
         AtomTable* atab = atom->getAtomTable();
@@ -194,11 +191,8 @@ public:
      */
     Handle getHandle(Type, const std::string&) const;
     Handle getHandle(Type, const HandleSeq&) const;
-    Handle getHandle(const AtomPtr&) const;
-    Handle getHandle(const Handle& h) const {
-        AtomPtr a(h); return getHandle(a);
-    }
-    Handle lookupHandle(const AtomPtr&) const;
+    Handle getHandle(const Handle&) const;
+    Handle lookupHandle(const Handle&) const;
 
     /**
      * Returns the set of atoms of a given type (subclasses optionally).
@@ -332,7 +326,7 @@ public:
      * @param The new atom to be added.
      * @return The handle of the newly added atom.
      */
-    Handle add(AtomPtr, bool force=false);
+    Handle add(Handle, bool force=false);
 
     /**
      * Read-write synchronization barrier fence.  When called, this
@@ -363,7 +357,7 @@ public:
      *        incoming set will also be extracted.
      * @return A set of the extracted atoms.
      */
-    AtomPtrSet extract(Handle& handle, bool recursive=true);
+    HandleSet extract(Handle& handle, bool recursive=true);
 
     /**
      * Return a random atom in the AtomTable.
@@ -371,7 +365,7 @@ public:
     Handle getRandom(RandGen* rng) const;
 
     AtomSignal& atomAddedSignal() { return _addAtomSignal; }
-    AtomPtrSignal& atomRemovedSignal() { return _removeAtomSignal; }
+    AtomSignal& atomRemovedSignal() { return _removeAtomSignal; }
 
     /** Provide ability for others to find out about TV changes */
     TVCHSigl& TVChangedSignal() { return _TVChangedSignal; }

--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -326,7 +326,7 @@ public:
      * Return true if the atom table holds this handle, else return false.
      */
     bool holds(const Handle& h) const {
-        return (NULL != h) and h->getAtomTable() == this;
+        return (nullptr != h) and h->getAtomTable() == this;
     }
 
     /**

--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -77,9 +77,6 @@ private:
     // them during add/remove.
     mutable std::recursive_mutex _mtx;
 
-    // Cached count of the number of atoms in the table.
-    size_t _size;
-
     //! Index of atoms.
     TypeIndex typeIndex;
 

--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -329,30 +329,15 @@ public:
     }
 
     /**
-     * Adds an atom to the table. If the atom already is in the
-     * atomtable, then the truth values and attention values of the
-     * two are merged (how, exactly? Is this done corrrectly!?)
+     * Adds an atom to the table.
      *
-     * If the async flag is set, then the atom addition is performed
-     * asynchronously; the atom might not be fully added by the time
-     * this method returns, although it will get added eventually.
-     * Async addition can improve the multi-threaded performance of
-     * lots of parallel adds.  The barrier() method can be used to
-     * force synchronization.
-     *
-     * XXX The async code path doesn't really do anything yet, since
-     * it also uses the big global lock, at the moment.  This needs
-     * fixing, mostly be creating a second mutex for the atom insertion,
-     * and also giving each index its own unique mutex, to avoid
-     * collisions.  So the API is here, but more work is still needed.
-     *
-     * The `force` flag forces the addtion of this atom into the
+     * The `force` flag forces the addition of this atom into the
      * atomtable, even if it is already in a parent atomspace.
      *
      * @param The new atom to be added.
      * @return The handle of the newly added atom.
      */
-    Handle add(AtomPtr, bool async, bool force=false);
+    Handle add(AtomPtr, bool force=false);
 
     /**
      * Read-write synchronization barrier fence.  When called, this

--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -79,11 +79,6 @@ private:
 
     // Cached count of the number of atoms in the table.
     size_t _size;
-    size_t _num_nodes;
-    size_t _num_links;
-
-    // Cached count of the number of atoms of each type.
-    std::vector<size_t> _size_by_type;
 
     //! Index of atoms.
     TypeIndex typeIndex;

--- a/opencog/atomspace/TypeIndex.cc
+++ b/opencog/atomspace/TypeIndex.cc
@@ -45,10 +45,12 @@ bool TypeIndex::contains_duplicate() const
 
 bool TypeIndex::contains_duplicate(const AtomSet& atoms) const
 {
+#if 0
 	for (AtomSet::const_iterator i = atoms.begin(); i != atoms.end(); ++i)
 		for (AtomSet::const_iterator j = std::next(i); j != atoms.end(); ++j)
 			if (**i == **j)
 				return true;
+#endif
 	return false;
 }
 
@@ -123,7 +125,7 @@ TypeIndex::iterator& TypeIndex::iterator::operator=(iterator v)
 Handle TypeIndex::iterator::operator*(void)
 {
 	if (s == send) return Handle::UNDEFINED;
-	return (*se)->get_handle();
+	return se->second;
 }
 
 bool TypeIndex::iterator::operator==(iterator v)

--- a/opencog/atomspace/TypeIndex.h
+++ b/opencog/atomspace/TypeIndex.h
@@ -95,9 +95,9 @@ class TypeIndex
 			return Handle::UNDEFINED;
 		}
 
-		size_t size(Type t)
+		size_t size(Type t) const
 		{
-			AtomSet& s(_idx.at(t));
+			const AtomSet& s(_idx.at(t));
 			return s.size();
 		}
 

--- a/tests/atomspace/AtomTableUTest.cxxtest
+++ b/tests/atomspace/AtomTableUTest.cxxtest
@@ -91,21 +91,21 @@ public:
 
     void testSimple()
     {
-        Handle time = table->add(createNode(TIME_NODE, "1"), true);
-        Handle word = table->add(createNode(NUMBER_NODE, "1"), true);
-        Handle sense = table->add(createNode(CONCEPT_NODE, "28675194"), true);
+        Handle time = table->add(createNode(TIME_NODE, "1"));
+        Handle word = table->add(createNode(NUMBER_NODE, "1"));
+        Handle sense = table->add(createNode(CONCEPT_NODE, "28675194"));
         HandleSeq os;
         os.push_back(time);
         os.push_back(word);
         os.push_back(sense);
-        table->add(createLink(os, INHERITANCE_LINK), true);
+        table->add(createLink(os, INHERITANCE_LINK));
         table->barrier();
     }
 
     void testHolds()
     {
         Handle h;
-        Handle word = table->add(createNode(NUMBER_NODE, "1"), false);
+        Handle word = table->add(createNode(NUMBER_NODE, "1"));
         TS_ASSERT(table->holds(word));
         TS_ASSERT(!table->holds(h));
     }
@@ -114,7 +114,7 @@ public:
     {
         atomSpace->clear();
         TS_ASSERT(0 == table->getSize());
-        Handle word = table->add(createNode(NUMBER_NODE, "1"), false);
+        Handle word = table->add(createNode(NUMBER_NODE, "1"));
         TS_ASSERT(1 == table->getSize());
     }
 
@@ -138,7 +138,7 @@ public:
         Handle hle(createLink(EVALUATION_LINK, hnp, hll));
 
         // Add the link.  All the outgoing atoms should get added too.
-        Handle hlet = table->add(hle, false);
+        Handle hlet = table->add(hle);
         const HandleSeq& hs = hlet->getOutgoingSet();
 
         const HandleSeq& hsl = hs[1]->getOutgoingSet();
@@ -191,7 +191,7 @@ public:
         for (unsigned i=0; i < numBuckets + 10; i++){
             oss.clear();
             oss << i;
-            table->add(createNode(NUMBER_NODE, oss.str()), true);
+            table->add(createNode(NUMBER_NODE, oss.str()));
         }
         table->barrier();
 
@@ -215,13 +215,13 @@ public:
     {
         Handle n1(createNode(NUMBER_NODE, "1"));
         Handle n2(createNode(NUMBER_NODE, "2"));
-        Handle hn1 = table->add(n1, false);
-        Handle hn2 = table->add(n2, false);
+        Handle hn1 = table->add(n1);
+        Handle hn2 = table->add(n2);
 
         HandleSeq os;
         os.push_back(hn1); os.push_back(hn1); os.push_back(hn2);
         Handle l1(createLink(os, LIST_LINK));
-        Handle hl1 = table->add(l1, false);
+        Handle hl1 = table->add(l1);
 
         // Now, remove hn1 from the table ...
         table->extract(hn1, true);
@@ -233,7 +233,7 @@ public:
         os.push_back(h3);
         os.push_back(h3);
 
-        Handle l33 = table->add(createLink(os, LIST_LINK), false);
+        Handle l33 = table->add(createLink(os, LIST_LINK));
         HandleSeq hs = l33->getOutgoingSet();
         printf("hs1 & hs2 ptr's: %p %p\n", hs[0].operator->(), hs[1].operator->());
         TS_ASSERT_EQUALS(hs[0], hs[1]);
@@ -248,14 +248,14 @@ public:
         nameserver().endTypeDecls();
         logger().debug("MY_NUMBER_NODE = %u, MY_CONCEPT_NODE = %u, MY_INHERITANCE_LINK = %u\n", MY_NUMBER_NODE, MY_CONCEPT_NODE, MY_INHERITANCE_LINK);
         Handle wp = createNode(MY_NUMBER_NODE, "1");
-        Handle word = table->add(wp, false);
+        Handle word = table->add(wp);
         Handle sp = createNode(MY_CONCEPT_NODE, "28675194");
-        Handle sense = table->add(sp, false);
+        Handle sense = table->add(sp);
         HandleSeq os;
         os.push_back(word);
         os.push_back(sense);
         Handle lp = createLink(os, MY_INHERITANCE_LINK);
-        Handle lh = table->add(lp, false);
+        Handle lh = table->add(lp);
 
 #define getHandlex(N,T) getHandle(T,N)
         TS_ASSERT(table->getHandlex("1", MY_NUMBER_NODE) != Handle::UNDEFINED);

--- a/tests/atomspace/MultiSpaceUTest.cxxtest
+++ b/tests/atomspace/MultiSpaceUTest.cxxtest
@@ -429,7 +429,7 @@ public:
 		ex.clear();
 
 		TS_ASSERT(as.get_size() == 1);
-		TS_ASSERT(ex.get_size() == 0);
+		TS_ASSERT(ex.get_size() == 1);
 
 		handle_set.clear();
 		ex.get_handles_by_type(handle_set, CONCEPT_NODE);

--- a/tests/atomspace/RemoveUTest.cxxtest
+++ b/tests/atomspace/RemoveUTest.cxxtest
@@ -70,7 +70,7 @@ void RemoveUTest::testSimple()
 	Handle hli = as2.add_link(LIST_LINK, hna, hnb);
 
 	TS_ASSERT(as1.get_size() == 2);
-	TS_ASSERT(as2.get_size() == 1);
+	TS_ASSERT(as2.get_size() == 3);
 
 	// Verify the link is sane
 	LinkPtr pli(LinkCast(hli));
@@ -82,7 +82,7 @@ void RemoveUTest::testSimple()
 	as2.remove_atom(hli);
 
 	TS_ASSERT(as1.get_size() == 2);
-	TS_ASSERT(as2.get_size() == 0);
+	TS_ASSERT(as2.get_size() == 2);
 
 	// Handle hli should still point to valid atoms
 	LinkPtr li(LinkCast(hli));
@@ -149,7 +149,7 @@ void RemoveUTest::testRecursive()
 	Handle hli = as2.add_link(LIST_LINK, hna, hnb);
 
 	TS_ASSERT(as1.get_size() == 2);
-	TS_ASSERT(as2.get_size() == 1);
+	TS_ASSERT(as2.get_size() == 3);
 
 	// Verify the link is sane
 	LinkPtr pli(LinkCast(hli));
@@ -161,7 +161,7 @@ void RemoveUTest::testRecursive()
 	as1.remove_atom(hna, true);
 
 	TS_ASSERT(as1.get_size() == 1);
-	TS_ASSERT(as2.get_size() == 0);
+	TS_ASSERT(as2.get_size() == 1);
 
 	// Both hna and hli should still point to valid atoms
 	LinkPtr li(LinkCast(hli));
@@ -191,7 +191,7 @@ void RemoveUTest::testCross()
 	Handle hli = as2.add_link(LIST_LINK, hna, hnb);
 
 	TS_ASSERT(as1.get_size() == 1);
-	TS_ASSERT(as2.get_size() == 2);
+	TS_ASSERT(as2.get_size() == 3);
 
 	// Verify the link is sane
 	LinkPtr pli(LinkCast(hli));
@@ -233,7 +233,7 @@ void RemoveUTest::testReCross()
 	Handle hli = as2.add_link(LIST_LINK, hna, hnb);
 
 	TS_ASSERT(as1.get_size() == 1);
-	TS_ASSERT(as2.get_size() == 2);
+	TS_ASSERT(as2.get_size() == 3);
 
 	// Verify the link is sane
 	LinkPtr pli(LinkCast(hli));
@@ -245,7 +245,7 @@ void RemoveUTest::testReCross()
 	as2.remove_atom(hnb, true);
 
 	TS_ASSERT(as1.get_size() == 1);
-	TS_ASSERT(as2.get_size() == 0);
+	TS_ASSERT(as2.get_size() == 1);
 
 	// Both hna and hli should still point to valid atoms
 	LinkPtr li(LinkCast(hli));
@@ -276,7 +276,7 @@ void RemoveUTest::testRepeat()
 	Handle hlili = as2.add_link(LIST_LINK, hli, hli);
 
 	TS_ASSERT(as1.get_size() == 2);
-	TS_ASSERT(as2.get_size() == 2);
+	TS_ASSERT(as2.get_size() == 4);
 
 	// Verify the link is sane
 	LinkPtr pli(LinkCast(hli));
@@ -288,7 +288,7 @@ void RemoveUTest::testRepeat()
 	as1.remove_atom(hna, true);
 
 	TS_ASSERT(as1.get_size() == 1);
-	TS_ASSERT(as2.get_size() == 0);
+	TS_ASSERT(as2.get_size() == 1);
 
 	// Both hna and hli should still point to valid atoms
 	LinkPtr li(LinkCast(hli));
@@ -337,7 +337,7 @@ void RemoveUTest::testHeads()
 	Handle hohoy = as2.add_link(LIST_LINK, hna, hoho, ho, hoo, hohox, hwa);
 
 	TS_ASSERT(as1.get_size() == 6);
-	TS_ASSERT(as2.get_size() == 7);
+	TS_ASSERT(as2.get_size() == 13);
 
 	// Verify the link is sane
 	LinkPtr pli(LinkCast(hli));
@@ -349,7 +349,7 @@ void RemoveUTest::testHeads()
 	as1.remove_atom(hna, true);
 
 	TS_ASSERT(as1.get_size() == 1);
-	TS_ASSERT(as2.get_size() == 0);
+	TS_ASSERT(as2.get_size() == 1);
 
 	// Both hna and hli should still point to valid atoms
 	LinkPtr li(LinkCast(hli));
@@ -393,12 +393,12 @@ void RemoveUTest::testTails()
 	Handle hohoy = as2.add_link(LIST_LINK, hna, hoho, ho, hoo, hohox, hwa);
 
 	TS_ASSERT(as1.get_size() == 6);
-	TS_ASSERT(as2.get_size() == 7);
+	TS_ASSERT(as2.get_size() == 13);
 
 	as2.remove_atom(hoo, true);
 
 	TS_ASSERT(as1.get_size() == 6);
-	TS_ASSERT(as2.get_size() == 3);
+	TS_ASSERT(as2.get_size() == 9);
 
 	as1.clear();
 	as2.clear();

--- a/tests/persist/sql/multi-driver/BasicSaveUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/BasicSaveUTest.cxxtest
@@ -308,13 +308,13 @@ void BasicSaveUTest::add_to_table(int idx, AtomTable *table, std::string id)
     n1[idx] = createNode(SCHEMA_NODE, id + "fromNode");
     TruthValuePtr stv(SimpleTruthValue::createTV(0.11, 1.0/(100.0+idx)));
     n1[idx]->setTruthValue(stv);
-    n1[idx] = table->add(n1[idx], false);
+    n1[idx] = table->add(n1[idx]);
     a1[idx] = n1[idx];
 
     n2[idx] = createNode(SCHEMA_NODE, id + "toNode");
     TruthValuePtr stv2(SimpleTruthValue::createTV(0.22, 1.0/(200.0+idx)));
     n2[idx]->setTruthValue(stv2);
-    n2[idx] = table->add(n2[idx], false);
+    n2[idx] = table->add(n2[idx]);
     a2[idx] = n2[idx];
 
     // ODBC fails when there is a question mark in the text.
@@ -325,7 +325,7 @@ void BasicSaveUTest::add_to_table(int idx, AtomTable *table, std::string id)
     // We need to test crazy-large and crazy-small float point values.
     TruthValuePtr stv3(SimpleTruthValue::createTV(1.0e33/3.0, (1.0e-30)/(300.0+idx)));
     n3[idx]->setTruthValue(stv3);
-    n3[idx] = table->add(n3[idx], false);
+    n3[idx] = table->add(n3[idx]);
     a3[idx] = n3[idx];
 
     // The NumberNode will go through the AtomTable clone factory
@@ -336,7 +336,7 @@ void BasicSaveUTest::add_to_table(int idx, AtomTable *table, std::string id)
     // We need to test crazy-large and crazy-small float point values.
     TruthValuePtr stv4(SimpleTruthValue::createTV((4.0e-200)/9.0, 1.0e40/(400.0+idx)));
     n4[idx]->setTruthValue(stv4);
-    n4[idx] = table->add(n4[idx], false);
+    n4[idx] = table->add(n4[idx]);
     a4[idx] = n4[idx];
 
     HandleSeq hvec;
@@ -346,7 +346,7 @@ void BasicSaveUTest::add_to_table(int idx, AtomTable *table, std::string id)
     hvec.push_back(a4[idx]->get_handle());
 
     l[idx] = createLink(hvec, SET_LINK);
-    l[idx] = table->add(l[idx], false);
+    l[idx] = table->add(l[idx]);
     al[idx] = l[idx];
 }
 

--- a/tests/scm/MultiAtomSpaceUTest.cxxtest
+++ b/tests/scm/MultiAtomSpaceUTest.cxxtest
@@ -303,13 +303,19 @@ void MultiAtomSpace::test_nest(void)
 	Handle hl = lev->eval_h("(ListLink a b)");
 
 	// The atomspace sizes should be as expected ...
-	TSM_ASSERT("Expect two atoms in main atomspace", 2 == main_as->get_size());
-	TSM_ASSERT("Expect two nodes in main atomspace", 2 == main_as->get_num_nodes());
-	TSM_ASSERT("Expect zero links in main atomspace", 0 == main_as->get_num_links());
+	size_t main_sz = main_as->get_size();
+	size_t main_no = main_as->get_num_nodes();
+	size_t main_li = main_as->get_num_links();
+	TSM_ASSERT("Expect two atoms in main atomspace", 2 == main_sz);
+	TSM_ASSERT("Expect two nodes in main atomspace", 2 == main_no);
+	TSM_ASSERT("Expect zero links in main atomspace", 0 == main_li);
 
-	TSM_ASSERT("Expect one atoms in local atomspace", 1 == locas->get_size());
-	TSM_ASSERT("Expect zero nodes in local atomspace", 0 == locas->get_num_nodes());
-	TSM_ASSERT("Expect one link in local atomspace", 1 == locas->get_num_links());
+	size_t locas_sz = locas->get_size() - main_sz;
+	size_t locas_no = locas->get_num_nodes() - main_no;
+	size_t locas_li = locas->get_num_links() - main_li;
+	TSM_ASSERT("Expect one atoms in local atomspace", 1 == locas_sz);
+	TSM_ASSERT("Expect zero nodes in local atomspace", 0 == locas_no);
+	TSM_ASSERT("Expect one link in local atomspace", 1 == locas_li);
 
 	// The outgoing set should not be copied, but should be the original.
 	TSM_ASSERT("Expect atom a in position 0", ha == hl->getOutgoingAtom(0));


### PR DESCRIPTION
Concepts like the AtomPtr date back to when it actually was Atom*.
This hasn't applied in a very long time, now, and mostly just added
complexity and  overhead to operations. Just remove it. Also remove
the `_atom_store` table; it just duplicated information already available.
Also remove the size-caches; no one except the unit tests use them.
Also fix bug in the size-computation that no one noticed before.