### PR TITLE
Fix persist unit test; it was too strict.

### DIFF
--- a/tests/persist/sql/multi-driver/MultiPersistUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/MultiPersistUTest.cxxtest
@@ -265,9 +265,17 @@ void MultiPersistUTest::atomCompare(AtomPtr a, AtomPtr b, std::string where)
         TSM_ASSERT("Missing truth value", tb);
         if (ta and tb)
         {
-            TSM_ASSERT("Truth value miscompare", (*ta)==(*tb));
+            // Only compare mean. Different threads set the
+            // confidence in a racey manner, and so anything
+            // might show up there. For the SQL backend, there
+            // is a sequence of coincidences/accidents that
+            // serialize just enough so that the confidence
+            // values do end up matching... but in general,
+            // this is not guaranteed.
+            bool okay = fabs(ta->get_mean() - tb->get_mean()) < 1e-6;
+            TSM_ASSERT("Truth value miscompare", okay);
 
-            if (not ((*ta) == (*tb)))
+            if (not okay)
             {
                 fprintf(stderr, "Error, truth value miscompare, "
                     "ma=%f mb=%f ca=%f cb=%f\n",


### PR DESCRIPTION
So, by accident (lucky coincidence) the unit test was passing;
but it was just wrong. Fix it.