### PR TITLE
Dynamic-load Python

### DIFF
--- a/opencog/atoms/grounded/CMakeLists.txt
+++ b/opencog/atoms/grounded/CMakeLists.txt
@@ -13,9 +13,8 @@ ADD_LIBRARY (grounded
 
 IF (HAVE_CYTHON)
 	INCLUDE_DIRECTORIES(${PYTHON_INCLUDE_PATH})
+	TARGET_SOURCES(grounded PRIVATE DLPython.cc)
 	TARGET_SOURCES(grounded PRIVATE PythonRunner.cc)
-	TARGET_LINK_LIBRARIES(grounded PythonEval)
-	TARGET_LINK_LIBRARIES(grounded ${PYTHON_LIBRARIES})
 ENDIF (HAVE_CYTHON)
 
 # Without this, parallel make will race and crap up the generated files.
@@ -24,11 +23,6 @@ ADD_DEPENDENCIES(grounded opencog_atom_types)
 TARGET_LINK_LIBRARIES(grounded
 	atombase
 )
-
-IF (HAVE_CYTHON)
-	TARGET_LINK_LIBRARIES(grounded PythonEval)
-	TARGET_LINK_LIBRARIES(grounded ${PYTHON_LIBRARIES})
-ENDIF (HAVE_CYTHON)
 
 INSTALL (TARGETS grounded
 	EXPORT AtomSpaceTargets

--- a/opencog/atoms/grounded/DLPython.cc
+++ b/opencog/atoms/grounded/DLPython.cc
@@ -1,0 +1,66 @@
+/*
+ * opencog/atoms/execution/DLPython.cc
+ *
+ * Copyright (C) 2019 Linas Vepstas
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <dlfcn.h>
+#include <mutex>
+#include <opencog/util/exceptions.h>
+#include "DLPython.h"
+
+using namespace opencog;
+
+PythonEval* opencog::get_evaluator_for_python(AtomSpace* as)
+{
+	typedef PythonEval* (*SEGetter)(AtomSpace*);
+	static SEGetter getter = nullptr;
+	if (getter) return getter(as);
+
+	static std::mutex mtx;
+	std::lock_guard<std::mutex> lock(mtx);
+
+	static void* library = nullptr;
+	if (nullptr == library) library = dlopen("libPythonEval.so", RTLD_LAZY);
+	if (nullptr == library)
+		throw RuntimeException(TRACE_INFO,
+			"Unable to dynamically load libPythonEval.so: %s",
+			dlerror());
+
+	static void* getev = nullptr;
+	if (nullptr == getev) getev = dlsym(library, "get_python_evaluator");
+	if (nullptr == getev)
+		throw RuntimeException(TRACE_INFO,
+			"Unable to dynamically load Python evaluator: %s",
+			dlerror());
+
+	// static SEGetter getter = std::reinterpret_cast<SEGetter>(getev);
+	getter = (SEGetter) getev;
+
+	return getter(as);
+}
+
+static __attribute__ ((destructor)) void fini(void)
+{
+	// Don't bother. This can trigger a pointless error:
+	//    Inconsistency detected by ld.so: dl-close.c: 811: _dl_close:
+	//    Assertion `map->l_init_called' failed!
+	// or we can just RTLD_NODELETE during the open, instead.
+	// if (library) dlclose(library);
+}

--- a/opencog/atoms/grounded/DLPython.h
+++ b/opencog/atoms/grounded/DLPython.h
@@ -1,8 +1,7 @@
 /*
- * opencog/atoms/grounded/PythonRunner.h
+ * opencog/atoms/execution/DLPython.h
  *
- * Copyright (C) 2020 Linas Vepstas
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * Copyright (C) 2019 Linas Vepstas
  * All Rights Reserved
  *
  * This program is free software; you can redistribute it and/or modify
@@ -21,33 +20,14 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef _OPENCOG_PYTHON_RUNNER_H
-#define _OPENCOG_PYTHON_RUNNER_H
-
-#include <string>
-#include <opencog/atoms/grounded/Runner.h>
+#ifndef _OPENCOG_DL_PYTHON_H
+#define _OPENCOG_DL_PYTHON_H
 
 namespace opencog
 {
-/** \addtogroup grp_atomspace
- *  @{
- */
-
-/// Base class for executing Python code.
-class PythonRunner : public Runner
-{
-	std::string _fname;
-
-public:
-	PythonRunner(const std::string);
-	PythonRunner(const PythonRunner&) = delete;
-	PythonRunner& operator=(const PythonRunner&) = delete;
-
-	virtual ValuePtr execute(AtomSpace*, const Handle&, bool=false);
-	virtual ValuePtr evaluate(AtomSpace*, const Handle&, bool=false);
-};
-
-/** @}*/
+class AtomSpace;
+class PythonEval;
+PythonEval* get_evaluator_for_python(AtomSpace*);
 }
 
-#endif // _OPENCOG_PYTHON_RUNNER_H
+#endif // _OPENCOG_DL_PYTHON_H

--- a/opencog/atoms/grounded/PythonRunner.cc
+++ b/opencog/atoms/grounded/PythonRunner.cc
@@ -28,12 +28,13 @@
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/cython/PythonEval.h>
 
+#include <opencog/atoms/grounded/DLPython.h>
 #include <opencog/atoms/grounded/PythonRunner.h>
 
 using namespace opencog;
 
 PythonRunner::PythonRunner(std::string s)
-	: _fname(s), applier(PythonEval::instance())
+	: _fname(s)
 {
 }
 
@@ -60,7 +61,9 @@ ValuePtr PythonRunner::execute(AtomSpace* as,
 	// functions smart enough to do lazy evaluation.
 	Handle args(force_execute(as, cargs, silent));
 
-	return applier.apply_v(as, _fname, args);
+	PythonEval* applier = get_evaluator_for_python(as);
+
+	return applier->apply_v(as, _fname, args);
 }
 
 ValuePtr PythonRunner::evaluate(AtomSpace* as,
@@ -74,5 +77,7 @@ ValuePtr PythonRunner::evaluate(AtomSpace* as,
 	// functions smart enough to do lazy evaluation.
 	Handle args(force_execute(as, cargs, silent));
 
-	return CastToValue(applier.apply_tv(as, _fname, args));
+	PythonEval* applier = get_evaluator_for_python(as);
+
+	return CastToValue(applier->apply_tv(as, _fname, args));
 }

--- a/opencog/cython/CMakeLists.txt
+++ b/opencog/cython/CMakeLists.txt
@@ -39,6 +39,7 @@ TARGET_LINK_LIBRARIES(PythonEval
 	execution
 	atomflow
 	atombase
+	atomspace
 	executioncontext
  	load_scm
 	${PYTHON_LIBRARIES}

--- a/opencog/cython/PythonEval.cc
+++ b/opencog/cython/PythonEval.cc
@@ -1440,4 +1440,13 @@ void PythonEval::interrupt(void)
     logger().warn("[PythonEval] interrupt not implemented!\n");
 }
 
+extern "C" {
+// Thin wrapper for easy dlopen/dlsym dynamic loading
+opencog::PythonEval* get_python_evaluator(opencog::AtomSpace* as)
+{
+   return &opencog::PythonEval::instance();
+}
+
+};
+
 // =========== END OF FILE =========

--- a/opencog/cython/PythonEval.h
+++ b/opencog/cython/PythonEval.h
@@ -167,7 +167,7 @@ class PythonEval : public GenericEval
          * Calls the Python function passed in `func`, passing it
          * the `varargs` as an argument, and returning a Handle.
          */
-        ValuePtr apply_v(AtomSpace * as, const std::string& func,
+        virtual ValuePtr apply_v(AtomSpace * as, const std::string& func,
                          Handle varargs);
 
         /**

--- a/opencog/cython/PythonEval.h
+++ b/opencog/cython/PythonEval.h
@@ -215,6 +215,11 @@ void global_python_initialize();
  */
 void global_python_finalize();
 
+extern "C" {
+   // For shared-library loading
+   opencog::PythonEval* get_python_evaluator(opencog::AtomSpace*);
+};
+
 } /* namespace opencog */
 
 #endif /* HAVE_CYTHON */

--- a/opencog/persist/sexpr/CMakeLists.txt
+++ b/opencog/persist/sexpr/CMakeLists.txt
@@ -8,6 +8,8 @@ ADD_LIBRARY (sexpr
 ADD_DEPENDENCIES(sexpr opencog_atom_types)
 
 TARGET_LINK_LIBRARIES(sexpr
+	atomspace
+	execution
 	atombase
 	${COGUTIL_LIBRARY}
 )
@@ -48,6 +50,7 @@ ADD_LIBRARY (persist-file
 )
 
 TARGET_LINK_LIBRARIES(persist-file
+	load_scm
 	sexpr
 	atomspace
 	smob


### PR DESCRIPTION
Dynamic-load Python instead of static linking. 

This might fix issue opencog/opencog#3653 maybe; not sure. The failure to dynamic-load python has been the source of many bugs over the years; we've patched and hacked-around the core bug for too long. I'm thinking this should fix it, or, at least, it should clear the path for resolving remaining issues.