### PR TITLE
Provide get-all-keys->alist scheme utility

### DIFF
--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -290,6 +290,7 @@ void SchemeSmob::register_procs()
 	register_proc("cog-outgoing-by-type",  2, 0, 0, C(ss_outgoing_by_type));
 	register_proc("cog-outgoing-atom",     2, 0, 0, C(ss_outgoing_atom));
 	register_proc("cog-keys",              1, 0, 0, C(ss_keys));
+	register_proc("cog-keys->alist",       1, 0, 0, C(ss_keys_alist));
 	register_proc("cog-value",             2, 0, 0, C(ss_value));
 	register_proc("cog-tv",                1, 0, 0, C(ss_tv));
 	register_proc("cog-atomspace",         0, 0, 1, C(ss_as));

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -121,6 +121,7 @@ private:
 	static SCM ss_get_confidence(SCM);
 	static SCM ss_get_count(SCM);
 	static SCM ss_keys(SCM);
+	static SCM ss_keys_alist(SCM);
 	static SCM ss_value(SCM, SCM);
 	static SCM ss_incoming_set(SCM);
 	static SCM ss_incoming_size(SCM);

--- a/opencog/guile/SchemeSmobValue.cc
+++ b/opencog/guile/SchemeSmobValue.cc
@@ -346,7 +346,7 @@ SCM SchemeSmob::ss_value (SCM satom, SCM skey)
 /** Return all of the keys on the atom */
 SCM SchemeSmob::ss_keys (SCM satom)
 {
-	Handle atom(verify_handle(satom, "cog-value"));
+	Handle atom(verify_handle(satom, "cog-keys"));
 	AtomSpace* as = atom->getAtomSpace();
 
 	SCM rv = SCM_EOL;
@@ -363,6 +363,35 @@ SCM SchemeSmob::ss_keys (SCM satom)
 			rv = scm_cons (handle_to_scm(as->add_atom(k)), rv);
 		else
 			rv = scm_cons (handle_to_scm(k), rv);
+	}
+	return rv;
+}
+
+/** Return association list of keys+values on the atom */
+SCM SchemeSmob::ss_keys_alist (SCM satom)
+{
+	Handle atom(verify_handle(satom, "cog-keys->alist"));
+	AtomSpace* as = atom->getAtomSpace();
+
+	SCM rv = SCM_EOL;
+	HandleSet keys = atom->getKeys();
+	for (const Handle& k : keys)
+	{
+		ValuePtr vp = atom->getValue(k);
+
+		// OK, this is kind-of weird and hacky, but if the keys
+		// are not in any atomspace at the time that we go to
+		// print them, they'll be converted to <undefined handle>.
+		// So we shove them into the same atomspace as the atom
+		// itself. I don't quite like this, but it seems to be
+		// needed to fit user expectations.
+		SCM pair;
+		if (as)
+			pair = scm_cons (handle_to_scm(as->add_atom(k)), protom_to_scm(vp));
+		else
+			pair = scm_cons (handle_to_scm(k), protom_to_scm(vp));
+
+		rv = scm_cons (pair, rv);
 	}
 	return rv;
 }

--- a/opencog/scm/opencog.scm
+++ b/opencog/scm/opencog.scm
@@ -54,6 +54,7 @@ cog-incoming-size
 cog-incoming-size-by-type
 cog-inc-value!
 cog-keys
+cog-keys->alist
 cog-link
 cog-link?
 cog-map-type

--- a/opencog/scm/opencog/base/core-docs.scm
+++ b/opencog/scm/opencog/base/core-docs.scm
@@ -746,6 +746,26 @@
                  (Concept \"abc\") (Predicate \"key\")
                  (FloatValue 1 2 3))
        guile> (cog-keys (Concept \"abc\"))
+
+    See also:
+       cog-keys->alist ATOM - return association list of keys+values
+       cog-value ATOM KEY - return a value for the given KEY
+")
+
+(set-procedure-property! cog-keys->alist 'documentation
+"
+ cog-keys->alist ATOM
+    Return an association list of all key-value pairs attached to ATOM.
+
+    Example:
+       guile> (cog-set-value!
+                 (Concept \"abc\") (Predicate \"key\")
+                 (FloatValue 1 2 3))
+       guile> (cog-keys->alist (Concept \"abc\"))
+
+    See also:
+       cog-keys ATOM - return list of all keys on ATOM
+       cog-value ATOM KEY - return a value for the given KEY
 ")
 
 (set-procedure-property! cog-value 'documentation


### PR DESCRIPTION
Gets all of the key-value pairs on an atom.