### PR TITLE
Add python id_string()

### DIFF
--- a/opencog/cython/opencog/atom.pyx
+++ b/opencog/cython/opencog/atom.pyx
@@ -61,6 +61,9 @@ cdef class Atom(Value):
             return
         atom_ptr.setTruthValue(deref((<TruthValue>truth_value)._tvptr()))
 
+    def id_string(self):
+        return self.get_c_handle().get().id_to_string().decode('UTF-8')
+
     def set_value(self, key, value):
         if not isinstance(key, Atom):
             raise TypeError("key should be an instance of Atom, got {0} instead".format(type(key)))

--- a/opencog/cython/opencog/atomspace.pxd
+++ b/opencog/cython/opencog/atomspace.pxd
@@ -127,6 +127,10 @@ cdef extern from "opencog/atoms/base/Atom.h" namespace "opencog":
 
         output_iterator getIncomingSetByType(output_iterator, Type type)
 
+        string to_string()
+        string to_short_string()
+        string id_to_string()
+
         # Conditionally-valid methods. Not defined for all atoms.
         string get_name()
         vector[cHandle] getOutgoingSet()
@@ -149,8 +153,6 @@ cdef extern from "opencog/atoms/base/Handle.h" namespace "opencog":
         cHandle(const cHandle&)
 
         cAtom* atom_ptr()
-        string to_string()
-        string to_short_string()
 
         bint operator==(cHandle h)
         bint operator!=(cHandle h)


### PR DESCRIPTION
Add Python binding for `Atom::id_to_string()`. Useful for identifying an atom without having to print its entire hypergraph.