### PR TITLE
Guile: use the current atomspace, when fetching  incoming set

### DIFF
--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -379,12 +379,27 @@ void Atom::swap_atom(const Handle& old, const Handle& neu)
 void Atom::install() {}
 void Atom::remove() {}
 
-size_t Atom::getIncomingSetSize() const
+size_t Atom::getIncomingSetSize(AtomSpace* as) const
 {
     if (nullptr == _incoming_set) return 0;
+
     std::lock_guard<std::mutex> lck (_mtx);
 
     size_t cnt = 0;
+    if (as)
+    {
+        const AtomTable *atab = &as->get_atomtable();
+        for (const auto& bucket : _incoming_set->_iset)
+        {
+            for (const WinkPtr& w : bucket.second)
+            {
+                Handle l(w.lock());
+                if (l and atab->in_environ(l)) cnt++;
+            }
+        }
+        return cnt;
+    }
+
     for (const auto& pr : _incoming_set->_iset)
         cnt += pr.second.size();
     return cnt;

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -306,7 +306,7 @@ public:
     std::string valuesToString() const;
 
     //! Get the size of the incoming set.
-    size_t getIncomingSetSize() const;
+    size_t getIncomingSetSize(AtomSpace* = nullptr) const;
 
     //! Return the incoming set of this atom.
     //! If the AtomSpace pointer is non-null, then only those atoms

--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -293,9 +293,11 @@ SCM SchemeSmob::ss_incoming_set (SCM satom)
 {
 	Handle h = verify_handle(satom, "cog-incoming-set");
 
+	AtomSpace* as = ss_get_env_as("cog-incoming-set");
+
 	// This reverses the order of the incoming set, but so what ...
 	SCM head = SCM_EOL;
-	IncomingSet iset = h->getIncomingSet();
+	IncomingSet iset = h->getIncomingSet(as);
 	for (const Handle& l : iset)
 	{
 		SCM smob = handle_to_scm(l);
@@ -314,8 +316,9 @@ SCM SchemeSmob::ss_incoming_by_type (SCM satom, SCM stype)
 	Handle h = verify_handle(satom, "cog-incoming-by-type");
 	Type t = verify_type(stype, "cog-incoming-by-type", 2);
 
-	HandleSeq iset;
-	h->getIncomingSetByType(std::back_inserter(iset), t);
+	AtomSpace* as = ss_get_env_as("cog-incoming-by-type");
+
+	IncomingSet iset = h->getIncomingSetByType(t, as);
 	SCM head = SCM_EOL;
 	for (const Handle& ih : iset)
 	{
@@ -333,7 +336,9 @@ SCM SchemeSmob::ss_incoming_by_type (SCM satom, SCM stype)
 SCM SchemeSmob::ss_incoming_size (SCM satom)
 {
 	Handle h = verify_handle(satom, "cog-incoming-size");
-	size_t sz = h->getIncomingSetSize();
+	AtomSpace* as = ss_get_env_as("cog-incoming-set");
+
+	size_t sz = h->getIncomingSetSize(as);
 	return scm_from_size_t(sz);
 }
 
@@ -347,7 +352,8 @@ SCM SchemeSmob::ss_incoming_size_by_type (SCM satom, SCM stype)
 	Handle h = verify_handle(satom, "cog-incoming-size-by-type");
 	Type t = verify_type(stype, "cog-incoming-size-by-type", 2);
 
-	size_t sz = h->getIncomingSetSizeByType(t);
+	AtomSpace* as = ss_get_env_as("cog-incoming-set");
+	size_t sz = h->getIncomingSetSizeByType(t, as);
 	return scm_from_size_t(sz);
 }
 


### PR DESCRIPTION
This helps avoid looking at atoms that were in scratch/temp atomspaces.