### PR TITLE
Implement starting points for deep-type searches.

### DIFF
--- a/opencog/atoms/pattern/Pattern.h
+++ b/opencog/atoms/pattern/Pattern.h
@@ -115,7 +115,7 @@ struct Pattern
 	/// Clauses that can be grounded in only one way; thus the result
 	/// of that grounding can be cached, for avoid rechecking.
 	/// These clauses cannot contain evaluatable elements (as that would
-	/// invalidate the results), cannot contiain unordered or choice links
+	/// invalidate the results), cannot contain unordered or choice links
 	/// (as those can have multiple groundings) and can only contain one
 	/// variable (there is no use case for two or more, right now.)
 	/// The idea could be extended to cacheable sub-terms, but this is

--- a/opencog/query/InitiateSearchCB.h
+++ b/opencog/query/InitiateSearchCB.h
@@ -75,8 +75,8 @@ protected:
 	struct Choice
 	{
 		Handle clause;
-		Handle best_start;
 		Handle start_term;
+		HandleSeq search_set;
 	};
 	Handle _curr_clause;
 	std::vector<Choice> _choices;

--- a/opencog/query/InitiateSearchCB.h
+++ b/opencog/query/InitiateSearchCB.h
@@ -92,6 +92,7 @@ protected:
 
 	bool setup_neighbor_search(void);
 	bool setup_no_search(void);
+	bool setup_deep_type_search(void);
 	bool setup_link_type_search(void);
 	bool setup_variable_search(void);
 


### PR DESCRIPTION
This removes a "not implemented" warning in the code.
Searches involving deep types are now much more efficient.
This is heavily used by the JoinLink implementation (per issue #2562)