### PR TITLE
Faster load

### DIFF
--- a/opencog/persist/file/fast_load.cc
+++ b/opencog/persist/file/fast_load.cc
@@ -143,7 +143,6 @@ static Handle recursive_parse(const std::string& s,
     l = r1;
     if (namer.isLink(atype))
     {
-        r--; // get rid of trailing paren
         HandleSeq outgoing;
         do {
             l1 = l;
@@ -223,9 +222,8 @@ void opencog::load_file(std::string fname, AtomSpace& as)
             if (l == r) break;
 
             expr_cnt++;
-            r++;
             as.add_atom(recursive_parse(expr, l, r, line_cnt));
-            expr = expr.substr(r);
+            expr = expr.substr(r+1);
         }
     }
     f.close();

--- a/opencog/persist/file/fast_load.cc
+++ b/opencog/persist/file/fast_load.cc
@@ -56,7 +56,7 @@ static int get_next_expr(const std::string& s, size_t& l, size_t& r,
     if (s[l] != '(')
         throw std::runtime_error(
             "Syntax error at line " + std::to_string(line_cnt) +
-            " Unexpected text: >>" + s + "<<");
+            " Unexpected text: >>" + s.substr(l) + "<<");
 
     size_t p = l;
     int count = 1;
@@ -170,13 +170,13 @@ static Handle recursive_parse(const std::string& s,
         get_node_name(s, l1, r1, line_cnt);
 
         // There might be an stv in the content. Handle it.. or not
-        size_t l2 = r1;
+        size_t l2 = r1+1;
         size_t r2 = r;
         get_next_expr(s, l2, r2, line_cnt);
         if (l2 < r2)
             throw std::runtime_error(
                 "Syntax error at line " + std::to_string(line_cnt) +
-                " Unsupported markup: " + s.substr(l2, r2-l2) +
+                " Unsupported markup: " + s.substr(l2, r2-l2+1) +
                 " in expr: " + s);
 
         const std::string name = s.substr(l1, r1-l1);

--- a/opencog/persist/file/fast_load.cc
+++ b/opencog/persist/file/fast_load.cc
@@ -43,7 +43,8 @@ using namespace opencog;
 // and `r` points at the matching close-paren.  Returns parenthesis
 // count. If zero, the parens match. If non-zero, then `r` points
 // at the first non-valid character in the string (e.g. comment char).
-static int get_next_expr(const std::string& s, size_t& l, size_t& r)
+static int get_next_expr(const std::string& s, size_t& l, size_t& r,
+                         size_t line_cnt)
 {
     // Advance past whitespace.
     while (l < r and (s[l] == ' ' or s[l] == '\t' or s[l] == '\n')) l++;
@@ -53,7 +54,9 @@ static int get_next_expr(const std::string& s, size_t& l, size_t& r)
     if (s[l] == ';') { r = l; return 1; }
 
     if (s[l] != '(')
-        throw std::runtime_error("Unexpected text: >>" + s + "<<");
+        throw std::runtime_error(
+            "Syntax error at line " + std::to_string(line_cnt) +
+            " Unexpected text: >>" + s + "<<");
 
     size_t p = l;
     int count = 1;
@@ -135,7 +138,7 @@ static Handle recursive_parse(const std::string& s,
         do {
             l1 = l;
             r1 = r;
-            get_next_expr(s, l1, r1);
+            get_next_expr(s, l1, r1, line_cnt);
 
             if (l1 == r1)
                 throw std::runtime_error(
@@ -200,7 +203,7 @@ void opencog::load_file(std::string fname, AtomSpace& as)
             size_t r = expr.length();
 
             // Zippy the Pinhead says: Are we having fun yet?
-            int pcount = get_next_expr(expr, l, r);
+            int pcount = get_next_expr(expr, l, r, line_cnt);
 
             // Trim away comments at end of line
             if (0 < pcount)

--- a/tests/cython/utilities/test_utilities.py
+++ b/tests/cython/utilities/test_utilities.py
@@ -44,7 +44,7 @@ class UtilitiesTest(TestCase):
             write_sorted_file(new_tmp, new_space)
             self.assertTrue(filecmp.cmp(tmp_file, new_tmp, shallow=False), "files are not equal")
             checklist = """(ListLink(ConceptNode "vfjv\\"jnvfé")
-                (ConceptNode "conceptIR~~gF\\",KV"))
+                (ConceptNode "conceptIR~~gF\\",KV")
                 (ConceptNode "вверху плыли редкие облачка"))"""
             with open(tmp_file, 'wt') as f:
                 f.write(checklist)

--- a/tests/scm/scm-load-file-test-data.scm
+++ b/tests/scm/scm-load-file-test-data.scm
@@ -2,6 +2,8 @@
 ; Test single-letter names; this was buggy.
 (Evaluation (Predicate "P") (List (Concept "A") (Concept "B")))
 
+; (Concept "B" (stv 1 1))
+
 ; Test UTF-8
 (ListLink(ConceptNode "тестирование кода приводит к успеху")
 


### PR DESCRIPTION
Refactor the fast-file-code.
Sorry, @noskill, I did not plan to do this work, except I got a hare-brained idea to use this in the cog-server to speed up network data transfer. Which was probably a poor idea, but .. there we are.  I ended up redoing much of the code.

* It's simpler, avoids un-needed string copies.
* Makes adding support for the `(stv 1 1)` stuff much easier.
* Improved error detection -- finds more problems with input file.