### PR TITLE
Remove cinit as init constructor is enough

### DIFF
--- a/opencog/cython/opencog/value.pyx
+++ b/opencog/cython/opencog/value.pyx
@@ -17,9 +17,6 @@ cdef class PtrHolder:
         return ptr_holder
 
 cdef class Value:
-    """C++ Value object wrapper for Python clients"""
-    def __cinit__(self, PtrHolder ptr_holder, *args, **kwargs):
-        self.ptr_holder = ptr_holder
 
     @staticmethod
     cdef Value create(cValuePtr& ptr):


### PR DESCRIPTION
`__cinit__` is required to initialize class instance on C level but Value doesn't require such initialization so `__init__` is enough and more safe.