### PR TITLE
All search functions now use QueueValue for results.

### DIFF
--- a/opencog/atoms/pattern/BindLink.cc
+++ b/opencog/atoms/pattern/BindLink.cc
@@ -8,8 +8,7 @@
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License v3 as
  * published by the Free Software Foundation and including the
- * exceptions
- * at http://opencog.org/wiki/Licenses
+ * exceptions at http://opencog.org/wiki/Licenses
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,12 +16,12 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public
- * License
- * along with this program; if not, write to:
+ * License along with this program; if not, write to:
  * Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <opencog/util/oc_assert.h>
 #include <opencog/atoms/atom_types/NameServer.h>
 #include <opencog/atoms/core/UnorderedLink.h>
 #include <opencog/atomspace/AtomSpace.h>
@@ -66,14 +65,22 @@ BindLink::BindLink(const HandleSeq&& hseq, Type t)
 /** Wrap query results in a SetLink, place them in the AtomSpace. */
 ValuePtr BindLink::execute(AtomSpace* as, bool silent)
 {
-	ValueSet rslt(do_execute(as, silent));
+	HandleSeq rslt;
+	QueueValuePtr qv(do_execute(as, silent));
+	OC_ASSERT(qv->is_closed(), "Unexpected queue state!");
+	std::queue<ValuePtr> vals(qv->wait_and_take_all());
+	while (not vals.empty())
+	{
+		rslt.push_back(HandleCast(vals.front()));
+		vals.pop();
+	}
 
 	// If there is an anchor, then attach results to the anchor.
 	// Otherwise, create a SetLink and return that.
 	if (_variables._anchor and as)
 	{
-		for (const ValuePtr& v: rslt)
-			as->add_link(MEMBER_LINK, HandleCast(v), _variables._anchor);
+		for (const Handle& h: rslt)
+			as->add_link(MEMBER_LINK, h, _variables._anchor);
 
 		return _variables._anchor;
 	}
@@ -81,9 +88,7 @@ ValuePtr BindLink::execute(AtomSpace* as, bool silent)
 	// The result_set contains a list of the grounded expressions.
 	// (The order of the list has no significance, so it's really a set.)
 	// Put the set into a SetLink, cache it, and return that.
-	HandleSeq hlist;
-	for (const ValuePtr& v: rslt) hlist.emplace_back(HandleCast(v));
-	Handle rewr(createUnorderedLink(std::move(hlist), SET_LINK));
+	Handle rewr(createUnorderedLink(std::move(rslt), SET_LINK));
 
 #define PLACE_RESULTS_IN_ATOMSPACE
 #ifdef PLACE_RESULTS_IN_ATOMSPACE

--- a/opencog/atoms/pattern/BindLink.cc
+++ b/opencog/atoms/pattern/BindLink.cc
@@ -65,15 +65,9 @@ BindLink::BindLink(const HandleSeq&& hseq, Type t)
 /** Wrap query results in a SetLink, place them in the AtomSpace. */
 ValuePtr BindLink::execute(AtomSpace* as, bool silent)
 {
-	HandleSeq rslt;
 	QueueValuePtr qv(do_execute(as, silent));
 	OC_ASSERT(qv->is_closed(), "Unexpected queue state!");
-	std::queue<ValuePtr> vals(qv->wait_and_take_all());
-	while (not vals.empty())
-	{
-		rslt.push_back(HandleCast(vals.front()));
-		vals.pop();
-	}
+	HandleSeq rslt(qv->to_handle_seq());
 
 	// If there is an anchor, then attach results to the anchor.
 	// Otherwise, create a SetLink and return that.

--- a/opencog/atoms/pattern/GetLink.cc
+++ b/opencog/atoms/pattern/GetLink.cc
@@ -59,15 +59,9 @@ QueueValuePtr GetLink::do_execute(AtomSpace* as, bool silent)
 
 ValuePtr GetLink::execute(AtomSpace* as, bool silent)
 {
-	HandleSeq hs;
 	QueueValuePtr qv(do_execute(as, silent));
 	OC_ASSERT(qv->is_closed(), "Unexpected queue state!");
-	std::queue<ValuePtr> vals(qv->wait_and_take_all());
-	while (not vals.empty())
-	{
-		hs.push_back(HandleCast(vals.front()));
-		vals.pop();
-	}
+	HandleSeq hs(qv->to_handle_seq());
 
 	// If there is an anchor, then attach results to the anchor.
 	// Otherwise, create a SetLink and return that.

--- a/opencog/atoms/pattern/GetLink.h
+++ b/opencog/atoms/pattern/GetLink.h
@@ -33,7 +33,7 @@ class GetLink : public PatternLink
 {
 protected:
 	void init(void);
-	virtual HandleSet do_execute(AtomSpace*, bool silent);
+	virtual QueueValuePtr do_execute(AtomSpace*, bool silent);
 
 public:
 	GetLink(const HandleSeq&&, Type=GET_LINK);

--- a/opencog/atoms/pattern/QueryLink.cc
+++ b/opencog/atoms/pattern/QueryLink.cc
@@ -155,9 +155,9 @@ ValueSet QueryLink::do_execute(AtomSpace* as, bool silent)
 	this->PatternLink::satisfy(impl);
 
 	// If we got a non-empty answer, just return it.
-	QueueValue& qv(impl.get_result_queue());
-	OC_ASSERT(qv.is_closed(), "Unexpected queue state!");
-	std::queue<ValuePtr> vals(qv.wait_and_take_all());
+	QueueValuePtr qv(impl.get_result_queue());
+	OC_ASSERT(qv->is_closed(), "Unexpected queue state!");
+	std::queue<ValuePtr> vals(qv->wait_and_take_all());
 	if (0 < vals.size())
 	{
 		// The result_set contains a list of the grounded expressions.

--- a/opencog/atoms/pattern/QueryLink.h
+++ b/opencog/atoms/pattern/QueryLink.h
@@ -23,6 +23,7 @@
 #define _OPENCOG_QUERY_LINK_H
 
 #include <opencog/atoms/pattern/PatternLink.h>
+#include <opencog/atoms/value/QueueValue.h>
 
 namespace opencog
 {
@@ -42,7 +43,7 @@ protected:
 	// will initialize the rewrite term _implicand.
 	void extract_variables(const HandleSeq& oset);
 
-	virtual ValueSet do_execute(AtomSpace*, bool silent);
+	virtual QueueValuePtr do_execute(AtomSpace*, bool silent);
 
 public:
 	QueryLink(const HandleSeq&&, Type=QUERY_LINK);

--- a/opencog/atoms/value/LinkValue.cc
+++ b/opencog/atoms/value/LinkValue.cc
@@ -20,10 +20,26 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <opencog/atoms/base/Atom.h>
 #include <opencog/atoms/value/LinkValue.h>
 #include <opencog/atoms/value/ValueFactory.h>
 
 using namespace opencog;
+
+
+HandleSeq LinkValue::to_handle_seq(void) const
+{
+	update();
+	HandleSeq hs;
+	for (const ValuePtr& v : _value)
+	{
+		if (v->is_atom())
+			hs.push_back(HandleCast(v));
+	}
+	return hs;
+}
+
+// ==============================================================
 
 bool LinkValue::operator==(const Value& other) const
 {

--- a/opencog/atoms/value/LinkValue.h
+++ b/opencog/atoms/value/LinkValue.h
@@ -25,6 +25,7 @@
 
 #include <vector>
 #include <opencog/atoms/value/Value.h>
+#include <opencog/atoms/base/Handle.h>
 #include <opencog/atoms/atom_types/atom_types.h>
 
 namespace opencog
@@ -57,6 +58,7 @@ public:
 	virtual ~LinkValue() {}
 
 	const std::vector<ValuePtr>& value() const { update(); return _value; }
+	HandleSeq to_handle_seq(void) const;
 
 	/** Returns a string representation of the value.  */
 	virtual std::string to_string(const std::string& indent = "") const;

--- a/opencog/atoms/value/QueueValue.h
+++ b/opencog/atoms/value/QueueValue.h
@@ -58,6 +58,11 @@ typedef std::shared_ptr<QueueValue> QueueValuePtr;
 static inline QueueValuePtr QueueValueCast(ValuePtr& a)
 	{ return std::dynamic_pointer_cast<QueueValue>(a); }
 
+template<typename ... Type>
+static inline std::shared_ptr<QueueValue> createQueueValue(Type&&... args) {
+   return std::make_shared<QueueValue>(std::forward<Type>(args)...);
+}
+
 /** @}*/
 } // namespace opencog
 

--- a/opencog/query/Implicator.cc
+++ b/opencog/query/Implicator.cc
@@ -64,21 +64,26 @@ bool Implicator::grounding(const GroundingMap &var_soln,
 	return (_result_set.size() >= max_results);
 }
 
-void Implicator::insert_result(const ValuePtr& v)
+void Implicator::insert_result(ValuePtr v)
 {
-	if (v and _result_set.end() == _result_set.find(v))
-	{
-		// Insert atom into the atomspace immediately, so that
-		// it becomes visible in other threads.
-		if (v->is_atom())
-		{
-			_result_set.insert(_as->add_atom(HandleCast(v)));
-		}
-		else
-		{
-			_result_set.insert(v);
-		}
-	}
+	if (nullptr == v) return;
+	if (_result_set.end() != _result_set.find(v)) return;
+
+	// Insert atom into the atomspace immediately, so that
+	// it becomes visible in other threads.
+	if (v->is_atom())
+		v = _as->add_atom(HandleCast(v));
+
+	if (_result_set.end() != _result_set.find(v)) return;
+
+	_result_set.insert(v);
+	_result_queue.push (std::move(v));
+}
+
+bool Implicator::search_finished(bool done)
+{
+	_result_queue.close();
+	return done;
 }
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/query/Implicator.cc
+++ b/opencog/query/Implicator.cc
@@ -82,7 +82,7 @@ void Implicator::insert_result(ValuePtr v)
 	if (_result_set.end() != _result_set.find(v)) return;
 
 	_result_set.insert(v);
-	_result_queue->push (std::move(v));
+	_result_queue->push(std::move(v));
 }
 
 bool Implicator::start_search(void)

--- a/opencog/query/Implicator.cc
+++ b/opencog/query/Implicator.cc
@@ -31,7 +31,6 @@ using namespace opencog;
 Implicator::Implicator(AtomSpace* as)
 	: _as(as), inst(as), max_results(SIZE_MAX)
 {
-	_result_queue = createQueueValue();
 }
 
 /**
@@ -88,7 +87,10 @@ void Implicator::insert_result(ValuePtr v)
 
 bool Implicator::start_search(void)
 {
-	_result_queue->open();
+	// *Every* search gets a brand new, fresh queue!
+	// This allows users to hang on to the old queue, holding
+	// previous results, if they need to.
+	_result_queue = createQueueValue();
 	return false;
 }
 

--- a/opencog/query/Implicator.cc
+++ b/opencog/query/Implicator.cc
@@ -28,6 +28,11 @@
 
 using namespace opencog;
 
+Implicator::Implicator(AtomSpace* as)
+	: _as(as), inst(as), max_results(SIZE_MAX)
+{
+}
+
 /**
  * This callback takes the reported grounding, runs it through the
  * instantiator, to create the implicand, and then records the result
@@ -78,6 +83,12 @@ void Implicator::insert_result(ValuePtr v)
 
 	_result_set.insert(v);
 	_result_queue.push (std::move(v));
+}
+
+bool Implicator::start_search(void)
+{
+	_result_queue.open();
+	return false;
 }
 
 bool Implicator::search_finished(bool done)

--- a/opencog/query/Implicator.cc
+++ b/opencog/query/Implicator.cc
@@ -31,6 +31,7 @@ using namespace opencog;
 Implicator::Implicator(AtomSpace* as)
 	: _as(as), inst(as), max_results(SIZE_MAX)
 {
+	_result_queue = createQueueValue();
 }
 
 /**
@@ -82,18 +83,18 @@ void Implicator::insert_result(ValuePtr v)
 	if (_result_set.end() != _result_set.find(v)) return;
 
 	_result_set.insert(v);
-	_result_queue.push (std::move(v));
+	_result_queue->push (std::move(v));
 }
 
 bool Implicator::start_search(void)
 {
-	_result_queue.open();
+	_result_queue->open();
 	return false;
 }
 
 bool Implicator::search_finished(bool done)
 {
-	_result_queue.close();
+	_result_queue->close();
 	return done;
 }
 

--- a/opencog/query/Implicator.h
+++ b/opencog/query/Implicator.h
@@ -29,6 +29,7 @@
 #include <opencog/atomspace/AtomSpace.h>
 
 #include <opencog/atoms/execution/Instantiator.h>
+#include <opencog/atoms/value/QueueValue.h>
 #include <opencog/query/PatternMatchCallback.h>
 
 
@@ -58,7 +59,8 @@ class Implicator :
 		AtomSpace* _as;
 
 		ValueSet _result_set;
-		void insert_result(const ValuePtr&);
+		QueueValue _result_queue;
+		void insert_result(ValuePtr);
 
 	public:
 		Implicator(AtomSpace* as) : _as(as), inst(as), max_results(SIZE_MAX) {}
@@ -69,8 +71,10 @@ class Implicator :
 		virtual bool grounding(const GroundingMap &var_soln,
 		                       const GroundingMap &term_soln);
 
-		virtual const ValueSet& get_result_set() const
-		{ return _result_set; }
+		virtual bool search_finished(bool);
+
+		virtual QueueValue& get_result_queue()
+		{ return _result_queue; }
 };
 
 }; // namespace opencog

--- a/opencog/query/Implicator.h
+++ b/opencog/query/Implicator.h
@@ -59,7 +59,7 @@ class Implicator :
 		AtomSpace* _as;
 
 		ValueSet _result_set;
-		QueueValue _result_queue;
+		QueueValuePtr _result_queue;
 		void insert_result(ValuePtr);
 
 	public:
@@ -74,7 +74,7 @@ class Implicator :
 		virtual bool start_search(void);
 		virtual bool search_finished(bool);
 
-		virtual QueueValue& get_result_queue()
+		virtual QueueValuePtr get_result_queue()
 		{ return _result_queue; }
 };
 

--- a/opencog/query/Implicator.h
+++ b/opencog/query/Implicator.h
@@ -63,7 +63,7 @@ class Implicator :
 		void insert_result(ValuePtr);
 
 	public:
-		Implicator(AtomSpace* as) : _as(as), inst(as), max_results(SIZE_MAX) {}
+		Implicator(AtomSpace*);
 		Instantiator inst;
 		HandleSeq implicand;
 		size_t max_results;
@@ -71,6 +71,7 @@ class Implicator :
 		virtual bool grounding(const GroundingMap &var_soln,
 		                       const GroundingMap &term_soln);
 
+		virtual bool start_search(void);
 		virtual bool search_finished(bool);
 
 		virtual QueueValue& get_result_queue()

--- a/opencog/query/PatternLinkRuntime.cc
+++ b/opencog/query/PatternLinkRuntime.cc
@@ -429,9 +429,13 @@ bool PatternLink::satisfy(PatternMatchCallback& pmcb) const
 	GroundingMap empty_vg;
 	GroundingMap empty_pg;
 	pmcb.set_pattern(_variables, _pat);
-	return recursive_virtual(pmcb, _virtual, _pat.optionals,
+	bool done = pmcb.start_search();
+	if (done) return done;
+	done = recursive_virtual(pmcb, _virtual, _pat.optionals,
 	                         empty_vg, empty_pg,
 	                         comp_var_gnds, comp_term_gnds);
+	done = pmcb.search_finished(done);
+	return done;
 }
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/query/Satisfier.h
+++ b/opencog/query/Satisfier.h
@@ -27,6 +27,7 @@
 #include <vector>
 
 #include <opencog/atoms/truthvalue/TruthValue.h>
+#include <opencog/atoms/value/QueueValue.h>
 #include <opencog/atomspace/AtomSpace.h>
 
 #include <opencog/query/InitiateSearchCB.h>
@@ -95,13 +96,17 @@ class SatisfyingSet :
 	public virtual InitiateSearchCB,
 	public virtual DefaultPatternMatchCB
 {
+	protected:
+		AtomSpace* _as;
+		HandleSeq _varseq;
+		HandleSet _satisfying_set;
+		QueueValuePtr _result_queue;
+
 	public:
 		SatisfyingSet(AtomSpace* as) :
 			InitiateSearchCB(as), DefaultPatternMatchCB(as),
-			max_results(SIZE_MAX) {}
+			_as(as), max_results(SIZE_MAX) {}
 
-		HandleSeq _varseq;
-		HandleSet _satisfying_set;
 		size_t max_results;
 
 		virtual void set_pattern(const Variables& vars,
@@ -119,6 +124,12 @@ class SatisfyingSet :
 		// groundings.
 		virtual bool grounding(const GroundingMap &var_soln,
 		                       const GroundingMap &term_soln);
+
+		virtual bool start_search(void);
+		virtual bool search_finished(bool);
+
+		virtual QueueValuePtr get_result_queue()
+		{ return _result_queue; }
 };
 
 }; // namespace opencog

--- a/opencog/query/Satisfier.h
+++ b/opencog/query/Satisfier.h
@@ -99,7 +99,10 @@ class SatisfyingSet :
 	protected:
 		AtomSpace* _as;
 		HandleSeq _varseq;
+// XXX fixme tempt hack for pattern miner
+public:
 		HandleSet _satisfying_set;
+protected:
 		QueueValuePtr _result_queue;
 
 	public:

--- a/tests/atoms/value/CMakeLists.txt
+++ b/tests/atoms/value/CMakeLists.txt
@@ -1,5 +1,7 @@
 LINK_LIBRARIES(
 	value
+	atombase
+	exec
 )
 
 # Tests in order of increasing functional complexity/dependency

--- a/tests/query/ExecutionOutputUTest.cxxtest
+++ b/tests/query/ExecutionOutputUTest.cxxtest
@@ -359,7 +359,7 @@ void ExecutionOutputUTest::test_value(void)
 	eval.eval("(load-from-path \"tests/query/exec-gsn.scm\")");
 
 	ValuePtr result = eval.eval_v("(cog-execute! exec-query-handle)");
-	TS_ASSERT_EQUALS(result->get_type(), LINK_VALUE);
+	TS_ASSERT(nameserver().isA(result->get_type(), LINK_VALUE));
 	ValueSeq vals = LinkValueCast(result)->value();
 	TS_ASSERT_EQUALS(vals.size(), 3);
 	for (const ValuePtr& va : vals)
@@ -367,7 +367,7 @@ void ExecutionOutputUTest::test_value(void)
 
 	//------------
 	result = eval.eval_v("(cog-execute! exec-query-link-value)");
-	TS_ASSERT_EQUALS(result->get_type(), LINK_VALUE);
+	TS_ASSERT(nameserver().isA(result->get_type(), LINK_VALUE));
 	vals = LinkValueCast(result)->value();
 	TS_ASSERT_EQUALS(vals.size(), 3);
 	for (const ValuePtr& va : vals)
@@ -375,7 +375,7 @@ void ExecutionOutputUTest::test_value(void)
 
 	//------------
 	result = eval.eval_v("(cog-execute! exec-query-string-value)");
-	TS_ASSERT_EQUALS(result->get_type(), LINK_VALUE);
+	TS_ASSERT(nameserver().isA(result->get_type(), LINK_VALUE));
 	vals = LinkValueCast(result)->value();
 	TS_ASSERT_EQUALS(vals.size(), 3);
 	for (const ValuePtr& va : vals)
@@ -383,7 +383,7 @@ void ExecutionOutputUTest::test_value(void)
 
 	//------------
 	result = eval.eval_v("(cog-execute! exec-query-truth-value)");
-	TS_ASSERT_EQUALS(result->get_type(), LINK_VALUE);
+	TS_ASSERT(nameserver().isA(result->get_type(), LINK_VALUE));
 	vals = LinkValueCast(result)->value();
 	TS_ASSERT_EQUALS(vals.size(), 3);
 	for (const ValuePtr& va : vals)

--- a/tests/query/ExecutionOutputUTest.cxxtest
+++ b/tests/query/ExecutionOutputUTest.cxxtest
@@ -251,6 +251,7 @@ void ExecutionOutputUTest::test_varsub(void)
 	situation->satisfy(simpl);
 
 	// The result_list contains a list of the grounded expressions.
+	simpl.get_result_queue().open();
 	Handle res = HandleCast(simpl.get_result_queue().value_pop());
 	printf("res is %s\n", res->to_short_string().c_str());
 	TSM_ASSERT_EQUALS("incorrect resolution", res, resolution);
@@ -261,6 +262,7 @@ void ExecutionOutputUTest::test_varsub(void)
 	predicament->satisfy(pimpl);
 
 	// The result_list contains a list of the grounded expressions.
+	pimpl.get_result_queue().open();
 	Handle del = HandleCast(pimpl.get_result_queue().value_pop());
 	printf("del is %s\n", del->to_short_string().c_str());
 	TSM_ASSERT_EQUALS("incorrect delivarance", del, deliverance);

--- a/tests/query/ExecutionOutputUTest.cxxtest
+++ b/tests/query/ExecutionOutputUTest.cxxtest
@@ -251,7 +251,7 @@ void ExecutionOutputUTest::test_varsub(void)
 	situation->satisfy(simpl);
 
 	// The result_list contains a list of the grounded expressions.
-	Handle res = HandleCast(*simpl.get_result_set().begin());
+	Handle res = HandleCast(simpl.get_result_queue().value_pop());
 	printf("res is %s\n", res->to_short_string().c_str());
 	TSM_ASSERT_EQUALS("incorrect resolution", res, resolution);
 
@@ -261,7 +261,7 @@ void ExecutionOutputUTest::test_varsub(void)
 	predicament->satisfy(pimpl);
 
 	// The result_list contains a list of the grounded expressions.
-	Handle del = HandleCast(*pimpl.get_result_set().begin());
+	Handle del = HandleCast(pimpl.get_result_queue().value_pop());
 	printf("del is %s\n", del->to_short_string().c_str());
 	TSM_ASSERT_EQUALS("incorrect delivarance", del, deliverance);
 

--- a/tests/query/ExecutionOutputUTest.cxxtest
+++ b/tests/query/ExecutionOutputUTest.cxxtest
@@ -251,8 +251,8 @@ void ExecutionOutputUTest::test_varsub(void)
 	situation->satisfy(simpl);
 
 	// The result_list contains a list of the grounded expressions.
-	simpl.get_result_queue().open();
-	Handle res = HandleCast(simpl.get_result_queue().value_pop());
+	simpl.get_result_queue()->open();
+	Handle res = HandleCast(simpl.get_result_queue()->value_pop());
 	printf("res is %s\n", res->to_short_string().c_str());
 	TSM_ASSERT_EQUALS("incorrect resolution", res, resolution);
 
@@ -262,8 +262,8 @@ void ExecutionOutputUTest::test_varsub(void)
 	predicament->satisfy(pimpl);
 
 	// The result_list contains a list of the grounded expressions.
-	pimpl.get_result_queue().open();
-	Handle del = HandleCast(pimpl.get_result_queue().value_pop());
+	pimpl.get_result_queue()->open();
+	Handle del = HandleCast(pimpl.get_result_queue()->value_pop());
 	printf("del is %s\n", del->to_short_string().c_str());
 	TSM_ASSERT_EQUALS("incorrect delivarance", del, deliverance);
 

--- a/tests/query/GreaterThanUTest.cxxtest
+++ b/tests/query/GreaterThanUTest.cxxtest
@@ -42,7 +42,6 @@ public:
 		as = new AtomSpace();
 		eval = new SchemeEval(as);
 		eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
-
 	}
 
 	~GreaterThanUTest()

--- a/tests/query/QueryUTest.cxxtest
+++ b/tests/query/QueryUTest.cxxtest
@@ -91,13 +91,14 @@ void QueryUTest::test_basic(void)
 
 	// Can we execute it?
 	ValuePtr sv = h->execute(as);
-	TS_ASSERT_EQUALS(sv->get_type(), LINK_VALUE);
+	TS_ASSERT(nameserver().isA(sv->get_type(), LINK_VALUE));
 	TS_ASSERT_EQUALS(LinkValueCast(sv)->value().size(), 0);
 
 	// A more complex query
 	ValuePtr v = eval->eval_v("(cog-execute! query)");
-	TS_ASSERT_EQUALS(v->get_type(), LINK_VALUE);
+	TS_ASSERT(nameserver().isA(v->get_type(), LINK_VALUE));
 	TS_ASSERT_EQUALS(LinkValueCast(v)->value().size(), 3);
+	printf("Got: %s\n", v->to_string().c_str());
 
 	logger().debug("END TEST: %s", __FUNCTION__);
 }

--- a/tests/query/imply.h
+++ b/tests/query/imply.h
@@ -36,9 +36,9 @@ static inline Handle imply(AtomSpace* as, Handle hclauses, Handle himplicand)
 	// The result_set contains a list of the grounded expressions.
 	// Turn it into a true list, and return it.
 	HandleSeq hlist;
-	QueueValue& qv(impl.get_result_queue());
-	OC_ASSERT(qv.is_closed(), "Unexpected queue state!");
-	std::queue<ValuePtr> vals(qv.wait_and_take_all());
+	QueueValuePtr qv(impl.get_result_queue());
+	OC_ASSERT(qv->is_closed(), "Unexpected queue state!");
+	std::queue<ValuePtr> vals(qv->wait_and_take_all());
 	while (not vals.empty())
 	{
 		hlist.push_back(HandleCast(vals.front()));

--- a/tests/query/imply.h
+++ b/tests/query/imply.h
@@ -1,4 +1,5 @@
 
+#include <opencog/util/oc_assert.h>
 #include <opencog/atoms/core/FindUtils.h>
 #include <opencog/atoms/pattern/BindLink.h>
 #include <opencog/atomspace/AtomSpace.h>
@@ -35,8 +36,14 @@ static inline Handle imply(AtomSpace* as, Handle hclauses, Handle himplicand)
 	// The result_set contains a list of the grounded expressions.
 	// Turn it into a true list, and return it.
 	HandleSeq hlist;
-	for (const ValuePtr& v: impl.get_result_set())
-		hlist.push_back(HandleCast(v));
+	QueueValue& qv(impl.get_result_queue());
+	OC_ASSERT(qv.is_closed(), "Unexpected queue state!");
+	std::queue<ValuePtr> vals(qv.wait_and_take_all());
+	while (not vals.empty())
+	{
+		hlist.push_back(HandleCast(vals.front()));
+		vals.pop();
+	}
 	Handle gl = as->add_link(LIST_LINK, std::move(hlist));
 	return gl;
 }


### PR DESCRIPTION
This pull req modifies all of the search functions to use the 
new `QueueValue` (#2569) to pass search results around. 
This partly addresses concerns in issues #2530 and  #1502

In principle, this allows queries to run in one (or more) threads,
while other threads process the queries as they arrive. Nothing
actually does this yet, but the possibility is now there.