### PR TITLE
Minor cleanup of old code.

### DIFF
--- a/opencog/atomspace/AtomSpace.cc
+++ b/opencog/atomspace/AtomSpace.cc
@@ -40,12 +40,6 @@
 //#define DPRINTF printf
 #define DPRINTF(...)
 
-using std::string;
-using std::cerr;
-using std::cout;
-using std::endl;
-using std::min;
-using std::max;
 using namespace opencog;
 
 // ====================================================================

--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -37,11 +37,6 @@ class BasicSaveUTest;
 
 namespace opencog
 {
-const bool EMIT_DIAGNOSTICS = true;
-const bool DONT_EMIT_DIAGNOSTICS = false;
-const bool CHECK_VALUES = true;
-const bool DONT_CHECK_VALUES = false;
-
 /** \addtogroup grp_atomspace
  *  @{
  */
@@ -65,6 +60,12 @@ class AtomSpace
     friend class ::AtomSpaceUTest;
     friend class ::BasicSaveUTest;   // Needs to call get_atomtable()
 
+    // Debug tools
+    static const bool EMIT_DIAGNOSTICS = true;
+    static const bool DONT_EMIT_DIAGNOSTICS = false;
+    static const bool CHECK_VALUES = true;
+    static const bool DONT_CHECK_VALUES = false;
+
     /**
      * Drop copy constructor and equals operator to
      * prevent accidental copying of large objects.
@@ -73,6 +74,7 @@ class AtomSpace
     AtomSpace(const AtomSpace&) = delete;
 
     AtomTable _atom_table;
+
     /**
      * Used to fetch atoms from disk.
      */


### PR DESCRIPTION
Avoid polluting the main namespace with debug variables.