### PR TITLE
Add failing substitute utest on scope

### DIFF
--- a/opencog/atoms/core/Quotation.h
+++ b/opencog/atoms/core/Quotation.h
@@ -47,7 +47,7 @@ class Quotation : public boost::totally_ordered<Quotation>
 	bool _local_quote;
 
 public:
-	Quotation(int ql=0, bool lq=false);
+	explicit Quotation(int ql=0, bool lq=false);
 
 	int level() const;
 	bool is_locally_quoted() const;

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -389,14 +389,14 @@ Handle FreeVariables::substitute_nocheck(const Handle& term,
                                          const HandleSeq& args,
                                          bool silent) const
 {
-	return substitute_scoped(term, args, silent, index, 0);
+	return substitute_scoped(term, args, silent, index);
 }
 
 Handle FreeVariables::substitute_nocheck(const Handle& term,
                                          const HandleMap& vm,
                                          bool silent) const
 {
-	return substitute_scoped(term, make_sequence(vm), silent, index, 0);
+	return substitute_scoped(term, make_sequence(vm), silent, index);
 }
 
 bool FreeVariables::operator<(const FreeVariables& other) const

--- a/tests/atoms/core/VariablesUTest.cxxtest
+++ b/tests/atoms/core/VariablesUTest.cxxtest
@@ -69,6 +69,7 @@ public:
 	void test_extend_4();
 	void test_extend_5();
 	void test_extend_6();
+
 	void test_find_variables_ordered_1();
 	void test_find_variables_ordered_2();
 	void test_find_variables_ordered_3();
@@ -93,6 +94,8 @@ public:
 	void test_is_type_2();
 	void test_is_type_3();
 	void test_is_type_4();
+
+	void xtest_substitute_nocheck_scope();
 };
 
 void VariablesUTest::test_extend_1()
@@ -845,4 +848,28 @@ void VariablesUTest::test_is_type_4()
 
 	TS_ASSERT(is_x);
 	TS_ASSERT(is_y);
+}
+
+void VariablesUTest::xtest_substitute_nocheck_scope()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Body with only one variable declared X, thus Y can be
+	// substituted but not X.
+	Handle body = al(SATISFACTION_LINK,
+	                 X,
+	                 al(PRESENT_LINK, al(INHERITANCE_LINK, X, Y)));
+
+	// Replace Y by X, thus X in the satisfaction link above should be
+	// renamed to avoid name collision.
+	HandleMap var2val{{Y, X}};
+	Handle result = Variables(Y).substitute_nocheck(body, var2val);
+	Handle expect = al(SATISFACTION_LINK,
+	                   Z,
+	                   al(PRESENT_LINK, al(INHERITANCE_LINK, Z, X)));
+
+	logger().debug() << "expect = " << oc_to_string(expect);
+	logger().debug() << "result = " << oc_to_string(result);
+
+	TS_ASSERT_EQUALS(result, expect);
 }


### PR DESCRIPTION
Adding failing and disabled unit test of `Variables::substitute_nocheck` over scope requiring alpha-conversion.