### PR TITLE
Fix alpha-equivalence of corner case

### DIFF
--- a/tests/atoms/AlphaConvertUTest.cxxtest
+++ b/tests/atoms/AlphaConvertUTest.cxxtest
@@ -55,6 +55,7 @@ public:
 	void test_vardecl_free_scope();
 	void test_variable_set_scope();
 	void test_inner_scope();
+	void test_getlink();
 };
 
 #define NA _asa.add_node
@@ -430,3 +431,29 @@ void AlphaConvertUTest::test_inner_scope()
 
 	TS_ASSERT(sc1->is_equal(h2));
 }
+
+// Test alpha equivalence between 2 get links.
+void AlphaConvertUTest::test_getlink()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle X = NA(VARIABLE_NODE, "$X");
+	Handle Y = NA(VARIABLE_NODE, "$Y");
+	Handle A = NA(CONCEPT_NODE, "A");
+	Handle B = NA(CONCEPT_NODE, "B");
+
+	// h1 and h2 are alpha-equivalent, indeed renaming X->Y and Y->X in
+	// h1 yields h2.
+	Handle h1 = LA(GET_LINK, LA(PRESENT_LINK,
+	                            LA(INHERITANCE_LINK, X, A),
+	                            LA(INHERITANCE_LINK, Y, B)));
+	Handle h2 = LA(GET_LINK, LA(PRESENT_LINK,
+	                            LA(INHERITANCE_LINK, Y, A),
+	                            LA(INHERITANCE_LINK, X, B)));
+
+	ScopeLinkPtr sc1 = ScopeLinkCast(h1);
+	ScopeLinkPtr sc2 = ScopeLinkCast(h2);
+
+	TS_ASSERT(sc1->is_equal(h2));
+}
+

--- a/tests/atoms/core/VariablesUTest.cxxtest
+++ b/tests/atoms/core/VariablesUTest.cxxtest
@@ -42,7 +42,7 @@ private:
 public:
 	VariablesUTest()
 	{
-		logger().set_level(Logger::INFO);
+		logger().set_level(Logger::DEBUG);
 		logger().set_timestamp_flag(false);
 		logger().set_print_to_stdout_flag(true);
 
@@ -89,6 +89,7 @@ public:
 	void test_find_variables_mixed_8();
 	void test_find_variables_mixed_9();
 	void test_find_variables_mixed_10();
+	void test_find_variables_mixed_11();
 
 	void test_is_type_1();
 	void test_is_type_2();
@@ -755,6 +756,34 @@ void VariablesUTest::test_find_variables_mixed_10()
 	logger().debug() << "varseq = " << oc_to_string(varseq);
 
 	TS_ASSERT_EQUALS(varseq, HandleSeq());
+}
+
+void VariablesUTest::test_find_variables_mixed_11()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Inferred vardecl of body1 should be the reverse of vardecl of
+	// body2 because swapping names makes them equivalent.
+	Handle body1 = al(PRESENT_LINK,
+	                  al(INHERITANCE_LINK, X, A),
+	                  al(INHERITANCE_LINK, Y, B));
+	Handle body2 = al(PRESENT_LINK,
+	                  al(INHERITANCE_LINK, Y, A),
+	                  al(INHERITANCE_LINK, X, B));
+	Variables vars1;
+	Variables vars2;
+	vars1.find_variables(body1);
+	vars2.find_variables(body2);
+	HandleSeq varseq1 = vars1.varseq;
+	HandleSeq varseq2 = vars2.varseq;
+
+	logger().debug() << "varseq1 = " << oc_to_string(varseq1);
+	logger().debug() << "varseq2 = " << oc_to_string(varseq2);
+
+	// Reverse varseq2 to test it if it equal to varseq1
+	std::reverse(varseq2.begin(), varseq2.end());
+
+	TS_ASSERT_EQUALS(varseq1, varseq2);
 }
 
 void VariablesUTest::test_is_type_1()


### PR DESCRIPTION
Indeed due to not properly handling variable equivalence, the
following where not found alpha-equivalent

```
(define gl1
  (GetLink
    (VariableSet
      (VariableNode "$X")
      (VariableNode "$Y")
    )
    (PresentLink
      (MemberLink
        (VariableNode "$X")
        (ConceptNode "GO:0007569")
      )
      (MemberLink
        (VariableNode "$Y")
        (ConceptNode "GO:0007568")
      )
    )
  )
)

(define gl2
  (GetLink
    (VariableSet
      (VariableNode "$Y")
      (VariableNode "$X")
    )
    (PresentLink
      (MemberLink
        (VariableNode "$Y")
        (ConceptNode "GO:0007569")
      )
      (MemberLink
        (VariableNode "$X")
        (ConceptNode "GO:0007568")
      )
    )
  )
)
```
