### PR TITLE
Use move, instead of copy, whenever possible.

### DIFF
--- a/opencog/atoms/base/Link.h
+++ b/opencog/atoms/base/Link.h
@@ -240,9 +240,8 @@ static inline LinkPtr LinkCast(const AtomPtr& a)
 template< class... Args >
 Handle createLink( Args&&... args )
 {
-	// Do we need to say (std::forward<Args>(args)...) instead ???
-	LinkPtr tmp(std::make_shared<Link>(args ...));
-	return classserver().factory(tmp->get_handle());
+	Handle tmp(std::make_shared<Link>(std::forward<Args>(args) ...));
+	return classserver().factory(tmp);
 }
 
 /** @}*/

--- a/opencog/atoms/base/Link.h
+++ b/opencog/atoms/base/Link.h
@@ -77,59 +77,40 @@ public:
         init(oset);
     }
 
-    Link(HandleSeq&& oset, Type t=LINK)
+    Link(const HandleSeq&& oset, Type t=LINK)
         : Atom(t)
     {
-        init(oset);
+        init(std::move(oset));
     }
 
     Link(Type t)
         : Atom(t)
     {
-        HandleSeq oset;
-        init(oset);
+        init({});
     }
 
 	Link(Type t, const Handle& h)
         : Atom(t)
     {
-        // reserve+assign is 2x faster than push_back()/emplace_back()
-        HandleSeq oset(1);
-        oset[0] = h;
-        init(oset);
+        init({h});
     }
 
     Link(Type t, const Handle& ha, const Handle &hb)
         : Atom(t)
     {
-        // reserve+assign is 2x faster than push_back()/emplace_back()
-        HandleSeq oset(2);
-        oset[0] = ha;
-        oset[1] = hb;
-        init(oset);
+        init({ha, hb});
     }
 
     Link(Type t, const Handle& ha, const Handle &hb, const Handle &hc)
         : Atom(t)
     {
-        // reserve+assign is 2x faster than push_back()/emplace_back()
-        HandleSeq oset(3);
-        oset[0] = ha;
-        oset[1] = hb;
-        oset[2] = hc;
-        init(oset);
+        init({ha, hb, hc});
     }
     Link(Type t, const Handle& ha, const Handle &hb,
 	      const Handle &hc, const Handle &hd)
         : Atom(t)
     {
-        // reserve+assign is 2x faster than push_back()/emplace_back()
-        HandleSeq oset(4);
-        oset[0] = ha;
-        oset[1] = hb;
-        oset[2] = hc;
-        oset[3] = hd;
-        init(oset);
+        init({ha, hb, hc, hd});
     }
 
     Link(const Link&) = delete;

--- a/opencog/atoms/base/Node.h
+++ b/opencog/atoms/base/Node.h
@@ -66,7 +66,7 @@ public:
     Node(Type t, const std::string&& s)
         : Atom(t)
     {
-        init(s);
+        init(std::move(s));
     }
 
     Node(const Node&) = delete;

--- a/opencog/atoms/base/Node.h
+++ b/opencog/atoms/base/Node.h
@@ -127,9 +127,8 @@ static inline NodePtr NodeCast(const AtomPtr& a)
 template< class... Args >
 Handle createNode( Args&&... args )
 {
-   // Do we need to say (std::forward<Args>(args)...) instead ???
-   NodePtr tmp(std::make_shared<Node>(args ...));
-   return classserver().factory(tmp->get_handle());
+   Handle tmp(std::make_shared<Node>(std::forward<Args>(args) ...));
+   return classserver().factory(tmp);
 }
 
 

--- a/opencog/atoms/core/PrenexLink.cc
+++ b/opencog/atoms/core/PrenexLink.cc
@@ -116,7 +116,7 @@ static Handle collect(const Variables& vtool,
 	do
 	{
 		std::string altname = randstr(newvar->get_name() + "-");
-		alt = createNode(VARIABLE_NODE, altname);
+		alt = createNode(VARIABLE_NODE, std::move(altname));
 	} while (used_vars.find(alt) != used_vars.end());
 
 	final_varlist.emplace_back(vtool.get_type_decl(origvar, alt));

--- a/opencog/atoms/core/PutLink.cc
+++ b/opencog/atoms/core/PutLink.cc
@@ -397,14 +397,14 @@ Handle PutLink::do_reduce(void) const
 			HandleSeq oset(bods->getOutgoingSet());
 			for (const Handle& arg : args->getOutgoingSet())
 				oset.emplace_back(expand(arg, _silent));
-			return createLink(oset, btype);
+			return createLink(std::move(oset), btype);
 		}
 
 		if (SET_LINK != vtype)
 		{
 			HandleSeq oset(bods->getOutgoingSet());
 			oset.emplace_back(args);
-			return createLink(oset, btype);
+			return createLink(std::move(oset), btype);
 		}
 
 		// If the arguments are given in a set, then iterate over the set...
@@ -416,16 +416,16 @@ Handle PutLink::do_reduce(void) const
 				HandleSeq oset(bods->getOutgoingSet());
 				for (const Handle& arg : h->getOutgoingSet())
 					oset.emplace_back(expand(arg, _silent));
-				bset.emplace_back(createLink(oset, btype));
+				bset.emplace_back(createLink(std::move(oset), btype));
 			}
 			else
 			{
 				HandleSeq oset(bods->getOutgoingSet());
 				oset.emplace_back(expand(h, _silent));
-				bset.emplace_back(createLink(oset, btype));
+				bset.emplace_back(createLink(std::move(oset), btype));
 			}
 		}
-		return createLink(bset, SET_LINK);
+		return createLink(std::move(bset), SET_LINK);
 	}
 
 	// If there is only one variable in the PutLink body...
@@ -448,7 +448,7 @@ Handle PutLink::do_reduce(void) const
 			}
 			catch (const TypeCheckException& ex) {}
 		}
-		return createLink(bset, SET_LINK);
+		return createLink(std::move(bset), SET_LINK);
 	}
 
 	// If we are here, then there are multiple variables in the body.
@@ -494,7 +494,7 @@ Handle PutLink::do_reduce(void) const
 		}
 		catch (const TypeCheckException& ex) {}
 	}
-	return createLink(bset, SET_LINK);
+	return createLink(std::move(bset), SET_LINK);
 }
 
 ValuePtr PutLink::execute(AtomSpace* as, bool silent)

--- a/opencog/atoms/core/RandomNumber.cc
+++ b/opencog/atoms/core/RandomNumber.cc
@@ -145,7 +145,7 @@ ValuePtr RandomNumberLink::execute(AtomSpace *as, bool silent)
 	for (size_t i=0; i< len; i++)
 		oset.push_back(get_ran(nmin[i], nmax[i]));
 
-	return ValuePtr(createLink(oset, SET_LINK));
+	return ValuePtr(createLink(std::move(oset), SET_LINK));
 }
 
 DEFINE_LINK_FACTORY(RandomNumberLink, RANDOM_NUMBER_LINK);

--- a/opencog/atoms/core/RewriteLink.cc
+++ b/opencog/atoms/core/RewriteLink.cc
@@ -61,7 +61,7 @@ RewriteLink::RewriteLink(const HandleSeq& oset, Type t)
 inline Handle append_rand_str(const Handle& var)
 {
 	std::string new_var_name = randstr(var->get_name() + "-");
-	return createNode(var->get_type(), new_var_name);
+	return createNode(var->get_type(), std::move(new_var_name));
 }
 
 inline HandleSeq append_rand_str(const HandleSeq& vars)
@@ -107,7 +107,7 @@ Handle RewriteLink::alpha_convert(const HandleSeq& vars) const
 		hs.push_back(_variables.substitute_nocheck(getOutgoingAtom(i), wrapped, _silent));
 
 	// Create the alpha converted scope link
-	return createLink(hs, get_type());
+	return createLink(std::move(hs), get_type());
 }
 
 Handle RewriteLink::alpha_convert(const HandleMap& vsmap) const
@@ -145,13 +145,13 @@ Handle RewriteLink::beta_reduce(const HandleMap& vm) const
 		// in it. So we must not call createLink(), below.
 		Type t = get_type();
 		if (PUT_LINK == t or LAMBDA_LINK == t)
-			return hs[0];
+			return hs.at(0);
 	}
 
 	// Create the substituted scope.  I suspect that this is a bad
 	// idea, when nvardecl==nullptr, I mean, its just gonna be weird,
 	// and cause issues thhrought the code ... but ... whatever.
-	return createLink(hs, get_type());
+	return createLink(std::move(hs), get_type());
 }
 
 Handle RewriteLink::beta_reduce(const HandleSeq& vals) const
@@ -287,7 +287,7 @@ Handle RewriteLink::substitute_vardecl(const Handle& vardecl,
 	{
 		OC_ASSERT(false, "Not implemented");
 	}
-	return createLink(oset, t);
+	return createLink(std::move(oset), t);
 }
 
 Handle RewriteLink::consume_quotations() const
@@ -311,7 +311,7 @@ Handle RewriteLink::consume_quotations() const
 		nouts.insert(nouts.begin(), vardecl);
 
 	// Recreate the scope
-	return createLink(nouts, get_type());
+	return createLink(std::move(nouts), get_type());
 }
 
 Handle RewriteLink::consume_quotations(const Handle& vardecl,

--- a/opencog/atoms/core/ScopeLink.cc
+++ b/opencog/atoms/core/ScopeLink.cc
@@ -45,7 +45,7 @@ void ScopeLink::init(void)
 }
 
 ScopeLink::ScopeLink(const Handle& vars, const Handle& body)
-	: Link(HandleSeq({vars, body}), SCOPE_LINK)
+	: Link({vars, body}, SCOPE_LINK)
 {
 	init();
 }

--- a/opencog/atoms/core/StateLink.cc
+++ b/opencog/atoms/core/StateLink.cc
@@ -43,7 +43,7 @@ StateLink::StateLink(const HandleSeq& oset, Type t)
 }
 
 StateLink::StateLink(const Handle& name, const Handle& defn)
-	: UniqueLink(HandleSeq({name, defn}), STATE_LINK)
+	: UniqueLink({name, defn}, STATE_LINK)
 {
 	init();
 }

--- a/opencog/atoms/core/TypeUtils.cc
+++ b/opencog/atoms/core/TypeUtils.cc
@@ -331,12 +331,12 @@ Handle filter_vardecl(const Handle& vardecl, const HandleSeq& hs)
 			return Handle::UNDEFINED;
 		if (subvardecls.size() == 1)
 			return subvardecls[0];
-		return Handle(createLink(subvardecls, t));
+		return createLink(std::move(subvardecls), t);
 	}
 
 	// If we're here we have failed to recognize vardecl as a useful
 	// and well-formed variable declaration, so Handle::UNDEFINED is
-	// returned.
+	// returned. XXX FIXME -- surely this should be a throw, instead!!!
 	return Handle::UNDEFINED;
 }
 

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -1,5 +1,5 @@
 /*
- * Variables.cc
+ * atoms/core/Variables.cc
  *
  * Copyright (C) 2009, 2014, 2015 Linas Vepstas
  *               2019 SingularityNET Foundation
@@ -471,8 +471,6 @@ Handle FreeVariables::substitute_scoped(const Handle& term,
 		// for as long as the bound variable is in scope. We hide it by
 		// removing it from the index.
 		ScopeLinkPtr sco(ScopeLinkCast(term));
-		if (nullptr == sco)
-			sco = createScopeLink(term->getOutgoingSet());
 
 		const Variables& vees = sco->get_variables();
 		bool alpha_hide = false;
@@ -533,7 +531,7 @@ Handle FreeVariables::substitute_scoped(const Handle& term,
 				oset.emplace_back(substitute_scoped(h, args, silent,
 				                                    hidden_map, quotation));
 			}
-			return createLink(oset, term->get_type());
+			return createLink(std::move(oset), term->get_type());
 		}
 	}
 
@@ -568,7 +566,7 @@ Handle FreeVariables::substitute_scoped(const Handle& term,
 
 	// Return the original atom, if it was not modified.
 	if (not changed) return term;
-	return createLink(oset, term->get_type());
+	return createLink(std::move(oset), term->get_type());
 }
 
 /* ================================================================= */
@@ -1340,7 +1338,7 @@ Handle Variables::get_type_decl(const Handle& var, const Handle& alt) const
 		for (Type t : sit->second)
 			types.push_back(Handle(createTypeNode(t)));
 		Handle types_h = types.size() == 1 ? types[0]
-			: createLink(types, TYPE_CHOICE);
+			: createLink(std::move(types), TYPE_CHOICE);
 		return Handle(createLink(TYPED_VARIABLE_LINK, alt, types_h));
 	}
 
@@ -1371,9 +1369,9 @@ Handle Variables::get_vardecl() const
 		return vardecls[0];
 
 	if (_ordered)
-		return Handle(createVariableList(vardecls));
+		return Handle(createVariableList(std::move(vardecls)));
 
-	return Handle(createVariableSet(vardecls));
+	return Handle(createVariableSet(std::move(vardecls)));
 }
 
 void Variables::validate_vardecl(const HandleSeq& oset)

--- a/opencog/atoms/execution/Instantiator.cc
+++ b/opencog/atoms/execution/Instantiator.cc
@@ -359,7 +359,7 @@ Handle Instantiator::walk_tree(const Handle& expr, bool silent)
 					unwrap.push_back(plo);
 				}
 			}
-			return createLink(unwrap, SET_LINK);
+			return createLink(std::move(unwrap), SET_LINK);
 		}
 
 		try {
@@ -415,7 +415,7 @@ Handle Instantiator::walk_tree(const Handle& expr, bool silent)
 			if (vardecl)
 				oset.insert(oset.begin(), vardecl);
 			// TODO: copy values
-			return createLink(oset, LAMBDA_LINK);
+			return createLink(std::move(oset), LAMBDA_LINK);
 		}
 		return expr;
 	}
@@ -511,7 +511,7 @@ mere_recursive_call:
 	bool changed = walk_sequence(oset_results, expr->getOutgoingSet(), silent);
 	if (changed)
 	{
-		Handle subl(createLink(oset_results, t));
+		Handle subl(createLink(std::move(oset_results), t));
 		subl->copyValues(expr);
 		return subl;
 	}
@@ -593,7 +593,7 @@ ValuePtr Instantiator::instantiate(const Handle& expr,
 				if (hg) oset_results.push_back(hg);
 			}
 		}
-		Handle flp(createLink(oset_results, t));
+		Handle flp(createLink(std::move(oset_results), t));
 		ValuePtr pap(flp->execute(_as, silent));
 		if (_as and pap->is_atom())
 			return _as->add_atom(HandleCast(pap));

--- a/opencog/atoms/execution/MapLink.cc
+++ b/opencog/atoms/execution/MapLink.cc
@@ -291,7 +291,7 @@ bool MapLink::extract(const Handle& termpat,
 			}
 
 			// If we are here, we've got a match. Record it.
-			Handle glp(createLink(glob_seq, LIST_LINK));
+			Handle glp(createLink(std::move(glob_seq), LIST_LINK));
 			valmap.emplace(std::make_pair(glob, glp));
 		}
 		else

--- a/opencog/atoms/reduct/ArithmeticLink.cc
+++ b/opencog/atoms/reduct/ArithmeticLink.cc
@@ -146,7 +146,7 @@ Handle ArithmeticLink::reorder(void) const
 	for (const Handle& h : exprs) result.push_back(h);
 	for (const Handle& h : numbers) result.push_back(h);
 
-	return Handle(createLink(result, get_type()));
+	return Handle(createLink(std::move(result), get_type()));
 }
 
 // ===========================================================

--- a/opencog/atoms/reduct/PlusLink.cc
+++ b/opencog/atoms/reduct/PlusLink.cc
@@ -103,7 +103,7 @@ ValuePtr PlusLink::kons(AtomSpace* as, bool silent,
 		{
 			seq.push_back(HandleCast(vj));
 		}
-		Handle foo(createLink(seq, PLUS_LINK));
+		Handle foo(createLink(std::move(seq), PLUS_LINK));
 		PlusLinkPtr ap = PlusLinkCast(foo);
 		return ap->delta_reduce(as, silent);
 	}
@@ -183,7 +183,7 @@ ValuePtr PlusLink::kons(AtomSpace* as, bool silent,
 				rest.push_back(jlpo[k]);
 
 			// a_plus is now (a+1) or (a+b) as described above.
-			Handle foo(createLink(rest, PLUS_LINK));
+			Handle foo(createLink(std::move(rest), PLUS_LINK));
 			PlusLinkPtr ap = PlusLinkCast(foo);
 			ValuePtr a_plus(ap->delta_reduce(as, silent));
 

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -141,7 +141,7 @@ void AtomTable::clear()
 
 Handle AtomTable::getHandle(Type t, const std::string& n) const
 {
-    Handle a(createNode(t,n));
+    Handle a(createNode(t, n));
     return lookupHandle(a);
 }
 
@@ -257,7 +257,7 @@ Handle AtomTable::add(const Handle& orig, bool force)
                 if (nullptr == h.operator->()) return Handle::UNDEFINED;
                 closet.emplace_back(add(h));
             }
-            atom = createLink(closet, atom->get_type());
+            atom = createLink(std::move(closet), atom->get_type());
         } else {
             atom->unsetRemovalFlag();
         }

--- a/opencog/persist/sql/multi-driver/SQLAtomLoad.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomLoad.cc
@@ -109,7 +109,7 @@ Handle SQLAtomStorage::get_recursive_if_not_exists(PseudoPtr p)
 		Handle ha(get_recursive_if_not_exists(po));
 		resolved_oset.emplace_back(ha);
 	}
-	Handle link(createLink(resolved_oset, p->type));
+	Handle link(createLink(std::move(resolved_oset), p->type));
 	_tlbuf.addAtom(link, p->uuid);
 	_num_rec_links++;
 	return link;

--- a/opencog/query/Satisfier.cc
+++ b/opencog/query/Satisfier.cc
@@ -49,7 +49,7 @@ bool Satisfier::grounding(const GroundingMap &var_soln,
 		{
 			vargnds.push_back(var_soln.at(hv));
 		}
-		_ground = createLink(vargnds, LIST_LINK);
+		_ground = createLink(std::move(vargnds), LIST_LINK);
 	}
 
 	// No need to look for more groundings as _result isn't going to change
@@ -141,7 +141,7 @@ bool SatisfyingSet::grounding(const GroundingMap &var_soln,
 	{
 		vargnds.push_back(var_soln.at(hv));
 	}
-	_satisfying_set.emplace(createLink(vargnds, LIST_LINK));
+	_satisfying_set.emplace(createLink(std::move(vargnds), LIST_LINK));
 
 	// If we found as many as we want, then stop looking for more.
 	return (_satisfying_set.size() >= max_results);

--- a/opencog/query/Substitutor.h
+++ b/opencog/query/Substitutor.h
@@ -71,7 +71,7 @@ private:
 		if (not changed) return expr;
 
 		// Create a duplicate link with the substitution.
-		Handle hret(createLink(oset_results, expr->get_type()));
+		Handle hret(createLink(std::move(oset_results), expr->get_type()));
 		hret->copyValues(expr);
 		return hret;
 	}


### PR DESCRIPTION
Avoid copying strings and HandleSeqs, just move them to their final destination.
This should provide some imperceptible performance bump.
This is the safe, non-invasive subset of pull req #2458 