### PR TITLE
Add support for parsing patterns that have variable type decls

### DIFF
--- a/tests/persist/file/FastLoadUTest.cxxtest
+++ b/tests/persist/file/FastLoadUTest.cxxtest
@@ -3,23 +3,23 @@
 
 using namespace opencog;
 
-class FastLoadUTest : public CxxTest::TestSuite
-{
+class FastLoadUTest : public CxxTest::TestSuite {
 
 private:
     AtomSpace _as;
 
 public:
-    FastLoadUTest()
-    {
+    FastLoadUTest() {
         logger().set_print_to_stdout_flag(true);
     }
 
     void setUp() {}
 
-	void tearDown() {}
+    void tearDown() {}
 
-	void test_expr_parse();
+    void test_expr_parse();
+
+    void test_pattern_parse();
 };
 
 // Test parseExpression
@@ -37,4 +37,24 @@ void FastLoadUTest::test_expr_parse()
 
     logger().info("END TEST: %s", __FUNCTION__);
 
+}
+
+void FastLoadUTest::test_pattern_parse()
+{
+    logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+    std::string in = "(Get\n"
+                     "           (VariableList\n"
+                     "              (TypedVariable (Variable \"$a\") (Type 'Concept)))\n"
+                     "           (Evaluation (Predicate \"test\")\n"
+                     "              (List (Variable \"$a\") (Concept \"A\"))))";
+
+    Handle h = parseExpression(in, _as);
+
+    //The atomspace size is 14 because this test adds additional 9 atoms
+    TS_ASSERT_EQUALS(14, _as.get_size());
+
+    TS_ASSERT_EQUALS(2, h->getOutgoingSet().size());
+
+    logger().info("END TEST: %s", __FUNCTION__);
 }


### PR DESCRIPTION
This PR improves the fast_load atomese parser to support variable type decls in pattern matching queries. It fixes #2681 