### PR TITLE
Bugfix variables extend

### DIFF
--- a/opencog/atoms/atom_types/NameServer.h
+++ b/opencog/atoms/atom_types/NameServer.h
@@ -160,6 +160,25 @@ public:
         return n_children;
     }
 
+    /**
+     * Given the type `type`, get all of the parents. This is
+     * recursive, that is, parents of the parents are returned.
+     * Stores the parent types on the OutputIterator 'result'.
+     * Returns the number of parent types.
+     */
+    template <typename OutputIterator>
+    unsigned long getParentsRecursive(Type type, OutputIterator result) const
+    {
+        unsigned long n_parents = 0;
+        for (Type i = 0; i < nTypes; ++i) {
+            if (recursiveMap[i][type] and (type != i)) {
+                *(result++) = i;
+                n_parents++;
+            }
+        }
+        return n_parents;
+    }
+
     template <typename Function>
     void foreachRecursive(Function func, Type type) const
     {

--- a/opencog/atoms/core/TypeUtils.cc
+++ b/opencog/atoms/core/TypeUtils.cc
@@ -21,6 +21,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <opencog/util/algorithm.h>
 #include <opencog/atoms/base/Link.h>
 #include <opencog/atoms/atom_types/NameServer.h>
 
@@ -351,46 +352,6 @@ bool is_well_typed(const TypeSet& ts)
 		if (not is_well_typed(t))
 			return false;
 	return true;
-}
-
-Type type_intersection(Type lhs, Type rhs)
-{
-	NameServer& ns = nameserver();
-	if (ns.isA(lhs, rhs))
-		return lhs;
-	if (ns.isA(rhs, lhs))
-		return rhs;
-	return NOTYPE;              // represent the bottom type
-}
-
-TypeSet type_intersection(Type lhs, const TypeSet& rhs)
-{
-	TypeSet res;
-	// Distribute the intersection over the union type rhs
-	for (Type rhst : rhs) {
-		Type ty = type_intersection(lhs, rhst);
-		if (ty != NOTYPE)
-			res.insert(ty);
-	}
-	return res;
-}
-
-TypeSet type_intersection(const TypeSet& lhs,
-                          const TypeSet& rhs)
-{
-	// Base cases
-	if (lhs.empty())
-		return rhs;
-	if (rhs.empty())
-		return lhs;
-
-	// Recursive cases
-	TypeSet res;
-	for (Type ty : lhs) {
-		TypeSet itr = type_intersection(ty, rhs);
-		res.insert(itr.begin(), itr.end());
-	}
-	return res;
 }
 
 VariableSetPtr gen_variable_set(const Handle& h)

--- a/opencog/atoms/core/TypeUtils.h
+++ b/opencog/atoms/core/TypeUtils.h
@@ -177,15 +177,6 @@ bool is_well_typed(Type t);
 bool is_well_typed(const TypeSet& ts);
 
 /**
- * Return shallow type intersection between lhs and rhs. Take into
- * account type inheritance as well.
- */
-Type type_intersection(Type lhs, Type rhs);
-TypeSet type_intersection(Type lhs, const TypeSet& rhs);
-TypeSet type_intersection(const TypeSet& lhs,
-                          const TypeSet& rhs);
-
-/**
  * Generate a VariableSet of the free variables of a given atom h.
  */
 VariableSetPtr gen_variable_set(const Handle& h);

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -717,7 +717,7 @@ void Variables::get_vartype(const Handle& htypelink)
 		Type vt = TypeNodeCast(vartype)->get_kind();
 		TypeSet ts;
 		TypeSet::iterator it = ts.begin();
-		nameserver().getChildren(vt, std::inserter(ts, it));
+		nameserver().getParentsRecursive(vt, std::inserter(ts, it));
 		_simple_typemap.insert({varname, ts});
 	}
 	else if (TYPE_CHOICE == t)
@@ -745,6 +745,17 @@ void Variables::get_vartype(const Handle& htypelink)
 					TypeSet ts;
 					auto i_it = std::inserter(ts, ts.begin());
 					nameserver().getChildrenRecursive(vt, i_it);
+					typeset.insert(ts.begin(), ts.end());
+				}
+			}
+			else if (TYPE_CO_INH_NODE == var_type)
+			{
+				Type vt = TypeNodeCast(ht)->get_kind();
+				if (ATOM != vt)
+				{
+					TypeSet ts;
+					auto i_it = std::inserter(ts, ts.begin());
+					nameserver().getParentsRecursive(vt, i_it);
 					typeset.insert(ts.begin(), ts.end());
 				}
 			}

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -737,6 +737,17 @@ void Variables::get_vartype(const Handle& htypelink)
 				Type vt = TypeNodeCast(ht)->get_kind();
 				if (ATOM != vt) typeset.insert(vt);
 			}
+			else if (TYPE_INH_NODE == var_type)
+			{
+				Type vt = TypeNodeCast(ht)->get_kind();
+				if (ATOM != vt)
+				{
+					TypeSet ts;
+					auto i_it = std::inserter(ts, ts.begin());
+					nameserver().getChildrenRecursive(vt, i_it);
+					typeset.insert(ts.begin(), ts.end());
+				}
+			}
 			else if (SIGNATURE_LINK == var_type)
 			{
 				const HandleSeq& sig = ht->getOutgoingSet();

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -1274,11 +1274,11 @@ void Variables::extend(const Variables& vset)
 			if (typemap_it != vset._simple_typemap.end())
 			{
 				const TypeSet& tms = typemap_it->second;
-				TypeSet mytypes =
-					type_intersection(_simple_typemap[h], tms);
-				_simple_typemap.erase(h);	 // is it safe to erase if
-                                             // h not in already?
-				_simple_typemap.insert({h, mytypes});
+				auto tti = _simple_typemap.find(h);
+				if(tti != _simple_typemap.end())
+					tti->second = set_intersection(tti->second, tms);
+				else
+					_simple_typemap.insert({h, tms});
 			}
 		}
 		else

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -709,7 +709,7 @@ void Variables::get_vartype(const Handle& htypelink)
 		Type vt = TypeNodeCast(vartype)->get_kind();
 		TypeSet ts;
 		TypeSet::iterator it = ts.begin();
-		nameserver().getChildren(vt, std::inserter(ts, it));
+		nameserver().getChildrenRecursive(vt, std::inserter(ts, it));
 		_simple_typemap.insert({varname, ts});
 	}
 	else if (TYPE_CO_INH_NODE == t)

--- a/tests/atoms/core/VariablesUTest.cxxtest
+++ b/tests/atoms/core/VariablesUTest.cxxtest
@@ -35,7 +35,7 @@ using namespace opencog;
 class VariablesUTest : public CxxTest::TestSuite
 {
 private:
-	Handle A, B, W, X, Y, Z, NT, PNT, CNT;
+	Handle A, B, W, X, Y, Z, NT, PNT, CNT, NTI, DPTCI, LLT, LTI;
 
 	AtomSpace _as;
 
@@ -55,10 +55,16 @@ public:
 		NT = an(TYPE_NODE, "Node");
 		PNT = an(TYPE_NODE, "PredicateNode");
 		CNT = an(TYPE_NODE, "ConceptNode");
+		NTI = an(TYPE_INH_NODE, "Node");
+		DPTCI = an(TYPE_CO_INH_NODE, "DefinedPredicateNode");
+		LLT = an(TYPE_NODE, "ListLink");
+		LTI = an(TYPE_INH_NODE, "Link");
 	}
 
 	void test_extend_1();
 	void test_extend_2();
+	void test_extend_3();
+	void test_extend_4();
 	void test_find_variables_ordered_1();
 	void test_find_variables_ordered_2();
 	void test_find_variables_ordered_3();
@@ -119,8 +125,66 @@ void VariablesUTest::test_extend_2()
 		              al(TYPED_VARIABLE_LINK, X, PNT),
 		              al(TYPED_VARIABLE_LINK, Y, al(TYPE_CHOICE, PNT, CNT))),
 		expect = al(VARIABLE_LIST,
-		            al(TYPED_VARIABLE_LINK, X, PNT),
+		            al(TYPED_VARIABLE_LINK, X, al(TYPE_CHOICE)),
 		            al(TYPED_VARIABLE_LINK, Y, CNT));
+
+	VariableList vl1(vardecl1), vl2(vardecl2);
+
+	Variables v1(vl1.get_variables()), v2(vl2.get_variables());
+
+	v1.extend(v2);
+
+	Handle result = _as.add_atom(v1.get_vardecl());
+
+	logger().debug() << "expect = " << oc_to_string(expect);
+	logger().debug() << "result = " << oc_to_string(result);
+
+	TS_ASSERT_EQUALS(result, expect);
+}
+
+void VariablesUTest::test_extend_3()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle
+			vardecl1 = al(VARIABLE_LIST,
+			              al(TYPED_VARIABLE_LINK, X, PNT),
+			              al(TYPED_VARIABLE_LINK, Y, CNT)),
+			vardecl2 = al(VARIABLE_LIST,
+			              al(TYPED_VARIABLE_LINK, X, NTI),
+			              al(TYPED_VARIABLE_LINK, Y, al(TYPE_CHOICE, PNT, CNT))),
+			expect = al(VARIABLE_LIST,
+			            al(TYPED_VARIABLE_LINK, X, PNT),
+			            al(TYPED_VARIABLE_LINK, Y, CNT));
+
+	VariableList vl1(vardecl1), vl2(vardecl2);
+
+	Variables v1(vl1.get_variables()), v2(vl2.get_variables());
+
+	v1.extend(v2);
+
+	Handle result = _as.add_atom(v1.get_vardecl());
+
+	logger().debug() << "expect = " << oc_to_string(expect);
+	logger().debug() << "result = " << oc_to_string(result);
+
+	TS_ASSERT_EQUALS(result, expect);
+}
+
+void VariablesUTest::test_extend_4()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle
+			vardecl1 = al(VARIABLE_LIST,
+			              al(TYPED_VARIABLE_LINK, X, al(TYPE_CHOICE, LLT, NTI)),
+			              al(TYPED_VARIABLE_LINK, Y, NT)),
+			vardecl2 = al(VARIABLE_LIST,
+			              al(TYPED_VARIABLE_LINK, X, al(TYPE_CHOICE, LTI, CNT)),
+			              al(TYPED_VARIABLE_LINK, Y, DPTCI)),
+			expect = al(VARIABLE_LIST,
+			            al(TYPED_VARIABLE_LINK, X, al(TYPE_CHOICE, CNT, LLT)),
+			            al(TYPED_VARIABLE_LINK, Y, NT));
 
 	VariableList vl1(vardecl1), vl2(vardecl2);
 


### PR DESCRIPTION
as per issue https://github.com/opencog/atomspace/issues/2485, this is a fix for `TypeNode` `TypeInhNode` and `TypeCoInhNode` misbehaving in `Variables::extend`. 

Note that TypeInhNode used to record immediate children and now will record recursive children, same is true for TypeCoInhNode with Parents.

And note that type_intersection is removed and replaced with just set intersection of the TypeSets, as it has no usage.