### PR TITLE
Easy-to-use API for EvaluationLinks

### DIFF
--- a/opencog/README.md
+++ b/opencog/README.md
@@ -1,7 +1,7 @@
 
 AtomSpace Source Code
 =====================
-The atomspace implementation is here. But first, a quick overview of the
+The AtomSpace implementation is here. But first, a quick overview of the
 basics.
 
 
@@ -163,7 +163,7 @@ What is the Matrix API?
 -----------------------
 Binary relations between things, for example "A is-a B", can be thought
 of as defining a (sparse) matrix between things of type A and type B,
-where A and B are individually the row and column lables in that matrix.
+where A and B are individually the row and column labels in that matrix.
 The value system allows arbitrary data to be stored at these matrix
 locations, such as counts, frequencies, probabilities, and so on. This
 in turn allows conditional probabilities, marginal probabilities and
@@ -172,7 +172,7 @@ computed and stored.
 
 This differs from traditional science packages, such as SciPy or Gnu R
 (or Octave, or MatLab ...) in that the AtomSpace enables extremely sparse
-matricies to be stored. For example, matricies of 200K by 200K entries
+matrices to be stored. For example, matrices of 200K by 200K entries
 are not uncommon in linguistics and genomics/proteomics.  Non-sparse
 representations would require 200K x 200K = 40 billion entries, the vast
 majority of which are zero. The AtomSpace allows for ultra-sparse,

--- a/opencog/README.md
+++ b/opencog/README.md
@@ -154,6 +154,39 @@ themselves are stored in the atomspace. This enables things like a
 graph. This allows the database to act as a rule engine, holding a large
 number of rules.
 
+Examples of "dual searches" include chatbots, which, given some input
+text, wish to locate possible replies by matching fragments of that
+input. The pattern matcher extends the idea of this kind of search to
+arbitrary graph structures.
+
+What is the Matrix API?
+-----------------------
+Binary relations between things, for example "A is-a B", can be thought
+of as defining a (sparse) matrix between things of type A and type B,
+where A and B are individually the row and column lables in that matrix.
+The value system allows arbitrary data to be stored at these matrix
+locations, such as counts, frequencies, probabilities, and so on. This
+in turn allows conditional probabilities, marginal probabilities and
+other statistical properties, or linear-algebra in general to be
+computed and stored.
+
+This differs from traditional science packages, such as SciPy or Gnu R
+(or Octave, or MatLab ...) in that the AtomSpace enables extremely sparse
+matricies to be stored. For example, matricies of 200K by 200K entries
+are not uncommon in linguistics and genomics/proteomics.  Non-sparse
+representations would require 200K x 200K = 40 billion entries, the vast
+majority of which are zero. The AtomSpace allows for ultra-sparse,
+ultra-high-dimension matrixes to be stored.
+
+This should also be contrasted to artificial neural nets and deep
+learning: in most common applications of neural nets, the dimensions
+of the "hidden layers" rarely exceed several thousand, precisely due
+to O(N^2) explosion of non-zero entries. In all of the standard
+approaches, the weight vectors in neural nets are NOT sparse. By
+contrast, the AtomSpace provides a framework for performing neural-net
+type research with ultra-high-dimension, ultra-sparse connectivity
+diagrams.
+
 
 What is the Unified Rule Engine?
 --------------------------------
@@ -169,6 +202,9 @@ There are four different ways of managing rules. Two are the traditional
 forward-chaining and backward-chaining algorithms, full analogous to
 those chainers commonly seen in many kinds of logic engines and theorem
 proving systems (most rule engines provide only a forward chainer).
+Its not in this repo; it's in the
+[opencog/ure](https://github.com/opencog/ure) repo, and is at release
+level, and fully supported.
 
 A third type of rule engine is based on the idea of parsing. It is
 neither a forward nor backward chainer, but combines a bit of both,

--- a/opencog/matrix/CMakeLists.txt
+++ b/opencog/matrix/CMakeLists.txt
@@ -5,6 +5,7 @@ ADD_GUILE_MODULE (FILES
 	cosine.scm
 	dynamic.scm
 	entropy.scm
+	eval-pairs.scm
 	filter.scm
 	fold-api.scm
 	loop-api.scm

--- a/opencog/matrix/README.md
+++ b/opencog/matrix/README.md
@@ -91,11 +91,17 @@ The tools implemented here include:
  * Performing cuts, to remove unwanted rows, columns and individual entries.
 
 To use these tools, all you need to do is to specify a low-level
-object that describes the matrix. It needs to provide some very simple
-but important methods: the `'left-type` and `'right-type` methods,
-that return the atom type of the rows and the columns; a `'pair-type`
-method that returns the atom-type of the pair, and a `'pair-count`
-method that returns the count, given the pair.
+object that describes the matrix. If the matrix is in the form of an
+`EvaluationLink`, as shown above, then it is sufficient to use the
+`make-evaluation-pair-api` to describe the types of the left and right
+(row and column) atoms, and the `PredicateNode` identifying the pair;
+everything else is automated. If the matrix is not of the above form,
+then it is quite easy to write a small, custom matrix-access object
+that defines what the pairs are. See `object-api.scm` for details;
+in short, one provides some very simple methods: the `'left-type` and
+`'right-type` methods, that return the atom type of the rows and the
+columns; a `'pair-type` method that returns the atom-type of the pair,
+and a `'pair-count` method that returns the count, given the pair.
 
 
 FAQ
@@ -136,7 +142,7 @@ FAQ
    Also: realize that the end-goal of OpenCog is not to export data
    once, analyze it once, and be done. Rather, the goal is to constantly
    and continuously monitor external, real-world events, pull them into
-   the atomspace, crunch it incessantly, and update knowledge of the
+   the AtomSpace, crunch it incessantly, and update knowledge of the
    external world as a result. This rules out GUI tools for data
    processing (because there's no GUI in a server) and it rules out
    popsicle-stick architectures as being a bit hokey.
@@ -148,7 +154,8 @@ FAQ
    to work with different cuts and filters, where you discard much of
    the data, or average together different parts: can you really afford
    the RAM needed to export all of these different cut and filtered
-   datasets?  Maybe you can, its just not trivial.
+   datasets?  Maybe you can, its just not trivial. (In my datasets,
+   petabytes of RAM would be needed for non-sparse representations.)
 
 **Q:** But if I did want to do it for Gnu R, how could I do it?
 
@@ -214,9 +221,9 @@ count (or other numeric value).
 
 The methods that need to be implemented are described in
 `object-api.scm`. Working examples of the base classes can be found in
-http://github.com/opencog/opencog/tree/master/opencog/nlp/learn/scm/batch-word-pair.scm
+https://github.com/opencog/learn/tree/master/scm/batch-word-pair.scm
 and in
-http://github.com/opencog/opencog/tree/master/opencog/nlp/learn/scm/pseudo-csets.scm
+https://github.com/opencog/learn/tree/master/scm/pseudo-csets.scm
 
 Basic definitions
 -----------------

--- a/opencog/matrix/eval-pairs.scm
+++ b/opencog/matrix/eval-pairs.scm
@@ -1,0 +1,253 @@
+;
+; eval-pairs.scm
+;
+; Define an EvaluationLink matrix API object.
+;
+; Copyright (c) 2013, 2014, 2017, 2020 Linas Vepstas
+;
+; ---------------------------------------------------------------------
+; OVERVIEW
+; --------
+; The object below provides a matrix API to access pairs of Atoms, held
+; in an EvaluationLink. This API unlocks a suite of tools for computing
+; various properties of the matrix, including frequencies, marginal
+; probabilities and assorted vector-space properties.  By "matrix" it
+; is meant a rank-2 parse matrix, a matrix of (left,right) paris or
+; (row, column) pairs. This is exactly the API needed to unlock the
+; toolset in the `(use-modules (opencog matrix))` statistical analysis
+; subsystem.
+;
+; To be explicit: a sparse matrix can be encoded in the AtomSpace as
+;
+;     EvaluationLink
+;         PredicateNode "some named relationship"
+;         ListLink
+;             SomeAtom "Some thing on the left (row)"
+;             OtherNode "some other atom on right (column)"
+;
+; Matrix entries N(x,y) are stored as counts (numbers) on the
+; EvaluationLink, with the `x` being the left atom, and `y`
+; being the right atom.
+;
+; Given the generic API, the matrx system will compute marginals N(x,*)
+; and N(*,y), a grand total N(*,*) and then probabilities:
+;     p(x,y) = N(x,y)/N(*,*)
+; and from this, various other statistical quantities, such as mutual
+; information.
+;
+; ---------------------------------------------------------------------
+;
+(use-modules (srfi srfi-1))
+(use-modules (opencog))
+(use-modules (opencog matrix))
+
+; ---------------------------------------------------------------------
+
+(define-public (make-evaluation-pair-api PRED-NODE LEFT-TYPE RIGHT-TYPE
+               ANY-LEFT ANY-RIGHT ID NAME)
+"
+  make-evaluation-pair-api -- Pair access methods for EvaluationLinks.
+
+  This implements a matrix object representing atom-pairs, when these
+  are encoded in an EvaluationLink in the usual style.  An atom pair is
+  represented as:
+
+    EvaluationLink
+       PredicateNode \"Some named relation\"
+       ListLink
+          SomeAtom \"some thing on left (in a row)\"
+          OtherNode \"other thing on right (in a column)\"
+
+  This Atom (the EvaluationLink) be used to record counts, frequencies,
+  entropies, etc pertaining to this particular pair, simply by placing
+  them, as values, on the EvaluationLink. The EvaluationLink serves as
+  a well-known location in a sparse rank-2 matrix; arbitrary data can
+  be placed there.
+
+  The PRED-NODE should be the `PredicateNode` encoding the relation.
+  The LEFT-TYPE should be the atom type of the row-atoms.
+  The RIGHT-TYPE should be the atom type of the column-atoms.
+    (Atom types are scheme symbols, for example 'ConceptNode.)
+
+  The ID should be a short string that serves as a unique id for
+  this particular matrix. It is used when constructing submatrixes
+  and filtered variants of this matrix.
+
+  The NAME should be a long string describing the contents of this
+  matrix. It is used as a title when printing summary reports.
+
+  The ANY-LEFT and ANY-RIGHT should be atoms where row and column
+  marginals can be stored.  The `AnyNode` is convenient for this
+  purpose. Thus, for example, marginal probabilities for rows of
+  genomic data might be encoded as:
+
+    EvaluationLink
+       PredicateNode \"Some named relation\"
+       ListLink
+          AnyNode \"left-gene\"
+          GeneNode \"SIRT1\"
+
+  The corresponding usage for this object would then be:
+
+    (make-evaluation-pair-api (Predicate \"Some named relation\")
+       'GeneNode 'GeneNode (Any \"left-gene\") (Any \"right-gene\")
+       \"gene-pairs\" \"Interacting pairs of genes\")
+"
+	(let ((all-pairs '()))
+
+		; Get the observational count on ATOM.
+		(define (get-count ATOM) (cog-count ATOM))
+
+		(define (get-left-type) LEFT-TYPE)
+		(define (get-right-type) RIGHT-TYPE)
+		(define (get-pair-type) 'EvaluationLink)
+
+		; Return the atom holding the count, if it exists, else
+		; return nil.
+		(define (get-pair L-ATOM R-ATOM)
+			(define maybe-list (cog-link 'ListLink L-ATOM R-ATOM))
+			(if (null? maybe-list) '()
+				(cog-link 'EvaluationLink PRED-NODE maybe-list)))
+
+		; Create an atom to hold the count (if it doesn't exist already).
+		(define (make-pair L-ATOM R-ATOM)
+			(EvaluationLink PRED-NODE (List L-ATOM R-ATOM)))
+
+		; Return the left member of the pair. Given the pair-atom,
+		; locate the left-side atom.
+		(define (get-left-element PAIR)
+			(gadr PAIR))
+		(define (get-right-element PAIR)
+			(gddr PAIR))
+
+		; Return the raw observational count on PAIR. If the counter for
+		; PAIR does not exist (was not observed), then return 0.
+		(define (get-pair-count L-ATOM R-ATOM)
+			(define pr (get-pair L-ATOM R-ATOM))
+			(if (null? pr) 0 (get-count pr)))
+
+		; Caution: this unconditionally creates the wildcard pair!
+		(define (get-left-wildcard WORD)
+			(make-pair ANY-LEFT WORD))
+
+		; Caution: this unconditionally creates the wildcard pair!
+		(define (get-right-wildcard WORD)
+			(make-pair WORD ANY-RIGHT))
+
+		(define (get-wild-wild)
+			(make-pair ANY-LEFT ANY-RIGHT))
+
+		; get-all-pairs - return a list holding all of the observed
+		; pairs.  Caution: this can be obscenely long!
+		(define (do-get-all-pairs)
+			; The list of pairs is mostly just the incoming set of the
+			; predicate node. However, this does include some junk, so
+			; filter out all rows and columns of the incorrect type.
+		   (filter!
+				(lambda (pair)
+					(and
+						(equal? LEFT-TYPE (cog-type (gadr pair)))
+						(equal? RIGHT-TYPE (cog-type (gddr pair)))))
+				(cog-incoming-by-type PRED-NODE 'EvaluationLink)))
+
+		(define (get-all-pairs)
+			(if (null? all-pairs) (set! all-pairs (do-get-all-pairs)))
+			all-pairs)
+
+		; fetch-all-pairs -- fetch all counts for atom pairs
+		; from the currently-open database.
+		(define (fetch-all-pairs)
+			(define start-time (current-time))
+			(fetch-incoming-set PRED-NODE)
+			(format #t "Elapsed time to load pairs: ~A secs\n"
+				(- (current-time) start-time))
+		)
+
+		; Delete the pairs from the atomspace AND the database.
+		; But only those that are currently in the atomspace are
+		; deleted; if any are hiding in the database, they will not be
+		; touched.
+		(define (delete-all-pairs)
+			(define start-time (current-time))
+			(for-each (lambda (PAIR) (cog-delete-recursive (gdr PAIR)))
+				(cog-incoming-set PRED-NODE))
+			(cog-delete PRED-NODE)
+			(cog-delete ANY-LEFT)
+			(cog-delete ANY-RIGHT)
+			(format #t "Elapsed time to delete pairs: ~A secs\n"
+				(- (current-time) start-time))
+		)
+
+      ;-------------------------------------------
+
+		(define (help)
+			(format #t
+				(string-append
+"This is the `make-evaluation-pair-api` object. It provides a matrix API\n"
+"for the EvaluationLinks of the following form:\n"
+"\n"
+"     EvaluationLink\n"
+"         PredicateNode \"~A\"\n"
+"         ListLink\n"
+"             ~A ...\n"
+"             ~A ...\n"
+"\n"
+"All of the core matrix API methods are provided; these include:\n"
+"\n"
+"    name             The string name of the object\n"
+"    id               The string ID of the object\n"
+"    left-type        The type of the row Atoms\n"
+"    right-type       The type of the column Atoms\n"
+"    pair-type        Returns 'EvalutionLink\n"
+"    pair-count L R   Returns the count on Evaluation Pred List L R\n"
+"    get-pair L R     Returns Evaluation Pred List L R, if it exists, else null\n"
+"    get-count E      Returns the count on E (an EvaluationLink)\n"
+"    make-pair L R    Unconditionally make Evaluation Pred List L R\n"
+"    left-element E   Return the row Atom of the EvaluationLink E\n"
+"    right-element E  Return the column Atom of the EvaluationLink E\n"
+"    left-wildcard R  Return Evaluation Pred List ANY R\n"
+"    right-wildcard L Return Evaluation Pred List L ANY\n"
+"    wild-wild        Return Evaluation Pred List ANY ANY\n"
+"    all-pairs        Return a list of all non-zero entries in the matrix\n"
+"    fetch-pairs      Fetch all matrix entries from currently-open database\n"
+"    delete-pairs     Delete all pairs for this matrix in the AtomSpace\n"
+"    help             Print this message\n"
+"    describe         Print documentation for make-evaluation-pair-api\n"
+)
+				(cog-name PRED-NODE) LEFT-TYPE RIGHT-TYPE)
+			*unspecified*)
+
+		(define (describe)
+			(display (procedure-property make-evaluation-pair-api 'documentation)))
+
+      ;-------------------------------------------
+
+		; Methods on the object.
+		(lambda (message . args)
+			(apply (case message
+					((name)             (lambda () NAME))
+					((id)               (lambda () ID))
+					((left-type)        get-left-type)
+					((right-type)       get-right-type)
+					((pair-type)        get-pair-type)
+					((pair-count)       get-pair-count)
+					((get-pair)         get-pair)
+					((get-count)        get-count)
+					((make-pair)        make-pair)
+					((left-element)     get-left-element)
+					((right-element)    get-right-element)
+					((left-wildcard)    get-left-wildcard)
+					((right-wildcard)   get-right-wildcard)
+					((wild-wild)        get-wild-wild)
+					((all-pairs)        get-all-pairs)
+					((fetch-pairs)      fetch-all-pairs)
+					((delete-pairs)     delete-all-pairs)
+					((provides)         (lambda (symb) #f))
+					((filters?)         (lambda () #f))
+					((help)             help)
+					((describe)         describe)
+					(else (error "Bad method call on evaluation-api:" message)))
+				args)))
+)
+
+; ---------------------------------------------------------------------

--- a/opencog/matrix/eval-pairs.scm
+++ b/opencog/matrix/eval-pairs.scm
@@ -36,12 +36,6 @@
 ; information.
 ;
 ; ---------------------------------------------------------------------
-;
-(use-modules (srfi srfi-1))
-(use-modules (opencog))
-(use-modules (opencog matrix))
-
-; ---------------------------------------------------------------------
 
 (define-public (make-evaluation-pair-api PRED-NODE LEFT-TYPE RIGHT-TYPE
                ANY-LEFT ANY-RIGHT ID NAME)

--- a/opencog/matrix/matrix.scm
+++ b/opencog/matrix/matrix.scm
@@ -3,6 +3,7 @@
 ; Wraps up the assorted tools and scripts into one module.
 ;
 (define-module (opencog matrix))
+(use-modules (opencog))
 
 ; ---------------------------------------------------------
 ; Common configuration
@@ -26,7 +27,7 @@
 ; The files are loaded in pipeline order.
 ; In general, the later files depend on definitions contained
 ; in the earlier files.
-(load "matrix/eval-pair.scm")
+(load "matrix/eval-pairs.scm")
 (load "matrix/object-api.scm")
 (load "matrix/dynamic.scm")
 (load "matrix/support.scm")

--- a/opencog/matrix/matrix.scm
+++ b/opencog/matrix/matrix.scm
@@ -26,6 +26,7 @@
 ; The files are loaded in pipeline order.
 ; In general, the later files depend on definitions contained
 ; in the earlier files.
+(load "matrix/eval-pair.scm")
 (load "matrix/object-api.scm")
 (load "matrix/dynamic.scm")
 (load "matrix/support.scm")

--- a/opencog/matrix/object-api.scm
+++ b/opencog/matrix/object-api.scm
@@ -67,15 +67,20 @@
 ;
 ; ---------------------------------------------------------------------
 ;
-; Example low-level API class. It has only six methods; these
-; return atoms on which observation counts are stored as values.
+; Example low-level API class. It provides a handful of core methods;
+; these return atoms on which observation counts are stored as values.
 ; Higher-level objects use this object to fetch counts, store them
-; into the database, or to return various statistics.
+; into the database, or to compute and return various statistics.
 ;
-; The `add-pair-count-api` class, below, is a typical user of this
-; class; it provides getters and setters for the counts.
+; Most users will find it easiest to use the `make-evaluation-pair-api`
+; to provide the low-level API.  It is ideal, when counts are stored
+; in the form of `EvaluationLink PredicateNode "..." ListLink ...`.
 ;
-; See `make-any-link-api` for a working example.
+; The `add-pair-freq-api` class, below, is a typical user of this
+; class; it provides getters and setters for the frequencies.
+;
+; See `make-evaluation-pair-api` and `make-any-link-api` for working
+; examples.
 ;
 ; When called, this will create a new instance of the class
 ; i.e. will create a new object.


### PR DESCRIPTION
Provide an easy-to-use API for matrix algebra for any sparse matrix encoded with `EvaluationLink`. This provides simple one-liner solutions for the most common use case. Examples include those from the MOZI and agi-bio datasets, for example gene-protein expression:
```
   (make-evaluation-pair-api
      (PredicateNode "expresses")
      'GeneNode 'MoleculeNode
      (AnyNode "left-gene") (AnyNode "right-protein")
      "Gene-expression"
      "Gene-Protein pairs, predicate `expresses`")
```
which defines a matrix for 
```
   EvaluationLink
       PredicateNode "expresses"
       ListLink
            GeneNode "foo"
            MoleculeNode "bar"
```