### PR TITLE
Create TypedVariableLink

### DIFF
--- a/opencog/atoms/container/JoinLink.cc
+++ b/opencog/atoms/container/JoinLink.cc
@@ -182,14 +182,15 @@ void JoinLink::setup_top_clauses(void)
 	for (const Handle& var : _variables.varseq)
 	{
 		// If its anywhere, its in the simple typemap.
-		const auto& styp = _variables._simple_typemap.find(var);
-		if (_variables._simple_typemap.end() == styp) continue;
+		const auto& vtyp = _variables._typemap.find(var);
+		if (_variables._typemap.end() == vtyp) continue;
 
 		// If it's specified, its a plain single type.
-		if (styp->second.size() != 1) continue;
+		const TypeSet& tset = vtyp->second->get_simple_typeset();
+		if (tset.size() != 1) continue;
 
 		// Its got to be JoinLink, or a derived type.
-		Type vt = *(styp->second.begin());
+		Type vt = *(tset.begin());
 		if (nameserver().isA(vt, JOIN_LINK))
 		{
 			_top_var = var;

--- a/opencog/atoms/core/CMakeLists.txt
+++ b/opencog/atoms/core/CMakeLists.txt
@@ -30,6 +30,7 @@ ADD_LIBRARY (atomcore
 	StateLink.cc
 	TimeLink.cc
 	TypedAtomLink.cc
+	TypedVariableLink.cc
 	TypeNode.cc
 	TypeUtils.cc
 	UniqueLink.cc
@@ -77,6 +78,7 @@ INSTALL (FILES
 	StateLink.h
 	TimeLink.h
 	TypedAtomLink.h
+	TypedVariableLink.h
 	TypeNode.h
 	TypeUtils.h
 	UniqueLink.h

--- a/opencog/atoms/core/ScopeLink.cc
+++ b/opencog/atoms/core/ScopeLink.cc
@@ -320,20 +320,35 @@ ContentHash ScopeLink::scope_hash(const FreeVariables::IndexMap& index) const
 	// typemaps will depend on the variable names. So must be
 	// abelian. That is, we must use addition.
 	ContentHash vth = 0;
-	for (const auto& pr : _variables._simple_typemap)
+#if 0
+	for (const auto& pr : _variables._typemap)
 	{
-		for (Type t : pr.second) vth += t;
+		// Why doesn't this very simple source of entropy work ??
+		vth += pr.second->get_hash();
+	}
+#endif
+
+	// Work really really hard to generate collionless hashes,
+	// based on the variable typing.
+	for (const auto& pr : _variables._typemap)
+	{
+		for (Type t : pr.second->get_simple_typeset())
+			vth += t;
 	}
 	fnv1a_hash(hsh, vth);
 
-	for (const auto& pr : _variables._deep_typemap)
+	for (const auto& pr : _variables._typemap)
 	{
-		for (const Handle& th : pr.second) vth += th->get_hash();
+		for (const Handle& th : pr.second->get_deep_typeset())
+			vth += th->get_hash();
 	}
 	fnv1a_hash(hsh, vth);
 
-	for(const auto& pr: _variables._glob_intervalmap){
-		vth += pr.first->get_hash();
+	for (const auto& pr : _variables._typemap)
+	{
+		if (pr.second->get_glob_interval() !=
+		    pr.second->default_interval())
+			vth += pr.second->get_variable()->get_hash();
 	}
 	fnv1a_hash(hsh, vth);
 

--- a/opencog/atoms/core/TypedAtomLink.h
+++ b/opencog/atoms/core/TypedAtomLink.h
@@ -1,5 +1,5 @@
 /*
- * opencog/atoms/TypedAtomLink.h
+ * opencog/atoms/core/TypedAtomLink.h
  *
  * Copyright (C) 2015 Linas Vepstas
  * All Rights Reserved

--- a/opencog/atoms/core/TypedVariableLink.cc
+++ b/opencog/atoms/core/TypedVariableLink.cc
@@ -387,12 +387,10 @@ bool TypedVariableLink::is_type(const Handle& h) const
 /// Perform typecheck, ignoring possible globbiness.
 bool TypedVariableLink::is_nonglob_type(const Handle& h) const
 {
-	Type htype = h->get_type();
-
 	// If the argument has the simple type, then we are good to go;
 	// we are done.  Else, fall through, and see if one of the
 	// others accept the match.
-	if (_simple_typeset.find(htype) != _simple_typeset.end())
+	if (_simple_typeset.find(h->get_type()) != _simple_typeset.end())
 		return true;
 
 	// Deep type restrictions?
@@ -401,8 +399,8 @@ bool TypedVariableLink::is_nonglob_type(const Handle& h) const
 		if (value_is_type(sig, h)) return true;
 	}
 
-	// There appear to be no type restrictions...
-	return false;
+	// True, only if there were no type restrictions...
+	return 0 == _simple_typeset.size() and 0 == _deep_typeset.size();
 }
 
 /* ================================================================= */

--- a/opencog/atoms/core/TypedVariableLink.cc
+++ b/opencog/atoms/core/TypedVariableLink.cc
@@ -360,6 +360,12 @@ bool TypedVariableLink::is_upper_bound(size_t n) const
 /* ================================================================= */
 
 /// Returns true if `h` satisfies the type restrictions.
+bool TypedVariableLink::is_type(Type t) const
+{
+	return _simple_typeset.end() != _simple_typeset.find(t);
+}
+
+/// Returns true if `h` satisfies the type restrictions.
 bool TypedVariableLink::is_type(const Handle& h) const
 {
 	// If the type is not globby, then the Atom must satisfy

--- a/opencog/atoms/core/TypedVariableLink.cc
+++ b/opencog/atoms/core/TypedVariableLink.cc
@@ -60,7 +60,7 @@ void TypedVariableLink::init()
 			"Expecting type defintion, got %s",
 				nameserver().getTypeName(dtype).c_str());
 
-	_glob_interval = std::make_pair(0, SIZE_MAX);
+	_glob_interval = default_interval;
 	analyze();
 }
 
@@ -122,7 +122,7 @@ void TypedVariableLink::analyze()
 	Type t = vartype->get_type();
 
 	// Specifying how many atoms can be matched to a GlobNode, if any
-	HandleSeq intervals;
+	HandleSeq interval;
 
 	// If its a defined type, unbundle it.
 	if (DEFINED_TYPE_NODE == t)
@@ -155,7 +155,7 @@ void TypedVariableLink::analyze()
 			Type th = h->get_type();
 
 			if (INTERVAL_LINK == th)
-				intervals = h->getOutgoingSet();
+				interval = h->getOutgoingSet();
 
 			else if (TYPE_NODE == th or
 			         TYPE_INH_NODE == th or
@@ -273,7 +273,7 @@ void TypedVariableLink::analyze()
 	}
 	else if (GLOB_NODE == nt and INTERVAL_LINK == t)
 	{
-		intervals = vartype->getOutgoingSet();
+		interval = vartype->getOutgoingSet();
 	}
 	else
 	{
@@ -289,10 +289,10 @@ void TypedVariableLink::analyze()
 			nameserver().getTypeName(t).c_str());
 	}
 
-	if (0 < intervals.size())
+	if (0 < interval.size())
 	{
-		long lb = std::lround(NumberNodeCast(intervals[0])->get_value());
-		long ub = std::lround(NumberNodeCast(intervals[1])->get_value());
+		long lb = std::lround(NumberNodeCast(interval[0])->get_value());
+		long ub = std::lround(NumberNodeCast(interval[1])->get_value());
 		if (lb < 0) lb = 0;
 		if (ub < 0) ub = SIZE_MAX;
 

--- a/opencog/atoms/core/TypedVariableLink.cc
+++ b/opencog/atoms/core/TypedVariableLink.cc
@@ -48,17 +48,21 @@ void TypedVariableLink::init()
 		throw SyntaxException(TRACE_INFO,
 			"Sorry, we expect type names to be variables!");
 
+	// Allow VARIABLE_NODE, although this is a bug in the URE,
+	// which should be using a SignatureLink for this case. XXX FIXME.
 	Type dtype = _outgoing[1]->get_type();
 	if (not nameserver().isA(dtype, TYPE_NODE) and
 	    DEFINED_TYPE_NODE != dtype and
 	    TYPE_CHOICE != dtype and
 	    TYPE_SET_LINK != dtype and
+	    VARIABLE_NODE != dtype and // XXX FIXME this is wrong; URE-bug
 	    SIGNATURE_LINK != dtype and
 	    INTERVAL_LINK != dtype and
 	    ARROW_LINK != dtype)
 		throw SyntaxException(TRACE_INFO,
-			"Expecting type defintion, got %s",
-				nameserver().getTypeName(dtype).c_str());
+			"Expecting type defintion, got %s in\n%s",
+				nameserver().getTypeName(dtype).c_str(),
+				to_short_string().c_str());
 
 	analyze();
 }
@@ -266,9 +270,10 @@ void TypedVariableLink::analyze()
 	}
 	else if (VARIABLE_NODE == t)
 	{
-		// This occurs when the variable type is a variable to be
-		// matched by the pattern matcher. There's nothing to do
-		// except not throwing an exception.
+		// This is a work-around to a URE bug. The URE should be
+		// using a SignatureLink, but its not. As a result, it
+		// gets undefined behavior and incorect results. Too bad.
+		// For now, just avoid throwing an exception. XXX FIXME.
 	}
 	else if (GLOB_NODE == nt and INTERVAL_LINK == t)
 	{

--- a/opencog/atoms/core/TypedVariableLink.cc
+++ b/opencog/atoms/core/TypedVariableLink.cc
@@ -60,6 +60,7 @@ void TypedVariableLink::init()
 			"Expecting type defintion, got %s",
 				nameserver().getTypeName(dtype).c_str());
 
+	_glob_interval = std::make_pair(0, SIZE_MAX);
 	analyze();
 }
 

--- a/opencog/atoms/core/TypedVariableLink.cc
+++ b/opencog/atoms/core/TypedVariableLink.cc
@@ -301,6 +301,14 @@ void TypedVariableLink::analyze()
 }
 
 /* ================================================================= */
+/// Return true if the type is completely unconstrained.
+
+bool TypedVariableLink::is_untyped(void) const
+{
+	return 0 == _simple_typeset.size() and 0 == _deep_typeset.size();
+}
+
+/* ================================================================= */
 
 /// Return true if the other TypedVariable is equal to this one,
 /// up to alpha-conversion. This returns `true` if the other

--- a/opencog/atoms/core/TypedVariableLink.cc
+++ b/opencog/atoms/core/TypedVariableLink.cc
@@ -115,7 +115,7 @@ TypedVariableLink::TypedVariableLink(const Handle& name, const Handle& defn)
  */
 void TypedVariableLink::analyze()
 {
-	Handle varname(_outgoing[0]);
+	const Handle& varname(_outgoing[0]);
 	Handle vartype(_outgoing[1]);
 
 	Type nt = varname->get_type();
@@ -298,6 +298,39 @@ void TypedVariableLink::analyze()
 
 		_glob_interval = std::make_pair(lb, ub);
 	}
+}
+
+/* ================================================================= */
+
+/// Return true if the other TypedVariable is equal to this one,
+/// up to alpha-conversion. This returns `true` if the other
+/// TypedVariable has the same type restrictions, even though it
+/// might have a different variable name. That is, return `true`
+/// if the two variables are alpha-convertable.
+///
+/// The compare is a semantic compare, not a syntactic compare. That
+/// is, the actual type restrictions are compared, and NOT the Atom
+/// used to specify the restriction.
+///
+bool TypedVariableLink::is_equal(const TypedVariableLink& other) const
+{
+	// If one is a GlobNode, and the other a VariableNode,
+	// then its a mismatch.
+	if (get_variable()->get_type() != other.get_variable()->get_type())
+		return false;
+
+	// If typed, types must match.
+	if (get_simple_typeset() != other.get_simple_typeset())
+		return false;
+
+	if (get_deep_typeset() != other.get_deep_typeset())
+		return false;
+
+	if (get_glob_interval() != other.get_glob_interval())
+		return false;
+
+	// If we got to here, everything must be OK.
+	return true;
 }
 
 /* ================================================================= */

--- a/opencog/atoms/core/TypedVariableLink.cc
+++ b/opencog/atoms/core/TypedVariableLink.cc
@@ -23,6 +23,10 @@
 
 #include <opencog/atoms/base/ClassServer.h>
 
+#include <opencog/atoms/core/DefineLink.h>
+#include <opencog/atoms/core/NumberNode.h>
+#include <opencog/atoms/core/TypeNode.h>
+
 #include "TypedVariableLink.h"
 
 using namespace opencog;
@@ -55,6 +59,8 @@ void TypedVariableLink::init()
 		throw SyntaxException(TRACE_INFO,
 			"Expecting type defintion, got %s",
 				nameserver().getTypeName(dtype).c_str());
+
+	analyze();
 }
 
 TypedVariableLink::TypedVariableLink(const HandleSeq&& oset, Type t)
@@ -68,6 +74,232 @@ TypedVariableLink::TypedVariableLink(const Handle& name, const Handle& defn)
 {
 	init();
 }
+
+/* ================================================================= */
+/**
+ * Extract the variable type(s) from a TypedVariableLink
+ *
+ * The call is expecting htypelink to point to one of the two
+ * following structures:
+ *
+ *    TypedVariableLink
+ *       VariableNode "$some_var_name"
+ *       TypeNode  "ConceptNode"
+ *
+ * or
+ *
+ *    TypedVariableLink
+ *       VariableNode "$some_var_name"
+ *       TypeChoice
+ *          TypeNode  "ConceptNode"
+ *          TypeNode  "NumberNode"
+ *          TypeNode  "WordNode"
+ *
+ * or possibly types that are SignatureLink's or polymorphic
+ * combinations thereof: e.g. the following is valid:
+ *
+ *    TypedVariableLink
+ *       VariableNode "$some_var_name"
+ *       TypeChoice
+ *          TypeNode  "ConceptNode"
+ *          SignatureLink
+ *              InheritanceLink
+ *                 PredicateNode "foobar"
+ *                 TypeNode  "ListLink"
+ *          SignatureLink
+ *              InheritanceLink
+ *                 ConceptNode "animal"
+ *                 ConceptNode "tiger"
+ *
+ */
+void TypedVariableLink::analyze()
+{
+	Handle varname(_outgoing[0]);
+	Handle vartype(_outgoing[1]);
+
+	Type nt = varname->get_type();
+	Type t = vartype->get_type();
+
+	// Specifying how many atoms can be matched to a GlobNode, if any
+	HandleSeq intervals;
+
+	// If its a defined type, unbundle it.
+	if (DEFINED_TYPE_NODE == t)
+	{
+		vartype = DefineLink::get_definition(vartype);
+		t = vartype->get_type();
+	}
+
+	// For GlobNode, we can specify either the interval or the type, e.g.
+	//
+	// TypedVariableLink
+	//   GlobNode  "$foo"
+	//   IntervalLink
+	//     NumberNode  2
+	//     NumberNode  3
+	//
+	// or both under a TypeSetLink, e.g.
+	//
+	// TypedVariableLink
+	//   GlobNode  "$foo"
+	//   TypeSetLink
+	//     IntervalLink
+	//       NumberNode  2
+	//       NumberNode  3
+	//     TypeNode "ConceptNode"
+	if (GLOB_NODE == nt and TYPE_SET_LINK == t)
+	{
+		for (const Handle& h : vartype->getOutgoingSet())
+		{
+			Type th = h->get_type();
+
+			if (INTERVAL_LINK == th)
+				intervals = h->getOutgoingSet();
+
+			else if (TYPE_NODE == th or
+			         TYPE_INH_NODE == th or
+			         TYPE_CO_INH_NODE == th)
+			{
+				vartype = h;
+				t = th;
+			}
+
+			else throw SyntaxException(TRACE_INFO,
+				"Unexpected contents in TypeSetLink\n"
+				"Expected IntervalLink and TypeNode, got %s",
+				h->to_string().c_str());
+		}
+	}
+
+	// The vartype is either a single type name, or a list of typenames.
+	if (TYPE_NODE == t)
+	{
+		Type vt = TypeNodeCast(vartype)->get_kind();
+		if (vt != ATOM)  // Atom type is same as untyped.
+		{
+			_simple_typeset.insert(vt);
+		}
+	}
+	else if (TYPE_INH_NODE == t)
+	{
+		Type vt = TypeNodeCast(vartype)->get_kind();
+		const TypeSet& ts = nameserver().getChildrenRecursive(vt);
+		_simple_typeset.insert(ts.begin(), ts.end());
+	}
+	else if (TYPE_CO_INH_NODE == t)
+	{
+		Type vt = TypeNodeCast(vartype)->get_kind();
+		const TypeSet& ts = nameserver().getParentsRecursive(vt);
+		_simple_typeset.insert(ts.begin(), ts.end());
+	}
+	else if (TYPE_CHOICE == t)
+	{
+		const HandleSeq& tset = vartype->getOutgoingSet();
+		size_t tss = tset.size();
+		for (size_t i=0; i<tss; i++)
+		{
+			Handle ht(tset[i]);
+			Type var_type = ht->get_type();
+			if (TYPE_NODE == var_type)
+			{
+				Type vt = TypeNodeCast(ht)->get_kind();
+				if (ATOM != vt) _simple_typeset.insert(vt);
+			}
+			else if (TYPE_INH_NODE == var_type)
+			{
+				Type vt = TypeNodeCast(ht)->get_kind();
+				if (ATOM != vt)
+				{
+					TypeSet ts = nameserver().getChildrenRecursive(vt);
+					_simple_typeset.insert(ts.begin(), ts.end());
+				}
+			}
+			else if (TYPE_CO_INH_NODE == var_type)
+			{
+				Type vt = TypeNodeCast(ht)->get_kind();
+				if (ATOM != vt)
+				{
+					TypeSet ts = nameserver().getParentsRecursive(vt);
+					_simple_typeset.insert(ts.begin(), ts.end());
+				}
+			}
+			else if (SIGNATURE_LINK == var_type)
+			{
+				const HandleSeq& sig = ht->getOutgoingSet();
+				if (1 != sig.size())
+					throw SyntaxException(TRACE_INFO,
+						"Unexpected contents in SignatureLink\n"
+						"Expected arity==1, got %s", vartype->to_string().c_str());
+
+				_deep_typeset.insert(ht);
+			}
+			else
+			{
+				throw InvalidParamException(TRACE_INFO,
+					"VariableChoice has unexpected content:\n"
+					"Expected TypeNode, got %s",
+					    nameserver().getTypeName(ht->get_type()).c_str());
+			}
+		}
+
+		// An empty disjunction corresponds to a bottom type.
+		if (tset.empty())
+			_simple_typeset.insert({NOTYPE});
+
+		// Check for (TypeChoice (TypCoInh 'Atom)) which is also bottom.
+		if (1 == tset.size() and TYPE_CO_INH_NODE == tset[0]->get_type())
+		{
+			Type vt = TypeNodeCast(tset[0])->get_kind();
+			if (ATOM == vt)
+				_simple_typeset.insert({NOTYPE});
+		}
+	}
+	else if (SIGNATURE_LINK == t)
+	{
+		const HandleSeq& tset = vartype->getOutgoingSet();
+		if (1 != tset.size())
+			throw SyntaxException(TRACE_INFO,
+				"Unexpected contents in SignatureLink\n"
+				"Expected arity==1, got %s", vartype->to_string().c_str());
+
+		_deep_typeset.insert(vartype);
+	}
+	else if (VARIABLE_NODE == t)
+	{
+		// This occurs when the variable type is a variable to be
+		// matched by the pattern matcher. There's nothing to do
+		// except not throwing an exception.
+	}
+	else if (GLOB_NODE == nt and INTERVAL_LINK == t)
+	{
+		intervals = vartype->getOutgoingSet();
+	}
+	else
+	{
+		// Instead of throwing here, we could also assume that
+		// there is an implied SignatureLink, and just poke the
+		// contents into the _deep_typeset. On the other hand,
+		// it seems better to throw, so that beginers aren't
+		// thrown off the trail for what essentially becomes
+		// a silent error with unexpected effects...
+		throw SyntaxException(TRACE_INFO,
+			"Unexpected contents in TypedVariableLink\n"
+			"Expected type specifier (e.g. TypeNode, TypeChoice, etc.), got %s",
+			nameserver().getTypeName(t).c_str());
+	}
+
+	if (0 < intervals.size())
+	{
+		long lb = std::lround(NumberNodeCast(intervals[0])->get_value());
+		long ub = std::lround(NumberNodeCast(intervals[1])->get_value());
+		if (lb < 0) lb = 0;
+		if (ub < 0) ub = SIZE_MAX;
+
+		_glob_interval = std::make_pair(lb, ub);
+	}
+}
+
+/* ================================================================= */
 
 DEFINE_LINK_FACTORY(TypedVariableLink, TYPED_VARIABLE_LINK);
 

--- a/opencog/atoms/core/TypedVariableLink.cc
+++ b/opencog/atoms/core/TypedVariableLink.cc
@@ -48,7 +48,9 @@ void TypedVariableLink::init()
 	if (not nameserver().isA(dtype, TYPE_NODE) and
 	    DEFINED_TYPE_NODE != dtype and
 	    TYPE_CHOICE != dtype and
+	    TYPE_SET_LINK != dtype and
 	    SIGNATURE_LINK != dtype and
+	    INTERVAL_LINK != dtype and
 	    ARROW_LINK != dtype)
 		throw SyntaxException(TRACE_INFO,
 			"Expecting type defintion, got %s",

--- a/opencog/atoms/core/TypedVariableLink.cc
+++ b/opencog/atoms/core/TypedVariableLink.cc
@@ -330,6 +330,29 @@ bool TypedVariableLink::is_untyped(void) const
 
 /* ================================================================= */
 
+/// Return true if the glob can match a variable number of items.
+/// i.e. if it is NOT an ordinary variable.
+bool TypedVariableLink::is_globby(void) const
+{
+	return (1 != _glob_interval.first or 1 != _glob_interval.second);
+}
+
+/// Returns true if the glob satisfies the lower bound
+/// interval restriction.
+bool TypedVariableLink::is_lower_bound(size_t n) const
+{
+	return n >= _glob_interval.first;
+}
+
+/// Returns true if the glob satisfies the upper bound
+/// interval restriction.
+bool TypedVariableLink::is_upper_bound(size_t n) const
+{
+	return n <= _glob_interval.second or _glob_interval.second < 0;
+}
+
+/* ================================================================= */
+
 /// Return true if the other TypedVariable is equal to this one,
 /// up to alpha-conversion. This returns `true` if the other
 /// TypedVariable has the same type restrictions, even though it

--- a/opencog/atoms/core/TypedVariableLink.h
+++ b/opencog/atoms/core/TypedVariableLink.h
@@ -52,7 +52,12 @@ namespace opencog
 class TypedVariableLink : public Link
 {
 protected:
+	TypeSet _simple_typeset;
+	HandleSet _deep_typeset;
+	std::pair<size_t, size_t> _glob_interval;
+
 	void init();
+	void analyze();
 public:
 	TypedVariableLink(const HandleSeq&&, Type=TYPED_VARIABLE_LINK);
 	TypedVariableLink(const Handle& alias, const Handle& body);

--- a/opencog/atoms/core/TypedVariableLink.h
+++ b/opencog/atoms/core/TypedVariableLink.h
@@ -76,6 +76,10 @@ public:
 	// The default interval for glob matching.
 	const std::pair<size_t, size_t> default_interval(void) const;
 
+	bool is_globby(void) const;
+	bool is_lower_bound(size_t) const;
+	bool is_upper_bound(size_t) const;
+
 	bool is_untyped(void) const;
 	bool is_equal(const TypedVariableLink&) const;
 	static Handle factory(const Handle&);

--- a/opencog/atoms/core/TypedVariableLink.h
+++ b/opencog/atoms/core/TypedVariableLink.h
@@ -77,6 +77,7 @@ public:
 	static constexpr std::pair<size_t, size_t> default_interval =
 		std::make_pair(1, SIZE_MAX);
 
+	bool is_untyped(void) const;
 	bool is_equal(const TypedVariableLink&) const;
 	static Handle factory(const Handle&);
 };

--- a/opencog/atoms/core/TypedVariableLink.h
+++ b/opencog/atoms/core/TypedVariableLink.h
@@ -74,8 +74,7 @@ public:
 		{ return _glob_interval; }
 
 	// The default interval for glob matching.
-	static constexpr std::pair<size_t, size_t> default_interval =
-		std::make_pair(1, SIZE_MAX);
+	const std::pair<size_t, size_t> default_interval(void) const;
 
 	bool is_untyped(void) const;
 	bool is_equal(const TypedVariableLink&) const;

--- a/opencog/atoms/core/TypedVariableLink.h
+++ b/opencog/atoms/core/TypedVariableLink.h
@@ -68,6 +68,11 @@ public:
 	Handle get_variable(void) const { return _outgoing.at(0); }
 	Handle get_type(void) const { return _outgoing.at(1); }
 
+	TypeSet get_simple_typeset(void) const { return _simple_typeset; }
+	HandleSet get_deep_typeset(void) const { return _deep_typeset; }
+	std::pair<size_t, size_t> get_glob_interval(void) const
+		{ return _glob_interval; }
+
 	static Handle factory(const Handle&);
 };
 

--- a/opencog/atoms/core/TypedVariableLink.h
+++ b/opencog/atoms/core/TypedVariableLink.h
@@ -58,6 +58,8 @@ protected:
 
 	void init();
 	void analyze();
+	bool is_nonglob_type(const Handle&) const;
+
 public:
 	TypedVariableLink(const HandleSeq&&, Type=TYPED_VARIABLE_LINK);
 	TypedVariableLink(const Handle& alias, const Handle& body);
@@ -79,6 +81,8 @@ public:
 	bool is_globby(void) const;
 	bool is_lower_bound(size_t) const;
 	bool is_upper_bound(size_t) const;
+
+	bool is_type(const Handle&) const;
 
 	bool is_untyped(void) const;
 	bool is_equal(const TypedVariableLink&) const;

--- a/opencog/atoms/core/TypedVariableLink.h
+++ b/opencog/atoms/core/TypedVariableLink.h
@@ -1,0 +1,80 @@
+/*
+ * opencog/atoms/core/TypedVariableLink.h
+ *
+ * Copyright (C) 2020 Linas Vepstas
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef _OPENCOG_TYPED_VARIABLE_LINK_H
+#define _OPENCOG_TYPED_VARIABLE_LINK_H
+
+#include <opencog/atoms/base/Link.h>
+
+namespace opencog
+{
+/** \addtogroup grp_atomspace
+ *  @{
+ */
+
+/// The TypedVariableLink is used to attach a name to a type description;
+/// the "name" is usually a VariableNode. Note that this is backwards
+/// from the usual idea of attaching a type specification to a variable:
+/// that is because we want to allow anonymous (unamed) types to be
+/// used, while, in certain special cases, we need to give names to
+/// those types: the name is the VariableNode.
+///
+/// This does NOT inherit from DefineLink, because we allow the same
+/// variable name to be used in diffent contexts to name completely
+/// unrelated types.  Thus, the naming is strongly context-dependent.
+///
+/// The TypedVariableLink has the format:
+/// ```
+///     TypedVariableLink
+///        <variable>
+///        <type-specification>
+/// ```
+///
+class TypedVariableLink : public Link
+{
+protected:
+	void init();
+public:
+	TypedVariableLink(const HandleSeq&&, Type=TYPED_VARIABLE_LINK);
+	TypedVariableLink(const Handle& alias, const Handle& body);
+
+	TypedVariableLink(const TypedVariableLink&) = delete;
+	TypedVariableLink& operator=(const TypedVariableLink&) = delete;
+
+	Handle get_variable(void) const { return _outgoing.at(0); }
+	Handle get_type(void) const { return _outgoing.at(1); }
+
+	static Handle factory(const Handle&);
+};
+
+typedef std::shared_ptr<TypedVariableLink> TypedVariableLinkPtr;
+static inline TypedVariableLinkPtr TypedVariableLinkCast(const Handle& h)
+	{ return std::dynamic_pointer_cast<TypedVariableLink>(h); }
+static inline TypedVariableLinkPtr TypedVariableLinkCast(AtomPtr a)
+	{ return std::dynamic_pointer_cast<TypedVariableLink>(a); }
+
+#define createTypedVariableLink std::make_shared<TypedVariableLink>
+
+/** @}*/
+}
+
+#endif // _OPENCOG_TYPED_VARIABLE_LINK_H

--- a/opencog/atoms/core/TypedVariableLink.h
+++ b/opencog/atoms/core/TypedVariableLink.h
@@ -77,6 +77,7 @@ public:
 	static constexpr std::pair<size_t, size_t> default_interval =
 		std::make_pair(1, SIZE_MAX);
 
+	bool is_equal(const TypedVariableLink&) const;
 	static Handle factory(const Handle&);
 };
 

--- a/opencog/atoms/core/TypedVariableLink.h
+++ b/opencog/atoms/core/TypedVariableLink.h
@@ -83,6 +83,7 @@ public:
 	bool is_upper_bound(size_t) const;
 
 	bool is_type(const Handle&) const;
+	bool is_type(Type) const;
 
 	bool is_untyped(void) const;
 	bool is_equal(const TypedVariableLink&) const;

--- a/opencog/atoms/core/TypedVariableLink.h
+++ b/opencog/atoms/core/TypedVariableLink.h
@@ -73,6 +73,10 @@ public:
 	std::pair<size_t, size_t> get_glob_interval(void) const
 		{ return _glob_interval; }
 
+	// The default interval for glob matching.
+	static constexpr std::pair<size_t, size_t> default_interval =
+		std::make_pair(1, SIZE_MAX);
+
 	static Handle factory(const Handle&);
 };
 

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -208,11 +208,15 @@ bool Variables::is_equal(const Variables& other, size_t index) const
 	auto sime = _typemap.find(vme);
 	auto soth = other._typemap.find(voth);
 	if (sime == _typemap.end() and
-	    soth != other._typemap.end()) return false;
+	    soth != other._typemap.end() and
+	    not soth->second->is_untyped()) return false;
 
 	if (sime != _typemap.end())
 	{
+		if (soth == other._typemap.end() and
+		    sime->second->is_untyped()) return true;
 		if (soth == other._typemap.end()) return false;
+
 		if (not sime->second->is_equal(*soth->second)) return false;
 	}
 

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -120,10 +120,6 @@ void Variables::unpack_vartype(const Handle& htypelink)
  */
 void Variables::validate_vardecl(const Handle& hdecls)
 {
-	// If no variable declaration then create the empty variables
-	if (not hdecls)
-		return;
-
 	// Expecting the declaration list to be either a single
 	// variable, a list or a set of variable declarations.
 	Type tdecls = hdecls->get_type();
@@ -153,6 +149,10 @@ void Variables::validate_vardecl(const Handle& hdecls)
 		// form (i.e. requires beta-reductions to be fully formed), thus
 		// variables inference is aborted for now.
 		return;
+	}
+	else if (ANCHOR_NODE == tdecls)
+	{
+		_anchor = hdecls;
 	}
 	else
 	{
@@ -489,6 +489,12 @@ void Variables::extend(const Variables& vset)
 		auto index_it = index.find(h);
 		if (index_it != index.end())
 		{
+#if 0
+			auto typemap_it = vset._typemap.find(h);
+			if (typemap_it != vset._typemap.end())
+				unpack_vartype(HandleCast(typemap_it->second));
+#endif
+
 			// Merge the two typemaps, if needed.
 			auto stypemap_it = vset._simple_typemap.find(h);
 			if (stypemap_it != vset._simple_typemap.end())
@@ -505,14 +511,14 @@ void Variables::extend(const Variables& vset)
 		{
 			// Found a new variable! Insert it.
 			index.insert({h, varseq.size()});
-			varseq.emplace_back(h);
-			varset.insert(h);
 
-			// Install the type constraints, as well.
-			auto typemap_it = vset._simple_typemap.find(h);
-			if (typemap_it != vset._simple_typemap.end())
+			auto typemap_it = vset._typemap.find(h);
+			if (typemap_it != vset._typemap.end())
+				unpack_vartype(HandleCast(typemap_it->second));
+			else
 			{
-				_simple_typemap.insert({h, typemap_it->second});
+				varseq.emplace_back(h);
+				varset.insert(h);
 			}
 		}
 		// extend _glob_interval_map

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -87,10 +87,8 @@ void Variables::get_vartype(const Handle& htypelink)
 	if (0 < hs.size())
 		_deep_typemap.insert({varname, hs});
 
-	static const std::pair<size_t, size_t>
-		default_interval(std::make_pair(0, SIZE_MAX));
 	const std::pair<size_t, size_t>& gi = tvlp->get_glob_interval();
-	if (default_interval != gi)
+	if (TypedVariableLink::default_interval != gi)
 		_glob_intervalmap.insert({varname, gi});
 
 	varset.insert(varname);

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -205,39 +205,15 @@ bool Variables::is_equal(const Variables& other, size_t index) const
 	if (vme->get_type() != voth->get_type()) return false;
 
 	// If typed, types must match.
-	auto sime = _simple_typemap.find(vme);
-	auto soth = other._simple_typemap.find(voth);
-	if (sime == _simple_typemap.end() and
-	    soth != other._simple_typemap.end()) return false;
+	auto sime = _typemap.find(vme);
+	auto soth = other._typemap.find(voth);
+	if (sime == _typemap.end() and
+	    soth != other._typemap.end()) return false;
 
-	if (sime != _simple_typemap.end())
+	if (sime != _typemap.end())
 	{
-		if (soth == other._simple_typemap.end()) return false;
-		if (sime->second != soth->second) return false;
-	}
-
-	// If typed, types must match.
-	auto dime = _deep_typemap.find(vme);
-	auto doth = other._deep_typemap.find(voth);
-	if (dime == _deep_typemap.end() and
-	    doth != other._deep_typemap.end()) return false;
-
-	if (dime != _deep_typemap.end())
-	{
-		if (doth == other._deep_typemap.end()) return false;
-		if (dime->second != doth->second) return false;
-	}
-
-	// If intervals specified, intervals must match.
-	auto iime = _glob_intervalmap.find(vme);
-	auto ioth = other._glob_intervalmap.find(voth);
-	if (iime == _glob_intervalmap.end() and
-	    ioth != other._glob_intervalmap.end()) return false;
-
-	if (iime != _glob_intervalmap.end())
-	{
-		if (ioth == other._glob_intervalmap.end()) return false;
-		if (iime->second != ioth->second) return false;
+		if (soth == other._typemap.end()) return false;
+		if (not sime->second->is_equal(*soth->second)) return false;
 	}
 
 	// If we got to here, everything must be OK.

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -120,6 +120,9 @@ void Variables::unpack_vartype(const Handle& htypelink)
  */
 void Variables::validate_vardecl(const Handle& hdecls)
 {
+	// XXX FIXME URE calls us with broken handle!!
+	if (nullptr == hdecls) return;
+
 	// Expecting the declaration list to be either a single
 	// variable, a list or a set of variable declarations.
 	Type tdecls = hdecls->get_type();
@@ -279,7 +282,24 @@ bool Variables::is_type(const Handle& var, const Handle& val) const
 	return tit->second->is_type(val);
 }
 
-/* ================================================================= */
+/**
+ * Return true if we contain just a single variable, and this one
+ * variable is of type gtype (or is untyped). A typical use is that
+ * gtype==VARIABLE_LIST.
+ */
+bool Variables::is_type(Type gtype) const
+{
+	if (1 != varseq.size()) return false;
+
+	// Are there any type restrictions?
+	const Handle& var = varseq[0];
+	VariableTypeMap::const_iterator tit = _typemap.find(var);
+	if (_typemap.end() == tit) return true;
+
+	// There are type restrictions; do they match?
+	return tit->second->is_type(gtype);
+}
+
 /**
  * Simple type checker.
  *
@@ -304,27 +324,7 @@ bool Variables::is_type(const HandleSeq& hseq) const
 	return true;
 }
 
-/**
- * Return true if we contain just a single variable, and this one
- * variable is of type gtype (or is untyped). A typical use is that
- * gtype==VARIABLE_LIST.
- */
-bool Variables::is_type(Type gtype) const
-{
-	if (1 != varseq.size()) return false;
-
-	// Are there any type restrictions?
-	const Handle& var = varseq[0];
-	VariableSimpleTypeMap::const_iterator tit = _simple_typemap.find(var);
-	if (_simple_typemap.end() == tit) return true;
-	const TypeSet &tchoice = tit->second;
-
-	// There are type restrictions; do they match?
-	TypeSet::const_iterator allow = tchoice.find(gtype);
-	if (allow != tchoice.end()) return true;
-	return false;
-}
-
+/* ================================================================= */
 /**
  * Interval checker.
  *

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -89,7 +89,7 @@ void Variables::unpack_vartype(const Handle& htypelink)
 		_deep_typemap.insert({varname, hs});
 
 	const std::pair<size_t, size_t>& gi = tvlp->get_glob_interval();
-	if (TypedVariableLink::default_interval != gi)
+	if (tvlp->default_interval() != gi)
 		_glob_intervalmap.insert({varname, gi});
 
 	varset.insert(varname);

--- a/opencog/atoms/core/Variables.cc
+++ b/opencog/atoms/core/Variables.cc
@@ -270,6 +270,78 @@ bool Variables::is_type(const Handle& h) const
  * Returns true if we are holding the variable `var`, and if
  * the `val` satisfies the type restrictions that apply to `var`.
  */
+#ifdef BOGUS_TYPE_CHECKING
+// XXX FIXME -- The URE Variable Unifier needs this code to be the
+// way it is, to work  properly ... that is because it does weird stuff
+// with extened() ... unfortunately, this is a blocker for fixing
+// pattern engine bugs ... so this code needs to move there...
+bool Variables::is_type(const Handle& var, const Handle& val) const
+{
+	if (varset.end() == varset.find(var)) return false;
+
+	VariableSimpleTypeMap::const_iterator tit = _simple_typemap.find(var);
+	VariableDeepTypeMap::const_iterator dit = _deep_typemap.find(var);
+
+	const Arity num_args = val->get_type() != LIST_LINK ? 1 : val->get_arity();
+
+	// If one is allowed in interval then there are two alternatives.
+	// one: val must satisfy type restriction.
+	// two: val must be list_link and its unique outgoing satisfies
+	//      type restriction.
+	if (is_lower_bound(var, 1) and is_upper_bound(var, 1)
+	    and is_type(tit, dit, val))
+		return true;
+	else if (val->get_type() != LIST_LINK or
+	         not is_lower_bound(var, num_args) or
+	         not is_upper_bound(var, num_args))
+		// If the number of arguments is out of the allowed interval
+		// of the variable/glob or val is not List_link, return false.
+		return false;
+
+	// Every outgoing atom in list must satisfy type restriction of var.
+	for (size_t i = 0; i < num_args; i++)
+		if (!is_type(tit, dit, val->getOutgoingAtom(i)))
+			return false;
+
+	return true;
+}
+
+bool Variables::is_type(VariableSimpleTypeMap::const_iterator tit,
+                        VariableDeepTypeMap::const_iterator dit,
+                        const Handle& val) const
+{
+	bool ret = true;
+
+	// Simple type restrictions?
+	if (_simple_typemap.end() != tit)
+	{
+		const TypeSet &tchoice = tit->second;
+		Type htype = val->get_type();
+		TypeSet::const_iterator allow = tchoice.find(htype);
+
+		// If the argument has the simple type, then we are good to go;
+		// we are done.  Else, fall through, and see if one of the
+		// others accept the match.
+		if (allow != tchoice.end()) return true;
+		ret = false;
+	}
+
+	// Deep type restrictions?
+	if (_deep_typemap.end() != dit)
+	{
+		const HandleSet &sigset = dit->second;
+		for (const Handle& sig : sigset)
+		{
+			if (value_is_type(sig, val)) return true;
+		}
+		ret = false;
+	}
+
+	// There appear to be no type restrictions...
+	return ret;
+}
+
+#else // BOGUS_TYPE_CHECKING
 bool Variables::is_type(const Handle& var, const Handle& val) const
 {
 	// If not holding, then fail.
@@ -281,6 +353,7 @@ bool Variables::is_type(const Handle& var, const Handle& val) const
 
 	return tit->second->is_type(val);
 }
+#endif // BOGUS_TYPE_CHECKING
 
 /**
  * Return true if we contain just a single variable, and this one
@@ -489,12 +562,7 @@ void Variables::extend(const Variables& vset)
 		auto index_it = index.find(h);
 		if (index_it != index.end())
 		{
-#if 0
-			auto typemap_it = vset._typemap.find(h);
-			if (typemap_it != vset._typemap.end())
-				unpack_vartype(HandleCast(typemap_it->second));
-#endif
-
+#ifdef BOGUS_TYPE_CHECKING
 			// Merge the two typemaps, if needed.
 			auto stypemap_it = vset._simple_typemap.find(h);
 			if (stypemap_it != vset._simple_typemap.end())
@@ -506,6 +574,11 @@ void Variables::extend(const Variables& vset)
 				else
 					_simple_typemap.insert({h, tms});
 			}
+#else
+			auto typemap_it = vset._typemap.find(h);
+			if (typemap_it != vset._typemap.end())
+				unpack_vartype(HandleCast(typemap_it->second));
+#endif // BOGUS_TYPE_CHECKING
 		}
 		else
 		{
@@ -529,6 +602,7 @@ void Variables::extend(const Variables& vset)
 	_ordered = _ordered or vset._ordered;
 }
 
+#ifdef BOGUS_TYPE_CHECKING
 inline GlobInterval interval_intersection(const GlobInterval &lhs,
                                           const GlobInterval &rhs)
 {
@@ -548,6 +622,7 @@ void Variables::extend_interval(const Handle &h, const Variables &vset)
 		else _glob_intervalmap.insert({h, intersection});
 	}
 }
+#endif // BOGUS_TYPE_CHECKING
 
 void Variables::erase(const Handle& var)
 {

--- a/opencog/atoms/core/Variables.h
+++ b/opencog/atoms/core/Variables.h
@@ -202,7 +202,6 @@ protected:
 
 	bool is_type(VariableSimpleTypeMap::const_iterator,
 			VariableDeepTypeMap::const_iterator,
-			VariableDeepTypeMap::const_iterator,
 			const Handle&) const;
 
 	void extend_interval(const Handle &h, const Variables &vset);

--- a/opencog/atoms/core/Variables.h
+++ b/opencog/atoms/core/Variables.h
@@ -77,11 +77,9 @@ struct Variables : public FreeVariables,
 	/// on the variable types. It holds a disjunction of class Type.
 	/// _deep_typemap holds complex or "deep" type definitions, such
 	/// as those defined by SignatureLink.
-	/// _fuzzy_typemap is obsolete and does nothing.
 	VariableTypeMap _typemap;
 	VariableSimpleTypeMap _simple_typemap;
 	VariableDeepTypeMap _deep_typemap;
-	VariableDeepTypeMap _fuzzy_typemap;
 
 	/// To restrict how many atoms should be matched for each of the
 	/// GlobNodes in the pattern.

--- a/opencog/atoms/core/Variables.h
+++ b/opencog/atoms/core/Variables.h
@@ -32,6 +32,7 @@
 #include <opencog/atoms/base/Handle.h>
 #include <opencog/atoms/base/Atom.h>
 #include <opencog/atoms/core/FreeVariables.h>
+#include <opencog/atoms/core/TypedVariableLink.h>
 
 namespace opencog
 {
@@ -39,7 +40,8 @@ namespace opencog
  *  @{
  */
 
-typedef std::map<Handle, TypeSet> VariableTypeMap;
+typedef std::map<Handle, TypedVariableLinkPtr> VariableTypeMap;
+typedef std::map<Handle, TypeSet> VariableSimpleTypeMap;
 typedef std::map<Handle, HandleSet> VariableDeepTypeMap;
 typedef std::pair<size_t, size_t> GlobInterval;
 typedef std::map<Handle, GlobInterval> GlobIntervalMap;
@@ -70,13 +72,14 @@ struct Variables : public FreeVariables,
 
 	/// Unbundled variables and type restrictions for them.
 
+	/// _typemap holds back-ponters to TypedVariableLinkPtrs
 	/// _simple_typemap is the (possibly empty) list of restrictions
 	/// on the variable types. It holds a disjunction of class Type.
 	/// _deep_typemap holds complex or "deep" type definitions, such
 	/// as those defined by SignatureLink.
-	/// _fuzzy_typemap holds approximate of "fuzzy" type definitions,
-	/// those which only need to be approximately matched.
-	VariableTypeMap _simple_typemap;
+	/// _fuzzy_typemap is obsolete and does nothing.
+	VariableTypeMap _typemap;
+	VariableSimpleTypeMap _simple_typemap;
 	VariableDeepTypeMap _deep_typemap;
 	VariableDeepTypeMap _fuzzy_typemap;
 
@@ -86,9 +89,6 @@ struct Variables : public FreeVariables,
 
 	/// Anchor, if present, else undefined.
 	Handle _anchor;
-
-	// See VariableList.cc for comments
-	void get_vartype(const Handle&);
 
 	// Validate the variable decls
 	void validate_vardecl(const Handle&);
@@ -198,7 +198,9 @@ struct Variables : public FreeVariables,
 	std::string to_string(const std::string& indent=empty_string) const;
 
 protected:
-	bool is_type(VariableTypeMap::const_iterator,
+	void unpack_vartype(const Handle&);
+
+	bool is_type(VariableSimpleTypeMap::const_iterator,
 			VariableDeepTypeMap::const_iterator,
 			VariableDeepTypeMap::const_iterator,
 			const Handle&) const;
@@ -211,7 +213,7 @@ protected:
 // The reason indent is not an optional argument with default is
 // because gdb doesn't support that, see
 // http://stackoverflow.com/questions/16734783 for more explanation.
-std::string oc_to_string(const VariableTypeMap& vtm,
+std::string oc_to_string(const VariableSimpleTypeMap& vtm,
                          const std::string& indent=empty_string);
 std::string oc_to_string(const GlobIntervalMap& gim,
                          const std::string& indent=empty_string);

--- a/opencog/atoms/core/Variables.h
+++ b/opencog/atoms/core/Variables.h
@@ -91,6 +91,7 @@ struct Variables : public FreeVariables,
 	// Validate the variable decls
 	void validate_vardecl(const Handle&);
 	void validate_vardecl(const HandleSeq&);
+	void unpack_vartype(const Handle&);
 
 	/// Return true iff all variables are well typed. For now only
 	/// simple types are supported, specifically if some variable is
@@ -205,7 +206,6 @@ protected:
 	             VariableDeepTypeMap::const_iterator,
 	             const Handle&) const;
 #endif
-	void unpack_vartype(const Handle&);
 
 	void extend_interval(const Handle &h, const Variables &vset);
 };

--- a/opencog/atoms/core/Variables.h
+++ b/opencog/atoms/core/Variables.h
@@ -198,6 +198,15 @@ struct Variables : public FreeVariables,
 	std::string to_string(const std::string& indent=empty_string) const;
 
 protected:
+
+#define BOGUS_TYPE_CHECKING
+#ifdef BOGUS_TYPE_CHECKING
+	// XXX FIXME .. this is needed by the URE Unifier ...
+	// This code should be copied there.
+	bool is_type(VariableSimpleTypeMap::const_iterator,
+	             VariableDeepTypeMap::const_iterator,
+	             const Handle&) const;
+#endif
 	void unpack_vartype(const Handle&);
 
 	void extend_interval(const Handle &h, const Variables &vset);

--- a/opencog/atoms/core/Variables.h
+++ b/opencog/atoms/core/Variables.h
@@ -200,10 +200,6 @@ struct Variables : public FreeVariables,
 protected:
 	void unpack_vartype(const Handle&);
 
-	bool is_type(VariableSimpleTypeMap::const_iterator,
-			VariableDeepTypeMap::const_iterator,
-			const Handle&) const;
-
 	void extend_interval(const Handle &h, const Variables &vset);
 };
 

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -193,17 +193,17 @@ PatternLink::PatternLink(const HandleSet& vars,
 	{
 		_variables.varseq.emplace_back(v);
 
-		auto it = varspec._simple_typemap.find(v);
-		if (it != varspec._simple_typemap.end())
-			_variables._simple_typemap.insert(*it);
+		auto it = varspec._typemap.find(v);
+		if (it != varspec._typemap.end())
+			_variables._typemap.insert(*it);
+
+		auto sit = varspec._simple_typemap.find(v);
+		if (sit != varspec._simple_typemap.end())
+			_variables._simple_typemap.insert(*sit);
 
 		auto dit = varspec._deep_typemap.find(v);
 		if (dit != varspec._deep_typemap.end())
 			_variables._deep_typemap.insert(*dit);
-
-		auto fit = varspec._fuzzy_typemap.find(v);
-		if (fit != varspec._fuzzy_typemap.end())
-			_variables._fuzzy_typemap.insert(*fit);
 
 		auto imit = varspec._glob_intervalmap.find(v);
 		if (imit != varspec._glob_intervalmap.end())

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -191,23 +191,9 @@ PatternLink::PatternLink(const HandleSet& vars,
 	_variables.varseq.clear();
 	for (const Handle& v : vars)
 	{
-		_variables.varseq.emplace_back(v);
-
 		auto it = varspec._typemap.find(v);
 		if (it != varspec._typemap.end())
-			_variables._typemap.insert(*it);
-
-		auto sit = varspec._simple_typemap.find(v);
-		if (sit != varspec._simple_typemap.end())
-			_variables._simple_typemap.insert(*sit);
-
-		auto dit = varspec._deep_typemap.find(v);
-		if (dit != varspec._deep_typemap.end())
-			_variables._deep_typemap.insert(*dit);
-
-		auto imit = varspec._glob_intervalmap.find(v);
-		if (imit != varspec._glob_intervalmap.end())
-			_variables._glob_intervalmap.insert(*imit);
+			_variables.unpack_vartype(HandleCast(it->second));
 	}
 
 	// Next, the body... there's no `_body` for lambda. The compo is

--- a/opencog/query/InitiateSearchMixin.cc
+++ b/opencog/query/InitiateSearchMixin.cc
@@ -809,9 +809,9 @@ bool InitiateSearchMixin::setup_variable_search(void)
 	{
 		DO_LOG({LAZY_LOG_FINE << "Examine variable " << var->to_short_string();})
 
-		const auto& tit = _variables->_simple_typemap.find(var);
-		if (_variables->_simple_typemap.end() == tit) continue;
-		const TypeSet& typeset = tit->second;
+		const auto& tit = _variables->_typemap.find(var);
+		if (_variables->_typemap.end() == tit) continue;
+		const TypeSet& typeset = tit->second->get_simple_typeset();
 		DO_LOG({LAZY_LOG_FINE << "Type-restriction set size = "
 		                      << typeset.size();})
 

--- a/tests/atoms/core/VariablesUTest.cxxtest
+++ b/tests/atoms/core/VariablesUTest.cxxtest
@@ -1,5 +1,5 @@
 /*
- * tests/atoms/VariablesUTest.cxxtest
+ * tests/atoms/core/VariablesUTest.cxxtest
  *
  * Copyright (C) 2016 OpenCog Foundation
  * All Rights Reserved
@@ -124,6 +124,8 @@ void VariablesUTest::test_extend_1()
 	logger().debug() << "result = " << oc_to_string(result);
 
 	TS_ASSERT_EQUALS(result, expect);
+
+	logger().info("END TEST: %s", __FUNCTION__);
 }
 
 void VariablesUTest::test_extend_2()
@@ -153,6 +155,8 @@ void VariablesUTest::test_extend_2()
 	logger().debug() << "result = " << oc_to_string(result);
 
 	TS_ASSERT_EQUALS(result, expect);
+
+	logger().info("END TEST: %s", __FUNCTION__);
 }
 
 void VariablesUTest::test_extend_3()
@@ -182,6 +186,8 @@ void VariablesUTest::test_extend_3()
 	logger().debug() << "result = " << oc_to_string(result);
 
 	TS_ASSERT_EQUALS(result, expect);
+
+	logger().info("END TEST: %s", __FUNCTION__);
 }
 
 void VariablesUTest::test_extend_4()
@@ -211,6 +217,8 @@ void VariablesUTest::test_extend_4()
 	logger().debug() << "result = " << oc_to_string(result);
 
 	TS_ASSERT_EQUALS(result, expect);
+
+	logger().info("END TEST: %s", __FUNCTION__);
 }
 
 void VariablesUTest::test_extend_5()
@@ -269,6 +277,8 @@ void VariablesUTest::test_extend_5()
 	logger().debug() << "result = " << oc_to_string(result);
 
 	TS_ASSERT_EQUALS(result, expect);
+
+	logger().info("END TEST: %s", __FUNCTION__);
 }
 
 void VariablesUTest::test_extend_6()
@@ -297,6 +307,8 @@ void VariablesUTest::test_extend_6()
 	logger().debug() << "result = " << oc_to_string(result);
 
 	TS_ASSERT_EQUALS(result, expect);
+
+	logger().info("END TEST: %s", __FUNCTION__);
 }
 
 void VariablesUTest::test_find_variables_ordered_1()
@@ -315,6 +327,8 @@ void VariablesUTest::test_find_variables_ordered_1()
 	logger().debug() << "expect = " << oc_to_string(expect);
 
 	TS_ASSERT_EQUALS(varseq, expect);
+
+	logger().info("END TEST: %s", __FUNCTION__);
 }
 
 void VariablesUTest::test_find_variables_ordered_2()
@@ -335,6 +349,8 @@ void VariablesUTest::test_find_variables_ordered_2()
 	logger().debug() << "expect = " << oc_to_string(expect);
 
 	TS_ASSERT_EQUALS(varseq, expect);
+
+	logger().info("END TEST: %s", __FUNCTION__);
 }
 
 void VariablesUTest::test_find_variables_ordered_3()
@@ -355,6 +371,8 @@ void VariablesUTest::test_find_variables_ordered_3()
 	logger().debug() << "expect = " << oc_to_string(expect);
 
 	TS_ASSERT_EQUALS(varseq, expect);
+
+	logger().info("END TEST: %s", __FUNCTION__);
 }
 
 void VariablesUTest::test_find_variables_ordered_4()
@@ -378,6 +396,8 @@ void VariablesUTest::test_find_variables_ordered_4()
 	logger().debug() << "expect = " << oc_to_string(expect);
 
 	TS_ASSERT_EQUALS(varseq, expect);
+
+	logger().info("END TEST: %s", __FUNCTION__);
 }
 
 void VariablesUTest::test_find_variables_unordered_1()
@@ -396,6 +416,8 @@ void VariablesUTest::test_find_variables_unordered_1()
 	logger().debug() << "expect = " << oc_to_string(expect);
 
 	TS_ASSERT_EQUALS(result, expect);
+
+	logger().info("END TEST: %s", __FUNCTION__);
 }
 
 void VariablesUTest::test_find_variables_unordered_2()
@@ -429,6 +451,8 @@ void VariablesUTest::test_find_variables_unordered_2()
 	logger().debug() << "expect2 = " << oc_to_string(expect2);
 
 	TS_ASSERT(varseq == expect1 or varseq == expect2);
+
+	logger().info("END TEST: %s", __FUNCTION__);
 }
 
 void VariablesUTest::test_find_variables_unordered_3()
@@ -453,6 +477,8 @@ void VariablesUTest::test_find_variables_unordered_3()
 	logger().debug() << "expect = " << oc_to_string(expect);
 
 	TS_ASSERT_EQUALS(varseq, expect);
+
+	logger().info("END TEST: %s", __FUNCTION__);
 }
 
 void VariablesUTest::test_find_variables_unordered_4()
@@ -478,6 +504,8 @@ void VariablesUTest::test_find_variables_unordered_4()
 	logger().debug() << "expect = " << oc_to_string(expect);
 
 	TS_ASSERT_EQUALS(varseq, expect);
+
+	logger().info("END TEST: %s", __FUNCTION__);
 }
 
 void VariablesUTest::test_find_variables_unordered_5()
@@ -506,6 +534,8 @@ void VariablesUTest::test_find_variables_unordered_5()
 	std::reverse(varseq2.begin(), varseq2.end());
 
 	TS_ASSERT_EQUALS(varseq1, varseq2);
+
+	logger().info("END TEST: %s", __FUNCTION__);
 }
 
 void VariablesUTest::test_find_variables_mixed_1()
@@ -527,6 +557,8 @@ void VariablesUTest::test_find_variables_mixed_1()
 
 	// Just make sure the vardecl has X and Y, regardless of the order
 	TS_ASSERT_EQUALS(result, expect);
+
+	logger().info("END TEST: %s", __FUNCTION__);
 }
 
 void VariablesUTest::test_find_variables_mixed_2()
@@ -548,6 +580,8 @@ void VariablesUTest::test_find_variables_mixed_2()
 	logger().debug() << "expect = " << oc_to_string(expect);
 
 	TS_ASSERT_EQUALS(varseq, expect);
+
+	logger().info("END TEST: %s", __FUNCTION__);
 }
 
 void VariablesUTest::test_find_variables_mixed_3()
@@ -574,6 +608,8 @@ void VariablesUTest::test_find_variables_mixed_3()
 	std::reverse(varseq2.begin(), varseq2.end());
 
 	TS_ASSERT_EQUALS(varseq1, varseq2);
+
+	logger().info("END TEST: %s", __FUNCTION__);
 }
 
 void VariablesUTest::test_find_variables_mixed_4()
@@ -617,6 +653,8 @@ void VariablesUTest::test_find_variables_mixed_4()
 	          result == expect6 or
 	          result == expect7 or
 	          result == expect8);
+
+	logger().info("END TEST: %s", __FUNCTION__);
 }
 
 void VariablesUTest::test_find_variables_mixed_5()
@@ -639,6 +677,8 @@ void VariablesUTest::test_find_variables_mixed_5()
 
 	// Just make sure the vardecl has X and Y, regardless of the order
 	TS_ASSERT_EQUALS(result, expect);
+
+	logger().info("END TEST: %s", __FUNCTION__);
 }
 
 void VariablesUTest::test_find_variables_mixed_6()
@@ -669,6 +709,8 @@ void VariablesUTest::test_find_variables_mixed_6()
 	std::reverse(varseq2.begin(), varseq2.end());
 
 	TS_ASSERT_EQUALS(varseq1, varseq2);
+
+	logger().info("END TEST: %s", __FUNCTION__);
 }
 
 void VariablesUTest::test_find_variables_mixed_7()
@@ -699,6 +741,8 @@ void VariablesUTest::test_find_variables_mixed_7()
 	std::reverse(varseq2.begin(), varseq2.end());
 
 	TS_ASSERT_EQUALS(varseq1, varseq2);
+
+	logger().info("END TEST: %s", __FUNCTION__);
 }
 
 void VariablesUTest::test_find_variables_mixed_8()
@@ -721,6 +765,8 @@ void VariablesUTest::test_find_variables_mixed_8()
 	logger().debug() << "expect = " << oc_to_string(expect);
 
 	TS_ASSERT_EQUALS(result, expect);
+
+	logger().info("END TEST: %s", __FUNCTION__);
 }
 
 void VariablesUTest::test_find_variables_mixed_9()
@@ -749,6 +795,8 @@ void VariablesUTest::test_find_variables_mixed_9()
 	std::reverse(varseq2.begin(), varseq2.end());
 
 	TS_ASSERT_EQUALS(varseq1, varseq2);
+
+	logger().info("END TEST: %s", __FUNCTION__);
 }
 
 void VariablesUTest::test_find_variables_mixed_10()
@@ -767,6 +815,8 @@ void VariablesUTest::test_find_variables_mixed_10()
 	logger().debug() << "varseq = " << oc_to_string(varseq);
 
 	TS_ASSERT_EQUALS(varseq, HandleSeq());
+
+	logger().info("END TEST: %s", __FUNCTION__);
 }
 
 void VariablesUTest::test_find_variables_mixed_11()
@@ -795,6 +845,8 @@ void VariablesUTest::test_find_variables_mixed_11()
 	std::reverse(varseq2.begin(), varseq2.end());
 
 	TS_ASSERT_EQUALS(varseq1, varseq2);
+
+	logger().info("END TEST: %s", __FUNCTION__);
 }
 
 void VariablesUTest::test_is_type_1()
@@ -812,6 +864,8 @@ void VariablesUTest::test_is_type_1()
 
 	TS_ASSERT(not is_x);
 	TS_ASSERT(is_y);
+
+	logger().info("END TEST: %s", __FUNCTION__);
 }
 
 void VariablesUTest::test_is_type_2()
@@ -839,6 +893,8 @@ void VariablesUTest::test_is_type_2()
 
 	TS_ASSERT(not is_x);
 	TS_ASSERT(is_y);
+
+	logger().info("END TEST: %s", __FUNCTION__);
 }
 
 void VariablesUTest::test_is_type_3()
@@ -861,6 +917,8 @@ void VariablesUTest::test_is_type_3()
 
 	TS_ASSERT(is_x);
 	TS_ASSERT(not is_y);
+
+	logger().info("END TEST: %s", __FUNCTION__);
 }
 
 void VariablesUTest::test_is_type_4()
@@ -888,6 +946,8 @@ void VariablesUTest::test_is_type_4()
 
 	TS_ASSERT(is_x);
 	TS_ASSERT(is_y);
+
+	logger().info("END TEST: %s", __FUNCTION__);
 }
 
 void VariablesUTest::test_substitute_nocheck_scope()
@@ -912,4 +972,6 @@ void VariablesUTest::test_substitute_nocheck_scope()
 	logger().debug() << "result = " << oc_to_string(result);
 
 	TS_ASSERT(content_eq(result, expect));
+
+	logger().info("END TEST: %s", __FUNCTION__);
 }

--- a/tests/query/GreaterComputeUTest.cxxtest
+++ b/tests/query/GreaterComputeUTest.cxxtest
@@ -97,4 +97,6 @@ void GreaterComputeUTest::test_computation(void)
     "         (NumberNode 1000))))");
 
     TS_ASSERT_EQUALS(crash_b, expected);
+
+    logger().debug("END TEST: %s", __FUNCTION__);
 }

--- a/tests/query/GreaterThanUTest.cxxtest
+++ b/tests/query/GreaterThanUTest.cxxtest
@@ -105,6 +105,8 @@ void GreaterThanUTest::test_numeric_greater(void)
 	TS_ASSERT_EQUALS(1, getarity(people_richer_than_obama));
 	TS_ASSERT_EQUALS(2, getarity(people_richer_than_george));
 	TS_ASSERT_EQUALS(3, getarity(people_richer_than_susan));
+
+	logger().debug("END TEST: %s", __FUNCTION__);
 }
 
 // Same test as above, but using a scheme func for the compares
@@ -128,7 +130,10 @@ void GreaterThanUTest::test_scm_greater(void)
 	TS_ASSERT_EQUALS(1, getarity(people_richer_than_obama));
 	TS_ASSERT_EQUALS(2, getarity(people_richer_than_george));
 	TS_ASSERT_EQUALS(3, getarity(people_richer_than_susan));
+
+	logger().debug("END TEST: %s", __FUNCTION__);
 }
+
 // Same test as above, but using the built-in GreaterThanLink
 void GreaterThanUTest::test_builtin_greater(void)
 {
@@ -150,4 +155,6 @@ void GreaterThanUTest::test_builtin_greater(void)
 	TS_ASSERT_EQUALS(1, getarity(people_richer_than_obama));
 	TS_ASSERT_EQUALS(2, getarity(people_richer_than_george));
 	TS_ASSERT_EQUALS(3, getarity(people_richer_than_susan));
+
+	logger().debug("END TEST: %s", __FUNCTION__);
 }


### PR DESCRIPTION
Move much of the code from `Variables.cc` to a new `TypedVariableLink.cc`
This is needed to enable fixing multiple pattern engine bugs, as part of the
ongoing work for #2644 

@ngeiswei , it appears that `Variables.cc` has various extensions that only the
URE Unifier needs... I will try to move that code over to live with the Unifier,
instead of living here. These extensions are currently blocking for work
on issue #2644

The long-range goal is to either get rid of `struct Variables` or drastically
reduce it's complexity. The problem with it is that it offers a single unified
view of all the variables, and I actually need a context-dependent tree of 
them  (so either a bunch of small  `struct Variables` or maybe none at all,
and just naked `TypedVariableLink`s.)

p.s. sorry about all the nasty things I said about Quotations, I am starting
to see that I have lots of little context-dependent parts in the pattern engine
that need to be handled kind-of-like Quotations.  its quite exhausting to 
redesign everything correctly, though.