### PR TITLE
Evaluate clauses with no variables

### DIFF
--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -594,35 +594,17 @@ void PatternLink::get_clause_variables(const HandleSeq& clauses)
 {
 	for (const Handle& hcl : clauses)
 	{
-		HandleSet vset;
-		get_clause_variables_recursive(hcl, vset);
+		HandleSet vset = get_free_variables(hcl);
 
 		// Put them into a sequence; any fixed sequence will do.
 		HandleSeq vseq;
-		for (const Handle& v: vset) vseq.emplace_back(v);
+		for (const Handle& v: vset)
+		{
+			if (_variables.varset.end() != _variables.varset.find(v))
+				vseq.emplace_back(v);
+		}
+
 		_pat.clause_variables.insert({hcl, vseq});
-	}
-}
-
-/// Helper for above.
-void PatternLink::get_clause_variables_recursive(const Handle& h,
-                                                 HandleSet& vset)
-{
-	if (h->is_link())
-	{
-		for (const Handle& ho : h->getOutgoingSet())
-			get_clause_variables_recursive(ho, vset);
-		return;
-	}
-
-	Type t = h->get_type();
-	if (VARIABLE_NODE == t or GLOB_NODE == t)
-	{
-		// _variables hold the unquoted, bound vars. Use that.
-		// XXX FIXME, except that the var might be quoted, in this
-		// particular clause!!
-		if (_variables.varset.end() != _variables.varset.find(h))
-			vset.insert(h);
 	}
 }
 

--- a/opencog/atoms/pattern/PatternLink.h
+++ b/opencog/atoms/pattern/PatternLink.h
@@ -124,7 +124,6 @@ protected:
 	                              PatternTermPtr&);
 
 	void get_clause_variables(const HandleSeq&);
-	void get_clause_variables_recursive(const Handle&, HandleSet&);
 
 	void init(void);
 	void common_init(void);

--- a/opencog/atoms/pattern/PatternUtils.cc
+++ b/opencog/atoms/pattern/PatternUtils.cc
@@ -151,10 +151,6 @@ bool is_constant(const HandleSet& vars, const Handle& clause)
  * speeds up the discovery of the next ungrounded clause: it is
  * trivially just the very next clause in the connected set.  Of
  * course, users will typically never specify clauses in such order.
- *
- * XXX FIXME: It can happen that some clauses have no variables at all
- * in them.  These end up in their own component, which can be
- * extremely confusing.
  */
 void get_connected_components(const HandleSet& vars,
                               const HandleSeq& clauses,
@@ -179,9 +175,14 @@ void get_connected_components(const HandleSet& vars,
 			for (size_t i = 0; i<nc; i++)
 			{
 				HandleSet& cur_vars(component_vars[i]);
-				// If clause cl is connected to this component, then add it
-				// to this component.
-				if (any_unquoted_in_tree(cl, cur_vars))
+				// If clause cl is connected to this component, then
+				// add it to this component. (Its connected if any of
+				// the `cur_vars` appear in the clause). Alternately,
+				// if the clause has NO variables, just jam it into the
+				// first component.
+				if (any_unquoted_in_tree(cl, cur_vars) or
+				    (not contains_atomtype(cl, VARIABLE_NODE) and
+				     not contains_atomtype(cl, GLOB_NODE)))
 				{
 					// Extend the component
 					components[i].emplace_back(cl);

--- a/opencog/atoms/pattern/QueryLink.cc
+++ b/opencog/atoms/pattern/QueryLink.cc
@@ -103,6 +103,7 @@ void QueryLink::extract_variables(const HandleSeq& oset)
 	size_t boff = 0;
 	Type vt = oset[0]->get_type();
 	if (VARIABLE_LIST == vt or
+	    VARIABLE_SET == vt or
 	    TYPED_VARIABLE_LINK == vt or
 	    VARIABLE_NODE == vt or
 	    GLOB_NODE == vt)


### PR DESCRIPTION
Clauses which have no variables in them were .. mistakenly placed into
a distinct component. When this was fixed, then they ended up being 
skipped. This fixes that. 