### PR TITLE
Move around code for transient atomspaces

### DIFF
--- a/opencog/atomspace/CMakeLists.txt
+++ b/opencog/atomspace/CMakeLists.txt
@@ -6,6 +6,7 @@ ADD_LIBRARY (atomspace
 	AtomSpace.cc
 	AtomTable.cc
 	BackingStore.cc
+	Transient.cc
 	TypeIndex.cc
 )
 
@@ -40,6 +41,7 @@ INSTALL (FILES
 	AtomSpace.h
 	AtomTable.h
 	BackingStore.h
+	Transient.h
 	TypeIndex.h
 	version.h
 	DESTINATION "include/opencog/atomspace"

--- a/opencog/atomspace/Transient.cc
+++ b/opencog/atomspace/Transient.cc
@@ -53,7 +53,7 @@ static std::vector<AtomSpace*> s_transient_cache;
 
 static std::atomic_int num_issued = 0;
 
-AtomSpace* grab_transient_atomspace(AtomSpace* parent)
+AtomSpace* opencog::grab_transient_atomspace(AtomSpace* parent)
 {
 	AtomSpace* transient_atomspace = nullptr;
 
@@ -91,7 +91,7 @@ AtomSpace* grab_transient_atomspace(AtomSpace* parent)
 	return transient_atomspace;
 }
 
-void release_transient_atomspace(AtomSpace* atomspace)
+void opencog::release_transient_atomspace(AtomSpace* atomspace)
 {
 	bool atomspace_cached = false;
 

--- a/opencog/atomspace/Transient.cc
+++ b/opencog/atomspace/Transient.cc
@@ -1,0 +1,125 @@
+/*
+ * Transient.cc
+ *
+ * Copyright (C) 2008,2009,2014,2015 Linas Vepstas
+ *
+ * Author: Linas Vepstas <linasvepstas@gmail.com>  February 2008
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <atomic>
+#include <opencog/util/Logger.h>
+
+#include <opencog/atomspace/AtomSpace.h>
+#include "Transient.h"
+
+using namespace opencog;
+
+/* ======================================================== */
+/// Cache for temp (transient) atomspaces.  The evaluation of
+/// expressions during pattern matching and during other operations
+/// requires having a temporary atomspace, treated as a scratch space,
+/// to hold temporary results. These are then discarded, after the
+/// match is confirmed or denied. The issue is that creating an
+/// atomspace is CPU-intensive, so its cheaper to just have a cache
+/// of empty atomspaces, hanging around, and ready to go. The code
+/// in this section implements this.
+
+// XXX TODO This should be changed to use an use-counting AtomSpacePtr
+// so that the transients are automatically released back to the pool.
+// This will avoid mem leakage due to bad exception handling and other
+// programming bugs.
+
+const bool TRANSIENT_SPACE = true;
+const int MAX_CACHED_TRANSIENTS = 32;
+
+// Allocated storage for the transient atomspace cache static variables.
+static std::mutex s_transient_cache_mutex;
+static std::vector<AtomSpace*> s_transient_cache;
+
+static std::atomic_int num_issued = 0;
+
+AtomSpace* grab_transient_atomspace(AtomSpace* parent)
+{
+	AtomSpace* transient_atomspace = nullptr;
+
+	// See if the cache has one...
+	if (s_transient_cache.size() > 0)
+	{
+		// Grab the mutex lock.
+		std::unique_lock<std::mutex> cache_lock(s_transient_cache_mutex);
+
+		// Check to make sure the cache still has one now that we have
+		// the mutex.
+		if (s_transient_cache.size() > 0)
+		{
+			// Pop the latest transient atomspace off the cache stack.
+			transient_atomspace = s_transient_cache.back();
+			s_transient_cache.pop_back();
+
+			// Ready it for the new parent atomspace.
+			transient_atomspace->ready_transient(parent);
+
+			num_issued ++;
+		}
+	}
+
+	// If we didn't get one from the cache, then create a new one.
+	if (!transient_atomspace)
+	{
+		transient_atomspace = new AtomSpace(parent, TRANSIENT_SPACE);
+		num_issued ++;
+	}
+
+	if (MAX_CACHED_TRANSIENTS < num_issued.load())
+		throw FatalErrorException(TRACE_INFO, "Transient space memleak!");
+
+	return transient_atomspace;
+}
+
+void release_transient_atomspace(AtomSpace* atomspace)
+{
+	bool atomspace_cached = false;
+
+	// If the cache is not full...
+	if (s_transient_cache.size() < MAX_CACHED_TRANSIENTS)
+	{
+		// Grab the mutex lock.
+		std::unique_lock<std::mutex> cache_lock(s_transient_cache_mutex);
+
+		// Check it again since we only now have the mutex locked.
+		if (s_transient_cache.size() < MAX_CACHED_TRANSIENTS)
+		{
+			// Clear this transient atomspace.
+			atomspace->clear_transient();
+
+			// Place this transient into the cache.
+			s_transient_cache.push_back(atomspace);
+
+			// The atomspace has been cached.
+			atomspace_cached = true;
+
+			num_issued--;
+		}
+	}
+
+	// If we didn't cache the atomspace, then delete it.
+	if (!atomspace_cached)
+		delete atomspace;
+}
+
+/* ===================== END OF FILE ===================== */

--- a/opencog/atomspace/Transient.h
+++ b/opencog/atomspace/Transient.h
@@ -1,0 +1,36 @@
+/*
+ * opencog/atomspace/Transient.h
+ *
+ * Copyright (C) 2008,2009,2014,2015 Linas Vepstas
+ *
+ * Author: Linas Vepstas <linasvepstas@gmail.com>  February 2008
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef _OPENCOG_TRANSIENT_H
+#define _OPENCOG_TRANSIENT_H
+
+namespace opencog
+{
+
+class AtomSpace;
+AtomSpace* grab_transient_atomspace(AtomSpace*);
+void release_transient_atomspace(AtomSpace*);
+
+} //namespace opencog
+
+#endif // _OPENCOG_TRANSIENT_H

--- a/opencog/query/TermMatchMixin.h
+++ b/opencog/query/TermMatchMixin.h
@@ -119,15 +119,6 @@ class TermMatchMixin : public virtual PatternMatchCallback
 		// Temp atomspace used for test-groundings of virtual links.
 		AtomSpace* _temp_aspace;
 
-		// The transient atomspace cache. The goal here is to
-		// avoid the overhead of constantly creating/deleting
-		// the temp atomspaces above. So instead, just keep a
-		// cache of empty ones, ready to go.
-		static std::mutex s_transient_cache_mutex;
-		static std::vector<AtomSpace*> s_transient_cache;
-		static AtomSpace* grab_transient_atomspace(AtomSpace* parent);
-		static void release_transient_atomspace(AtomSpace* atomspace);
-
 		// Crisp-logic evaluation of evaluatable terms
 		TypeSet _connectives;
 		bool eval_term(const Handle& pat, const GroundingMap& gnds);


### PR DESCRIPTION
Move existing code to where other subsystems can use it.