### PR TITLE
Cond link reduction

### DIFF
--- a/opencog/atoms/core/CondLink.cc
+++ b/opencog/atoms/core/CondLink.cc
@@ -106,7 +106,8 @@ ValuePtr CondLink::execute(AtomSpace *scratch, bool silent)
 
 	if (default_exp->is_executable())
 		return default_exp->execute(scratch, silent);
-	return default_exp;
+	Instantiator inst(scratch);
+	return inst.execute(default_exp);
 }
 
 DEFINE_LINK_FACTORY(CondLink, COND_LINK)

--- a/opencog/atoms/core/CondLink.cc
+++ b/opencog/atoms/core/CondLink.cc
@@ -98,7 +98,9 @@ ValuePtr CondLink::execute(AtomSpace *scratch, bool silent)
 			if (exps[i]->is_executable())
 				return exps[i]->execute(scratch, silent);
 
-			// Reduce the clause further, if possible.
+			// At this time, not every Atom type knows how to execute
+			// itself. So if the above didn't work, try again, forcing
+			// further reduction.
 			Instantiator inst(scratch);
 			return inst.execute(exps[i]);
 		}

--- a/opencog/atoms/core/CondLink.cc
+++ b/opencog/atoms/core/CondLink.cc
@@ -21,6 +21,7 @@
 
 #include <opencog/atoms/base/ClassServer.h>
 #include <opencog/atoms/execution/EvaluationLink.h>
+#include <opencog/atoms/execution/Instantiator.h>
 
 #include "CondLink.h"
 
@@ -96,7 +97,10 @@ ValuePtr CondLink::execute(AtomSpace *scratch, bool silent)
 		{
 			if (exps[i]->is_executable())
 				return exps[i]->execute(scratch, silent);
-			return exps[i];
+
+			// Reduce the clause further, if possible.
+			Instantiator inst(scratch);
+			return inst.execute(exps[i]);
 		}
 	}
 

--- a/tests/atoms/core/CondLinkUTest.cxxtest
+++ b/tests/atoms/core/CondLinkUTest.cxxtest
@@ -151,18 +151,17 @@ void CondLinkUTest::test_knobs()
 
 	Handle result = eval->eval_h("(cog-execute! put-00)");
 
-	Handle baz = eval->eval_h("(And (Not (Predicate \"$a\")) (Not (Predicate \"$b\")))");
+	Handle baz = eval->eval_h("(Not (And (Predicate \"$a\") (Not (Predicate \"$b\"))))");
 	printf("p00 got %s\n", result->to_string().c_str());
-	printf("p00 expected %s\n", baz->to_string().c_str());
+	printf("p00 expected %s\n\n", baz->to_string().c_str());
 
 	TS_ASSERT(result == baz);
 
 	result = eval->eval_h("(cog-execute! put-01)");
 
-	baz = eval->eval_h("(NumberNode 2)");
-	baz = eval->eval_h("(And (Not (Predicate \"$a\")) (Predicate \"$b\"))");
+	baz = eval->eval_h("(Not (And (Predicate \"$a\") (Predicate \"$b\")))");
 	printf("p01 got %s\n", result->to_string().c_str());
-	printf("p01 expected %s\n", baz->to_string().c_str());
+	printf("p01 expected %s\n\n", baz->to_string().c_str());
 
 	TS_ASSERT(result == baz);
 
@@ -170,7 +169,7 @@ void CondLinkUTest::test_knobs()
 
 	baz = eval->eval_h("(And (Predicate \"$a\") (Not (Predicate \"$b\")))");
 	printf("p10 got %s\n", result->to_string().c_str());
-	printf("p10 expected %s\n", baz->to_string().c_str());
+	printf("p10 expected %s\n\n", baz->to_string().c_str());
 
 	TS_ASSERT(result == baz);
 
@@ -178,7 +177,7 @@ void CondLinkUTest::test_knobs()
 
 	baz = eval->eval_h("(And (Predicate \"$a\") (Predicate \"$b\"))");
 	printf("p11 got %s\n", result->to_string().c_str());
-	printf("p11 expected %s\n", baz->to_string().c_str());
+	printf("p11 expected %s\n\n", baz->to_string().c_str());
 
 	TS_ASSERT(result == baz);
 

--- a/tests/atoms/core/CondLinkUTest.cxxtest
+++ b/tests/atoms/core/CondLinkUTest.cxxtest
@@ -59,12 +59,10 @@ public:
 	void tearDown(void);
 
 	void test_singleton(void);
-
 	void test_nondefault_exp(void);
-
 	void test_wrapped_exp();
-
 	void test_grounded_cond();
+	void test_knobs();
 };
 
 void CondLinkUTest::tearDown(void)
@@ -90,6 +88,8 @@ void CondLinkUTest::test_singleton()
 	printf("expected %s\n", baz->to_string().c_str());
 
 	TS_ASSERT(result == baz);
+
+	logger().debug("END TEST: %s", __FUNCTION__);
 }
 
 void CondLinkUTest::test_nondefault_exp()
@@ -105,6 +105,8 @@ void CondLinkUTest::test_nondefault_exp()
 	printf("expected %s\n", baz->to_string().c_str());
 
 	TS_ASSERT(result == baz);
+
+	logger().debug("END TEST: %s", __FUNCTION__);
 }
 
 void CondLinkUTest::test_wrapped_exp()
@@ -120,6 +122,8 @@ void CondLinkUTest::test_wrapped_exp()
 	printf("expected %s\n", baz->to_string().c_str());
 
 	TS_ASSERT(result == baz);
+
+	logger().debug("END TEST: %s", __FUNCTION__);
 }
 
 void CondLinkUTest::test_grounded_cond()
@@ -135,4 +139,48 @@ void CondLinkUTest::test_grounded_cond()
 	printf("expected %s\n", baz->to_string().c_str());
 
 	TS_ASSERT(result == baz);
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+void CondLinkUTest::test_knobs()
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	eval->eval("(load-from-path \"tests/atoms/core/condlink.scm\")");
+
+	Handle result = eval->eval_h("(cog-execute! put-00)");
+
+	Handle baz = eval->eval_h("(And (Not (Predicate \"$a\")) (Not (Predicate \"$b\")))");
+	printf("p00 got %s\n", result->to_string().c_str());
+	printf("p00 expected %s\n", baz->to_string().c_str());
+
+	TS_ASSERT(result == baz);
+
+	result = eval->eval_h("(cog-execute! put-01)");
+
+	baz = eval->eval_h("(NumberNode 2)");
+	baz = eval->eval_h("(And (Not (Predicate \"$a\")) (Predicate \"$b\"))");
+	printf("p01 got %s\n", result->to_string().c_str());
+	printf("p01 expected %s\n", baz->to_string().c_str());
+
+	TS_ASSERT(result == baz);
+
+	result = eval->eval_h("(cog-execute! put-10)");
+
+	baz = eval->eval_h("(And (Predicate \"$a\") (Not (Predicate \"$b\")))");
+	printf("p10 got %s\n", result->to_string().c_str());
+	printf("p10 expected %s\n", baz->to_string().c_str());
+
+	TS_ASSERT(result == baz);
+
+	result = eval->eval_h("(cog-execute! put-11)");
+
+	baz = eval->eval_h("(And (Predicate \"$a\") (Predicate \"$b\"))");
+	printf("p11 got %s\n", result->to_string().c_str());
+	printf("p11 expected %s\n", baz->to_string().c_str());
+
+	TS_ASSERT(result == baz);
+
+	logger().debug("END TEST: %s", __FUNCTION__);
 }

--- a/tests/atoms/core/condlink.scm
+++ b/tests/atoms/core/condlink.scm
@@ -73,3 +73,32 @@
 		(GroundedPredicate "scm:grounded_cond2")
 		(List ))
 	(NumberNode 2)))
+
+; ---------------------------------
+; AS-MOSES uses this to simplify kobby trees
+
+(define sub-expr
+   (AndLink
+      (PredicateNode "$a")
+      (CondLink
+         (EqualLink (Variable "$knob-2") (NumberNode 1))
+         (PredicateNode "$b")
+         (NotLink (PredicateNode "$b")))))
+
+(DefineLink
+   (DefinedSchema "rep")
+   (LambdaLink
+      (VariableList
+         (Variable "$knob-1")
+         (Variable "$knob-2"))
+      (CondLink
+         (EqualLink (Variable "$knob-1") (NumberNode 1))
+         sub-expr
+         (NotLink sub-expr))))
+
+(define put-00 (Put (DefinedSchema "rep") (List (Number 0) (Number 0))))
+(define put-01 (Put (DefinedSchema "rep") (List (Number 0) (Number 1))))
+(define put-10 (Put (DefinedSchema "rep") (List (Number 1) (Number 0))))
+(define put-11 (Put (DefinedSchema "rep") (List (Number 1) (Number 1))))
+
+*unspecified*


### PR DESCRIPTION
Bug fix for #2546 -- At this time, not every Atom type knows how to execute
itself. So if `execute()` didn't work, try again, forcing further reduction.