### PR TITLE
Implicitly assume presence of variables

### DIFF
--- a/opencog/atoms/pattern/PatternUtils.cc
+++ b/opencog/atoms/pattern/PatternUtils.cc
@@ -302,7 +302,7 @@ void get_bridged_components(const HandleSet& vars,
 	// The user might want to reject such bridges, but allow each
 	// opt individually, as long as they don't bridge. As of today,
 	// specifying this kind of pattern would take some hard work,
-	// (I'm not sure its even possible with toeay's API) and so it
+	// (I'm not sure its even possible with today's API) and so it
 	// seems very unlikely that any user would want this, and thus
 	// very unlikely that they'll hit this bug.
 }

--- a/tests/query/DisconnectedUTest.cxxtest
+++ b/tests/query/DisconnectedUTest.cxxtest
@@ -59,6 +59,7 @@ class DisconnectedUTest :  public CxxTest::TestSuite
 		void test_components(void);
 		void test_variables(void);
 		void test_cvariables(void);
+		void test_dancers(void);
 };
 
 /*
@@ -119,7 +120,9 @@ void DisconnectedUTest::test_components(void)
 }
 
 /*
- * Test several patterns carrying ill-formed variable declarations
+ * Test several patterns with missing grounding clauses.
+ * These used to be considered to be ill-formed, but now
+ * we allow them to create implicit grounding clauses.
  */
 void DisconnectedUTest::test_variables(void)
 {
@@ -155,8 +158,7 @@ void DisconnectedUTest::test_cvariables(void)
 		Handle blv(createLink(VARIABLE_LIST, va, vb));
 		Handle blb(createLink(AND_LINK, va));
 		Handle blt(createLink(LIST_LINK, va));
-		HandleSeq bll = {blv, blb, blt};
-		Handle bl_final(createLink(std::move(bll), BIND_LINK));
+		Handle bl_final(createLink(BIND_LINK, blv, blb, blt));
 		as->add_atom(bl_final);
 	}
 	catch (const InvalidParamException& ex)
@@ -169,3 +171,34 @@ void DisconnectedUTest::test_cvariables(void)
 
 	logger().debug("END TEST: %s", __FUNCTION__);
 }
+
+/*
+ * Test pattern with missing grounding clauses. It should not
+ * only be specifiable, but it should also obtain the correct
+ * (expceted) results.  See issue #2516 for details.
+ */
+void DisconnectedUTest::test_dancers(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	eval->eval("(load-from-path \"tests/query/disco-dancers.scm\")");
+
+	// We do NOT expect to catch an error here.
+	Handle h = eval->eval_h("(get-dancers)");
+	TSM_ASSERT("Failed to create GetLink", Handle::UNDEFINED != h);
+
+	h = eval->eval_h("(cog-execute! (get-dancers))");
+
+	Handle a(createNode(CONCEPT_NODE, "alice"));
+	Handle b(createNode(CONCEPT_NODE, "bob"));
+	Handle ab(createLink(LIST_LINK, a, b));
+	Handle ba(createLink(LIST_LINK, b, a));
+	Handle both(createLink(SET_LINK, ab, ba));
+	Handle ans = as->add_atom(both);
+
+	// They should be identical.
+	TSM_ASSERT("Wrong result", *ans == *h);
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+

--- a/tests/query/DisconnectedUTest.cxxtest
+++ b/tests/query/DisconnectedUTest.cxxtest
@@ -127,54 +127,20 @@ void DisconnectedUTest::test_variables(void)
 
 	eval->eval("(load-from-path \"tests/query/disco-vars.scm\")");
 
-#if DO_NOT_TEST_THIS_IS_NOW_LEGAL
-	// We expect to catch an error here. ------------------------------
-	bool caught = false;
-	try
-	{
-		eval->eval_h("(B)");
-	}
-	catch (const RuntimeException& ex)
-	{
-		logger().debug("Caught exception, just as expected: %s", ex.get_message());
-		caught = true;
-	}
-	logger().info("Caught exception? %d\n", caught);
-	TSM_ASSERT("Failed to catch expected exception", caught);
-#endif
+	// We do NOT expect to catch an error here.
+	Handle h = eval->eval_h("(B)");
+	TSM_ASSERT("Failed to create GetLink", Handle::UNDEFINED != h);
 
-	// We expect to catch an error here. ------------------------------
-	bool caught = false;
-	try
-	{
-		eval->eval_h("(Ba)");
-	}
-	catch (const RuntimeException& ex)
-	{
-		logger().debug("Caught exception, just as expected: %s", ex.get_message());
-		caught = true;
-	}
-	logger().info("Caught exception? %d\n", caught);
-	TSM_ASSERT("Failed to catch expected exception", caught);
+	h = eval->eval_h("(Ba)");
+	TSM_ASSERT("Failed to create GetLink", Handle::UNDEFINED != h);
 
-	// We expect to catch an error here. ------------------------------
-	caught = false;
-	try
-	{
-		eval->eval_h("(Bu)");
-	}
-	catch (const RuntimeException& ex)
-	{
-		logger().debug("Caught exception, just as expected: %s", ex.get_message());
-		caught = true;
-	}
-	logger().info("Caught exception? %d\n", caught);
-	TSM_ASSERT("Failed to catch expected exception", caught);
+	h = eval->eval_h("(Bu)");
+	TSM_ASSERT("Failed to create GetLink", Handle::UNDEFINED != h);
 
 	logger().debug("END TEST: %s", __FUNCTION__);
 }
 
-// Similar to above, except that the stuff is build up in C++ not in
+// Similar to above, except that the stuff is built up in C++ not in
 // scheme.  See bug #172.
 void DisconnectedUTest::test_cvariables(void)
 {

--- a/tests/query/disco-dancers.scm
+++ b/tests/query/disco-dancers.scm
@@ -1,0 +1,30 @@
+;
+; disco-dancers.scm
+;
+; Test the addition of implict clauses for variables appearing in
+; virtual clauses but not otherwise groundable.  Per bug #2516
+;
+
+(use-modules (opencog))
+(use-modules (opencog exec))
+
+(Concept "alice")
+(Concept "bob")
+
+(define variables (VariableList
+    (TypedVariable
+        (Variable "person1")
+        (Type "ConceptNode"))
+    (TypedVariable
+        (Variable "person2")
+        (Type "ConceptNode"))))
+
+(define target (Not (Identical
+                        (Variable "person1")
+                        (Variable "person2") )))
+
+; This should not throw...
+(define (get-dancers) (Get variables target))
+
+; This should work...
+; (cog-execute! (get-dancers))

--- a/tests/query/disco-vars.scm
+++ b/tests/query/disco-vars.scm
@@ -1,12 +1,17 @@
 ;
 ; disco-vars.scm
 ;
-; Several patterns with ill-formed variable declarations.
+; Several patterns with implicit clauses.
+;
+; Prior to issue #2516, these were considered to be ill-formed
+; search patterns, because they lacked explicit clauses that
+; asserted the presence of a variable in the atompsace.  However,
+; it seems to be OK to assume implicit presence, when it is not
+; declared explicity. So, in fact, everything below should be
+; considered to be valid.
 
-; The below used to be ill-formed, but the current matcher
-; accepts this and ... wastes CPU time with it.  Technically,
-; it is kind-of ill-formed, since there should be a "present"
-; search being made for it. But we punt for now.
+(use-modules (opencog))
+
 (define (B)
 (GetLink
    (VariableList (VariableNode "$A") (VariableNode "$B"))


### PR DESCRIPTION
This fixes issue #2516 -- it seems reasonable to implicitly assume that variables are present.