### PR TITLE
Glob support variables

### DIFF
--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -1210,6 +1210,16 @@ bool Variables::is_upper_bound(const Handle& glob, size_t n) const
 	return (n <= intervals.second or intervals.second < 0);
 }
 
+const GlobInterval& Variables::get_interval(const Handle& var) const
+{
+	const auto interval = _glob_intervalmap.find(var);
+
+	if (interval == _glob_intervalmap.end())
+		return default_interval(var->get_type());
+
+	return interval->second;
+}
+
 /* ================================================================= */
 /**
  * Substitute the given arguments for the variables occuring in a tree.

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -1175,16 +1175,7 @@ bool Variables::is_type(Type gtype) const
  */
 bool Variables::is_lower_bound(const Handle& glob, size_t n) const
 {
-	// Are there any interval restrictions?
-	GlobIntervalMap::const_iterator iit = _glob_intervalmap.find(glob);
-
-	// If there are no interval restrictions, the default
-	// restrictions apply. The default restriction is 1 or more,
-	// so return true as long as `n` is larger than 0.
-	if (_glob_intervalmap.end() == iit)
-		return (n > 0);
-
-	const std::pair<double, double>& intervals = iit->second;
+	const GlobInterval &intervals = get_interval(glob);
 	return (n >= intervals.first);
 }
 
@@ -1194,19 +1185,9 @@ bool Variables::is_lower_bound(const Handle& glob, size_t n) const
  * Returns true/false if the glob satisfies the upper bound
  * interval restriction.
  */
-bool Variables::is_upper_bound(const Handle& glob, size_t n) const
+bool Variables::is_upper_bound(const Handle &glob, size_t n) const
 {
-	// Are there any interval restrictions?
-	GlobIntervalMap::const_iterator iit = _glob_intervalmap.find(glob);
-
-	// If there are no interval restrictions, the default
-	// restrictions apply. The default upper bound is
-	// "unbounded"; any number of matches are OK.
-	if (_glob_intervalmap.end() == iit)
-		return true;
-
-	// Negative upper bound means "unbounded" (infinity).
-	const std::pair<double, double>& intervals = iit->second;
+	const GlobInterval &intervals = get_interval(glob);
 	return (n <= intervals.second or intervals.second < 0);
 }
 

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -681,7 +681,9 @@ void Variables::get_vartype(const Handle& htypelink)
 			if (INTERVAL_LINK == th)
 				intervals = h->getOutgoingSet();
 
-			else if (TYPE_NODE == th)
+			else if (TYPE_NODE == th or
+			         TYPE_INH_NODE == th or
+			         TYPE_CO_INH_NODE == th)
 			{
 				vartype = h;
 				t = th;

--- a/opencog/atoms/core/Variables.h
+++ b/opencog/atoms/core/Variables.h
@@ -339,6 +339,8 @@ protected:
 			VariableDeepTypeMap::const_iterator,
 			const Handle&) const;
 
+	void extend_interval(const Handle &h, const Variables &vset);
+
 private:
 	inline const GlobInterval &default_interval(Type t) const
 	{

--- a/opencog/atoms/core/Variables.h
+++ b/opencog/atoms/core/Variables.h
@@ -181,7 +181,8 @@ protected:
 
 typedef std::map<Handle, TypeSet> VariableTypeMap;
 typedef std::map<Handle, HandleSet> VariableDeepTypeMap;
-typedef std::map<Handle, std::pair<double, double>> GlobIntervalMap;
+typedef std::pair<double, double> GlobInterval;
+typedef std::map<Handle, GlobInterval> GlobIntervalMap;
 
 /// The Variables struct defines a list of typed variables "unbundled"
 /// from the hypergraph in which they normally occur. The goal of this
@@ -327,6 +328,8 @@ struct Variables : public FreeVariables,
 	void find_variables(const Handle& body);
 	void find_variables(const HandleSeq& oset, bool ordered_link=true);
 
+	const GlobInterval& get_interval(const Handle&) const;
+
 	// Useful for debugging
 	std::string to_string(const std::string& indent=empty_string) const;
 
@@ -335,6 +338,18 @@ protected:
 			VariableDeepTypeMap::const_iterator,
 			VariableDeepTypeMap::const_iterator,
 			const Handle&) const;
+
+private:
+	inline const GlobInterval &default_interval(Type t) const
+	{
+		static const GlobInterval var_def_interval =
+				GlobInterval(1, 1);
+		static const GlobInterval glob_def_interval =
+				GlobInterval(1, std::numeric_limits<double>::infinity());
+		return t == GLOB_NODE ? glob_def_interval :
+		       var_def_interval;
+	}
+
 };
 
 // Debugging helpers see

--- a/opencog/atoms/core/Variables.h
+++ b/opencog/atoms/core/Variables.h
@@ -329,6 +329,12 @@ struct Variables : public FreeVariables,
 
 	// Useful for debugging
 	std::string to_string(const std::string& indent=empty_string) const;
+
+protected:
+	bool is_type(VariableTypeMap::const_iterator,
+			VariableDeepTypeMap::const_iterator,
+			VariableDeepTypeMap::const_iterator,
+			const Handle&) const;
 };
 
 // Debugging helpers see

--- a/tests/atoms/core/VariablesUTest.cxxtest
+++ b/tests/atoms/core/VariablesUTest.cxxtest
@@ -35,7 +35,7 @@ using namespace opencog;
 class VariablesUTest : public CxxTest::TestSuite
 {
 private:
-	Handle A, B, W, X, Y, Z, NT, PNT, CNT, NTI, DPTCI, LLT, LTI;
+	Handle A, B, W, X, Y, Z, G1, G2, NT, PNT, CNT, NTI, DPTCI, LLT, LTI;
 
 	AtomSpace _as;
 
@@ -52,6 +52,8 @@ public:
 		Y = an(VARIABLE_NODE, "$Y");
 		Z = an(VARIABLE_NODE, "$Z");
 		W = an(VARIABLE_NODE, "$W");
+		G1 = an(GLOB_NODE, "$G1");
+		G2 = an(GLOB_NODE, "$G2");
 		NT = an(TYPE_NODE, "Node");
 		PNT = an(TYPE_NODE, "PredicateNode");
 		CNT = an(TYPE_NODE, "ConceptNode");
@@ -84,6 +86,11 @@ public:
 	void test_find_variables_mixed_8();
 	void test_find_variables_mixed_9();
 	void test_find_variables_mixed_10();
+
+	void test_is_type_1();
+	void test_is_type_2();
+	void test_is_type_3();
+	void test_is_type_4();
 };
 
 void VariablesUTest::test_extend_1()
@@ -657,4 +664,97 @@ void VariablesUTest::test_find_variables_mixed_10()
 	logger().debug() << "varseq = " << oc_to_string(varseq);
 
 	TS_ASSERT_EQUALS(varseq, HandleSeq());
+}
+
+void VariablesUTest::test_is_type_1()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle vardecl = al(VARIABLE_LIST,
+	                    al(TYPED_VARIABLE_LINK, X, PNT),
+	                    al(TYPED_VARIABLE_LINK, Y, CNT));
+
+	Variables v1(vardecl);
+
+	bool is_x = v1.is_type(X, A);
+	bool is_y = v1.is_type(Y, A);
+
+	TS_ASSERT(not is_x);
+	TS_ASSERT(is_y);
+}
+
+void VariablesUTest::test_is_type_2()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle vardecl = al(VARIABLE_LIST,
+	                    al(TYPED_VARIABLE_LINK, G1,
+	                       al(TYPE_SET_LINK,
+	                          al(INTERVAL_LINK,
+	                             an(NUMBER_NODE, "0"),
+	                             an(NUMBER_NODE, "1")),
+	                          CNT)),
+	                    al(TYPED_VARIABLE_LINK, G2,
+	                       al(TYPE_SET_LINK,
+	                          al(INTERVAL_LINK,
+	                             an(NUMBER_NODE, "0"),
+	                             an(NUMBER_NODE, "2")),
+	                          CNT)));
+
+	Variables v1(vardecl);
+
+	bool is_x = v1.is_type(G1, al(LIST_LINK, A, B));
+	bool is_y = v1.is_type(G2, al(LIST_LINK, A, B));
+
+	TS_ASSERT(not is_x);
+	TS_ASSERT(is_y);
+}
+
+void VariablesUTest::test_is_type_3()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle vardecl = al(VARIABLE_LIST,
+	                    al(TYPED_VARIABLE_LINK, G1, CNT),
+	                    al(TYPED_VARIABLE_LINK, G2,
+	                       al(TYPE_SET_LINK,
+	                          al(INTERVAL_LINK,
+	                             an(NUMBER_NODE, "0"),
+	                             an(NUMBER_NODE, "2")),
+	                          PNT)));
+
+	Variables v1(vardecl);
+
+	bool is_x = v1.is_type(G1, al(LIST_LINK, A, B));
+	bool is_y = v1.is_type(G2, al(LIST_LINK, A, B));
+
+	TS_ASSERT(is_x);
+	TS_ASSERT(not is_y);
+}
+
+void VariablesUTest::test_is_type_4()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle vardecl = al(VARIABLE_LIST,
+	                    al(TYPED_VARIABLE_LINK, G1,
+	                       al(TYPE_SET_LINK,
+	                          al(INTERVAL_LINK,
+	                             an(NUMBER_NODE, "1"),
+	                             an(NUMBER_NODE, "1")),
+	                          CNT)),
+	                    al(TYPED_VARIABLE_LINK, G2,
+	                       al(TYPE_SET_LINK,
+	                          al(INTERVAL_LINK,
+	                             an(NUMBER_NODE, "1"),
+	                             an(NUMBER_NODE, "1")),
+	                          CNT)));
+
+	Variables v1(vardecl);
+
+	bool is_x = v1.is_type(G1, al(LIST_LINK, A));
+	bool is_y = v1.is_type(G2, A);
+
+	TS_ASSERT(is_x);
+	TS_ASSERT(is_y);
 }

--- a/tests/atoms/core/VariablesUTest.cxxtest
+++ b/tests/atoms/core/VariablesUTest.cxxtest
@@ -67,6 +67,8 @@ public:
 	void test_extend_2();
 	void test_extend_3();
 	void test_extend_4();
+	void test_extend_5();
+	void test_extend_6();
 	void test_find_variables_ordered_1();
 	void test_find_variables_ordered_2();
 	void test_find_variables_ordered_3();
@@ -192,6 +194,92 @@ void VariablesUTest::test_extend_4()
 			expect = al(VARIABLE_LIST,
 			            al(TYPED_VARIABLE_LINK, X, al(TYPE_CHOICE, CNT, LLT)),
 			            al(TYPED_VARIABLE_LINK, Y, NT));
+
+	VariableList vl1(vardecl1), vl2(vardecl2);
+
+	Variables v1(vl1.get_variables()), v2(vl2.get_variables());
+
+	v1.extend(v2);
+
+	Handle result = _as.add_atom(v1.get_vardecl());
+
+	logger().debug() << "expect = " << oc_to_string(expect);
+	logger().debug() << "result = " << oc_to_string(result);
+
+	TS_ASSERT_EQUALS(result, expect);
+}
+
+void VariablesUTest::test_extend_5()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle vardecl1 = al(VARIABLE_LIST,
+	                    al(TYPED_VARIABLE_LINK, G1,
+	                       al(TYPE_SET_LINK,
+	                          al(INTERVAL_LINK,
+	                             an(NUMBER_NODE, "0"),
+	                             an(NUMBER_NODE, "2")),
+	                          NTI)),
+	                    al(TYPED_VARIABLE_LINK, G2,
+	                       al(TYPE_SET_LINK,
+	                          al(INTERVAL_LINK,
+	                             an(NUMBER_NODE, "0"),
+	                             an(NUMBER_NODE, "2")),
+	                          PNT))),
+			vardecl2 = al(VARIABLE_LIST,
+			              al(TYPED_VARIABLE_LINK, G1,
+			                 al(TYPE_SET_LINK,
+			                    al(INTERVAL_LINK,
+			                       an(NUMBER_NODE, "1"),
+			                       an(NUMBER_NODE, "-1")),
+			                    PNT)),
+			              al(TYPED_VARIABLE_LINK, G2,
+			                 al(TYPE_SET_LINK,
+			                    al(INTERVAL_LINK,
+			                       an(NUMBER_NODE, "1"),
+			                       an(NUMBER_NODE, "3")),
+			                    PNT))),
+			expect = al(VARIABLE_LIST,
+			            al(TYPED_VARIABLE_LINK, G1,
+			               al(TYPE_SET_LINK,
+			                  al(INTERVAL_LINK,
+			                     an(NUMBER_NODE, "1"),
+			                     an(NUMBER_NODE, "2")),
+			                  PNT)),
+			            al(TYPED_VARIABLE_LINK, G2,
+			               al(TYPE_SET_LINK,
+			                  al(INTERVAL_LINK,
+			                     an(NUMBER_NODE, "1"),
+			                     an(NUMBER_NODE, "2")),
+			                  PNT)));
+
+	VariableList vl1(vardecl1), vl2(vardecl2);
+
+	Variables v1(vl1.get_variables()), v2(vl2.get_variables());
+
+	v1.extend(v2);
+
+	Handle result = _as.add_atom(v1.get_vardecl());
+
+	logger().debug() << "expect = " << oc_to_string(expect);
+	logger().debug() << "result = " << oc_to_string(result);
+
+	TS_ASSERT_EQUALS(result, expect);
+}
+
+void VariablesUTest::test_extend_6()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle vardecl1 = al(VARIABLE_LIST,
+	                     al(TYPED_VARIABLE_LINK, X, NTI),
+	                     al(TYPED_VARIABLE_LINK, G2, PNT)),
+			vardecl2 = al(VARIABLE_LIST,
+			              al(TYPED_VARIABLE_LINK, X, PNT),
+			              al(TYPED_VARIABLE_LINK, G2, PNT)),
+			expect = al(VARIABLE_LIST,
+			            al(TYPED_VARIABLE_LINK, X, PNT),
+			            al(TYPED_VARIABLE_LINK, G2, PNT));
 
 	VariableList vl1(vardecl1), vl2(vardecl2);
 


### PR DESCRIPTION
This PR contains the changes I needed to support Glob Unification in the URE.

1/ Enhance `Variables::is_type` to conceder variable interval restrictions.
Example:
<pre>
al(TYPED_VARIABLE_LINK, G,
    al(TYPE_SET_LINK,
        al(INTERVAL_LINK,
            an(NUMBER_NODE, "2"),
	    an(NUMBER_NODE, "3")),
	 CNT)))

v.is_type(G, al(LIST_LINK, A, B));     // true
v.is_type(G, al(LIST_LINK, A));         // false
</pre>

2/ Support `_glob_interval_map` in `Variables::extend` and `Variables::get_type_decl`.

3/ Support `TypeInh` and `TypeCoInh` in `Glob`

Example:
`al(TYPED_VARIABLE_LINK, G1, an(TYPE_INH_NODE, "Node"))`

4/ BugFix Pattern matcher: the PM used to exploit the `Variables::is_type` in its inner implementation of `glob_compare` to disregard lower bound interval restrictions.

Note: for backward compatibility purposes `-1` and `inf` are similar. and I used `NAN` as invalid interval.