### PR TITLE
Grounded Python and Scheme Nodes

### DIFF
--- a/opencog/atoms/grounded/CMakeLists.txt
+++ b/opencog/atoms/grounded/CMakeLists.txt
@@ -7,6 +7,7 @@ ADD_LIBRARY (grounded
 	GroundedPredicateNode.cc
 	GroundedSchemaNode.cc
 	LibraryManager.cc
+	LibraryRunner.cc
 	SCMRunner.cc
 )
 

--- a/opencog/atoms/grounded/CMakeLists.txt
+++ b/opencog/atoms/grounded/CMakeLists.txt
@@ -11,6 +11,7 @@ ADD_LIBRARY (grounded
 	GroundedPredicateNode.cc
 	GroundedSchemaNode.cc
 	LibraryManager.cc
+	SCMRunner.cc
 )
 
 # Without this, parallel make will race and crap up the generated files.

--- a/opencog/atoms/grounded/CMakeLists.txt
+++ b/opencog/atoms/grounded/CMakeLists.txt
@@ -2,10 +2,6 @@
 # The atom_types.h file is written to the build directory
 INCLUDE_DIRECTORIES( ${CMAKE_CURRENT_BINARY_DIR})
 
-IF (HAVE_CYTHON)
-	INCLUDE_DIRECTORIES(${PYTHON_INCLUDE_PATH})
-ENDIF (HAVE_CYTHON)
-
 ADD_LIBRARY (grounded
 	DLScheme.cc
 	GroundedPredicateNode.cc
@@ -13,6 +9,13 @@ ADD_LIBRARY (grounded
 	LibraryManager.cc
 	SCMRunner.cc
 )
+
+IF (HAVE_CYTHON)
+	INCLUDE_DIRECTORIES(${PYTHON_INCLUDE_PATH})
+	TARGET_SOURCES(grounded PRIVATE PythonRunner.cc)
+	TARGET_LINK_LIBRARIES(grounded PythonEval)
+	TARGET_LINK_LIBRARIES(grounded ${PYTHON_LIBRARIES})
+ENDIF (HAVE_CYTHON)
 
 # Without this, parallel make will race and crap up the generated files.
 ADD_DEPENDENCIES(grounded opencog_atom_types)

--- a/opencog/atoms/grounded/GroundedPredicateNode.cc
+++ b/opencog/atoms/grounded/GroundedPredicateNode.cc
@@ -206,6 +206,9 @@ ValuePtr GroundedPredicateNode::execute(AtomSpace* as,
 {
 	if (_runner) return _runner->evaluate(as, cargs, silent);
 
+	// XXX FIXME -- can we get rid of the stuff from here on down?
+	// Does anybody actually use any of this?
+
 	// Force execution of the arguments. We have to do this, because
 	// the user-defined functions are black-boxes, and cannot be trusted
 	// to do lazy execution correctly. Right now, forcing is the policy.

--- a/opencog/atoms/grounded/GroundedPredicateNode.cc
+++ b/opencog/atoms/grounded/GroundedPredicateNode.cc
@@ -1,5 +1,5 @@
 /*
- * opencog/atoms/execution/GroundedPredicateNode.cc
+ * opencog/atoms/grounded/GroundedPredicateNode.cc
  *
  * Copyright (C) 2009, 2013, 2014, 2015, 2020 Linas Vepstas
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -33,6 +33,7 @@
 #include <opencog/atoms/grounded/GroundedPredicateNode.h>
 #include "DLScheme.h"
 #include "LibraryManager.h"
+#include "Runner.h"
 
 
 using namespace opencog;
@@ -40,6 +41,7 @@ using namespace opencog;
 GroundedPredicateNode::GroundedPredicateNode(std::string s)
 	: GroundedProcedureNode(GROUNDED_PREDICATE_NODE, std::move(s))
 {
+	init();
 }
 
 GroundedPredicateNode::GroundedPredicateNode(Type t, std::string s)
@@ -51,6 +53,12 @@ GroundedPredicateNode::GroundedPredicateNode(Type t, std::string s)
 		throw InvalidParamException(TRACE_INFO,
 			"Expecting a GroundedProcedureNode, got %s", tname.c_str());
 	}
+	init();
+}
+
+void GroundedPredicateNode::init()
+{
+	_runner = nullptr;
 }
 
 // ----------------------------------------------------------

--- a/opencog/atoms/grounded/GroundedPredicateNode.cc
+++ b/opencog/atoms/grounded/GroundedPredicateNode.cc
@@ -192,7 +192,7 @@ ValuePtr GroundedPredicateNode::execute(AtomSpace* as,
 	Handle args(force_execute(as, cargs, silent));
 
 	if (_runner)
-		return _runner->execute(as, args, silent);
+		return _runner->evaluate(as, args, silent);
 
 	// Get the schema name.
 	const std::string& schema = get_name();

--- a/opencog/atoms/grounded/GroundedPredicateNode.cc
+++ b/opencog/atoms/grounded/GroundedPredicateNode.cc
@@ -184,15 +184,14 @@ ValuePtr GroundedPredicateNode::execute(AtomSpace* as,
                                         const Handle& cargs,
                                         bool silent)
 {
+	if (_runner) return _runner->evaluate(as, cargs, silent);
+
 	// Force execution of the arguments. We have to do this, because
 	// the user-defined functions are black-boxes, and cannot be trusted
 	// to do lazy execution correctly. Right now, forcing is the policy.
 	// We could add "scm-lazy:" and "py-lazy:" URI's for user-defined
 	// functions smart enough to do lazy evaluation.
 	Handle args(force_execute(as, cargs, silent));
-
-	if (_runner)
-		return _runner->evaluate(as, args, silent);
 
 	// Get the schema name.
 	const std::string& schema = get_name();

--- a/opencog/atoms/grounded/GroundedPredicateNode.h
+++ b/opencog/atoms/grounded/GroundedPredicateNode.h
@@ -46,6 +46,7 @@ public:
 	GroundedPredicateNode(const std::string);
 	GroundedPredicateNode(const GroundedPredicateNode&) = delete;
 	GroundedPredicateNode& operator=(const GroundedPredicateNode&) = delete;
+	virtual ~GroundedPredicateNode();
 
 	virtual ValuePtr execute(AtomSpace*, const Handle&, bool silent=false);
 

--- a/opencog/atoms/grounded/GroundedPredicateNode.h
+++ b/opencog/atoms/grounded/GroundedPredicateNode.h
@@ -1,5 +1,5 @@
 /*
- * opencog/atoms/execution/GroundedPredicateNode.h
+ * opencog/atoms/grounded/GroundedPredicateNode.h
  *
  * Copyright (C) 2020 Linas Vepstas
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -33,10 +33,14 @@ namespace opencog
  */
 
 class AtomSpace;
+class Runner;
 
 /// Execute scheme, python or other things.
 class GroundedPredicateNode : public GroundedProcedureNode
 {
+	void init();
+	Runner* _runner;
+
 public:
 	GroundedPredicateNode(Type, const std::string);
 	GroundedPredicateNode(const std::string);

--- a/opencog/atoms/grounded/GroundedSchemaNode.cc
+++ b/opencog/atoms/grounded/GroundedSchemaNode.cc
@@ -70,6 +70,11 @@ void GroundedSchemaNode::init()
 	}
 }
 
+GroundedSchemaNode::~GroundedSchemaNode()
+{
+	if (_runner) delete _runner;
+}
+
 /// execute -- execute the SchemaNode of the ExecutionOutputLink
 ///
 /// Expects "cargs" to be a ListLink unless there is only one argument

--- a/opencog/atoms/grounded/GroundedSchemaNode.cc
+++ b/opencog/atoms/grounded/GroundedSchemaNode.cc
@@ -82,14 +82,14 @@ ValuePtr GroundedSchemaNode::execute(AtomSpace* as,
 	LAZY_LOG_FINE << "Execute gsn: " << to_short_string()
 	              << "with arguments: " << oc_to_string(cargs);
 
+	if (_runner) return _runner->execute(as, cargs, silent);
+
 	// Force execution of the arguments. We have to do this, because
 	// the user-defined functions are black-boxes, and cannot be trusted
 	// to do lazy execution correctly. Right now, forcing is the policy.
 	// We could add "scm-lazy:" and "py-lazy:" URI's for user-defined
 	// functions smart enough to do lazy evaluation.
 	Handle args = force_execute(as, cargs, silent);
-
-	if (_runner) return _runner->execute(as, args, silent);
 
 	// Get the schema name.
 	const std::string& schema = get_name();

--- a/opencog/atoms/grounded/GroundedSchemaNode.cc
+++ b/opencog/atoms/grounded/GroundedSchemaNode.cc
@@ -1,5 +1,5 @@
 /*
- * opencog/atoms/execution/GroundedSchemaNode.cc
+ * opencog/atoms/grounded/GroundedSchemaNode.cc
  *
  * Copyright (C) 2009, 2013, 2015, 2020 Linas Vepstas
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -30,6 +30,7 @@
 #include <opencog/atoms/grounded/GroundedSchemaNode.h>
 #include "DLScheme.h"
 #include "LibraryManager.h"
+#include "Runner.h"
 
 
 using namespace opencog;
@@ -37,6 +38,7 @@ using namespace opencog;
 GroundedSchemaNode::GroundedSchemaNode(std::string s)
 	: GroundedProcedureNode(GROUNDED_SCHEMA_NODE, std::move(s))
 {
+	init();
 }
 
 GroundedSchemaNode::GroundedSchemaNode(Type t, std::string s)
@@ -48,6 +50,12 @@ GroundedSchemaNode::GroundedSchemaNode(Type t, std::string s)
 		throw InvalidParamException(TRACE_INFO,
 			"Expecting a GroundedProcedureNode, got %s", tname.c_str());
 	}
+	init();
+}
+
+void GroundedSchemaNode::init()
+{
+	_runner = nullptr;
 }
 
 /// execute -- execute the SchemaNode of the ExecutionOutputLink

--- a/opencog/atoms/grounded/GroundedSchemaNode.h
+++ b/opencog/atoms/grounded/GroundedSchemaNode.h
@@ -1,5 +1,5 @@
 /*
- * opencog/atoms/execution/GroundedSchemaNode.h
+ * opencog/atoms/grounded/GroundedSchemaNode.h
  *
  * Copyright (C) 2020 Linas Vepstas
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -33,10 +33,14 @@ namespace opencog
  */
 
 class AtomSpace;
+class Runner;
 
 /// Virtual base class for all grounded nodes.
 class GroundedSchemaNode : public GroundedProcedureNode
 {
+	Runner* _runner;
+	void init();
+
 public:
 	GroundedSchemaNode(Type, const std::string);
 	GroundedSchemaNode(const std::string);

--- a/opencog/atoms/grounded/GroundedSchemaNode.h
+++ b/opencog/atoms/grounded/GroundedSchemaNode.h
@@ -46,6 +46,7 @@ public:
 	GroundedSchemaNode(const std::string);
 	GroundedSchemaNode(const GroundedSchemaNode&) = delete;
 	GroundedSchemaNode& operator=(const GroundedSchemaNode&) = delete;
+	virtual ~GroundedSchemaNode();
 
 	virtual ValuePtr execute(AtomSpace*, const Handle&, bool silent=false);
 

--- a/opencog/atoms/grounded/LibraryRunner.cc
+++ b/opencog/atoms/grounded/LibraryRunner.cc
@@ -1,0 +1,113 @@
+/*
+ * opencog/atoms/grounded/LibraryRunner.cc
+ *
+ * Copyright (C) 2009, 2013, 2014, 2015, 2020 Linas Vepstas
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/atoms/atom_types/atom_types.h>
+#include <opencog/atoms/execution/Force.h>
+#include <opencog/atoms/truthvalue/TruthValue.h>
+#include <opencog/atoms/value/Value.h>
+#include <opencog/atomspace/AtomSpace.h>
+
+#include <opencog/atoms/grounded/LibraryManager.h>
+#include <opencog/atoms/grounded/LibraryRunner.h>
+
+using namespace opencog;
+
+LibraryRunner::LibraryRunner(std::string s)
+	: _fname(s)
+{
+	// Extract the language, library and function from schema
+	std::string lang, lib, fun;
+	LibraryManager::parse_schema(_fname, lang, lib, fun);
+
+	sym = LibraryManager::getFunc(lib,fun);
+}
+
+// ----------------------------------------------------------
+
+static void throwSyntaxException(bool silent, const char* message...)
+{
+	if (silent)
+		throw NotEvaluatableException();
+	va_list args;
+	va_start(args, message);
+	throw SyntaxException(TRACE_INFO, message, args);
+	va_end(args);
+}
+
+// ----------------------------------------------------------
+
+/// `execute()` -- evaluate a LibraryRunner with arguments.
+///
+/// Expects "args" to be a ListLink. These arguments will be
+///     substituted into the predicate.
+///
+/// The arguments are "eager-evaluated", because it is assumed that
+/// the GPN is unaware of the concept of lazy evaluation, and can't
+/// do it itself. The arguments are then inserted into the predicate,
+/// and the predicate as a whole is then evaluated.
+///
+ValuePtr LibraryRunner::execute(AtomSpace* as,
+                               const Handle& cargs,
+                               bool silent)
+{
+	// Force execution of the arguments. We have to do this, because
+	// the user-defined functions are black-boxes, and cannot be trusted
+	// to do lazy execution correctly. Right now, forcing is the policy.
+	// We could add "scm-lazy:" and "py-lazy:" URI's for user-defined
+	// functions smart enough to do lazy evaluation.
+	Handle args(force_execute(as, cargs, silent));
+
+}
+
+ValuePtr LibraryRunner::evaluate(AtomSpace* as,
+                                const Handle& cargs,
+                                bool silent)
+{
+	// Force execution of the arguments. We have to do this, because
+	// the user-defined functions are black-boxes, and cannot be trusted
+	// to do lazy execution correctly. Right now, forcing is the policy.
+	// We could add "scm-lazy:" and "py-lazy:" URI's for user-defined
+	// functions smart enough to do lazy evaluation.
+	Handle args(force_execute(as, cargs, silent));
+
+	// Convert the void* pointer to the correct function type.
+	TruthValuePtr* (*func)(AtomSpace*, Handle*);
+	func = reinterpret_cast<TruthValuePtr* (*)(AtomSpace *, Handle*)>(sym);
+
+	// Evaluate the predicate
+	TruthValuePtr* res = func(as, &args);
+	TruthValuePtr result;
+	if(res != NULL)
+	{
+		result = *res;
+		free(res);
+	}
+
+	if (nullptr == result)
+		throwSyntaxException(silent,
+	        "Invalid return value from predicate %s\nArgs: %s",
+		        _fname.c_str(),
+		        cargs->to_short_string().c_str());
+
+	return CastToValue(result);
+}

--- a/opencog/atoms/grounded/LibraryRunner.h
+++ b/opencog/atoms/grounded/LibraryRunner.h
@@ -1,0 +1,55 @@
+/*
+ * opencog/atoms/grounded/LibraryRunner.h
+ *
+ * Copyright (C) 2020 Linas Vepstas
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef _OPENCOG_LIBRARY_RUNNER_H
+#define _OPENCOG_LIBRARY_RUNNER_H
+
+#include <string>
+#include <opencog/atoms/grounded/Runner.h>
+
+namespace opencog
+{
+/** \addtogroup grp_atomspace
+ *  @{
+ */
+
+/// Generic shared-library foreign-function interface.
+/// Currently used only by the Haskell bindings.
+class LibraryRunner : public Runner
+{
+	std::string _fname;
+	void* sym;
+
+public:
+	LibraryRunner(const std::string);
+	LibraryRunner(const LibraryRunner&) = delete;
+	LibraryRunner& operator=(const LibraryRunner&) = delete;
+
+	virtual ValuePtr execute(AtomSpace*, const Handle&, bool=false);
+	virtual ValuePtr evaluate(AtomSpace*, const Handle&, bool=false);
+};
+
+/** @}*/
+}
+
+#endif // _OPENCOG_LIBRARY_RUNNER_H

--- a/opencog/atoms/grounded/PythonRunner.cc
+++ b/opencog/atoms/grounded/PythonRunner.cc
@@ -1,0 +1,59 @@
+/*
+ * opencog/atoms/grounded/PythonRunner.cc
+ *
+ * Copyright (C) 2009, 2013, 2014, 2015, 2020 Linas Vepstas
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/atoms/atom_types/atom_types.h>
+#include <opencog/atoms/core/DefineLink.h>
+#include <opencog/atoms/core/NumberNode.h>
+#include <opencog/atoms/execution/Force.h>
+#include <opencog/atoms/truthvalue/TruthValue.h>
+#include <opencog/atomspace/AtomSpace.h>
+#include <opencog/cython/PythonEval.h>
+#include <opencog/guile/SchemeEval.h>
+
+#include <opencog/atoms/grounded/PythonRunner.h>
+#include "DLScheme.h"
+
+using namespace opencog;
+
+PythonRunner::PythonRunner(std::string s)
+	: _fname(s)
+{
+}
+
+// ----------------------------------------------------------
+
+/// `execute()` -- evaluate a PythonRunner with arguments.
+///
+/// Expects "args" to be a ListLink. These arguments will be
+///     substituted into the predicate.
+///
+/// The arguments are "eager-evaluated", because it is assumed that
+/// the GPN is unaware of the concept of lazy evaluation, and can't
+/// do it itself. The arguments are then inserted into the predicate,
+/// and the predicate as a whole is then evaluated.
+///
+ValuePtr PythonRunner::execute(AtomSpace* as,
+                               const Handle& cargs,
+                               bool silent)
+{
+}

--- a/opencog/atoms/grounded/PythonRunner.cc
+++ b/opencog/atoms/grounded/PythonRunner.cc
@@ -22,16 +22,13 @@
  */
 
 #include <opencog/atoms/atom_types/atom_types.h>
-#include <opencog/atoms/core/DefineLink.h>
-#include <opencog/atoms/core/NumberNode.h>
 #include <opencog/atoms/execution/Force.h>
 #include <opencog/atoms/truthvalue/TruthValue.h>
+#include <opencog/atoms/value/Value.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/cython/PythonEval.h>
-#include <opencog/guile/SchemeEval.h>
 
 #include <opencog/atoms/grounded/PythonRunner.h>
-#include "DLScheme.h"
 
 using namespace opencog;
 
@@ -63,8 +60,7 @@ ValuePtr PythonRunner::execute(AtomSpace* as,
 	// functions smart enough to do lazy evaluation.
 	Handle args(force_execute(as, cargs, silent));
 
-	// Be sure to specify the atomspace in which to work!
-	return CastToValue(applier.apply_tv(as, _fname, args));
+	return applier.apply_v(as, _fname, args);
 }
 
 ValuePtr PythonRunner::evaluate(AtomSpace* as,
@@ -78,6 +74,5 @@ ValuePtr PythonRunner::evaluate(AtomSpace* as,
 	// functions smart enough to do lazy evaluation.
 	Handle args(force_execute(as, cargs, silent));
 
-	// Be sure to specify the atomspace in which to work!
 	return CastToValue(applier.apply_tv(as, _fname, args));
 }

--- a/opencog/atoms/grounded/PythonRunner.cc
+++ b/opencog/atoms/grounded/PythonRunner.cc
@@ -36,7 +36,7 @@
 using namespace opencog;
 
 PythonRunner::PythonRunner(std::string s)
-	: _fname(s)
+	: _fname(s), applier(PythonEval::instance())
 {
 }
 
@@ -56,4 +56,28 @@ ValuePtr PythonRunner::execute(AtomSpace* as,
                                const Handle& cargs,
                                bool silent)
 {
+	// Force execution of the arguments. We have to do this, because
+	// the user-defined functions are black-boxes, and cannot be trusted
+	// to do lazy execution correctly. Right now, forcing is the policy.
+	// We could add "scm-lazy:" and "py-lazy:" URI's for user-defined
+	// functions smart enough to do lazy evaluation.
+	Handle args(force_execute(as, cargs, silent));
+
+	// Be sure to specify the atomspace in which to work!
+	return CastToValue(applier.apply_tv(as, _fname, args));
+}
+
+ValuePtr PythonRunner::evaluate(AtomSpace* as,
+                                const Handle& cargs,
+                                bool silent)
+{
+	// Force execution of the arguments. We have to do this, because
+	// the user-defined functions are black-boxes, and cannot be trusted
+	// to do lazy execution correctly. Right now, forcing is the policy.
+	// We could add "scm-lazy:" and "py-lazy:" URI's for user-defined
+	// functions smart enough to do lazy evaluation.
+	Handle args(force_execute(as, cargs, silent));
+
+	// Be sure to specify the atomspace in which to work!
+	return CastToValue(applier.apply_tv(as, _fname, args));
 }

--- a/opencog/atoms/grounded/PythonRunner.h
+++ b/opencog/atoms/grounded/PythonRunner.h
@@ -34,7 +34,7 @@ namespace opencog
  *  @{
  */
 
-/// Base class for executing guile code.
+/// Base class for executing Python code.
 class PythonRunner : public Runner
 {
 	std::string _fname;

--- a/opencog/atoms/grounded/PythonRunner.h
+++ b/opencog/atoms/grounded/PythonRunner.h
@@ -26,6 +26,7 @@
 
 #include <string>
 #include <opencog/atoms/grounded/Runner.h>
+#include <opencog/cython/PythonEval.h>
 
 namespace opencog
 {
@@ -37,6 +38,7 @@ namespace opencog
 class PythonRunner : public Runner
 {
 	std::string _fname;
+	PythonEval &applier;
 
 public:
 	PythonRunner(const std::string);
@@ -44,7 +46,7 @@ public:
 	PythonRunner& operator=(const PythonRunner&) = delete;
 
 	virtual ValuePtr execute(AtomSpace*, const Handle&, bool=false);
-	virtual TruthValuePtr evaluate(AtomSpace*, const Handle&, bool=false);
+	virtual ValuePtr evaluate(AtomSpace*, const Handle&, bool=false);
 };
 
 /** @}*/

--- a/opencog/atoms/grounded/PythonRunner.h
+++ b/opencog/atoms/grounded/PythonRunner.h
@@ -1,0 +1,53 @@
+/*
+ * opencog/atoms/grounded/PythonRunner.h
+ *
+ * Copyright (C) 2020 Linas Vepstas
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef _OPENCOG_PYTHON_RUNNER_H
+#define _OPENCOG_PYTHON_RUNNER_H
+
+#include <string>
+#include <opencog/atoms/grounded/Runner.h>
+
+namespace opencog
+{
+/** \addtogroup grp_atomspace
+ *  @{
+ */
+
+/// Base class for executing guile code.
+class PythonRunner : public Runner
+{
+	std::string _fname;
+
+public:
+	PythonRunner(const std::string);
+	PythonRunner(const PythonRunner&) = delete;
+	PythonRunner& operator=(const PythonRunner&) = delete;
+
+	virtual ValuePtr execute(AtomSpace*, const Handle&, bool=false);
+	virtual TruthValuePtr evaluate(AtomSpace*, const Handle&, bool=false);
+};
+
+/** @}*/
+}
+
+#endif // _OPENCOG_PYTHON_RUNNER_H

--- a/opencog/atoms/grounded/Runner.h
+++ b/opencog/atoms/grounded/Runner.h
@@ -1,11 +1,9 @@
 /*
- * opencog/atoms/atom_types/types.h
+ * opencog/atoms/grounded/Runner.h
  *
- * Copyright (C) 2002-2007 Novamente LLC
+ * Copyright (C) 2020 Linas Vepstas
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  * All Rights Reserved
- *
- * Written by Thiago Maia <thiago@vettatech.com>
- *            Andre Senna <senna@vettalabs.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License v3 as
@@ -23,28 +21,32 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-/**
- * basic type definitions.
- */
-
-#ifndef _OPENCOG_TYPES_H
-#define _OPENCOG_TYPES_H
-
-#include <set>
+#ifndef _OPENCOG_RUNNER_H
+#define _OPENCOG_RUNNER_H
 
 namespace opencog
 {
 /** \addtogroup grp_atomspace
  *  @{
  */
+#include <opencog/atoms/value/Value.h>
+#include <opencog/atoms/truthvalue/TruthValue.h>
 
-//! type of Atoms, represented as short integer (16 bits)
-typedef unsigned short Type;
+class AtomSpace;
 
-//! Set of atom types
-typedef std::set<Type> TypeSet;
+/// Virtual base class for all grounded nodes.
+class Runner
+{
+public:
+	Runner(const std::string);
+	Runner(const Runner&) = delete;
+	Runner& operator=(const Runner&) = delete;
+
+	virtual TruthValuePtr evaluate(AtomSpace*, const Handle&, bool=false) = 0;
+	virtual ValuePtr execute(AtomSpace*, const Handle&, bool=false) = 0;
+};
 
 /** @}*/
-} // namespace opencog
+}
 
-#endif // _OPENCOG_TYPES_H
+#endif // _OPENCOG_RUNNER_H

--- a/opencog/atoms/grounded/Runner.h
+++ b/opencog/atoms/grounded/Runner.h
@@ -38,7 +38,7 @@ class AtomSpace;
 class Runner
 {
 public:
-	Runner(const std::string);
+	Runner(void) {}
 	Runner(const Runner&) = delete;
 	Runner& operator=(const Runner&) = delete;
 	virtual ~Runner() {}

--- a/opencog/atoms/grounded/Runner.h
+++ b/opencog/atoms/grounded/Runner.h
@@ -25,7 +25,6 @@
 #define _OPENCOG_RUNNER_H
 
 #include <opencog/atoms/value/Value.h>
-#include <opencog/atoms/truthvalue/TruthValue.h>
 
 namespace opencog {
 /** \addtogroup grp_atomspace
@@ -43,7 +42,7 @@ public:
 	Runner& operator=(const Runner&) = delete;
 	virtual ~Runner() {}
 
-	virtual TruthValuePtr evaluate(AtomSpace*, const Handle&, bool=false) = 0;
+	virtual ValuePtr evaluate(AtomSpace*, const Handle&, bool=false) = 0;
 	virtual ValuePtr execute(AtomSpace*, const Handle&, bool=false) = 0;
 };
 

--- a/opencog/atoms/grounded/SCMRunner.cc
+++ b/opencog/atoms/grounded/SCMRunner.cc
@@ -22,11 +22,8 @@
  */
 
 #include <opencog/atoms/atom_types/atom_types.h>
-#include <opencog/atoms/core/DefineLink.h>
-#include <opencog/atoms/core/NumberNode.h>
 #include <opencog/atoms/execution/Force.h>
 #include <opencog/atomspace/AtomSpace.h>
-#include <opencog/cython/PythonEval.h>
 #include <opencog/guile/SchemeEval.h>
 
 #include <opencog/atoms/grounded/SCMRunner.h>

--- a/opencog/atoms/grounded/SCMRunner.cc
+++ b/opencog/atoms/grounded/SCMRunner.cc
@@ -1,0 +1,68 @@
+/*
+ * opencog/atoms/grounded/SCMRunner.cc
+ *
+ * Copyright (C) 2009, 2013, 2014, 2015, 2020 Linas Vepstas
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/atoms/atom_types/atom_types.h>
+#include <opencog/atoms/core/DefineLink.h>
+#include <opencog/atoms/core/NumberNode.h>
+#include <opencog/atoms/execution/Force.h>
+#include <opencog/atoms/truthvalue/TruthValue.h>
+#include <opencog/atomspace/AtomSpace.h>
+#include <opencog/cython/PythonEval.h>
+#include <opencog/guile/SchemeEval.h>
+
+#include <opencog/atoms/grounded/SCMRunner.h>
+#include "DLScheme.h"
+
+using namespace opencog;
+
+SCMRunner::SCMRunner(std::string s)
+	: _fname(s)
+{
+}
+
+// ----------------------------------------------------------
+
+/// `execute()` -- evaluate a SCMRunner with arguments.
+///
+/// Expects "args" to be a ListLink. These arguments will be
+///     substituted into the predicate.
+///
+/// The arguments are "eager-evaluated", because it is assumed that
+/// the GPN is unaware of the concept of lazy evaluation, and can't
+/// do it itself. The arguments are then inserted into the predicate,
+/// and the predicate as a whole is then evaluated.
+///
+ValuePtr SCMRunner::execute(AtomSpace* as,
+                            const Handle& cargs,
+                            bool silent)
+{
+	// Force execution of the arguments. We have to do this, because
+	// the user-defined functions are black-boxes, and cannot be trusted
+	// to do lazy execution correctly. Right now, forcing is the policy.
+	// We could add "scm-lazy:" and "py-lazy:" URI's for user-defined
+	// functions smart enough to do lazy evaluation.
+	Handle args(force_execute(as, cargs, silent));
+
+	SchemeEval* applier = get_evaluator_for_scheme(as);
+	return applier->apply_v(_fname, args);
+}

--- a/opencog/atoms/grounded/SCMRunner.h
+++ b/opencog/atoms/grounded/SCMRunner.h
@@ -44,8 +44,8 @@ public:
 	SCMRunner& operator=(const SCMRunner&) = delete;
 
 	virtual ValuePtr execute(AtomSpace*, const Handle&, bool=false);
-	virtual TruthValuePtr evaluate(AtomSpace*as, const Handle& args, bool silent)
-	{ return TruthValueCast(execute(as, args, silent)); }
+	virtual ValuePtr evaluate(AtomSpace* as, const Handle& args, bool silent=false)
+	{ return execute(as, args, silent); }
 };
 
 /** @}*/

--- a/opencog/atoms/grounded/SCMRunner.h
+++ b/opencog/atoms/grounded/SCMRunner.h
@@ -25,13 +25,13 @@
 #define _OPENCOG_SCM_RUNNER_H
 
 #include <string>
+#include <opencog/atoms/grounded/Runner.h>
 
 namespace opencog
 {
 /** \addtogroup grp_atomspace
  *  @{
  */
-#include <opencog/atoms/grounded/Runner.h>
 
 /// Base class for executing guile code.
 class SCMRunner : public Runner

--- a/opencog/atoms/grounded/SCMRunner.h
+++ b/opencog/atoms/grounded/SCMRunner.h
@@ -1,5 +1,5 @@
 /*
- * opencog/atoms/grounded/Runner.h
+ * opencog/atoms/grounded/SCMRunner.h
  *
  * Copyright (C) 2020 Linas Vepstas
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -21,33 +21,34 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef _OPENCOG_RUNNER_H
-#define _OPENCOG_RUNNER_H
+#ifndef _OPENCOG_SCM_RUNNER_H
+#define _OPENCOG_SCM_RUNNER_H
 
-#include <opencog/atoms/value/Value.h>
-#include <opencog/atoms/truthvalue/TruthValue.h>
+#include <string>
 
-namespace opencog {
+namespace opencog
+{
 /** \addtogroup grp_atomspace
  *  @{
  */
+#include <opencog/atoms/grounded/Runner.h>
 
-class AtomSpace;
-
-/// Virtual base class for all grounded nodes.
-class Runner
+/// Base class for executing guile code.
+class SCMRunner : public Runner
 {
-public:
-	Runner(const std::string);
-	Runner(const Runner&) = delete;
-	Runner& operator=(const Runner&) = delete;
-	virtual ~Runner() {}
+	std::string _fname;
 
-	virtual TruthValuePtr evaluate(AtomSpace*, const Handle&, bool=false) = 0;
-	virtual ValuePtr execute(AtomSpace*, const Handle&, bool=false) = 0;
+public:
+	SCMRunner(const std::string);
+	SCMRunner(const SCMRunner&) = delete;
+	SCMRunner& operator=(const SCMRunner&) = delete;
+
+	virtual ValuePtr execute(AtomSpace*, const Handle&, bool=false);
+	virtual TruthValuePtr evaluate(AtomSpace*as, const Handle& args, bool silent)
+	{ return TruthValueCast(execute(as, args, silent)); }
 };
 
 /** @}*/
 }
 
-#endif // _OPENCOG_RUNNER_H
+#endif // _OPENCOG_SCM_RUNNER_H


### PR DESCRIPTION
Split out the if-then-else in the GroundedPredicate/GroundedSchema  
into distinct python and scheme classes. This allows language-specific
optimizations to be performed for each different language, thus potentially
improving perforrmance, on a per-language level.