### PR TITLE
Return an empty scheme list if handle vector. is empty

### DIFF
--- a/opencog/guile/SchemePrimitive.h
+++ b/opencog/guile/SchemePrimitive.h
@@ -393,6 +393,8 @@ protected:
 	}
 	SCM scm_from(const HandleSeq& hs)
 	{
+	    if(hs.empty()) return SCM_EOL;
+
 		SCM rc;
 		HandleSeq::const_iterator it = hs.begin();
 		if (it != hs.end())


### PR DESCRIPTION
This fixes segfault error that happens when `scm_from` method is passed an empty handle vector. It checks whether the handle vector is empty and returns an empty scheme list if it is.