### PR TITLE
Restore stubbed-out unit test.

### DIFF
--- a/opencog/cython/PythonEval.cc
+++ b/opencog/cython/PythonEval.cc
@@ -338,18 +338,12 @@ static bool try_to_load_modules(const char ** config_paths)
 
 static bool already_initialized = false;
 static bool initialized_outside_opencog = false;
-static bool was_finalized_by_us = false;
 static void *_dlso = nullptr;
 
 void opencog::global_python_initialize()
 {
     // Don't initialize twice
     if (already_initialized) return;
-
-    // https://docs.python.org/3/c-api/init.html#c.Py_FinalizeEx
-    // Some extensions may not work properly if their initialization routine is called more than once; this can happen if an application calls Py_Initialize() and Py_FinalizeEx() more than once.
-    if (was_finalized_by_us)
-        throw std::runtime_error("reinitialization is not supported by python");
 
     already_initialized = true;
 
@@ -435,7 +429,6 @@ void opencog::global_python_finalize()
         PyGILState_Ensure(); // yes this is needed, see bug #671
         Py_Finalize();
         if (_dlso) dlclose(_dlso);
-        was_finalized_by_us = true;
     }
 
     // No longer initialized.

--- a/tests/cython/PythonEvalUTest.cxxtest
+++ b/tests/cython/PythonEvalUTest.cxxtest
@@ -309,17 +309,9 @@ public:
         // Initialize and finalize Python.
         global_python_initialize();
         global_python_finalize();
-        bool thrown = false;
-
-        // Initialize and finalize Python.
-        try{
-            global_python_initialize(); }
-        catch (const std::runtime_error & e){
-            if (std::string(e.what()) != "reinitialization is not supported by python")
-                throw e;
-            thrown = true;
-        }
-        TS_ASSERT(thrown);
+        global_python_initialize();
+        global_python_finalize();
+        global_python_initialize();
         global_python_finalize();
 
         logger().debug("[PythonEvalUTest] testGlobalPythonInitializationFinalization() DONE");


### PR DESCRIPTION
Placing a check in our code base because some other unknown
third-party code might be broken according to a post on the
internet does not make sense in any rational way that I can
understand it.  If other users have bugs in their code, that
should not be our problem, nor is it our duty to perform a
check on their behalf.