### PR TITLE
No interpretation in pattern engine

### DIFF
--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -654,7 +654,7 @@ bool Variables::is_type(Type gtype) const
 /**
  * Interval checker.
  *
- * Returns true/false if the glob satisfies the lower bound
+ * Returns true if the glob satisfies the lower bound
  * interval restriction.
  */
 bool Variables::is_lower_bound(const Handle& glob, size_t n) const
@@ -666,13 +666,25 @@ bool Variables::is_lower_bound(const Handle& glob, size_t n) const
 /**
  * Interval checker.
  *
- * Returns true/false if the glob satisfies the upper bound
+ * Returns true if the glob satisfies the upper bound
  * interval restriction.
  */
 bool Variables::is_upper_bound(const Handle &glob, size_t n) const
 {
 	const GlobInterval &intervals = get_interval(glob);
 	return (n <= intervals.second or intervals.second < 0);
+}
+
+/**
+ * Interval checker.
+ *
+ * Returns true if the glob can match a variable number of items.
+ * i.e. if it is NOT an ordinary variable.
+ */
+bool Variables::is_globby(const Handle &glob) const
+{
+	const GlobInterval &intervals = get_interval(glob);
+	return (1 != intervals.first or 1 != intervals.second);
 }
 
 static const GlobInterval& default_interval(Type t)
@@ -687,7 +699,7 @@ static const GlobInterval& default_interval(Type t)
 
 const GlobInterval& Variables::get_interval(const Handle& var) const
 {
-	const auto interval = _glob_intervalmap.find(var);
+	const auto& interval = _glob_intervalmap.find(var);
 
 	if (interval == _glob_intervalmap.end())
 		return default_interval(var->get_type());

--- a/opencog/atoms/core/Variables.h
+++ b/opencog/atoms/core/Variables.h
@@ -146,6 +146,10 @@ struct Variables : public FreeVariables,
 	// Return false otherwise.
 	bool is_upper_bound(const Handle& glob, size_t n) const;
 
+	// Return true if the variable is has a range other than
+	// (1,1) i.e. if it can match more than one thing.
+	bool is_globby(const Handle& glob) const;
+
 	// Given the tree `tree` containing variables in it, create and
 	// return a new tree with the indicated arguments `args` substituted
 	// for the variables. The `args` must pass the typecheck, else an

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -1123,11 +1123,9 @@ void PatternLink::make_term_tree_recursive(const Handle& root,
 	{
 		ptm->addBoundVariable();
 
-		// It's globby, if it's explicitly a glob, or if it's a
-		// variable with a non-trivial matching interval.
-		if (GLOB_NODE == t or
-		    _variables._glob_intervalmap.end() !=
-		    _variables._glob_intervalmap.find(h))
+		// It's globby, if it is explicitly a GLOB_NODE, or if
+		// it has a non-trivial matching interval.
+		if (GLOB_NODE == t or _variables.is_globby(h))
 			ptm->addGlobbyVar();
 		return;
 	}

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -1138,36 +1138,23 @@ void PatternLink::make_term_tree_recursive(const Handle& root,
 	}
 
 	// If a term is literal then the corresponding pattern term
-	// should be also. Marking should be easy, except due to a bug
-	// up above, both top-level PresentLinks and ChoiceLinks are
-	// being marked literal, when they aren't actually. Untangling
-	// that bug is a headache, so instead, we pile on the rubbish.
-	// XXX FIXME .. this is a hack to hide a hack.
+	// should be also. We should be creating PatternTerms earlier ...
 	if (std::find(_pat.literal_clauses.begin(), _pat.literal_clauses.end(), h)
 	    != _pat.literal_clauses.end()
 	    or
 	    _pat.evaluatable_holders.find(h) == _pat.evaluatable_holders.end())
    {
-		if (PRESENT_LINK == t)
-		{
-			for (PatternTermPtr& optm: ptm->getOutgoingSet())
-				optm->markLiteral();
-		}
-		else if (CHOICE_LINK == t)
+		if (CHOICE_LINK == t)
 		{
 			for (PatternTermPtr& optm: ptm->getOutgoingSet())
 			{
-				const Handle& oh = optm->getHandle();
-				Type ot = oh->get_type();
-				if (PRESENT_LINK != ot)
-					optm->markLiteral();
-				else
-				{
-					for (PatternTermPtr& xptm: optm->getOutgoingSet())
-						xptm->markLiteral();
-				}
+				if (PRESENT_LINK == optm->getHandle()->get_type())
+					optm->markPresent();
 			}
+			ptm->markChoice();
 		}
+		else if (PRESENT_LINK == t)
+			ptm->markPresent();
 		else
 			ptm->markLiteral();
    }

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -1122,7 +1122,13 @@ void PatternLink::make_term_tree_recursive(const Handle& root,
 	    and _variables.varset.end() != _variables.varset.find(h))
 	{
 		ptm->addBoundVariable();
-		if (GLOB_NODE == t) ptm->addGlobbyVar();
+
+		// It's globby, if it's explicitly a glob, or if it's a
+		// variable with a non-trivial matching interval.
+		if (GLOB_NODE == t or
+		    _variables._glob_intervalmap.end() !=
+		    _variables._glob_intervalmap.find(h))
+			ptm->addGlobbyVar();
 		return;
 	}
 

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -1119,7 +1119,6 @@ void PatternLink::make_term_tree_recursive(const Handle& root,
 	// set this flag.
 	Type t = h->get_type();
 	if ((VARIABLE_NODE == t or GLOB_NODE == t)
-	    and not ptm->getQuotation().is_quoted()
 	    and _variables.varset.end() != _variables.varset.find(h))
 	{
 		ptm->addBoundVariable();

--- a/opencog/atoms/pattern/PatternTerm.cc
+++ b/opencog/atoms/pattern/PatternTerm.cc
@@ -224,7 +224,7 @@ void PatternTerm::markLiteral()
 void PatternTerm::markPresent()
 {
 	// If its literal, its effectively quoted, so cannot be present.
-	if (_is_literal) return;
+	if (_is_literal or isQuoted()) return;
 
 	_is_present = true;
 
@@ -238,7 +238,7 @@ void PatternTerm::markPresent()
 void PatternTerm::markChoice()
 {
 	// If its literal, its effectively quoted, so cannot be a choice.
-	if (_is_literal) return;
+	if (_is_literal or isQuoted()) return;
 
 	_is_choice = true;
 

--- a/opencog/atoms/pattern/PatternTerm.cc
+++ b/opencog/atoms/pattern/PatternTerm.cc
@@ -221,6 +221,36 @@ void PatternTerm::markLiteral()
 
 // ==============================================================
 
+void PatternTerm::markPresent()
+{
+	// If its literal, its effectively quoted, so cannot be present.
+	if (_is_literal) return;
+
+	_is_present = true;
+
+	// By definition, everything underneath is literal
+	for (PatternTermPtr& ptm : getOutgoingSet())
+		ptm->markLiteral();
+}
+
+// ==============================================================
+
+void PatternTerm::markChoice()
+{
+	// If its literal, its effectively quoted, so cannot be a choice.
+	if (_is_literal) return;
+
+	_is_choice = true;
+
+	// By definition, everything underneath is present, or literal
+	for (PatternTermPtr& ptm : getOutgoingSet())
+	{
+		if (not ptm->isPresent()) ptm->markLiteral();
+	}
+}
+
+// ==============================================================
+
 std::string PatternTerm::to_string() const { return to_string(": "); }
 
 std::string PatternTerm::to_string(const std::string& indent) const

--- a/opencog/atoms/pattern/PatternTerm.cc
+++ b/opencog/atoms/pattern/PatternTerm.cc
@@ -23,6 +23,7 @@ PatternTerm::PatternTerm(void)
 	  _has_bound_var(false),
 	  _has_any_globby_var(false),
 	  _has_globby_var(false),
+	  _is_globby_var(false),
 	  _has_any_evaluatable(false),
 	  _has_evaluatable(false),
 	  _has_any_unordered_link(false),
@@ -39,6 +40,7 @@ PatternTerm::PatternTerm(const PatternTermPtr& parent, const Handle& h)
 	  _has_bound_var(false),
 	  _has_any_globby_var(false),
 	  _has_globby_var(false),
+	  _is_globby_var(false),
 	  _has_any_evaluatable(false),
 	  _has_evaluatable(false),
 	  _has_any_unordered_link(false),
@@ -170,7 +172,7 @@ void PatternTerm::addAnyGlobbyVar()
 
 void PatternTerm::addGlobbyVar()
 {
-	_has_globby_var = true;
+	_is_globby_var = true;
 
 	if (_parent != PatternTerm::UNDEFINED)
 		_parent->_has_globby_var = true;

--- a/opencog/atoms/pattern/PatternTerm.cc
+++ b/opencog/atoms/pattern/PatternTerm.cc
@@ -21,6 +21,7 @@ PatternTerm::PatternTerm(void)
 	  _parent(PatternTerm::UNDEFINED),
 	  _has_any_bound_var(false),
 	  _has_bound_var(false),
+	  _is_bound_var(false),
 	  _has_any_globby_var(false),
 	  _has_globby_var(false),
 	  _is_globby_var(false),
@@ -38,6 +39,7 @@ PatternTerm::PatternTerm(const PatternTermPtr& parent, const Handle& h)
 	             false /* necessarily false since it is local */),
 	  _has_any_bound_var(false),
 	  _has_bound_var(false),
+	  _is_bound_var(false),
 	  _has_any_globby_var(false),
 	  _has_globby_var(false),
 	  _is_globby_var(false),
@@ -147,9 +149,11 @@ void PatternTerm::addAnyBoundVar()
 /// variable).
 void PatternTerm::addBoundVariable()
 {
+	if (isQuoted()) return;
+
 	// Mark just this term (the variable itself)
 	// and mark the term that holds us.
-	_has_bound_var = true;
+	_is_bound_var = true;
 	if (_parent != PatternTerm::UNDEFINED)
 			_parent->_has_bound_var = true;
 
@@ -162,8 +166,6 @@ void PatternTerm::addBoundVariable()
 
 void PatternTerm::addAnyGlobbyVar()
 {
-	if (isQuoted()) return;
-
 	if (not _has_any_globby_var)
 	{
 		_has_any_globby_var = true;
@@ -183,6 +185,7 @@ void PatternTerm::addGlobbyVar()
 
 	addAnyGlobbyVar();
 }
+
 
 // ==============================================================
 // Just like above, but for evaluatables.

--- a/opencog/atoms/pattern/PatternTerm.cc
+++ b/opencog/atoms/pattern/PatternTerm.cc
@@ -26,7 +26,9 @@ PatternTerm::PatternTerm(void)
 	  _has_any_evaluatable(false),
 	  _has_evaluatable(false),
 	  _has_any_unordered_link(false),
-	  _is_literal(false)
+	  _is_literal(false),
+	  _is_present(false),
+	  _is_choice(false)
 {}
 
 PatternTerm::PatternTerm(const PatternTermPtr& parent, const Handle& h)
@@ -40,7 +42,9 @@ PatternTerm::PatternTerm(const PatternTermPtr& parent, const Handle& h)
 	  _has_any_evaluatable(false),
 	  _has_evaluatable(false),
 	  _has_any_unordered_link(false),
-	  _is_literal(false)
+	  _is_literal(false),
+	  _is_present(false),
+	  _is_choice(false)
 {
 	Type t = h->get_type();
 

--- a/opencog/atoms/pattern/PatternTerm.cc
+++ b/opencog/atoms/pattern/PatternTerm.cc
@@ -162,6 +162,8 @@ void PatternTerm::addBoundVariable()
 
 void PatternTerm::addAnyGlobbyVar()
 {
+	if (isQuoted()) return;
+
 	if (not _has_any_globby_var)
 	{
 		_has_any_globby_var = true;
@@ -172,6 +174,8 @@ void PatternTerm::addAnyGlobbyVar()
 
 void PatternTerm::addGlobbyVar()
 {
+	if (isQuoted()) return;
+
 	_is_globby_var = true;
 
 	if (_parent != PatternTerm::UNDEFINED)

--- a/opencog/atoms/pattern/PatternTerm.h
+++ b/opencog/atoms/pattern/PatternTerm.h
@@ -97,6 +97,9 @@ protected:
 	// variables, but this flag will not be set.
 	bool _has_bound_var;
 
+	// As above, but zero terms deep. This one is the variable.
+	bool _is_bound_var;
+
 	// True if any pattern subtree rooted in this tree node contains
 	// an GlobNode. Trees without any GlobNodes can be searched in a
 	// straight-forward manner; those with them need to have all
@@ -177,11 +180,12 @@ public:
 	void addBoundVariable();
 	bool hasAnyBoundVariable() const noexcept { return _has_any_bound_var; }
 	bool hasBoundVariable() const noexcept { return _has_bound_var; }
+	bool isBoundVariable() const noexcept { return _is_bound_var; }
 
 	void addGlobbyVar();
-	bool isGlobbyVar() const noexcept { return _is_globby_var; }
-	bool hasGlobbyVar() const noexcept { return _has_globby_var; }
 	bool hasAnyGlobbyVar() const noexcept { return _has_any_globby_var; }
+	bool hasGlobbyVar() const noexcept { return _has_globby_var; }
+	bool isGlobbyVar() const noexcept { return _is_globby_var; }
 
 	void addEvaluatable();
 	bool hasAnyEvaluatable() const noexcept { return _has_any_evaluatable; }

--- a/opencog/atoms/pattern/PatternTerm.h
+++ b/opencog/atoms/pattern/PatternTerm.h
@@ -106,6 +106,9 @@ protected:
 	// As above, but only one level deep.
 	bool _has_globby_var;
 
+	// As above, but zero levels deep. This is a glob.
+	bool _is_globby_var;
+
 	// As above, but for evaluatables.
 	bool _has_any_evaluatable;
 	bool _has_evaluatable;
@@ -176,8 +179,9 @@ public:
 	bool hasBoundVariable() const noexcept { return _has_bound_var; }
 
 	void addGlobbyVar();
-	bool hasAnyGlobbyVar() const noexcept { return _has_any_globby_var; }
+	bool isGlobbyVar() const noexcept { return _is_globby_var; }
 	bool hasGlobbyVar() const noexcept { return _has_globby_var; }
+	bool hasAnyGlobbyVar() const noexcept { return _has_any_globby_var; }
 
 	void addEvaluatable();
 	bool hasAnyEvaluatable() const noexcept { return _has_any_evaluatable; }

--- a/opencog/atoms/pattern/PatternTerm.h
+++ b/opencog/atoms/pattern/PatternTerm.h
@@ -123,6 +123,19 @@ protected:
 	// are still variables, unless they are quoted or scope-hidden.)
 	bool _is_literal;
 
+	// True if this contains a set of subterms, all of which must be
+	// simultaneously present in the pattern. All of the sub-terms are
+	// necessarily literal. This corresponds to PRESENT_LINK in the
+	// default interpretation.
+	bool _is_present;
+
+	// True if this contains a set of subterms, one of which must be
+	// present in the pattern. All of the sub-terms are present, or
+	// are literal. This corresponds to CHOICE_LINK in the default
+	// interpretation; it can also be an OR_LINK when that OR_LINK
+	// is in a boolean evaluatable context.
+	bool _is_choice;
+
 	void addAnyBoundVar();
 	void addAnyGlobbyVar();
 	void addAnyEvaluatable();
@@ -151,6 +164,12 @@ public:
 
 	void markLiteral();
 	bool isLiteral() const { return _is_literal; }
+
+	void markPresent();
+	bool isPresent() const { return _is_present; }
+
+	void markChoice();
+	bool isChoice() const { return _is_choice; }
 
 	void addBoundVariable();
 	bool hasAnyBoundVariable() const noexcept { return _has_any_bound_var; }

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -320,7 +320,7 @@ bool PatternMatchEngine::choice_compare(const PatternTermPtr& ptm,
 		              << " of " << iend;})
 
 		bool match;
-		if (PRESENT_LINK == hp->get_type())
+		if (hop->isPresent())
 			match = present_compare(hop, hg);
 		else
 			match = tree_compare(hop, hg, CALL_CHOICE);

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -248,13 +248,13 @@ bool PatternMatchEngine::ordered_compare(const PatternTermPtr& ptm,
 
 /* ======================================================== */
 
-/// Compare the contents of a PresentLink in the pattern to the
-/// proposed grounding. The term `ptm` points at the PresentLink.
+/// Compare the contents of a Present term in the pattern to the
+/// proposed grounding. The term `ptm` points at the Present term.
 ///
 /// XXX FIXME: this is currently a weak stop-gap measure to handle
-/// the special case of PresentLink's embedded in ChoiceLinks.
-/// PresentLinks that are NOT in a ChoiceLink are handled by the
-/// do_next_clause() system, which assumes that PresentLinks happen
+/// the special case of Present terms embedded in Choice terms.
+/// Present terms that are NOT in a Choice are handled by the
+/// do_next_clause() system, which assumes that Present terms happen
 /// only as top-level clauses. Someday, someone should merge these
 /// two mechanisms, so that this guy gets the sophistication of
 /// the get_next_untried_clause() mechanism.
@@ -281,12 +281,12 @@ hg->to_string().c_str());
 
 /* ======================================================== */
 
-/// Compare a ChoiceLink in the pattern to the proposed grounding.
-/// The term `ptm` points at the ChoiceLink.
+/// Compare a Choice term in the pattern to the proposed grounding.
+/// The term `ptm` points at the Choice term.
 ///
-/// CHOICE_LINK's are multiple-choice links. As long as we can
-/// can match one of the sub-expressions of the ChoiceLink, then
-/// the ChoiceLink as a whole can be considered to be grounded.
+/// Choice terms are multiple-choice links. As long as we can
+/// can match one of the sub-expressions of the Choice term, then
+/// the Choice term as a whole can be considered to be grounded.
 ///
 bool PatternMatchEngine::choice_compare(const PatternTermPtr& ptm,
                                         const Handle& hg)
@@ -1174,13 +1174,13 @@ bool PatternMatchEngine::tree_compare(const PatternTermPtr& ptm,
 	if (hp->is_node() and hg->is_node())
 		return node_compare(hp, hg);
 
-	// CHOICE_LINK's are multiple-choice links. As long as we can
-	// can match one of the sub-expressions of the ChoiceLink, then
-	// the ChoiceLink as a whole can be considered to be grounded.
+	// Choice terms are multiple-choice links. As long as we can
+	// can match one of the sub-expressions of the Choice, then
+	// the Choice term as a whole can be considered to be grounded.
 	// Note, we must do this before the fuzzy_match below, because
 	// hg might be a node (i.e. we compare a choice of nodes to one
 	// node).
-	if (CHOICE_LINK == tp)
+	if (ptm->isChoice())
 		return choice_compare(ptm, hg);
 
 	// If they're not both links, then it is clearly a mismatch.
@@ -1225,8 +1225,8 @@ bool PatternMatchEngine::tree_compare(const PatternTermPtr& ptm,
  * This is the reason why we use PatternTerm pointers instead of atom Handles
  * while traversing the pattern tree.
  *
- * Next, suppose our joining atom repeats in several sub-branches of a single
- * ChoiceLink. For example:
+ * Next, suppose our joining atom repeats in several sub-branches of a
+ * single ChoiceLink. For example:
  *
  * ChoiceLink
  *   UnorderedLink
@@ -1634,7 +1634,7 @@ bool PatternMatchEngine::explore_type_branches(const PatternTermPtr& ptm,
 }
 
 /// See explore_unordered_branches() for a general explanation.
-/// This method handles the ChoiceLink branch alternatives only.
+/// This method handles the Choice term branch alternatives only.
 /// This method is never called, currently.
 bool PatternMatchEngine::explore_choice_branches(const PatternTermPtr& ptm,
                                                  const Handle& hg,
@@ -1684,13 +1684,13 @@ static PatternTermPtr find_variable_term(const PatternTermPtr& term,
 }
 
 
-/// This attempts to obtain a grounding for an embedded PresentLink
-/// That is, for a PresentLink that is not at the top-most level.
+/// This attempts to obtain a grounding for an embedded Present terms.
+/// That is, for a Present term that is not at the top-most level.
 /// At this time, we expect to encounter these only inside of
-/// ChoiceLinks and inside of evaluatable terms.
-/// This tries to verify that each of the terms of the PresentLink
+/// Choice terms and inside of evaluatable terms.
+/// This tries to verify that each of the terms under the Present term
 /// can be grounded. The branch exploration consists of examining
-/// each differrent way in which tis can be accomplished.
+/// each differrent way in which this can be accomplished.
 bool PatternMatchEngine::explore_present_branches(const PatternTermPtr& ptm,
                                                   const Handle& hg,
                                                   const Handle& clause_root)
@@ -1731,7 +1731,7 @@ bool PatternMatchEngine::explore_present_branches(const PatternTermPtr& ptm,
 	const Handle& jvar = varseq[0];
 	const Handle& jgnd = var_grounding.at(jvar);
 
-	// Loop over all the other terms in the PresentLink
+	// Loop over all the other terms in the Present term
 	for (const PatternTermPtr& pterm: osp)
 	{
 		const Handle& hpt = pterm->getHandle();
@@ -1835,9 +1835,9 @@ bool PatternMatchEngine::explore_single_branch(const PatternTermPtr& ptm,
 ///    we don't want to go to the immediate parent, we want to go to
 ///    the larger evaluatable term, and offer that up as the thing to
 ///    match (i.e. to evaluate, to invoke callbacks, etc.)
-///  * The parent is a ChoiceLink. In this case, the ChoiceLink
+///  * The parent is a Choice term. In this case, the Choice term
 ///    itself cannot be directly matched, as is; only its children can
-///    be. So in this case, we fetch the ChoiceLink's parent, instead.
+///    be. So in this case, we fetch the Choice terms's parent, instead.
 ///  * Some crazy combination of the above.
 ///
 /// If it weren't for these complications, this method would be small
@@ -1937,40 +1937,39 @@ bool PatternMatchEngine::do_term_up(const PatternTermPtr& ptm,
 	const PatternTermPtr& parent = ptm->getParent();
 	OC_ASSERT(PatternTerm::UNDEFINED != parent, "Unknown term parent");
 	const Handle& hi = parent->getHandle();
-	Type hit = hi->get_type();
 
 	if (parent->isPresent())
 	{
-		OC_ASSERT(hi != clause_root, "Not expecting a PresentLink here!");
+		OC_ASSERT(hi != clause_root, "Not expecting a Present term here!");
 		return explore_present_branches(ptm, hg, clause_root);
 	}
 
-	// Do the simple case first, ChoiceLinks are harder.
-	if (CHOICE_LINK != hit or parent->isQuoted())
+	// Do the simple case first, Choice terms are harder.
+	if (not parent->isChoice())
 	{
 		bool found = explore_up_branches(ptm, hg, clause_root);
 		DO_LOG({logger().fine("After moving up the clause, found = %d", found);})
 		return found;
 	}
 
-	// If we are here, then we have ChoiceLink.
+	// If we are here, then we have Choice term.
 	if (hi == clause_root)
 	{
-		DO_LOG({logger().fine("Exploring ChoiceLink at root");})
+		DO_LOG({logger().fine("Exploring Choice term at root");})
 		return clause_accept(clause_root, hg);
 	}
 
-	// If we are here, we have an embedded ChoiceLink, i.e. a
-	// ChoiceLink that is not at the clause root. It's contained
+	// If we are here, then we have an embedded Choice term, e.g.
+	// a ChoiceLink that is not at the clause root. It's contained
 	// in some other link, and we have to get that link and
 	// perform comparisons on it. i.e. we have to "hop over"
-	// (hop up) past the ChoiceLink, before resuming the search.
+	// (hop up) past the Choice term, before resuming the search.
 	// The easiest way to hop is to do it recursively... i.e.
 	// call ourselves again.
-	DO_LOG({logger().fine("Exploring ChoiceLink below root");})
+	DO_LOG({logger().fine("Exploring Choice term below root");})
 
 	OC_ASSERT(not have_choice(parent, hg),
-	          "Something is wrong with the ChoiceLink code");
+	          "Something is wrong with the Choice code");
 
 	_need_choice_push = true;
 	return do_term_up(parent, hg, clause_root);
@@ -2917,7 +2916,7 @@ void PatternMatchEngine::clear_current_state(void)
 
 	depth = 0;
 
-	// ChoiceLink state
+	// Choice state
 	_choice_state.clear();
 	_need_choice_push = false;
 	_choose_next = true;

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1938,7 +1938,7 @@ bool PatternMatchEngine::do_term_up(const PatternTermPtr& ptm,
 	OC_ASSERT(PatternTerm::UNDEFINED != parent, "Unknown term parent");
 	const Handle& hi = parent->getHandle();
 
-	if (parent->isPresent())
+	if (parent->isPresent() and not parent->isLiteral())
 	{
 		OC_ASSERT(hi != clause_root, "Not expecting a Present term here!");
 		return explore_present_branches(ptm, hg, clause_root);

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -898,13 +898,11 @@ bool PatternMatchEngine::glob_compare(const PatternTermSeq& osp,
 			break;
 		}
 
-		const Handle& ohp(osp[ip]->getHandle());
-		Type ptype = ohp->get_type();
-
-		if (GLOB_NODE == ptype)
+		if (osp[ip]->isGlobbyVar())
 		{
 			HandleSeq glob_seq;
 			const PatternTermPtr& glob(osp[ip]);
+			const Handle& ohp(glob->getHandle());
 
 			// A glob may appear more than once in the pattern,
 			// so check if that's the case. If we have already
@@ -1149,7 +1147,7 @@ bool PatternMatchEngine::tree_compare(const PatternTermPtr& ptm,
 
 	// Handle hp is from the pattern clause, and it might be one
 	// of the bound variables. If so, then declare a match.
-	if ((VARIABLE_NODE == tp or GLOB_NODE == tp) and not ptm->isQuoted())
+	if ((VARIABLE_NODE == tp or ptm->isGlobbyVar()) and not ptm->isQuoted())
 	{
 		if (_variables->varset.end() != _variables->varset.find(hp))
 			return variable_compare(hp, hg);

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1939,7 +1939,7 @@ bool PatternMatchEngine::do_term_up(const PatternTermPtr& ptm,
 	const Handle& hi = parent->getHandle();
 	Type hit = hi->get_type();
 
-	if (PRESENT_LINK == hit and not parent->isLiteral())
+	if (parent->isPresent())
 	{
 		OC_ASSERT(hi != clause_root, "Not expecting a PresentLink here!");
 		return explore_present_branches(ptm, hg, clause_root);


### PR DESCRIPTION
Avoid interpreting the meaning of atom types in the pattern engine.

This is also a baby-step along the way of issue #2673 