### PR TITLE
Relax boolean link validator

### DIFF
--- a/opencog/atoms/core/Checkers.cc
+++ b/opencog/atoms/core/Checkers.cc
@@ -72,6 +72,18 @@ bool check_evaluatable(const Handle& bool_atom)
 		if (QUOTE_LINK == t) continue;
 		if (UNQUOTE_LINK == t) continue;
 
+		// Negation, conjunction or disjunction over Implication,
+		// Equivalence, Inheritance, Similarity and their subtypes is
+		// currently required by PLN for higher order reasoning. We may
+		// want to forbid it in the future by maybe introducing a
+		// specialized operator to explicitely map the higher order into
+		// the lower order but as of today it is required.
+		if (h->is_type(INHERITANCE_LINK) or
+		    h->is_type(SIMILARITY_LINK) or
+		    h->is_type(IMPLICATION_LINK) or
+		    h->is_type(EQUIVALENCE_LINK))
+			continue;
+
 		if (not h->is_type(EVALUATABLE_LINK)) return false;
 	}
 	return true;


### PR DESCRIPTION
Currently the validator associated to BOOLEAN_LINK is
check_evaluatable, the problem is boolean links can also be used on
atoms that are not evaluatable, such as implication links, according
to PLN.

These links cannot be made evaluatable without invalidating the
function is_constant in PatternUtils.h.  So I think the best thing for
now is to relax the validator of BOOLEAN_LINK.  I have relaxed
check_evaluatable, however I suppose the latter should either be
renamed check_boolean, or a new check_boolean validator should be
introduced that uses check_evaluatable + the additional code in this
commit.