### PR TITLE
Explain that NOTYPE means bottom type

### DIFF
--- a/opencog/atoms/atom_types/atom_types.script
+++ b/opencog/atoms/atom_types/atom_types.script
@@ -12,7 +12,9 @@
 // CamelCase names).
 // ===========================================================
 
-// Special type designating that no atom type has been assigned.
+// Special type designating that no atom type has been assigned. It is
+// equivalent to the bottom type in type theory, see
+// https://en.wikipedia.org/wiki/Bottom_type
 NOTYPE
 
 // --------------------------------------------------------------


### PR DESCRIPTION
Indeed it wasn't clear from that comment alone whether it meant bottom
or unknown, but after reviewing the code using it, it is clear that it
means bottom.