### PR TITLE
Explicit check for badly-formed patterns

### DIFF
--- a/opencog/query/DefaultPatternMatchCB.h
+++ b/opencog/query/DefaultPatternMatchCB.h
@@ -94,8 +94,8 @@ class DefaultPatternMatchCB : public virtual PatternMatchCallback
 		}
 
 		bool optionals_present(void) { return _optionals_present; }
-	protected:
 
+	protected:
 		NameServer& _nameserver;
 
 		const Variables* _vars = nullptr;

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -2529,6 +2529,20 @@ bool PatternMatchEngine::explore_clause_direct(const Handle& term,
 	if (term->get_type() == VARIABLE_NODE)
 		var_grounding[term] = grnd;
 
+	// This is an expensive, CPU-wasting check to catch the bug described
+	// in https://github.com/opencog/atomspace/issues/2315
+	// It would be nice to have a better fix, but its not clear what
+	// that fix should be; its a thorny architectural problem.
+	for (const Handle &v : _variables->varset)
+	{
+		if (is_unquoted_unscoped_in_tree(clause, v) and
+		    var_grounding.find(v) == var_grounding.end())
+		{
+			throw RuntimeException(TRACE_INFO,
+			      "Unable to evaluate clause with ungrounded variables!");
+		}
+	}
+
 	bool found = _pmc.evaluate_sentence(clause, var_grounding);
 	DO_LOG({logger().fine("Post evaluating clause, found = %d", found);})
 	if (found)

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -2529,6 +2529,7 @@ bool PatternMatchEngine::explore_clause_direct(const Handle& term,
 	if (term->get_type() == VARIABLE_NODE)
 		var_grounding[term] = grnd;
 
+#ifdef QDEBUG
 	// This is an expensive, CPU-wasting check to catch the bug described
 	// in https://github.com/opencog/atomspace/issues/2315
 	// It would be nice to have a better fix, but its not clear what
@@ -2542,6 +2543,7 @@ bool PatternMatchEngine::explore_clause_direct(const Handle& term,
 			      "Unable to evaluate clause with ungrounded variables!");
 		}
 	}
+#endif
 
 	bool found = _pmc.evaluate_sentence(clause, var_grounding);
 	DO_LOG({logger().fine("Post evaluating clause, found = %d", found);})


### PR DESCRIPTION
The correct solution for issue #2315 remains unclear; in the meanwhile,
this explicitly checks for the invalid condition. Unfortunately, it is
a bit of a CPU-time-waster when presented with a valid pattern.
