### PR TITLE
Provide scheme wrapper for the TLB utility

### DIFF
--- a/opencog/atoms/base/Handle.h
+++ b/opencog/atoms/base/Handle.h
@@ -55,13 +55,15 @@ namespace opencog
 {
 
 //! UUID == Universally Unique Identifier
-typedef unsigned long UUID;
+typedef size_t UUID;
+
+//! ContentHash == 64-bit hash of an Atom.
 typedef size_t ContentHash;
 
 class Atom;
 typedef std::shared_ptr<Atom> AtomPtr;
 
-//! contains an unique identificator
+//! Pointer to an Atom, providing extra utility/convenience methods.
 class Handle : public AtomPtr
 {
 

--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -59,6 +59,7 @@ class AtomSpace
     friend class BackingStore;
     friend class IPFSAtomStorage;    // Needs to call get_atomtable()
     friend class SQLAtomStorage;     // Needs to call get_atomtable()
+    friend class UuidSCM;            // Needs to call get_atomtable()
     friend class ZMQPersistSCM;
     friend class ::AtomTableUTest;
     friend class ::AtomSpaceUTest;

--- a/opencog/atomspaceutils/TLB.cc
+++ b/opencog/atomspaceutils/TLB.cc
@@ -111,8 +111,15 @@ UUID TLB::addAtom(const Handle& h, UUID uuid)
     {
         if (_handle_map.end() != pr) return pr->second;
 
-        // Not found; we need a new uuid.
-        uuid = _uuid_pool->get_uuid();
+        while (true)
+        {
+            // Not found; we need a new uuid.
+            uuid = _uuid_pool->get_uuid();
+
+            // Oh wait, is it being used already?
+            auto pr = _uuid_map.find(uuid);
+            if (_uuid_map.end() == pr) break;
+        }
     }
     else
     {

--- a/opencog/guile/SchemePrimitive.h
+++ b/opencog/guile/SchemePrimitive.h
@@ -375,6 +375,10 @@ protected:
 	{
 		return scm_from_int(i);
 	}
+	SCM scm_from(size_t i)
+	{
+		return scm_from_size_t(i);
+	}
 	SCM scm_from(double d)
 	{
 		return scm_from_double(d);

--- a/opencog/guile/SchemePrimitive.h
+++ b/opencog/guile/SchemePrimitive.h
@@ -456,7 +456,7 @@ protected:
 	virtual SCM invoke (SCM args)
 	{
 		super::cpp_invoke(args);
-		return SCM_EOL;
+		return SCM_UNSPECIFIED;
 	}
 };
 

--- a/opencog/guile/modules/CMakeLists.txt
+++ b/opencog/guile/modules/CMakeLists.txt
@@ -34,6 +34,7 @@ TARGET_LINK_LIBRARIES(type-utils
 ADD_GUILE_EXTENSION(SCM_CONFIG type-utils "opencog-ext-path-type-utils")
 
 TARGET_LINK_LIBRARIES(guile-uuid
+	atomspaceutils
 	smob
 	${COGUTIL_LIBRARY}
 )

--- a/opencog/guile/modules/CMakeLists.txt
+++ b/opencog/guile/modules/CMakeLists.txt
@@ -11,6 +11,10 @@ ADD_LIBRARY (type-utils
 	TypeUtilsSCM.cc
 )
 
+ADD_LIBRARY (guile-uuid
+	UuidSCM.cc
+)
+
 TARGET_LINK_LIBRARIES(logger
 	smob
 	${COGUTIL_LIBRARY}
@@ -29,7 +33,13 @@ TARGET_LINK_LIBRARIES(type-utils
 )
 ADD_GUILE_EXTENSION(SCM_CONFIG type-utils "opencog-ext-path-type-utils")
 
-INSTALL (TARGETS logger randgen type-utils
+TARGET_LINK_LIBRARIES(guile-uuid
+	smob
+	${COGUTIL_LIBRARY}
+)
+ADD_GUILE_EXTENSION(SCM_CONFIG guile-uuid "opencog-ext-path-uuid")
+
+INSTALL (TARGETS logger randgen type-utils guile-uuid
 	EXPORT AtomSpaceTargets
 	DESTINATION "lib${LIB_DIR_SUFFIX}/opencog"
 )

--- a/opencog/guile/modules/UuidSCM.cc
+++ b/opencog/guile/modules/UuidSCM.cc
@@ -54,7 +54,9 @@ UUID UuidSCM::add_atom(Handle h, UUID uuid)
 
 Handle UuidSCM::get_atom(UUID uuid)
 {
-	return _tlb.getAtom(uuid);
+	Handle h = _tlb.getAtom(uuid);
+	if (h) return h;
+	return SCM_BOOL_F;
 }
 
 void UuidSCM::remove_atom(Handle h)

--- a/opencog/guile/modules/UuidSCM.cc
+++ b/opencog/guile/modules/UuidSCM.cc
@@ -39,7 +39,6 @@ protected:
 
 	UUID add_atom(Handle, UUID);
 	Handle get_atom(UUID);
-	UUID get_uuid(Handle);
 	void remove_atom(Handle);
 	void remove_uuid(UUID);
 
@@ -56,11 +55,6 @@ UUID UuidSCM::add_atom(Handle h, UUID uuid)
 Handle UuidSCM::get_atom(UUID uuid)
 {
 	return _tlb.getAtom(uuid);
-}
-
-UUID UuidSCM::get_uuid(Handle h)
-{
-	return _tlb.getUUID(h);
 }
 
 void UuidSCM::remove_atom(Handle h)
@@ -90,12 +84,10 @@ void UuidSCM::init(void)
 	AtomSpace* as = SchemeSmob::ss_get_env_as("uuid");
 	_tlb.set_resolver(&as->get_atomtable());
 
-	define_scheme_primitive("cog-assign-uuid",
+	define_scheme_primitive("cog-add-uuid",
 		&UuidSCM::add_atom, this, "uuid");
-	define_scheme_primitive("cog-atom-from-uuid",
+	define_scheme_primitive("cog-lookup-uuid",
 		&UuidSCM::get_atom, this, "uuid");
-	define_scheme_primitive("cog-uuid-from-atom",
-		&UuidSCM::get_uuid, this, "uuid");
 	define_scheme_primitive("cog-unassign-uuid",
 		&UuidSCM::remove_atom, this, "uuid");
 	define_scheme_primitive("cog-remove-uuid",

--- a/opencog/guile/modules/UuidSCM.cc
+++ b/opencog/guile/modules/UuidSCM.cc
@@ -1,0 +1,74 @@
+/*
+ * UuidSCM.cc
+ *
+ * Copyright (c) 2020 Linas Vepstas
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/guile/SchemeModule.h>
+#include <opencog/guile/SchemePrimitive.h>
+#include <opencog/atomspaceutils/TLB.h>
+
+using namespace opencog;
+namespace opencog {
+
+/**
+ * Wrapper for the UUID subsystem.
+ */
+
+class UuidSCM : public ModuleWrap
+{
+protected:
+	virtual void init();
+
+	UUID add_atom(Handle, UUID);
+	Handle get_atom(UUID);
+	UUID get_uuid(Handle);
+	void remove_atom(Handle);
+	void remove_uuid(UUID);
+
+public:
+	UuidSCM();
+};
+
+
+UUID UuidSCM::add_atom(Handle h, UUID uuid)
+{
+	return 0;
+}
+
+} /*end of namespace opencog*/
+
+UuidSCM::UuidSCM() : ModuleWrap("opencog uuid") {}
+
+/// This is called while (opencog uuid) is the current module.
+/// Thus, all the definitions below happen in that module.
+void UuidSCM::init(void)
+{
+	define_scheme_primitive("cog-assign-uuid",
+		&UuidSCM::add_atom, this, "uuid");
+}
+
+extern "C" {
+void opencog_uuid_init(void);
+};
+
+void opencog_uuid_init(void)
+{
+    static UuidSCM uuid_scm;
+    uuid_scm.module_init();
+}

--- a/opencog/guile/modules/UuidSCM.cc
+++ b/opencog/guile/modules/UuidSCM.cc
@@ -54,9 +54,7 @@ UUID UuidSCM::add_atom(Handle h, UUID uuid)
 
 Handle UuidSCM::get_atom(UUID uuid)
 {
-	Handle h = _tlb.getAtom(uuid);
-	if (h) return h;
-	return SCM_BOOL_F;
+	return _tlb.getAtom(uuid);
 }
 
 void UuidSCM::remove_atom(Handle h)

--- a/opencog/scm/CMakeLists.txt
+++ b/opencog/scm/CMakeLists.txt
@@ -29,6 +29,7 @@ ADD_GUILE_MODULE (FILES
 	opencog/query.scm
 	opencog/test-runner.scm
 	opencog/type-utils.scm
+	opencog/uuid.scm
 	MODULE_DESTINATION "${GUILE_SITE_DIR}/opencog"
 )
 

--- a/opencog/scm/opencog/uuid.scm
+++ b/opencog/scm/opencog/uuid.scm
@@ -56,7 +56,7 @@
  cog-lookup-uuid UUID
 
    Given the `UUID` (universally-unique integer), return the
-   corresponding Atom in the lookup table. Otherwise return #f.
+   corresponding Atom in the lookup table. Otherwise return '().
 
    Example:
       (define uuid-for-a (cog-assign-uuid (Concept \"A\")))

--- a/opencog/scm/opencog/uuid.scm
+++ b/opencog/scm/opencog/uuid.scm
@@ -55,6 +55,13 @@
 "
  cog-lookup-uuid UUID
 
+   Given the `UUID` (universally-unique integer), return the
+   corresponding Atom in the lookup table. Otherwise return #f.
+
+   Example:
+      (define uuid-for-a (cog-assign-uuid (Concept \"A\")))
+      (cog-lookup-uuid uuid-for-a)
+
    See also: cog-assign-uuid cog-remove-uuid cog-unassign-uuid
 ")
 
@@ -62,12 +69,28 @@
 "
  cog-unassign-uuid ATOM
 
+   Given the `ATOM`, remove it from the UUID lookup table.
+
+   Example:
+      (define uuid-for-a (cog-assign-uuid (Concept \"A\")))
+      (cog-lookup-uuid uuid-for-a)
+      (cog-unassign-uuid (Concept \"A\"))
+      (cog-lookup-uuid uuid-for-a)
+
    See also: cog-remove-uuid cog-assign-uuid cog-lookup-uuid
 ")
 
 (set-procedure-property! cog-remove-uuid 'documentation
 "
  cog-remove-uuid UUID
+
+   Given the `UUID`, remove it from the UUID lookup table.
+
+   Example:
+      (define uuid-for-a (cog-assign-uuid (Concept \"A\")))
+      (cog-lookup-uuid uuid-for-a)
+      (cog-unassign-uuid uuid-for-a)
+      (cog-lookup-uuid uuid-for-a)
 
    See also: cog-unassign-uuid cog-assign-uuid cog-lookup-id
 ")

--- a/opencog/scm/opencog/uuid.scm
+++ b/opencog/scm/opencog/uuid.scm
@@ -15,11 +15,19 @@
 ; because other scheme code cannot guess what names the shared lib
 ; actually exported.  So we list them here.
 (export
+	cog-add-uuid
 	cog-assign-uuid
 	cog-lookup-uuid
 	cog-unassign-uuid
 	cog-remove-uuid
 )
+
+(set-procedure-property! cog-add-uuid 'documentation
+"
+ cog-add-uuid ATOM UUID
+
+   Same as `cog-assign-uuid`, except the UUID argument is mandatory.
+")
 
 (define* (cog-assign-uuid ATOM #:optional (UUID -1))
 "

--- a/opencog/scm/opencog/uuid.scm
+++ b/opencog/scm/opencog/uuid.scm
@@ -1,0 +1,28 @@
+;
+; OpenCog UUID module
+;
+
+(define-module (opencog uuid))
+
+(use-modules (opencog))
+(use-modules (opencog as-config))
+(load-extension
+	(string-append opencog-ext-path-uuid "libguile-uuid")
+	"opencog_uuid_init")
+
+; We need to list everything that was already exported by the shared
+; library; failure to do so causes warning messages to be printed,
+; because other scheme code cannot guess what names the shared lib
+; actually exported.  So we list them here.
+(export
+	cog-assign-uuid
+	cog-atom-from-uuid
+	cog-uuid-from-atom
+	cog-unassign-uuid
+	cog-remove-uuid
+)
+
+(set-procedure-property! cog-assign-uuid 'documentation
+"
+ cog-assign-uuid ATOM UUID
+")

--- a/opencog/scm/opencog/uuid.scm
+++ b/opencog/scm/opencog/uuid.scm
@@ -16,13 +16,61 @@
 ; actually exported.  So we list them here.
 (export
 	cog-assign-uuid
-	cog-atom-from-uuid
-	cog-uuid-from-atom
+	cog-lookup-uuid
 	cog-unassign-uuid
 	cog-remove-uuid
 )
 
-(set-procedure-property! cog-assign-uuid 'documentation
+(define* (cog-assign-uuid ATOM #:optional (UUID -1))
 "
- cog-assign-uuid ATOM UUID
+ cog-assign-uuid ATOM [UUID]
+
+   Assign a UUID (universally-unique integer) to `ATOM`. If the second
+   argument is absent, then a new, unused UUID is issued. If the second
+   argument is provided, then that will be used as the UUID.  This
+   function memorizes the Atom-to-UUID associations, and so will always
+   provide the same UUID for the same atom.
+
+   Example:
+      ; Generate new UUID's
+      (cog-assign-uuid (Concept "A"))
+      (cog-assign-uuid (Concept "B"))
+      (cog-assign-uuid (Concept "C") 4)
+      (cog-assign-uuid (Concept "D"))
+      (cog-assign-uuid (Concept "E"))
+
+      ; Fetch existing UUID's
+      (cog-assign-uuid (Concept "A"))
+      (cog-assign-uuid (Concept "B"))
+      (cog-assign-uuid (Concept "C") 444)
+      (cog-assign-uuid (Concept "D"))
+      (cog-assign-uuid (Concept "E"))
+
+   The second call, attempting to assign a new UUID to `C` will throw
+   an error.
+
+   See also: cog-lookup-uuid cog-remove-uuid cog-unassign-uuid
+"
+	(cog-add-uuid ATOM UUID)
+)
+
+(set-procedure-property! cog-lookup-uuid 'documentation
+"
+ cog-lookup-uuid UUID
+
+   See also: cog-assign-uuid cog-remove-uuid cog-unassign-uuid
+")
+
+(set-procedure-property! cog-unassign-uuid 'documentation
+"
+ cog-unassign-uuid ATOM
+
+   See also: cog-remove-uuid cog-assign-uuid cog-lookup-uuid
+")
+
+(set-procedure-property! cog-remove-uuid 'documentation
+"
+ cog-remove-uuid UUID
+
+   See also: cog-unassign-uuid cog-assign-uuid cog-lookup-id
 ")

--- a/opencog/scm/opencog/uuid.scm
+++ b/opencog/scm/opencog/uuid.scm
@@ -33,21 +33,18 @@
 
    Example:
       ; Generate new UUID's
-      (cog-assign-uuid (Concept "A"))
-      (cog-assign-uuid (Concept "B"))
-      (cog-assign-uuid (Concept "C") 4)
-      (cog-assign-uuid (Concept "D"))
-      (cog-assign-uuid (Concept "E"))
+      (cog-assign-uuid (Concept \"A\"))    ;; gets 1
+      (cog-assign-uuid (Concept \"B\"))    ;; gets 2
+      (cog-assign-uuid (Concept \"C\") 4)  ;; gets 4, as requested
+      (cog-assign-uuid (Concept \"D\"))    ;; gets 3
+      (cog-assign-uuid (Concept \"E\"))    ;; gets 5
 
       ; Fetch existing UUID's
-      (cog-assign-uuid (Concept "A"))
-      (cog-assign-uuid (Concept "B"))
-      (cog-assign-uuid (Concept "C") 444)
-      (cog-assign-uuid (Concept "D"))
-      (cog-assign-uuid (Concept "E"))
-
-   The second call, attempting to assign a new UUID to `C` will throw
-   an error.
+      (cog-assign-uuid (Concept \"A\"))    ;; returns 1, as before
+      (cog-assign-uuid (Concept \"B\"))    ;; returns 2, as before
+      (cog-assign-uuid (Concept \"C\") 44) ;; throws error
+      (cog-assign-uuid (Concept \"D\"))    ;; returns 3, as before
+      (cog-assign-uuid (Concept \"E\"))    ;; returns 5, as before
 
    See also: cog-lookup-uuid cog-remove-uuid cog-unassign-uuid
 "


### PR DESCRIPTION
The TLB utility is a handy-dandy tool for associating UUID's to Atoms.
Expose it to scheme.