### PR TITLE
Bug-fix usage of `set_truthvalue()` in guile bindings.

### DIFF
--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -180,8 +180,10 @@ SCM SchemeSmob::ss_inc_count (SCM satom, SCM scnt)
 		tv->get_mean(), tv->get_confidence(), cnt);
 
 	AtomSpace* as = ss_get_env_as("cog-inc-count!");
-	as->set_truthvalue(h, tv);
-	return satom;
+	Handle ha(as->set_truthvalue(h, tv));
+	if (ha == h)
+		return satom;
+	return handle_to_scm(ha);
 }
 
 /* ============================================================== */
@@ -218,8 +220,10 @@ SCM SchemeSmob::ss_inc_value (SCM satom, SCM skey, SCM scnt, SCM sref)
 	new_value[ref] += cnt;
 
 	AtomSpace* as = ss_get_env_as("cog-inc-value!");
-	as->set_value(h, key, createFloatValue(new_value));
-	return satom;
+	Handle ha(as->set_value(h, key, createFloatValue(new_value)));
+	if (ha == h)
+		return satom;
+	return handle_to_scm(ha);
 }
 
 /* ============================================================== */

--- a/opencog/guile/SchemeSmobNew.cc
+++ b/opencog/guile/SchemeSmobNew.cc
@@ -407,7 +407,7 @@ SCM SchemeSmob::ss_new_node (SCM stype, SCM sname, SCM kv_pairs)
 		if (h)
 		{
 			const TruthValuePtr tv(get_tv_from_list(kv_pairs));
-			if (tv) atomspace->set_truthvalue(h, tv);
+			if (tv) h = atomspace->set_truthvalue(h, tv);
 		}
 
 		return handle_to_scm(h);
@@ -442,7 +442,7 @@ SCM SchemeSmob::ss_node (SCM stype, SCM sname, SCM kv_pairs)
 
 	// If there was a truth value, change it.
 	const TruthValuePtr tv(get_tv_from_list(kv_pairs));
-	if (tv) atomspace->set_truthvalue(h, tv);
+	if (tv) h = atomspace->set_truthvalue(h, tv);
 
 	scm_remember_upto_here_1(kv_pairs);
 	return handle_to_scm (h);
@@ -526,7 +526,7 @@ SCM SchemeSmob::ss_new_link (SCM stype, SCM satom_list)
 		if (h)
 		{
 			const TruthValuePtr tv(get_tv_from_list(satom_list));
-			if (tv) atomspace->set_truthvalue(h, tv);
+			if (tv) h = atomspace->set_truthvalue(h, tv);
 		}
 
 		return handle_to_scm(h);
@@ -560,7 +560,7 @@ SCM SchemeSmob::ss_link (SCM stype, SCM satom_list)
 
 	// If there was a truth value, change it.
 	const TruthValuePtr tv(get_tv_from_list(satom_list));
-	if (tv) atomspace->set_truthvalue(h, tv);
+	if (tv) h = atomspace->set_truthvalue(h, tv);
 
 	scm_remember_upto_here_1(satom_list);
 	return handle_to_scm (h);


### PR DESCRIPTION
copy-on-write may cause a new atom to be returned.
Hand the new atom, not the old one, back to the user.