### PR TITLE
Enable copy-on-write atomspaces

### DIFF
--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -81,6 +81,7 @@ class AtomSpace
     AtomTable& get_atomtable(void) { return _atom_table; }
 
     bool _read_only;
+    bool _copy_on_write;
 protected:
 
     /**
@@ -96,15 +97,29 @@ public:
     AtomSpace(AtomSpace* parent=nullptr, bool transient=false);
     ~AtomSpace();
 
-    // Transient atomspaces are lighter-weight, faster, but are missing
-    // some features. They are used during pattern matching, to hold
-    // temporary results.
+    /// Transient atomspaces are lighter-weight, faster, but are missing
+    /// some features. They are used during pattern matching, to hold
+    /// temporary results. The are always copy-on-write spaces.
     void ready_transient(AtomSpace* parent);
     void clear_transient();
 
+    /// Read-only (RO) atomspaces provide protection against update of the
+    /// AtomSpace contents. Atoms in a read-only atomspace canot be
+    /// deleted, nor can thier values (including truthvalues) be changed.
+    /// New atoms cannot be added to a read-only atomspace.
     void set_read_only(void);
     void set_read_write(void);
     bool get_read_only(void) { return _read_only; }
+
+    /// Copy-on-write (COW) atomspaces provide protection against the
+    /// update of the parent atomspace. When an atomspace is marked COW,
+    /// it behaves as if it is read-write, but the parent is read-only.
+    /// This is convenient for creating temporary atomspaces, wherein
+    /// updates will not trash the parent. Transient atomspaces are
+    /// always COW.
+    void set_copy_on_write(void) { _copy_on_write = true; }
+    void clear_copy_on_write(void) { _copy_on_write = false; }
+    bool get_copy_on_write(void) { return _copy_on_write; }
 
     /// Get the environment that this atomspace was created in.
     AtomSpace* get_environ() const {

--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -312,6 +312,8 @@ void SchemeSmob::register_procs()
 	register_proc("cog-atomspace-readonly?", 0, 1, 0, C(ss_as_readonly_p));
 	register_proc("cog-atomspace-ro!",     0, 1, 0, C(ss_as_mark_readonly));
 	register_proc("cog-atomspace-rw!",     0, 1, 0, C(ss_as_mark_readwrite));
+	register_proc("cog-atomspace-cow?",    0, 1, 0, C(ss_as_cow_p));
+	register_proc("cog-atomspace-cow!",    1, 1, 0, C(ss_as_mark_cow));
 
 	// Taking AtomSpace as optional argument
 	register_proc("cog-count-atoms",       1, 1, 0, C(ss_count));

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -155,6 +155,8 @@ private:
 	static SCM ss_as_mark_readonly(SCM);
 	static SCM ss_as_mark_readwrite(SCM);
 	static SCM ss_as_readonly_p(SCM);
+	static SCM ss_as_mark_cow(SCM, SCM);
+	static SCM ss_as_cow_p(SCM);
 	static SCM make_as(AtomSpace *);
 	static void release_as(AtomSpace *);
 	static AtomSpace* ss_to_atomspace(SCM);

--- a/opencog/guile/SchemeSmobAS.cc
+++ b/opencog/guile/SchemeSmobAS.cc
@@ -263,6 +263,20 @@ SCM SchemeSmob::ss_as_readonly_p(SCM sas)
 	return SCM_BOOL_F;
 }
 
+/**
+ * Return COW flag of the atomspace.  If no atomspace specified,
+ * then get the current atomspace.
+ */
+SCM SchemeSmob::ss_as_cow_p(SCM sas)
+{
+	AtomSpace* as = ss_to_atomspace(sas);
+	scm_remember_upto_here_1(sas);
+	if (nullptr == as) as = ss_get_env_as("cog-atomspace-cow?");
+
+	if (as->get_copy_on_write()) return SCM_BOOL_T;
+	return SCM_BOOL_F;
+}
+
 /* ============================================================== */
 /**
  * Set the readonly flag of the atomspace.  If no atomspace specified,
@@ -286,6 +300,18 @@ SCM SchemeSmob::ss_as_mark_readwrite(SCM sas)
 	if (nullptr == as) as = ss_get_env_as("cog-atomspace-rw!");
 
 	as->set_read_write();
+	return SCM_BOOL_T;
+}
+
+SCM SchemeSmob::ss_as_mark_cow(SCM scow, SCM sas)
+{
+	AtomSpace* as = ss_to_atomspace(sas);
+	scm_remember_upto_here_1(sas);
+	if (nullptr == as) as = ss_get_env_as("cog-atomspace-cow!");
+
+	bool cow = scm_to_bool(scow);
+	if (cow) as->set_copy_on_write();
+	else as->clear_copy_on_write();
 	return SCM_BOOL_T;
 }
 

--- a/opencog/scm/opencog/base/core-docs.scm
+++ b/opencog/scm/opencog/base/core-docs.scm
@@ -901,6 +901,80 @@
      remove them from the backingstore.
 ")
 
+(set-procedure-property! cog-atomspace-ro! 'documentation
+"
+ cog-atomspace-ro! [ATOMSPACE]
+     Mark the ATOMSPACE as being read-only. New atoms cannot be added
+     to a read-only atomspace, nor can atoms be removed. The Values
+     (including the TruthValues) of atoms in the read-only atomspace
+     cannot be changed.
+
+     The ATOMSPACE argument is optional; if not specified, the current
+     atomspace is assumed.
+
+     See also: cog-atomspace-rw!, cog-atomspace-readonly?,
+         cog-atomspace-cow! and cog-atomspace-cow?
+")
+
+(set-procedure-property! cog-atomspace-rw! 'documentation
+"
+ cog-atomspace-rw! [ATOMSPACE]
+     Mark the ATOMSPACE as being read-write. See cog-atomspace-ro!
+     for a detailed explanation.
+
+     The ATOMSPACE argument is optional; if not specified, the current
+     atomspace is assumed.
+
+     See also: cog-atomspace-readonly?, cog-atomspace-cow! and
+         cog-atomspace-cow?
+")
+
+(set-procedure-property! cog-atomspace-readonly? 'documentation
+"
+ cog-atomspace-readonly? [ATOMSPACE]
+     Return #t if the ATOMSPACE is marked read-only. See
+     cog-atomspace-ro! for a detailed explanation.
+
+     The ATOMSPACE argument is optional; if not specified, the current
+     atomspace is assumed.
+
+     See also: cog-atomspace-cow! and cog-atomspace-cow?
+")
+
+(set-procedure-property! cog-atomspace-cow! 'documentation
+"
+ cog-atomspace-cow! BOOL [ATOMSPACE]
+     Set the copy-on-write (COW) bit on the ATOMSPACE to BOOL.
+
+     A COW atomspace behaves as if the parent has been marked read-only,
+     and so any modifications to atoms in a COW space do not affect the
+     parent. (It does not make sense to mark an atomsapce as being COW,
+     if there is no parent.)
+
+     COW spaces are useful as temporary or transient AtomSpaces, so that
+     scratch calculations and updates can be performed without affecting
+     the parent.
+
+     The ATOMSPACE argument is optional; if not specified, the current
+     atomspace is assumed.
+
+     See also: cog-atomspace-cow?, cog-atomspace-readonly?,
+         cog-atomspace-ro! and cog-atomspace-rw!,
+")
+
+(set-procedure-property! cog-atomspace-cow? 'documentation
+"
+ cog-atomspace-cow? [ATOMSPACE]
+     Return the copy-on-write (COW) bit on the ATOMSPACE to BOOL.
+     See cog-atomspace-cow! for an explanation.
+
+     The ATOMSPACE argument is optional; if not specified, the current
+     atomspace is assumed.
+
+     See also: cog-atomspace-ro! and cog-atomspace-rw! and
+         cog-atomspace-readonly?,
+")
+
 ;set-procedure-property! cog-yield 'documentation
 ;"
 ; cog-yield

--- a/tests/atomspace/COWSpaceUTest.cxxtest
+++ b/tests/atomspace/COWSpaceUTest.cxxtest
@@ -50,7 +50,10 @@ public:
 		ovly = new AtomSpace(base);
 	}
 
-	void tearDown() {}
+	void tearDown() {
+		delete ovly;
+		delete base;
+	}
 
 	void testSimple()
 	{
@@ -95,6 +98,58 @@ public:
 		Handle h2c = base->add_node(CONCEPT_NODE, "Grade A2");
 		TS_ASSERT(h2 == h2c);
 		TS_ASSERT(h2c->getTruthValue() == tv2);
+
+		logger().debug("END TEST: %s", __FUNCTION__);
+	}
+
+	void testCOW()
+	{
+		logger().debug("BEGIN TEST: %s", __FUNCTION__);
+		TruthValuePtr tv1(SimpleTruthValue::createTV(0.1, 0.1));
+		TruthValuePtr tv2(SimpleTruthValue::createTV(0.2, 0.2));
+		TruthValuePtr tv3(SimpleTruthValue::createTV(0.3, 0.3));
+		TruthValuePtr tv4(SimpleTruthValue::createTV(0.4, 0.4));
+		TruthValuePtr tv5(SimpleTruthValue::createTV(0.5, 0.5));
+
+		// Mark the overlay as a COW space.
+		ovly->set_copy_on_write();
+
+		// Create two atoms in the base atomspace
+		Handle h1 = base->add_node(CONCEPT_NODE, "A1 beef");
+		Handle h1t = base->set_truthvalue(h1, tv1);
+		TS_ASSERT(h1 == h1t);
+
+		Handle h2 = base->add_node(CONCEPT_NODE, "Grade A2");
+		Handle h2t = base->set_truthvalue(h2, tv2);
+		TS_ASSERT(h2 == h2t);
+
+		// Setting truth value in overlay should trigger COW
+		Handle h2o = ovly->set_truthvalue(h2, tv3);
+		TS_ASSERT(h2 != h2o);
+		TS_ASSERT(h2o->getTruthValue() == tv3);
+		TS_ASSERT(h2->getTruthValue() == tv2);
+
+		// No problem touching the base space.
+		Handle h2b = base->add_node(CONCEPT_NODE, "Grade A2");
+		TS_ASSERT(h2 == h2b);
+		TS_ASSERT(h2b->getTruthValue() == tv2);
+
+		// No problem altering the base space.
+		Handle h4b = base->set_truthvalue(h2, tv4);
+		TS_ASSERT(h2 == h4b);
+		TS_ASSERT(h4b->getTruthValue() == tv4);
+
+		// Setting truth value a second time in overlay should NOT COW
+		Handle h2v = ovly->set_truthvalue(h2, tv5);
+		TS_ASSERT(h2 != h2v);
+		TS_ASSERT(h2o == h2v);
+		TS_ASSERT(h2o->getTruthValue() == tv5);
+		TS_ASSERT(h2->getTruthValue() == tv4);
+
+		// Base should be OK.
+		Handle h2c = base->add_node(CONCEPT_NODE, "Grade A2");
+		TS_ASSERT(h2 == h2c);
+		TS_ASSERT(h2c->getTruthValue() == tv4);
 
 		logger().debug("END TEST: %s", __FUNCTION__);
 	}

--- a/tests/atomspace/COWSpaceUTest.cxxtest
+++ b/tests/atomspace/COWSpaceUTest.cxxtest
@@ -139,6 +139,13 @@ public:
 		TS_ASSERT(h2 == h4b);
 		TS_ASSERT(h4b->getTruthValue() == tv4);
 
+		// The TV in the overlay should not have been affected,
+		// when the TV in the base was changed.
+		Handle h2u = ovly->add_node(CONCEPT_NODE, "Grade A2");
+		TS_ASSERT(h2 != h2u);
+		TS_ASSERT(h2o == h2u);
+		TS_ASSERT(h2u->getTruthValue() == tv3);
+
 		// Setting truth value a second time in overlay should NOT COW
 		Handle h2v = ovly->set_truthvalue(h2, tv5);
 		TS_ASSERT(h2 != h2v);

--- a/tests/scm/MultiAtomSpaceUTest.cxxtest
+++ b/tests/scm/MultiAtomSpaceUTest.cxxtest
@@ -23,6 +23,7 @@
 #include <boost/algorithm/string.hpp>
 
 #include <opencog/atomspace/AtomSpace.h>
+#include <opencog/atoms/truthvalue/TruthValue.h>
 #include <opencog/guile/SchemeEval.h>
 #include <opencog/util/Logger.h>
 
@@ -565,6 +566,10 @@ void MultiAtomSpace::test_readonly_scm(void)
 
 	TS_ASSERT_THROWS_ANYTHING(evaluator->eval_h("(cog-set-tv! A tv)"));
 	TS_ASSERT_THROWS_ANYTHING(evaluator->eval_h("(Concept \"A\" tv)"));
+
+	// Verify that the TV never changed.
+	TruthValuePtr tvp = evaluator->eval_tv("(cog-tv (Concept \"A\"))");
+	TS_ASSERT (TruthValue::DEFAULT_TV() == tvp);
 
 	logger().debug("END TEST: %s", __FUNCTION__);	
 }


### PR DESCRIPTION
The copyon-write atomspace provides an easier-to-use, safer API for
temporary atomspaces, where changes to the temporary should not bleed 
over onto the parent atomspace. This idea came up in the context of #2556

The docs:
```
     A COW atomspace behaves as if the parent has been marked read-only,
     and so any modifications to atoms in a COW space do not affect the
     parent. (It does not make sense to mark an atomsapce as being COW,
     if there is no parent.)

     COW spaces are useful as temporary or transient AtomSpaces, so that
     scratch calculations and updates can be performed without affecting
     the parent.
```