### PR TITLE
Print simple truth values with 16 decimal places.

### DIFF
--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -243,6 +243,8 @@ void SchemeSmob::module_init(void*)
 
 void SchemeSmob::register_procs()
 {
+	register_proc("cog-set-server-mode!",  1, 0, 0, C(ss_set_server_mode));
+
 	register_proc("cog-new-value",         1, 0, 1, C(ss_new_value));
 	register_proc("cog-new-atom",          1, 0, 1, C(ss_new_atom));
 	register_proc("cog-new-node",          2, 0, 1, C(ss_new_node));

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -52,6 +52,7 @@ private:
 		COG_EXTEND      // callbacks into C++ code.
 	};
 
+	static bool server_mode;
 	static std::atomic_flag is_inited;
 	static void module_init(void*);
 	static void register_procs();
@@ -63,6 +64,7 @@ private:
 
 	// Initialization functions
 	static void init_smob_type(void);
+	static SCM ss_set_server_mode(SCM);
 
 	static int print_misc(SCM, SCM, scm_print_state *);
 	static SCM equalp_misc(SCM, SCM);
@@ -215,6 +217,7 @@ private:
 
 	static SCM atomspace_fluid;
 	static void ss_set_env_as(AtomSpace *);
+
 	SchemeSmob();
 public:
 	// This makes init publicly visible; needed for the guile module.

--- a/opencog/guile/SchemeSmobNew.cc
+++ b/opencog/guile/SchemeSmobNew.cc
@@ -18,6 +18,18 @@
 
 using namespace opencog;
 
+/// If server_mode is true, then do things that a server would want;
+/// otherwise, behave in a human-friendly interactive way.  Currently,
+/// server-mode enables printing of 16-decimal-place truth values.
+bool SchemeSmob::server_mode = false;
+
+SCM SchemeSmob::ss_set_server_mode(SCM boo)
+{
+	bool old_mode = server_mode;
+	server_mode = (SCM_BOOL_F != boo);
+	return old_mode ? SCM_BOOL_T : SCM_BOOL_F;
+}
+
 /* ============================================================== */
 /**
  * Return a string holding the scheme representation of an opencog object.
@@ -39,10 +51,27 @@ std::string SchemeSmob::protom_to_string(SCM node)
 	ValuePtr pa(scm_to_protom(node));
 	if (nullptr == pa) return "#<Invalid handle>";
 
-	// Need to have a newline printed; otherewise cog-value->list
-	// prints badly-formatted grunge.
 	if (not pa->is_atom())
+	{
+		if (server_mode)
+		{
+			// Print high-precision simple truth values.
+			if (nameserver().isA(pa->get_type(), FLOAT_VALUE))
+			{
+				// The FloatValue to_string() print prints out a
+				// high-precision form of the value, as compared
+				// to SimpleTruthValue, which only prints 6 digits
+				// and breaks distributed-storage unit tests.
+				FloatValuePtr fv(FloatValueCast(pa));
+				return fv->FloatValue::to_string();
+			}
+			return pa->to_short_string();
+		}
+
+		// Need to have a newline printed; otherewise
+		// cog-value->list prints badly-formatted grunge.
 		return pa->to_short_string() + "\n";
+	}
 
 	// Avoid printing atoms that are not in any atomspace.
 	// Doing so, and more generally, keeping these around

--- a/opencog/scm/opencog.scm
+++ b/opencog/scm/opencog.scm
@@ -72,6 +72,7 @@ cog-outgoing-atom
 cog-outgoing-by-type
 cog-outgoing-set
 cog-set-atomspace!
+cog-set-server-mode!
 cog-set-tv!
 cog-set-value!
 cog-set-values!

--- a/opencog/scm/opencog/base/core-docs.scm
+++ b/opencog/scm/opencog/base/core-docs.scm
@@ -1099,6 +1099,15 @@
          cog-atomspace-readonly?,
 ")
 
+(set-procedure-property! cog-set-server-mode! 'documentation
+"
+ cog-set-server-mode! BOOL
+     If BOOL is #t, then some server-freindly options are enabled,
+     including the high-precision printing of TruthValues. Otherwise,
+     human-friendly shell-evaluator style is used. The default is
+     false. Returns the previous setting.
+")
+
 ;set-procedure-property! cog-yield 'documentation
 ;"
 ; cog-yield


### PR DESCRIPTION
... but only when guile is in "server mode". Otherwise,
the old default human-freindly printing is used.