### PR TITLE
Don't compile debug prints.

### DIFF
--- a/opencog/query/DefaultPatternMatchCB.cc
+++ b/opencog/query/DefaultPatternMatchCB.cc
@@ -33,7 +33,7 @@
 
 using namespace opencog;
 
-#define DEBUG 1
+// #define DEBUG 1
 #ifdef DEBUG
 #define DO_LOG(STUFF) STUFF
 #else

--- a/opencog/query/InitiateSearchCB.cc
+++ b/opencog/query/InitiateSearchCB.cc
@@ -39,7 +39,7 @@
 
 using namespace opencog;
 
-#define DEBUG 1
+// #define DEBUG 1
 #ifdef DEBUG
 #define DO_LOG(STUFF) STUFF
 #else

--- a/opencog/query/PatternLinkRuntime.cc
+++ b/opencog/query/PatternLinkRuntime.cc
@@ -33,7 +33,7 @@
 
 using namespace opencog;
 
-#define DEBUG 1
+// #define DEBUG 1
 
 /* ================================================================= */
 /// A pass-through class, which wraps a regular callback, but captures

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -50,7 +50,7 @@ using namespace opencog;
 // wouldn't be kept no matter what (it's not like it's gonna take up a
 // lot of resources).
 
-#define DEBUG 1
+// #define DEBUG 1
 #ifdef DEBUG
 #define DO_LOG(STUFF) STUFF
 #else

--- a/opencog/query/Recognizer.cc
+++ b/opencog/query/Recognizer.cc
@@ -28,7 +28,7 @@
 using namespace opencog;
 
 // Uncomment below to enable debug print
-#define DEBUG 1
+// #define DEBUG 1
 #ifdef DEBUG
 #define dbgprt(f, varargs...) logger().fine(f, ##varargs)
 #else


### PR DESCRIPTION
Disabling the fine-level printing improves performance by 1% or 2%.
Since fine-level printing is only needed during debugging (which is
rare), making this a compile-time option seems reasonable to me.

This is based on the query-link benchmark, am retesting other benches.