### PR TITLE
Add python binding for Logger::set_sync_flag

### DIFF
--- a/opencog/cython/opencog/logger.pxd
+++ b/opencog/cython/opencog/logger.pxd
@@ -26,6 +26,7 @@ cdef extern from "opencog/util/Logger.h" namespace "opencog":
         void set_component(string c)
         loglevel get_level()
         void set_print_to_stdout_flag(bool flag)
+        void set_sync_flag(bool flag)
 
         void log(loglevel lvl, string txt)
 

--- a/opencog/cython/opencog/logger.pyx
+++ b/opencog/cython/opencog/logger.pyx
@@ -106,8 +106,10 @@ cdef class Logger:
 
     def is_enabled(self, int lvl):
         return self.clog.is_enabled(<loglevel>lvl)
-    def use_stdout(self,use_it=True):
+    def use_stdout(self, use_it=True):
         self.clog.set_print_to_stdout_flag(use_it)
+    def set_sync(self, s):
+        self.clog.set_sync_flag(s)
 
 # This is the singleton instance created by cogutil.
 log = Logger()


### PR DESCRIPTION
I didn't add a unit test because it's rather difficult to test without a get sync flag accessor (which the Logger class misses), but it seems to work for me.