### PR TITLE
Test for bad return value

### DIFF
--- a/opencog/atoms/execution/ExecutionOutputLink.cc
+++ b/opencog/atoms/execution/ExecutionOutputLink.cc
@@ -286,7 +286,7 @@ ValuePtr ExecutionOutputLink::do_execute(AtomSpace* as,
 #ifdef HAVE_CYTHON
 		// Get a reference to the python evaluator.
 		PythonEval &applier = PythonEval::instance();
-		result = applier.apply(as, fun, args);
+		result = applier.apply_v(as, fun, args);
 #else
 		throw RuntimeException(TRACE_INFO,
 		                       "Cannot evaluate python GroundedSchemaNode!");

--- a/opencog/cython/PythonEval.cc
+++ b/opencog/cython/PythonEval.cc
@@ -1055,7 +1055,7 @@ TruthValuePtr PythonEval::apply_tv(AtomSpace * as,
     // If we got a non-null truth value there were no errors.
     if (NULL == pyTruthValue)
         throw RuntimeException(TRACE_INFO,
-            "Python function '%s' did not return TruthValue!",
+            "Python function '%s' did not return a TruthValue!",
             func.c_str());
 
     // Grab the GIL.
@@ -1068,7 +1068,7 @@ TruthValuePtr PythonEval::apply_tv(AtomSpace * as,
         Py_DECREF(pyTruthValue);
         PyGILState_Release(gstate);
         throw RuntimeException(TRACE_INFO,
-            "Python function '%s' did not return TruthValue!",
+            "Python function '%s' did not return a TruthValue!",
             func.c_str());
     }
 
@@ -1085,7 +1085,7 @@ TruthValuePtr PythonEval::apply_tv(AtomSpace * as,
         if (pyTruthValuePtrPtr) Py_DECREF(pyTruthValuePtrPtr);
         PyGILState_Release(gstate);
         throw RuntimeException(TRACE_INFO,
-            "Python function '%s' did not return TruthValue!",
+            "Python function '%s' did not return a TruthValue!",
             func.c_str());
     }
 

--- a/opencog/cython/PythonEval.cc
+++ b/opencog/cython/PythonEval.cc
@@ -1011,7 +1011,7 @@ ValuePtr PythonEval::apply_v(AtomSpace * as,
     // Grab the GIL.
     PyGILState_STATE gstate = PyGILState_Ensure();
 
-    // Did we actually get a TruthValue?
+    // Did we actually get a Value?
     if (0 == PyObject_HasAttrString(pyValue, "value_ptr"))
     {
         Py_DECREF(pyValue);

--- a/opencog/cython/PythonEval.cc
+++ b/opencog/cython/PythonEval.cc
@@ -1012,6 +1012,10 @@ ValuePtr PythonEval::apply_v(AtomSpace * as,
     PyGILState_STATE gstate = PyGILState_Ensure();
 
     // Did we actually get a Value?
+    // One way to do this would be to say
+    //    PyObject *vtype = find_object("Value");
+    //    if (0 == PyObject_IsInstance(pyValue, vtype)) ...
+    // but just grabbing the attr is easier, for now.
     if (0 == PyObject_HasAttrString(pyValue, "value_ptr"))
     {
         Py_DECREF(pyValue);

--- a/opencog/cython/PythonEval.h
+++ b/opencog/cython/PythonEval.h
@@ -48,6 +48,7 @@
 
 #include <boost/filesystem/operations.hpp>
 
+#include <opencog/atoms/base/Atom.h>
 #include <opencog/atoms/base/Handle.h>
 #include <opencog/atoms/truthvalue/TruthValue.h>
 #include <opencog/eval/GenericEval.h>

--- a/opencog/cython/PythonEval.h
+++ b/opencog/cython/PythonEval.h
@@ -167,13 +167,24 @@ class PythonEval : public GenericEval
          * Calls the Python function passed in `func`, passing it
          * the `varargs` as an argument, and returning a Handle.
          */
-        Handle apply(AtomSpace * as, const std::string& func, Handle varargs);
+        ValuePtr apply_v(AtomSpace * as, const std::string& func,
+                         Handle varargs);
+
+        /**
+         * Calls the Python function passed in `func`, passing it
+         * the `varargs` as an argument, and returning a Handle.
+         */
+        Handle apply(AtomSpace * as, const std::string& func,
+                     Handle varargs)
+        { return HandleCast(apply_v(as, func, varargs)); }
 
         /**
          * Calls the Python function passed in `func`, passing it
          * the `varargs` as an argument, returning a TruthValuePtr.
          */
-        TruthValuePtr apply_tv(opencog::AtomSpace *as, const std::string& func, Handle varargs);
+        TruthValuePtr apply_tv(AtomSpace *as,
+                               const std::string& func, Handle varargs)
+        { return TruthValueCast(apply_v(as, func, varargs)); }
 
         /**
          * Calls the Python function passed in `func`, passing it

--- a/opencog/cython/opencog/atom.pyx
+++ b/opencog/cython/opencog/atom.pyx
@@ -127,9 +127,6 @@ cdef class Atom(Value):
         self.tv = createTruthValue(mean, count)
         return self
 
-    def handle_ptr(self):
-        return PyLong_FromVoidPtr(self.handle)
-
     def __richcmp__(self, other, int op):
         assert isinstance(other, Atom), "Only Atom instances are comparable with atoms"
         if op == Py_LT:

--- a/opencog/cython/opencog/truth_value.pyx
+++ b/opencog/cython/opencog/truth_value.pyx
@@ -57,4 +57,3 @@ cdef class TruthValue(Value):
 
     def truth_value_ptr_object(self):
         return PyLong_FromVoidPtr(<void*>self._tvptr())
-

--- a/opencog/cython/opencog/truth_value.pyx
+++ b/opencog/cython/opencog/truth_value.pyx
@@ -54,6 +54,3 @@ cdef class TruthValue(Value):
 
     cdef tv_ptr* _tvptr(self):
         return <tv_ptr*>&((<PtrHolder>self.ptr_holder).shared_ptr)
-
-    def truth_value_ptr_object(self):
-        return PyLong_FromVoidPtr(<void*>self._tvptr())

--- a/opencog/cython/opencog/value.pyx
+++ b/opencog/cython/opencog/value.pyx
@@ -36,6 +36,9 @@ cdef class Value:
         """Return C++ shared_ptr from PtrHolder instance"""
         return <cValuePtr&>(self.ptr_holder.shared_ptr)
 
+    def value_ptr(self):
+        return PyLong_FromVoidPtr(<cValuePtr*>&(self.ptr_holder.shared_ptr))
+
     @property
     def type(self):
         return self.get_c_value_ptr().get().get_type()

--- a/tests/cython/README.md
+++ b/tests/cython/README.md
@@ -21,9 +21,9 @@ export PYTHONPATH=build/opencog/cython
 Then from atomspace root source dir execute:
 
 ```
-nosetests -vs ./tests/cython/
-nosetests -vs ./tests/cython/atomspace/
-nosetests -vs ./tests/cython/bindlink/
-nosetests -vs ./tests/cython/guile/
-nosetests -vs ./tests/cython/utilities/
+nosetests3 -vs ./tests/cython/
+nosetests3 -vs ./tests/cython/atomspace/
+nosetests3 -vs ./tests/cython/bindlink/
+nosetests3 -vs ./tests/cython/guile/
+nosetests3 -vs ./tests/cython/utilities/
 ```

--- a/tests/cython/atomspace/test_exception.py
+++ b/tests/cython/atomspace/test_exception.py
@@ -1,7 +1,7 @@
 import unittest
 from opencog.utilities import initialize_opencog, finalize_opencog
 from opencog.type_constructors import *
-from opencog.bindlink import evaluate_atom
+from opencog.exec import evaluate_atom, execute_atom
 
 import __main__
 
@@ -27,6 +27,7 @@ class TestExceptions(unittest.TestCase):
            print("The exception message is " + str(e))
            self.assertTrue("Expecting" in str(e))
 
+    # --------------------------------------------------------------
     # First, make sure that evaluation works.
     def test_good_evaluation(self):
         atom1 = ConceptNode("atom1")
@@ -39,6 +40,7 @@ class TestExceptions(unittest.TestCase):
         expect = TruthValue(0.5, 0.5)
         self.assertTrue(okay == expect)
 
+    # --------------------------------------------------------------
     # Call a non-existent function.
     def test_bogus_evaluation(self):
         atom1 = ConceptNode("atom1")
@@ -52,6 +54,7 @@ class TestExceptions(unittest.TestCase):
            print("The exception message is " + str(e))
            self.assertTrue("not found in module" in str(e))
 
+    # Call function that returns None
     def test_pass_evaluation(self):
         atom1 = ConceptNode("atom1")
         eval_link = EvaluationLink(GroundedPredicateNode("py:no_ret"),
@@ -112,6 +115,95 @@ class TestExceptions(unittest.TestCase):
             print("The exception message is " + str(e))
             self.assertTrue("did not return a TruthValue" in str(e))
 
+    # --------------------------------------------------------------
+    # First, make sure that evaluation works.
+    def test_good_execution(self):
+        atom1 = ConceptNode("atom1")
+        exec_link = ExecutionOutputLink(GroundedSchemaNode("py:good_tv"),
+                                        ListLink(atom1, atom1, atom1))
+        okay = execute_atom(self.space, exec_link)
+
+        # Use `nosetests3 --nocapture` to see this print...
+        print("The good TV is " + str(okay))
+        expect = TruthValue(0.5, 0.5)
+        self.assertTrue(okay == expect)
+
+    # --------------------------------------------------------------
+    # Call a non-existent function.
+    def test_bogus_execution(self):
+        atom1 = ConceptNode("atom1")
+        exec_link = ExecutionOutputLink(GroundedSchemaNode("py:foobar"),
+                                        ListLink(atom1, atom1, atom1))
+        try:
+            execute_atom(self.space, exec_link)
+            self.assertFalse("call should fail")
+        except RuntimeError as e:
+            # Use `nosetests3 --nocapture` to see this print...
+            print("The exception message is " + str(e))
+            self.assertTrue("not found in module" in str(e))
+
+    # Call function that returns None
+    def test_pass_execution(self):
+        atom1 = ConceptNode("atom1")
+        exec_link = ExecutionOutputLink(GroundedSchemaNode("py:no_ret"),
+                                        ListLink(atom1, atom1, atom1))
+        try:
+            execute_atom(self.space, exec_link)
+            self.assertFalse("call should fail")
+        except RuntimeError as e:
+            # Use `nosetests3 --nocapture` to see this print...
+            print("The exception message is " + str(e))
+            self.assertTrue("not found in module" in str(e))
+
+    def test_num_execution(self):
+        atom1 = ConceptNode("atom1")
+        exec_link = ExecutionOutputLink(GroundedSchemaNode("py:ret_num"),
+                                        ListLink(atom1, atom1, atom1))
+        try:
+            execute_atom(self.space, exec_link)
+            self.assertFalse("call should fail")
+        except RuntimeError as e:
+            # Use `nosetests3 --nocapture` to see this print...
+            print("The exception message is " + str(e))
+            self.assertTrue("not found in module" in str(e))
+
+    def test_str_execution(self):
+        atom1 = ConceptNode("atom1")
+        exec_link = ExecutionOutputLink(GroundedSchemaNode("py:ret_str"),
+                                        ListLink(atom1, atom1, atom1))
+        try:
+            execute_atom(self.space, exec_link)
+            self.assertFalse("call should fail")
+        except RuntimeError as e:
+            # Use `nosetests3 --nocapture` to see this print...
+            print("The exception message is " + str(e))
+            self.assertTrue("not found in module" in str(e))
+
+    def test_nil_execution(self):
+        atom1 = ConceptNode("atom1")
+        exec_link = ExecutionOutputLink(GroundedSchemaNode("py:ret_nil"),
+                                        ListLink(atom1, atom1, atom1))
+        try:
+            execute_atom(self.space, exec_link)
+            self.assertFalse("call should fail")
+        except RuntimeError as e:
+            # Use `nosetests3 --nocapture` to see this print...
+            print("The exception message is " + str(e))
+            self.assertTrue("not found in module" in str(e))
+
+    def test_lst_execution(self):
+        atom1 = ConceptNode("atom1")
+        exec_link = ExecutionOutputLink(GroundedSchemaNode("py:ret_lst"),
+                                        ListLink(atom1, atom1, atom1))
+        try:
+            execute_atom(self.space, exec_link)
+            self.assertFalse("call should fail")
+        except RuntimeError as e:
+            # Use `nosetests3 --nocapture` to see this print...
+            print("The exception message is " + str(e))
+            self.assertTrue("not found in module" in str(e))
+
+
 
 def good_tv(*args):
     print(args)
@@ -123,19 +215,19 @@ def no_ret(*args):
 
 def ret_num(*args):
     print(args)
-    42
+    return 42
 
 def ret_str(*args):
     print(args)
-    "My name is Jon Jonson, I come from Wisconsin"
+    return "My name is Jon Jonson, I come from Wisconsin"
 
 def ret_nil(*args):
     print(args)
-    []
+    return {}
 
 def ret_lst(*args):
     print(args)
-    ['a', 'b', 'c']
+    return ['a', 'b', 'c']
 
 __main__.good_tv = good_tv
 __main__.no_ret = no_ret

--- a/tests/cython/atomspace/test_exception.py
+++ b/tests/cython/atomspace/test_exception.py
@@ -65,7 +65,7 @@ class TestExceptions(unittest.TestCase):
         except RuntimeError as e:
             # Use `nosetests3 --nocapture` to see this print...
             print("The exception message is " + str(e))
-            self.assertTrue("did not return a TruthValue" in str(e))
+            self.assertTrue("did not return Atomese" in str(e))
 
     def test_num_evaluation(self):
         atom1 = ConceptNode("atom1")
@@ -77,7 +77,7 @@ class TestExceptions(unittest.TestCase):
         except RuntimeError as e:
             # Use `nosetests3 --nocapture` to see this print...
             print("The exception message is " + str(e))
-            self.assertTrue("did not return a TruthValue" in str(e))
+            self.assertTrue("did not return Atomese" in str(e))
 
     def test_str_evaluation(self):
         atom1 = ConceptNode("atom1")
@@ -89,7 +89,7 @@ class TestExceptions(unittest.TestCase):
         except RuntimeError as e:
             # Use `nosetests3 --nocapture` to see this print...
             print("The exception message is " + str(e))
-            self.assertTrue("did not return a TruthValue" in str(e))
+            self.assertTrue("did not return Atomese" in str(e))
 
     def test_nil_evaluation(self):
         atom1 = ConceptNode("atom1")
@@ -101,7 +101,7 @@ class TestExceptions(unittest.TestCase):
         except RuntimeError as e:
             # Use `nosetests3 --nocapture` to see this print...
             print("The exception message is " + str(e))
-            self.assertTrue("did not return a TruthValue" in str(e))
+            self.assertTrue("did not return Atomese" in str(e))
 
     def test_lst_evaluation(self):
         atom1 = ConceptNode("atom1")
@@ -113,7 +113,7 @@ class TestExceptions(unittest.TestCase):
         except RuntimeError as e:
             # Use `nosetests3 --nocapture` to see this print...
             print("The exception message is " + str(e))
-            self.assertTrue("did not return a TruthValue" in str(e))
+            self.assertTrue("did not return Atomese" in str(e))
 
     # --------------------------------------------------------------
     # First, make sure that evaluation works.
@@ -153,7 +153,7 @@ class TestExceptions(unittest.TestCase):
         except RuntimeError as e:
             # Use `nosetests3 --nocapture` to see this print...
             print("The exception message is " + str(e))
-            self.assertTrue("not found in module" in str(e))
+            self.assertTrue("did not return Atomese" in str(e))
 
     def test_num_execution(self):
         atom1 = ConceptNode("atom1")
@@ -165,7 +165,7 @@ class TestExceptions(unittest.TestCase):
         except RuntimeError as e:
             # Use `nosetests3 --nocapture` to see this print...
             print("The exception message is " + str(e))
-            self.assertTrue("not found in module" in str(e))
+            self.assertTrue("did not return Atomese" in str(e))
 
     def test_str_execution(self):
         atom1 = ConceptNode("atom1")
@@ -177,7 +177,7 @@ class TestExceptions(unittest.TestCase):
         except RuntimeError as e:
             # Use `nosetests3 --nocapture` to see this print...
             print("The exception message is " + str(e))
-            self.assertTrue("not found in module" in str(e))
+            self.assertTrue("did not return Atomese" in str(e))
 
     def test_nil_execution(self):
         atom1 = ConceptNode("atom1")
@@ -189,7 +189,7 @@ class TestExceptions(unittest.TestCase):
         except RuntimeError as e:
             # Use `nosetests3 --nocapture` to see this print...
             print("The exception message is " + str(e))
-            self.assertTrue("not found in module" in str(e))
+            self.assertTrue("did not return Atomese" in str(e))
 
     def test_lst_execution(self):
         atom1 = ConceptNode("atom1")
@@ -201,7 +201,7 @@ class TestExceptions(unittest.TestCase):
         except RuntimeError as e:
             # Use `nosetests3 --nocapture` to see this print...
             print("The exception message is " + str(e))
-            self.assertTrue("not found in module" in str(e))
+            self.assertTrue("did not return Atomese" in str(e))
 
 
 

--- a/tests/cython/atomspace/test_exception.py
+++ b/tests/cython/atomspace/test_exception.py
@@ -52,9 +52,57 @@ class TestExceptions(unittest.TestCase):
            print("The exception message is " + str(e))
            self.assertTrue("not found in module" in str(e))
 
-    def test_null_evaluation(self):
+    def test_pass_evaluation(self):
         atom1 = ConceptNode("atom1")
         eval_link = EvaluationLink(GroundedPredicateNode("py:no_ret"),
+                                        atom1, atom1, atom1)
+        try:
+            evaluate_atom(self.space, eval_link)
+            self.assertFalse("call should fail")
+        except RuntimeError as e:
+            # Use `nosetests3 --nocapture` to see this print...
+            print("The exception message is " + str(e))
+            self.assertTrue("did not return a TruthValue" in str(e))
+
+    def test_num_evaluation(self):
+        atom1 = ConceptNode("atom1")
+        eval_link = EvaluationLink(GroundedPredicateNode("py:ret_num"),
+                                        atom1, atom1, atom1)
+        try:
+            evaluate_atom(self.space, eval_link)
+            self.assertFalse("call should fail")
+        except RuntimeError as e:
+            # Use `nosetests3 --nocapture` to see this print...
+            print("The exception message is " + str(e))
+            self.assertTrue("did not return a TruthValue" in str(e))
+
+    def test_str_evaluation(self):
+        atom1 = ConceptNode("atom1")
+        eval_link = EvaluationLink(GroundedPredicateNode("py:ret_str"),
+                                        atom1, atom1, atom1)
+        try:
+            evaluate_atom(self.space, eval_link)
+            self.assertFalse("call should fail")
+        except RuntimeError as e:
+            # Use `nosetests3 --nocapture` to see this print...
+            print("The exception message is " + str(e))
+            self.assertTrue("did not return a TruthValue" in str(e))
+
+    def test_nil_evaluation(self):
+        atom1 = ConceptNode("atom1")
+        eval_link = EvaluationLink(GroundedPredicateNode("py:ret_nil"),
+                                        atom1, atom1, atom1)
+        try:
+            evaluate_atom(self.space, eval_link)
+            self.assertFalse("call should fail")
+        except RuntimeError as e:
+            # Use `nosetests3 --nocapture` to see this print...
+            print("The exception message is " + str(e))
+            self.assertTrue("did not return a TruthValue" in str(e))
+
+    def test_lst_evaluation(self):
+        atom1 = ConceptNode("atom1")
+        eval_link = EvaluationLink(GroundedPredicateNode("py:ret_lst"),
                                         atom1, atom1, atom1)
         try:
             evaluate_atom(self.space, eval_link)
@@ -73,8 +121,28 @@ def no_ret(*args):
     print(args)
     pass
 
+def ret_num(*args):
+    print(args)
+    42
+
+def ret_str(*args):
+    print(args)
+    "My name is Jon Jonson, I come from Wisconsin"
+
+def ret_nil(*args):
+    print(args)
+    []
+
+def ret_lst(*args):
+    print(args)
+    ['a', 'b', 'c']
+
 __main__.good_tv = good_tv
 __main__.no_ret = no_ret
+__main__.ret_num = ret_num
+__main__.ret_str = ret_str
+__main__.ret_nil = ret_nil
+__main__.ret_lst = ret_lst
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/cython/atomspace/test_exception.py
+++ b/tests/cython/atomspace/test_exception.py
@@ -5,7 +5,6 @@ from opencog.bindlink import evaluate_atom
 
 import __main__
 
-
 # All of these tests try to make sure that python doesn't
 # crash when a C++ exception is thrown.
 class TestExceptions(unittest.TestCase):
@@ -28,6 +27,19 @@ class TestExceptions(unittest.TestCase):
            print("The exception message is " + str(e))
            self.assertTrue("Expecting" in str(e))
 
+    # First, make sure that evaluation works.
+    def test_good_evaluation(self):
+        atom1 = ConceptNode("atom1")
+        eval_link = EvaluationLink(GroundedPredicateNode("py:good_tv"),
+                                        atom1, atom1, atom1)
+        okay = evaluate_atom(self.space, eval_link)
+
+        # Use `nosetests3 --nocapture` to see this print...
+        print("The good TV is " + str(okay))
+        expect = TruthValue(0.5, 0.5)
+        self.assertTrue(okay == expect)
+
+    # Call a non-existent function.
     def test_bogus_evaluation(self):
         atom1 = ConceptNode("atom1")
         eval_link = EvaluationLink(GroundedPredicateNode("py:foobar"),
@@ -39,5 +51,32 @@ class TestExceptions(unittest.TestCase):
            # Use `nosetests3 --nocapture` to see this print...
            print("The exception message is " + str(e))
            self.assertTrue("not found in module" in str(e))
+
+    def test_null_evaluation(self):
+        atom1 = ConceptNode("atom1")
+        eval_link = EvaluationLink(GroundedPredicateNode("py:no_ret"),
+                                        atom1, atom1, atom1)
+        try:
+            evaluate_atom(self.space, eval_link)
+            self.assertFalse("call should fail")
+        except RuntimeError as e:
+            # Use `nosetests3 --nocapture` to see this print...
+            print("The exception message is " + str(e))
+            self.assertTrue("did not return a TruthValue" in str(e))
+
+
+def good_tv(*args):
+    print(args)
+    return TruthValue(0.5, 0.5)
+
+def no_ret(*args):
+    print(args)
+    pass
+
+__main__.good_tv = good_tv
+__main__.no_ret = no_ret
+
+if __name__ == '__main__':
+    unittest.main()
 
 # ===================== END OF FILE =================

--- a/tests/scm/SCMExecutionOutputUTest.cxxtest
+++ b/tests/scm/SCMExecutionOutputUTest.cxxtest
@@ -42,6 +42,8 @@ class SCMExecutionOutputUTest :  public CxxTest::TestSuite
 	{
 		logger().set_level(Logger::DEBUG);
 		logger().set_print_to_stdout_flag(true);
+		logger().set_timestamp_flag(false);
+		logger().set_sync_flag(true);
 	}
 
 	~SCMExecutionOutputUTest()
@@ -71,6 +73,8 @@ class SCMExecutionOutputUTest :  public CxxTest::TestSuite
 
 	void test_execute_single_arg(void);
 	void test_evaluate_single_arg(void);
+
+	void test_bad_gsn(void);
 };
 
 void SCMExecutionOutputUTest::setUp(void)
@@ -90,8 +94,11 @@ void SCMExecutionOutputUTest::tearDown(void)
 #define CHKEV(ev) \
 	TSM_ASSERT("Caught scm error during eval", \
 		(false == ev->eval_error()));
+
 void SCMExecutionOutputUTest::test_execute(void)
 {
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
 	Handle julian = as->add_node(CONCEPT_NODE, "julian");
 	Handle prince = as->add_node(CONCEPT_NODE, "prince");
 	Handle king = as->add_node(CONCEPT_NODE, "king");
@@ -116,6 +123,8 @@ void SCMExecutionOutputUTest::test_execute(void)
 
 	// Now there should be a king
 	TS_ASSERT_EQUALS(king->getIncomingSetSize(), 1);
+
+	logger().debug("END TEST: %s", __FUNCTION__);
 }
 
 
@@ -209,6 +218,8 @@ void SCMExecutionOutputUTest::test_multi_threads(void)
 // Thus, this winds up the C++ stack for the recursion.
 void SCMExecutionOutputUTest::test_recursive(void)
 {
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
 	// Empty out the atomspace
 	as->clear();
 	size_t size = as->get_size();
@@ -310,6 +321,8 @@ void SCMExecutionOutputUTest::test_recursive(void)
 	TS_ASSERT_EQUALS(size, 9);
 
 	size = as->get_size();
+
+	logger().debug("END TEST: %s", __FUNCTION__);
 }
 
 // Test nested execution links. github issue #1340
@@ -329,6 +342,8 @@ void SCMExecutionOutputUTest::test_recursive(void)
 //
 void SCMExecutionOutputUTest::test_nested(void)
 {
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
 	// Empty out the atomspace
 	as->clear();
 	size_t size = as->get_size();
@@ -367,10 +382,14 @@ void SCMExecutionOutputUTest::test_nested(void)
 	double dni = ni->get_value();
 	TS_ASSERT_LESS_THAN(fabs(dne - dni), 0.000001);
 	TS_ASSERT_LESS_THAN(fabs(9.0 - dne), 0.000001);
+
+	logger().debug("END TEST: %s", __FUNCTION__);
 }
 
 void SCMExecutionOutputUTest::test_evaluate(void)
 {
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
 	// Define a Scheme procedure that return a TV
 	eval->eval("(define (grab-tv x) (cog-tv x))");
 	CHKEV(eval);
@@ -398,12 +417,16 @@ void SCMExecutionOutputUTest::test_evaluate(void)
 	CHKEV(eval);
 	eval->eval("(chk-tv (ConceptNode \"glurg\" (cog-new-ctv 0.123 0.456 789)))");
 	CHKEV(eval);
+
+	logger().debug("END TEST: %s", __FUNCTION__);
 }
 
 
 // the fix for bug #695 (contents of True/False links not evaluated)
 void SCMExecutionOutputUTest::test_wrapped_evaluate(void)
 {
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
 	// Define a Scheme procedure that return a TV
 	eval->eval(
 		"(define (copy-tv x) "
@@ -436,10 +459,14 @@ void SCMExecutionOutputUTest::test_wrapped_evaluate(void)
 	CHKEV(eval);
 	eval->eval("(chk-copied-tv (ConceptNode \"glurg\" (cog-new-ctv 0.123 0.456 789)))");
 	CHKEV(eval);
+
+	logger().debug("END TEST: %s", __FUNCTION__);
 }
 
 void SCMExecutionOutputUTest::test_numeric(void)
 {
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
 	// A Numeric expression
 	eval->eval(
 		"(define expr "
@@ -462,10 +489,14 @@ void SCMExecutionOutputUTest::test_numeric(void)
 	double dnt = nt->get_value();
 	TS_ASSERT_LESS_THAN(fabs(dne - dnt), 0.000001);
 	TS_ASSERT_LESS_THAN(fabs(24.0 - dne), 0.000001);
+
+	logger().debug("END TEST: %s", __FUNCTION__);
 }
 
 void SCMExecutionOutputUTest::test_boolean(void)
 {
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
 	// A boolean-valued expression
 	eval->eval(
 		"(define expr "
@@ -491,10 +522,14 @@ void SCMExecutionOutputUTest::test_boolean(void)
 	// When evaluated, this one should be false.
 	tv = EvaluationLink::do_evaluate(as, boolex);
 	TS_ASSERT_LESS_THAN_EQUALS(tv->get_mean(), 0.001);
+
+	logger().debug("END TEST: %s", __FUNCTION__);
 }
 
 void SCMExecutionOutputUTest::test_dsn(void)
 {
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
 	// A boolean-valued expression
 	eval->eval(
 	   "(DefineLink"
@@ -549,12 +584,16 @@ void SCMExecutionOutputUTest::test_dsn(void)
 	std::cout << "Lambda is " << result->to_string() << std::endl;
 	std::cout << "Expected " << expect->to_string() << std::endl;
 	TS_ASSERT_EQUALS(result, expect);
+
+	logger().debug("END TEST: %s", __FUNCTION__);
 }
 
 // Execute a call with a single argument, by-passing the need for
 // wrapping the arguments in a ListLink.
 void SCMExecutionOutputUTest::test_execute_single_arg(void)
 {
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
 	// Test scheme execution function taking a single argument
 
 	eval->eval(
@@ -596,10 +635,14 @@ void SCMExecutionOutputUTest::test_execute_single_arg(void)
 	std::cout << "Expression is " << result->to_string() << std::endl;
 	std::cout << "Expected " << expect->to_string() << std::endl;
 	TS_ASSERT_EQUALS(result, expect);
+
+	logger().debug("END TEST: %s", __FUNCTION__);
 }
 
 void SCMExecutionOutputUTest::test_evaluate_single_arg(void)
 {
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
 	// Define a Scheme procedure that return a TV
 	eval->eval("(define (grab-tv x) (cog-tv x))");
 	CHKEV(eval);
@@ -627,4 +670,43 @@ void SCMExecutionOutputUTest::test_evaluate_single_arg(void)
 	CHKEV(eval);
 	eval->eval("(chk-tv (ConceptNode \"glurg\" (cog-new-ctv 0.123 0.456 789)))");
 	CHKEV(eval);
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+// Execute calls with badly-defined return values.
+void SCMExecutionOutputUTest::test_bad_gsn(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	eval->eval(
+	   "(define (call-gsn str)"
+	   "   (cog-execute!"
+	   "      (ExecutionOutputLink"
+	   "         (GroundedSchema str)"
+	   "         (Concept \"A\"))))"
+	);
+	CHKEV(eval);
+
+	eval->eval("(define (no-ret x) *unspecified*)");
+	CHKEV(eval);
+	TS_ASSERT_THROWS_ANYTHING(eval->eval_h("(call-gsn \"scm: no-ret\")"));
+
+	eval->eval("(define (ret-num x) 42)");
+	CHKEV(eval);
+	TS_ASSERT_THROWS_ANYTHING(eval->eval_h("(call-gsn \"scm: ret-num\")"));
+
+	eval->eval("(define (ret-str x) \"oh noooo!\")");
+	CHKEV(eval);
+	TS_ASSERT_THROWS_ANYTHING(eval->eval_h("(call-gsn \"scm: ret-str\")"));
+
+	eval->eval("(define (ret-nil x) '())");
+	CHKEV(eval);
+	TS_ASSERT_THROWS_ANYTHING(eval->eval_h("(call-gsn \"scm: ret-nil\")"));
+
+	eval->eval("(define (ret-lst x) (list 'a 'b 'c))");
+	CHKEV(eval);
+	TS_ASSERT_THROWS_ANYTHING(eval->eval_h("(call-gsn \"scm: ret-lst\")"));
+
+	logger().debug("END TEST: %s", __FUNCTION__);
 }

--- a/tests/scm/SCMExecutionOutputUTest.cxxtest
+++ b/tests/scm/SCMExecutionOutputUTest.cxxtest
@@ -75,6 +75,7 @@ class SCMExecutionOutputUTest :  public CxxTest::TestSuite
 	void test_evaluate_single_arg(void);
 
 	void test_bad_gsn(void);
+	void test_bad_gpn(void);
 };
 
 void SCMExecutionOutputUTest::setUp(void)
@@ -684,6 +685,42 @@ void SCMExecutionOutputUTest::test_bad_gsn(void)
 	   "   (cog-execute!"
 	   "      (ExecutionOutputLink"
 	   "         (GroundedSchema str)"
+	   "         (Concept \"A\"))))"
+	);
+	CHKEV(eval);
+
+	eval->eval("(define (no-ret x) *unspecified*)");
+	CHKEV(eval);
+	TS_ASSERT_THROWS_ANYTHING(eval->eval_h("(call-gsn \"scm: no-ret\")"));
+
+	eval->eval("(define (ret-num x) 42)");
+	CHKEV(eval);
+	TS_ASSERT_THROWS_ANYTHING(eval->eval_h("(call-gsn \"scm: ret-num\")"));
+
+	eval->eval("(define (ret-str x) \"oh noooo!\")");
+	CHKEV(eval);
+	TS_ASSERT_THROWS_ANYTHING(eval->eval_h("(call-gsn \"scm: ret-str\")"));
+
+	eval->eval("(define (ret-nil x) '())");
+	CHKEV(eval);
+	TS_ASSERT_THROWS_ANYTHING(eval->eval_h("(call-gsn \"scm: ret-nil\")"));
+
+	eval->eval("(define (ret-lst x) (list 'a 'b 'c))");
+	CHKEV(eval);
+	TS_ASSERT_THROWS_ANYTHING(eval->eval_h("(call-gsn \"scm: ret-lst\")"));
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+void SCMExecutionOutputUTest::test_bad_gpn(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	eval->eval(
+	   "(define (call-gpn str)"
+	   "   (cog-evaluate!"
+	   "      (EvaluationLink"
+	   "         (GroundedPredicate str)"
 	   "         (Concept \"A\"))))"
 	);
 	CHKEV(eval);


### PR DESCRIPTION
Add unit tests for GroundedSchema / GroundedPredicate's that return bad values.
 * Scheme code was already handling these properly.
 * Python was handling some of these properly, but not all.
   In some cases, it threw opaque, hard to understand errors.
   In the case of #2627 it was not noticing a bad return value.

Also, consolidate two different python execution paths into one.
They were cut-n-paste copies of each-other. Merge them back
together again. This results in an error being throw for #2627