### PR TITLE
Use Handles, not LinkPtr for the incoming set

### DIFF
--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -61,7 +61,7 @@ namespace std {
 opencog::Type
 hash<opencog::WinkPtr>::operator()(const opencog::WinkPtr& w) const noexcept
 {
-    opencog::LinkPtr h(w.lock());
+    opencog::Handle h(w.lock());
     if (nullptr == h) return 0;
     return h->get_type();
 }
@@ -72,14 +72,16 @@ equal_to<opencog::WinkPtr>::operator()(const opencog::WinkPtr& lw,
 {
     opencog::Handle hl(lw.lock());
     opencog::Handle hr(rw.lock());
-    return hl == hr;
+    return hl == hr;  /* hang on, should this be content-compare??? */
 }
 
+#if 0
 // Overloading operator<< for Incoming Set
 ostream& operator<<(ostream& out, const opencog::IncomingSet& iset)
 {
     return out << opencog::oc_to_string(iset);
 }
+#endif
 
 } // namespace std
 
@@ -305,7 +307,7 @@ void Atom::drop_incoming_set()
 }
 
 /// Add an atom to the incoming set.
-void Atom::insert_atom(const LinkPtr& a)
+void Atom::insert_atom(const Handle& a)
 {
     if (nullptr == _incoming_set) return;
     std::lock_guard<std::mutex> lck (_mtx);
@@ -326,7 +328,7 @@ void Atom::insert_atom(const LinkPtr& a)
 }
 
 /// Remove an atom from the incoming set.
-void Atom::remove_atom(const LinkPtr& a)
+void Atom::remove_atom(const Handle& a)
 {
     if (nullptr == _incoming_set) return;
     std::lock_guard<std::mutex> lck (_mtx);
@@ -342,7 +344,7 @@ void Atom::remove_atom(const LinkPtr& a)
 /// Remove old, and add new, atomically, so that every user
 /// will see either one or the other, but not both/neither in
 /// the incoming set. This is used to manage the StateLink.
-void Atom::swap_atom(const LinkPtr& old, const LinkPtr& neu)
+void Atom::swap_atom(const Handle& old, const Handle& neu)
 {
     if (nullptr == _incoming_set) return;
     std::lock_guard<std::mutex> lck (_mtx);
@@ -401,8 +403,8 @@ IncomingSet Atom::getIncomingSet(AtomSpace* as) const
         {
             for (const WinkPtr& w : bucket.second)
             {
-                LinkPtr l(w.lock());
-                if (l and atab->in_environ(l->get_handle()))
+                Handle l(w.lock());
+                if (l and atab->in_environ(l))
                     iset.emplace_back(l);
             }
         }
@@ -416,7 +418,7 @@ IncomingSet Atom::getIncomingSet(AtomSpace* as) const
     {
         for (const WinkPtr& w : bucket.second)
         {
-            LinkPtr l(w.lock());
+            Handle l(w.lock());
             if (l) iset.emplace_back(l);
         }
     }
@@ -439,8 +441,8 @@ IncomingSet Atom::getIncomingSetByType(Type type, AtomSpace* as) const
         const AtomTable *atab = &as->get_atomtable();
         for (const WinkPtr& w : bucket->second)
         {
-            LinkPtr l(w.lock());
-            if (l and atab->in_environ(l->get_handle()))
+            Handle l(w.lock());
+            if (l and atab->in_environ(l))
                 result.emplace_back(l);
         }
         return result;
@@ -448,7 +450,7 @@ IncomingSet Atom::getIncomingSetByType(Type type, AtomSpace* as) const
 
     for (const WinkPtr& w : bucket->second)
     {
-        LinkPtr l(w.lock());
+        Handle l(w.lock());
         if (l) result.emplace_back(l);
     }
     return result;
@@ -468,15 +470,15 @@ size_t Atom::getIncomingSetSizeByType(Type type, AtomSpace* as) const
         const AtomTable *atab = &as->get_atomtable();
         for (const WinkPtr& w : bucket->second)
         {
-            LinkPtr l(w.lock());
-            if (l and atab->in_environ(l->get_handle())) cnt++;
+            Handle l(w.lock());
+            if (l and atab->in_environ(l)) cnt++;
         }
         return cnt;
     }
 
     for (const WinkPtr& w : bucket->second)
     {
-        LinkPtr l(w.lock());
+        Handle l(w.lock());
         if (l) cnt++;
     }
     return cnt;
@@ -492,6 +494,7 @@ std::string Atom::id_to_string() const
     return ss.str();
 }
 
+#if 0
 std::string oc_to_string(const IncomingSet& iset, const std::string& indent)
 {
 	std::stringstream ss;
@@ -501,6 +504,7 @@ std::string oc_to_string(const IncomingSet& iset, const std::string& indent)
 		   << iset[i]->to_string(indent + OC_TO_STRING_INDENT);
 	return ss.str();
 }
+#endif
 
 std::string oc_to_string(const Atom& atom, const std::string& indent)
 {

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -41,9 +41,7 @@
 
 namespace opencog
 {
-class Link;
-typedef std::shared_ptr<Link> LinkPtr;
-typedef std::weak_ptr<Link> WinkPtr;
+typedef std::weak_ptr<Atom> WinkPtr;
 }
 
 namespace std
@@ -87,8 +85,8 @@ typedef std::size_t Arity;
 //! virtually all access will be either insert, or iterate, so we get
 //! O(1) performance. Note that sometimes incoming sets can be huge,
 //! millions of atoms.
-typedef std::vector<LinkPtr> IncomingSet; // use vector; see below.
-typedef SigSlot<AtomPtr, LinkPtr> AtomPairSignal;
+typedef HandleSeq IncomingSet;
+typedef SigSlot<Handle, Handle> AtomPairSignal;
 
 // typedef std::unordered_set<WinkPtr> WincomingSet;
 typedef std::set<WinkPtr, std::owner_less<WinkPtr> > WincomingSet;
@@ -198,9 +196,9 @@ protected:
     void drop_incoming_set();
 
     // Insert and remove links from the incoming set.
-    void insert_atom(const LinkPtr&);
-    void remove_atom(const LinkPtr&);
-    void swap_atom(const LinkPtr&, const LinkPtr&);
+    void insert_atom(const Handle&);
+    void remove_atom(const Handle&);
+    void swap_atom(const Handle&, const Handle&);
     virtual void install();
     virtual void remove();
 
@@ -354,8 +352,8 @@ public:
         // callback with locks held.
         IncomingSet vh(getIncomingSet());
 
-        for (const LinkPtr& lp : vh)
-            if ((data->*cb)(Handle(std::static_pointer_cast<Atom>(lp)))) return true;
+        for (const Handle& lp : vh)
+            if ((data->*cb)(lp)) return true;
         return false;
     }
 
@@ -443,8 +441,8 @@ static inline Handle HandleCast(const ValuePtr& pa)
 // The reason indent is not an optional argument with default is
 // because gdb doesn't support that, see
 // http://stackoverflow.com/questions/16734783 for more explanation.
-std::string oc_to_string(const IncomingSet& iset,
-                         const std::string& indent=empty_string);
+// std::string oc_to_string(const IncomingSet& iset,
+//                          const std::string& indent=empty_string);
 std::string oc_to_string(const Atom& atom,
                          const std::string& indent=empty_string);
 

--- a/opencog/atoms/base/Link.cc
+++ b/opencog/atoms/base/Link.cc
@@ -210,16 +210,14 @@ ContentHash Link::compute_hash() const
 ///
 void Link::install()
 {
-	LinkPtr llc(LinkCast(get_handle()));
-	size_t arity = get_arity();
-	for (size_t i = 0; i < arity; i++)
-		_outgoing[i]->insert_atom(llc);
+	Handle llc(get_handle());
+	for (Handle& h : _outgoing)
+		h->insert_atom(llc);
 }
 
 void Link::remove()
 {
-	LinkPtr lll(LinkCast(get_handle()));
-	size_t arity = get_arity();
-	for (size_t i = 0; i < arity; i++)
-		_outgoing[i]->remove_atom(lll);
+	Handle lll(get_handle());
+	for (Handle& h : _outgoing)
+		h->remove_atom(lll);
 }

--- a/opencog/atoms/base/Link.h
+++ b/opencog/atoms/base/Link.h
@@ -213,6 +213,7 @@ public:
     virtual bool operator<(const Atom&) const;
 };
 
+typedef std::shared_ptr<Link> LinkPtr;
 static inline LinkPtr LinkCast(const Handle& h)
     { return std::dynamic_pointer_cast<Link>(h); }
 static inline LinkPtr LinkCast(const AtomPtr& a)

--- a/opencog/atoms/core/StateLink.cc
+++ b/opencog/atoms/core/StateLink.cc
@@ -84,7 +84,7 @@ void StateLink::install()
 	bool swapped = false;
 	const Handle& alias = get_alias();
 	IncomingSet defs = alias->getIncomingSetByType(STATE_LINK);
-	for (const LinkPtr& defl : defs)
+	for (const Handle& defl : defs)
 	{
 		if (defl->getOutgoingAtom(0) != alias) continue;
 		if (defl.get() == this) continue;
@@ -97,14 +97,14 @@ void StateLink::install()
 		setAtomSpace(as);
 
 		// Atomic update of the incoming set.
-		const LinkPtr& new_state = LinkCast(get_handle());
-		alias->swap_atom(old_state, new_state);
+		const Handle& new_state(get_handle());
+		alias->swap_atom(defl, new_state);
 
 		// Install the other atom as well.
 		_outgoing[1]->insert_atom(new_state);
 
 		// Remove the old StateLink too. It must be no more.
-		as->remove_atom(defl->get_handle(), true);
+		as->remove_atom(defl, true);
 		swapped = true;
 	}
 

--- a/opencog/atoms/core/UniqueLink.cc
+++ b/opencog/atoms/core/UniqueLink.cc
@@ -41,7 +41,7 @@ void UniqueLink::init(bool allow_open)
 
 	const Handle& alias = _outgoing[0];
 	IncomingSet defs = alias->getIncomingSetByType(_type);
-	for (const LinkPtr& def : defs)
+	for (const Handle& def : defs)
 	{
 		if (def->getOutgoingAtom(0) == alias)
 		{
@@ -91,7 +91,7 @@ Handle UniqueLink::get_unique(const Handle& alias, Type type,
 
 	// Return the first (supposedly unique) definition that has no
 	// variables in it.
-	for (const LinkPtr& defl : defs)
+	for (const Handle& defl : defs)
 	{
 		if (defl->getOutgoingAtom(0) == alias)
 		{
@@ -100,7 +100,7 @@ Handle UniqueLink::get_unique(const Handle& alias, Type type,
 				UniqueLinkPtr ulp(UniqueLinkCast(defl));
 				if (0 < ulp->get_vars().varseq.size()) continue;
 			}
-			return defl->get_handle();
+			return defl;
 		}
 	}
 

--- a/opencog/atomspace/AtomSpace.cc
+++ b/opencog/atomspace/AtomSpace.cc
@@ -411,8 +411,8 @@ Handle AtomSpace::fetch_incoming_set(Handle h, bool recursive)
     if (not recursive) return h;
 
     IncomingSet vh(h->getIncomingSet());
-    for (const LinkPtr& lp : vh)
-        fetch_incoming_set(Handle(lp), true);
+    for (const Handle& lp : vh)
+        fetch_incoming_set(lp, true);
 
     return h;
 }

--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -296,9 +296,9 @@ SCM SchemeSmob::ss_incoming_set (SCM satom)
 	// This reverses the order of the incoming set, but so what ...
 	SCM head = SCM_EOL;
 	IncomingSet iset = h->getIncomingSet();
-	for (const LinkPtr& l : iset)
+	for (const Handle& l : iset)
 	{
-		SCM smob = handle_to_scm(l->get_handle());
+		SCM smob = handle_to_scm(l);
 		head = scm_cons(smob, head);
 	}
 

--- a/tests/atoms/base/AtomUTest.cxxtest
+++ b/tests/atoms/base/AtomUTest.cxxtest
@@ -88,15 +88,13 @@ public:
 
         // {inh01, l012} is the incoming set of ConceptNode "0"
         IncomingSet i0 = sortedHandles[0]->getIncomingSet();
-        std::set<LinkPtr> expected_i0 = {LinkCast(inh01), LinkCast(l012)};
-        TS_ASSERT_EQUALS(std::set<LinkPtr>(i0.begin(), i0.end()), expected_i0);
+        std::set<Handle> expected_i0 = {inh01, l012};
+        TS_ASSERT_EQUALS(std::set<Handle>(i0.begin(), i0.end()), expected_i0);
 
         // {inh01, inh12, 012} is the incoming set of ConceptNode "1"
         IncomingSet i1 = sortedHandles[1]->getIncomingSet();
-        std::set<LinkPtr> expected_i1 = { LinkCast(inh01),
-                                          LinkCast(inh12),
-                                          LinkCast(l012) };
-        TS_ASSERT_EQUALS(std::set<LinkPtr>(i1.begin(), i1.end()), expected_i1);
+        std::set<Handle> expected_i1 = { inh01, inh12, l012 };
+        TS_ASSERT_EQUALS(std::set<Handle>(i1.begin(), i1.end()), expected_i1);
     }
 
     void test_getIncomingSetByType()
@@ -106,16 +104,16 @@ public:
         // {inh01} is the incoming set of ConceptNode "0" by type
         // InheritanceLink
         IncomingSet i0 = sortedHandles[0]->getIncomingSetByType(INHERITANCE_LINK);
-        std::set<LinkPtr> expected_i0 = {LinkCast(inh01)};
+        std::set<Handle> expected_i0 = {inh01};
         printf("Expected %s\n", inh01->to_string().c_str());
         printf("got a set of size %lu\n", i0.size());
 
-        TS_ASSERT_EQUALS(std::set<LinkPtr>(i0.begin(), i0.end()), expected_i0);
+        TS_ASSERT_EQUALS(std::set<Handle>(i0.begin(), i0.end()), expected_i0);
 
         // {inh01, inh12} is the incoming set of ConceptNode "1" by
         // type InheritanceLink
         IncomingSet i1 = sortedHandles[1]->getIncomingSetByType(INHERITANCE_LINK);
-        std::set<LinkPtr> expected_i1 = {LinkCast(inh01), LinkCast(inh12)};
-        TS_ASSERT_EQUALS(std::set<LinkPtr>(i1.begin(), i1.end()), expected_i1);
+        std::set<Handle> expected_i1 = {inh01, inh12};
+        TS_ASSERT_EQUALS(std::set<Handle>(i1.begin(), i1.end()), expected_i1);
     }
 };


### PR DESCRIPTION
The  goal here is to save CPU overhead associated with casting
between LinkPtr and Handle. Based on actual measurements, it
seems that `getIncomingSet`is now 10% faster, which is not as 
dramatic as expected. Both `addNode` and `addLink` improve very
slightly (as this is where some of the casting occurs.)