### PR TITLE
Safety checks for private link types

### DIFF
--- a/opencog/atoms/core/FreeLink.cc
+++ b/opencog/atoms/core/FreeLink.cc
@@ -29,6 +29,10 @@ using namespace opencog;
 FreeLink::FreeLink(const HandleSeq&& oset, Type t)
     : Link(std::move(oset), t)
 {
+	if (FREE_LINK == t)
+		throw InvalidParamException(TRACE_INFO,
+			"FreeLinks are private and cannot be instantiated.");
+
 	if (not nameserver().isA(t, FREE_LINK))
 		throw InvalidParamException(TRACE_INFO, "Expecting a FreeLink");
 

--- a/opencog/atoms/core/FunctionLink.cc
+++ b/opencog/atoms/core/FunctionLink.cc
@@ -28,6 +28,9 @@ using namespace opencog;
 
 void FunctionLink::check_type(Type t)
 {
+	if (FUNCTION_LINK == t)
+		throw InvalidParamException(TRACE_INFO,
+			"FunctionLinks are private and cannot be instantiated.");
 	if (not nameserver().isA(t, FUNCTION_LINK))
 		throw InvalidParamException(TRACE_INFO, "Expecting a FunctionLink");
 }

--- a/opencog/atoms/core/PrenexLink.cc
+++ b/opencog/atoms/core/PrenexLink.cc
@@ -33,6 +33,9 @@ using namespace opencog;
 void PrenexLink::init(void)
 {
 	Type t = get_type();
+	if (PRENEX_LINK == t)
+		throw InvalidParamException(TRACE_INFO,
+			"PrenexLinks are private and cannot be instantiated.");
 	if (not nameserver().isA(t, PRENEX_LINK))
 	{
 		const std::string& tname = nameserver().getTypeName(t);

--- a/opencog/atoms/core/RewriteLink.cc
+++ b/opencog/atoms/core/RewriteLink.cc
@@ -34,6 +34,13 @@ using namespace opencog;
 void RewriteLink::init(void)
 {
 	Type t = get_type();
+
+#if 0
+	// The unit tests create this directly, so this check bombs.
+	if (REWRITE_LINK == t)
+		throw InvalidParamException(TRACE_INFO,
+			"RewriteLinks are private and cannot be instantiated.");
+#endif
 	if (not nameserver().isA(t, REWRITE_LINK))
 	{
 		const std::string& tname = nameserver().getTypeName(t);

--- a/opencog/atoms/core/ScopeLink.cc
+++ b/opencog/atoms/core/ScopeLink.cc
@@ -52,6 +52,13 @@ ScopeLink::ScopeLink(const Handle& vars, const Handle& body)
 bool ScopeLink::skip_init(Type t)
 {
 	// Type must be as expected.
+#if 0
+	// ScopeLinks are created directly in unit tests, so this safety
+	// check won't work.
+	if (SCOPE_LINK == t)
+		throw InvalidParamException(TRACE_INFO,
+			"ScopeLinks are private and cannot be instantiated.");
+#endif
 	if (not nameserver().isA(t, SCOPE_LINK))
 	{
 		const std::string& tname = nameserver().getTypeName(t);

--- a/opencog/atoms/core/UniqueLink.cc
+++ b/opencog/atoms/core/UniqueLink.cc
@@ -29,6 +29,16 @@ using namespace opencog;
 
 void UniqueLink::init(bool allow_open)
 {
+	if (UNIQUE_LINK == _type)
+		throw InvalidParamException(TRACE_INFO,
+			"UniqueLinks are private and cannot be instantiated.");
+	if (not nameserver().isA(_type, UNIQUE_LINK))
+	{
+		const std::string& tname = nameserver().getTypeName(_type);
+		throw InvalidParamException(TRACE_INFO,
+			"Expecting a UniqueLink, got %s", tname.c_str());
+	}
+
 	if (allow_open)
 	{
 		FreeLink::init();
@@ -62,13 +72,6 @@ void UniqueLink::init(bool allow_open)
 UniqueLink::UniqueLink(const HandleSeq&& oset, Type type)
 	: FreeLink(std::move(oset), type)
 {
-	if (not nameserver().isA(type, UNIQUE_LINK))
-	{
-		const std::string& tname = nameserver().getTypeName(type);
-		throw InvalidParamException(TRACE_INFO,
-			"Expecting a UniqueLink, got %s", tname.c_str());
-	}
-
 	// Derived types have thier own initialization
 	if (UNIQUE_LINK != type) return;
 	init(true);

--- a/opencog/atoms/reduct/ArithmeticLink.cc
+++ b/opencog/atoms/reduct/ArithmeticLink.cc
@@ -39,6 +39,10 @@ ArithmeticLink::ArithmeticLink(const HandleSeq&& oset, Type t)
 void ArithmeticLink::init(void)
 {
 	Type tscope = get_type();
+	if (ARITHMETIC_LINK == tscope)
+		throw InvalidParamException(TRACE_INFO,
+			"ArithmeticLinks are private and cannot be instantiated.");
+
 	if (not nameserver().isA(tscope, ARITHMETIC_LINK))
 		throw InvalidParamException(TRACE_INFO, "Expecting an ArithmeticLink");
 

--- a/opencog/atoms/reduct/FoldLink.cc
+++ b/opencog/atoms/reduct/FoldLink.cc
@@ -38,6 +38,10 @@ FoldLink::FoldLink(const HandleSeq&& oset, Type t)
 void FoldLink::init(void)
 {
 	Type tscope = get_type();
+	if (FOLD_LINK == tscope)
+		throw InvalidParamException(TRACE_INFO,
+			"FoldLinks are private and cannot be instantiated.");
+
 	if (not nameserver().isA(tscope, FOLD_LINK))
 		throw InvalidParamException(TRACE_INFO, "Expecting a FoldLink");
 }


### PR DESCRIPTION
Users should never instantiate any of the private link types.
Add a safety check to make sure that this is so.

(These are helper classes, that implement assorted useful
methods that can only be accessed via C++. They don't 
provide anything useful to final end-users)