### PR TITLE
Fix cog-get-atoms

### DIFF
--- a/opencog/scm/opencog/base/utilities.scm
+++ b/opencog/scm/opencog/base/utilities.scm
@@ -250,7 +250,8 @@
 			#f
 		)
 		(if (and (not (null? subtypes)) (eq? (car subtypes) #t))
-			(for-each (lambda (x) (cog-map-type mklist x)) (cog-get-all-subtypes atom-type))
+			(for-each (lambda (x) (cog-map-type mklist x))
+				(cons atom-type (cog-get-all-subtypes atom-type)))
 			(cog-map-type mklist atom-type))
 		lst
 	)

--- a/tests/scm/SCMUtilsUTest.cxxtest
+++ b/tests/scm/SCMUtilsUTest.cxxtest
@@ -147,6 +147,24 @@ void SCMUtilsUTest::test_utils(void)
 	TSM_ASSERT("Error setting up for cog-get-link", Handle::UNDEFINED != ref);
 	TSM_ASSERT_EQUALS("wrong cog-get-link found ", ref, wref);
 
+	// Test cog-get-atoms -----------------------------
+	Handle cpts = evaluator->eval_h("cpts");
+	CHKERR;
+	Handle cpts_n_subtypes = evaluator->eval_h("cpts-n-subtypes");
+	CHKERR;
+	Handle nodes_n_subtypes = evaluator->eval_h("nodes-n-subtypes");
+	CHKERR;
+	Handle x_cpts = evaluator->eval_h("x-cpts");
+	CHKERR;
+	Handle x_cpts_n_subtypes = evaluator->eval_h("x-cpts-n-subtypes");
+	CHKERR;
+	Handle x_nodes_n_subtypes = evaluator->eval_h("x-nodes-n-subtypes");
+	CHKERR;
+
+	TS_ASSERT_EQUALS(cpts, x_cpts);
+	TS_ASSERT_EQUALS(cpts_n_subtypes, x_cpts_n_subtypes);
+	TS_ASSERT_EQUALS(nodes_n_subtypes, x_nodes_n_subtypes);
+
 	logger().debug("END TEST: %s", __FUNCTION__);
 }
 

--- a/tests/scm/utils-test.scm
+++ b/tests/scm/utils-test.scm
@@ -20,3 +20,17 @@
 ; test cog-get-link
 (define ref (ReferenceLink (ConceptNode "asdf") (WordNode "pqrs")))
 (define wref (car (cog-get-link 'ReferenceLink 'ConceptNode (WordNode "pqrs"))))
+
+; test cog-get-atoms. Warning: it uses previously defined nodes, so
+; should be updated if any new nodes are introduced above.
+(define cpts (Set (cog-get-atoms 'ConceptNode)))
+(define cpts-n-subtypes (Set (cog-get-atoms 'ConceptNode #t)))
+(define nodes-n-subtypes (Set (cog-get-atoms 'Node #t)))
+(define x-cpts (Set (ConceptNode "asdf") (ConceptNode "partner")))
+(define x-cpts-n-subtypes x-cpts)
+(define x-nodes-n-subtypes (Set
+                             (ConceptNode "asdf")
+                             (ConceptNode "partner")
+                             (PredicateNode "key")
+                             (WordNode "asdf")
+                             (WordNode "pqrs")))


### PR DESCRIPTION
That function did not follow its specification, as stated in its comment. That is the given type was not considered when its subtypes where to be considered.