### PR TITLE
Python module cleanup

### DIFF
--- a/opencog/cython/PythonEval.cc
+++ b/opencog/cython/PythonEval.cc
@@ -801,6 +801,7 @@ void PythonEval::module_for_function(const std::string& moduleFunction,
     pyModule = _pyRootModule;
     pyObject = nullptr;
     functionName = moduleFunction;
+
     // Get the correct module and extract the function name.
     int index = moduleFunction.find_first_of('.');
     if (0 < index) {
@@ -823,20 +824,24 @@ void PythonEval::module_for_function(const std::string& moduleFunction,
             functionName = moduleFunction.substr(index+1);
         }
     }
-    // Iteratively check for objects in the selected (either root or loaded) module
+
+    // Iteratively check for objects in the selected (either root
+    // or loaded) module.
     index = functionName.find_first_of('.');
     bool bDecRef = false;
     while (0 < index) {
         std::string objectName = functionName.substr(0, index);
         // If there is no object yet, find it in Module
         // Else find it as Attr in Object
-        if(nullptr == pyObject) {
+        if (nullptr == pyObject) {
             pyObject = find_object(pyModule, objectName);
         } else {
-            PyObject* pyTmp = PyObject_GetAttrString(pyObject, objectName.c_str());
-            if(bDecRef) Py_DECREF(pyObject);
+            PyObject* pyTmp = PyObject_GetAttrString(pyObject,
+                                              objectName.c_str());
+            if (bDecRef) Py_DECREF(pyObject);
             pyObject =  pyTmp;
-            // next time, we should use DECREF, since PyObject_GetAttrString returns new reference
+            // Next time, we should use DECREF, since
+            // PyObject_GetAttrString returns new reference
             bDecRef = true;
         }
 
@@ -848,7 +853,9 @@ void PythonEval::module_for_function(const std::string& moduleFunction,
         functionName = functionName.substr(index+1);
         index = functionName.find_first_of('.');
     }
-    if(pyObject && !bDecRef) Py_INCREF(pyObject); // for uniformity to DEC later in any case
+
+    // For uniformity to DEC later in any case
+    if (pyObject && !bDecRef) Py_INCREF(pyObject);
 }
 
 // ===========================================================
@@ -914,7 +921,7 @@ PyObject* PythonEval::call_user_function(const std::string& moduleFunction,
     // Promote the borrowed reference for pyUserFunc since it will
     // be passed to a Python C API function later that "steals" it.
     // PyObject_GetAttrString already returns new reference, so we do this only for PyDict_GetItemString
-    if(nullptr == pyObject) Py_INCREF(pyUserFunc);
+    if (nullptr == pyObject) Py_INCREF(pyUserFunc);
     if (pyObject) Py_DECREF(pyObject); // We don't need it anymore
 
     // Make sure the function is callable.
@@ -1100,7 +1107,7 @@ void PythonEval::apply_as(const std::string& moduleFunction,
 
     // If we can't find that function then throw an exception.
     if (!pyUserFunc) {
-        if(pyObject) Py_DECREF(pyObject);
+        if (pyObject) Py_DECREF(pyObject);
         PyGILState_Release(gstate);
         throw RuntimeException(TRACE_INFO,
             "Python function '%s' not found!",

--- a/opencog/cython/PythonEval.cc
+++ b/opencog/cython/PythonEval.cc
@@ -887,27 +887,23 @@ PyObject* PythonEval::call_user_function(const std::string& moduleFunction,
     }
 
     // Get a reference to the user function.
-    PyObject* pyDict = PyModule_GetDict(pyModule);
-
     PyObject* pyUserFunc;
     // If there is no object, then search in module
-    if(nullptr == pyObject) {
+    if (nullptr == pyObject) {
 #ifdef DEBUG
         printf("Looking for %s in module %s; here's what we have:\n",
             functionName.c_str(), PyModule_GetName(pyModule));
         print_dictionary(pyDict);
 #endif
+        PyObject* pyDict = PyModule_GetDict(pyModule);
         pyUserFunc = PyDict_GetItemString(pyDict, functionName.c_str());
     } else {
         pyUserFunc = PyObject_GetAttrString(pyObject, functionName.c_str());
     }
 
-    // PyModule_GetDict returns a borrowed reference, so don't do this:
-    // Py_DECREF(pyDict);
-
     // If we can't find that function then throw an exception.
     if (!pyUserFunc) {
-        if(pyObject) Py_DECREF(pyObject);
+        if (pyObject) Py_DECREF(pyObject);
         PyGILState_Release(gstate);
         const char * moduleName = PyModule_GetName(pyModule);
         throw RuntimeException(TRACE_INFO,
@@ -1073,7 +1069,6 @@ void PythonEval::apply_as(const std::string& moduleFunction,
 {
     std::lock_guard<std::recursive_mutex> lck(_mtx);
     PyObject *pyModule, *pyObject, *pyUserFunc;
-    PyObject *pyDict;
     std::string functionName;
 
     // Grab the GIL.
@@ -1095,16 +1090,13 @@ void PythonEval::apply_as(const std::string& moduleFunction,
     }
 
     // Get a reference to the user function.
-    pyDict = PyModule_GetDict(pyModule);
     // If there is no object, then search in module
-    if(nullptr == pyObject) {
+    if (nullptr == pyObject) {
+        PyObject *pyDict = PyModule_GetDict(pyModule);
         pyUserFunc = PyDict_GetItemString(pyDict, functionName.c_str());
     } else {
         pyUserFunc = PyObject_GetAttrString(pyObject, functionName.c_str());
     }
-
-    // PyModule_GetDict returns a borrowed reference, so don't do this:
-    // Py_DECREF(pyDict);
 
     // If we can't find that function then throw an exception.
     if (!pyUserFunc) {

--- a/opencog/cython/PythonEval.cc
+++ b/opencog/cython/PythonEval.cc
@@ -780,18 +780,18 @@ void PythonEval::add_modules_from_abspath(std::string pathString)
 }
 
 /**
- * Find the Python object by its name in the given module'.
+ * Find the Python object by its name in the given module.
  */
-PyObject* PythonEval::find_object(const PyObject* pyModule,
+PyObject* PythonEval::find_object(PyObject* pyModule,
                                   const std::string& objectName)
 {
-    PyObject* pyDict = PyModule_GetDict(_pyRootModule);
+    PyObject* pyDict = PyModule_GetDict(pyModule);
     return PyDict_GetItemString(pyDict, objectName.c_str());
 }
 
 /**
- * Get the Python module and/or object and stripped function name given the identifer of
- * the form '[module.][object.[attribute.]*]function'.
+ * Get the Python module and/or object and stripped function name, given
+ * the identifer of the form '[module.][object.[attribute.]*]function'.
  */
 void PythonEval::module_for_function(const std::string& moduleFunction,
                                      PyObject*& pyModule,

--- a/opencog/cython/PythonEval.cc
+++ b/opencog/cython/PythonEval.cc
@@ -810,7 +810,7 @@ PyObject* PythonEval::get_function(const std::string& moduleFunction)
         // Then try loading it.
         // We have to guess, if its a single file, or an entire
         // directory with an __init__.py file in it ...
-        if (nullptr == pyModuleTmp &&
+        if (nullptr == pyModuleTmp and
             nullptr == find_object(pyModule, moduleName))
         {
             add_modules_from_path(moduleName);
@@ -825,11 +825,6 @@ PyObject* PythonEval::get_function(const std::string& moduleFunction)
             functionName = moduleFunction.substr(index+1);
         }
     }
-
-    // If we can't find that module then throw an exception.
-    if (!pyModule)
-        throw RuntimeException(TRACE_INFO,
-            "Python module for '%s' not found!", moduleFunction.c_str());
 
     // Iteratively check for objects in the selected (either root
     // or loaded) module.

--- a/opencog/cython/PythonEval.h
+++ b/opencog/cython/PythonEval.h
@@ -80,7 +80,7 @@ class PythonEval : public GenericEval
         void add_to_sys_path(std::string path);
         PyObject * atomspace_py_object(AtomSpace *);
         void print_dictionary(PyObject*);
-        PyObject* find_object(const PyObject* pyModule,
+        PyObject* find_object(PyObject* pyModule,
                               const std::string& objectName);
         void module_for_function(const std::string& moduleFunction,
                                  PyObject*& pyModule, PyObject*& pyObject,

--- a/opencog/cython/PythonEval.h
+++ b/opencog/cython/PythonEval.h
@@ -87,6 +87,11 @@ class PythonEval : public GenericEval
                                  std::string& functionName);
         PyObject* get_user_function(const std::string& moduleFunction,
                                     PyGILState_STATE gstate);
+        PyObject* call_function(PyObject* pyUserFunc,
+                                PyObject* pyArguments,
+                                PyGILState_STATE gstate,
+                                const std::string& moduleFunction);
+
 
         // Call functions; execute scripts.
         PyObject* call_user_function(const std::string& func,
@@ -100,13 +105,12 @@ class PythonEval : public GenericEval
         // Single-threded design.
         static PythonEval* singletonInstance;
 
-
         // Single, global mutex for serializing access to the atomspace.
         // The singleton-instance design of this class forces us to
         // serialize access (the GIL is not enough), because there is
         // no way to guarantee that python won't accidentally be called
         // from multiple threads.  That's because the EvaluationLink
-        // is called from scheme and from the pattern matcher, and its
+        // is called from scheme and from the pattern engine, and its
         // unknown how many threads those things might be running in.
         // The lock is recursive, because we may need to use multiple
         // different atomspaces with the evaluator, in some nested

--- a/opencog/cython/PythonEval.h
+++ b/opencog/cython/PythonEval.h
@@ -85,6 +85,8 @@ class PythonEval : public GenericEval
         void module_for_function(const std::string& moduleFunction,
                                  PyObject*& pyModule, PyObject*& pyObject,
                                  std::string& functionName);
+        PyObject* get_user_function(const std::string& moduleFunction,
+                                    PyGILState_STATE gstate);
 
         // Call functions; execute scripts.
         PyObject* call_user_function(const std::string& func,

--- a/opencog/cython/PythonEval.h
+++ b/opencog/cython/PythonEval.h
@@ -82,9 +82,7 @@ class PythonEval : public GenericEval
         void print_dictionary(PyObject*);
         PyObject* find_object(PyObject* pyModule,
                               const std::string& objectName);
-        void module_for_function(const std::string& moduleFunction,
-                                 PyObject*& pyModule, PyObject*& pyObject,
-                                 std::string& functionName);
+        PyObject* get_function(const std::string& moduleFunction);
         PyObject* do_call_user_function(const std::string& moduleFunction,
                                         PyObject* pyArguments);
 

--- a/opencog/cython/PythonEval.h
+++ b/opencog/cython/PythonEval.h
@@ -86,7 +86,6 @@ class PythonEval : public GenericEval
                                  PyObject*& pyModule, PyObject*& pyObject,
                                  std::string& functionName);
         PyObject* do_call_user_function(const std::string& moduleFunction,
-                                        PyGILState_STATE gstate,
                                         PyObject* pyArguments);
 
         // Call functions; execute scripts.

--- a/opencog/cython/PythonEval.h
+++ b/opencog/cython/PythonEval.h
@@ -85,13 +85,9 @@ class PythonEval : public GenericEval
         void module_for_function(const std::string& moduleFunction,
                                  PyObject*& pyModule, PyObject*& pyObject,
                                  std::string& functionName);
-        PyObject* get_user_function(const std::string& moduleFunction,
-                                    PyGILState_STATE gstate);
-        PyObject* call_function(PyObject* pyUserFunc,
-                                PyObject* pyArguments,
-                                PyGILState_STATE gstate,
-                                const std::string& moduleFunction);
-
+        PyObject* do_call_user_function(const std::string& moduleFunction,
+                                        PyGILState_STATE gstate,
+                                        PyObject* pyArguments);
 
         // Call functions; execute scripts.
         PyObject* call_user_function(const std::string& func,


### PR DESCRIPTION
Remove many years of accumulated cruft.
* Consolidate cut-n-pasted sections of code
* Reduce complexity of internal API calls
* Simplify flow
* Assorted white-space adjustments.