### PR TITLE
"classical logic" support for booleans in pattern matcher.

### DIFF
--- a/opencog/atoms/core/StateLink.cc
+++ b/opencog/atoms/core/StateLink.cc
@@ -78,16 +78,21 @@ void StateLink::install()
 		return;
 	}
 
-	// Find all existing copies of this particular StateLink
-	// (There should be only one).
+	// Find all existing copies of this particular StateLink.
+	// There should be only one, **in this atomspace**.
+	// We do allow child atomspaces to over-ride the state in
+	// the parent; the net effect is that the state in the child
+	// will hide the state in the parent.
+	//
 	// Perform an atomic swap, replacing the old with the new.
 	bool swapped = false;
 	const Handle& alias = get_alias();
 	IncomingSet defs = alias->getIncomingSetByType(STATE_LINK);
 	for (const Handle& defl : defs)
 	{
-		if (defl->getOutgoingAtom(0) != alias) continue;
 		if (defl.get() == this) continue;
+		if (defl->getOutgoingAtom(0) != alias) continue;
+		if (defl->getAtomSpace() != getAtomSpace()) continue;
 
 		StateLinkPtr old_state(StateLinkCast(defl));
 		if (not old_state->is_closed()) continue;

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -394,14 +394,8 @@ void PatternLink::unbundle_clauses(const Handle& hbody)
 		const HandleSeq& oset = hbody->getOutgoingSet();
 		for (const Handle& ho : oset)
 		{
-			Type ot = ho->get_type();
-			if (connectives.find(ot) != connectives.end() and
+			if (not record_literal(ho) and
 			    not unbundle_clauses_rec(ho, connectives))
-			{
-				_pat.unquoted_clauses.emplace_back(ho);
-				_pat.mandatory.emplace_back(ho);
-			}
-			if (not record_literal(ho))
 			{
 				_pat.unquoted_clauses.emplace_back(ho);
 				_pat.mandatory.emplace_back(ho);

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -464,10 +464,11 @@ void PatternLink::unbundle_clauses(const Handle& hbody)
 /// Search for any PRESENT_LINK or ABSENT_LINK's that are recusively
 /// embedded inside some evaluatable clause.  Note these as literal,
 /// groundable clauses.
-void PatternLink::unbundle_clauses_rec(const Handle& bdy,
+bool PatternLink::unbundle_clauses_rec(const Handle& bdy,
                                        const TypeSet& connectives,
                                        bool reverse)
 {
+	bool unquoted = false;
 	if (NOT_LINK == bdy->get_type()) reverse = not reverse;
 	const HandleSeq& oset = bdy->getOutgoingSet();
 	for (const Handle& ho : oset)
@@ -481,7 +482,10 @@ void PatternLink::unbundle_clauses_rec(const Handle& bdy,
 		{
 			unbundle_clauses_rec(ho, connectives, reverse);
 		}
+		else
+			unquoted = true;
 	}
+	return unquoted;
 }
 
 void PatternLink::locate_defines(const HandleSeq& clauses)

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -396,7 +396,7 @@ void PatternLink::unbundle_clauses(const Handle& hbody)
 		{
 			Type ot = ho->get_type();
 			if (connectives.find(ot) != connectives.end() and
-				 not unbundle_clauses_rec(ho, connectives))
+			    not unbundle_clauses_rec(ho, connectives))
 			{
 				_pat.unquoted_clauses.emplace_back(ho);
 				_pat.mandatory.emplace_back(ho);
@@ -470,22 +470,18 @@ bool PatternLink::unbundle_clauses_rec(const Handle& bdy,
                                        const TypeSet& connectives,
                                        bool reverse)
 {
+	Type t = bdy->get_type();
+
+	if (connectives.find(t) == connectives.end())
+		return false;
+
+	if (NOT_LINK == t) reverse = not reverse;
+
 	bool recorded = true;
-	if (NOT_LINK == bdy->get_type()) reverse = not reverse;
-	const HandleSeq& oset = bdy->getOutgoingSet();
-	for (const Handle& ho : oset)
+	for (const Handle& ho : bdy->getOutgoingSet())
 	{
-		Type ot = ho->get_type();
-		if (record_literal(ho, reverse))
-		{
-			/* no-op */
-		}
-		else if (connectives.find(ot) != connectives.end())
-		{
+		if (not record_literal(ho, reverse))
 			recorded = recorded and unbundle_clauses_rec(ho, connectives, reverse);
-		}
-		else
-			recorded = false;
 	}
 	return recorded;
 }

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -432,11 +432,10 @@ void PatternLink::unbundle_clauses(const Handle& hbody)
 	// for anyone giving alternative interpretations. Yuck.
 	else if (OR_LINK == t and 1 == hbody->get_arity())
 	{
-		if (not record_literal(hbody->getOutgoingAtom(0)))
-		{
-			_pat.unquoted_clauses.emplace_back(hbody);
-			_pat.mandatory.emplace_back(hbody);
-		}
+		// BUG - XXX FIXME Handle of OrLink is incorrect, here.
+		// See also FIXME above.
+		TypeSet connectives({AND_LINK, OR_LINK, NOT_LINK});
+		unbundle_clauses_rec(hbody, connectives);
 	}
 
 	// A single top-level clause that is a NotLink.
@@ -446,6 +445,10 @@ void PatternLink::unbundle_clauses(const Handle& hbody)
 	{
 		if (not record_literal(hbody->getOutgoingAtom(0), true))
 		{
+			// XXX FIXME Handle of OrLink is incorrect, here.
+			TypeSet connectives({AND_LINK, OR_LINK, NOT_LINK});
+			unbundle_clauses_rec(hbody, connectives);
+
 			_pat.unquoted_clauses.emplace_back(hbody);
 			_pat.mandatory.emplace_back(hbody);
 		}

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -432,6 +432,11 @@ void PatternLink::unbundle_clauses(const Handle& hbody)
 		// See also FIXME above.
 		TypeSet connectives({AND_LINK, OR_LINK, NOT_LINK});
 		unbundle_clauses_rec(hbody, connectives);
+		if (not unbundle_clauses_rec(hbody, connectives))
+		{
+			_pat.unquoted_clauses.emplace_back(hbody);
+			_pat.mandatory.emplace_back(hbody);
+		}
 	}
 
 	// A single top-level clause that is a NotLink.
@@ -439,12 +444,10 @@ void PatternLink::unbundle_clauses(const Handle& hbody)
 	// for anyone giving alternative interpretations. Yuck.
 	else if (NOT_LINK == t)
 	{
-		if (not record_literal(hbody->getOutgoingAtom(0), true))
+		// XXX FIXME Handle of OrLink is incorrect, here.
+		TypeSet connectives({AND_LINK, OR_LINK, NOT_LINK});
+		if (not unbundle_clauses_rec(hbody, connectives))
 		{
-			// XXX FIXME Handle of OrLink is incorrect, here.
-			TypeSet connectives({AND_LINK, OR_LINK, NOT_LINK});
-			unbundle_clauses_rec(hbody, connectives);
-
 			_pat.unquoted_clauses.emplace_back(hbody);
 			_pat.mandatory.emplace_back(hbody);
 		}

--- a/opencog/atoms/pattern/PatternLink.h
+++ b/opencog/atoms/pattern/PatternLink.h
@@ -95,7 +95,7 @@ protected:
 
 	bool record_literal(const Handle&, bool reverse=false);
 	void unbundle_clauses(const Handle& body);
-	void unbundle_clauses_rec(const Handle&,
+	bool unbundle_clauses_rec(const Handle&,
 	                          const TypeSet&,
 	                          bool reverse=false);
 

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -269,9 +269,9 @@ Handle AtomTable::add(const Handle& orig, bool force)
     }
 
     if (atom != orig) atom->copyValues(orig);
+    atom->setAtomSpace(_as);
     atom->install();
     atom->keep_incoming_set();
-    atom->setAtomSpace(_as);
 
     typeIndex.insertAtom(atom);
 

--- a/tests/query/CMakeLists.txt
+++ b/tests/query/CMakeLists.txt
@@ -61,6 +61,7 @@ IF (HAVE_GUILE)
 	ADD_CXXTEST(AnchorUTest)
 	ADD_CXXTEST(NotLinkUTest)
 	ADD_CXXTEST(GetStateUTest)
+	ADD_CXXTEST(ClassicalBooleanUTest)
 	ADD_CXXTEST(DeepTypeUTest)
 
 	ADD_CXXTEST(GreaterThanUTest)

--- a/tests/query/ClassicalBooleanUTest.cxxtest
+++ b/tests/query/ClassicalBooleanUTest.cxxtest
@@ -1,0 +1,130 @@
+/*
+ * tests/query/ClassicalBooleanUTest.cxxtest
+ *
+ * Copyright (C) 2018 Linas Vepstas
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/guile/SchemeEval.h>
+#include <opencog/atoms/truthvalue/SimpleTruthValue.h>
+#include <opencog/atomspace/AtomSpace.h>
+#include <opencog/util/Logger.h>
+#include <cxxtest/TestSuite.h>
+
+using namespace opencog;
+
+#define al as->add_link
+#define an as->add_node
+
+class ClassicalBooleanUTest: public CxxTest::TestSuite
+{
+private:
+	AtomSpace *as;
+	SchemeEval* eval;
+
+public:
+	ClassicalBooleanUTest(void)
+	{
+		// logger().set_level(Logger::FINE);
+		logger().set_level(Logger::DEBUG);
+		logger().set_print_to_stdout_flag(true);
+		logger().set_timestamp_flag(false);
+		logger().set_sync_flag(false);
+
+		as = new AtomSpace();
+		eval = new SchemeEval(as);
+		eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+	}
+
+	~ClassicalBooleanUTest()
+	{
+		delete as;
+		// Erase the log file if no assertions failed.
+		if (!CxxTest::TestTracker::tracker().suiteFailed())
+				std::remove(logger().get_filename().c_str());
+	}
+
+	void setUp(void);
+	void tearDown(void);
+
+	void test_double_clause(void);
+	// void test_positive_single_clause(void);
+	void xtest_negative_single_clause(void);
+};
+
+void ClassicalBooleanUTest::tearDown(void)
+{
+}
+
+void ClassicalBooleanUTest::setUp(void)
+{
+}
+
+/*
+ * Test positive double-clause boolean constructions.
+ * One positive cluase forces examination of entire universe;
+ * One negative clause rejects members of the universe.
+ */
+void ClassicalBooleanUTest::test_double_clause(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+	eval->eval("(load-from-path \"tests/query/classical-boolean.scm\")");
+
+	Handle hans = eval->eval_h("(Set (Concept \"you\") (Concept \"her\"))");
+	printf("Expected this: %s\n", hans->to_string().c_str());
+
+	Handle hgnd = eval->eval_h("(cog-execute! double-a)");
+	printf("Found double-a: %s\n", hgnd->to_string().c_str());
+	TSM_ASSERT("double-a bad grounding", hans == hgnd);
+
+	hgnd = eval->eval_h("(cog-execute! double-b)");
+	printf("Found double-b: %s\n", hgnd->to_string().c_str());
+	TSM_ASSERT("double-b bad grounding", hans == hgnd);
+
+	hgnd = eval->eval_h("(cog-execute! double-c)");
+	printf("Found double-c: %s\n", hgnd->to_string().c_str());
+	TSM_ASSERT("double-c bad grounding", hans == hgnd);
+
+	hgnd = eval->eval_h("(cog-execute! double-d)");
+	printf("Found double-d: %s\n", hgnd->to_string().c_str());
+	TSM_ASSERT("double-d bad grounding", hans == hgnd);
+
+	hgnd = eval->eval_h("(cog-execute! double-e)");
+	printf("Found double-e: %s\n", hgnd->to_string().c_str());
+	TSM_ASSERT("double-e bad grounding", hans == hgnd);
+
+	hgnd = eval->eval_h("(cog-execute! double-f)");
+	printf("Found double-f: %s\n", hgnd->to_string().c_str());
+	TSM_ASSERT("double-f bad grounding", hans == hgnd);
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+/*
+ * Test negative single-clause boolean constructions.
+ * These have no positive clauses, and so should return the empty set.
+ */
+void ClassicalBooleanUTest::xtest_negative_single_clause(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+#undef al
+#undef an

--- a/tests/query/ClassicalBooleanUTest.cxxtest
+++ b/tests/query/ClassicalBooleanUTest.cxxtest
@@ -63,8 +63,7 @@ public:
 	void tearDown(void);
 
 	void test_double_clause(void);
-	// void test_positive_single_clause(void);
-	void xtest_negative_single_clause(void);
+	void test_single_clause(void);
 };
 
 void ClassicalBooleanUTest::tearDown(void)
@@ -118,10 +117,39 @@ void ClassicalBooleanUTest::test_double_clause(void)
 /*
  * Test negative single-clause boolean constructions.
  * These have no positive clauses, and so should return the empty set.
+ * Unlike the above, the universe is never exampled.
  */
-void ClassicalBooleanUTest::xtest_negative_single_clause(void)
+void ClassicalBooleanUTest::test_single_clause(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+	eval->eval("(load-from-path \"tests/query/classical-boolean.scm\")");
+
+	Handle hans = eval->eval_h("(Set)");
+	printf("Expected this: %s\n", hans->to_string().c_str());
+
+	Handle hgnd = eval->eval_h("(cog-execute! single-a)");
+	printf("Found single-a: %s\n", hgnd->to_string().c_str());
+	TSM_ASSERT("single-a bad grounding", hans == hgnd);
+
+	hgnd = eval->eval_h("(cog-execute! single-b)");
+	printf("Found single-b: %s\n", hgnd->to_string().c_str());
+	TSM_ASSERT("single-b bad grounding", hans == hgnd);
+
+	hgnd = eval->eval_h("(cog-execute! single-c)");
+	printf("Found single-c: %s\n", hgnd->to_string().c_str());
+	TSM_ASSERT("single-c bad grounding", hans == hgnd);
+
+	hgnd = eval->eval_h("(cog-execute! single-d)");
+	printf("Found single-d: %s\n", hgnd->to_string().c_str());
+	TSM_ASSERT("single-d bad grounding", hans == hgnd);
+
+	hgnd = eval->eval_h("(cog-execute! single-e)");
+	printf("Found single-e: %s\n", hgnd->to_string().c_str());
+	TSM_ASSERT("single-e bad grounding", hans == hgnd);
+
+	hgnd = eval->eval_h("(cog-execute! single-f)");
+	printf("Found single-f: %s\n", hgnd->to_string().c_str());
+	TSM_ASSERT("single-f bad grounding", hans == hgnd);
 
 	logger().debug("END TEST: %s", __FUNCTION__);
 }

--- a/tests/query/classical-boolean.scm
+++ b/tests/query/classical-boolean.scm
@@ -48,3 +48,33 @@
 	(And
 		(Present (Variable "s"))
 		(Or (Not (Present (State (Variable "s") (Predicate "hungry"))))))))
+
+(define single-a
+(Get
+	(TypedVariable (Variable "s") (Type 'Concept))
+	(Absent (State (Variable "s") (Predicate "hungry")))))
+
+(define single-b
+(Get
+	(TypedVariable (Variable "s") (Type 'Concept))
+	(Not (Present (State (Variable "s") (Predicate "hungry"))))))
+
+(define single-c
+(Get
+	(TypedVariable (Variable "s") (Type 'Concept))
+	(Not (And (Present (State (Variable "s") (Predicate "hungry")))))))
+
+(define single-d
+(Get
+	(TypedVariable (Variable "s") (Type 'Concept))
+	(Not (Or (Present (State (Variable "s") (Predicate "hungry")))))))
+
+(define single-e
+(Get
+	(TypedVariable (Variable "s") (Type 'Concept))
+	(And (Not (Present (State (Variable "s") (Predicate "hungry")))))))
+
+(define single-f
+(Get
+	(TypedVariable (Variable "s") (Type 'Concept))
+	(Or (Not (Present (State (Variable "s") (Predicate "hungry")))))))

--- a/tests/query/classical-boolean.scm
+++ b/tests/query/classical-boolean.scm
@@ -1,0 +1,50 @@
+;
+; Most users assume basic classical logic. Lets make sure they get that.
+;
+(use-modules (opencog) (opencog exec))
+
+(State (Concept "me") (Predicate "hungry"))
+(State (Concept "you") (Predicate "bored"))
+(State (Concept "her") (Predicate "tired"))
+
+(define double-a
+(Get
+	(TypedVariable (Variable "s") (Type 'Concept))
+	(And
+		(Present (Variable "s"))
+		(Absent (State (Variable "s") (Predicate "hungry"))))))
+
+(define double-b
+(Get
+	(TypedVariable (Variable "s") (Type 'Concept))
+	(And
+		(Present (Variable "s"))
+		(Not (Present (State (Variable "s") (Predicate "hungry")))))))
+
+(define double-c
+(Get
+	(TypedVariable (Variable "s") (Type 'Concept))
+	(And
+		(Present (Variable "s"))
+		(Not (And (Present (State (Variable "s") (Predicate "hungry"))))))))
+
+(define double-d
+(Get
+	(TypedVariable (Variable "s") (Type 'Concept))
+	(And
+		(Present (Variable "s"))
+		(Not (Or (Present (State (Variable "s") (Predicate "hungry"))))))))
+
+(define double-e
+(Get
+	(TypedVariable (Variable "s") (Type 'Concept))
+	(And
+		(Present (Variable "s"))
+		(And (Not (Present (State (Variable "s") (Predicate "hungry"))))))))
+
+(define double-f
+(Get
+	(TypedVariable (Variable "s") (Type 'Concept))
+	(And
+		(Present (Variable "s"))
+		(Or (Not (Present (State (Variable "s") (Predicate "hungry"))))))))


### PR DESCRIPTION
Past support for boolean operations in the pattern matcher has been sloppy 
or non-existent; see bug #2625 This pull req improves the situation a little bit.

There are still issues: SequentialAnd, SequentialOr and OrLink are still
incompletely supported, and may elicit bugs. 