### PR TITLE
Provide a faster, thinner way of getting the root set

### DIFF
--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -480,6 +480,30 @@ public:
     }
 
     /**
+     * Gets a set of handles that matches with the given type,
+     * but ONLY if they have an empty incoming set! This might
+     * spend more time under the atomtable lock, but should use
+     * less RAM when getting large sets, and thus might be faster.
+     *
+     * @param hset the HandleSet into which to insert handles.
+     * @param type The desired type.
+     * @param subclass Whether type subclasses should be considered.
+     *
+     * Example of call to this method, which would return all ConceptNodes
+     * in the AtomSpace:
+     * @code
+     *         HandleSet atoms;
+     *         atomSpace.get_rootset_by_type(atoms, CONCEPT_NODE);
+     * @endcode
+     */
+    void get_rootset_by_type(HandleSet& hset,
+                             Type type,
+                             bool subclass=false) const
+    {
+        return _atom_table.getRootSetByType(hset, type, subclass);
+    }
+
+    /**
      * Gets a sequence of handles that matches with the given type
      * (subclasses optionally).
      * Caution: this is slower than using get_handleset_by_type() to

--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -208,6 +208,7 @@ public:
      * Returns the set of atoms of a given type, but only if they have
      * and empty outgoing set. This holds the AtomTable lock for a
      * longer period of time, but wastes less RAM when getting big sets.
+     * As a net result, it might run faster, maybe.
      *
      * @param The desired type.
      * @param Whether type subclasses should be considered.

--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -205,6 +205,35 @@ public:
     }
 
     /**
+     * Returns the set of atoms of a given type, but only if they have
+     * and empty outgoing set. This holds the AtomTable lock for a
+     * longer period of time, but wastes less RAM when getting big sets.
+     *
+     * @param The desired type.
+     * @param Whether type subclasses should be considered.
+     * @return The set of atoms of a given type (subclasses optionally).
+     */
+    void
+    getRootSetByType(HandleSet& hset,
+                     Type type,
+                     bool subclass=false,
+                     bool parent=true) const
+    {
+        std::lock_guard<std::recursive_mutex> lck(_mtx);
+        auto tit = typeIndex.begin(type, subclass);
+        auto tend = typeIndex.end();
+        while (tit != tend) {
+            if (0 == (*tit)->getIncomingSetSize())
+                 hset.insert(*tit);
+            tit++;
+        }
+        // If an atom is already in the set, it will hide any duplicate
+        // atom in the parent.
+        if (parent and _environ)
+            _environ->getRootSetByType(hset, type, subclass, parent);
+    }
+
+    /**
      * Returns the set of atoms of a given type (subclasses optionally).
      *
      * @param The desired type.


### PR DESCRIPTION
Sometimes, one just wants all of the atoms in the atomspace ... this is most easily
accomplished by just getting the top-most, "root" atoms only. This will use less RAM,
and therefore might run faster, for large atom sets.