### PR TITLE
Add dependency on base types being generated to storage types generation

### DIFF
--- a/opencog/persist/storage/CMakeLists.txt
+++ b/opencog/persist/storage/CMakeLists.txt
@@ -16,7 +16,7 @@ ADD_LIBRARY(storage-types SHARED
 )
 
 # Without this, parallel make will race and crap up the generated files.
-ADD_DEPENDENCIES(storage-types storage_types)
+ADD_DEPENDENCIES(storage-types storage_types opencog_atom_types)
 
 TARGET_LINK_LIBRARIES(storage-types
 	${ATOMSPACE_atomtypes_LIBRARY}


### PR DESCRIPTION
To prevent race conditions. Building storage types has to wait until base types are **generated**, conditioning on the library being built is not strict enough.