### PR TITLE
Pattern term conversion

### DIFF
--- a/opencog/atoms/atom_types/atom_types.script
+++ b/opencog/atoms/atom_types/atom_types.script
@@ -842,8 +842,8 @@ INTENSIONAL_SIMILARITY_LINK <- SIMILARITY_LINK
 //
 // XXX These are currently not implemented (viz they don't actually
 // work as virtual links).
-FORALL_LINK <- SCOPE_LINK,CRISP_OUTPUT_LINK "ForAllLink"
-EXISTS_LINK <- SCOPE_LINK,CRISP_OUTPUT_LINK
+FORALL_LINK <- SCOPE_LINK "ForAllLink"
+EXISTS_LINK <- SCOPE_LINK
 
 // Concept constructor
 SATISFYING_SET_SCOPE_LINK <- SCOPE_LINK

--- a/opencog/atoms/atom_types/atom_types.script
+++ b/opencog/atoms/atom_types/atom_types.script
@@ -824,14 +824,8 @@ SIMILARITY_LINK <- UNORDERED_LINK
 EXTENSIONAL_SIMILARITY_LINK <- SIMILARITY_LINK
 INTENSIONAL_SIMILARITY_LINK <- SIMILARITY_LINK
 
-// Logical quantifiers (adjoints to pullbacks of relations)
-// These are ill-defined, at the moment: do they return truth
-// values, or sets of atoms? Do they express a predicate, or a subset?
-// Should these inherit from ReWriteLink or PrenexLink instead ???
-// I think PLN uses these; otherwise they are not yet properly defined.
-//
-// Lojban uses ExistsLink, but incorrectly (it is unaware that Exists
-// is scoped!)
+// Logical quantifiers (adjoints to pullbacks of relations). Both are
+// scoped.
 //
 // Exists == left adjoint to the pullback functor of a relation.
 //           Note that PRESENT_LINK below is the unscoped variant
@@ -840,10 +834,21 @@ INTENSIONAL_SIMILARITY_LINK <- SIMILARITY_LINK
 //           Note that ALWAYS_LINK below is the unscoped variant
 //           of this, used in the pattern matcher.
 //
-// XXX These are currently not implemented (viz they don't actually
-// work as virtual links).
+// ExistsLink is currently defined to return a crisp true/false value,
+// when it is evaluated. It works outside of the pattern engine...
+//
+// These are currently a poorly-defined and a messy hash. They could be
+// defined to return (crisp) truth values, or to return satsifying sets.
+//
+// -- PLN uses ForAllLink, but fails to quote it qhen giving it to the
+//    pattern engine. A unit test fails, if we make it actually
+//    evaluatable.
+//
+// -- Lojban uses ExistsLink, but incorrectly (it is unaware that Exists
+//    is scoped.)
+//
+EXISTS_LINK <- SCOPE_LINK,CRISP_OUTPUT_LINK
 FORALL_LINK <- SCOPE_LINK "ForAllLink"
-EXISTS_LINK <- SCOPE_LINK
 
 // Concept constructor
 SATISFYING_SET_SCOPE_LINK <- SCOPE_LINK

--- a/opencog/atoms/pattern/DualLink.cc
+++ b/opencog/atoms/pattern/DualLink.cc
@@ -54,9 +54,9 @@ void DualLink::init(void)
 	// ScopeLink::extract_variables(_outgoing);
 	_body = _outgoing[0];
 
-	_fixed.emplace_back(_body);
 	PatternTermPtr root_term(make_term_tree(_body));
 	_pat.pmandatory.emplace_back(root_term);
+	_fixed.emplace_back(root_term);
 
 	_pat.body = _body;
 

--- a/opencog/atoms/pattern/DualLink.cc
+++ b/opencog/atoms/pattern/DualLink.cc
@@ -54,7 +54,6 @@ void DualLink::init(void)
 	// ScopeLink::extract_variables(_outgoing);
 	_body = _outgoing[0];
 
-	_pat.mandatory.emplace_back(_body);
 	_fixed.emplace_back(_body);
 	PatternTermPtr root_term(make_term_tree(_body));
 	_pat.pmandatory.emplace_back(root_term);

--- a/opencog/atoms/pattern/Pattern.cc
+++ b/opencog/atoms/pattern/Pattern.cc
@@ -37,13 +37,6 @@ std::string Pattern::to_string(const std::string& indent) const
 		   << oc_to_string(undeclared_clauses, indent + OC_TO_STRING_INDENT);
 		first = false;
 	}
-	if (not mandatory.empty())
-	{
-		if (not first) ss << std::endl;
-		ss << indent << "mandatory:" << std::endl
-		   << oc_to_string(mandatory, indent + OC_TO_STRING_INDENT);
-		first = false;
-	}
 	if (not optionals.empty())
 	{
 		if (not first) ss << std::endl;

--- a/opencog/atoms/pattern/Pattern.cc
+++ b/opencog/atoms/pattern/Pattern.cc
@@ -30,13 +30,6 @@ std::string Pattern::to_string(const std::string& indent) const
 
 	ss << indent << "Pattern: " << redex_name << std::endl;
 
-	if (not undeclared_clauses.empty())
-	{
-		if (not first) ss << std::endl;
-		ss << indent << "undeclared clauses:" << std::endl
-		   << oc_to_string(undeclared_clauses, indent + OC_TO_STRING_INDENT);
-		first = false;
-	}
 	if (not optionals.empty())
 	{
 		if (not first) ss << std::endl;

--- a/opencog/atoms/pattern/Pattern.cc
+++ b/opencog/atoms/pattern/Pattern.cc
@@ -51,13 +51,6 @@ std::string Pattern::to_string(const std::string& indent) const
 		   << oc_to_string(optionals, indent + OC_TO_STRING_INDENT);
 		first = false;
 	}
-	if (not black.empty())
-	{
-		if (not first) ss << std::endl;
-		ss << indent << "black:" << std::endl
-		   << oc_to_string(black, indent + OC_TO_STRING_INDENT);
-		first = false;
-	}
 	if (not evaluatable_terms.empty())
 	{
 		if (not first) ss << std::endl;

--- a/opencog/atoms/pattern/Pattern.cc
+++ b/opencog/atoms/pattern/Pattern.cc
@@ -30,7 +30,12 @@ std::string Pattern::to_string(const std::string& indent) const
 
 	ss << indent << "Pattern: " << redex_name << std::endl;
 
-	// FIXME Add printing here.
+	if (body)
+		ss << indent << "PatternLink body: " << body->to_string() << std::endl;
+	else
+		ss << indent << "No pattern body" << std::endl;
+
+	// FIXME Add more printing here.
 
 	return ss.str();
 }

--- a/opencog/atoms/pattern/Pattern.cc
+++ b/opencog/atoms/pattern/Pattern.cc
@@ -51,14 +51,6 @@ std::string Pattern::to_string(const std::string& indent) const
 		   << oc_to_string(optionals, indent + OC_TO_STRING_INDENT);
 		first = false;
 	}
-	if (not evaluatable_terms.empty())
-	{
-		if (not first) ss << std::endl;
-		ss << indent << "evaluatable_terms:" << std::endl
-		   << oc_to_string(evaluatable_terms,
-		                   indent + OC_TO_STRING_INDENT);
-		first = false;
-	}
 	return ss.str();
 }
 

--- a/opencog/atoms/pattern/Pattern.cc
+++ b/opencog/atoms/pattern/Pattern.cc
@@ -66,14 +66,6 @@ std::string Pattern::to_string(const std::string& indent) const
 		                   indent + OC_TO_STRING_INDENT);
 		first = false;
 	}
-	if (not evaluatable_holders.empty())
-	{
-		if (not first) ss << std::endl;
-		ss << indent << "evaluatable_holders:" << std::endl
-		   << oc_to_string(evaluatable_holders,
-		                   indent + OC_TO_STRING_INDENT);
-		first = false;
-	}
 	return ss.str();
 }
 

--- a/opencog/atoms/pattern/Pattern.cc
+++ b/opencog/atoms/pattern/Pattern.cc
@@ -30,13 +30,8 @@ std::string Pattern::to_string(const std::string& indent) const
 
 	ss << indent << "Pattern: " << redex_name << std::endl;
 
-	if (not optionals.empty())
-	{
-		if (not first) ss << std::endl;
-		ss << indent << "optionals:" << std::endl
-		   << oc_to_string(optionals, indent + OC_TO_STRING_INDENT);
-		first = false;
-	}
+	// FIXME Add printing here.
+
 	return ss.str();
 }
 

--- a/opencog/atoms/pattern/Pattern.cc
+++ b/opencog/atoms/pattern/Pattern.cc
@@ -30,13 +30,6 @@ std::string Pattern::to_string(const std::string& indent) const
 
 	ss << indent << "Pattern: " << redex_name << std::endl;
 
-	if (not literal_clauses.empty())
-	{
-		if (not first) ss << std::endl;
-		ss << indent << "literal clauses:" << std::endl
-		   << oc_to_string(literal_clauses, indent + OC_TO_STRING_INDENT);
-		 first = false;
-	}
 	if (not undeclared_clauses.empty())
 	{
 		if (not first) ss << std::endl;

--- a/opencog/atoms/pattern/Pattern.h
+++ b/opencog/atoms/pattern/Pattern.h
@@ -103,9 +103,9 @@ struct Pattern
 	/// way. Any grounding failure at all invalidates all other groundings.
 	PatternTermSeq always;
 
-	/// Evaluatable terms are those that hold a GroundedPredicateNode
-	/// (GPN) in them, or are stand-ins (e.g. GreaterThanLink, EqualLink).
-	HandleSet evaluatable_terms;   // smallest term that is evaluatable
+	/// Evaluatable terms are those that need to be evalutated to
+	/// find out if they hold true. For example, GreaterThanLink,
+	/// and anything with a GroundedPredicateNode (GPN) in them.
 	bool have_evaluatables;
 
 	/// Evaluatables with two or more variables, bridging across

--- a/opencog/atoms/pattern/Pattern.h
+++ b/opencog/atoms/pattern/Pattern.h
@@ -73,6 +73,8 @@ struct Pattern
 	typedef std::pair<Handle, PatternTermPtr> AtomInClausePair;
 	typedef std::map<AtomInClausePair, PatternTermSeq> ConnectTermMap;
 
+	Pattern() : have_evaluatables(false), have_black_boxes(false) {}
+
 	// -------------------------------------------
 	/// The current set of clauses (beta redex context) being grounded.
 	std::string redex_name;  // for debugging only!
@@ -101,16 +103,16 @@ struct Pattern
 	/// way. Any grounding failure at all invalidates all other groundings.
 	PatternTermSeq always;
 
+	/// Evaluatable terms are those that hold a GroundedPredicateNode
+	/// (GPN) in them, or are stand-ins (e.g. GreaterThanLink, EqualLink).
+	HandleSet evaluatable_terms;   // smallest term that is evaluatable
+	bool have_evaluatables;
+
 	/// Black-box clauses. These are clauses that contain GPN's. These
 	/// have to drop into scheme or python to get evaluated, which means
 	/// that they will be slow.  So, we leave these for last, so that the
 	/// faster clauses can run first, and rule out un-needed evaluations.
-	HandleSet black;       // Black-box clauses
-
-	/// Evaluatable terms are those that hold a GroundedPredicateNode
-	/// (GPN) in them, or are stand-ins (e.g. GreaterThanLink, EqualLink).
-	HandleSet evaluatable_terms;   // smallest term that is evaluatable
-	bool have_evaluatable_holders;
+	bool have_black_boxes;
 
 	/// Defined terms are terms that are a DefinedPredicateNode (DPN)
 	/// or a DefineSchemaNode (DSN).

--- a/opencog/atoms/pattern/Pattern.h
+++ b/opencog/atoms/pattern/Pattern.h
@@ -89,7 +89,6 @@ struct Pattern
 
 	/// The mandatory clauses must be satisfied. This includes both
 	/// literal clauses and virtual clauses.
-	HandleSeq        mandatory;
 	PatternTermSeq   pmandatory;
 
 	/// The optional clauses must be ungroundable. They are always

--- a/opencog/atoms/pattern/Pattern.h
+++ b/opencog/atoms/pattern/Pattern.h
@@ -110,7 +110,7 @@ struct Pattern
 	/// Evaluatable terms are those that hold a GroundedPredicateNode
 	/// (GPN) in them, or are stand-ins (e.g. GreaterThanLink, EqualLink).
 	HandleSet evaluatable_terms;   // smallest term that is evaluatable
-	HandleSet evaluatable_holders; // holds something evaluatable.
+	bool have_evaluatable_holders;
 
 	/// Defined terms are terms that are a DefinedPredicateNode (DPN)
 	/// or a DefineSchemaNode (DSN).

--- a/opencog/atoms/pattern/Pattern.h
+++ b/opencog/atoms/pattern/Pattern.h
@@ -73,7 +73,7 @@ struct Pattern
 	typedef std::pair<Handle, PatternTermPtr> AtomInClausePair;
 	typedef std::map<AtomInClausePair, PatternTermSeq> ConnectTermMap;
 
-	Pattern() : have_evaluatables(false), have_black_boxes(false) {}
+	Pattern() : have_evaluatables(false), have_virtuals(false) {}
 
 	// -------------------------------------------
 	/// The current set of clauses (beta redex context) being grounded.
@@ -108,11 +108,11 @@ struct Pattern
 	HandleSet evaluatable_terms;   // smallest term that is evaluatable
 	bool have_evaluatables;
 
-	/// Black-box clauses. These are clauses that contain GPN's. These
-	/// have to drop into scheme or python to get evaluated, which means
-	/// that they will be slow.  So, we leave these for last, so that the
-	/// faster clauses can run first, and rule out un-needed evaluations.
-	bool have_black_boxes;
+	/// Evaluatables with two or more variables, bridging across
+	/// different pattern components. In principle, these exist only
+	/// if the pattern has two or more components; in practice, there
+	// may be skew due to imperfect code ... XXX FIXME.
+	bool have_virtuals;
 
 	/// Defined terms are terms that are a DefinedPredicateNode (DPN)
 	/// or a DefineSchemaNode (DSN).

--- a/opencog/atoms/pattern/Pattern.h
+++ b/opencog/atoms/pattern/Pattern.h
@@ -82,11 +82,6 @@ struct Pattern
 	/// The original body containing the link (if any).
 	Handle           body;
 
-	/// Clauses that might be virtual. User never explictly declared
-	/// them one way or the other, so we will have to guess, based on
-	/// what's in them. Set by unbundle_clauses().
-	HandleSeq        undeclared_clauses;
-
 	/// The mandatory clauses must be satisfied. This includes both
 	/// literal clauses and virtual clauses.
 	PatternTermSeq   pmandatory;

--- a/opencog/atoms/pattern/Pattern.h
+++ b/opencog/atoms/pattern/Pattern.h
@@ -73,7 +73,7 @@ struct Pattern
 	typedef std::pair<Handle, PatternTermPtr> AtomInClausePair;
 	typedef std::map<AtomInClausePair, PatternTermSeq> ConnectTermMap;
 
-	Pattern() : have_evaluatables(false), have_virtuals(false) {}
+	Pattern() : have_evaluatables(false) {}
 
 	// -------------------------------------------
 	/// The current set of clauses (beta redex context) being grounded.
@@ -86,11 +86,9 @@ struct Pattern
 	/// literal clauses and virtual clauses.
 	PatternTermSeq   pmandatory;
 
-	/// The optional clauses must be ungroundable. They are always
-	/// literal, and are never evaluatable or virtual. XXX This member
-	/// is mis-named: in the current implementation, the optional
-	/// clauses must be literally absent. XXX FIXME rename this member.
-	HandleSeq      optionals;
+	/// The absent clauses must be ungroundable; they must literally
+	/// be absent. They are always literal, and are never evaluatable
+	/// or virtual.
 	PatternTermSeq absents;
 
 	/// The always (for-all) clauses have to always be grounded the same
@@ -101,12 +99,6 @@ struct Pattern
 	/// find out if they hold true. For example, GreaterThanLink,
 	/// and anything with a GroundedPredicateNode (GPN) in them.
 	bool have_evaluatables;
-
-	/// Evaluatables with two or more variables, bridging across
-	/// different pattern components. In principle, these exist only
-	/// if the pattern has two or more components; in practice, there
-	// may be skew due to imperfect code ... XXX FIXME.
-	bool have_virtuals;
 
 	/// Defined terms are terms that are a DefinedPredicateNode (DPN)
 	/// or a DefineSchemaNode (DSN).

--- a/opencog/atoms/pattern/Pattern.h
+++ b/opencog/atoms/pattern/Pattern.h
@@ -130,12 +130,6 @@ struct Pattern
 	/// Used in conjunction with the `cacheable_multi` above.
 	std::map<PatternTermPtr, HandleSeq> clause_variables;
 
-	/// Maps; the value is the largest (evaluatable or executable)
-	/// term containing the variable. Its a multimap, because
-	/// a variable may appear in several different evaluatables.
-	std::unordered_multimap<Handle,Handle> in_evaluatable;
-	std::unordered_multimap<Handle,Handle> in_executable;
-
 	/// Any given atom may appear in one or more clauses. Given an atom,
 	/// the connectivy map tells you what clauses it appears in. It
 	/// captures how the clauses are connected to one-another, so that,

--- a/opencog/atoms/pattern/Pattern.h
+++ b/opencog/atoms/pattern/Pattern.h
@@ -80,8 +80,6 @@ struct Pattern
 	/// The original body containing the link (if any).
 	Handle           body;
 
-	/// Clauses that are never virtual. Set by unbundle_clauses().
-	HandleSeq        literal_clauses;
 	/// Clauses that might be virtual. User never explictly declared
 	/// them one way or the other, so we will have to guess, based on
 	/// what's in them. Set by unbundle_clauses().

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -850,8 +850,6 @@ void PatternLink::unbundle_virtual(const HandleSeq& clauses)
 				is_black = true;
 			}
 		}
-		if (0 < fgpn.holders.size())
-			_pat.have_evaluatable_holders = true;
 
 		// ----------
 		// One might hope to fish out all EvaluatableLinks, and handle
@@ -869,8 +867,6 @@ void PatternLink::unbundle_virtual(const HandleSeq& clauses)
 			if (is_virtual(sh))
 				is_virtu = true;
 		}
-		if (0 < fpfl.holders.size())
-			_pat.have_evaluatable_holders = true;
 
 		// ----------
 		// Subclasses of VirtualLink, e.g. GreaterThanLink, which
@@ -881,7 +877,6 @@ void PatternLink::unbundle_virtual(const HandleSeq& clauses)
 		// because its a link...
 		for (const Handle& sh : fgtl.varset)
 		{
-			_pat.have_evaluatable_holders = true;
 			_pat.evaluatable_terms.insert(sh);
 
 			if (is_virtual(sh)) is_virtu = true;
@@ -1149,6 +1144,7 @@ void PatternLink::make_term_tree_recursive(const PatternTermPtr& root,
 				}
 		}
 
+		_pat.have_evaluatable_holders = true;
 		ptm->addEvaluatable();
 		return;
 	}

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -733,17 +733,6 @@ void PatternLink::validate_variables(HandleSet& vars,
 /// To add support, we would have to split executable clauses into
 /// component graphs, the same way we currently split VirtualLinks.
 ///
-
-static bool is_relational_link(const Handle& h)
-{
-	Type t = h->get_type();
-
-	if (nameserver().isA(t, VIRTUAL_LINK)
-	    and not (SATISFACTION_LINK == t))
-		return true;
-	return false;
-}
-
 bool PatternLink::is_virtual(const Handle& clause)
 {
 	size_t nfree = num_unquoted_unscoped_in_tree(clause, _variables.varset);
@@ -967,11 +956,15 @@ void PatternLink::make_term_tree_recursive(const PatternTermPtr& root,
 			_pat.have_evaluatables = true;
 			ptm->addEvaluatable();
 
+			// XXX FIXME -- this is wrong. What we really want is to
+			// identify those clauses that bridge across multiple
+			// components... not everything here does so. The
+			// get_bridged_components() should be modified to
+			// identify the bridging cluases...
 			if ((parent->getHandle() == nullptr or not parent->isVirtual())
 			     and is_virtual(h))
 			{
 				_virtual.emplace_back(h);
-				_pat.have_virtuals = true;
 				ptm->markVirtual();
 			}
 		}

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -51,7 +51,7 @@ void PatternLink::common_init(void)
 		return;
 	}
 
-	// Locate the black-box and clear-box clauses.
+	// Locate the clear-box clauses.
 	unbundle_virtual(_pat.undeclared_clauses);
 	_num_virts = _virtual.size();
 
@@ -134,7 +134,6 @@ void PatternLink::setup_components(void)
 
 void PatternLink::init(void)
 {
-	_pat.have_evaluatable_holders = false;
 	_pat.redex_name = "anonymous PatternLink";
 	ScopeLink::extract_variables(_outgoing);
 
@@ -176,7 +175,6 @@ PatternLink::PatternLink(const Variables& vars, const Handle& body)
 
 	_variables = vars;
 	_body = body;
-	_pat.have_evaluatable_holders = false;
 	unbundle_clauses(_body);
 	common_init();
 	setup_components();
@@ -193,7 +191,6 @@ PatternLink::PatternLink(const HandleSet& vars,
                          const PatternTermSeq& absts)
 	: PrenexLink(HandleSeq(), PATTERN_LINK)
 {
-	_pat.have_evaluatable_holders = false;
 
 	// First, lets deal with the vars. We have discarded the original
 	// order of the variables, and I think that's OK, because we will
@@ -279,7 +276,6 @@ PatternLink::PatternLink(const HandleSet& vars,
                          const HandleSeq& clauses)
 	: PrenexLink(HandleSeq(), PATTERN_LINK)
 {
-	_pat.have_evaluatable_holders = false;
 	_variables.varset = vars;
 	_pat.undeclared_clauses = clauses;
 	for (const Handle& clause : clauses)
@@ -835,7 +831,6 @@ void PatternLink::unbundle_virtual(const HandleSeq& clauses)
 	for (const Handle& clause: clauses)
 	{
 		bool is_virtu = false;
-		bool is_black = false;
 
 		// ----------
 		FindAtoms fgpn(GROUNDED_PREDICATE_NODE, true);
@@ -847,7 +842,6 @@ void PatternLink::unbundle_virtual(const HandleSeq& clauses)
 			if (is_virtual(sh))
 			{
 				is_virtu = true;
-				is_black = true;
 			}
 		}
 
@@ -903,9 +897,6 @@ void PatternLink::unbundle_virtual(const HandleSeq& clauses)
 			_virtual.emplace_back(clause);
 		else
 			_fixed.emplace_back(clause);
-
-		if (is_black)
-			_pat.black.insert(clause);
 	}
 }
 
@@ -1144,8 +1135,15 @@ void PatternLink::make_term_tree_recursive(const PatternTermPtr& root,
 				}
 		}
 
-		_pat.have_evaluatable_holders = true;
+		_pat.have_evaluatables = true;
 		ptm->addEvaluatable();
+
+		if (is_black_box(h) and is_virtual(h))
+		{
+			_pat.have_black_boxes = true;
+			ptm->markBlackBox();
+		}
+
 		return;
 	}
 

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -433,7 +433,6 @@ _pat.pmandatory.push_back(term);
 		for (const Handle& ah: h->getOutgoingSet())
 		{
 			PatternTermPtr term(make_term_tree(ah));
-			term->markLiteral();
 			term->markAlways();
 			_pat.always.push_back(term);
 			_pat.undeclared_clauses.emplace_back(ah);

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -319,6 +319,8 @@ bool PatternLink::record_literal(const Handle& h, bool reverse)
 	{
 		for (const Handle& ph : h->getOutgoingSet())
 		{
+			if (is_constant(_variables.varset, ph)) continue;
+
 			PatternTermPtr term(make_term_tree(ph));
 			term->markLiteral();
 			_pat.pmandatory.push_back(term);
@@ -342,12 +344,13 @@ bool PatternLink::record_literal(const Handle& h, bool reverse)
 			{
 				for (const Handle& php : ph->getOutgoingSet())
 				{
+					if (is_constant(_variables.varset, php)) continue;
 					PatternTermPtr term(make_term_tree(php));
 					term->markLiteral();
 					_pat.pmandatory.push_back(term);
 				}
 			}
-			else
+			else if (not is_constant(_variables.varset, ph))
 			{
 				PatternTermPtr term(make_term_tree(ph));
 				term->markLiteral();
@@ -377,6 +380,8 @@ _pat.pmandatory.push_back(term);
 				"AbsentLink can have an arity of one only!");
 
 		const Handle& inv(h->getOutgoingAtom(0));
+		if (is_constant(_variables.varset, inv)) return true;
+
 		PatternTermPtr term(make_term_tree(inv));
 		term->markLiteral();
 		term->markAbsent();
@@ -394,6 +399,7 @@ _pat.pmandatory.push_back(term);
 	{
 		for (const Handle& ah: h->getOutgoingSet())
 		{
+			if (is_constant(_variables.varset, ah)) continue;
 			PatternTermPtr term(make_term_tree(ah));
 			term->markAlways();
 			_pat.always.push_back(term);

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -893,7 +893,6 @@ void PatternLink::add_dummies(const PatternTermPtr& ptm)
 			continue;
 
 		_fixed.emplace_back(sh);
-		_pat.pmandatory.push_back(ptm);
 	}
 }
 

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -912,25 +912,19 @@ void PatternLink::add_dummies(const PatternTermPtr& ptm)
 	const Handle& h = ptm->getHandle();
 	Type t = h->get_type();
 
-	if (EQUAL_LINK != t and
-	    GREATER_THAN_LINK != t and
-	    IDENTICAL_LINK != t)
-	{
+	if (not nameserver().isA(VIRTUAL_LINK, t)
+	    or SATISFACTION_LINK == t)
 		return;
-	}
 
-	const Handle& left = h->getOutgoingAtom(0);
-	const Handle& right = h->getOutgoingAtom(1);
-
-	for (const Handle& v : _variables.varset)
+	for (const PatternTermPtr& sub: ptm->getOutgoingSet())
 	{
-		if (is_free_in_tree(left, v) or
-		    is_free_in_tree(right, v))
-		{
-			_fixed.emplace_back(v);
+		const Handle& sh = sub->getHandle();
+		if (can_evaluate(sh)) continue;
+		if (not any_unquoted_unscoped_in_tree(sh, _variables.varset))
+			continue;
 
-			_pat.pmandatory.push_back(ptm);
-		}
+		_fixed.emplace_back(sh);
+		_pat.pmandatory.push_back(ptm);
 	}
 }
 

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -238,16 +238,11 @@ PatternLink::PatternLink(const HandleSet& vars,
 		}
 		else
 		{
-			_pat.mandatory.emplace_back(h);
-
 			PatternTermPtr term(make_term_tree(h));
 			_pat.pmandatory.push_back(term);
 		}
 	}
 	locate_defines(compo);
-
-	// The rest is easy: the evaluatables and the connection map
-	unbundle_virtual(_pat.mandatory);
 
 	_num_virts = _virtual.size();
 	OC_ASSERT (0 == _num_virts, "Must not have any virtuals!");
@@ -333,8 +328,6 @@ bool PatternLink::record_literal(const Handle& h, bool reverse)
 	{
 		for (const Handle& ph : h->getOutgoingSet())
 		{
-			_pat.mandatory.emplace_back(ph);
-
 			PatternTermPtr term(make_term_tree(ph));
 			term->markLiteral();
 			_pat.pmandatory.push_back(term);
@@ -358,8 +351,6 @@ bool PatternLink::record_literal(const Handle& h, bool reverse)
 			{
 				for (const Handle& php : ph->getOutgoingSet())
 				{
-					_pat.mandatory.emplace_back(php);
-
 					PatternTermPtr term(make_term_tree(php));
 					term->markLiteral();
 					_pat.pmandatory.push_back(term);
@@ -367,8 +358,6 @@ bool PatternLink::record_literal(const Handle& h, bool reverse)
 			}
 			else
 			{
-				_pat.mandatory.emplace_back(ph);
-
 				PatternTermPtr term(make_term_tree(ph));
 				term->markLiteral();
 				_pat.pmandatory.push_back(term);
@@ -379,8 +368,6 @@ bool PatternLink::record_literal(const Handle& h, bool reverse)
 // XXX FIXME both statements below are wrong, but they are needed for
 // the unit tests. More bu0fxing to straighten this stuff out. That
 // is why this code is badly indented!
-_pat.mandatory.emplace_back(h);
-
 PatternTermPtr term(make_term_tree(h));
 term->markChoice();
 _pat.pmandatory.push_back(term);
@@ -491,7 +478,6 @@ void PatternLink::unbundle_clauses(const Handle& hbody)
 			    not unbundle_clauses_rec(ho, connectives))
 			{
 				_pat.undeclared_clauses.emplace_back(ho);
-				_pat.mandatory.emplace_back(ho);
 
 				PatternTermPtr term(make_term_tree(ho));
 				_pat.pmandatory.push_back(term);
@@ -516,7 +502,6 @@ void PatternLink::unbundle_clauses(const Handle& hbody)
 		unbundle_clauses_rec(hbody, connectives);
 
 		_pat.undeclared_clauses.emplace_back(hbody);
-		_pat.mandatory.emplace_back(hbody);
 
 		PatternTermPtr term(make_term_tree(hbody));
 		_pat.pmandatory.push_back(term);
@@ -533,7 +518,6 @@ void PatternLink::unbundle_clauses(const Handle& hbody)
 		if (not unbundle_clauses_rec(hbody, connectives))
 		{
 			_pat.undeclared_clauses.emplace_back(hbody);
-			_pat.mandatory.emplace_back(hbody);
 
 			PatternTermPtr term(make_term_tree(hbody));
 			_pat.pmandatory.push_back(term);
@@ -550,7 +534,6 @@ void PatternLink::unbundle_clauses(const Handle& hbody)
 		if (not unbundle_clauses_rec(hbody, connectives))
 		{
 			_pat.undeclared_clauses.emplace_back(hbody);
-			_pat.mandatory.emplace_back(hbody);
 
 			PatternTermPtr term(make_term_tree(hbody));
 			_pat.pmandatory.push_back(term);
@@ -560,7 +543,6 @@ void PatternLink::unbundle_clauses(const Handle& hbody)
 	{
 		// There's just one single clause!
 		_pat.undeclared_clauses.emplace_back(hbody);
-		_pat.mandatory.emplace_back(hbody);
 
 		PatternTermPtr term(make_term_tree(hbody));
 		_pat.pmandatory.push_back(term);
@@ -945,7 +927,6 @@ void PatternLink::add_dummies(const PatternTermPtr& ptm)
 		if (is_free_in_tree(left, v) or
 		    is_free_in_tree(right, v))
 		{
-			_pat.mandatory.emplace_back(v);
 			_fixed.emplace_back(v);
 
 			_pat.pmandatory.push_back(ptm);

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -71,7 +71,8 @@ void PatternLink::common_init(void)
 	// with some ungrounded variable.
 	HandleSeq concrete_clauses;
 	for (const PatternTermPtr& ptm : _fixed)
-		concrete_clauses.emplace_back(ptm->getHandle());
+		concrete_clauses.emplace_back(
+			ptm->isQuoted() ? ptm->getQuote() : ptm->getHandle());
 	for (const PatternTermPtr& ptm : _pat.absents)
 		concrete_clauses.emplace_back(ptm->getHandle());
 	validate_variables(_variables.varset, concrete_clauses);
@@ -1056,7 +1057,8 @@ void PatternLink::debug_log(void) const
 	int cl = 0;
 	for (const PatternTermPtr& ptm : _pat.pmandatory)
 	{
-		const Handle& h = ptm->getHandle();
+		const Handle& h =
+			ptm->isQuoted() ? ptm->getQuote() : ptm->getHandle();
 		std::stringstream ss;
 		ss << "Mandatory " << cl << ":";
 		if (ptm->hasAnyEvaluatable()) ss << " (evaluatable)";
@@ -1072,7 +1074,8 @@ void PatternLink::debug_log(void) const
 		cl = 0;
 		for (const PatternTermPtr& ptm : _pat.absents)
 		{
-			const Handle& h = ptm->getHandle();
+			const Handle& h =
+				ptm->isQuoted() ? ptm->getQuote() : ptm->getHandle();
 			std::stringstream ss;
 			ss << "Optional clause " << cl << ":" << std::endl;
 			ss << h->to_short_string();
@@ -1089,7 +1092,8 @@ void PatternLink::debug_log(void) const
 		cl = 0;
 		for (const PatternTermPtr& ptm : _pat.always)
 		{
-			const Handle& h = ptm->getHandle();
+			const Handle& h =
+				ptm->isQuoted() ? ptm->getQuote() : ptm->getHandle();
 			std::stringstream ss;
 			ss << "Always clause " << cl << ":";
 			if (ptm->hasAnyEvaluatable()) ss << " (evaluatable)";

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -407,7 +407,6 @@ _pat.pmandatory.push_back(term);
 			PatternTermPtr term(make_term_tree(ah));
 			term->markAlways();
 			_pat.always.push_back(term);
-			_pat.undeclared_clauses.emplace_back(ah);
 		}
 		return true;
 	}
@@ -501,8 +500,6 @@ void PatternLink::unbundle_clauses(const Handle& hbody)
 		// running the sequential. So that's a bug.
 		unbundle_clauses_rec(hbody, connectives);
 
-		_pat.undeclared_clauses.emplace_back(hbody);
-
 		PatternTermPtr term(make_term_tree(hbody));
 		_pat.pmandatory.push_back(term);
 	}
@@ -517,8 +514,6 @@ void PatternLink::unbundle_clauses(const Handle& hbody)
 		TypeSet connectives({AND_LINK, OR_LINK, NOT_LINK});
 		if (not unbundle_clauses_rec(hbody, connectives))
 		{
-			_pat.undeclared_clauses.emplace_back(hbody);
-
 			PatternTermPtr term(make_term_tree(hbody));
 			_pat.pmandatory.push_back(term);
 		}

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -930,8 +930,8 @@ void PatternLink::make_term_tree_recursive(const PatternTermPtr& root,
 		bool is_ev = true;
 		if (AND_LINK == t)
 		{
-			for (const PatternTermPtr& ptc : ptm->getOutgoingSet())
-				if (not can_evaluate(ptc->getHandle()))
+			for (const Handle& ho : h->getOutgoingSet())
+				if (not can_evaluate(ho))
 				{
 					is_ev = false;
 					break;
@@ -997,7 +997,7 @@ void PatternLink::make_term_tree_recursive(const PatternTermPtr& root,
 		if (AND_LINK == t)
 		{
 			for (const PatternTermPtr& ptc : ptm->getOutgoingSet())
-				if (not can_evaluate(ptc->getHandle()))
+				if (ptc->isQuoted() or not can_evaluate(ptc->getHandle()))
 				{
 					ptm->markLiteral();
 					return;

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -840,9 +840,7 @@ void PatternLink::unbundle_virtual(const HandleSeq& clauses)
 		{
 			_pat.evaluatable_terms.insert(sh);
 			if (is_virtual(sh))
-			{
 				is_virtu = true;
-			}
 		}
 
 		// ----------
@@ -893,9 +891,7 @@ void PatternLink::unbundle_virtual(const HandleSeq& clauses)
 		}
 
 		// ----------
-		if (is_virtu)
-			_virtual.emplace_back(clause);
-		else
+		if (not is_virtu)
 			_fixed.emplace_back(clause);
 	}
 }
@@ -1138,10 +1134,11 @@ void PatternLink::make_term_tree_recursive(const PatternTermPtr& root,
 		_pat.have_evaluatables = true;
 		ptm->addEvaluatable();
 
-		if (is_black_box(h) and is_virtual(h))
+		if (is_virtual(h))
 		{
-			_pat.have_black_boxes = true;
-			ptm->markBlackBox();
+			_virtual.emplace_back(h);
+			_pat.have_virtuals = true;
+			ptm->markVirtual();
 		}
 
 		return;

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -55,18 +55,6 @@ void PatternLink::common_init(void)
 
 	_num_virts = _virtual.size();
 
-	// Here, we assume that
-	// we are being run with the TermMatchMixin, and so we assume
-	// that the logical connectives are AndLink, OrLink and NotLink.
-	// XXX FIXME; long-term, this should be replaced by a check to
-	// see if a link inherits from EvaluatableLink. However, this can
-	// only be done after all existing BindLinks have been converted to
-	// use PresentLink... so this might not be practical to fix, for a
-	// while.
-	TypeSet connectives({AND_LINK, SEQUENTIAL_AND_LINK,
-	                     OR_LINK, SEQUENTIAL_OR_LINK,
-	                     NOT_LINK, TRUE_LINK, FALSE_LINK});
-
 	// Compute the intersection of literal clauses, and mandatory
 	// clauses. This is the set of mandatory clauses that must be
 	// present in thier literal form.
@@ -75,14 +63,6 @@ void PatternLink::common_init(void)
 		if (ptm->isLiteral() or ptm->isPresent() or ptm->isChoice())
 			_fixed.push_back(ptm->getHandle());
 	}
-
-	HandleSeq opts;
-	for (const PatternTermPtr& ptm : _pat.absents)
-		opts.emplace_back(ptm->getHandle());
-
-	// Split the non-virtual clauses into connected components
-	get_bridged_components(_variables.varset, _fixed, opts,
-	                       _components, _component_vars);
 
 	// Make sure every variable appears in some concrete
 	// (non-evaluatable) clause. This consists of non-evaluatable
@@ -93,6 +73,14 @@ void PatternLink::common_init(void)
 	for (const PatternTermPtr& ptm : _pat.absents)
 		concrete_clauses.emplace_back(ptm->getHandle());
 	validate_variables(_variables.varset, concrete_clauses);
+
+	HandleSeq opts;
+	for (const PatternTermPtr& ptm : _pat.absents)
+		opts.emplace_back(ptm->getHandle());
+
+	// Split the non-virtual clauses into connected components
+	get_bridged_components(_variables.varset, _fixed, opts,
+	                       _components, _component_vars);
 
 	// Make sure every variable is in some component.
 	check_satisfiability(_variables.varset, _component_vars);

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -836,9 +836,7 @@ void PatternLink::unbundle_virtual(const HandleSeq& clauses)
 		fgpn.search_set(clause);
 		for (const Handle& sh : fgpn.least_holders)
 		{
-			_pat.evaluatable_terms.insert(sh);
-			if (is_virtual(sh))
-				is_virtu = true;
+			if (is_virtual(sh)) is_virtu = true;
 		}
 
 		// ----------
@@ -853,9 +851,7 @@ void PatternLink::unbundle_virtual(const HandleSeq& clauses)
 		fpfl.search_set(clause);
 		for (const Handle& sh : fpfl.least_holders)
 		{
-			_pat.evaluatable_terms.insert(sh);
-			if (is_virtual(sh))
-				is_virtu = true;
+			if (is_virtual(sh)) is_virtu = true;
 		}
 
 		// ----------
@@ -867,8 +863,6 @@ void PatternLink::unbundle_virtual(const HandleSeq& clauses)
 		// because its a link...
 		for (const Handle& sh : fgtl.varset)
 		{
-			_pat.evaluatable_terms.insert(sh);
-
 			if (is_virtual(sh)) is_virtu = true;
 		}
 

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -881,7 +881,7 @@ void PatternLink::add_dummies(const PatternTermPtr& ptm)
 	const Handle& h = ptm->getHandle();
 	Type t = h->get_type();
 
-	if (not nameserver().isA(VIRTUAL_LINK, t)
+	if (not nameserver().isA(t, VIRTUAL_LINK)
 	    or SATISFACTION_LINK == t)
 		return;
 

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -122,7 +122,9 @@ void PatternLink::common_init(void)
 	get_clause_variables(_pat.always);
 
 	// Find prunable terms.
-	locate_cacheable(concrete_clauses);
+	locate_cacheable(_pat.pmandatory);
+	locate_cacheable(_pat.absents);
+	locate_cacheable(_pat.always);
 }
 
 
@@ -668,13 +670,14 @@ void PatternLink::locate_defines(const HandleSeq& clauses)
  *
  * This is kind-of the opposite of `is_virtual()`.
  */
-void PatternLink::locate_cacheable(const HandleSeq& clauses)
+void PatternLink::locate_cacheable(const PatternTermSeq& clauses)
 {
-	for (const Handle& claw: clauses)
+	for (const PatternTermPtr& ptm: clauses)
 	{
-		// Skip over anything unsuitable.
-		if (_pat.evaluatable_holders.find(claw) !=
-		    _pat.evaluatable_holders.end()) continue;
+		if (not ptm->isLiteral() and not ptm->isPresent() and
+		    not ptm->isChoice() and not ptm->isAbsent()) continue;
+
+		const Handle& claw = ptm->getHandle();
 
 		if (1 == num_unquoted_unscoped_in_tree(claw, _variables.varset))
 		{

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -54,11 +54,12 @@ void PatternLink::common_init(void)
 	// Compute the intersection of literal clauses, and mandatory
 	// clauses. This is the set of mandatory clauses that must be
 	// present in thier literal form.
-	for (const Handle& h : _pat.mandatory)
+	for (const PatternTermPtr& ptm : _pat.pmandatory)
 	{
-		if (std::find(_pat.literal_clauses.begin(), _pat.literal_clauses.end(), h)
+		if (std::find(_pat.literal_clauses.begin(), _pat.literal_clauses.end(),
+		              ptm->getHandle())
 			 != _pat.literal_clauses.end())
-		_fixed.push_back(h);
+		_fixed.push_back(ptm->getHandle());
 	}
 
 	// Locate the black-box and clear-box clauses.

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -292,7 +292,11 @@ PatternLink::PatternLink(const HandleSet& vars,
 {
 	_variables.varset = vars;
 	_pat.undeclared_clauses = clauses;
-	_pat.mandatory = clauses;
+	for (const Handle& clause : clauses)
+	{
+		PatternTermPtr root_term(make_term_tree(clause));
+		_pat.pmandatory.push_back(root_term);
+	}
 	common_init();
 	setup_components();
 }

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -1233,8 +1233,7 @@ void PatternLink::debug_log(void) const
 		const Handle& h = ptm->getHandle();
 		std::stringstream ss;
 		ss << "Mandatory " << cl << ":";
-		if (_pat.evaluatable_holders.find(h) != _pat.evaluatable_holders.end())
-			ss << " (evaluatable)";
+		if (ptm->hasAnyEvaluatable()) ss << " (evaluatable)";
 		ss << std::endl;
 		ss << h->to_short_string();
 		logger().fine() << ss.str();
@@ -1250,9 +1249,6 @@ void PatternLink::debug_log(void) const
 			const Handle& h = ptm->getHandle();
 			std::stringstream ss;
 			ss << "Optional clause " << cl << ":" << std::endl;
-			OC_ASSERT(_pat.evaluatable_holders.find(h) ==
-			          _pat.evaluatable_holders.end(),
-			          "Absent clauses cannot be evaluatable!");
 			ss << h->to_short_string();
 			logger().fine() << ss.str();
 			cl++;
@@ -1270,8 +1266,7 @@ void PatternLink::debug_log(void) const
 			const Handle& h = ptm->getHandle();
 			std::stringstream ss;
 			ss << "Always clause " << cl << ":";
-			if (_pat.evaluatable_holders.find(h) != _pat.evaluatable_holders.end())
-				ss << " (evaluatable)";
+			if (ptm->hasAnyEvaluatable()) ss << " (evaluatable)";
 			ss << std::endl;
 			ss << h->to_short_string();
 			logger().fine() << ss.str();

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -1182,6 +1182,8 @@ void PatternLink::make_term_tree_recursive(const PatternTermPtr& root,
 	if (nameserver().isA(t, UNORDERED_LINK))
 		ptm->addUnorderedLink();
 
+	if (can_evaluate(h)) ptm->addEvaluatable();
+
 	if (h->is_link())
 	{
 		for (const Handle& ho: h->getOutgoingSet())
@@ -1192,8 +1194,8 @@ void PatternLink::make_term_tree_recursive(const PatternTermPtr& root,
 	}
 
 	// If a term is literal then the corresponding pattern term
-	// should be also. We should be creating PatternTerms earlier ...
-	if (_pat.evaluatable_holders.find(h) == _pat.evaluatable_holders.end())
+	// should be also.
+	if (not ptm->hasEvaluatable())
    {
 		if (CHOICE_LINK == t)
 		{

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -346,7 +346,6 @@ bool PatternLink::record_literal(const Handle& h, bool reverse)
 	{
 		for (const Handle& ph : h->getOutgoingSet())
 		{
-			_pat.literal_clauses.emplace_back(ph);
 			_pat.mandatory.emplace_back(ph);
 
 			PatternTermPtr term(make_term_tree(ph));
@@ -373,7 +372,6 @@ bool PatternLink::record_literal(const Handle& h, bool reverse)
 				for (const Handle& php : ph->getOutgoingSet())
 				{
 					_pat.mandatory.emplace_back(php);
-					_pat.literal_clauses.emplace_back(php);
 
 					PatternTermPtr term(make_term_tree(php));
 					term->markLiteral();
@@ -383,7 +381,6 @@ bool PatternLink::record_literal(const Handle& h, bool reverse)
 			else
 			{
 				_pat.mandatory.emplace_back(ph);
-				_pat.literal_clauses.emplace_back(ph);
 
 				PatternTermPtr term(make_term_tree(ph));
 				term->markLiteral();
@@ -392,28 +389,9 @@ bool PatternLink::record_literal(const Handle& h, bool reverse)
 			return true;
 		}
 
-		// More than just one alternative in the choice.
-		for (const Handle& ph : h->getOutgoingSet())
-		{
-			Type pht = ph->get_type();
-			if (PRESENT_LINK == pht)
-			{
-				for (const Handle& php : ph->getOutgoingSet())
-					_pat.literal_clauses.emplace_back(php);
-				continue;
-			}
-
-			if (ABSENT_LINK == pht)
-				throw InvalidParamException(TRACE_INFO,
-					"AbsentLink under a Choice is not supported yet!");
-
-			_pat.literal_clauses.emplace_back(ph);
-		}
-
 // XXX FIXME both statements below are wrong, but they are needed for
 // the unit tests. More bu0fxing to straighten this stuff out. That
 // is why this code is badly indented!
-_pat.literal_clauses.emplace_back(h);
 _pat.mandatory.emplace_back(h);
 
 PatternTermPtr term(make_term_tree(h));
@@ -435,7 +413,6 @@ _pat.pmandatory.push_back(term);
 
 		const Handle& inv(h->getOutgoingAtom(0));
 		_pat.optionals.emplace_back(inv);
-		_pat.literal_clauses.emplace_back(inv);
 		PatternTermPtr term(make_term_tree(inv));
 		term->markLiteral();
 		term->markAbsent();
@@ -997,8 +974,6 @@ void PatternLink::unbundle_virtual(const HandleSeq& clauses)
 ///
 bool PatternLink::add_dummies()
 {
-	if (0 < _pat.literal_clauses.size()) return false;
-
 	// The below is almost but not quite the same as
 	// if (0 < _fixed.size()) return; because fixed can be
 	// non-zero, if the virtual term has only one variable

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -972,7 +972,7 @@ void PatternLink::unbundle_virtual(const HandleSeq& clauses)
 /// atomspace, resulting in infinite recursion and a blown stack.
 /// Not clear how to avoid that...
 ///
-bool PatternLink::add_dummies()
+void PatternLink::add_dummies()
 {
 	// The below is almost but not quite the same as
 	// if (0 < _fixed.size()) return; because fixed can be
@@ -981,7 +981,7 @@ bool PatternLink::add_dummies()
 	for (const Handle& cl : _pat.undeclared_clauses)
 	{
 		// if (0 == _pat.evaluatable_holders.count(cl)) return;
-		if (0 == _pat.evaluatable_terms.count(cl)) return false;
+		if (0 == _pat.evaluatable_terms.count(cl)) return;
 	}
 
 	for (const Handle& t : _pat.evaluatable_terms)
@@ -1008,8 +1008,6 @@ bool PatternLink::add_dummies()
 			}
 		}
 	}
-
-	return true;
 }
 
 /* ================================================================= */

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -1156,7 +1156,15 @@ void PatternLink::make_term_tree_recursive(const PatternTermPtr& root,
 	if (nameserver().isA(t, UNORDERED_LINK))
 		ptm->addUnorderedLink();
 
-	if (can_evaluate(h)) ptm->addEvaluatable();
+	// If the parent isn't evaluatable, it makes no sense to
+	// mark the child evaluatable. The problem here is that
+	// users insert stray AndLinks into random places.
+	const PatternTermPtr& parent = ptm->getParent();
+	if ((parent->getHandle() == nullptr or parent->hasEvaluatable())
+	    and can_evaluate(h))
+	{
+		ptm->addEvaluatable();
+	}
 
 	if (h->is_link())
 	{

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -103,8 +103,6 @@ void PatternLink::common_init(void)
 
 	add_dummies();
 
-	make_term_trees();
-
 	// Split the non-virtual clauses into connected components
 	get_bridged_components(_variables.varset, _fixed, _pat.optionals,
 	                       _components, _component_vars);
@@ -419,10 +417,9 @@ bool PatternLink::record_literal(const Handle& h, bool reverse)
 _pat.literal_clauses.emplace_back(h);
 _pat.mandatory.emplace_back(h);
 
-// Doing the below wrecks ChoiceLinkUTest
-//PatternTermPtr term(make_term_tree(h));
-//term->markLiteral();
-//_pat.pmandatory.push_back(term);
+PatternTermPtr term(make_term_tree(h));
+term->markChoice();
+_pat.pmandatory.push_back(term);
 		return true;
 	}
 
@@ -1145,24 +1142,6 @@ void PatternLink::check_satisfiability(const HandleSet& vars,
 			throw SyntaxException(TRACE_INFO,
 				"Poorly-formed query; a variable declaration for %s is needed!",
 				v->to_short_string().c_str());
-	}
-}
-
-void PatternLink::make_term_trees()
-{
-	for (const Handle& clause : _pat.mandatory)
-	{
-		auto done_already = [&](const PatternTermPtr& pman)
-		{
-			return pman->getHandle() == clause;
-		};
-		auto it = std::find_if(_pat.pmandatory.begin(),
-		            _pat.pmandatory.end(), done_already);
-		if (_pat.pmandatory.end() == it)
-		{
-			PatternTermPtr root_term(make_term_tree(clause));
-			_pat.pmandatory.push_back(root_term);
-		}
 	}
 }
 

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -51,30 +51,9 @@ void PatternLink::common_init(void)
 		return;
 	}
 
-	// Compute the intersection of literal clauses, and mandatory
-	// clauses. This is the set of mandatory clauses that must be
-	// present in thier literal form.
-	for (const PatternTermPtr& ptm : _pat.pmandatory)
-	{
-		if (std::find(_pat.literal_clauses.begin(), _pat.literal_clauses.end(),
-		              ptm->getHandle())
-			 != _pat.literal_clauses.end())
-		_fixed.push_back(ptm->getHandle());
-	}
-
 	// Locate the black-box and clear-box clauses.
 	unbundle_virtual(_pat.undeclared_clauses);
 	_num_virts = _virtual.size();
-
-	// Make sure every variable appears in some concrete
-	// (non-evaluatable) clause. This consists of non-evaluatable
-	// mandatory clauses and clauses which must be absent.
-	// Otherwise, we risk not being able to evaluate a clause
-	// with some ungrounded variable.
-	HandleSeq concrete_clauses(_fixed);
-	for (const PatternTermPtr& ptm : _pat.absents)
-		concrete_clauses.emplace_back(ptm->getHandle());
-	validate_variables(_variables.varset, concrete_clauses);
 
 	// unbundle_virtual does not handle connectives. Here, we assume that
 	// we are being run with the TermMatchMixin, and so we assume
@@ -103,6 +82,27 @@ void PatternLink::common_init(void)
 	}
 
 	add_dummies();
+
+	// Compute the intersection of literal clauses, and mandatory
+	// clauses. This is the set of mandatory clauses that must be
+	// present in thier literal form.
+	for (const PatternTermPtr& ptm : _pat.pmandatory)
+	{
+		if (std::find(_pat.literal_clauses.begin(), _pat.literal_clauses.end(),
+		              ptm->getHandle())
+			 != _pat.literal_clauses.end())
+		_fixed.push_back(ptm->getHandle());
+	}
+
+	// Make sure every variable appears in some concrete
+	// (non-evaluatable) clause. This consists of non-evaluatable
+	// mandatory clauses and clauses which must be absent.
+	// Otherwise, we risk not being able to evaluate a clause
+	// with some ungrounded variable.
+	HandleSeq concrete_clauses(_fixed);
+	for (const PatternTermPtr& ptm : _pat.absents)
+		concrete_clauses.emplace_back(ptm->getHandle());
+	validate_variables(_variables.varset, concrete_clauses);
 
 	// Split the non-virtual clauses into connected components
 	get_bridged_components(_variables.varset, _fixed, _pat.optionals,

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -88,10 +88,8 @@ void PatternLink::common_init(void)
 	// present in thier literal form.
 	for (const PatternTermPtr& ptm : _pat.pmandatory)
 	{
-		if (std::find(_pat.literal_clauses.begin(), _pat.literal_clauses.end(),
-		              ptm->getHandle())
-			 != _pat.literal_clauses.end())
-		_fixed.push_back(ptm->getHandle());
+		if (ptm->isLiteral() or ptm->isPresent() or ptm->isChoice())
+			_fixed.push_back(ptm->getHandle());
 	}
 
 	// Make sure every variable appears in some concrete

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -54,10 +54,10 @@ void PatternLink::common_init(void)
 	// Compute the intersection of literal clauses, and mandatory
 	// clauses. This is the set of mandatory clauses that must be
 	// present in thier literal form.
-	for (const Handle& h : _pat.literal_clauses)
+	for (const Handle& h : _pat.mandatory)
 	{
-		if (std::find(_pat.mandatory.begin(), _pat.mandatory.end(), h)
-			 != _pat.mandatory.end())
+		if (std::find(_pat.literal_clauses.begin(), _pat.literal_clauses.end(), h)
+			 != _pat.literal_clauses.end())
 		_fixed.push_back(h);
 	}
 

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -256,15 +256,14 @@ PatternLink::PatternLink(const HandleSet& vars,
 		{
 			_pat.mandatory.emplace_back(h);
 
-			// PatternTermPtr term(make_term_tree(h));
-			// _pat.pmandatory.push_back(term);
+			PatternTermPtr term(make_term_tree(h));
+			_pat.pmandatory.push_back(term);
 		}
 	}
 	locate_defines(compo);
 
 	// The rest is easy: the evaluatables and the connection map
 	unbundle_virtual(_pat.mandatory);
-	make_term_trees();
 
 	_num_virts = _virtual.size();
 	OC_ASSERT (0 == _num_virts, "Must not have any virtuals!");

--- a/opencog/atoms/pattern/PatternLink.h
+++ b/opencog/atoms/pattern/PatternLink.h
@@ -175,7 +175,7 @@ public:
 	const HandleSeq& get_component_patterns(void) const
 		{ return _component_patterns; }
 
-	// Return the list of fixed and virtual clauses we are holding.
+	// Return the list virtual clauses we are holding.
 	const HandleSeq& get_virtual(void) const { return _virtual; }
 
 	void debug_log(void) const;

--- a/opencog/atoms/pattern/PatternLink.h
+++ b/opencog/atoms/pattern/PatternLink.h
@@ -111,7 +111,7 @@ protected:
 	                          const TypeSet&,
 	                          bool reverse=false);
 
-	void locate_defines(const HandleSeq& clauses);
+	void locate_defines(const PatternTermSeq& clauses);
 	void validate_variables(HandleSet& vars,
 	                        const HandleSeq& clauses);
 

--- a/opencog/atoms/pattern/PatternLink.h
+++ b/opencog/atoms/pattern/PatternLink.h
@@ -122,10 +122,6 @@ protected:
 
 	void add_dummies(void);
 
-	void trace_connectives(const TypeSet&,
-	                       const Handle& body,
-	                       Quotation quotation=Quotation());
-
 	void make_connectivity_map(void);
 	void make_map_recursive(const Handle&, const PatternTermPtr&);
 	void check_connectivity(const HandleSeqSeq&);

--- a/opencog/atoms/pattern/PatternLink.h
+++ b/opencog/atoms/pattern/PatternLink.h
@@ -94,7 +94,7 @@ protected:
 	/// by determining if the virtual clasues that tie them together
 	/// are true or not.
 	///
-	HandleSeq _fixed;
+	PatternTermSeq _fixed;
 	size_t _num_virts;
 	HandleSeq _virtual;
 

--- a/opencog/atoms/pattern/PatternLink.h
+++ b/opencog/atoms/pattern/PatternLink.h
@@ -116,7 +116,6 @@ protected:
 	                        const HandleSeq& clauses);
 
 	bool is_virtual(const Handle&);
-	void unbundle_virtual(const HandleSeq& clauses);
 
 	void locate_cacheable(const PatternTermSeq& clauses);
 

--- a/opencog/atoms/pattern/PatternLink.h
+++ b/opencog/atoms/pattern/PatternLink.h
@@ -120,7 +120,7 @@ protected:
 
 	void locate_cacheable(const PatternTermSeq& clauses);
 
-	void add_dummies(void);
+	void add_dummies(const PatternTermPtr&);
 
 	void make_connectivity_map(void);
 	void make_map_recursive(const Handle&, const PatternTermPtr&);

--- a/opencog/atoms/pattern/PatternLink.h
+++ b/opencog/atoms/pattern/PatternLink.h
@@ -177,7 +177,6 @@ public:
 		{ return _component_patterns; }
 
 	// Return the list of fixed and virtual clauses we are holding.
-	const HandleSeq& get_fixed(void) const { return _fixed; }
 	const HandleSeq& get_virtual(void) const { return _virtual; }
 
 	void debug_log(void) const;

--- a/opencog/atoms/pattern/PatternLink.h
+++ b/opencog/atoms/pattern/PatternLink.h
@@ -120,7 +120,7 @@ protected:
 
 	void locate_cacheable(const HandleSeq& clauses);
 
-	bool add_dummies();
+	void add_dummies(void);
 
 	void trace_connectives(const TypeSet&,
 	                       const Handle& body,

--- a/opencog/atoms/pattern/PatternLink.h
+++ b/opencog/atoms/pattern/PatternLink.h
@@ -132,7 +132,6 @@ protected:
 	void check_satisfiability(const HandleSet&,
 	                          const HandleSetSeq&);
 
-	void make_term_trees();
 	PatternTermPtr make_term_tree(const Handle&);
 	void make_term_tree_recursive(const PatternTermPtr&,
 	                              PatternTermPtr&);

--- a/opencog/atoms/pattern/PatternLink.h
+++ b/opencog/atoms/pattern/PatternLink.h
@@ -118,7 +118,7 @@ protected:
 	bool is_virtual(const Handle&);
 	void unbundle_virtual(const HandleSeq& clauses);
 
-	void locate_cacheable(const HandleSeq& clauses);
+	void locate_cacheable(const PatternTermSeq& clauses);
 
 	void add_dummies(void);
 

--- a/opencog/atoms/pattern/PatternTerm.cc
+++ b/opencog/atoms/pattern/PatternTerm.cc
@@ -27,6 +27,7 @@ PatternTerm::PatternTerm(void)
 	  _is_globby_var(false),
 	  _has_any_evaluatable(false),
 	  _has_evaluatable(false),
+	  _is_black_box(false),
 	  _has_any_unordered_link(false),
 	  _is_literal(false),
 	  _is_present(false),
@@ -47,6 +48,7 @@ PatternTerm::PatternTerm(const PatternTermPtr& parent, const Handle& h)
 	  _is_globby_var(false),
 	  _has_any_evaluatable(false),
 	  _has_evaluatable(false),
+	  _is_black_box(false),
 	  _has_any_unordered_link(false),
 	  _is_literal(false),
 	  _is_present(false),
@@ -211,6 +213,16 @@ void PatternTerm::addEvaluatable()
 		_parent->_has_evaluatable = true;
 
 	addAnyEvaluatable();
+}
+
+// ==============================================================
+
+void PatternTerm::markBlackBox()
+{
+	// If quoted, it cannot be evaluated.
+	if (isQuoted()) return;
+
+	_is_black_box = true;
 }
 
 // ==============================================================

--- a/opencog/atoms/pattern/PatternTerm.cc
+++ b/opencog/atoms/pattern/PatternTerm.cc
@@ -27,7 +27,7 @@ PatternTerm::PatternTerm(void)
 	  _is_globby_var(false),
 	  _has_any_evaluatable(false),
 	  _has_evaluatable(false),
-	  _is_black_box(false),
+	  _is_virtual(false),
 	  _has_any_unordered_link(false),
 	  _is_literal(false),
 	  _is_present(false),
@@ -48,7 +48,7 @@ PatternTerm::PatternTerm(const PatternTermPtr& parent, const Handle& h)
 	  _is_globby_var(false),
 	  _has_any_evaluatable(false),
 	  _has_evaluatable(false),
-	  _is_black_box(false),
+	  _is_virtual(false),
 	  _has_any_unordered_link(false),
 	  _is_literal(false),
 	  _is_present(false),
@@ -217,12 +217,12 @@ void PatternTerm::addEvaluatable()
 
 // ==============================================================
 
-void PatternTerm::markBlackBox()
+void PatternTerm::markVirtual()
 {
 	// If quoted, it cannot be evaluated.
 	if (isQuoted()) return;
 
-	_is_black_box = true;
+	_is_virtual = true;
 }
 
 // ==============================================================

--- a/opencog/atoms/pattern/PatternTerm.cc
+++ b/opencog/atoms/pattern/PatternTerm.cc
@@ -141,7 +141,7 @@ void PatternTerm::addAnyBoundVar()
 	if (not _has_any_bound_var)
 	{
 		_has_any_bound_var = true;
-		if (_parent != PatternTerm::UNDEFINED)
+		if (_parent->_handle)
 			_parent->addAnyBoundVar();
 	}
 }
@@ -158,7 +158,7 @@ void PatternTerm::addBoundVariable()
 	// Mark just this term (the variable itself)
 	// and mark the term that holds us.
 	_is_bound_var = true;
-	if (_parent != PatternTerm::UNDEFINED)
+	if (_parent->_handle)
 			_parent->_has_bound_var = true;
 
 	// Mark recursively, all the way to the root.
@@ -173,7 +173,7 @@ void PatternTerm::addAnyGlobbyVar()
 	if (not _has_any_globby_var)
 	{
 		_has_any_globby_var = true;
-		if (_parent != PatternTerm::UNDEFINED)
+		if (_parent->_handle)
 			_parent->addAnyGlobbyVar();
 	}
 }
@@ -184,7 +184,7 @@ void PatternTerm::addGlobbyVar()
 
 	_is_globby_var = true;
 
-	if (_parent != PatternTerm::UNDEFINED)
+	if (_parent->_handle)
 		_parent->_has_globby_var = true;
 
 	addAnyGlobbyVar();
@@ -196,19 +196,18 @@ void PatternTerm::addGlobbyVar()
 
 void PatternTerm::addAnyEvaluatable()
 {
-	if (not _has_any_evaluatable)
-	{
-		_has_any_evaluatable = true;
-		if (_parent != PatternTerm::UNDEFINED)
-			_parent->addAnyEvaluatable();
-	}
+	if (_has_any_evaluatable) return;
+
+	_has_any_evaluatable = true;
+	if (_parent->_handle)
+		_parent->addAnyEvaluatable();
 }
 
 void PatternTerm::addEvaluatable()
 {
 	_has_evaluatable = true;
 
-	if (_parent != PatternTerm::UNDEFINED)
+	if (_parent->_handle)
 		_parent->_has_evaluatable = true;
 
 	addAnyEvaluatable();
@@ -221,7 +220,7 @@ void PatternTerm::addUnorderedLink()
 	if (_has_any_unordered_link) return;
 
 	_has_any_unordered_link = true;
-	if (_parent != PatternTerm::UNDEFINED)
+	if (_parent->_handle)
 		_parent->addUnorderedLink();
 }
 
@@ -232,6 +231,8 @@ void PatternTerm::markLiteral()
 	if (_is_literal) return;
 
 	_is_literal = true;
+	_has_evaluatable = false;
+	_has_any_evaluatable = false;
 	for (PatternTermPtr& ptm : getOutgoingSet())
 		ptm->markLiteral();
 }

--- a/opencog/atoms/pattern/PatternTerm.h
+++ b/opencog/atoms/pattern/PatternTerm.h
@@ -115,6 +115,7 @@ protected:
 	// As above, but for evaluatables.
 	bool _has_any_evaluatable;
 	bool _has_evaluatable;
+	bool _is_black_box;
 
 	// True if any pattern subtree rooted in this tree node contains
 	// an unordered link. Trees without any unordered links can be
@@ -212,6 +213,9 @@ public:
 	void addEvaluatable();
 	bool hasAnyEvaluatable() const noexcept { return _has_any_evaluatable; }
 	bool hasEvaluatable() const noexcept { return _has_evaluatable; }
+
+	void markBlackBox();
+	bool isBlackBox() const noexcept { return _is_black_box; }
 
 	void addUnorderedLink();
 	bool hasUnorderedLink() const noexcept { return _has_any_unordered_link; }

--- a/opencog/atoms/pattern/PatternTerm.h
+++ b/opencog/atoms/pattern/PatternTerm.h
@@ -115,7 +115,10 @@ protected:
 	// As above, but for evaluatables.
 	bool _has_any_evaluatable;
 	bool _has_evaluatable;
-	bool _is_black_box;
+
+	// An evaluatable term, with two or more variables in it.
+	// In general, these bridge across components.
+	bool _is_virtual;
 
 	// True if any pattern subtree rooted in this tree node contains
 	// an unordered link. Trees without any unordered links can be
@@ -214,8 +217,8 @@ public:
 	bool hasAnyEvaluatable() const noexcept { return _has_any_evaluatable; }
 	bool hasEvaluatable() const noexcept { return _has_evaluatable; }
 
-	void markBlackBox();
-	bool isBlackBox() const noexcept { return _is_black_box; }
+	void markVirtual();
+	bool isVirtual() const noexcept { return _is_virtual; }
 
 	void addUnorderedLink();
 	bool hasUnorderedLink() const noexcept { return _has_any_unordered_link; }

--- a/opencog/atoms/pattern/PatternTerm.h
+++ b/opencog/atoms/pattern/PatternTerm.h
@@ -167,6 +167,11 @@ public:
 
 	PatternTermPtr getParent() const noexcept { return _parent; }
 	bool isDescendant(const PatternTermPtr&) const;
+	PatternTermPtr getRoot() noexcept {
+		PatternTermPtr root = shared_from_this();
+		while (root->_parent->_handle) root = _parent;
+		return root;
+	}
 
 	PatternTermPtr addOutgoingTerm(const Handle&);
 	PatternTermSeq getOutgoingSet() const;

--- a/opencog/atoms/pattern/PatternUtils.cc
+++ b/opencog/atoms/pattern/PatternUtils.cc
@@ -172,11 +172,21 @@ void get_connected_components(const HandleSet& vars,
 }
 
 void get_bridged_components(const HandleSet& vars,
-                            const HandleSeq& nonopts,
-                            const HandleSeq& opts,
+                            const PatternTermSeq& prsnts,
+                            const PatternTermSeq& absnts,
                             HandleSeqSeq& components,
                             HandleSetSeq& component_vars)
 {
+	HandleSeq nonopts;
+	for (const PatternTermPtr& ptm: prsnts)
+		nonopts.emplace_back(ptm->getHandle());
+		// nonopts.emplace_back(ptm->isQuoted() ? ptm->getQuote() : ptm->getHandle());
+
+	HandleSeq opts;
+	for (const PatternTermPtr& ptm: absnts)
+		opts.emplace_back(ptm->getHandle());
+		// opts.emplace_back(ptm->isQuoted() ? ptm->getQuote() : ptm->getHandle());
+
 	if (0 == opts.size())
 	{
 		get_connected_components(vars, nonopts, components, component_vars);

--- a/opencog/atoms/pattern/PatternUtils.cc
+++ b/opencog/atoms/pattern/PatternUtils.cc
@@ -179,13 +179,11 @@ void get_bridged_components(const HandleSet& vars,
 {
 	HandleSeq nonopts;
 	for (const PatternTermPtr& ptm: prsnts)
-		nonopts.emplace_back(ptm->getHandle());
-		// nonopts.emplace_back(ptm->isQuoted() ? ptm->getQuote() : ptm->getHandle());
+		nonopts.emplace_back(ptm->isQuoted() ? ptm->getQuote() : ptm->getHandle());
 
 	HandleSeq opts;
 	for (const PatternTermPtr& ptm: absnts)
-		opts.emplace_back(ptm->getHandle());
-		// opts.emplace_back(ptm->isQuoted() ? ptm->getQuote() : ptm->getHandle());
+		opts.emplace_back(ptm->isQuoted() ? ptm->getQuote() : ptm->getHandle());
 
 	if (0 == opts.size())
 	{

--- a/opencog/atoms/pattern/PatternUtils.cc
+++ b/opencog/atoms/pattern/PatternUtils.cc
@@ -30,16 +30,13 @@ namespace opencog {
 bool is_black_box(const Handle& clause)
 {
 	return
-		contains_atomtype(clause, GROUNDED_PREDICATE_NODE)
-		or contains_atomtype(clause, GROUNDED_SCHEMA_NODE);
+		contains_atomtype(clause, GROUNDED_PREDICATE_NODE);
 }
 
 bool can_evaluate(const Handle& clause)
 {
 	Type ct = clause->get_type();
 	bool evaluatable =
-		TRUE_LINK == ct or FALSE_LINK == ct or
-
 		// If it is an EvaluatableLink, then is is evaluatable,
 		// unless it is one of the pattern-matching links, or
 		// if it is a non-gpn EvaluationLink (i.e. a plain

--- a/opencog/atoms/pattern/PatternUtils.cc
+++ b/opencog/atoms/pattern/PatternUtils.cc
@@ -52,7 +52,8 @@ bool can_evaluate(const Handle& clause)
 		   and not (CHOICE_LINK == ct)
 		   and (not (EVALUATION_LINK == ct)
 		      or 0 == clause->get_arity()
-		      or clause->getOutgoingAtom(0)->get_type() != PREDICATE_NODE))
+		      or (clause->getOutgoingAtom(0)->get_type() != PREDICATE_NODE
+		      and clause->getOutgoingAtom(0)->get_type() != VARIABLE_NODE)))
 
 		// XXX FIXME Are the below needed?
 		or contains_atomtype(clause, DEFINED_PREDICATE_NODE)

--- a/opencog/atoms/pattern/PatternUtils.cc
+++ b/opencog/atoms/pattern/PatternUtils.cc
@@ -27,6 +27,13 @@ using namespace opencog;
 
 namespace opencog {
 
+bool is_black_box(const Handle& clause)
+{
+	return
+		contains_atomtype(clause, GROUNDED_PREDICATE_NODE)
+		or contains_atomtype(clause, GROUNDED_SCHEMA_NODE);
+}
+
 bool can_evaluate(const Handle& clause)
 {
 	Type ct = clause->get_type();
@@ -44,8 +51,7 @@ bool can_evaluate(const Handle& clause)
 		// XXX FIXME Are the below needed?
 		or contains_atomtype(clause, DEFINED_PREDICATE_NODE)
 		or contains_atomtype(clause, DEFINED_SCHEMA_NODE)
-		or contains_atomtype(clause, GROUNDED_PREDICATE_NODE)
-		or contains_atomtype(clause, GROUNDED_SCHEMA_NODE);
+		or is_black_box(clause);
 
 	return evaluatable;
 }

--- a/opencog/atoms/pattern/PatternUtils.cc
+++ b/opencog/atoms/pattern/PatternUtils.cc
@@ -41,9 +41,15 @@ bool can_evaluate(const Handle& clause)
 		TRUE_LINK == ct or FALSE_LINK == ct or
 
 		// If it is an EvaluatableLink, then is is evaluatable,
+		// unless it is one of the pattern-matching links, or
+		// if it is a non-gpn EvaluationLink (i.e. a plain
+		// old PredicateNode style EvaluationLink).
 		// unless it is a closed (variable-free) EvaluationLink
 		// over a PredicateNode.
 		(nameserver().isA(ct, EVALUATABLE_LINK)
+		   and not (PRESENT_LINK == ct)
+		   and not (ABSENT_LINK == ct)
+		   and not (CHOICE_LINK == ct)
 		   and (not (EVALUATION_LINK == ct)
 		      or 0 == clause->get_arity()
 		      or clause->getOutgoingAtom(0)->get_type() != PREDICATE_NODE))

--- a/opencog/atoms/pattern/PatternUtils.cc
+++ b/opencog/atoms/pattern/PatternUtils.cc
@@ -52,8 +52,8 @@ bool can_evaluate(const Handle& clause)
 		   and not (CHOICE_LINK == ct)
 		   and (not (EVALUATION_LINK == ct)
 		      or 0 == clause->get_arity()
-		      or (clause->getOutgoingAtom(0)->get_type() != PREDICATE_NODE
-		      and clause->getOutgoingAtom(0)->get_type() != VARIABLE_NODE)))
+		      or nameserver().isA(clause->getOutgoingAtom(0)->get_type(),
+		                          EVALUATABLE_LINK)))
 
 		// XXX FIXME Are the below needed?
 		or contains_atomtype(clause, DEFINED_PREDICATE_NODE)

--- a/opencog/atoms/pattern/PatternUtils.h
+++ b/opencog/atoms/pattern/PatternUtils.h
@@ -52,8 +52,8 @@ void get_connected_components(const HandleSet& vars,
                               HandleSetSeq& compvars);
 
 void get_bridged_components(const HandleSet& vars,
-                            const HandleSeq& clauses,
-                            const HandleSeq& opts,
+                            const PatternTermSeq& clauses,
+                            const PatternTermSeq& opts,
                             HandleSeqSeq& compset,
                             HandleSetSeq& compvars);
 

--- a/opencog/atoms/pattern/PatternUtils.h
+++ b/opencog/atoms/pattern/PatternUtils.h
@@ -42,6 +42,9 @@ bool can_evaluate(const Handle& clause);
 // Return true iff the clause is constant.
 bool is_constant(const HandleSet& vars, const Handle& clause);
 
+// Return true iff the clause is a "black box" evaluatable.
+bool is_black_box(const Handle& clause);
+
 // See C file for description
 void get_connected_components(const HandleSet& vars,
                               const HandleSeq& clauses,

--- a/opencog/atoms/pattern/QueryLink.cc
+++ b/opencog/atoms/pattern/QueryLink.cc
@@ -193,7 +193,7 @@ QueueValuePtr QueryLink::do_execute(AtomSpace* as, bool silent)
 	const Pattern& pat = this->get_pattern();
 	TermMatchMixin* intu =
 		dynamic_cast<TermMatchMixin*>(&impl);
-	if (0 == pat.mandatory.size() and 0 < pat.optionals.size()
+	if (0 == pat.pmandatory.size() and 0 < pat.absents.size()
 	    and not intu->optionals_present())
 	{
 		qv->open();

--- a/opencog/query/InitiateSearchMixin.cc
+++ b/opencog/query/InitiateSearchMixin.cc
@@ -751,8 +751,10 @@ bool InitiateSearchMixin::setup_link_type_search()
 	if (PatternTerm::UNDEFINED == _root)
 		return false;
 
-	DO_LOG({LAZY_LOG_FINE << "Start clause is: " << std::endl
-	                      << _root->getHandle()->to_string();})
+	DO_LOG({const Handle& s =
+		_root->isQuoted() ? _root->getQuote() : _root->getHandle();
+		LAZY_LOG_FINE << "Start clause is: " << std::endl
+		              << s->to_string();})
 	DO_LOG({LAZY_LOG_FINE << "Start term is: " << std::endl
 	                      << _starter_term->to_string();})
 

--- a/opencog/query/InitiateSearchMixin.cc
+++ b/opencog/query/InitiateSearchMixin.cc
@@ -495,7 +495,7 @@ bool InitiateSearchMixin::perform_search(PatternMatchCallback& pmc)
 	{
 		PatternMatchEngine pme(pmc);
 		pme.set_pattern(*_variables, *_pattern);
-		return pme.explore_constant_evaluatables(_pattern->mandatory);
+		return pme.explore_constant_evaluatables(_pattern->pmandatory);
 	}
 
 	DO_LOG({logger().fine("Cannot use no-var search, use deep-type search");})

--- a/opencog/query/InitiateSearchMixin.cc
+++ b/opencog/query/InitiateSearchMixin.cc
@@ -224,7 +224,6 @@ InitiateSearchMixin::find_starter_recursive(const Handle& h, size_t& depth,
  * exist in the atomspace, anyway.
  */
 Handle InitiateSearchMixin::find_thinnest(const PatternTermSeq& clauses,
-                                          const HandleSet& evl,
                                           Handle& starter_term,
                                           PatternTermPtr& bestclause)
 {
@@ -238,7 +237,7 @@ Handle InitiateSearchMixin::find_thinnest(const PatternTermSeq& clauses,
 	for (const PatternTermPtr& ptm: clauses)
 	{
 		// Cannot start with an evaluatable clause!
-		if (0 < evl.count(ptm->getHandle())) continue;
+		if (ptm->hasAnyEvaluatable()) continue;
 
 		_curr_clause = ptm;
 		size_t depth = 0;
@@ -327,8 +326,7 @@ bool InitiateSearchMixin::setup_neighbor_search(void)
 	// no constants in them at all.  In this case, the search is
 	// performed by looping over all links of the given types.
 	PatternTermPtr bestclause;
-	Handle best_start = find_thinnest(clauses, _pattern->evaluatable_holders,
-	                                  _starter_term, bestclause);
+	Handle best_start = find_thinnest(clauses, _starter_term, bestclause);
 
 	// Cannot find a starting point! This can happen if:
 	// 1) all of the clauses contain nothing but variables,
@@ -795,7 +793,7 @@ bool InitiateSearchMixin::setup_variable_search(void)
 	bool all_clauses_are_evaluatable = true;
 	for (const PatternTermPtr& cl : clauses)
 	{
-		if (0 < _pattern->evaluatable_holders.count(cl->getHandle())) continue;
+		if (cl->hasAnyEvaluatable()) continue;
 		all_clauses_are_evaluatable = false;
 		break;
 	}
@@ -836,7 +834,7 @@ bool InitiateSearchMixin::setup_variable_search(void)
 				// they are all evaluatable, in which case we pick a clause
 				// that has a variable with the narrowest type-membership.
 				if (not all_clauses_are_evaluatable and
-				    0 < _pattern->evaluatable_holders.count(cl->getHandle())) continue;
+				    cl->hasAnyEvaluatable()) continue;
 
 				if (cl->getHandle() == var)
 				{
@@ -907,7 +905,7 @@ bool InitiateSearchMixin::setup_variable_search(void)
 		// the EvaluationLinks to be evaluated later.
 		for (const PatternTermPtr& m : _pattern->pmandatory)
 		{
-			if (0 == _pattern->evaluatable_holders.count(m->getHandle()))
+			if (not m->hasAnyEvaluatable())
 			{
 				_root = m;
 				_starter_term = m->getHandle();

--- a/opencog/query/InitiateSearchMixin.cc
+++ b/opencog/query/InitiateSearchMixin.cc
@@ -303,7 +303,7 @@ bool InitiateSearchMixin::setup_neighbor_search(void)
 	bool try_optionals = true;
 	for (const PatternTermPtr& m : _pattern->pmandatory)
 	{
-		if (0 == _pattern->evaluatable_holders.count(m->getHandle()))
+		if (not m->hasAnyEvaluatable())
 		{
 			try_optionals = false;
 			break;
@@ -734,7 +734,7 @@ bool InitiateSearchMixin::setup_link_type_search()
 	{
 		// Evaluatables don't exist in the atomspace, in general.
 		// Cannot start a search with them.
-		if (0 < _pattern->evaluatable_holders.count(cl->getHandle())) continue;
+		if (cl->hasAnyEvaluatable()) continue;
 		const size_t prev = count;
 		find_rarest(cl, _starter_term, count);
 		if (count < prev)

--- a/opencog/query/InitiateSearchMixin.h
+++ b/opencog/query/InitiateSearchMixin.h
@@ -63,7 +63,6 @@ protected:
 
 	const Variables* _variables;
 	const Pattern* _pattern;
-	const HandleSet* _dynamic;
 	bool _recursing;
 
 	PatternTermPtr _root;
@@ -79,9 +78,10 @@ protected:
 	PatternTermPtr _curr_clause;
 	std::vector<Choice> _choices;
 
-	virtual Handle find_starter(const Handle&, size_t&, Handle&, size_t&);
-	virtual Handle find_starter_recursive(const Handle&, size_t&, Handle&,
-	                                      size_t&);
+	virtual Handle find_starter(const PatternTermPtr&,
+	                            size_t&, Handle&, size_t&);
+	virtual Handle find_starter_recursive(const PatternTermPtr&,
+	                                      size_t&, Handle&, size_t&);
 	virtual Handle find_thinnest(const PatternTermSeq&,
 	                             Handle&, PatternTermPtr&);
 	virtual void find_rarest(const PatternTermPtr&, Handle&,

--- a/opencog/query/InitiateSearchMixin.h
+++ b/opencog/query/InitiateSearchMixin.h
@@ -83,7 +83,6 @@ protected:
 	virtual Handle find_starter_recursive(const Handle&, size_t&, Handle&,
 	                                      size_t&);
 	virtual Handle find_thinnest(const PatternTermSeq&,
-	                             const HandleSet&,
 	                             Handle&, PatternTermPtr&);
 	virtual void find_rarest(const PatternTermPtr&, Handle&,
 	                         size_t&, Quotation quotation=Quotation());

--- a/opencog/query/PatternMatchCallback.h
+++ b/opencog/query/PatternMatchCallback.h
@@ -162,30 +162,18 @@ class PatternMatchCallback
 		 *
 		 * An 'evaluatable term' is any pattern term (term occuring in the
 		 * search pattern, either a node or link) that was  previously
-		 * declared as 'evaluatable', by the 'set_evaluatable_terms()'
-		 * callback below.  Thus, for example, the canonical, default
-		 * convention is that evaluatable terms are any terms that
-		 * contain a GPN -- a 'GroundedPredicateNode', and therefore
-		 * requires running code that lies outside of the pattern matcher
-		 * (typically scheme or python code).  In general, though,
-		 * evaluatable terms don't have to be of this sort -- they can
-		 * be any part of the search pattern that was previously
-		 * specified by the  'set_evaluatable_terms()' callback.
+		 * declared as 'evaluatable'.  The canonical, default convention
+		 * is that evaluatable terms are any terms that contain a GPN --
+		 * a 'GroundedPredicateNode', or are assorted relations, such
+		 * as EqualLink, GreaterThanLink, etc.  Evaluatables may also be
+		 * "connectives"; in the default canonical interpretation, these
+		 * are AndLink, OrLink, NotLink, SequentialAnd and SequentialOr.
 		 *
-		 * Connectives are any link types that were declared by the
-		 * 'get_connectives()' callback, below. Connectives are those
-		 * link types that are are able to combine evaluatable terms.
-		 * For example, the canonical, default connectives are logic
-		 * connectives: AndLink, OrLink, NotLink. They don't have to
-		 * be these, but, that is what they would be if emulating a
-		 * logic that uses the classical boolean logic values of
-		 * true/false.
-		 *
-		 * For another example, they might be SetUnion, SetIntersectionLink,
-		 * and SetComplimentLink if emulating a logic that uses probability
-		 * values for truth values (so, e.g. SetUnionLink would connect
-		 * the probability of A or B, i.e. it would compute P(A or B)
-		 * SetIntersectionLink would compute P(A and B), and so on.
+		 * The canonical interpretation is compiled in PatternLink. That
+		 * is, PatternLink performs a static analysis of the pattern, and
+		 * marks each term in the pattern as being evaluatable, or not.
+		 * Other pattern compilers are free to choose other conventions;
+		 * the pattern engine does not care.
 		 *
 		 * Unlike the other callbacks, this takes arguments in slightly
 		 * different form.  Here, 'eval' is the evaluatable term, and

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -2220,7 +2220,7 @@ void PatternMatchEngine::get_next_untried_clause(void)
 	if (get_next_thinnest_clause(false, false, false)) return;
 
 	// Don't bother looking for evaluatables if they are not there.
-	if (not _pat->evaluatable_holders.empty())
+	if (_pat->have_evaluatable_holders)
 	{
 		if (get_next_thinnest_clause(true, false, false)) return;
 		if (not _pat->black.empty())
@@ -2233,7 +2233,7 @@ void PatternMatchEngine::get_next_untried_clause(void)
 	if (not _pat->absents.empty())
 	{
 		if (get_next_thinnest_clause(false, false, true)) return;
-		if (not _pat->evaluatable_holders.empty())
+		if (_pat->have_evaluatable_holders)
 		{
 			if (get_next_thinnest_clause(true, false, true)) return;
 			if (not _pat->black.empty())

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -2183,10 +2183,10 @@ void PatternMatchEngine::get_next_untried_clause(void)
 	if (get_next_thinnest_clause(false, false, false)) return;
 
 	// Don't bother looking for evaluatables if they are not there.
-	if (_pat->have_evaluatable_holders)
+	if (_pat->have_evaluatables)
 	{
 		if (get_next_thinnest_clause(true, false, false)) return;
-		if (not _pat->black.empty())
+		if (_pat->have_black_boxes)
 		{
 			if (get_next_thinnest_clause(true, true, false)) return;
 		}
@@ -2196,10 +2196,10 @@ void PatternMatchEngine::get_next_untried_clause(void)
 	if (not _pat->absents.empty())
 	{
 		if (get_next_thinnest_clause(false, false, true)) return;
-		if (_pat->have_evaluatable_holders)
+		if (_pat->have_evaluatables)
 		{
 			if (get_next_thinnest_clause(true, false, true)) return;
-			if (not _pat->black.empty())
+			if (_pat->have_black_boxes)
 			{
 				if (get_next_thinnest_clause(true, true, true)) return;
 			}
@@ -2388,7 +2388,7 @@ bool PatternMatchEngine::get_next_thinnest_clause(bool search_virtual,
 			const PatternTermPtr& root = it->second;
 			if ((issued.end() == issued.find(root))
 			        and (search_virtual or not root->hasAnyEvaluatable())
-			        and (search_black or not is_black(root))
+			        and (search_black or not root->isBlackBox())
 			        and (search_absents or not root->isAbsent()))
 			{
 				unsigned int root_thickness = thickness(root, ungrounded_vars);
@@ -2409,7 +2409,7 @@ bool PatternMatchEngine::get_next_thinnest_clause(bool search_virtual,
 	// variable-free clauses run last. If the user wants to run them
 	// earlier, they can always use a SequentialAndLink.
 	if (not unsolved and search_virtual and
-		 (search_black or _pat->black.empty()))
+		 (search_black or not _pat->have_black_boxes))
 	{
 		for (const PatternTermPtr& root : _pat->pmandatory)
 		{

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -2634,6 +2634,7 @@ bool PatternMatchEngine::explore_neighborhood(const Handle& term,
 	clause_stacks_clear();
 	clear_current_state();
 	issued.insert(clause);
+	_nack_cache.clear();
 
 	bool halt = explore_clause(term, grnd, clause);
 	bool stop = report_forall();

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -1921,14 +1921,6 @@ bool PatternMatchEngine::do_term_up(const PatternTermPtr& ptm,
 		//    is too harsh. It may be in the middle of some function that
 		//    expects a boolean value as an argument. But I don't know of
 		//    any, just right now.
-		//
-		// Anyway, all of this talk abbout booleans is emphasizing the
-		// point that, someday, we need to replace this crisp logic with
-		// probabalistic logic of some sort.
-		//
-		// By the way, if we are here, then `hp` is surely a variable;
-		// or, at least, it is, if we are working in the canonical
-		// interpretation.
 
 		auto evra = _pat->in_evaluatable.equal_range(hp);
 		for (auto evit = evra.first; evit != evra.second; evit++)

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -2180,29 +2180,21 @@ void PatternMatchEngine::get_next_untried_clause(void)
 {
 	// First, try to ground all the mandatory clauses, only.
 	// no virtuals, no black boxes, no absents.
-	if (get_next_thinnest_clause(false, false, false)) return;
+	if (get_next_thinnest_clause(false, false)) return;
 
 	// Don't bother looking for evaluatables if they are not there.
 	if (_pat->have_evaluatables)
 	{
-		if (get_next_thinnest_clause(true, false, false)) return;
-		if (_pat->have_virtuals)
-		{
-			if (get_next_thinnest_clause(true, true, false)) return;
-		}
+		if (get_next_thinnest_clause(true, false)) return;
 	}
 
 	// Try again, this time, considering the absent clauses.
 	if (not _pat->absents.empty())
 	{
-		if (get_next_thinnest_clause(false, false, true)) return;
+		if (get_next_thinnest_clause(false, true)) return;
 		if (_pat->have_evaluatables)
 		{
-			if (get_next_thinnest_clause(true, false, true)) return;
-			if (_pat->have_virtuals)
-			{
-				if (get_next_thinnest_clause(true, true, true)) return;
-			}
+			if (get_next_thinnest_clause(true, true)) return;
 		}
 	}
 
@@ -2323,7 +2315,6 @@ Handle PatternMatchEngine::get_glob_embedding(const Handle& glob)
 ///
 /// Return true if we found the next ungrounded clause.
 bool PatternMatchEngine::get_next_thinnest_clause(bool search_eval,
-                                                  bool search_virtual,
                                                   bool search_absents)
 {
 	// Search for an as-yet ungrounded clause. Search for required
@@ -2388,7 +2379,6 @@ bool PatternMatchEngine::get_next_thinnest_clause(bool search_eval,
 			const PatternTermPtr& root = it->second;
 			if ((issued.end() == issued.find(root))
 			        and (search_eval or not root->hasAnyEvaluatable())
-			        and (search_virtual or not root->isVirtual())
 			        and (search_absents or not root->isAbsent()))
 			{
 				unsigned int root_thickness = thickness(root, ungrounded_vars);
@@ -2408,8 +2398,7 @@ bool PatternMatchEngine::get_next_thinnest_clause(bool search_eval,
 	// will not find them. Try these now. This means that the
 	// variable-free clauses run last. If the user wants to run them
 	// earlier, they can always use a SequentialAndLink.
-	if (not unsolved and search_eval and
-		 (search_virtual or not _pat->have_virtuals))
+	if (not unsolved and search_eval)
 	{
 		for (const PatternTermPtr& root : _pat->pmandatory)
 		{

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -2032,7 +2032,7 @@ bool PatternMatchEngine::clause_accept(const PatternTermPtr& clause,
 	}
 	if (not match) return false;
 
-	if (not is_evaluatable(clause))
+	if (not clause->hasAnyEvaluatable())
 	{
 		clause_grounding[clause_root] = hg;
 
@@ -2112,7 +2112,7 @@ bool PatternMatchEngine::do_next_clause(void)
 	DO_LOG({LAZY_LOG_FINE << "This clause is "
 		              << (do_clause->isAbsent()? "absent" : "required");})
 	DO_LOG({LAZY_LOG_FINE << "This clause is "
-		              << (is_evaluatable(do_clause)?
+		              << (do_clause->hasAnyEvaluatable()?
 		                  "dynamically evaluatable" : "non-dynamic");
 	logmsg("Joining variable is", joiner);
 	logmsg("Joining grounding is", var_grounding[joiner]); })
@@ -2432,7 +2432,7 @@ bool PatternMatchEngine::get_next_thinnest_clause(bool search_virtual,
 		{
 			const PatternTermPtr& root = it->second;
 			if ((issued.end() == issued.find(root))
-			        and (search_virtual or not is_evaluatable(root))
+			        and (search_virtual or not root->hasAnyEvaluatable())
 			        and (search_black or not is_black(root))
 			        and (search_absents or not root->isAbsent()))
 			{
@@ -2858,7 +2858,7 @@ bool PatternMatchEngine::explore_clause(const Handle& term,
                                         const PatternTermPtr& pclause)
 {
 	// Evaluatable clauses are not cacheable.
-	if (is_evaluatable(pclause))
+	if (pclause->hasAnyEvaluatable())
 		return explore_clause_evaluatable(term, grnd, pclause);
 
 	// Build the cache lookup key

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -2186,7 +2186,7 @@ void PatternMatchEngine::get_next_untried_clause(void)
 	if (_pat->have_evaluatables)
 	{
 		if (get_next_thinnest_clause(true, false, false)) return;
-		if (_pat->have_black_boxes)
+		if (_pat->have_virtuals)
 		{
 			if (get_next_thinnest_clause(true, true, false)) return;
 		}
@@ -2199,7 +2199,7 @@ void PatternMatchEngine::get_next_untried_clause(void)
 		if (_pat->have_evaluatables)
 		{
 			if (get_next_thinnest_clause(true, false, true)) return;
-			if (_pat->have_black_boxes)
+			if (_pat->have_virtuals)
 			{
 				if (get_next_thinnest_clause(true, true, true)) return;
 			}
@@ -2322,8 +2322,8 @@ Handle PatternMatchEngine::get_glob_embedding(const Handle& glob)
 /// else all clauses are considered.
 ///
 /// Return true if we found the next ungrounded clause.
-bool PatternMatchEngine::get_next_thinnest_clause(bool search_virtual,
-                                                  bool search_black,
+bool PatternMatchEngine::get_next_thinnest_clause(bool search_eval,
+                                                  bool search_virtual,
                                                   bool search_absents)
 {
 	// Search for an as-yet ungrounded clause. Search for required
@@ -2387,8 +2387,8 @@ bool PatternMatchEngine::get_next_thinnest_clause(bool search_virtual,
 		{
 			const PatternTermPtr& root = it->second;
 			if ((issued.end() == issued.find(root))
-			        and (search_virtual or not root->hasAnyEvaluatable())
-			        and (search_black or not root->isBlackBox())
+			        and (search_eval or not root->hasAnyEvaluatable())
+			        and (search_virtual or not root->isVirtual())
 			        and (search_absents or not root->isAbsent()))
 			{
 				unsigned int root_thickness = thickness(root, ungrounded_vars);
@@ -2408,8 +2408,8 @@ bool PatternMatchEngine::get_next_thinnest_clause(bool search_virtual,
 	// will not find them. Try these now. This means that the
 	// variable-free clauses run last. If the user wants to run them
 	// earlier, they can always use a SequentialAndLink.
-	if (not unsolved and search_virtual and
-		 (search_black or not _pat->have_black_boxes))
+	if (not unsolved and search_eval and
+		 (search_virtual or not _pat->have_virtuals))
 	{
 		for (const PatternTermPtr& root : _pat->pmandatory)
 		{

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -2956,12 +2956,14 @@ void PatternMatchEngine::clear_current_state(void)
 	issued.clear();
 }
 
-bool PatternMatchEngine::explore_constant_evaluatables(const HandleSeq& clauses)
+bool PatternMatchEngine::explore_constant_evaluatables(const PatternTermSeq& clauses)
 {
 	bool found = true;
-	for (const Handle& clause : clauses) {
-		if (is_in(clause, _pat->evaluatable_holders)) {
-			found = _pmc.evaluate_sentence(clause, GroundingMap());
+	for (const PatternTermPtr& clause : clauses)
+	{
+		if (clause->hasAnyEvaluatable())
+		{
+			found = _pmc.evaluate_sentence(clause->getHandle(), GroundingMap());
 			if (not found)
 				break;
 		}

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -168,7 +168,7 @@ private:
 	bool clause_accepted;
 	void get_next_untried_clause(void);
 	Handle get_glob_embedding(const Handle&);
-	bool get_next_thinnest_clause(bool, bool, bool);
+	bool get_next_thinnest_clause(bool, bool);
 	unsigned int thickness(const PatternTermPtr&, const HandleSet&);
 	PatternTermPtr next_clause;
 	Handle next_joint;

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -53,12 +53,6 @@ private:
 	const Variables* _variables;
 	const Pattern* _pat;
 
-	// XXX FIXME, change to call ptm->hasAnyEvaluatable().
-	bool is_evaluatable(const Handle& h) {
-		return (_pat->evaluatable_holders.count(h) != 0); }
-	bool is_evaluatable(const PatternTermPtr& ptm) {
-		return (_pat->evaluatable_holders.count(ptm->getHandle()) != 0); }
-
 	bool is_black(const PatternTermPtr& ptm) {
 		return (_pat->black.count(ptm->getHandle()) != 0); }
 

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -53,9 +53,6 @@ private:
 	const Variables* _variables;
 	const Pattern* _pat;
 
-	bool is_black(const PatternTermPtr& ptm) {
-		return (_pat->black.count(ptm->getHandle()) != 0); }
-
 	// -------------------------------------------
 	// Recursive redex support. These are stacks of the clauses
 	// above, that are being searched.

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -312,7 +312,7 @@ public:
 	// Evaluate constant evaluatable and ground it via the
 	// PatternMatchCallback. It is assumed that all clauses are
 	// connected by an AndLink.
-	bool explore_constant_evaluatables(const HandleSeq& clauses);
+	bool explore_constant_evaluatables(const PatternTermSeq& clauses);
 
 	// Handy-dandy utilities
 	static void print_solution(const GroundingMap &vars,

--- a/opencog/query/Satisfier.h
+++ b/opencog/query/Satisfier.h
@@ -52,6 +52,9 @@ class Satisfier :
 	public TermMatchMixin,
 	public SatisfyMixin
 {
+		Handle _pattern_body;
+		bool _have_variables;
+
 	public:
 		Satisfier(AtomSpace* as) :
 			InitiateSearchMixin(as),
@@ -69,6 +72,8 @@ class Satisfier :
 			_varseq = vars.varseq;
 			InitiateSearchMixin::set_pattern(vars, pat);
 			TermMatchMixin::set_pattern(vars, pat);
+			_have_variables = not vars.varseq.empty();
+			_pattern_body = pat.body;
 		}
 
 		// Return true if a satisfactory grounding has been

--- a/opencog/query/Satisfier.h
+++ b/opencog/query/Satisfier.h
@@ -52,6 +52,7 @@ class Satisfier :
 	public TermMatchMixin,
 	public SatisfyMixin
 {
+	public: // Arghhh. OpenPsi accesses these directly...
 		Handle _pattern_body;
 		bool _have_variables;
 

--- a/opencog/query/SatisfyMixin.cc
+++ b/opencog/query/SatisfyMixin.cc
@@ -401,7 +401,7 @@ bool SatisfyMixin::satisfy(const PatternLinkPtr& form)
 		PatternLinkPtr clp(PatternLinkCast(comp_patterns.at(i)));
 		const Pattern& pat(clp->get_pattern());
 		bool is_pure_absent = false;
-		if (pat.mandatory.size() == 0 and pat.absents.size() > 0)
+		if (pat.pmandatory.size() == 0 and pat.absents.size() > 0)
 			is_pure_absent = true;
 
 		// Pass through the callbacks, collect up answers.

--- a/opencog/query/TermMatchMixin.cc
+++ b/opencog/query/TermMatchMixin.cc
@@ -151,10 +151,6 @@ void TermMatchMixin::set_pattern(const Variables& vars,
                                  const Pattern& pat)
 {
 	_vars = &vars;
-	_dynamic = &pat.evaluatable_terms;
-	_have_evaluatables = ! _dynamic->empty();
-	_have_variables = ! vars.varseq.empty();
-	_pattern_body = pat.body;
 }
 
 /* ======================================================== */
@@ -297,11 +293,7 @@ bool TermMatchMixin::post_link_match(const Handle& lpat,
 		_gnd_bound_vars = nullptr;
 	}
 
-	// The if (STATE_LINK) below is a temp hack until we get a nicer
-	// solution, viz, get around to implementing executable terms in
-	// the search pattern. So: an executable term is anything that
-	// should be executed before the match is made... in this case,
-	// the StateLink has a single, unique closed-term value (or possibly
+	// The StateLink has a single, unique closed-term value (or possibly
 	// no value at all), and the check below discards all matches that
 	// aren't closed form, i.e. all StateLinks with a variable as state.
 	//
@@ -309,18 +301,9 @@ bool TermMatchMixin::post_link_match(const Handle& lpat,
 	// between the time that the search was started, and the time that
 	// we arrive here...
 	if (STATE_LINK == pattype)
-	{
 		return StateLinkCast(lgnd)->is_closed();
-	}
 
-	if (not _have_evaluatables) return true;
-	Handle hp(lpat);
-	if (_dynamic->find(hp) == _dynamic->end()) return true;
-
-	// We will find ourselves here whenever the link contains a
-	// GroundedPredicateNode. In this case, execute the node, and
-	// declare a match, or no match, depending on the resulting TV.
-	return EvaluationLink::crisp_evaluate(_as, lgnd);
+	return true;
 }
 
 void TermMatchMixin::post_link_mismatch(const Handle& lpat,

--- a/opencog/query/TermMatchMixin.cc
+++ b/opencog/query/TermMatchMixin.cc
@@ -770,9 +770,9 @@ bool TermMatchMixin::eval_sentence(const Handle& top,
 	{
 		// If *any* clause in the AbsentLink has been grounded, then
 		// return false.  That is, AbsentLink behaves like an AndLink
-		// for term-absence.  Note that this conflicts with
-		// PatternLink::extract_optionals(), which insists on an arity
-		// of one. Viz "must all be absent"? or "if any are absent"?
+		// for term-absence.  Note that this conflicts with static
+		// analysis in PatternLink, which insists on an arity of one.
+		// Viz "must all be absent"? or "if any are absent"?
 		//
 		// AbsentLink is same as NotLink PresentLink.
 		for (const Handle& h : oset)

--- a/opencog/query/TermMatchMixin.h
+++ b/opencog/query/TermMatchMixin.h
@@ -106,11 +106,6 @@ class TermMatchMixin : public virtual PatternMatchCallback
 		NameServer& _nameserver;
 
 		const Variables* _vars = nullptr;
-		const HandleSet* _dynamic = nullptr;
-		bool _have_evaluatables = false;
-
-		bool _have_variables;
-		Handle _pattern_body;
 
 		bool is_self_ground(const Handle&, const Handle&,
 		                    const GroundingMap&, const HandleSet&,

--- a/tests/atoms/container/true-join.scm
+++ b/tests/atoms/container/true-join.scm
@@ -61,3 +61,5 @@
 	(MaximalJoin
 		(TypedVariable (Variable "P") (Type 'PredicateNode))
 		(Present (Concept "B"))))
+
+; (cog-execute! max-const-ap)

--- a/tests/query/ConstantClausesUTest.cxxtest
+++ b/tests/query/ConstantClausesUTest.cxxtest
@@ -74,6 +74,7 @@ public:
 	void test_mixed_clauses_1();
 	void test_mixed_clauses_2();
 	void test_mixed_clauses_3();
+	void test_constant_present();
 };
 
 void ConstantClausesUTest::tearDown()
@@ -500,6 +501,21 @@ void ConstantClausesUTest::test_mixed_clauses_3()
 	logger().debug() << "more_expected = " << oc_to_string(more_expected);
 
 	TS_ASSERT_EQUALS(results, more_expected);
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+void ConstantClausesUTest::test_constant_present()
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+	eval.eval("(load-from-path \"constant-present.scm\")");
+
+	Handle results = eval.eval_h("(cog-execute! query)");
+	Handle expected = eval.eval_h("expected");
+
+	logger().debug() << " results = " << oc_to_string(results);
+	logger().debug() << "expected = " << oc_to_string(expected);
+
+	TS_ASSERT_EQUALS(results, expected);
 	logger().debug("END TEST: %s", __FUNCTION__);
 }
 

--- a/tests/query/DisconnectedUTest.cxxtest
+++ b/tests/query/DisconnectedUTest.cxxtest
@@ -196,6 +196,9 @@ void DisconnectedUTest::test_dancers(void)
 	Handle both(createLink(SET_LINK, ab, ba));
 	Handle ans = as->add_atom(both);
 
+	printf("Expected: %s\n", ans->to_string().c_str());
+	printf("     Got: %s\n",   h->to_string().c_str());
+
 	// They should be identical.
 	TSM_ASSERT("Wrong result", *ans == *h);
 

--- a/tests/query/ExecutionOutputUTest.cxxtest
+++ b/tests/query/ExecutionOutputUTest.cxxtest
@@ -253,6 +253,11 @@ void ExecutionOutputUTest::test_varsub(void)
 
 	// The result_list contains a list of the grounded expressions.
 	simpl.get_result_queue()->open();
+
+	// If it's empty, it will hang ...
+	TSM_ASSERT_EQUALS("no results returned",
+		false, simpl.get_result_queue()->is_empty());
+
 	Handle res = HandleCast(simpl.get_result_queue()->value_pop());
 	printf("res is %s\n", res->to_short_string().c_str());
 	TSM_ASSERT_EQUALS("incorrect resolution", res, resolution);

--- a/tests/query/NoExceptionUTest.cxxtest
+++ b/tests/query/NoExceptionUTest.cxxtest
@@ -65,6 +65,7 @@ public:
 	void tearDown();
 
 	void test_exception();
+	void test_bad_analysis();
 };
 
 /*
@@ -83,15 +84,14 @@ void NoExceptionUTest::tearDown(void)
 	as->clear();
 }
 
-// See no-exception.scm for comments. It's not clear though we want
-// that so it is disabled for now.
+// See no-exception.scm for comments.
 void NoExceptionUTest::test_exception()
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
 	std::string result = eval->eval("(load-from-path \"tests/query/no-exception.scm\")");
 	std::cout << "result = " << result;
-	
+
 	Handle bl = eval->eval_h("bl");
 	std::cout << "bl = " << oc_to_string(bl);
 
@@ -100,6 +100,19 @@ void NoExceptionUTest::test_exception()
 
 	// We expect NOT to catch an error.
 	TS_ASSERT_THROWS_NOTHING(bindlink(as, bl));
-	
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+// Pattern matcher mis-understood some EvlautationLinks.
+void NoExceptionUTest::test_bad_analysis()
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	eval->eval("(load-from-path \"tests/query/no-exception-analysis.scm\")");
+
+	// We expect NOT to catch an error.
+	TS_ASSERT_THROWS_NOTHING(eval->eval_h("(meet)"));
+
 	logger().debug("END TEST: %s", __FUNCTION__);
 }

--- a/tests/query/QuoteUTest.cxxtest
+++ b/tests/query/QuoteUTest.cxxtest
@@ -75,6 +75,7 @@ public:
     void test_exec_getlink(void);
     void test_quote_self(void);
     void test_quote_glob(void);
+    void test_quote_scope(void);
 };
 
 void QuoteUTest::tearDown(void)
@@ -362,6 +363,25 @@ void QuoteUTest::test_quote_glob(void)
     eval->eval("(load-from-path \"tests/query/quote-glob.scm\")");
 
     ValuePtr vp = eval->eval_v("(cog-execute! quote-glob)");
+    TS_ASSERT(nameserver().isA(vp->get_type(), LINK_VALUE));
+
+    HandleSeq hs(LinkValueCast(vp)->to_handle_seq());
+    TS_ASSERT_EQUALS(1, hs.size());
+
+    Handle ex = eval->eval_h("expect");
+    TS_ASSERT_EQUALS(ex, hs[0]);
+
+    logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+// URE meta-pattern
+void QuoteUTest::test_quote_scope(void)
+{
+    logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+    eval->eval("(load-from-path \"tests/query/quote-scope.scm\")");
+
+    ValuePtr vp = eval->eval_v("(cog-execute! quote-scope)");
     TS_ASSERT(nameserver().isA(vp->get_type(), LINK_VALUE));
 
     HandleSeq hs(LinkValueCast(vp)->to_handle_seq());

--- a/tests/query/constant-present.scm
+++ b/tests/query/constant-present.scm
@@ -1,0 +1,36 @@
+;
+; constant-present.scm
+;
+; Contains a constant clause insidde of a PresentLink.
+; This occurs naturally in the URE ForwardChainerUTest
+;
+
+(use-modules (opencog) (opencog exec))
+
+(Inheritance (Concept "B") (Concept "foo"))
+
+(define query
+	(Bind
+		(TypedVariable (Variable "$C-7a4842c1") (Type "Concept"))
+		(And
+			(Present
+				(Inheritance (Concept "A") (Concept "B"))
+				(Inheritance (Concept "B") (Variable "$C-7a4842c1")))
+			(Not (Identical (Variable "$C-7a4842c1") (Concept "A"))))
+		(Execution
+			(Schema "scm: fc-deduction-formula")
+			(List
+				(Inheritance (Concept "A") (Variable "$C-7a4842c1"))
+				(Inheritance (Concept "A") (Concept "B"))
+				(Inheritance (Concept "B") (Variable "$C-7a4842c1"))))))
+
+; (cog-execute! query)
+
+(define expected
+	(Set
+		(Execution
+			(Schema "scm: fc-deduction-formula")
+			(List
+				(Inheritance (Concept "A") (Concept "foo"))
+				(Inheritance (Concept "A") (Concept "B"))
+				(Inheritance (Concept "B") (Concept "foo"))))))

--- a/tests/query/get-link-equal.scm
+++ b/tests/query/get-link-equal.scm
@@ -89,6 +89,8 @@
               (VariableNode "$body")))))))
 )
 
+; (cog-execute! gl)
+
 (define expect
   (SetLink
     (ListLink

--- a/tests/query/no-exception-analysis.scm
+++ b/tests/query/no-exception-analysis.scm
@@ -1,0 +1,52 @@
+;
+; no-exception-analysis.scm
+;
+; Backward-chainer creates something like the following.
+; It triggered an exception during pattern analysis.
+; If the MeetLink can be creted without a throw, then test passes.
+;
+(use-modules (opencog) (opencog exec))
+
+(define (meet)
+(Meet
+  (VariableList
+    (TypedVariable (Variable "$who") (Type "ConceptNode"))
+    (TypedVariable (Variable "$B-7e054a97") (Type "ConceptNode"))
+    (TypedVariable (Variable "$y-281a7166") (Type "ConceptNode"))
+    (TypedVariable (Variable "$z-8b8dc93") (Type "ConceptNode"))
+  )
+  (And
+    (Evaluation
+      (GroundedPredicate "scm: true-enough")
+      (Inheritance (Concept "criminal") (Variable "$B-7e054a97")))
+    (Evaluation
+      (GroundedPredicate "scm: true-enough")
+      (And
+        (Evaluation
+          (Predicate "sell")
+          (List
+            (Variable "$who")
+            (Variable "$y-281a7166")
+            (Variable "$z-8b8dc93")))
+        (Inheritance (Variable "$who") (Concept "American"))
+        (Inheritance (Variable "$y-281a7166") (Concept "weapon"))
+        (Inheritance (Variable "$z-8b8dc93") (Concept "hostile"))))
+    (Not (Identical (Concept "criminal") (Variable "$who")))
+    (And
+      (Evaluation
+        (Predicate "sell")
+        (List
+          (Variable "$who")
+          (Variable "$y-281a7166")
+          (Variable "$z-8b8dc93")))
+      (Inheritance (Variable "$who") (Concept "American"))
+      (Inheritance (Variable "$y-281a7166") (Concept "weapon"))
+      (Inheritance (Variable "$z-8b8dc93") (Concept "hostile")))
+    (Present
+      (Inheritance (Variable "$B-7e054a97") (Concept "criminal"))
+      (Inheritance (Concept "criminal") (Variable "$B-7e054a97")))
+    (Evaluation
+      (GroundedPredicate "scm: true-enough")
+      (Inheritance (Variable "$B-7e054a97") (Concept "criminal")))
+    (Not (Identical (Concept "criminal") (Concept "criminal")))
+  )))

--- a/tests/query/quote-scope.scm
+++ b/tests/query/quote-scope.scm
@@ -1,0 +1,32 @@
+;
+; quote-scope.scm
+;
+; This shows up in the URE, as a meta-pattern searching for patterns.
+;
+(use-modules (opencog) (opencog exec))
+
+(ImplicationScope
+	(TypedVariable (Variable "X") (Type 'Concept))
+	(Member (Variable "X") (Concept "foo"))
+	(Member (Concept "bar") (Variable "X")))
+
+(define quote-scope
+	(Meet
+		(VariableSet
+			(Variable "$P")
+			(Variable "$Q")
+			(TypedVariable
+				(Variable "$TyVs")
+				(TypeChoice (Type "TypedVariable") (Type "VariableList"))))
+		(Present
+			(Quote
+				(ImplicationScope
+					(Unquote (Variable "$TyVs"))
+					(Unquote (Variable "$P"))
+					(Unquote (Variable "$Q")))))))
+
+(define expect
+	(List
+		(Member (Variable "X") (Concept "foo"))
+		(Member (Concept "bar") (Variable "X"))
+		(TypedVariable (Variable "X") (Type 'Concept))))

--- a/tests/query/quote-scope.scm
+++ b/tests/query/quote-scope.scm
@@ -12,7 +12,7 @@
 
 (define quote-scope
 	(Meet
-		(VariableSet
+		(VariableList
 			(Variable "$P")
 			(Variable "$Q")
 			(TypedVariable
@@ -24,6 +24,8 @@
 					(Unquote (Variable "$TyVs"))
 					(Unquote (Variable "$P"))
 					(Unquote (Variable "$Q")))))))
+
+; (cog-execute! quote-scope)
 
 (define expect
 	(List


### PR DESCRIPTION
This is an almost-total rewrite of the static-analysis performed in `PatternLink`.
This substantially addresses issue #2673 by eliminating almost all ad-hoc
maps and lists and pointers, replacing them by PatternTermPtr almost everywhere.