### PR TITLE
Use the correct system call for pipe creation depending on the platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,12 +66,6 @@ ELSE (CMAKE_BUILD_TYPE STREQUAL "Profile")
 	SET(BUILD_SHARED_LIBS ON)
 ENDIF (CMAKE_BUILD_TYPE STREQUAL "Profile")
 
-##Check whether the platform is Mac OS. This fixes cython
-IF(APPLE)
-	ADD_DEFINITIONS(-DON_APPLE)
-	SET(ON_APPLE 1)
-ENDIF(APPLE)
-
 # ===============================================================
 # Check for existance of various required, optional packages.
 # Listed in alphabetical order, more or less.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,12 @@ ELSE (CMAKE_BUILD_TYPE STREQUAL "Profile")
 	SET(BUILD_SHARED_LIBS ON)
 ENDIF (CMAKE_BUILD_TYPE STREQUAL "Profile")
 
+##Check whether the platform is Mac OS. This fixes cython
+IF(APPLE)
+	ADD_DEFINITIONS(-DON_APPLE)
+	SET(ON_APPLE 1)
+ENDIF(APPLE)
+
 # ===============================================================
 # Check for existance of various required, optional packages.
 # Listed in alphabetical order, more or less.

--- a/opencog/cython/PythonEval.cc
+++ b/opencog/cython/PythonEval.cc
@@ -1267,7 +1267,11 @@ std::string PythonEval::exec_wrap_stdout(const std::string& expr)
     // Capture whatever python prints to stdout
     // What used to be stdout will now go to the pipe.
     int pipefd[2];
+#ifdef ON_APPLE
+    int rc = pipe(pipefd);  // O_NONBLOCK);
+#else
     int rc = pipe2(pipefd, 0);  // O_NONBLOCK);
+#endif
     OC_ASSERT(0 == rc, "pipe creation failure");
     int stdout_backup = dup(fileno(stdout));
     OC_ASSERT(0 < stdout_backup, "stdout dup failure");

--- a/opencog/cython/PythonEval.cc
+++ b/opencog/cython/PythonEval.cc
@@ -1267,11 +1267,7 @@ std::string PythonEval::exec_wrap_stdout(const std::string& expr)
     // Capture whatever python prints to stdout
     // What used to be stdout will now go to the pipe.
     int pipefd[2];
-#ifdef ON_APPLE
-    int rc = pipe(pipefd);  // O_NONBLOCK);
-#else
-    int rc = pipe2(pipefd, 0);  // O_NONBLOCK);
-#endif
+    int rc = pipe(pipefd);
     OC_ASSERT(0 == rc, "pipe creation failure");
     int stdout_backup = dup(fileno(stdout));
     OC_ASSERT(0 < stdout_backup, "stdout dup failure");


### PR DESCRIPTION
This PR provides a fixe for #2465 by using the correct `pipe` system call depending on whether the platform is Mac OSX or not.