### PR TITLE
RevDemonstrate and test a reversed recursive walk

### DIFF
--- a/opencog/atoms/execution/ExecutionOutputLink.cc
+++ b/opencog/atoms/execution/ExecutionOutputLink.cc
@@ -167,7 +167,19 @@ ValuePtr ExecutionOutputLink::execute_once(AtomSpace* as, bool silent)
 		const HandleSeq& oset(LIST_LINK == args->get_type() ?
 			args->getOutgoingSet(): HandleSeq{args});
 
-		return vars.substitute_nocheck(body, execute_args(as, oset, silent));
+		// If one of the arguments is a SetLink, then apply the
+		// lambda expression to each of the mebers in the set.
+		// This is also how PutLink works. It's needed to handle
+		// the case where GetLink returns a set of multiple results;
+		// we want to emulate that set passing through the processing
+		// pipeline. (XXX Is there a better way of doing this?)
+		bool have_set = false;
+		HandleSeq xargs(execute_args(as, oset, silent, have_set));
+
+		if (not have_set)
+			return vars.substitute_nocheck(body, xargs);
+		else
+			return vars.substitute_nocheck(body, xargs);
 	}
 
 	return get_handle();

--- a/opencog/atoms/execution/ExecutionOutputLink.cc
+++ b/opencog/atoms/execution/ExecutionOutputLink.cc
@@ -153,10 +153,11 @@ static inline HandleSeq execute_args(AtomSpace* as, HandleSeq args,
 			Handle hex(HandleCast(vp));
 			if (SET_LINK == hex->get_type())
 			{
+				size_t sz = hex->get_arity();
 				// Unwrap SetLink singletons.
-				if (1 == hex->get_arity())
+				if (1 == sz)
 					hex = hex->getOutgoingAtom(0);
-				else
+				else if (1 < sz)
 					have_set = true;
 			}
 			exargs.push_back(hex);

--- a/opencog/atoms/execution/ExecutionOutputLink.cc
+++ b/opencog/atoms/execution/ExecutionOutputLink.cc
@@ -116,10 +116,16 @@ static inline HandleSeq execute_args(AtomSpace* as, HandleSeq args, bool silent)
 		if (h->is_executable())
 		{
 			ValuePtr vp = h->execute(as, silent);
-			if (not vp->is_atom())
+			if (not vp->is_atom()) // Yuck!
 				exargs.push_back(h);
 			else
-				exargs.push_back(HandleCast(vp));
+			{
+				Handle hex(HandleCast(vp));
+				// Unwrap SetLink singletons.
+				if (SET_LINK == hex->get_type() and 1 == hex->get_arity())
+					hex = hex->getOutgoingAtom(0);
+				exargs.push_back(hex);
+			}
 		}
 		else
 			exargs.push_back(h);

--- a/tests/atoms/execution/DefinedSchemaUTest.cxxtest
+++ b/tests/atoms/execution/DefinedSchemaUTest.cxxtest
@@ -60,7 +60,7 @@ public:
 	void test_get_tail(void);
 	void test_compose(void);
 	void test_nest(void);
-	void test_recursive(void);
+	void test_reversive(void);
 };
 
 void DefinedSchemaUTest::tearDown(void)
@@ -160,23 +160,21 @@ void DefinedSchemaUTest::test_nest(void)
 
 // Test the recursive operation of ExecutionOutputLinks, where the
 // DefinedSchema is used to define recursive execution.
-// Still brokenm, XXX FIXME later, someday.
-void DefinedSchemaUTest::test_recursive(void)
+// This is called "reversive" because it inverts the tree,
+// upside-down, with a path from each leaf to the root.
+void DefinedSchemaUTest::test_reversive(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	Handle result = eval->eval_h("(cog-execute! recursive)");
+	Handle result = eval->eval_h("(cog-execute! reversive)");
 
 	printf("got %s\n", result->to_string().c_str());
 
-#if 0
-	Handle edge = eval->eval_h(""
-	);
+	Handle leaves = eval->eval_h("reversive-result");
 
-	printf("expected %s\n", edge->to_string().c_str());
+	printf("expected %s\n", leaves->to_string().c_str());
 
-	TS_ASSERT(result == edge);
-#endif
+	TS_ASSERT(result == leaves);
 
 	logger().debug("END TEST: %s", __FUNCTION__);
 }

--- a/tests/atoms/execution/DefinedSchemaUTest.cxxtest
+++ b/tests/atoms/execution/DefinedSchemaUTest.cxxtest
@@ -60,7 +60,7 @@ public:
 	void test_get_tail(void);
 	void test_compose(void);
 	void test_nest(void);
-	void xtest_recursive(void);
+	void test_recursive(void);
 };
 
 void DefinedSchemaUTest::tearDown(void)
@@ -142,7 +142,7 @@ void DefinedSchemaUTest::test_nest(void)
 
 	Handle edge = eval->eval_h(
 	"(ListLink"
-	"	(Set (ConceptNode \"B\"))"
+	"	(ConceptNode \"B\")"
 	"	(EvaluationLink"
 	"		(PredicateNode \"yikes\")"
 	"		(ListLink"
@@ -158,12 +158,10 @@ void DefinedSchemaUTest::test_nest(void)
 	logger().debug("END TEST: %s", __FUNCTION__);
 }
 
-// This is meant to test the recursive operation of ExecutionOutputLinks
-// where the DefinedSchema is used to allow recursion.  But this is
-// broken in several ways; the definition in the scm file is bad, and
-// also the C++ class ExecutionOutputLink is also not quite right.
-// XXX FIXME later, someday.
-void DefinedSchemaUTest::xtest_recursive(void)
+// Test the recursive operation of ExecutionOutputLinks, where the
+// DefinedSchema is used to define recursive execution.
+// Still brokenm, XXX FIXME later, someday.
+void DefinedSchemaUTest::test_recursive(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 

--- a/tests/atoms/execution/defined-schema.scm
+++ b/tests/atoms/execution/defined-schema.scm
@@ -121,19 +121,18 @@
 
 ; --------------------------------------------------------------
 
-; Define a recursive tree-walker.
-; XXX FIXME this is wrong; as written, this is infinitely-recursive
-; because there is no check for the empty-set during the recursion.
-; So this is a mess, but I'm too lazy to fix this right now.
+; Define a recursive tree-walker. It not only recurses, it reverses,
+; tracing a path from each leaf, back up to the root. The return is
+; a set-link, each element a path from leaf to root.
 (DefineLink
-	(DefinedSchemaNode "recursive-rewrite")
+	(DefinedSchemaNode "reversive-rewrite")
 	(Lambda
 		(VariableList (Variable "$hd") (Variable "$out"))
 		(Cond
 			(Equal (Variable "$hd") (Set))
 			(Variable "$out")
 			(ExecutionOutput
-				(DefinedSchemaNode "recursive-rewrite")
+				(DefinedSchemaNode "reversive-rewrite")
 					(List
 						(ExecutionOutputLink
 							(DefinedSchema "get-the-tail")
@@ -147,9 +146,30 @@
 
 
 ; (cog-execute!
-(define recursive
+(define reversive
 	(ExecutionOutput
-		(DefinedSchema "recursive-rewrite")
-		(List (Concept "A") (Concept "null"))))
+		(DefinedSchema "reversive-rewrite")
+		(List (Concept "A") (Concept "root"))))
+
+; What the above generates, when executed.
+(define reversive-result
+	(SetLink
+		(EvaluationLink (PredicateNode "yikes") (ListLink
+			(ConceptNode "F")
+			(EvaluationLink (PredicateNode "yikes") (ListLink
+				(ConceptNode "B")
+				(EvaluationLink (PredicateNode "yikes") (ListLink
+					(ConceptNode "A")
+					(ConceptNode "root")))))))
+		(EvaluationLink (PredicateNode "yikes") (ListLink
+			(ConceptNode "D")
+			(EvaluationLink (PredicateNode "yikes") (ListLink
+				(ConceptNode "C")
+				(EvaluationLink (PredicateNode "yikes") (ListLink
+					(ConceptNode "B")
+					(EvaluationLink (PredicateNode "yikes") (ListLink
+						(ConceptNode "A")
+						(ConceptNode "root"))))))))))
+)
 
 *unspecified*


### PR DESCRIPTION
 This pertains to the discussion in #2472, and fixes one bug discovered there.

Apparently, creating recursive lambdas in atomese is not quite as easy as one might hope. Buymmer.

I see no immediate utility for this, this is more of an exercise of principles; the Atomese "language" can express it, and so "it should have worked".
