### PR TITLE
Modernize the backing-store API

### DIFF
--- a/opencog/atomspace/AtomSpace.cc
+++ b/opencog/atomspace/AtomSpace.cc
@@ -382,6 +382,7 @@ Handle AtomSpace::fetch_atom(const Handle& h)
     // else, then save the old TV, fetch the new TV, and combine them
     // with your favorite algo.
     Handle ah = add_atom(h);
+    if (nullptr == ah) return ah; // if read-only, then cannot update.
     _backing_store->getAtom(ah);
     return ah;
 }

--- a/opencog/atomspace/AtomSpace.cc
+++ b/opencog/atomspace/AtomSpace.cc
@@ -381,25 +381,9 @@ Handle AtomSpace::fetch_atom(const Handle& h)
     // and not to play monkey-shines with them.  If you want something
     // else, then save the old TV, fetch the new TV, and combine them
     // with your favorite algo.
-    Handle hv;
-    if (h->is_node()) {
-        hv = _backing_store->getNode(h->get_type(),
-                                     h->get_name().c_str());
-    }
-    else if (h->is_link()) {
-        hv = _backing_store->getLink(h->get_type(),
-                                     h->getOutgoingSet());
-    }
-
-    // If we found it, add it to the atomspace -- even when the
-    // atomspace is marked read-only; the atomspace is acting as
-    // a cache for the backingstore.
-    if (hv) return _atom_table.add(hv);
-
-    // If it is not found, then it cannot be added.
-    if (_read_only) return Handle::UNDEFINED;
-
-    return _atom_table.add(h);
+    add_atom(h);
+    _backing_store->getAtom(h);
+    return h;
 }
 
 Handle AtomSpace::fetch_value(const Handle& h, const Handle& key)

--- a/opencog/atomspace/AtomSpace.cc
+++ b/opencog/atomspace/AtomSpace.cc
@@ -381,9 +381,9 @@ Handle AtomSpace::fetch_atom(const Handle& h)
     // and not to play monkey-shines with them.  If you want something
     // else, then save the old TV, fetch the new TV, and combine them
     // with your favorite algo.
-    add_atom(h);
-    _backing_store->getAtom(h);
-    return h;
+    Handle ah = add_atom(h);
+    _backing_store->getAtom(ah);
+    return ah;
 }
 
 Handle AtomSpace::fetch_value(const Handle& h, const Handle& key)

--- a/opencog/atomspace/BackingStore.cc
+++ b/opencog/atomspace/BackingStore.cc
@@ -51,10 +51,12 @@ void BackingStore::getAtom(const Handle& h)
 	if (hv)
 	{
 		AtomSpace *as = h->getAtomSpace();
-		if (nullptr != as and not as->get_read_only())
+		if (nullptr != as)
 			for (const Handle& k: hv->getKeys())
 			{
 				Handle ak = as->add_atom(k);
+				// Read-only AtomSpaces won't allow insertion.
+				if (nullptr == ak) continue;
 				as->set_value(h, ak, hv->getValue(k));
 			}
 		else

--- a/opencog/atomspace/BackingStore.cc
+++ b/opencog/atomspace/BackingStore.cc
@@ -51,9 +51,12 @@ void BackingStore::getAtom(const Handle& h)
 	if (hv)
 	{
 		AtomSpace *as = h->getAtomSpace();
-		if (nullptr != as)
+		if (nullptr != as and not as->get_read_only())
 			for (const Handle& k: hv->getKeys())
-				as->set_value(h, k, hv->getValue(k));
+			{
+				Handle ak = as->add_atom(k);
+				as->set_value(h, ak, hv->getValue(k));
+			}
 		else
 			h->copyValues(hv);
 	}

--- a/opencog/atomspace/BackingStore.cc
+++ b/opencog/atomspace/BackingStore.cc
@@ -37,3 +37,24 @@ void BackingStore::unregisterWith(AtomSpace* atomspace)
 {
 	atomspace->unregisterBackingStore(this);
 }
+
+/* Provide a backwards-compat implementation. */
+void BackingStore::getAtom(const Handle& h)
+{
+	Handle hv;
+	if (h->is_node())
+		hv = getNode(h->get_type(), h->get_name().c_str());
+	else
+		hv = getLink(h->get_type(), h->getOutgoingSet());
+
+	barrier();
+	if (hv)
+	{
+		AtomSpace *as = h->getAtomSpace();
+		if (nullptr != as)
+			for (const Handle& k: hv->getKeys())
+				as->set_value(h, k, hv->getValue(k));
+		else
+			h->copyValues(hv);
+	}
+}

--- a/opencog/atomspace/BackingStore.h
+++ b/opencog/atomspace/BackingStore.h
@@ -56,26 +56,20 @@ class BackingStore
 		virtual ~BackingStore() {}
 
 		/**
-		 * Return a Link with the indicated type and outset,
-		 * if it exists; else return nullptr. The returned atom
-		 * will have all values attached to it, that the backing
-		 * store knows about.
+		 * Fetch all the Values attached to the indicated Atom,
+		 * if any. The Values are automatically installed on the
+		 * provided Atom. If the Atom is in some AtomSpace, then
+		 * the keys, as well as any (other) Atoms appearing inside
+		 * of the Values are placed into that AtomSpace. (That is,
+		 * just provide a null AtomSpace if this is not wanted.)
 		 *
 		 * See also `loadValue()` below, which can fetch just one
 		 * single value.
-		 */
-		virtual Handle getLink(Type, const HandleSeq&) = 0;
-
-		/**
-		 * Return a Node with the indicated type and name, if it
-		 * exists; else return nullptr. The returned atom will have
-		 * all values attached to it, that the backing store knows
-		 * about.
 		 *
-		 * See also `loadValue()` below, which can fetch just one
-		 * single value.
+		 * FYI: This replaces the deprecated getNode() and getLink().
+		 * A backwards-compat implementation is provided.
 		 */
-		virtual Handle getNode(Type, const char *) = 0;
+		virtual void getAtom(const Handle&);
 
 		/**
 		 * Fetch the entire incoming set of the indicated Atom,
@@ -252,6 +246,14 @@ class BackingStore
 		 * Unregister this backing store with the atomspace.
 		 */
 		void unregisterWith(AtomSpace*);
+
+		/**  Deprecated. Implement getAtom() instead. */
+		virtual Handle getLink(Type, const HandleSeq&) {
+			throw IOException(TRACE_INFO, "Implementation is buggy!");
+		}
+		virtual Handle getNode(Type, const char *) {
+			throw IOException(TRACE_INFO, "Implementation is buggy!");
+		}
 };
 
 /** @}*/

--- a/opencog/persist/sexpr/AtomSexpr.cc
+++ b/opencog/persist/sexpr/AtomSexpr.cc
@@ -46,6 +46,7 @@ int Sexpr::get_next_expr(const std::string& s, size_t& l, size_t& r,
                          size_t line_cnt)
 {
 	// Advance past whitespace.
+	// Would be more efficient to say l = s.find_first_not_of(" \t\n", l);
 	while (l < r and (s[l] == ' ' or s[l] == '\t' or s[l] == '\n')) l++;
 	if (l == r) return 0;
 


### PR DESCRIPTION
The old API proved to be problematic on several levels, so replace it with
something better. Provide a backwards-compat implementation as well.