### PR TITLE
Short-cut certain types of pattern searches. 

### DIFF
--- a/opencog/atoms/pattern/Pattern.h
+++ b/opencog/atoms/pattern/Pattern.h
@@ -112,10 +112,6 @@ struct Pattern
 	/// or a DefineSchemaNode (DSN).
 	HandleSet defined_terms;    // The DPN/DSN itself.
 
-	/// Globby terms are terms that contain a GlobNode
-	HandleSet globby_terms;     // Smallest term that has a glob.
-	HandleSet globby_holders;   // holds something globby.
-
 	/// Terms that may be grounded in an imprecise way. Similar to a
 	/// GlobNode, but uses a different algorithm.
 	HandleSet fuzzy_terms;

--- a/opencog/atoms/pattern/Pattern.h
+++ b/opencog/atoms/pattern/Pattern.h
@@ -112,10 +112,6 @@ struct Pattern
 	/// or a DefineSchemaNode (DSN).
 	HandleSet defined_terms;    // The DPN/DSN itself.
 
-	/// Terms that may be grounded in an imprecise way. Similar to a
-	/// GlobNode, but uses a different algorithm.
-	HandleSet fuzzy_terms;
-
 	/// Clauses that can be grounded in only one way; thus the result
 	/// of that grounding can be cached, for avoid rechecking.
 	/// These clauses cannot contain evaluatable elements (as that would

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -477,7 +477,6 @@ void PatternLink::locate_cacheable(const HandleSeq& clauses)
 // XXX FIXME later ... we need to be able to call hasAnyGlobbyVar()
 // which means we need to have terms, here ...
 		// if (claw->hasAnyGlobbyVar()) continue;
-		if (_pat.fuzzy_terms.find(claw) != _pat.fuzzy_terms.end()) continue;
 		// black terms are evaluatble; no need to do it twice.
 		// if (_pat.black.find(claw) != _pat.black.end()) continue;
 

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -875,17 +875,17 @@ void PatternLink::make_term_trees()
 {
 	for (const Handle& clause : _pat.mandatory)
 	{
-		PatternTermPtr root_term(std::make_shared<PatternTerm>());
+		PatternTermPtr root_term(createPatternTerm());
 		make_term_tree_recursive(clause, clause, root_term);
 	}
 	for (const Handle& clause : _pat.optionals)
 	{
-		PatternTermPtr root_term(std::make_shared<PatternTerm>());
+		PatternTermPtr root_term(createPatternTerm());
 		make_term_tree_recursive(clause, clause, root_term);
 	}
 	for (const Handle& clause : _pat.always)
 	{
-		PatternTermPtr root_term(std::make_shared<PatternTerm>());
+		PatternTermPtr root_term(createPatternTerm());
 		make_term_tree_recursive(clause, clause, root_term);
 	}
 }
@@ -894,7 +894,7 @@ void PatternLink::make_term_tree_recursive(const Handle& root,
                                            Handle h,
                                            PatternTermPtr& parent)
 {
-	PatternTermPtr ptm(std::make_shared<PatternTerm>(parent, h));
+	PatternTermPtr ptm(createPatternTerm(parent, h));
 	h = ptm->getHandle();
 	parent->addOutgoingTerm(ptm);
 	_pat.connected_terms_map[{h, root}].emplace_back(ptm);

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -39,8 +39,6 @@ using namespace opencog;
 void PatternLink::common_init(void)
 {
 	locate_defines(_pat.unquoted_clauses);
-	locate_globs(_pat.unquoted_clauses);
-	locate_globs(_pat.quoted_clauses);
 
 	// If there are any defines in the pattern, then all bets are off
 	// as to whether it is connected or not, what's virtual, what isn't.
@@ -227,7 +225,6 @@ PatternLink::PatternLink(const HandleSet& vars,
 		}
 	}
 	locate_defines(compo);
-	locate_globs(compo);
 
 	// The rest is easy: the evaluatables and the connection map
 	unbundle_virtual(_pat.mandatory);
@@ -454,25 +451,6 @@ void PatternLink::locate_defines(const HandleSeq& clauses)
 	}
 }
 
-void PatternLink::locate_globs(const HandleSeq& clauses)
-{
-	for (const Handle& clause: clauses)
-	{
-		FindAtoms fgn(GLOB_NODE, true);
-		fgn.search_set(clause);
-
-		for (const Handle& sh : fgn.least_holders)
-		{
-			_pat.globby_terms.insert(sh);
-		}
-
-		for (const Handle& h : fgn.holders)
-		{
-			_pat.globby_holders.insert(h);
-		}
-	}
-}
-
 /* ================================================================= */
 /**
  * Locate cacheable clauses. These are clauses whose groundings can be
@@ -495,7 +473,10 @@ void PatternLink::locate_cacheable(const HandleSeq& clauses)
 	{
 		// Skip over anything unsuitable.
 		if (_pat.evaluatable_holders.find(claw) != _pat.evaluatable_holders.end()) continue;
-		if (_pat.globby_holders.find(claw) != _pat.globby_holders.end()) continue;
+
+// XXX FIXME later ... we need to be able to call hasAnyGlobbyVar()
+// which means we need to have terms, here ...
+		// if (claw->hasAnyGlobbyVar()) continue;
 		if (_pat.fuzzy_terms.find(claw) != _pat.fuzzy_terms.end()) continue;
 		// black terms are evaluatble; no need to do it twice.
 		// if (_pat.black.find(claw) != _pat.black.end()) continue;

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -914,6 +914,10 @@ void PatternLink::make_term_tree_recursive(const Handle& root,
 		return;
 	}
 
+	// If the term is unordered, all parents must know about it.
+	if (nameserver().isA(t, UNORDERED_LINK))
+		ptm->addUnorderedLink();
+
 	if (h->is_link())
 	{
 		for (const Handle& ho: h->getOutgoingSet())

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -623,21 +623,6 @@ void PatternLink::unbundle_virtual(const HandleSeq& clauses)
 		bool is_virtu = false;
 		bool is_black = false;
 
-#ifdef BROKEN_DOESNT_WORK
-// The below should have worked to set things up, but it doesn't,
-// and I'm too lazy to investigate, because an alternate hack is
-// working, at the moment.
-		// If a clause is a variable, we have to make the worst-case
-		// assumption that it is evaluatable, so that we can evaluate
-		// it later.
-		if (VARIABLE_NODE == clause->get_type())
-		{
-			_pat.evaluatable_terms.insert(clause);
-			add_to_map(_pat.in_evaluatable, clause, clause);
-			is_black = true;
-		}
-#endif
-
 		FindAtoms fgpn(GROUNDED_PREDICATE_NODE, true);
 		fgpn.stopset.insert(SCOPE_LINK);
 		fgpn.search_set(clause);

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -911,6 +911,7 @@ void PatternLink::make_term_tree_recursive(const Handle& root,
 	    and _variables.varset.end() != _variables.varset.find(h))
 	{
 		ptm->addBoundVariable();
+		if (GLOB_NODE == t) ptm->addGlobbyVar();
 		return;
 	}
 

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -477,7 +477,7 @@ void PatternLink::locate_cacheable(const HandleSeq& clauses)
 // XXX FIXME later ... we need to be able to call hasAnyGlobbyVar()
 // which means we need to have terms, here ...
 		// if (claw->hasAnyGlobbyVar()) continue;
-		// black terms are evaluatble; no need to do it twice.
+		// black terms are evalutable; no need to do it twice.
 		// if (_pat.black.find(claw) != _pat.black.end()) continue;
 
 		if (contains_atomtype(claw, UNORDERED_LINK)) continue;

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -891,11 +891,13 @@ void PatternLink::make_term_trees()
 }
 
 void PatternLink::make_term_tree_recursive(const Handle& root,
-                                           Handle h,
+                                           const Handle& term,
                                            PatternTermPtr& parent)
 {
-	PatternTermPtr ptm(createPatternTerm(parent, h));
-	h = ptm->getHandle();
+	PatternTermPtr ptm(createPatternTerm(parent, term));
+
+	// `h` is usually the same as `term`, unless there's quotation.
+	Handle h(ptm->getHandle());
 	parent->addOutgoingTerm(ptm);
 	_pat.connected_terms_map[{h, root}].emplace_back(ptm);
 

--- a/opencog/atoms/pattern/PatternLink.h
+++ b/opencog/atoms/pattern/PatternLink.h
@@ -100,7 +100,6 @@ protected:
 	                          bool reverse=false);
 
 	void locate_defines(const HandleSeq& clauses);
-	void locate_globs(const HandleSeq& clauses);
 	void validate_variables(HandleSet& vars,
 	                        const HandleSeq& clauses);
 

--- a/opencog/atoms/pattern/PatternLink.h
+++ b/opencog/atoms/pattern/PatternLink.h
@@ -122,7 +122,7 @@ protected:
 	                          const HandleSetSeq&);
 
 	void make_term_trees();
-	void make_term_tree_recursive(const Handle&, Handle,
+	void make_term_tree_recursive(const Handle&, const Handle&,
 	                              PatternTermPtr&);
 
 	void init(void);

--- a/opencog/atoms/pattern/PatternTerm.cc
+++ b/opencog/atoms/pattern/PatternTerm.cc
@@ -20,7 +20,8 @@ PatternTerm::PatternTerm()
 	  _quote(Handle::UNDEFINED),
 	  _parent(PatternTerm::UNDEFINED),
 	  _has_any_bound_var(false),
-	  _has_bound_var(false)
+	  _has_bound_var(false),
+	  _has_any_unordered_link(false)
 {}
 
 PatternTerm::PatternTerm(const PatternTermPtr& parent, const Handle& h)
@@ -28,7 +29,8 @@ PatternTerm::PatternTerm(const PatternTermPtr& parent, const Handle& h)
 	  _quotation(parent->_quotation.level(),
 	             false /* necessarily false since it is local */),
 	  _has_any_bound_var(false),
-	  _has_bound_var(false)
+	  _has_bound_var(false),
+	  _has_any_unordered_link(false)
 {
 	Type t = h->get_type();
 
@@ -108,7 +110,7 @@ bool PatternTerm::operator==(const PatternTerm& other)
 
 void PatternTerm::addAnyBoundVar()
 {
-	if (!_has_any_bound_var)
+	if (not _has_any_bound_var)
 	{
 		_has_any_bound_var = true;
 		if (_parent != PatternTerm::UNDEFINED)
@@ -131,6 +133,16 @@ void PatternTerm::addBoundVariable()
 
 	// Mark recursively, all the way to the root.
 	addAnyBoundVar();
+}
+
+void PatternTerm::addUnorderedLink()
+{
+	if (not _has_any_unordered_link)
+	{
+		_has_any_unordered_link = true;
+		if (_parent != PatternTerm::UNDEFINED)
+			_parent->addUnorderedLink();
+	}
 }
 
 std::string PatternTerm::to_string() const { return to_string(":"); }

--- a/opencog/atoms/pattern/PatternTerm.cc
+++ b/opencog/atoms/pattern/PatternTerm.cc
@@ -23,6 +23,8 @@ PatternTerm::PatternTerm()
 	  _has_bound_var(false),
 	  _has_any_globby_var(false),
 	  _has_globby_var(false),
+	  _has_any_evaluatable(false),
+	  _has_evaluatable(false),
 	  _has_any_unordered_link(false)
 {}
 
@@ -34,6 +36,8 @@ PatternTerm::PatternTerm(const PatternTermPtr& parent, const Handle& h)
 	  _has_bound_var(false),
 	  _has_any_globby_var(false),
 	  _has_globby_var(false),
+	  _has_any_evaluatable(false),
+	  _has_evaluatable(false),
 	  _has_any_unordered_link(false)
 {
 	Type t = h->get_type();
@@ -164,6 +168,29 @@ void PatternTerm::addGlobbyVar()
 		_parent->_has_globby_var = true;
 
 	addAnyGlobbyVar();
+}
+
+// ==============================================================
+// Just like above, but for evaluatables.
+
+void PatternTerm::addAnyEvaluatable()
+{
+	if (not _has_any_evaluatable)
+	{
+		_has_any_evaluatable = true;
+		if (_parent != PatternTerm::UNDEFINED)
+			_parent->addAnyEvaluatable();
+	}
+}
+
+void PatternTerm::addEvaluatable()
+{
+	_has_evaluatable = true;
+
+	if (_parent != PatternTerm::UNDEFINED)
+		_parent->_has_evaluatable = true;
+
+	addAnyEvaluatable();
 }
 
 // ==============================================================

--- a/opencog/atoms/pattern/PatternTerm.cc
+++ b/opencog/atoms/pattern/PatternTerm.cc
@@ -21,6 +21,7 @@ PatternTerm::PatternTerm()
 	  _parent(PatternTerm::UNDEFINED),
 	  _has_any_bound_var(false),
 	  _has_bound_var(false),
+	  _has_any_globby_var(false),
 	  _has_any_unordered_link(false)
 {}
 
@@ -30,6 +31,7 @@ PatternTerm::PatternTerm(const PatternTermPtr& parent, const Handle& h)
 	             false /* necessarily false since it is local */),
 	  _has_any_bound_var(false),
 	  _has_bound_var(false),
+	  _has_any_globby_var(false),
 	  _has_any_unordered_link(false)
 {
 	Type t = h->get_type();
@@ -95,6 +97,7 @@ bool PatternTerm::isDescendant(const PatternTermPtr& ptm) const
 	return _parent->isDescendant(ptm);
 }
 
+// ==============================================================
 /**
  * Equality operator.  Both the content must match, and the path
  * taken to get to the content must match.
@@ -108,6 +111,9 @@ bool PatternTerm::operator==(const PatternTerm& other)
 	return _parent->operator==(*other._parent);
 }
 
+// ==============================================================
+
+// Mark recursively, all the way to the root.
 void PatternTerm::addAnyBoundVar()
 {
 	if (not _has_any_bound_var)
@@ -135,6 +141,31 @@ void PatternTerm::addBoundVariable()
 	addAnyBoundVar();
 }
 
+// ==============================================================
+// Just like above, but for globs.
+
+void PatternTerm::addAnyGlobbyVar()
+{
+	if (not _has_any_globby_var)
+	{
+		_has_any_globby_var = true;
+		if (_parent != PatternTerm::UNDEFINED)
+			_parent->addAnyGlobbyVar();
+	}
+}
+
+void PatternTerm::addGlobbyVar()
+{
+	_has_globby_var = true;
+
+	if (_parent != PatternTerm::UNDEFINED)
+		_parent->_has_globby_var = true;
+
+	addAnyGlobbyVar();
+}
+
+// ==============================================================
+
 void PatternTerm::addUnorderedLink()
 {
 	if (not _has_any_unordered_link)
@@ -144,6 +175,8 @@ void PatternTerm::addUnorderedLink()
 			_parent->addUnorderedLink();
 	}
 }
+
+// ==============================================================
 
 std::string PatternTerm::to_string() const { return to_string(":"); }
 

--- a/opencog/atoms/pattern/PatternTerm.cc
+++ b/opencog/atoms/pattern/PatternTerm.cc
@@ -22,6 +22,7 @@ PatternTerm::PatternTerm()
 	  _has_any_bound_var(false),
 	  _has_bound_var(false),
 	  _has_any_globby_var(false),
+	  _has_globby_var(false),
 	  _has_any_unordered_link(false)
 {}
 
@@ -32,6 +33,7 @@ PatternTerm::PatternTerm(const PatternTermPtr& parent, const Handle& h)
 	  _has_any_bound_var(false),
 	  _has_bound_var(false),
 	  _has_any_globby_var(false),
+	  _has_globby_var(false),
 	  _has_any_unordered_link(false)
 {
 	Type t = h->get_type();

--- a/opencog/atoms/pattern/PatternTerm.cc
+++ b/opencog/atoms/pattern/PatternTerm.cc
@@ -19,7 +19,7 @@ PatternTerm::PatternTerm()
 	: _handle(Handle::UNDEFINED),
 	  _quote(Handle::UNDEFINED),
 	  _parent(PatternTerm::UNDEFINED),
-	  _has_any_bound_var(false)
+	  _has_any_bound_var(false),
 	  _has_bound_var(false)
 {}
 

--- a/opencog/atoms/pattern/PatternTerm.cc
+++ b/opencog/atoms/pattern/PatternTerm.cc
@@ -20,13 +20,15 @@ PatternTerm::PatternTerm()
 	  _quote(Handle::UNDEFINED),
 	  _parent(PatternTerm::UNDEFINED),
 	  _has_any_bound_var(false)
+	  _has_bound_var(false)
 {}
 
 PatternTerm::PatternTerm(const PatternTermPtr& parent, const Handle& h)
 	: _handle(h), _quote(Handle::UNDEFINED), _parent(parent),
 	  _quotation(parent->_quotation.level(),
 	             false /* necessarily false since it is local */),
-	  _has_any_bound_var(false)
+	  _has_any_bound_var(false),
+	  _has_bound_var(false)
 {
 	Type t = h->get_type();
 
@@ -104,14 +106,20 @@ bool PatternTerm::operator==(const PatternTerm& other)
 	return _parent->operator==(*other._parent);
 }
 
-void PatternTerm::addBoundVariable()
+void PatternTerm::addAnyBoundVar()
 {
 	if (!_has_any_bound_var)
 	{
 		_has_any_bound_var = true;
 		if (_parent != PatternTerm::UNDEFINED)
-			_parent->addBoundVariable();
+			_parent->addAnyBoundVar();
 	}
+}
+
+void PatternTerm::addBoundVariable()
+{
+	_has_bound_var = true;
+	addAnyBoundVar();
 }
 
 std::string PatternTerm::to_string() const { return to_string(":"); }

--- a/opencog/atoms/pattern/PatternTerm.cc
+++ b/opencog/atoms/pattern/PatternTerm.cc
@@ -116,9 +116,20 @@ void PatternTerm::addAnyBoundVar()
 	}
 }
 
+/// Set two flags: one flag (the "any" flag) is set recursively from
+/// a variable, all the way up to the root, indicating that there's
+/// a variable on this path.  The other flag gets set only on the
+/// variable, and it's immediate parent (i.e. the holder of the
+/// variable).
 void PatternTerm::addBoundVariable()
 {
+	// Mark just this term (the variable itself)
+	// and mark the term that holds us.
 	_has_bound_var = true;
+	if (_parent != PatternTerm::UNDEFINED)
+			_parent->_has_bound_var = true;
+
+	// Mark recursively, all the way to the root.
 	addAnyBoundVar();
 }
 

--- a/opencog/atoms/pattern/PatternTerm.h
+++ b/opencog/atoms/pattern/PatternTerm.h
@@ -97,12 +97,22 @@ protected:
 	bool _has_bound_var;
 
 	// True if any pattern subtree rooted in this tree node contains
+	// an GlobNode. Trees without any GlobNodes can be searched in a
+	// straight-forward manner; those with them need to have all
+	// possible glob matches explored.
+	bool _has_any_globby_var;
+
+	// As above, but only one level deep.
+	bool _has_globby_var;
+
+	// True if any pattern subtree rooted in this tree node contains
 	// an unordered link. Trees without any unordered links can be
 	// searched in a straight-forward manner; those with them need to
 	// have all possible permutations explored.
 	bool _has_any_unordered_link;
 
 	void addAnyBoundVar();
+	void addAnyGlobbyVar();
 
 public:
 	static const PatternTermPtr UNDEFINED;
@@ -130,6 +140,10 @@ public:
 	void addBoundVariable();
 	bool hasAnyBoundVariable() const noexcept { return _has_any_bound_var; }
 	bool hasBoundVariable() const noexcept { return _has_bound_var; }
+
+	void addGlobbyVar();
+	bool hasAnyGlobbyVar() const noexcept { return _has_any_globby_var; }
+	bool hasGlobbyVar() const noexcept { return _has_globby_var; }
 
 	void addUnorderedLink();
 	bool hasUnorderedLink() const noexcept { return _has_any_unordered_link; }

--- a/opencog/atoms/pattern/PatternTerm.h
+++ b/opencog/atoms/pattern/PatternTerm.h
@@ -74,6 +74,7 @@ class PatternTerm
 protected:
 	Handle _handle;
 	Handle _quote;
+
 	// TODO: it would probably be more efficient to swap which of these
 	// two is weak, since I think _outgoing is requested far more often
 	// than _parent, and having it run faster would be a performance win.
@@ -87,6 +88,13 @@ protected:
 	// contain any bound variables. This means that the term is constant
 	// and may be self-grounded.
 	bool _has_any_bound_var;
+
+	// True if none of the outgoing set are bound variables. Unlike the
+	// above, this is for the immediate outgoing set only, and not any
+	// deeper terms.
+	bool _has_bound_var;
+
+	void addAnyBoundVar();
 
 public:
 	static const PatternTermPtr UNDEFINED;
@@ -113,6 +121,7 @@ public:
 
 	void addBoundVariable();
 	bool hasAnyBoundVariable() const noexcept { return _has_any_bound_var; }
+	bool hasBoundVariable() const noexcept { return _has_bound_var; }
 
 	bool operator==(const PatternTerm&);
 

--- a/opencog/atoms/pattern/PatternTerm.h
+++ b/opencog/atoms/pattern/PatternTerm.h
@@ -105,6 +105,10 @@ protected:
 	// As above, but only one level deep.
 	bool _has_globby_var;
 
+	// As above, but for evaluatables.
+	bool _has_any_evaluatable;
+	bool _has_evaluatable;
+
 	// True if any pattern subtree rooted in this tree node contains
 	// an unordered link. Trees without any unordered links can be
 	// searched in a straight-forward manner; those with them need to
@@ -113,6 +117,7 @@ protected:
 
 	void addAnyBoundVar();
 	void addAnyGlobbyVar();
+	void addAnyEvaluatable();
 
 public:
 	static const PatternTermPtr UNDEFINED;
@@ -144,6 +149,10 @@ public:
 	void addGlobbyVar();
 	bool hasAnyGlobbyVar() const noexcept { return _has_any_globby_var; }
 	bool hasGlobbyVar() const noexcept { return _has_globby_var; }
+
+	void addEvaluatable();
+	bool hasAnyEvaluatable() const noexcept { return _has_any_evaluatable; }
+	bool hasEvaluatable() const noexcept { return _has_evaluatable; }
 
 	void addUnorderedLink();
 	bool hasUnorderedLink() const noexcept { return _has_any_unordered_link; }

--- a/opencog/atoms/pattern/PatternTerm.h
+++ b/opencog/atoms/pattern/PatternTerm.h
@@ -131,6 +131,8 @@ public:
 	std::string to_string(const std::string& indent) const;
 };
 
+#define createPatternTerm std::make_shared<PatternTerm>
+
 // For gdb, see
 // http://wiki.opencog.org/w/Development_standards#Print_OpenCog_Objects
 std::string oc_to_string(const PatternTerm& pt,

--- a/opencog/atoms/pattern/PatternTerm.h
+++ b/opencog/atoms/pattern/PatternTerm.h
@@ -96,6 +96,12 @@ protected:
 	// variables, but this flag will not be set.
 	bool _has_bound_var;
 
+	// True if any pattern subtree rooted in this tree node contains
+	// an unordered link. Trees without any unordered links can be
+	// searched in a straight-forward manner; those with them need to
+	// have all possible permutations explored.
+	bool _has_any_unordered_link;
+
 	void addAnyBoundVar();
 
 public:
@@ -124,6 +130,9 @@ public:
 	void addBoundVariable();
 	bool hasAnyBoundVariable() const noexcept { return _has_any_bound_var; }
 	bool hasBoundVariable() const noexcept { return _has_bound_var; }
+
+	void addUnorderedLink();
+	bool hasUnorderedLink() const noexcept { return _has_any_unordered_link; }
 
 	bool operator==(const PatternTerm&);
 

--- a/opencog/atoms/pattern/PatternTerm.h
+++ b/opencog/atoms/pattern/PatternTerm.h
@@ -84,14 +84,16 @@ protected:
 	// Quotation level and local quotation
 	Quotation _quotation;
 
-	// True if the pattern subtree rooted in this tree node does not
-	// contain any bound variables. This means that the term is constant
-	// and may be self-grounded.
+	// True if any pattern subtree rooted in this tree node contains
+	// a variable bound to the search pattern. Trees without any bound
+	// search variables are constants, and are satisfied by themselves.
 	bool _has_any_bound_var;
 
-	// True if none of the outgoing set are bound variables. Unlike the
-	// above, this is for the immediate outgoing set only, and not any
-	// deeper terms.
+	// True if none of the outgoing set of this particular term are
+	// variables bound to the search pattern. Unlike the above flag,
+	// this flag is set for the immediate outgoing set only, and not
+	// any deeper terms.  That is, deeper terms may contain bound
+	// variables, but this flag will not be set.
 	bool _has_bound_var;
 
 	void addAnyBoundVar();

--- a/opencog/query/DefaultPatternMatchCB.cc
+++ b/opencog/query/DefaultPatternMatchCB.cc
@@ -155,7 +155,6 @@ void DefaultPatternMatchCB::set_pattern(const Variables& vars,
 	_have_evaluatables = ! _dynamic->empty();
 	_have_variables = ! vars.varseq.empty();
 	_pattern_body = pat.body;
-	_globs = &pat.globby_terms;
 }
 
 /* ======================================================== */
@@ -247,7 +246,7 @@ bool DefaultPatternMatchCB::link_match(const PatternTermPtr& ptm,
 	if (pattype != soltype) return false;
 
 	// Reject mis-sized compares, unless the pattern has a glob in it.
-	if (0 == _globs->count(lpat) and lpat->get_arity() != lsoln->get_arity())
+	if (not ptm->hasGlobbyVar() and lpat->get_arity() != lsoln->get_arity())
 		return false;
 
 	// If the link is a ScopeLink, we need to deal with the

--- a/opencog/query/DefaultPatternMatchCB.h
+++ b/opencog/query/DefaultPatternMatchCB.h
@@ -101,7 +101,6 @@ class DefaultPatternMatchCB : public virtual PatternMatchCallback
 		const Variables* _vars = nullptr;
 		const HandleSet* _dynamic = nullptr;
 		bool _have_evaluatables = false;
-		const HandleSet* _globs = nullptr;
 
 		bool _have_variables;
 		Handle _pattern_body;

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1223,14 +1223,11 @@ bool PatternMatchEngine::explore_term_branches(const Handle& term,
 	auto pl = _pat->connected_terms_map.find({term, clause});
 	OC_ASSERT(_pat->connected_terms_map.end() != pl, "Internal error");
 
-	// Check if the pattern has globs in it.
-	bool has_glob = (0 < _pat->globby_holders.count(term));
-
 	for (const PatternTermPtr &ptm : pl->second)
 	{
 		DO_LOG({LAZY_LOG_FINE << "Begin exploring term: " << ptm->to_string();})
 		bool found;
-		if (has_glob)
+		if (ptm->hasAnyGlobbyVar())
 			found = explore_glob_branches(ptm, hg, clause);
 		else
 			found = explore_odometer(ptm, hg, clause);

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1293,6 +1293,20 @@ bool PatternMatchEngine::explore_upvar_branches(const PatternTermPtr& ptm,
 	// and directly move upwards. Do this by assembling the single
 	// (unique) upward term, and then seeing if it's acceptable
 	// to the gaunlet of callbacks. If it is, we are done.
+	//
+	// The prototypical csearch being handled here is that of
+	//
+	//     EvaluationLink
+	//         PredicateNode "some const"
+	//         ListLink
+	//             VariableNode "$x"
+	//             ConceptNode "foo"
+	//
+	// If we arrive here, with `ptm` being teh ListLink, and the `hg`
+	// being the grounding of the ListLink, then we should be able to
+	// immediately jump to the EvaluationLink, withot any further ado.
+	// Specifically, there is no need to search the incoming set of `hg`
+	// just build up the EvaluationLink and offer it as the ground.
 	if (not parent->hasBoundVariable() and not ptm->hasUnorderedLink())
 	{
 		bool need_search = false;
@@ -1304,9 +1318,13 @@ bool PatternMatchEngine::explore_upvar_branches(const PatternTermPtr& ptm,
 				oset.push_back(hg);
 			else
 			{
+				// OK, so I think the if-statement below is hiding a bug
+				// of some kind. It triggers on a suspiscious construction
+				// in ScopeLinkUTest. XXX FIXME this needs more investigation.
 				if (pp->hasAnyBoundVariable())
 				{
 					need_search = true;
+					break;
 				}
 				oset.push_back(pp->getHandle());
 			}
@@ -1316,7 +1334,7 @@ bool PatternMatchEngine::explore_upvar_branches(const PatternTermPtr& ptm,
 			Handle hup(hg->getAtomSpace()->get_link(t, oset));
 			if (hup)
 				return explore_type_branches(parent, hup, clause);
-			// return false;
+			return false;
 		}
 	}
 

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -192,7 +192,7 @@ bool PatternMatchEngine::ordered_compare(const PatternTermPtr& ptm,
 
 	bool match = true;
 	const Handle &hp = ptm->getHandle();
-	if (0 < _pat->globby_terms.count(hp))
+	if (ptm->hasGlobbyVar())
 	{
 		match = glob_compare(osp, osg);
 	}
@@ -426,7 +426,7 @@ bool PatternMatchEngine::unorder_compare(const PatternTermPtr& ptm,
 	const HandleSeq& osg = hg->getOutgoingSet();
 	PatternTermSeq osp = ptm->getOutgoingSet();
 	size_t arity = osp.size();
-	bool has_glob = (0 < _pat->globby_holders.count(hp));
+	bool has_glob = ptm->hasAnyGlobbyVar();
 
 	// They've got to be the same size, at the least!
 	// unless there are globs in the pattern
@@ -1273,7 +1273,7 @@ bool PatternMatchEngine::explore_up_branches(const PatternTermPtr& ptm,
 {
 	// Check if the pattern has globs in it.
 	PatternTermPtr parent(ptm->getParent());
-	if (0 < _pat->globby_holders.count(parent->getHandle()))
+	if (parent->hasAnyGlobbyVar())
 		return explore_upglob_branches(ptm, hg, clause);
 	return explore_upvar_branches(ptm, hg, clause);
 }
@@ -1399,7 +1399,7 @@ bool PatternMatchEngine::explore_glob_branches(const PatternTermPtr& ptm,
                                                const Handle& clause_root)
 {
 	// Check if the pattern has globs in it,
-	OC_ASSERT(0 < _pat->globby_holders.count(ptm->getHandle()),
+	OC_ASSERT(ptm->hasAnyGlobbyVar(),
 	          "Glob exploration went horribly wrong!");
 
 	// Record the glob_state *before* starting exploration.

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1229,8 +1229,10 @@ bool PatternMatchEngine::explore_term_branches(const Handle& term,
 		bool found;
 		if (ptm->hasAnyGlobbyVar())
 			found = explore_glob_branches(ptm, hg, clause);
-		else
+		else if(ptm->hasUnorderedLink())
 			found = explore_odometer(ptm, hg, clause);
+		else
+			found = explore_type_branches(ptm, hg, clause);
 
 		DO_LOG({LAZY_LOG_FINE << "Finished exploring term: "
 		                      << ptm->to_string()
@@ -1413,7 +1415,7 @@ bool PatternMatchEngine::explore_glob_branches(const PatternTermPtr& ptm,
 	do
 	{
 		// It's not clear if the odometer can play nice with
-		// globby terms. Anyway, no unit test mixs these two.
+		// globby terms. Anyway, no unit test mixes these two.
 		// So, for now, we ignore it.
 		// if (explore_odometer(ptm, hg, clause_root))
 		if (explore_type_branches(ptm, hg, clause_root))

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1297,7 +1297,7 @@ bool PatternMatchEngine::explore_upvar_branches(const PatternTermPtr& ptm,
 
 	// If there aren't any unordered links anywhere, just explore
 	// directly upwards.
-	if (not parent->hasUnorderedLink())
+	if (not ptm->hasUnorderedLink())
 	{
 		bool found = false;
 		for (size_t i = 0; i < sz; i++)

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1295,17 +1295,39 @@ bool PatternMatchEngine::explore_upvar_branches(const PatternTermPtr& ptm,
 	                      << "The grounded pivot point " << hg->to_string()
 	                      << " has " << sz << " branches";})
 
+	// If there aren't any unordered links anywhere, just explore
+	// directly upwards.
+	if (not parent->hasUnorderedLink())
+	{
+		bool found = false;
+		for (size_t i = 0; i < sz; i++)
+		{
+			DO_LOG({LAZY_LOG_FINE << "Try upward branch " << i+1 << " of " << sz
+			                      << " at term=" << parent->to_string()
+			                      << " propose=" << iset[i]->to_string();})
+
+			found = explore_type_branches(parent, iset[i], clause);
+			if (found) break;
+		}
+
+		DO_LOG({LAZY_LOG_FINE << "Found upward soln = " << found;})
+		return found;
+	}
+
+	// If we are here, then there's at least one (and maybe more)
+	// unordered links, somewhere at this level, next to us or to
+	// the side and below us. Explore all of the differrent possible
+	// permutations.
 	_perm_breakout = _perm_to_step;
 	bool found = false;
 	for (size_t i = 0; i < sz; i++)
 	{
-		DO_LOG({LAZY_LOG_FINE << "Try upward branch " << i+1 << " of " << sz
+		DO_LOG({LAZY_LOG_FINE << "Try upward permutable branch "
+		                      << i+1 << " of " << sz
 		                      << " at term=" << parent->to_string()
 		                      << " propose=" << iset[i]->to_string();})
 
 		_perm_odo.clear();
-		// XXX TODO Perhaps this push can be avoided,
-		// if there are no unordered terms?
 		perm_push();
 		_perm_go_around = false;
 		found = explore_odometer(parent, iset[i], clause);

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1288,13 +1288,14 @@ bool PatternMatchEngine::explore_upvar_branches(const PatternTermPtr& ptm,
 	PatternTermPtr parent(ptm->getParent());
 	Type t = parent->getHandle()->get_type();
 
-	// If the pattern term doesn't have any other bound variables,
-	// aside from the one grounded by hg, then we can immediately
-	// and directly move upwards. Do this by assembling the single
-	// (unique) upward term, and then seeing if it's acceptable
-	// to the gaunlet of callbacks. If it is, we are done.
+	// If the parent pattern term doesn't have any other bound
+	// variables, aside from `ptm` which is grounded by `hg`,
+	// then we can immediately and directly move upwards. Do this
+	// by assembling the single (unique) upward term, and then
+	// seeing if it's acceptable to the gauntlet of callbacks.
+	// If it is, we are done.
 	//
-	// The prototypical csearch being handled here is that of
+	// The prototypical search being handled here is that of
 	//
 	//     EvaluationLink
 	//         PredicateNode "some const"
@@ -1302,12 +1303,12 @@ bool PatternMatchEngine::explore_upvar_branches(const PatternTermPtr& ptm,
 	//             VariableNode "$x"
 	//             ConceptNode "foo"
 	//
-	// If we arrive here, with `ptm` being teh ListLink, and the `hg`
+	// If we arrive here, with `ptm` being the ListLink, and the `hg`
 	// being the grounding of the ListLink, then we should be able to
-	// immediately jump to the EvaluationLink, withot any further ado.
+	// immediately jump to the EvaluationLink, without any further ado.
 	// Specifically, there is no need to search the incoming set of `hg`
 	// just build up the EvaluationLink and offer it as the ground.
-	if (not parent->hasBoundVariable() and not ptm->hasUnorderedLink())
+	if (not ptm->hasUnorderedLink())
 	{
 		bool need_search = false;
 		HandleSeq oset;

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1337,7 +1337,7 @@ bool PatternMatchEngine::explore_upvar_branches(const PatternTermPtr& ptm,
 		}
 		if (not need_search)
 		{
-			// Yuck. What we really wnat to do here is to find out
+			// Yuck. What we really want to do here is to find out
 			// if `Link(t, oset)` is in the incoming set of `hg`. But
 			// there isn't any direct way of doing this (at this time).
 			// So hack around this by asking the AtomSpace about it,

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1319,11 +1319,9 @@ bool PatternMatchEngine::explore_upvar_branches(const PatternTermPtr& ptm,
 				oset.push_back(hg);
 			else
 			{
-				// OK, so I think the if-statement below is hiding a bug
-				// of some kind. It triggers on a suspiscious construction
-				// in ScopeLinkUTest. XXX FIXME this needs more investigation.
 				if (pp->hasAnyBoundVariable())
 				{
+					// Oh no! Abandon ship!
 					need_search = true;
 					break;
 				}
@@ -1332,6 +1330,11 @@ bool PatternMatchEngine::explore_upvar_branches(const PatternTermPtr& ptm,
 		}
 		if (not need_search)
 		{
+			// Yuck. What we really wnat to do here is to find out
+			// if `Link(t, oset)` is in the incoming set of `hg`. But
+			// there isn't any direct way of doing this (at this time).
+			// So hack around this by asking the AtomSpace about it,
+			// instead.
 			Handle hup(hg->getAtomSpace()->get_link(t, oset));
 			if (hup)
 				return explore_type_branches(parent, hup, clause);


### PR DESCRIPTION
I'm pretty sure this will speed up a certain class of simple searches. 
The prototype here is a search of the form
```
      EvaluationLink
          PredicateNode "some const"
          ListLink
              VariableNode "$x"
              ConceptNode "foo"
```
The old code examined the entire incoming set of the ListLink; since that 
ListLink might be in several predicates, that was just time wasted.  The new
code jumps directly to the `EvaluationLink`, short-cutting the search.

I am fairly certain that this will provide a large speedup for the
MOZI gene annotations, as considered here:
https://github.com/MOZI-AI/annotation-scheme/issues/98
Fingers crossed.
