### PR TITLE
Cache clauses that are repeatedly grounded.

### DIFF
--- a/opencog/atoms/core/FindUtils.cc
+++ b/opencog/atoms/core/FindUtils.cc
@@ -329,6 +329,17 @@ unsigned int num_unquoted_unscoped_in_tree(const Handle& tree,
 	return count;
 }
 
+HandleSet unquoted_unscoped_in_tree(const Handle& tree,
+                                    const HandleSet& atoms)
+{
+	HandleSet rv;
+	for (const Handle& n: atoms)
+	{
+		if (is_unquoted_unscoped_in_tree(tree, n)) rv.insert(n);
+	}
+	return rv;
+}
+
 bool is_atom_in_any_tree(const HandleSeq& trees,
                          const Handle& atom)
 {

--- a/opencog/atoms/core/FindUtils.h
+++ b/opencog/atoms/core/FindUtils.h
@@ -297,6 +297,15 @@ unsigned int num_unquoted_unscoped_in_tree(const Handle& tree,
                                            const HandleSet& atoms);
 
 /**
+ * Return the subset of `atoms` that occur somewhere in the tree
+ * that are not quoted or bound. This acts as a filter on the set
+ * of atoms; the number in the returned set equals the value
+ * returned by `num_unquoted_unscoped_in_tree()` above.
+ */
+HandleSet unquoted_unscoped_in_tree(const Handle& tree,
+                                    const HandleSet& atoms);
+
+/**
  * Return true if the indicated atom occurs somewhere in any of the trees.
  */
 bool is_atom_in_any_tree(const HandleSeq& trees,

--- a/opencog/atoms/pattern/Pattern.h
+++ b/opencog/atoms/pattern/Pattern.h
@@ -120,6 +120,14 @@ struct Pattern
 	/// GlobNode, but uses a different algorithm.
 	HandleSet fuzzy_terms;
 
+	/// Terms that can be grounded in only one way; thus the result
+	/// of that grounding can be cached, for avoid rechecking.
+	/// These terms cannot be evaluatable (as that would invalidate
+	/// the results), and can only contain on variable (there is no
+	/// use case for two or more, right now.) The pair here is
+	/// (term, variable), the vairable making lookup faster.
+	std::unordered_map<Handle,Handle> cacheable_terms;
+
 	/// Maps; the value is the largest (evaluatable or executable)
 	/// term containing the variable. Its a multimap, because
 	/// a variable may appear in several different evaluatables.

--- a/opencog/atoms/pattern/Pattern.h
+++ b/opencog/atoms/pattern/Pattern.h
@@ -93,8 +93,8 @@ struct Pattern
 	/// grounded, they might be rejected (depending on the callback).
 	HandleSeq optionals;    // Optional clauses
 
-	/// The always (for-all) clauses have to always be the same way.
-	/// Any grounding failure at all invalidates all other groundings.
+	/// The always (for-all) clauses have to always be grounded the same
+	/// way. Any grounding failure at all invalidates all other groundings.
 	HandleSeq always;       // ForAll clauses
 
 	/// Black-box clauses. These are clauses that contain GPN's. These
@@ -120,13 +120,15 @@ struct Pattern
 	/// GlobNode, but uses a different algorithm.
 	HandleSet fuzzy_terms;
 
-	/// Terms that can be grounded in only one way; thus the result
+	/// Clauses that can be grounded in only one way; thus the result
 	/// of that grounding can be cached, for avoid rechecking.
-	/// These terms cannot be evaluatable (as that would invalidate
-	/// the results), and can only contain on variable (there is no
-	/// use case for two or more, right now.) The pair here is
-	/// (term, variable), the vairable making lookup faster.
-	std::unordered_map<Handle,Handle> cacheable_terms;
+	/// These clauses cannot contain evaluatable elements (as that would
+	/// invalidate the results), cannot contiain unordered or choice links
+	/// (as those can have multiple groundings) and can only contain one
+	/// variable (there is no use case for two or more, right now.)
+	/// The idea could be extended to cacheable sub-terms, but this is
+	/// more complex, and not implemented.
+	HandleSet cacheable_clauses;
 
 	/// Maps; the value is the largest (evaluatable or executable)
 	/// term containing the variable. Its a multimap, because

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -497,7 +497,8 @@ void PatternLink::locate_cacheable(const HandleSeq& clauses)
 		if (_pat.evaluatable_holders.find(claw) != _pat.evaluatable_holders.end()) continue;
 		if (_pat.globby_holders.find(claw) != _pat.globby_holders.end()) continue;
 		if (_pat.fuzzy_terms.find(claw) != _pat.fuzzy_terms.end()) continue;
-		if (_pat.black.find(claw) != _pat.black.end()) continue;
+		// black terms are evaluatble; no need to do it twice.
+		// if (_pat.black.find(claw) != _pat.black.end()) continue;
 
 		if (contains_atomtype(claw, UNORDERED_LINK)) continue;
 		if (contains_atomtype(claw, CHOICE_LINK)) continue;

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -500,7 +500,8 @@ void PatternLink::locate_cacheable(const Handle& term)
 	}
 
 	// How about subterms?
-	locate_cacheable(term->getOutgoingSet());
+	if (term->is_link())
+		locate_cacheable(term->getOutgoingSet());
 }
 
 void PatternLink::locate_cacheable(const HandleSeq& clauses)

--- a/opencog/atoms/pattern/PatternLink.h
+++ b/opencog/atoms/pattern/PatternLink.h
@@ -107,6 +107,9 @@ protected:
 	bool is_virtual(const Handle&);
 	void unbundle_virtual(const HandleSeq& clauses);
 
+	void locate_cacheable(const HandleSeq& clauses);
+	void locate_cacheable(const Handle& term);
+
 	bool add_dummies();
 
 	void trace_connectives(const TypeSet&,

--- a/opencog/atoms/pattern/PatternLink.h
+++ b/opencog/atoms/pattern/PatternLink.h
@@ -108,7 +108,6 @@ protected:
 	void unbundle_virtual(const HandleSeq& clauses);
 
 	void locate_cacheable(const HandleSeq& clauses);
-	void locate_cacheable(const Handle& term);
 
 	bool add_dummies();
 

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -2407,9 +2407,9 @@ bool PatternMatchEngine::explore_redex(const Handle& term,
  * This method simply dispatches a given clause to be either pattern
  * matched, or to be evaluated.
  */
-bool PatternMatchEngine::explore_clause(const Handle& term,
-                                        const Handle& grnd,
-                                        const Handle& clause)
+bool PatternMatchEngine::explore_clause_direct(const Handle& term,
+                                               const Handle& grnd,
+                                               const Handle& clause)
 {
 	// If we are looking for a pattern to match, then ... look for it.
 	// Evaluatable clauses are not patterns; they are clauses that
@@ -2460,6 +2460,22 @@ bool PatternMatchEngine::explore_clause(const Handle& term,
 
 	return false;
 }
+
+/**
+ * Same as explore_clause, but looks at the cache of pre-grounded
+ * clauses, first. Should save smoe CPU time.
+ */
+bool PatternMatchEngine::explore_clause(const Handle& term,
+                                        const Handle& grnd,
+                                        const Handle& clause)
+{
+	// If not cacheable, nothing to do.
+	if (_pat->cacheable_clauses.find(clause) == _pat->cacheable_clauses.end())
+		return explore_clause_direct(term, grnd, clause);
+
+	return explore_clause_direct(term, grnd, clause);
+}
+
 
 void PatternMatchEngine::record_grounding(const PatternTermPtr& ptm,
                                           const Handle& hg)

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1804,8 +1804,9 @@ bool PatternMatchEngine::clause_accept(const Handle& clause_root,
 			(_pat->cacheable_clauses.find(clause_root) !=
 		    _pat->cacheable_clauses.end()))
 		{
-			Handle jgnd(var_grounding[next_joint]);
-			_gnd_cache.insert({{clause_root, jgnd}, hg});
+			auto jgnd(var_grounding.find(next_joint));
+			if (jgnd != var_grounding.end())
+				_gnd_cache.insert({{clause_root, jgnd->second}, hg});
 		}
 	}
 

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -2513,6 +2513,19 @@ bool PatternMatchEngine::explore_clause_direct(const Handle& term,
  * In the above example, the start/end-points would be genes, and the
  * paths would be reactome grid paths. The above pattern has two cache
  * hits, one on "x" and one on the "z" end-point.
+ *
+ * TODO: The implementation here is minimal - very simple, very basic.
+ * One could get much fancier. For example, the cache could be held in
+ * the atomspace (thus making it effective across multiple searches,
+ * e.g. with different start points but with the same end-points.)
+ * In this case, maybe the cache should be held in a special Value
+ * attached to a clause.  Size and bloat issues occur with atomspace
+ * caching; these would need to be managed.
+ *
+ * A different fancy approach would be to spot more complex recurring
+ * sub-patterns, and cache those. This adds considerable complexity,
+ * and would become effective only for large, complex searches, of
+ * which I haven't seen any good examples of, yet.
  */
 bool PatternMatchEngine::explore_clause(const Handle& term,
                                         const Handle& grnd,

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -2514,6 +2514,9 @@ bool PatternMatchEngine::explore_clause_direct(const Handle& term,
  * paths would be reactome grid paths. The above pattern has two cache
  * hits, one on "x" and one on the "z" end-point.
  *
+ * There's no unit test for this. Caching does hurt some workloads by
+ * as much as 5%. It helps the genome-annotation code by 25%.
+ *
  * TODO: The implementation here is minimal - very simple, very basic.
  * One could get much fancier. For example, the cache could be held in
  * the atomspace (thus making it effective across multiple searches,

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -193,6 +193,9 @@ private:
 	typedef HandleSet IssuedSet;
 	IssuedSet issued;     // stacked on issued_stack
 
+	// Cacheable grounded clauses
+	std::unordered_map<std::pair<Handle,Handle>, Handle> _gnd_cache;
+
 	// -------------------------------------------
 	// Stack used to store current traversal state for a single
 	// clause. These are pushed when a clause is fully grounded,
@@ -256,6 +259,7 @@ private:
 	// See PatternMatchEngine.cc for descriptions
 	bool explore_redex(const Handle&, const Handle&, const Handle&);
 	bool explore_clause(const Handle&, const Handle&, const Handle&);
+	bool explore_clause_direct(const Handle&, const Handle&, const Handle&);
 	bool explore_term_branches(const Handle&, const Handle&,
 	                           const Handle&);
 	bool explore_up_branches(const PatternTermPtr&, const Handle&,


### PR DESCRIPTION
The gene annotation code (https://github.com/MOZI-AI/annotation-scheme/)
contains patterns that have endpoints that are repeatedly searched.  For
those cases, performance is improved by as much as 25% by caching the
repeated search results. 

The code here does come at a cost; other searches are penalized by a few 
percent. :-(

There's no unit test, because I cannot figure out how to unit test, as this does
not alter search results.