### PR TITLE
Constify the API for parsing s-expressions

### DIFF
--- a/opencog/persist/sexpr/Sexpr.h
+++ b/opencog/persist/sexpr/Sexpr.h
@@ -52,8 +52,8 @@ public:
 		return decode_atom(s, junk);
 	}
 
-	static ValuePtr decode_value(std::string&, size_t&);
-	static void decode_alist(Handle&, std::string&);
+	static ValuePtr decode_value(const std::string&, size_t&);
+	static void decode_alist(Handle&, const std::string&);
 
 	// API more suitable to very long, file-driven I/O.
 	static int get_next_expr(const std::string&,

--- a/opencog/persist/sexpr/ValueSexpr.cc
+++ b/opencog/persist/sexpr/ValueSexpr.cc
@@ -43,7 +43,7 @@ using namespace opencog;
  * XXX FIXME This needs to be fuzzed; it is very likely to crash
  * and/or contain bugs if it is given strings of unexpected formats.
  */
-ValuePtr Sexpr::decode_value(std::string& stv, size_t& pos)
+ValuePtr Sexpr::decode_value(const std::string& stv, size_t& pos)
 {
 	size_t totlen = stv.size();
 
@@ -174,7 +174,7 @@ ValuePtr Sexpr::decode_value(std::string& stv, size_t& pos)
  * ((KEY . VALUE)(KEY2 . VALUE2)...)
  * Store the results as values on the atom.
  */
-void Sexpr::decode_alist(Handle& atom, std::string& alist)
+void Sexpr::decode_alist(Handle& atom, const std::string& alist)
 {
 	// Skip over opening paren
 	size_t pos = 1;


### PR DESCRIPTION
Add change `std::string&` to `const std::string&` in the s-expression API.