### PR TITLE
In scheme, undefined atom should be #f instead of '()

### DIFF
--- a/opencog/guile/SchemeSmobNew.cc
+++ b/opencog/guile/SchemeSmobNew.cc
@@ -151,7 +151,7 @@ SCM SchemeSmob::handle_to_scm (const Handle& h)
 
 SCM SchemeSmob::protom_to_scm (const ValuePtr& pa)
 {
-	if (nullptr == pa) return SCM_EOL;
+	if (nullptr == pa) return SCM_BOOL_F;
 
 	// Use new so that the smart pointer increments!
 	ValuePtr* pap = new ValuePtr(pa);


### PR DESCRIPTION
Fix an error made a very long time ago, of returning an
empty list for the undefined atom. This was an OK decision
if this had been common lisp, but, for scheme, and for srfi-1
this was a bad decision, polluting all sorts of code with
pointless checks for the empty list.  So this attempts to
fix that age-old problem.

This might break existing code ... hopefully not, but no
obvious way of knowing...