### PR TITLE
Basic command interpreter

### DIFF
--- a/opencog/atoms/value/LinkValue.cc
+++ b/opencog/atoms/value/LinkValue.cc
@@ -67,8 +67,26 @@ std::string LinkValue::to_string(const std::string& indent) const
 	for (ValuePtr v :_value)
 		rv += v->to_short_string(more_indent) + "\n";
 
-	// Remove trailing newline before writing the ast paren
+	// Remove trailing newline before writing the last paren
 	rv.pop_back();
+	rv += ")";
+	return rv;
+}
+
+/// Identical to above, except that it does not write any newlines.
+/// This avoids cogserver issues, where the newline is interpreted
+/// as an end-of-messege marker by GenericShell. The SchemeShell
+/// deals with pending input just fine, but the SexprShell does not:
+/// its a waste of CPU-cycles to work around newlines by scanning
+/// for balanced parens in strings. So ... no newlines, here.
+std::string LinkValue::to_short_string(const std::string& indent) const
+{
+	update();
+	std::string more_indent = indent + "  "; // two spaces, same as Link
+	std::string rv = indent + "(" + nameserver().getTypeName(_type);
+	for (ValuePtr v :_value)
+		rv += v->to_short_string(more_indent);
+
 	rv += ")";
 	return rv;
 }

--- a/opencog/atoms/value/LinkValue.h
+++ b/opencog/atoms/value/LinkValue.h
@@ -63,6 +63,7 @@ public:
 
 	/** Returns a string representation of the value.  */
 	virtual std::string to_string(const std::string& indent = "") const;
+	virtual std::string to_short_string(const std::string& indent = "") const;
 
 	/** Returns true if the two atoms are equal, else false.  */
 	virtual bool operator==(const Value&) const;

--- a/opencog/atomspace/BackingStore.h
+++ b/opencog/atomspace/BackingStore.h
@@ -206,23 +206,22 @@ class BackingStore
 
 		/**
 		 * Fetch *all* Atoms of the given type, and place them into the
-		 * AtomTable. If a given Atom does not yet exist locally, then
-		 * all of the Values will also be fetched, and copied locally.
-		 * If a given Atom DOES exist locally, then NONE of the local
-		 * Values are updated! (This avoids the need to make complex
-		 * decisions about how to merge conflicting Values).
+		 * AtomTable. All of the associated Values are also be fetched,
+		 * and clobber any earlier values that might be present on
+		 * existing Atoms. Values on the outgoing set of Type are NOT
+		 * fetched!
 		 */
 		virtual void loadType(AtomTable&, Type) = 0;
 
 		/**
 		 * Load *all* atoms from the remote server into this (local)
-		 * AtomTable.
+		 * AtomTable. Also load all Values attached to the Atoms.
 		 */
 		virtual void loadAtomSpace(AtomTable&) = 0;
 
 		/**
 		 * Store *all* atoms from this (local) AtomTable to the remote
-		 * server.
+		 * server. This stores all Values as well.
 		 */
 		virtual void storeAtomSpace(const AtomTable&) = 0;
 

--- a/opencog/cython/opencog/value.pyx
+++ b/opencog/cython/opencog/value.pyx
@@ -66,7 +66,7 @@ cdef class Value:
         return self.get_c_value_ptr().get().to_short_string().decode('UTF-8')
 
     def __str__(self):
-        return self.short_string()
+        return self.long_string()
 
     def __repr__(self):
         return self.long_string()

--- a/opencog/cython/opencog/value.pyx
+++ b/opencog/cython/opencog/value.pyx
@@ -66,6 +66,8 @@ cdef class Value:
         return self.get_c_value_ptr().get().to_short_string().decode('UTF-8')
 
     def __str__(self):
+        if self.is_atom():
+           return self.short_string()
         return self.long_string()
 
     def __repr__(self):

--- a/opencog/guile/SchemeEval.cc
+++ b/opencog/guile/SchemeEval.cc
@@ -5,6 +5,21 @@
  * the appropriate Atomspace, etc.
  *
  * Copyright (c) 2008, 2014, 2015 Linas Vepstas
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
 #include <atomic>

--- a/opencog/guile/SchemeEval.h
+++ b/opencog/guile/SchemeEval.h
@@ -3,6 +3,21 @@
  *
  * Scheme expression evaluator for OpenCog
  * Copyright (c) 2008, 2014 Linas Vepstas <linas@linas.org>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
 #ifndef OPENCOG_SCHEME_EVAL_H

--- a/opencog/guile/SchemeModule.cc
+++ b/opencog/guile/SchemeModule.cc
@@ -3,6 +3,21 @@
  *
  * Simplified API for creating guile modules.
  * Copyright (c) 2008, 2014, 2015 Linas Vepstas <linas@linas.org>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
 #include <opencog/atomspace/AtomSpace.h>

--- a/opencog/guile/SchemeModule.h
+++ b/opencog/guile/SchemeModule.h
@@ -3,6 +3,21 @@
  *
  * Simplified wrapper for creating guile modules.
  * Copyright (c) 2008, 2014, 2015 Linas Vepstas <linas@linas.org>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
 #ifndef _OPENCOG_SCHEME_MODULE_H

--- a/opencog/guile/SchemePrimitive.cc
+++ b/opencog/guile/SchemePrimitive.cc
@@ -5,6 +5,21 @@
  * by defining a scheme primitive function.
  *
  * Copyright (C) 2009, 2014, 2015 Linas Vepstas
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
 #include <exception>

--- a/opencog/guile/SchemePrimitive.h
+++ b/opencog/guile/SchemePrimitive.h
@@ -5,6 +5,21 @@
  * by creating a new scheme primitive function.
  *
  * Copyright (C) 2009,2015 Linas Vepstas
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
 #ifdef HAVE_GUILE

--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -4,6 +4,21 @@
  * Scheme small objects (SMOBS) for opencog -- core functions.
  *
  * Copyright (c) 2008, 2013, 2014, 2015 Linas Vepstas <linas@linas.org>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
 #include <cstddef>

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -6,6 +6,21 @@
  * when it sees the opencog-specific proceedures.
  *
  * Copyright (c) 2008,2009 Linas Vepstas <linasvepstas@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
 #ifdef HAVE_GUILE

--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -4,6 +4,21 @@
  * Scheme small objects (SMOBS) for opencog atom properties
  *
  * Copyright (c) 2008,2009 Linas Vepstas <linas@linas.org>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
 #include <vector>

--- a/opencog/guile/SchemeSmobValue.cc
+++ b/opencog/guile/SchemeSmobValue.cc
@@ -4,6 +4,21 @@
  * Scheme small objects (SMOBS) for ProtoAtoms [now renamed Value].
  *
  * Copyright (c) 2008,2009,2016 Linas Vepstas <linas@linas.org>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
 #include <cstddef>

--- a/opencog/persist/sexpr/CMakeLists.txt
+++ b/opencog/persist/sexpr/CMakeLists.txt
@@ -3,6 +3,7 @@
 ADD_LIBRARY (sexpr
 	AtomSexpr
 	Commands
+	SexprEval
 	ValueSexpr
 )
 
@@ -22,6 +23,7 @@ INSTALL (TARGETS sexpr EXPORT AtomSpaceTargets
 INSTALL (FILES
 	Commands.h
 	Sexpr.h
+	SexprEval.h
 	DESTINATION "include/opencog/persist/sexpr"
 )
 

--- a/opencog/persist/sexpr/CMakeLists.txt
+++ b/opencog/persist/sexpr/CMakeLists.txt
@@ -19,6 +19,7 @@ INSTALL (TARGETS sexpr EXPORT AtomSpaceTargets
 )
 
 INSTALL (FILES
+	Commands.h
 	Sexpr.h
 	DESTINATION "include/opencog/persist/sexpr"
 )

--- a/opencog/persist/sexpr/CMakeLists.txt
+++ b/opencog/persist/sexpr/CMakeLists.txt
@@ -2,6 +2,7 @@
 # Generic S-expression decoding.
 ADD_LIBRARY (sexpr
 	AtomSexpr
+	Commands
 	ValueSexpr
 )
 

--- a/opencog/persist/sexpr/Commands.cc
+++ b/opencog/persist/sexpr/Commands.cc
@@ -39,7 +39,7 @@ std::string Commands::interpret_command(AtomSpace* as,
 	// Fast dispatch. There should be zero hash collisions
 	// here. If there are, we are in trouble. (Well, if there
 	// are collisions, pre-pent the paren, post-pend the space.)
-	static const size_t clear = std::hash<std::string>{}("cog-atomspace-clear");
+	static const size_t clear = std::hash<std::string>{}("cog-atomspace-clear)");
 	static const size_t cache = std::hash<std::string>{}("cog-execute-cache!");
 	static const size_t extra = std::hash<std::string>{}("cog-extract!");
 	static const size_t recur = std::hash<std::string>{}("cog-extract-recursive!");

--- a/opencog/persist/sexpr/Commands.cc
+++ b/opencog/persist/sexpr/Commands.cc
@@ -238,9 +238,18 @@ std::string Commands::interpret_command(AtomSpace* as,
 		return "()\n";
 	}
 
-	//    cog-value
+	// (cog-value (Concept "foo") (Predicate "key"))
 	if (value == act)
-		throw SyntaxException(TRACE_INFO, "Not implemented");
+	{
+		pos = epos + 1;
+		Handle atom = Sexpr::decode_atom(cmd, pos);
+		atom = as->add_atom(atom);
+		Handle key = Sexpr::decode_atom(cmd, ++pos);
+		key = as->add_atom(key);
+
+		ValuePtr vp = atom->getValue(key);
+		return Sexpr::encode_value(vp);
+	}
 
 	throw SyntaxException(TRACE_INFO, "Command not supported: >>%s<<",
 		cmd.substr(pos, epos-pos).c_str());

--- a/opencog/persist/sexpr/Commands.cc
+++ b/opencog/persist/sexpr/Commands.cc
@@ -74,7 +74,7 @@ std::string Commands::interpret_command(AtomSpace* as,
 
 	size_t act = std::hash<std::string>{}(cmd.substr(pos, epos-pos));
 
-	//    cog-atomspace-clear
+	// (cog-atomspace-clear)
 	if (clear == act)
 	{
 		as->clear();
@@ -166,9 +166,17 @@ std::string Commands::interpret_command(AtomSpace* as,
 		return "()\n";
 	}
 
-	//    cog-set-values!
+	// (cog-set-values! (Concpet "foo")
+	//     (list (cons (Predicate "bar") (stv 0.9 0.8)) ...))
 	if (svals == act)
-		throw SyntaxException(TRACE_INFO, "Not implemented");
+	{
+		pos = epos + 1;
+		Handle h = Sexpr::decode_atom(cmd, pos);
+		as->add_atom(h);
+		pos++; // skip past close-paren
+		Sexpr::decode_slist(h, cmd, pos);
+		return "()\n";
+	}
 
 	// (cog-set-tv! (Concept "foo") (stv 1 0))
 	if (settv == act)

--- a/opencog/persist/sexpr/Commands.cc
+++ b/opencog/persist/sexpr/Commands.cc
@@ -125,16 +125,24 @@ std::string Commands::interpret_command(AtomSpace* as,
 	if (incty == act)
 		throw SyntaxException(TRACE_INFO, "Not implemented");
 
-	//    cog-incoming-set
+	// (cog-incoming-set (Concept "foo"))
 	if (incom == act)
-		throw SyntaxException(TRACE_INFO, "Not implemented");
+	{
+		pos = epos + 1;
+		Handle h = as->add_atom(Sexpr::decode_atom(cmd, pos));
+		std::string alist = "(";
+		for (const Handle& hi : h->getIncomingSet())
+			alist += Sexpr::encode_atom(hi);
+
+		alist += ")\n";
+		return alist;
+	}
 
 	// (cog-keys->alist (Concept "foo"))
 	if (keys == act)
 	{
 		pos = epos + 1;
-		Handle h = Sexpr::decode_atom(cmd, pos);
-		h = as->add_atom(h);
+		Handle h = as->add_atom(Sexpr::decode_atom(cmd, pos));
 		std::string alist = "(";
 		for (const Handle& key : h->getKeys())
 		{

--- a/opencog/persist/sexpr/Commands.cc
+++ b/opencog/persist/sexpr/Commands.cc
@@ -29,6 +29,7 @@
 #include <opencog/atoms/base/Link.h>
 #include <opencog/atoms/base/Node.h>
 #include <opencog/atoms/value/FloatValue.h>
+#include <opencog/atoms/truthvalue/TruthValue.h>
 #include <opencog/atomspace/AtomSpace.h>
 
 #include "Commands.h"
@@ -283,7 +284,10 @@ std::string Commands::interpret_command(AtomSpace* as,
 	{
 		pos = epos + 1;
 		Handle h = Sexpr::decode_atom(cmd, pos);
-		as->add_atom(h);
+		Handle ha = as->add_atom(h);
+		if (nullptr == ha) return "()\n"; // read-only atomspace.
+		ValuePtr tv = Sexpr::decode_value(cmd, ++pos);
+		ha->setTruthValue(TruthValueCast(tv));
 		return "()\n";
 	}
 

--- a/opencog/persist/sexpr/Commands.cc
+++ b/opencog/persist/sexpr/Commands.cc
@@ -183,8 +183,7 @@ std::string Commands::interpret_command(AtomSpace* as,
 	if (svals == act)
 	{
 		pos = epos + 1;
-		Handle h = Sexpr::decode_atom(cmd, pos);
-		as->add_atom(h);
+		Handle h = as->add_atom(Sexpr::decode_atom(cmd, pos));
 		pos++; // skip past close-paren
 		Sexpr::decode_slist(h, cmd, pos);
 		return "()\n";

--- a/opencog/persist/sexpr/Commands.cc
+++ b/opencog/persist/sexpr/Commands.cc
@@ -149,14 +149,15 @@ std::string Commands::interpret_command(AtomSpace* as,
 			HandleSeq outgoing;
 			size_t l = nos+1;
 			size_t r = cmd.size();
-			do {
+			while (l < r and ')' != cmd[l])
+			{
 				size_t l1 = l;
 				size_t r1 = r;
 				Sexpr::get_next_expr(cmd, l1, r1, 0);
 				if (l1 == r1) break;
 				outgoing.push_back(Sexpr::decode_atom(cmd, l1, r1, 0));
 				l = r1 + 1;
-			} while (l < r and ')' != cmd[l]);
+			}
 			h = as->get_link(t, std::move(outgoing));
 		}
 		if (nullptr == h) return "()\n";

--- a/opencog/persist/sexpr/Commands.cc
+++ b/opencog/persist/sexpr/Commands.cc
@@ -1,0 +1,118 @@
+/*
+ * Commands.cc
+ * Fast command interpreter for basic AtomSpace commands.
+ *
+ * Copyright (C) 2020 Linas Vepstas
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <functional>
+#include <string>
+
+#include <opencog/atoms/atom_types/NameServer.h>
+#include <opencog/atoms/base/Link.h>
+#include <opencog/atoms/base/Node.h>
+
+#include "Commands.h"
+#include "Sexpr.h"
+
+using namespace opencog;
+
+std::string Commands::interpret_command(AtomSpace* as,
+                                        const std::string& cmd)
+{
+	static const size_t clear = std::hash<std::string>{}("cog-atomspace-clear");
+	static const size_t cache = std::hash<std::string>{}("cog-execute-cache!");
+	static const size_t extra = std::hash<std::string>{}("cog-extract!");
+	static const size_t recur = std::hash<std::string>{}("cog-extract-recursive!");
+	static const size_t gtatm = std::hash<std::string>{}("cog-get-atoms");
+	static const size_t incty = std::hash<std::string>{}("cog-incoming-by-type");
+	static const size_t incom = std::hash<std::string>{}("cog-incoming-set");
+	static const size_t keys = std::hash<std::string>{}("cog-keys->alist");
+	static const size_t link = std::hash<std::string>{}("cog-link");
+	static const size_t node = std::hash<std::string>{}("cog-node");
+	static const size_t stval = std::hash<std::string>{}("cog-set-value!");
+	static const size_t svals = std::hash<std::string>{}("cog-set-values!");
+	static const size_t settv = std::hash<std::string>{}("cog-set-tv!");
+	static const size_t value = std::hash<std::string>{}("cog-value");
+	
+	size_t pos = cmd.find_first_of(" \n\t", 1);
+	if (std::string::npos == pos)
+		throw SyntaxException(TRACE_INFO, "Not a command %s",
+			cmd.c_str());
+
+	size_t act = std::hash<std::string>{}(cmd.substr(1, pos));
+
+	//    cog-atomspace-clear
+	if (clear == act)
+		throw SyntaxException(TRACE_INFO, "Not implemented");
+
+	//    cog-execute-cache!
+	if (cache == act)
+		throw SyntaxException(TRACE_INFO, "Not implemented");
+
+	//    cog-extract!
+	if (extra == act)
+		throw SyntaxException(TRACE_INFO, "Not implemented");
+
+	//    cog-extract-recursive!
+	if (recur == act)
+		throw SyntaxException(TRACE_INFO, "Not implemented");
+
+	//    cog-get-atoms
+	if (gtatm == act)
+		throw SyntaxException(TRACE_INFO, "Not implemented");
+
+	//    cog-incoming-by-type
+	if (incty == act)
+		throw SyntaxException(TRACE_INFO, "Not implemented");
+
+	//    cog-incoming-set
+	if (incom == act)
+		throw SyntaxException(TRACE_INFO, "Not implemented");
+
+	//    cog-keys->alist
+	if (keys == act)
+		throw SyntaxException(TRACE_INFO, "Not implemented");
+
+	//    cog-link
+	if (link == act)
+		throw SyntaxException(TRACE_INFO, "Not implemented");
+
+	//    cog-node
+	if (node == act)
+		throw SyntaxException(TRACE_INFO, "Not implemented");
+
+	//    cog-set-value!
+	if (stval == act)
+		throw SyntaxException(TRACE_INFO, "Not implemented");
+
+	//    cog-set-values!
+	if (svals == act)
+		throw SyntaxException(TRACE_INFO, "Not implemented");
+
+	//    cog-set-tv!
+	if (settv == act)
+		throw SyntaxException(TRACE_INFO, "Not implemented");
+
+	//    cog-value
+	if (value == act)
+		throw SyntaxException(TRACE_INFO, "Not implemented");
+
+	throw SyntaxException(TRACE_INFO, "Command not supported: >>%s<<",
+		cmd.substr(1, pos-1).c_str());
+}

--- a/opencog/persist/sexpr/Commands.cc
+++ b/opencog/persist/sexpr/Commands.cc
@@ -105,9 +105,21 @@ std::string Commands::interpret_command(AtomSpace* as,
 	if (incom == act)
 		throw SyntaxException(TRACE_INFO, "Not implemented");
 
-	//    cog-keys->alist
+	// (cog-keys->alist (Concept "foo"))
 	if (keys == act)
-		throw SyntaxException(TRACE_INFO, "Not implemented");
+	{
+		pos = epos + 1;
+		Handle h = Sexpr::decode_atom(cmd, pos);
+		h = as->add_atom(h);
+		std::string alist = "(";
+		for (const Handle& key : h->getKeys())
+		{
+			alist += "(" + Sexpr::encode_atom(key) + " . ";
+			alist += Sexpr::encode_value(h->getValue(key)) + ")";
+		}
+		alist += ")\n";
+		return alist;
+	}
 
 	// (cog-node 'Concept "foobar")
 	// (cog-link 'ListLink (Atom) (Atom) (Atom))

--- a/opencog/persist/sexpr/Commands.cc
+++ b/opencog/persist/sexpr/Commands.cc
@@ -85,13 +85,25 @@ std::string Commands::interpret_command(AtomSpace* as,
 	if (cache == act)
 		throw SyntaxException(TRACE_INFO, "Not implemented");
 
-	//    cog-extract!
+	// (cog-extract! (Concept "foo"))
 	if (extra == act)
-		throw SyntaxException(TRACE_INFO, "Not implemented");
+	{
+		pos = epos + 1;
+		Handle h = as->get_atom(Sexpr::decode_atom(cmd, pos));
+		if (nullptr == h) return "#t\n";
+		if (as->extract_atom(h, false)) return "#t\n";
+		return "#f\n";
+	}
 
-	//    cog-extract-recursive!
+	// (cog-extract-recursive! (Concept "foo"))
 	if (recur == act)
-		throw SyntaxException(TRACE_INFO, "Not implemented");
+	{
+		pos = epos + 1;
+		Handle h = as->get_atom(Sexpr::decode_atom(cmd, pos));
+		if (nullptr == h) return "#t\n";
+		if (as->extract_atom(h, true)) return "#t\n";
+		return "#f\n";
+	}
 
 	// (cog-get-atoms 'Node #t)
 	if (gtatm == act)

--- a/opencog/persist/sexpr/Commands.h
+++ b/opencog/persist/sexpr/Commands.h
@@ -24,13 +24,14 @@
 #define _COMMANDS_H
 
 #include <string>
-#include <opencog/atoms/base/Handle.h>
 
 namespace opencog
 {
 /** \addtogroup grp_persist
  *  @{
  */
+
+class AtomSpace;
 
 class Commands
 {

--- a/opencog/persist/sexpr/Commands.h
+++ b/opencog/persist/sexpr/Commands.h
@@ -1,0 +1,71 @@
+/*
+ * Commands.h
+ * Minimalist command interpreter.
+ *
+ * Copyright (C) 2020 Linas Vepstas
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef _COMMANDS_H
+#define _COMMANDS_H
+
+#include <string>
+#include <opencog/atoms/base/Handle.h>
+
+namespace opencog
+{
+/** \addtogroup grp_persist
+ *  @{
+ */
+
+class Commands
+{
+public:
+	/// Interpret a very small subset of singular scheme commands.
+	/// This is an ultra-minimalistic command interpreter. It only
+	/// supports those commands needed for network I/O of AtomSpace
+	/// contents (The cogserver uses this to provide peer AtomSpace
+	/// network services). The goal is to provide much higher
+	/// performance than what is possible through the guile interfaces.
+   ///
+   /// The supported commands are:
+	///    cog-atomspace-clear
+	///    cog-execute-cache!
+	///    cog-extract!
+	///    cog-extract-recursive!
+	///    cog-get-atoms
+	///    cog-incoming-by-type
+	///    cog-incoming-set
+	///    cog-keys->alist
+	///    cog-link
+	///    cog-node
+	///    cog-set-value!
+	///    cog-set-values!
+	///    cog-set-tv!
+	///    cog-value
+   ///
+   /// They MUST appear only once in the string, at the very begining,
+	/// and they MUST be followed by valid Atomese s-expressions, and
+	/// nothing else.
+	///
+	static std::string interpret_command(const std::string&);
+};
+
+/** @}*/
+} // namespace opencog
+
+#endif // _COMMANDS_H

--- a/opencog/persist/sexpr/Commands.h
+++ b/opencog/persist/sexpr/Commands.h
@@ -62,7 +62,7 @@ public:
 	/// and they MUST be followed by valid Atomese s-expressions, and
 	/// nothing else.
 	///
-	static std::string interpret_command(const std::string&);
+	static std::string interpret_command(AtomSpace*, const std::string&);
 };
 
 /** @}*/

--- a/opencog/persist/sexpr/Sexpr.h
+++ b/opencog/persist/sexpr/Sexpr.h
@@ -53,7 +53,12 @@ public:
 	}
 
 	static ValuePtr decode_value(const std::string&, size_t&);
-	static void decode_alist(Handle&, const std::string&);
+	static void decode_slist(Handle&, const std::string&, size_t&);
+	static void decode_alist(Handle&, const std::string&, size_t&);
+	static void decode_alist(Handle& h, const std::string& s) {
+		size_t junk = 0;
+		decode_alist(h, s, junk);
+	}
 
 	// API more suitable to very long, file-driven I/O.
 	static int get_next_expr(const std::string&,

--- a/opencog/persist/sexpr/Sexpr.h
+++ b/opencog/persist/sexpr/Sexpr.h
@@ -53,6 +53,8 @@ public:
 	}
 
 	static ValuePtr decode_value(const std::string&, size_t&);
+	static Type decode_type(const std::string& s, size_t& pos);
+
 	static void decode_slist(Handle&, const std::string&, size_t&);
 	static void decode_alist(Handle&, const std::string&, size_t&);
 	static void decode_alist(Handle& h, const std::string& s) {
@@ -60,6 +62,7 @@ public:
 		decode_alist(h, s, junk);
 	}
 
+	// -------------------------------------------
 	// API more suitable to very long, file-driven I/O.
 	static int get_next_expr(const std::string&,
                             size_t& l, size_t& r, size_t line_cnt);

--- a/opencog/persist/sexpr/SexprEval.cc
+++ b/opencog/persist/sexpr/SexprEval.cc
@@ -45,11 +45,21 @@ SexprEval::~SexprEval()
  */
 void SexprEval::eval_expr(const std::string &expr)
 {
+	try {
+		_answer = Commands::interpret_command(_atomspace, expr);
+	}
+	catch (const StandardException& ex)
+	{
+		_error_string = ex.what();
+		_caught_error = true;
+	}
 }
 
 std::string SexprEval::poll_result()
 {
-	return _answer;
+	std::string ret;
+	ret.swap(_answer);
+	return ret;
 }
 
 
@@ -65,7 +75,8 @@ void SexprEval::begin_eval()
  */
 void SexprEval::interrupt(void)
 {
-	throw IOException(TRACE_INFO, "Caught interrupt!");
+	_caught_error = true;
+	_error_string = "Caught interrupt!";
 }
 
 SexprEval* SexprEval::get_evaluator(AtomSpace* as)

--- a/opencog/persist/sexpr/SexprEval.cc
+++ b/opencog/persist/sexpr/SexprEval.cc
@@ -1,0 +1,85 @@
+/**
+ * SexprEval.cc
+ *
+ * S-expression evaluator.
+ *
+ * Copyright (c) 2008, 2014, 2015, 2020 Linas Vepstas
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/util/Logger.h>
+#include <opencog/atomspace/AtomSpace.h>
+#include <opencog/persist/sexpr/Commands.h>
+
+#include "SexprEval.h"
+
+using namespace opencog;
+
+SexprEval::SexprEval(AtomSpace* as)
+	: GenericEval()
+{
+	_atomspace = as;
+}
+
+SexprEval::~SexprEval()
+{
+}
+
+/* ============================================================== */
+/**
+ * Evaluate an s-expresion.
+ */
+void SexprEval::eval_expr(const std::string &expr)
+{
+}
+
+std::string SexprEval::poll_result()
+{
+	return _answer;
+}
+
+
+void SexprEval::begin_eval()
+{
+	_answer.clear();
+}
+
+/* ============================================================== */
+
+/**
+ * interrupt() - convert user's control-C at keyboard into exception.
+ */
+void SexprEval::interrupt(void)
+{
+	throw IOException(TRACE_INFO, "Caught interrupt!");
+}
+
+SexprEval* SexprEval::get_evaluator(AtomSpace* as)
+{
+	static thread_local SexprEval* evaluator = new SexprEval(as);
+
+	// The eval_dtor runs when this thread is destroyed.
+	class eval_dtor {
+		public:
+		~eval_dtor() { delete evaluator; }
+	};
+	static thread_local eval_dtor killer;
+
+	return evaluator;
+}
+
+/* ===================== END OF FILE ======================== */

--- a/opencog/persist/sexpr/SexprEval.h
+++ b/opencog/persist/sexpr/SexprEval.h
@@ -24,6 +24,7 @@
 #define _OPENCOG_SEXPR_EVAL_H
 
 #include <string>
+#include <opencog/eval/GenericEval.h>
 
 /**
  * The SexprEval class implements a very simple API for s-exprssion
@@ -37,17 +38,24 @@ namespace opencog {
  *  @{
  */
 
+class AtomSpace;
 class SexprEval : public GenericEval
 {
+	private:
+		AtomSpace* _atomspace;
+		std::string _answer;
+
+		SexprEval(AtomSpace*);
 	public:
-		SexprEval(void) : GenericEval() {}
-		virtual ~SexprEval() {}
+		virtual ~SexprEval();
 
 		virtual void begin_eval(void);
 		virtual void eval_expr(const std::string&);
 		virtual std::string poll_result(void);
 
 		virtual void interrupt(void);
+
+		static SexprEval* get_evaluator(AtomSpace*);
 };
 
 /** @}*/

--- a/opencog/persist/sexpr/SexprEval.h
+++ b/opencog/persist/sexpr/SexprEval.h
@@ -1,0 +1,56 @@
+/*
+ * SexprEval.h
+ *
+ * A simple s-expression shell-oriented evaluator
+ * Copyright (c) 2008, 2013, 2014, 2020 Linas Vepstas <linas@linas.org>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef _OPENCOG_SEXPR_EVAL_H
+#define _OPENCOG_SEXPR_EVAL_H
+
+#include <string>
+
+/**
+ * The SexprEval class implements a very simple API for s-exprssion
+ * evaluation.  It supports just enough commands to allow AtomSpaces
+ * and portions there-of to be easily transported across the network.
+ * It is used by the CogServer, and the atomsspace-cog network backend.
+ */
+
+namespace opencog {
+/** \addtogroup grp_server
+ *  @{
+ */
+
+class SexprEval : public GenericEval
+{
+	public:
+		SexprEval(void) : GenericEval() {}
+		virtual ~SexprEval() {}
+
+		virtual void begin_eval(void);
+		virtual void eval_expr(const std::string&);
+		virtual std::string poll_result(void);
+
+		virtual void interrupt(void);
+};
+
+/** @}*/
+}
+
+#endif // _OPENCOG_SEXPR_EVAL_H

--- a/opencog/persist/sexpr/ValueSexpr.cc
+++ b/opencog/persist/sexpr/ValueSexpr.cc
@@ -30,9 +30,41 @@
 using namespace opencog;
 
 /* ================================================================== */
+/**
+ * Look for a type name, either of the form "ConceptNode" (wwith quotes)
+ * or 'ConceptNode (symbol) starting at location `pos` in `tna`.
+ * Return the type and update `pos` to point after the typename.
+ */
+Type Sexpr::decode_type(const std::string& tna, size_t& pos)
+{
+	// Advance past whitespace.
+	pos = tna.find_first_not_of(" \n\t", pos);
+	if (std::string::npos == pos)
+		throw SyntaxException(TRACE_INFO, "Bad Type >>%s<<",
+			tna.substr(pos).c_str());
+
+	// Advance to next whitespace.
+	size_t nos = tna.find_first_of(") \n\t", pos);
+	if (std::string::npos == nos)
+		nos = tna.size();
+
+	size_t sos = nos;
+	if ('\'' == tna[pos]) pos++;
+	if ('"' == tna[pos]) { pos++; sos--; }
+
+	Type t = nameserver().getType(tna.substr(pos, sos-pos));
+	if (NOTYPE == t)
+		throw SyntaxException(TRACE_INFO, "Unknown Type >>%s<<",
+			tna.substr(pos, sos-pos).c_str());
+
+	pos = nos;
+	return t;
+}
+
+/* ================================================================== */
 
 /**
- * Return a Value correspnding to the input string.
+ * Return a Value corresponding to the input string.
  * It is assumed the input string is encoded as a scheme string.
  * For example, `(FloatValue 1 2 3 4)` or more complex things:
  * `(LinkValue (Concept "a") (FloatValue 1 2 3))`

--- a/opencog/persist/sexpr/ValueSexpr.cc
+++ b/opencog/persist/sexpr/ValueSexpr.cc
@@ -50,6 +50,9 @@ ValuePtr Sexpr::decode_value(const std::string& stv, size_t& pos)
 {
 	size_t totlen = stv.size();
 
+	// Skip past whitespace
+	pos = stv.find_first_not_of(" \n\t", pos);
+
 	// Special-case: Both #f and '() are used to denote "no value".
 	// This is commonly used to erase keys from atoms. So handle this
 	// first.
@@ -73,8 +76,16 @@ ValuePtr Sexpr::decode_value(const std::string& stv, size_t& pos)
 
 	Type vtype = nameserver().getType(stv.substr(pos, vos-pos));
 	if (NOTYPE == vtype)
+	{
+		if (0 == stv.compare(pos, 3, "stv"))
+			vtype = SIMPLE_TRUTH_VALUE;
+		else
+		if (0 == stv.compare(pos, 3, "ctv"))
+			vtype = COUNT_TRUTH_VALUE;
+		else
 		throw SyntaxException(TRACE_INFO, "Unknown Value >>%s<<",
 			stv.substr(pos, vos-pos).c_str());
+	}
 
 	if (nameserver().isA(vtype, ATOM))
 	{

--- a/opencog/persist/sexpr/ValueSexpr.cc
+++ b/opencog/persist/sexpr/ValueSexpr.cc
@@ -190,12 +190,14 @@ void Sexpr::decode_alist(Handle& atom, const std::string& alist, size_t& pos)
 	{
 		++pos;  // over first paren of pair
 		Handle key(decode_atom(alist, pos));
+
 		pos = alist.find(" . ", pos);
 		pos += 3;
 		ValuePtr val(decode_value(alist, pos));
-		if (as)
+
+		// Make sure all atoms have found a nice home.
+		if (as and not as->get_read_only())
 		{
-			// Make sure all atoms have found a nice home.
 			key = as->add_atom(key);
 			val = add_atoms(as, val);
 		}

--- a/opencog/persist/sql/README.md
+++ b/opencog/persist/sql/README.md
@@ -22,6 +22,30 @@ by tuning the Postgres server, using SSD disks, and using HugePages.
 Tuning details are given below. The [performance diary](README-perf.md)
 provides some benchmarking results.
 
+Meta-Status
+-----------
+In retrospect, database-backed storage is a fundamental design mistake.
+Why?
+
+* A vast number of cycles are wasted serializing and unserializing
+  Atoms and Values, and converting them to "unnatural" formats.
+* Almost all database features, bells and whistles are not required
+  and are not used.
+* There are easier and faster ways to get distributed AtomSpaces, e.g.
+  by using https://github.com/opencog/atomspace-cog/ which is *fast*.
+
+In retrospect, what was really needed was a fast, efficient single-user
+file-storage system, something that is tuned to the vagaries of
+file-system performance. This could be provided by a fairly minimalist
+key-value of "column store" database that is small, simple, fast and
+feature-poor. Something that doesn't eat RAM, so that it does not
+compete with the AtomSpace for RAM.
+
+Well, in a futuristic world, there would be one nice feature to have:
+pattern matching in the file-backed database. But this would have to
+somehow be faster and more effective that pattern-matching in RAM, and
+so this is a very high bar to exceed.
+
 Features
 --------
  * Save and restore of individual atoms and values.

--- a/opencog/persist/sql/multi-driver/SQLResponse.h
+++ b/opencog/persist/sql/multi-driver/SQLResponse.h
@@ -349,6 +349,16 @@ class SQLAtomStorage::Response
 				store->_tlbuf.addAtom(hkey, key);
 			}
 
+			// The below usually triggers only on tvpred,
+			// and so we could save some CPU cycles by handling
+			// tvpred earlier, and avoiding this check.
+			if (nullptr == hkey->getAtomTable() and
+			    nullptr != atom->getAtomTable())
+			{
+				hkey = atom->getAtomTable()->add(hkey, false);
+				store->_tlbuf.addAtom(hkey, key);
+			}
+
 			ValuePtr pap = store->doUnpackValue(*this);
 			atom->setValue(hkey, pap);
 			return false;

--- a/tests/persist/file/CMakeLists.txt
+++ b/tests/persist/file/CMakeLists.txt
@@ -1,3 +1,4 @@
 LINK_LIBRARIES(atomspace load_scm)
 
 ADD_CXXTEST(FastLoadUTest)
+ADD_CXXTEST(CommandsUTest)

--- a/tests/persist/file/CommandsUTest.cxxtest
+++ b/tests/persist/file/CommandsUTest.cxxtest
@@ -22,6 +22,9 @@
 
 #include <opencog/util/Logger.h>
 #include <opencog/atomspace/AtomSpace.h>
+#include <opencog/atoms/value/FloatValue.h>
+#include <opencog/atoms/value/StringValue.h>
+#include <opencog/atoms/truthvalue/SimpleTruthValue.h>
 
 #include "opencog/persist/sexpr/Commands.h"
 
@@ -47,6 +50,7 @@ class CommandsUTest : public CxxTest::TestSuite
 		void test_set_tv();
 		void test_set_value();
 		void test_set_values();
+		void test_get_values();
 };
 
 // Test cog-node
@@ -175,6 +179,30 @@ void CommandsUTest::test_set_values()
 	vp = h->getValue(key);
 	TS_ASSERT(nullptr != vp);
 	TS_ASSERT_EQUALS(STRING_VALUE, vp->get_type());
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// Test cog-keys->alist
+void CommandsUTest::test_get_values()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle h = as->add_node(CONCEPT_NODE, "a");
+	Handle key = as->add_node(PREDICATE_NODE, "key");
+	Handle fiz = as->add_node(PREDICATE_NODE, "fiz");
+	Handle buz = as->add_node(PREDICATE_NODE, "buz");
+
+	h->setValue(key, createFloatValue(std::vector<double>{4, 5, 6}));
+	h->setValue(fiz, createStringValue(std::vector<std::string>{"a", "b"}));
+	h->setValue(buz, ValueCast(createSimpleTruthValue(0.3, 0.4)));
+
+	std::string in = "(cog-keys->alist (Concept \"a\"))";
+
+	std::string out = Commands::interpret_command(as, in);
+	printf("Got %s\n", out.c_str());
+
+	TS_ASSERT(140 < out.size());
 
 	logger().info("END TEST: %s", __FUNCTION__);
 }

--- a/tests/persist/file/CommandsUTest.cxxtest
+++ b/tests/persist/file/CommandsUTest.cxxtest
@@ -51,6 +51,7 @@ class CommandsUTest : public CxxTest::TestSuite
 		void test_set_value();
 		void test_set_values();
 		void test_get_values();
+		void test_extract();
 };
 
 // Test cog-node
@@ -203,6 +204,35 @@ void CommandsUTest::test_get_values()
 	printf("Got %s\n", out.c_str());
 
 	TS_ASSERT(140 < out.size());
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// Test cog-extract!
+void CommandsUTest::test_extract()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle a = as->add_node(CONCEPT_NODE, "a");
+	Handle l = as->add_link(LIST_LINK, a);
+
+	std::string in = "(cog-extract! (Concept \"a\"))";
+
+	std::string out = Commands::interpret_command(as, in);
+	printf("Got %s\n", out.c_str());
+	TS_ASSERT(0 == out.compare("#f\n"));
+
+	Handle ax = as->get_node(CONCEPT_NODE, "a");
+	TS_ASSERT(a == ax);
+
+	in = "(cog-extract-recursive! (Concept \"a\"))";
+
+	out = Commands::interpret_command(as, in);
+	printf("Got %s\n", out.c_str());
+	TS_ASSERT(0 == out.compare("#t\n"));
+
+	ax = as->get_node(CONCEPT_NODE, "a");
+	TS_ASSERT(nullptr == ax);
 
 	logger().info("END TEST: %s", __FUNCTION__);
 }

--- a/tests/persist/file/CommandsUTest.cxxtest
+++ b/tests/persist/file/CommandsUTest.cxxtest
@@ -53,6 +53,7 @@ class CommandsUTest : public CxxTest::TestSuite
 		void test_set_values();
 		void test_get_values();
 		void test_extract();
+		void test_execute();
 };
 
 // Test cog-node
@@ -267,6 +268,43 @@ void CommandsUTest::test_extract()
 
 	ax = as->get_node(CONCEPT_NODE, "a");
 	TS_ASSERT(nullptr == ax);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// Test cog-execute-cache!
+void CommandsUTest::test_execute()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Populate teh AtomSpace
+	Handle a = as->add_node(CONCEPT_NODE, "a");
+	Handle b = as->add_node(CONCEPT_NODE, "b");
+	Handle l = as->add_link(LIST_LINK, a, b);
+
+	// Run this query
+	std::string in =
+	"(cog-execute-cache! "
+		"(Meet (Variable \"x\")"
+		"(Present (List (Variable \"x\") (Concept \"b\"))))"
+		"(Predicate \"key\"))";
+
+	std::string out = Commands::interpret_command(as, in);
+	printf("Got >>%s<<\n", out.c_str());
+	TS_ASSERT(0 == out.compare("(QueueValue  (ConceptNode \"a\"))"));
+
+	// Verify that the result was placed onto the key.
+#define an as->add_node
+#define al as->add_link
+	Handle q = al(MEET_LINK, an(VARIABLE_NODE, "x"),
+		al(PRESENT_LINK,
+			al(LIST_LINK, an(VARIABLE_NODE, "x"), an(CONCEPT_NODE, "b"))));
+
+	Handle key = as->add_node(PREDICATE_NODE, "key");
+	ValuePtr vp = q->getValue(key);
+	TS_ASSERT(nullptr != vp);
+	printf("Got %s\n", vp->to_short_string().c_str());
+	TS_ASSERT(QUEUE_VALUE == vp->get_type());
 
 	logger().info("END TEST: %s", __FUNCTION__);
 }

--- a/tests/persist/file/CommandsUTest.cxxtest
+++ b/tests/persist/file/CommandsUTest.cxxtest
@@ -1,0 +1,68 @@
+/*
+ * CommandsUTest.cxxtest
+ *
+ * Copyright (c) 2020 Linas Vepstas
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/util/Logger.h>
+#include <opencog/atomspace/AtomSpace.h>
+
+#include "opencog/persist/sexpr/Commands.h"
+
+using namespace opencog;
+
+class CommandsUTest : public CxxTest::TestSuite
+{
+	private:
+		AtomSpace* as;
+
+	public:
+		CommandsUTest()
+		{
+			logger().set_print_to_stdout_flag(true);
+			as = new AtomSpace();
+		}
+
+		void setUp() { as->clear(); }
+		void tearDown() {}
+
+		void test_node();
+};
+
+// Test parseExpression
+void CommandsUTest::test_node()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	std::string in = R"((cog-node 'Concept "foo"))";
+
+	std::string out = Commands::interpret_command(as, in);
+	printf("Got %s\n", out.c_str());
+ 
+	TS_ASSERT_EQUALS(0, as->get_size());
+	TS_ASSERT(0 == out.compare("()"));
+
+	as->add_node(CONCEPT_NODE, "foo");
+	out = Commands::interpret_command(as, in);
+	printf("Got >>%s<<\n", out.c_str());
+	TS_ASSERT_EQUALS(1, as->get_size());
+	TS_ASSERT(0 == out.compare("(ConceptNode \"foo\")"));
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}

--- a/tests/persist/file/CommandsUTest.cxxtest
+++ b/tests/persist/file/CommandsUTest.cxxtest
@@ -46,6 +46,7 @@ class CommandsUTest : public CxxTest::TestSuite
 		void test_link();
 		void test_set_tv();
 		void test_set_value();
+		void test_set_values();
 };
 
 // Test cog-node
@@ -137,6 +138,43 @@ void CommandsUTest::test_set_value()
 	ValuePtr vp = h->getValue(key);
 	TS_ASSERT(nullptr != vp);
 	TS_ASSERT_EQUALS(SIMPLE_TRUTH_VALUE, vp->get_type());
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// Test cog-set-values!
+void CommandsUTest::test_set_values()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	std::string in = "(cog-set-values! (Concept \"a\") (list "
+		"(cons (Predicate \"key\") (stv 0.6 0.8))"
+		"(cons (Predicate \"fiz\") (FloatValue 1 2 3))"
+		"(cons (Predicate \"buz\") (StringValue \"gee\" \"golly\"))))";
+
+	std::string out = Commands::interpret_command(as, in);
+	printf("Got %s\n", out.c_str());
+
+	TS_ASSERT_EQUALS(4, as->get_size());
+	TS_ASSERT(0 == out.compare("()\n"));
+
+	Handle h = as->get_node(CONCEPT_NODE, "a");
+	TS_ASSERT(nullptr != h);
+
+	Handle key = as->add_node(PREDICATE_NODE, "key");
+	ValuePtr vp = h->getValue(key);
+	TS_ASSERT(nullptr != vp);
+	TS_ASSERT_EQUALS(SIMPLE_TRUTH_VALUE, vp->get_type());
+
+	key = as->add_node(PREDICATE_NODE, "fiz");
+	vp = h->getValue(key);
+	TS_ASSERT(nullptr != vp);
+	TS_ASSERT_EQUALS(FLOAT_VALUE, vp->get_type());
+
+	key = as->add_node(PREDICATE_NODE, "buz");
+	vp = h->getValue(key);
+	TS_ASSERT(nullptr != vp);
+	TS_ASSERT_EQUALS(STRING_VALUE, vp->get_type());
 
 	logger().info("END TEST: %s", __FUNCTION__);
 }

--- a/tests/persist/file/CommandsUTest.cxxtest
+++ b/tests/persist/file/CommandsUTest.cxxtest
@@ -25,6 +25,7 @@
 #include <opencog/atoms/value/FloatValue.h>
 #include <opencog/atoms/value/StringValue.h>
 #include <opencog/atoms/truthvalue/SimpleTruthValue.h>
+#include <opencog/atoms/truthvalue/CountTruthValue.h>
 
 #include "opencog/persist/sexpr/Commands.h"
 
@@ -187,6 +188,7 @@ void CommandsUTest::test_set_values()
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
 	std::string in = "(cog-set-values! (Concept \"a\") (list "
+		"(cons (Predicate \"*-TruthValueKey-*\") (stv 0.3 0.5))"
 		"(cons (Predicate \"key\") (stv 0.6 0.8))"
 		"(cons (Predicate \"fiz\") (FloatValue 1 2 3))"
 		"(cons (Predicate \"buz\") (StringValue \"gee\" \"golly\"))))";
@@ -194,11 +196,19 @@ void CommandsUTest::test_set_values()
 	std::string out = Commands::interpret_command(as, in);
 	printf("Got %s\n", out.c_str());
 
-	TS_ASSERT_EQUALS(4, as->get_size());
+	TS_ASSERT_EQUALS(5, as->get_size());
 	TS_ASSERT(0 == out.compare("()\n"));
 
 	Handle h = as->get_node(CONCEPT_NODE, "a");
 	TS_ASSERT(nullptr != h);
+
+	TruthValuePtr tvp = h->getTruthValue();
+	TS_ASSERT_EQUALS(SIMPLE_TRUTH_VALUE, tvp->get_type());
+	double mean = tvp->get_mean();
+	double conf = tvp->get_confidence();
+	TS_ASSERT_EQUALS(SIMPLE_TRUTH_VALUE, tvp->get_type());
+	TS_ASSERT(0.2999 < mean and mean < 0.3001);
+	TS_ASSERT(0.4999 < conf and conf < 0.5001);
 
 	Handle key = as->add_node(PREDICATE_NODE, "key");
 	ValuePtr vp = h->getValue(key);
@@ -230,15 +240,17 @@ void CommandsUTest::test_get_values()
 
 	h->setValue(key, createFloatValue(std::vector<double>{4, 5, 6}));
 	h->setValue(fiz, createStringValue(std::vector<std::string>{"a", "b"}));
-	h->setValue(buz, ValueCast(createSimpleTruthValue(0.3, 0.4)));
+	h->setValue(buz, ValueCast(createCountTruthValue(0.3, 0.4, 42)));
+	h->setTruthValue(createSimpleTruthValue(0.1, 0.9));
 
 	std::string in = "(cog-keys->alist (Concept \"a\"))";
 
 	std::string out = Commands::interpret_command(as, in);
-	printf("Got %s\n", out.c_str());
+	printf("Got %lu %s\n", out.size(), out.c_str());
 
 	TS_ASSERT(0 == out.compare(0, 17, "(((PredicateNode "));
-	TS_ASSERT(140 < out.size());
+	TS_ASSERT(std::string::npos != out.find("SimpleTruthValue"));
+	TS_ASSERT(210 < out.size());
 
 	logger().info("END TEST: %s", __FUNCTION__);
 }

--- a/tests/persist/file/CommandsUTest.cxxtest
+++ b/tests/persist/file/CommandsUTest.cxxtest
@@ -44,6 +44,8 @@ class CommandsUTest : public CxxTest::TestSuite
 
 		void test_node();
 		void test_link();
+		void test_set_tv();
+		void test_set_value();
 };
 
 // Test cog-node
@@ -57,7 +59,7 @@ void CommandsUTest::test_node()
 	printf("Got %s\n", out.c_str());
 
 	TS_ASSERT_EQUALS(0, as->get_size());
-	TS_ASSERT(0 == out.compare("()"));
+	TS_ASSERT(0 == out.compare("()\n"));
 
 	as->add_node(CONCEPT_NODE, "foo");
 	out = Commands::interpret_command(as, in);
@@ -82,7 +84,7 @@ void CommandsUTest::test_link()
 	printf("Got %s\n", out.c_str());
 
 	TS_ASSERT_EQUALS(2, as->get_size());
-	TS_ASSERT(0 == out.compare("()"));
+	TS_ASSERT(0 == out.compare("()\n"));
 
 	as->add_link(LIST_LINK, ca, cb);
 
@@ -91,6 +93,50 @@ void CommandsUTest::test_link()
 	TS_ASSERT_EQUALS(3, as->get_size());
 	TS_ASSERT(0 == out.compare(
 		"(ListLink (ConceptNode \"a\")(ConceptNode \"b\"))"));
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// Test cog-set-tv!
+void CommandsUTest::test_set_tv()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	std::string in = R"((cog-set-tv! (Concept "a") (stv 1 0)))";
+
+	std::string out = Commands::interpret_command(as, in);
+	printf("Got %s\n", out.c_str());
+
+	TS_ASSERT_EQUALS(1, as->get_size());
+	TS_ASSERT(0 == out.compare("()\n"));
+
+	Handle h = as->get_node(CONCEPT_NODE, "a");
+	TS_ASSERT(nullptr != h);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// Test cog-set-value!
+void CommandsUTest::test_set_value()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	std::string in =
+		R"((cog-set-value! (Concept "a") (Predicate "key") (stv 0.6 0.8)))";
+
+	std::string out = Commands::interpret_command(as, in);
+	printf("Got %s\n", out.c_str());
+
+	TS_ASSERT_EQUALS(2, as->get_size());
+	TS_ASSERT(0 == out.compare("()\n"));
+
+	Handle h = as->get_node(CONCEPT_NODE, "a");
+	TS_ASSERT(nullptr != h);
+
+	Handle key = as->add_node(PREDICATE_NODE, "key");
+	ValuePtr vp = h->getValue(key);
+	TS_ASSERT(nullptr != vp);
+	TS_ASSERT_EQUALS(SIMPLE_TRUTH_VALUE, vp->get_type());
 
 	logger().info("END TEST: %s", __FUNCTION__);
 }

--- a/tests/persist/file/CommandsUTest.cxxtest
+++ b/tests/persist/file/CommandsUTest.cxxtest
@@ -43,9 +43,10 @@ class CommandsUTest : public CxxTest::TestSuite
 		void tearDown() {}
 
 		void test_node();
+		void test_link();
 };
 
-// Test parseExpression
+// Test cog-node
 void CommandsUTest::test_node()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
@@ -54,7 +55,7 @@ void CommandsUTest::test_node()
 
 	std::string out = Commands::interpret_command(as, in);
 	printf("Got %s\n", out.c_str());
- 
+
 	TS_ASSERT_EQUALS(0, as->get_size());
 	TS_ASSERT(0 == out.compare("()"));
 
@@ -63,6 +64,33 @@ void CommandsUTest::test_node()
 	printf("Got >>%s<<\n", out.c_str());
 	TS_ASSERT_EQUALS(1, as->get_size());
 	TS_ASSERT(0 == out.compare("(ConceptNode \"foo\")"));
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// Test cog-link
+void CommandsUTest::test_link()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle ca = as->add_node(CONCEPT_NODE, "a");
+	Handle cb = as->add_node(CONCEPT_NODE, "b");
+
+	std::string in = R"((cog-link 'List (Concept "a") (Concept "b")))";
+
+	std::string out = Commands::interpret_command(as, in);
+	printf("Got %s\n", out.c_str());
+
+	TS_ASSERT_EQUALS(2, as->get_size());
+	TS_ASSERT(0 == out.compare("()"));
+
+	as->add_link(LIST_LINK, ca, cb);
+
+	out = Commands::interpret_command(as, in);
+	printf("Got >>%s<<\n", out.c_str());
+	TS_ASSERT_EQUALS(3, as->get_size());
+	TS_ASSERT(0 == out.compare(
+		"(ListLink (ConceptNode \"a\")(ConceptNode \"b\"))"));
 
 	logger().info("END TEST: %s", __FUNCTION__);
 }

--- a/tests/persist/file/CommandsUTest.cxxtest
+++ b/tests/persist/file/CommandsUTest.cxxtest
@@ -122,6 +122,18 @@ void CommandsUTest::test_set_tv()
 	Handle h = as->get_node(CONCEPT_NODE, "a");
 	TS_ASSERT(nullptr != h);
 
+	// ------------
+	h = as->add_node(CONCEPT_NODE, "b");
+	as->set_truthvalue(h, createSimpleTruthValue(0.5, 0.5));
+
+	// Clobber the TV on B back to Default
+	in = R"((cog-set-tv! (Concept "b") (stv 1 0)))";
+	out = Commands::interpret_command(as, in);
+
+	TruthValuePtr tv = h->getTruthValue();
+	printf("new TV is %s\n", tv->to_string().c_str());
+	TS_ASSERT(*tv == *TruthValue::DEFAULT_TV());
+
 	logger().info("END TEST: %s", __FUNCTION__);
 }
 

--- a/tests/persist/file/CommandsUTest.cxxtest
+++ b/tests/persist/file/CommandsUTest.cxxtest
@@ -49,6 +49,7 @@ class CommandsUTest : public CxxTest::TestSuite
 		void test_link();
 		void test_set_tv();
 		void test_set_value();
+		void test_get_value();
 		void test_set_values();
 		void test_get_values();
 		void test_extract();
@@ -147,6 +148,38 @@ void CommandsUTest::test_set_value()
 	logger().info("END TEST: %s", __FUNCTION__);
 }
 
+// Test cog-value
+void CommandsUTest::test_get_value()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle h = as->add_node(CONCEPT_NODE, "a");
+	Handle key = as->add_node(PREDICATE_NODE, "key");
+	Handle fiz = as->add_node(PREDICATE_NODE, "fiz");
+	Handle buz = as->add_node(PREDICATE_NODE, "buz");
+
+	h->setValue(key, createFloatValue(std::vector<double>{4, 5, 6}));
+	h->setValue(fiz, createStringValue(std::vector<std::string>{"a", "b"}));
+	h->setValue(buz, ValueCast(createSimpleTruthValue(0.3, 0.4)));
+
+	std::string in = "(cog-value (Concept \"a\") (Predicate \"key\"))";
+	std::string out = Commands::interpret_command(as, in);
+	printf("Got %s\n", out.c_str());
+	TS_ASSERT(0 == out.compare(0, 12, "(FloatValue "));
+
+	in = "(cog-value (Concept \"a\") (Predicate \"fiz\"))";
+	out = Commands::interpret_command(as, in);
+	printf("Got %s\n", out.c_str());
+	TS_ASSERT(0 == out.compare("(StringValue \"a\" \"b\")"));
+
+	in = "(cog-value (Concept \"a\") (Predicate \"buz\"))";
+	out = Commands::interpret_command(as, in);
+	printf("Got %s\n", out.c_str());
+	TS_ASSERT(0 == out.compare(0, 18, "(SimpleTruthValue "));
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
 // Test cog-set-values!
 void CommandsUTest::test_set_values()
 {
@@ -203,6 +236,7 @@ void CommandsUTest::test_get_values()
 	std::string out = Commands::interpret_command(as, in);
 	printf("Got %s\n", out.c_str());
 
+	TS_ASSERT(0 == out.compare(0, 17, "(((PredicateNode "));
 	TS_ASSERT(140 < out.size());
 
 	logger().info("END TEST: %s", __FUNCTION__);

--- a/tests/persist/sql/multi-driver/DeleteUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/DeleteUTest.cxxtest
@@ -542,8 +542,10 @@ void DeleteUTest::do_test_remove(void)
     for (i=0; i<idx; i++)
         delete_links(i, _as);
 
-    printf("Post-remove size=%lu expect=%d\n", _as->get_size(), 4*idx);
-    TSM_ASSERT("Post-remove unexpected atomspace size", ((unsigned)(4*idx)) == _as->get_size());
+    // Plus-one for PredicateNode "*-TruthValueKey-*"
+    printf("Post-remove size=%lu expect=%d\n", _as->get_size(), 4*idx+1);
+    TSM_ASSERT_EQUALS("Post-remove unexpected atomspace size",
+		((unsigned)(4*idx+1)), _as->get_size());
 
     /* Verify that the atoms are really gone from storage. */
     for (i=0; i<idx; i++) {
@@ -551,8 +553,9 @@ void DeleteUTest::do_test_remove(void)
         check_remove(i, _as, "verify-gone");
     }
 
-    printf("Post-referesh size=%lu expect=%d\n", _as->get_size(), 7*idx);
-    TSM_ASSERT("Post-refetch unexpected atomspace size", ((unsigned)(7*idx)) == _as->get_size());
+    printf("Post-referesh size=%lu expect=%d\n", _as->get_size(), 7*idx+1);
+    TSM_ASSERT_EQUALS("Post-refetch unexpected atomspace size",
+		((unsigned)(7*idx+1)), _as->get_size());
 
     /* Kill data for good */
     _as->clear();
@@ -637,7 +640,8 @@ void DeleteUTest::do_test_recurse(void)
     for (i=0; i<zap; i++)
         extract_nodes(i, _as);
 
-    size_t expsz = 7*(idx-zap) + 3*zap;
+    // Plus-one for PredicateNode "*-TruthValueKey-*"
+    size_t expsz = 7*(idx-zap) + 3*zap; // + 1;
     printf("Atomspace size=%lu expect=%lu\n",
          _as->get_size(), expsz);
     TSM_ASSERT("Unexpected atomspace size", expsz == _as->get_size());
@@ -652,6 +656,8 @@ void DeleteUTest::do_test_recurse(void)
     for (i=0; i<zap; i++)
         delete_nodes(i, _as);
 
+    // Plus-one for PredicateNode "*-TruthValueKey-*"
+    expsz += 1;
     printf("Post-remove size=%lu expect=%lu\n",
          _as->get_size(), expsz);
     TSM_ASSERT("Unexpected atomspace size", expsz == _as->get_size());
@@ -664,9 +670,9 @@ void DeleteUTest::do_test_recurse(void)
     }
 
     printf("Post-refetch size=%lu expect=%d\n",
-         _as->get_size(), 7*idx);
+         _as->get_size(), 7*idx+1);
     TSM_ASSERT("Unexpected atomspace size",
-         ((unsigned) 7*idx) == _as->get_size());
+         ((unsigned) 7*idx+1) == _as->get_size());
 
     /* Check that the removed atoms really got zapped. */
     for (i=0; i<zap; i++) {

--- a/tests/persist/sql/multi-driver/FetchUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/FetchUTest.cxxtest
@@ -342,20 +342,20 @@ void FetchUTest::test_readonly(void)
 	TS_ASSERT((*tv) == (*etv));
 
 	// Should be possible to extract, even though its read-only
-	TS_ASSERT(2 == _as->get_size());
+	TS_ASSERT(3 == _as->get_size());
 	eval->eval(R"((cog-extract! (Concept "AAA")))");
 	eval->eval(R"((cog-extract! (Concept "BBB")))");
-	TS_ASSERT(0 == _as->get_size());
+	TS_ASSERT(1 == _as->get_size());
 
 	// And re-load them again.
 	eval->eval(R"((load-atoms-of-type 'ConceptNode))");
 	eval->eval("(barrier)");
-	TS_ASSERT(2 == _as->get_size());
+	TS_ASSERT(3 == _as->get_size());
 
 	TS_ASSERT(true == _as->get_read_only());
 	Handle d = _as->add_node(CONCEPT_NODE, "barfoo");
 	TS_ASSERT(d == nullptr);
-	TS_ASSERT(2 == _as->get_size());
+	TS_ASSERT(3 == _as->get_size());
 
 	logger().debug("END TEST: %s", __FUNCTION__);
 }

--- a/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
@@ -512,6 +512,17 @@ void ValueSaveUTest::do_test_load_by_type()
 	as->fetch_all_atoms_of_type(CONCEPT_NODE);
 	as->barrier();
 
+	// Six: 4 ConceptNodes, the PredicateNode "*-TruthValueKey-*"
+	// and PredicateNode "some pred key" -- the two preds show up
+	// when the attached values are fetched.
+	TSM_ASSERT_EQUALS("Wrong number of Atoms fetched!", as->get_size(), 6);
+
+	printf("Got %lu Atoms\n", as->get_size());
+	HandleSet hset;
+	as->get_rootset_by_type(hset, ATOM, true);
+	for (const Handle& h : hset)
+		printf("%s\n", h->to_string().c_str());
+
 	Handle gkey = as->add_node(PREDICATE_NODE, "some pred key");
 	Handle gaf = as->add_node(CONCEPT_NODE, "float node");
 	Handle gat = as->add_node(CONCEPT_NODE, "string node");

--- a/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
@@ -683,6 +683,7 @@ void ValueSaveUTest::do_test_link_by_type()
 	// only the values on the C-links should be fetched.
 	as->fetch_all_atoms_of_type(LIST_LINK);
 	as->barrier();
+	TSM_ASSERT("Wrong number of Atoms fetched!", as->get_size() == 14);
 
 	Handle gbf = as->add_node(CONCEPT_NODE, "b float node");
 	Handle gbt = as->add_node(CONCEPT_NODE, "b string node");
@@ -896,6 +897,7 @@ void ValueSaveUTest::do_test_incoming()
 	as->fetch_incoming_set(gal, false);
 	as->fetch_incoming_set(gav, false);
 	as->barrier();
+	TSM_ASSERT("Wrong number of Atoms fetched!", as->get_size() == 14);
 
 	Handle gbf = as->add_node(CONCEPT_NODE, "b float node");
 	Handle gbt = as->add_node(CONCEPT_NODE, "b string node");


### PR DESCRIPTION
Implement a basic "command interpreter" for a certain specific set of
scheme commands - about a dozen - that are used to send Atoms and
Values over the network.  This interpreter completely avoids using guile
or scheme -- it just hard-codes the handful of strings as "commands",
and nothing more.  The Atoms/Values are just s-expressions, decoded
using the recently added "fast file" s-expression code.

The goal is to have as-fast-as-possible network I/O of Atoms/Values,
without going all the way to a binary file format. So, the s-expressions
are pretty fast, but still human readable. Obviously, they're more verbose
than a binary file format, but they're ... easy to deal with.

Used by https://github.com/opencog/atomspace-cog/