### PR TITLE
Fix mis-handling of virtual clauses

### DIFF
--- a/opencog/atoms/pattern/CMakeLists.txt
+++ b/opencog/atoms/pattern/CMakeLists.txt
@@ -18,6 +18,8 @@ ADD_LIBRARY (lambda
 # Without this, parallel make will race and crap up the generated files.
 ADD_DEPENDENCIES(lambda opencog_atom_types)
 
+# TARGET_COMPILE_OPTIONS(lambda PRIVATE -DQDEBUG=1)
+
 TARGET_LINK_LIBRARIES(lambda
 	query-engine
 	atomcore

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -754,9 +754,6 @@ bool PatternLink::is_virtual(const Handle& clause)
 ///
 void PatternLink::unbundle_virtual(const HandleSeq& clauses)
 {
-	TypeSet connectives({AND_LINK, SEQUENTIAL_AND_LINK,
-	                     OR_LINK, SEQUENTIAL_OR_LINK, NOT_LINK});
-
 	for (const Handle& clause: clauses)
 	{
 		bool is_virtu = false;
@@ -800,17 +797,16 @@ void PatternLink::unbundle_virtual(const HandleSeq& clauses)
 		// For example, `(Equal (Var X) (List (Var A) (Var B)))`
 		// the `(List (Var A) (Var B))` must be implcitly present.
 		// That is, assuming the two sides are not virtual
-		// themselves... XXX FIXME.
+		// themselves... XXX FIXME. We could call `unbundle_clauses_rec`
+		// to do this, but it seems premature, as that step hasn't been
+		// started yet. This is a bit of a mess ...
 		for (const Handle& sh : fgtl.varset)
 		{
 			if (SATISFACTION_LINK == sh->get_type()) continue;
 			for (const Handle& term : sh->getOutgoingSet())
 			{
 				if (is_constant(_variables.varset, term)) continue;
-				if (term->get_type() == VARIABLE_NODE)
-					_fixed.emplace_back(term);
-				else
-					unbundle_clauses_rec(term, connectives);
+				_fixed.emplace_back(term);
 			}
 		}
 

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -754,6 +754,9 @@ bool PatternLink::is_virtual(const Handle& clause)
 ///
 void PatternLink::unbundle_virtual(const HandleSeq& clauses)
 {
+	TypeSet connectives({AND_LINK, SEQUENTIAL_AND_LINK,
+	                     OR_LINK, SEQUENTIAL_OR_LINK, NOT_LINK});
+
 	for (const Handle& clause: clauses)
 	{
 		bool is_virtu = false;
@@ -804,8 +807,10 @@ void PatternLink::unbundle_virtual(const HandleSeq& clauses)
 			for (const Handle& term : sh->getOutgoingSet())
 			{
 				if (is_constant(_variables.varset, term)) continue;
-
-				_fixed.emplace_back(term);
+				if (term->get_type() == VARIABLE_NODE)
+					_fixed.emplace_back(term);
+				else
+					unbundle_clauses_rec(term, connectives);
 			}
 		}
 

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -439,7 +439,7 @@ void PatternLink::unbundle_clauses(const Handle& hbody)
 	// for anyone giving alternative interpretations. Yuck.
 	else if (OR_LINK == t and 1 == hbody->get_arity())
 	{
-		// BUG - XXX FIXME Handle of OrLink is incorrect, here.
+		// BUG - XXX FIXME Handling of OrLink is incorrect, here.
 		// See also FIXME above.
 		TypeSet connectives({AND_LINK, OR_LINK, NOT_LINK});
 		unbundle_clauses_rec(hbody, connectives);
@@ -802,7 +802,11 @@ void PatternLink::unbundle_virtual(const HandleSeq& clauses)
 		{
 			if (SATISFACTION_LINK == sh->get_type()) continue;
 			for (const Handle& term : sh->getOutgoingSet())
+			{
+				if (is_constant(_variables.varset, term)) continue;
+
 				_fixed.emplace_back(term);
+			}
 		}
 
 		if (is_virtu)

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -159,6 +159,10 @@ void PatternLink::init(void)
 	unbundle_clauses(_body);
 	common_init();
 	setup_components();
+
+#ifdef QDEBUG
+	logger().fine("Pattern: %s", to_long_string("").c_str());
+#endif
 }
 
 /* ================================================================= */
@@ -1132,7 +1136,7 @@ std::string PatternLink::to_long_string(const std::string& indent) const
 {
 	std::string indent_p = indent + oc_to_string_indent;
 	std::stringstream ss;
-	ss << to_string(indent);
+	ss << to_string(indent) << std::endl;
 	ss << indent << "_pat:" << std::endl
 	   << oc_to_string(_pat, indent_p) << std::endl;
 	ss << indent << "_fixed:" << std::endl

--- a/opencog/atoms/pattern/QueryLink.cc
+++ b/opencog/atoms/pattern/QueryLink.cc
@@ -48,6 +48,10 @@ void QueryLink::init(void)
 	common_init();
 	setup_components();
 	_pat.redex_name = "anonymous QueryLink";
+
+#ifdef QDEBUG
+	logger().fine("Query: %s", to_long_string("").c_str());
+#endif
 }
 
 QueryLink::QueryLink(const Handle& vardecl,

--- a/tests/query/BuggyEqualUTest.cxxtest
+++ b/tests/query/BuggyEqualUTest.cxxtest
@@ -21,6 +21,7 @@
  */
 
 #include <opencog/atoms/core/NumberNode.h>
+#include <opencog/atoms/value/LinkValue.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/guile/SchemeEval.h>
 #include <opencog/util/Logger.h>
@@ -39,12 +40,13 @@ class BuggyEqual :  public CxxTest::TestSuite
 		{
 			logger().set_level(Logger::DEBUG);
 			logger().set_print_to_stdout_flag(true);
+			logger().set_timestamp_flag(false);
+			logger().set_sync_flag(true);
 
 			as = new AtomSpace();
 			eval = new SchemeEval(as);
 			eval->eval("(use-modules (opencog exec))");
 			eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
-
 		}
 
 		~BuggyEqual()
@@ -63,6 +65,7 @@ class BuggyEqual :  public CxxTest::TestSuite
 		void test_bugeq(void);
 		void test_bugalt(void);
 		void test_arithmetic(void);
+		void test_unify(void);
 };
 
 void BuggyEqual::setUp(void)
@@ -125,6 +128,32 @@ void BuggyEqual::test_arithmetic(void)
 	double dsix = nn->get_value();
 	TS_ASSERT_LESS_THAN_EQUALS(5.99999, dsix);
 	TS_ASSERT_LESS_THAN_EQUALS(dsix, 6.00001);
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+/*
+ * Failed variable unification
+ */
+void BuggyEqual::test_unify(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	eval->eval("(load-from-path \"tests/query/buggy-equal-unify.scm\")");
+
+	ValuePtr listl = eval->eval_v("(cog-execute! qunify)");
+	printf("Unify result:\n%s\n", listl->to_short_string().c_str());
+	TSM_ASSERT("Wrong return type!",
+		nameserver().isA(listl->get_type(), LINK_VALUE));
+	TSM_ASSERT_EQUALS("Wrong number of solutions!",
+		LinkValueCast(listl)->value().size(), 1);
+	// Handle gotu = HandleCast(LinkValueCast(listl)->value()[0]);
+	ValuePtr gotu = LinkValueCast(listl)->value()[0];
+
+	Handle expect = eval->eval_h("expected");
+	printf("Unify expect: %s\n", expect->to_short_string().c_str());
+
+	TSM_ASSERT_EQUALS("Bad unification!", expect, gotu);
 
 	logger().debug("END TEST: %s", __FUNCTION__);
 }

--- a/tests/query/buggy-equal-unify.scm
+++ b/tests/query/buggy-equal-unify.scm
@@ -1,0 +1,30 @@
+;
+; buggy-equal-unify.scm
+; Unit test for https://github.com/opencog/atomspace/issues/2650
+; Unification of variables was mis-handled.
+;
+
+(use-modules (opencog) (opencog exec))
+
+(Member
+	(Evaluation
+		(Predicate "has_name")
+		(List (Concept "node1") (Concept "name1")))
+	(Concept "node2"))
+
+(define qunify
+	(Query
+		(And
+			(Member
+				(Evaluation (Predicate "has_name") (Variable "Y"))
+				(Concept "node2"))
+			(Equal
+				(Variable "Y")
+				(List (Variable "N") (Concept "name1"))))
+		(Variable "Y")))
+
+; (cog-evaluate! qunify)
+
+; Exptected result of above
+(define expected
+	(List (Concept "node1") (Concept "name1")))


### PR DESCRIPTION
Groundable sub-terms of virtual clauses should have been taken as implicitly "present".

This fixes (one part of) issue #2650