### PR TITLE
Dramatically lower the inf-loop counter bound.

### DIFF
--- a/opencog/query/InitiateSearchCB.cc
+++ b/opencog/query/InitiateSearchCB.cc
@@ -718,7 +718,6 @@ bool InitiateSearchCB::setup_variable_search(void)
 	// There were no type restrictions!
 	if (nullptr == _root)
 	{
-
 		if (not _variables->_deep_typemap.empty())
 		{
 			logger().warn("Full deep-type support not implemented!");
@@ -744,7 +743,7 @@ bool InitiateSearchCB::setup_variable_search(void)
 			if (prev != _pattern) { prev = _pattern; count = 0; }
 			else {
 				count++;
-				if (300 < count)
+				if (5 < count)
 					throw RuntimeException(TRACE_INFO,
 						"Infinite Loop detected! Recursed %u times!", count);
 			}

--- a/tests/query/buggy-selfgnd.scm
+++ b/tests/query/buggy-selfgnd.scm
@@ -1,5 +1,5 @@
 ;
-; In this case, the instatiator tried to instantiate and add a new
+; In this case, the instantiator tried to instantiate and add a new
 ; BindLink atom to Atomspace, throwing exception. More details here:
 ; https://github.com/opencog/atomspace/issues/210
 


### PR DESCRIPTION
Some simple test cases are combinatorially explosive, and
take minutes to get up to a count of 20. So lower the count.