### PR TITLE
Provide and use crisp-true/false whenever possible.

### DIFF
--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -1021,4 +1021,21 @@ TruthValuePtr EvaluationLink::do_evaluate(AtomSpace* as,
 	return do_eval_scratch(as, evelnk, as, silent);
 }
 
+bool EvaluationLink::crisp_eval_scratch(AtomSpace* as,
+                                        const Handle& evelnk,
+                                        AtomSpace* scratch,
+                                        bool silent)
+{
+	const TruthValuePtr& tvp = do_eval_scratch(as, evelnk, scratch, silent);
+	return tvp->get_mean() >= 0.5;
+}
+
+bool EvaluationLink::crisp_evaluate(AtomSpace* as,
+                                    const Handle& evelnk,
+                                    bool silent)
+{
+	const TruthValuePtr& tvp = do_eval_scratch(as, evelnk, as, silent);
+	return tvp->get_mean() >= 0.5;
+}
+
 DEFINE_LINK_FACTORY(EvaluationLink, EVALUATION_LINK)

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -466,10 +466,10 @@ static TruthValuePtr bool_to_tv(bool truf)
 /// that were wrapped up by TrueLink, FalseLink. This is needed to get
 /// SequentialAndLink to work correctly, when moving down the sequence.
 ///
-static bool crisp_eval_scratch(AtomSpace* as,
-                               const Handle& evelnk,
-                               AtomSpace* scratch,
-                               bool silent)
+static bool crispy_eval_scratch(AtomSpace* as,
+                                const Handle& evelnk,
+                                AtomSpace* scratch,
+                                bool silent)
 {
 	Type t = evelnk->get_type();
 
@@ -500,14 +500,14 @@ static bool crisp_eval_scratch(AtomSpace* as,
 	// Crisp-binary-valued Boolean Logical connectives
 	if (NOT_LINK == t)
 	{
-		return not crisp_eval_scratch(as,
+		return not crispy_eval_scratch(as,
 		      evelnk->getOutgoingAtom(0), scratch, silent);
 	}
 	else if (AND_LINK == t)
 	{
 		for (const Handle& h : evelnk->getOutgoingSet())
 		{
-			bool tv = crisp_eval_scratch(as, h, scratch, silent);
+			bool tv = crispy_eval_scratch(as, h, scratch, silent);
 			if (not tv) return false;
 		}
 		return true;
@@ -516,7 +516,7 @@ static bool crisp_eval_scratch(AtomSpace* as,
 	{
 		for (const Handle& h : evelnk->getOutgoingSet())
 		{
-			bool tv = crisp_eval_scratch(as, h, scratch, silent);
+			bool tv = crispy_eval_scratch(as, h, scratch, silent);
 			if (tv) return true;
 		}
 		return false;
@@ -536,7 +536,7 @@ static bool crisp_eval_scratch(AtomSpace* as,
 		{
 			for (size_t i=0; i<arity; i++)
 			{
-				bool tv = crisp_eval_scratch(as, oset[i], scratch, silent);
+				bool tv = crispy_eval_scratch(as, oset[i], scratch, silent);
 				if (not tv) return false;
 			}
 		} while (is_trec);
@@ -557,7 +557,7 @@ static bool crisp_eval_scratch(AtomSpace* as,
 		{
 			for (size_t i=0; i<arity; i++)
 			{
-				bool tv = crisp_eval_scratch(as, oset[i], scratch, silent);
+				bool tv = crispy_eval_scratch(as, oset[i], scratch, silent);
 				if (tv) return true;
 			}
 		} while (is_trec);
@@ -867,7 +867,7 @@ TruthValuePtr do_eval_with_args(AtomSpace* as,
 
 /// `do_eval_scratch()` -- evaluate any Atoms that can meaningfully
 /// result in a fuzzy or probabilistic truth value. See description
-/// for `crisp_eval_scratch()`, up above, for a general explanation.
+/// for `crispy_eval_scratch()`, up above, for a general explanation.
 /// This function handles miscellaneous Atoms that don't have a natural
 /// interpretation in terms of crisp truth values.
 ///
@@ -1011,7 +1011,7 @@ TruthValuePtr EvaluationLink::do_eval_scratch(AtomSpace* as,
 		return TruthValueCast(pap);
 	}
 
-	return bool_to_tv(crisp_eval_scratch(as, evelnk, scratch, silent));
+	return bool_to_tv(crispy_eval_scratch(as, evelnk, scratch, silent));
 }
 
 TruthValuePtr EvaluationLink::do_evaluate(AtomSpace* as,

--- a/opencog/atoms/execution/EvaluationLink.h
+++ b/opencog/atoms/execution/EvaluationLink.h
@@ -38,6 +38,13 @@ public:
 	                                     AtomSpace* scratch,
 	                                     bool silent=false);
 
+	static bool crisp_evaluate(AtomSpace*, const Handle&,
+	                           bool silent=false);
+	static bool crisp_eval_scratch(AtomSpace* main,
+	                               const Handle&,
+	                               AtomSpace* scratch,
+	                               bool silent=false);
+
 	static Handle factory(const Handle&);
 };
 

--- a/opencog/query/TermMatchMixin.cc
+++ b/opencog/query/TermMatchMixin.cc
@@ -320,7 +320,7 @@ bool TermMatchMixin::post_link_match(const Handle& lpat,
 	// We will find ourselves here whenever the link contains a
 	// GroundedPredicateNode. In this case, execute the node, and
 	// declare a match, or no match, depending on the resulting TV.
-	return crisp_truth_from_tv(EvaluationLink::do_evaluate(_as, lgnd));
+	return EvaluationLink::crisp_evaluate(_as, lgnd);
 }
 
 void TermMatchMixin::post_link_mismatch(const Handle& lpat,
@@ -492,12 +492,12 @@ bool TermMatchMixin::clause_match(const Handle& ptrn,
 		// default callback ignores the TV on EvaluationLinks. So this
 		// is kind-of schizophrenic here.  Not sure what else to do.
 		_temp_aspace->clear();
-		TruthValuePtr tvp(EvaluationLink::do_eval_scratch(_as, grnd, _temp_aspace));
+		bool crispy = EvaluationLink::crisp_eval_scratch(_as, grnd, _temp_aspace);
 
-		DO_LOG({LAZY_LOG_FINE << "Clause_match evaluation yielded tv"
-		              << std::endl << tvp->to_string() << std::endl;})
+		DO_LOG({LAZY_LOG_FINE << "Clause_match evaluation yielded: "
+		                      << crispy << std::endl;})
 
-		return crisp_truth_from_tv(tvp);
+		return crispy;
 	}
 
 	return not is_self_ground(ptrn, grnd, term_gnds, _vars->varset);

--- a/opencog/query/TermMatchMixin.cc
+++ b/opencog/query/TermMatchMixin.cc
@@ -669,7 +669,6 @@ bool TermMatchMixin::eval_term(const Handle& virt,
 	// do_evaluate callback.  Alternately, perhaps the
 	// EvaluationLink::do_evaluate() method should do this ??? Its a toss-up.
 
-	TruthValuePtr tvp;
 	// The instantiator would have taken care of expanding out
 	// and executing any FunctionLinks and the like.  Just use
 	// the TV value on the resulting atom.
@@ -682,37 +681,38 @@ bool TermMatchMixin::eval_term(const Handle& virt,
 	    _nameserver.isA(vty, FUNCTION_LINK))
 	{
 		gvirt = _as->add_atom(gvirt);
-		tvp = gvirt->getTruthValue();
+		TruthValuePtr tvp = gvirt->getTruthValue();
+
+		// Avoid null-pointer dereference if user specified a bogus evaluation.
+		// i.e. an evaluation that failed to return a TV.
+		if (nullptr == tvp)
+			throw InvalidParamException(TRACE_INFO,
+			        "Expecting a TruthValue for an evaluatable link: %s\n",
+			         gvirt->to_short_string().c_str());
+
+		DO_LOG({LAZY_LOG_FINE << "Eval_term evaluation yielded tv="
+		                      << tvp->to_string() << std::endl;})
+
+		return crisp_truth_from_tv(tvp);
 	}
-	else
+
+	_temp_aspace->clear();
+	try
 	{
-		_temp_aspace->clear();
-		try
-		{
-			tvp = EvaluationLink::do_eval_scratch(_as, gvirt, _temp_aspace, true);
-		}
-		catch (const SilentException& ex)
-		{
-			// The do_evaluate()/do_eval_scratch() above can throw if
-			// it is given ungrounded expressions. It can be given
-			// ungrounded expressions if no grounding was found, and
-			// a final pass, run by the search_finished() callback,
-			// puts us here. So handle this case gracefully.
-			return false;
-		}
+		bool crispy = EvaluationLink::crisp_eval_scratch(_as, gvirt, _temp_aspace, true);
+		DO_LOG({LAZY_LOG_FINE << "Eval_term evaluation yielded crisp-tv="
+		                      << crispy << std::endl;})
+		return crispy;
 	}
-
-	// Avoid null-pointer dereference if user specified a bogus evaluation.
-	// i.e. an evaluation that failed to return a TV.
-	if (nullptr == tvp)
-		throw InvalidParamException(TRACE_INFO,
-	            "Expecting a TruthValue for an evaluatable link: %s\n",
-	            gvirt->to_short_string().c_str());
-
-	DO_LOG({LAZY_LOG_FINE << "Eval_term evaluation yielded tv="
-	              << tvp->to_string() << std::endl;})
-
-	return crisp_truth_from_tv(tvp);
+	catch (const SilentException& ex)
+	{
+		// The do_evaluate()/do_eval_scratch() above can throw if
+		// it is given ungrounded expressions. It can be given
+		// ungrounded expressions if no grounding was found, and
+		// a final pass, run by the search_finished() callback,
+		// puts us here. So handle this case gracefully.
+		return false;
+	}
 }
 
 /* ======================================================== */


### PR DESCRIPTION
This is an optimization. Or, at least, a partial step in that direction.