### PR TITLE
Re-enable multi-variable caching.

### DIFF
--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -2593,8 +2593,23 @@ bool PatternMatchEngine::explore_clause_evaluatable(const Handle& term,
 
 	// All variables in the clause had better be grounded!
 	if (not is_clause_grounded(clause))
+	{
+#ifdef THROW_NASTY_ERROR
 		throw RuntimeException(TRACE_INFO,
 		      "Unable to evaluate clause with ungrounded variables!");
+#else
+		logger().warn("Evaluating clause with ungrounded variables!");
+		logger().info("You are depending on unspecified behavior!");
+		logger().info("Clause variables are %s",
+			oc_to_string(_pat->clause_variables.at(clause)).c_str());
+		logger().info("Current grounding=%s",
+			oc_to_string(var_grounding).c_str());
+		logger().info("The ungrounded clause is:\n%s",
+			clause->to_string().c_str());
+		logger().info("The pattern body containing this clause is:\n%s",
+			_pat->to_string("").c_str());
+#endif
+	}
 
 	bool found = _pmc.evaluate_sentence(clause, var_grounding);
 	DO_LOG({logger().fine("Post evaluating clause, found = %d", found);})

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -2599,7 +2599,7 @@ bool PatternMatchEngine::explore_clause_evaluatable(const Handle& term,
 		      "Unable to evaluate clause with ungrounded variables!");
 #else
 		logger().warn("Evaluating clause with ungrounded variables!");
-		logger().info("You are depending on unspecified behavior!");
+		logger().info("This is an internal bug! See issue #2631");
 		logger().info("Clause variables are %s",
 			oc_to_string(_pat->clause_variables.at(clause)).c_str());
 		logger().info("Current grounding=%s",

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1878,33 +1878,13 @@ bool PatternMatchEngine::clause_accept(const Handle& clause_root,
 		logmsg("---------------------\nclause:", clause_root);
 		logmsg("ground:", hg);
 
-		// The multi-variable cache is is disabled for now, because in the
-		// one large test that I can test on (complex search over millions
-		// of atoms - the tetrahedron search) this slows things down by
-		// about 2%. .. Which is not much, but it also didn't speed
-		// anything up either... so, until a clear benefit shows up,
-		// this is disabled. Single-variable caching is enabled, it is
-		// a big winner (improving MOZI genome search code by 25%-30%).
-#ifndef ENABLE_MULTIVARIABLE_CACHE
-		// Cache the result, so that it can be reused.
-		// See commentary on `explore_clause()` for more info.
-		const HandleSeq& clvars(_pat->clause_variables.at(clause_root));
-		size_t cvsz = clvars.size();
-		if (1 == cvsz and
-			 _pat->cacheable_clauses.find(clause_root) !=
-		    _pat->cacheable_clauses.end())
-		{
-			const Handle& jgnd(var_grounding.at(clvars[0]));
-			HandleSeq key({clause_root, jgnd});
-			_gnd_cache.insert({key, hg});
-		}
-
-#else // ENABLE_MULTIVARIABLE_CACHE
 		// Cache the result, so that it can be reused.
 		// See commentary on `explore_clause()` for more info.
 		HandleSeq key;
 		const HandleSeq& clvars(_pat->clause_variables.at(clause_root));
 		size_t cvsz = clvars.size();
+
+		// Clause contains just a single variable
 		if (1 == cvsz and
 			 _pat->cacheable_clauses.find(clause_root) !=
 		    _pat->cacheable_clauses.end())
@@ -1912,6 +1892,8 @@ bool PatternMatchEngine::clause_accept(const Handle& clause_root,
 			const Handle& jgnd(var_grounding.at(clvars[0]));
 			key = HandleSeq({clause_root, jgnd});
 		}
+
+		// Clause contains two or more variables.
 		if (1 < cvsz and
 			 _pat->cacheable_multi.find(clause_root) !=
 		    _pat->cacheable_multi.end())
@@ -1930,7 +1912,6 @@ bool PatternMatchEngine::clause_accept(const Handle& clause_root,
 #endif
 			_gnd_cache.insert({key, hg});
 		}
-#endif // ENABLE_MULTIVARIABLE_CACHE
 	}
 
 	// Now go and do more clauses.
@@ -2704,18 +2685,12 @@ bool PatternMatchEngine::explore_clause(const Handle& term,
 	if (_pat->cacheable_clauses.find(clause) != _pat->cacheable_clauses.end())
 		key = HandleSeq({clause, grnd});
 
-#ifdef ENABLE_MULTIVARIABLE_CACHE
-	// This is disabled for now, because in the one large test that
-	// I have (complex search over millions of atoms - the tetrahedron
-	// search) this slows things down by about 2%. .. Which is not
-	// much, but it also didn't speed anything up either...
 	// Multi-variable cache.
 	if (_pat->cacheable_multi.find(clause) != _pat->cacheable_multi.end())
 	{
 		const HandleSeq& varseq = _pat->clause_variables.at(clause);
 		key = clause_grounding_key(clause, varseq);
 	}
-#endif // ENABLE_MULTIVARIABLE_CACHE
 
 	if (0 < key.size())
 	{


### PR DESCRIPTION
It actually provides a 3.5% speedup on my test-case.  The previous
measurements were done incorrectly.