### PR TITLE
Add function for wrapping existing loggers

### DIFF
--- a/opencog/cython/opencog/CMakeLists.txt
+++ b/opencog/cython/opencog/CMakeLists.txt
@@ -93,7 +93,7 @@ SET_TARGET_PROPERTIES(atomspace_cython PROPERTIES
 INSTALL (FILES
 	__init__.py
 	atomspace.pxd
-        logger.pxd
+	logger.pxd
 	value_types.pxd
 	DESTINATION "include/opencog/cython/opencog"
 )

--- a/opencog/cython/opencog/CMakeLists.txt
+++ b/opencog/cython/opencog/CMakeLists.txt
@@ -93,6 +93,7 @@ SET_TARGET_PROPERTIES(atomspace_cython PROPERTIES
 INSTALL (FILES
 	__init__.py
 	atomspace.pxd
+        logger.pxd
 	value_types.pxd
 	DESTINATION "include/opencog/cython/opencog"
 )

--- a/opencog/cython/opencog/logger.pxd
+++ b/opencog/cython/opencog/logger.pxd
@@ -1,0 +1,45 @@
+from libcpp cimport bool
+
+# basic wrapping for std::string conversion
+cdef extern from "<string>" namespace "std":
+    cdef cppclass string:
+        string()
+        string(char *)
+        char * c_str()
+        int size()
+
+
+cdef extern from "opencog/util/Logger.h" namespace "opencog":
+    # Need to get around cython's lack of support for nested types
+    enum loglevel "opencog::Logger::Level":
+        NONE "opencog::Logger::NONE"
+        ERROR "opencog::Logger::ERROR"
+        WARN "opencog::Logger::WARN"
+        INFO "opencog::Logger::INFO"
+        DEBUG "opencog::Logger::DEBUG"
+        FINE "opencog::Logger::FINE"
+        BAD_LEVEL "opencog::Logger::BAD_LEVEL"
+    cdef cppclass cLogger "opencog::Logger":
+        cLogger()
+        cLogger(string s)
+        void set_level(loglevel lvl)
+        void set_component(string c)
+        loglevel get_level()
+        void set_print_to_stdout_flag(bool flag)
+
+        void log(loglevel lvl, string txt)
+
+        bool is_enabled(loglevel lvl)
+
+    cdef loglevel string_to_log_level "opencog::Logger::get_level_from_string"(string s)
+    cdef string log_level_to_string "opencog::Logger::get_level_string"(loglevel lvl)
+    cLogger& logger()
+
+
+cdef class Logger:
+    cdef cLogger *clog
+    cdef not_singleton_logger
+    cdef _set_level(self,int lvl)
+    cdef _level_as_string(self)
+
+cdef Logger wrap_clogger(cLogger *clog, bool not_singleton=*)

--- a/opencog/cython/opencog/logger.pxd
+++ b/opencog/cython/opencog/logger.pxd
@@ -42,4 +42,4 @@ cdef class Logger:
     cdef _set_level(self,int lvl)
     cdef _level_as_string(self)
 
-cdef Logger wrap_clogger(cLogger *clog, bool not_singleton=*)
+cdef Logger wrap_clogger(cLogger *clog)

--- a/opencog/cython/opencog/logger.pyx
+++ b/opencog/cython/opencog/logger.pyx
@@ -1,7 +1,7 @@
 from libcpp cimport bool
 from cython.operator cimport dereference as deref
 
-cdef create_logger(filename):
+def create_logger(filename):
     cdef Logger l = Logger.__new__(Logger)
     py_byte_string = filename.encode('UTF-8')
     # create temporary cpp string

--- a/opencog/cython/opencog/logger.pyx
+++ b/opencog/cython/opencog/logger.pyx
@@ -12,10 +12,13 @@ cdef create_logger(filename):
     del c_filename
     return l
 
-cdef Logger wrap_clogger(cLogger *clog, bool not_singleton=False):
+cdef Logger wrap_clogger(cLogger *clog):
     cdef Logger l = Logger.__new__(Logger)
     l.clog = clog
-    l.not_singleton_logger = not_singleton
+    # Setting to False allows to not deallocate when the caller of
+    # wrap_clogger goes out of scope (which can be the case if used in
+    # a singleton manner).
+    l.not_singleton_logger = False
     return l
 
 cdef class Logger:

--- a/opencog/cython/opencog/logger.pyx
+++ b/opencog/cython/opencog/logger.pyx
@@ -1,7 +1,7 @@
 from libcpp cimport bool
 from cython.operator cimport dereference as deref
 
-def create_logger(filename):
+cdef create_logger(filename):
     cdef Logger l = Logger.__new__(Logger)
     py_byte_string = filename.encode('UTF-8')
     # create temporary cpp string


### PR DESCRIPTION
Define `wrap_clogger` for wrapping existings loggers. Used by the ure for exposing the ure logger to Python.