### PR TITLE
Allow AbsentLink's in GetLink's

### DIFF
--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -2390,12 +2390,11 @@ bool PatternMatchEngine::report_grounding(const GroundingMap &var_soln,
 	if (_pat->always.size() == 0)
 		return _pmc.grounding(var_soln, term_soln);
 
-	// If we are here, we need to record groundings, until later,
-	// when we find out if the for-all clauses were satsified.
-
 	// Don't even bother caching, if we know we are losing.
 	if (not _forall_state) return false;
 
+	// If we are here, we need to record groundings, until later,
+	// when we find out if the for-all clauses were satsified.
 	_var_ground_cache.push_back(var_soln);
 	_term_ground_cache.push_back(term_soln);
 

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1960,7 +1960,6 @@ bool PatternMatchEngine::do_next_clause(void)
 		joiner = next_joint;
 		curr_root = next_clause;
 
-		DO_LOG({logmsg("Next optional clause is", curr_root);})
 		if (nullptr == curr_root)
 		{
 			DO_LOG({logger().fine("==================== FINITO BANDITO!");
@@ -1969,6 +1968,8 @@ bool PatternMatchEngine::do_next_clause(void)
 		}
 		else
 		{
+			DO_LOG({logmsg("Next optional clause is", curr_root);})
+
 			// Now see if this optional clause has any solutions,
 			// or not. If it does, we'll recurse. If it does not,
 			// we'll loop around back to here again.

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -2789,10 +2789,11 @@ void PatternMatchEngine::log_solution(
 	int i = 0;
 	for (m = clauses.begin(); m != clauses.end(); ++m, ++i)
 	{
+		// AbsentLink's won't be grounded...
 		if (not m->second)
 		{
 			Handle mf(m->first);
-			logmsg("ERROR: ungrounded clause", mf);
+			logmsg("Ungrounded clause", mf);
 			continue;
 		}
 		std::string str = m->second->to_short_string();

--- a/opencog/query/Satisfier.cc
+++ b/opencog/query/Satisfier.cc
@@ -47,10 +47,10 @@ bool Satisfier::grounding(const GroundingMap &var_soln,
 		HandleSeq vargnds;
 		for (const Handle& hv : _varseq)
 		{
-			// Optional clauses appearing in a GetLink may have
+			// Optional clauses (e.g. AbsentLink) may have
 			// variables in them that are not grounded.
-			// (e.g. AbsentLink). Those variables won't have
-			// a grounding; this will cause std::map::at to throw.
+			// Those variables won't have a grounding;
+			// this will cause std::map::at to throw.
 			try
 			{
 				vargnds.push_back(var_soln.at(hv));

--- a/opencog/query/Satisfier.cc
+++ b/opencog/query/Satisfier.cc
@@ -47,7 +47,15 @@ bool Satisfier::grounding(const GroundingMap &var_soln,
 		HandleSeq vargnds;
 		for (const Handle& hv : _varseq)
 		{
-			vargnds.push_back(var_soln.at(hv));
+			// Optional clauses appearing in a GetLink may have
+			// variables in them that are not grounded.
+			// (e.g. AbsentLink). Variables in them won't have
+			// a grounding; this will cause std::map::at to throw.
+			try
+			{
+				vargnds.push_back(var_soln.at(hv));
+			}
+			catch (...) {}
 		}
 		_ground = createLink(std::move(vargnds), LIST_LINK);
 	}
@@ -107,6 +115,7 @@ bool Satisfier::search_finished(bool done)
 
 // ===========================================================
 
+// GetLink groundings go through here.
 bool SatisfyingSet::grounding(const GroundingMap &var_soln,
                               const GroundingMap &term_soln)
 {
@@ -139,7 +148,14 @@ bool SatisfyingSet::grounding(const GroundingMap &var_soln,
 	HandleSeq vargnds;
 	for (const Handle& hv : _varseq)
 	{
-		vargnds.push_back(var_soln.at(hv));
+		// Optional clauses (e.g. AbsentLink) may have variables
+		// in them that are not grounded. Variables in them won't
+		// have a grounding; this will cause std::map::at to throw.
+		try
+		{
+			vargnds.push_back(var_soln.at(hv));
+		}
+		catch (...) {}
 	}
 	_satisfying_set.emplace(createLink(std::move(vargnds), LIST_LINK));
 

--- a/opencog/query/Satisfier.cc
+++ b/opencog/query/Satisfier.cc
@@ -49,13 +49,16 @@ bool Satisfier::grounding(const GroundingMap &var_soln,
 		{
 			// Optional clauses appearing in a GetLink may have
 			// variables in them that are not grounded.
-			// (e.g. AbsentLink). Variables in them won't have
+			// (e.g. AbsentLink). Those variables won't have
 			// a grounding; this will cause std::map::at to throw.
 			try
 			{
 				vargnds.push_back(var_soln.at(hv));
 			}
-			catch (...) {}
+			catch (...)
+			{
+				vargnds.push_back(hv);
+			}
 		}
 		_ground = createLink(std::move(vargnds), LIST_LINK);
 	}
@@ -149,13 +152,16 @@ bool SatisfyingSet::grounding(const GroundingMap &var_soln,
 	for (const Handle& hv : _varseq)
 	{
 		// Optional clauses (e.g. AbsentLink) may have variables
-		// in them that are not grounded. Variables in them won't
+		// in them that are not grounded. Those variables won't
 		// have a grounding; this will cause std::map::at to throw.
 		try
 		{
 			vargnds.push_back(var_soln.at(hv));
 		}
-		catch (...) {}
+		catch (...)
+		{
+			vargnds.push_back(hv);
+		}
 	}
 	_satisfying_set.emplace(createLink(std::move(vargnds), LIST_LINK));
 


### PR DESCRIPTION
Allowing AbsentLink's in GetLink's seems like a plausible thing to allow,
even if the result is that there are ungrounded variables.

Per discussion with @alexander-gabriel on mailing list.