### PR TITLE
Allow multiple rewrites for a given search.

### DIFF
--- a/opencog/atoms/pattern/QueryLink.cc
+++ b/opencog/atoms/pattern/QueryLink.cc
@@ -85,7 +85,7 @@ void QueryLink::extract_variables(const HandleSeq& oset)
 	if (2 == sz)
 	{
 		_body = oset[0];
-		_implicand = oset[1];
+		_implicand.push_back(oset[1]);
 		_variables.find_variables(oset);
 		return;
 	}
@@ -94,7 +94,8 @@ void QueryLink::extract_variables(const HandleSeq& oset)
 	// a variable declaration.
 	_vardecl = oset[0];
 	_body = oset[1];
-	_implicand = oset[2];
+	for (size_t i=2; i < oset.size(); i++)
+		_implicand.push_back(oset[i]);
 
 	// Initialize _variables with the scoped variables
 	init_scoped_variables(_vardecl);
@@ -178,7 +179,8 @@ ValueSet QueryLink::do_execute(AtomSpace* as, bool silent)
 	    and not intu->optionals_present())
 	{
 		ValueSet result;
-		result.insert(impl.inst.execute(impl.implicand, true));
+		for (const Handle& himp: impl.implicand)
+			result.insert(impl.inst.execute(himp, true));
 		return result;
 	}
 

--- a/opencog/atoms/pattern/QueryLink.cc
+++ b/opencog/atoms/pattern/QueryLink.cc
@@ -70,15 +70,17 @@ QueryLink::QueryLink(const HandleSeq& hseq, Type t)
 /// Find and unpack variable declarations, if any; otherwise, just
 /// find all free variables.
 ///
-/// On top of that initialize _body and _implicand with the
-/// clauses and the rewrite rule.
+/// On top of that, initialize _body and _implicand with the
+/// clauses and the rewrite rule(s). (Multiple implicands are
+/// allowed, this can save some CPU cycles when one search needs to
+/// create several rewrites.)
 ///
 void QueryLink::extract_variables(const HandleSeq& oset)
 {
 	size_t sz = oset.size();
-	if (sz < 2 or 3 < sz)
+	if (sz < 2)
 		throw InvalidParamException(TRACE_INFO,
-			"Expecting an outgoing set size of at most two, got %d", sz);
+			"Expecting an outgoing set size of at least two, got %d", sz);
 
 	// If the outgoing set size is two, then there are no variable
 	// declarations; extract all free variables.

--- a/opencog/atoms/pattern/QueryLink.cc
+++ b/opencog/atoms/pattern/QueryLink.cc
@@ -134,7 +134,7 @@ ValueSet QueryLink::do_execute(AtomSpace* as, bool silent)
 	if (nullptr == as) as = _atom_space;
 
 	DefaultImplicator impl(as);
-	impl.implicand = this->get_implicand();
+	impl.implicand = this->get_implicand_seq();
 
 	/*
 	 * The `do_conn_check` flag stands for "do connectivity check"; if the

--- a/opencog/atoms/pattern/QueryLink.h
+++ b/opencog/atoms/pattern/QueryLink.h
@@ -51,7 +51,8 @@ public:
 	QueryLink(const QueryLink&) = delete;
 	QueryLink& operator=(const QueryLink&) = delete;
 
-	const HandleSeq& get_implicand(void) { return _implicand; }
+	const Handle& get_implicand(void) { return _implicand[0]; }
+	const HandleSeq& get_implicand_seq(void) { return _implicand; }
 
 	virtual bool is_executable() const { return true; }
 	virtual ValuePtr execute(AtomSpace*, bool silent=false);

--- a/opencog/atoms/pattern/QueryLink.h
+++ b/opencog/atoms/pattern/QueryLink.h
@@ -35,7 +35,7 @@ protected:
 	void init(void);
 
 	/// The rewrite term
-	Handle _implicand;
+	HandleSeq _implicand;
 
 	// Overwrite PatternLink::extract_variables as QueryLink has one
 	// more outgoing for the rewrite rule. In addition this method
@@ -51,7 +51,7 @@ public:
 	QueryLink(const QueryLink&) = delete;
 	QueryLink& operator=(const QueryLink&) = delete;
 
-	const Handle& get_implicand(void) { return _implicand; }
+	const HandleSeq& get_implicand(void) { return _implicand; }
 
 	virtual bool is_executable() const { return true; }
 	virtual ValuePtr execute(AtomSpace*, bool silent=false);

--- a/opencog/query/Implicator.cc
+++ b/opencog/query/Implicator.cc
@@ -43,16 +43,21 @@ bool Implicator::grounding(const GroundingMap &var_soln,
 {
 	// PatternMatchEngine::print_solution(var_soln, term_soln);
 
-	// Ignore the case where the URE creates ill-formed links
+	// Catch and ignore SilentExceptions. This arises when
+	// running with the URE, which creates ill-formed links
 	// (due to rules producing nothing). Ideally this should
 	// be treated as a user error, that is, the user should
 	// design rule pre-conditions to prevent them from producing
 	// nothing.  In practice it is difficult to insure, so
 	// meanwhile this try-catch is used.
 	// See issue #950 and pull req #962. XXX FIXME later.
+	// Tested by BuggyBindLinkUTest and NoExceptionUTest.
 	try {
-		ValuePtr v(inst.instantiate(implicand, var_soln, true));
-		insert_result(v);
+		for (const Handle& himp: implicand)
+		{
+			ValuePtr v(inst.instantiate(himp, var_soln, true));
+			insert_result(v);
+		}
 	} catch (const SilentException& ex) {}
 
 	// If we found as many as we want, then stop looking for more.

--- a/opencog/query/Implicator.h
+++ b/opencog/query/Implicator.h
@@ -63,7 +63,7 @@ class Implicator :
 	public:
 		Implicator(AtomSpace* as) : _as(as), inst(as), max_results(SIZE_MAX) {}
 		Instantiator inst;
-		Handle implicand;
+		HandleSeq implicand;
 		size_t max_results;
 
 		virtual bool grounding(const GroundingMap &var_soln,

--- a/tests/query/ExecutionOutputUTest.cxxtest
+++ b/tests/query/ExecutionOutputUTest.cxxtest
@@ -247,7 +247,7 @@ void ExecutionOutputUTest::test_varsub(void)
 
 	// Now perform the search.
 	DefaultImplicator simpl(&as);
-	simpl.implicand = situation->get_implicand();
+	simpl.implicand = situation->get_implicand_seq();
 	situation->satisfy(simpl);
 
 	// The result_list contains a list of the grounded expressions.
@@ -257,7 +257,7 @@ void ExecutionOutputUTest::test_varsub(void)
 
 	// Now perform the search.
 	DefaultImplicator pimpl(&as);
-	pimpl.implicand = predicament->get_implicand();
+	pimpl.implicand = predicament->get_implicand_seq();
 	predicament->satisfy(pimpl);
 
 	// The result_list contains a list of the grounded expressions.

--- a/tests/query/ImplicationUTest.cxxtest
+++ b/tests/query/ImplicationUTest.cxxtest
@@ -34,7 +34,7 @@ class ImplicationUTest :  public CxxTest::TestSuite
 	private:
 		AtomSpace *as;
 		SchemeEval *eval;
-		Handle varscope, restrict, restrict2;
+		Handle varscope, restrict, restrict2, restrict_multi;
 		Handle clauses1, implicand1, clauses2, implicand2;
 
 	public:
@@ -224,6 +224,56 @@ void ImplicationUTest::setUp(void)
 	eval->eval(strict2);
 	restrict2 = eval->apply("restrict2", Handle::UNDEFINED);
 
+	// Create a varscope link with multiple implicands
+	const char * strict_multi =
+	"(define (restrict-multi)\n"
+	"(BindLink\n"
+	"   (VariableList\n"
+	"      (TypedVariableLink\n"
+	"         (VariableNode \"$predNode\")\n"
+	"         (TypeNode \"PredicateNode\")\n"
+	"      )\n"
+	"      (TypedVariableLink\n"
+	"         (VariableNode \"$framNode\")\n"
+	"         (TypeNode \"WordSenseNode\")\n"
+	"      )\n"
+	"      (TypedVariableLink\n"
+	"         (VariableNode \"$framboise\")\n"
+	"         (TypeNode \"WordSenseNode\")\n"
+	"      )\n"
+	"   )\n"
+	"   (AndLink\n"
+	"      (InheritanceLink (stv 1 1)\n"
+	"         (VariableNode \"$predNode\")\n"
+	"         (VariableNode \"$framboise\")\n"
+	"      )\n"
+	"      (InheritanceLink (stv 1 1)\n"
+	"         (VariableNode \"$framNode\")\n"
+	"         (VariableNode \"$framboise\")\n"
+	"      )\n"
+	"   )\n"
+	"   (ListLink\n"
+	"      (Concept \"version one\")\n"
+	"      (VariableNode \"$predNode\")\n"
+	"      (VariableNode \"$framNode\")\n"
+	"   )\n"
+	"   (ListLink\n"
+	"      (Concept \"version two\")\n"
+	"      (VariableNode \"$framNode\")\n"
+	"      (VariableNode \"$predNode\")\n"
+	"   )\n"
+	"   (ListLink\n"
+	"      (VariableNode \"$framNode\")\n"
+	"      (VariableNode \"$predNode\")\n"
+	"      (Concept \"version middle\")\n"
+	"      (VariableNode \"$predNode\")\n"
+	"      (VariableNode \"$framNode\")\n"
+	"   )\n"
+	")\n"
+	")\n";
+	eval->eval(strict_multi);
+	restrict_multi = eval->apply("restrict-multi", Handle::UNDEFINED);
+
 	// Create data on which the above pattern should match
 	const char * str = 
 	"(InheritanceLink (stv 1.0 1.0)\n"
@@ -282,6 +332,11 @@ void ImplicationUTest::test_exec(void)
 	result = bindlink(as, restrict2);
 	logger().debug("fifth result is %s\n", SchemeSmob::to_string(result).c_str());
 	TSM_ASSERT_EQUALS("wrong number of solutions found", 1, getarity(result));
+
+	// Result should be a ListLink w/ three solutions
+	result = bindlink(as, restrict_multi);
+	logger().debug("sixth result is %s\n", SchemeSmob::to_string(result).c_str());
+	TSM_ASSERT_EQUALS("wrong number of solutions found", 3, getarity(result));
 
 	logger().debug("END TEST: %s", __FUNCTION__);
 }

--- a/tests/query/imply.h
+++ b/tests/query/imply.h
@@ -28,7 +28,7 @@ static inline Handle imply(AtomSpace* as, Handle hclauses, Handle himplicand)
 
 	// Now perform the search.
 	DefaultImplicator impl(as);
-	impl.implicand = himplicand;
+	impl.implicand.push_back(himplicand);
 
 	bl->satisfy(impl);
 


### PR DESCRIPTION
There is no particular reason for a rewrite to produce only one result, and considerable performance gains are possible by allowing multiple rewrites at once.  So remove that artificial restriction. (This is a rather simple change.)