### PR TITLE
Add IsTrueLink and IsFalseLink

### DIFF
--- a/opencog/atoms/atom_types/atom_types.script
+++ b/opencog/atoms/atom_types/atom_types.script
@@ -630,6 +630,10 @@ GREATER_THAN_LINK <- VIRTUAL_LINK,NUMERIC_LINK
 // any free variable.
 IS_CLOSED_LINK <- UNORDERED_LINK,VIRTUAL_LINK
 
+// Test whether all outgoing atoms have a TRUE_TV (resp. FALSE_TV).
+IS_TRUE_LINK <- UNORDERED_LINK,VIRTUAL_LINK
+IS_FALSE_LINK <- UNORDERED_LINK,VIRTUAL_LINK
+
 // IdenticalLink tests for syntactic equality.  It does NOT execute its
 // arguments; it is true only if both sides are the same atom.
 // EqualLink tests for semantic equality: the two sides are equal, if,

--- a/opencog/atoms/atom_types/atom_types.script
+++ b/opencog/atoms/atom_types/atom_types.script
@@ -626,9 +626,9 @@ ANCHOR_NODE <- NODE
 VIRTUAL_LINK <- CRISP_OUTPUT_LINK
 GREATER_THAN_LINK <- VIRTUAL_LINK,NUMERIC_LINK
 
-// Test whether an atom is closed, that is does not contain any free
-// variable.
-IS_CLOSED_LINK <- VIRTUAL_LINK
+// Test whether all outgoing atoms are closed, that is do not contain
+// any free variable.
+IS_CLOSED_LINK <- UNORDERED_LINK,VIRTUAL_LINK
 
 // IdenticalLink tests for syntactic equality.  It does NOT execute its
 // arguments; it is true only if both sides are the same atom.

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -190,11 +190,8 @@ static bool greater(AtomSpace* as, const Handle& h, bool silent)
 static bool is_closed(AtomSpace* as, const Handle& h, bool silent)
 {
 	const HandleSeq& oset = h->getOutgoingSet();
-	if (1 != oset.size())
-		throw SyntaxException(TRACE_INFO,
-		     "IsClosedLink expects one argument");
-
-	return is_closed(oset[0]);
+	return std::all_of(oset.begin(), oset.end(),
+	                   [](const Handle& h) { return is_closed(h); });
 }
 
 static ValuePtr exec_or_eval(AtomSpace* as,

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -37,6 +37,7 @@
 #include <opencog/atoms/reduct/FoldLink.h>
 #include <opencog/atoms/truthvalue/FormulaTruthValue.h>
 #include <opencog/atoms/truthvalue/SimpleTruthValue.h>
+#include <opencog/atoms/truthvalue/TruthValue.h>
 #include <opencog/atoms/value/LinkValue.h>
 
 #include <opencog/atomspace/AtomSpace.h>
@@ -187,11 +188,29 @@ static bool greater(AtomSpace* as, const Handle& h, bool silent)
 }
 
 /// Perform a IsClosed check
-static bool is_closed(AtomSpace* as, const Handle& h, bool silent)
+static bool is_outgoing_closed(const Handle& h)
 {
 	const HandleSeq& oset = h->getOutgoingSet();
 	return std::all_of(oset.begin(), oset.end(),
-	                   [](const Handle& h) { return is_closed(h); });
+	                   [](const Handle& o) { return is_closed(o); });
+}
+
+/// Perform a IsTrue check
+static bool is_outgoing_true(const Handle& h)
+{
+	const HandleSeq& oset = h->getOutgoingSet();
+	return std::all_of(oset.begin(), oset.end(),
+		[](const Handle& o)
+			{ return *o->getTruthValue() == *TruthValue::TRUE_TV(); });
+}
+
+/// Perform a IsFalse check
+static bool is_outgoing_false(const Handle& h)
+{
+	const HandleSeq& oset = h->getOutgoingSet();
+	return std::all_of(oset.begin(), oset.end(),
+		[](const Handle& o)
+			{ return *o->getTruthValue() == *TruthValue::FALSE_TV(); });
 }
 
 static ValuePtr exec_or_eval(AtomSpace* as,
@@ -571,7 +590,9 @@ static bool crispy_maybe(AtomSpace* as,
 	if (EQUAL_LINK == t) return equal(scratch, evelnk, silent);
 	if (ALPHA_EQUAL_LINK == t) return alpha_equal(scratch, evelnk, silent);
 	if (GREATER_THAN_LINK == t) return greater(scratch, evelnk, silent);
-	if (IS_CLOSED_LINK == t) return is_closed(scratch, evelnk, silent);
+	if (IS_CLOSED_LINK == t) return is_outgoing_closed(evelnk);
+	if (IS_TRUE_LINK == t) return is_outgoing_true(evelnk);
+	if (IS_FALSE_LINK == t) return is_outgoing_false(evelnk);
 	if (MEMBER_LINK == t) return member(scratch, evelnk, silent);
 	if (SUBSET_LINK == t) return subset(scratch, evelnk, silent);
 	if (EXCLUSIVE_LINK == t) return exclusive(scratch, evelnk, silent);

--- a/tests/query/CMakeLists.txt
+++ b/tests/query/CMakeLists.txt
@@ -67,6 +67,8 @@ IF (HAVE_GUILE)
 
 	ADD_CXXTEST(GreaterThanUTest)
 	ADD_CXXTEST(IsClosedUTest)
+	ADD_CXXTEST(IsTrueUTest)
+	ADD_CXXTEST(IsFalseUTest)
 	ADD_CXXTEST(GreaterComputeUTest)
 	ADD_CXXTEST(VirtualUTest)
 	ADD_CXXTEST(PredicateFormulaUTest)

--- a/tests/query/IsClosedUTest.cxxtest
+++ b/tests/query/IsClosedUTest.cxxtest
@@ -26,7 +26,7 @@
 
 using namespace opencog;
 
-class IsClosedUTest: public CxxTest::TestSuite
+class IsClosedUTest : public CxxTest::TestSuite
 {
 private:
 	AtomSpace *as;

--- a/tests/query/IsFalseUTest.cxxtest
+++ b/tests/query/IsFalseUTest.cxxtest
@@ -1,0 +1,100 @@
+/*
+ * tests/query/IsFalseUTest.cxxtest
+ *
+ * Copyright (C) 2020 SingularityNET Foundation
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/guile/SchemeEval.h>
+#include <opencog/atomspace/AtomSpace.h>
+#include <opencog/util/Logger.h>
+
+using namespace opencog;
+
+class IsFalseUTest : public CxxTest::TestSuite
+{
+private:
+	AtomSpace *as;
+	SchemeEval* eval;
+
+public:
+	IsFalseUTest(void)
+	{
+		logger().set_level(Logger::DEBUG);
+		logger().set_print_to_stdout_flag(true);
+
+		as = new AtomSpace();
+		eval = new SchemeEval(as);
+		eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+	}
+
+	~IsFalseUTest()
+	{
+		delete as;
+		// Erase the log file if no assertions failed.
+		if (!CxxTest::TestTracker::tracker().suiteFailed())
+			std::remove(logger().get_filename().c_str());
+	}
+
+	void setUp(void);
+	void tearDown(void);
+
+	void test_basic_is_false(void);
+};
+
+void IsFalseUTest::tearDown(void)
+{
+}
+
+void IsFalseUTest::setUp(void)
+{
+}
+
+/*
+ * Basic IsFalseLink unit test. The atomspace contains 2 atoms, one
+ * with a FALSE_TV
+ *
+ * (Concept "A" (stv 1 1))
+ *
+ * one without
+ *
+ * (Concept "B")
+ *
+ * querying such atomspace with the condition that the candidates are
+ * false should return only the first atom.
+ */
+void IsFalseUTest::test_basic_is_false(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	eval->eval("(load-from-path \"tests/query/is_false.scm\")");
+
+	Handle query = eval->eval_h("query");
+	Handle false_query = eval->eval_h("false-query");
+
+	Handle results = HandleCast(query->execute());
+	Handle false_results = HandleCast(false_query->execute());
+
+	logger().debug() << "results = " << oc_to_string(results);
+	logger().debug() << "false_results = " << oc_to_string(false_results);
+
+	TS_ASSERT_EQUALS(2, results->get_arity());
+	TS_ASSERT_EQUALS(1, false_results->get_arity());
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}

--- a/tests/query/IsTrueUTest.cxxtest
+++ b/tests/query/IsTrueUTest.cxxtest
@@ -1,0 +1,100 @@
+/*
+ * tests/query/IsTrueUTest.cxxtest
+ *
+ * Copyright (C) 2020 SingularityNET Foundation
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/guile/SchemeEval.h>
+#include <opencog/atomspace/AtomSpace.h>
+#include <opencog/util/Logger.h>
+
+using namespace opencog;
+
+class IsTrueUTest : public CxxTest::TestSuite
+{
+private:
+	AtomSpace *as;
+	SchemeEval* eval;
+
+public:
+	IsTrueUTest(void)
+	{
+		logger().set_level(Logger::DEBUG);
+		logger().set_print_to_stdout_flag(true);
+
+		as = new AtomSpace();
+		eval = new SchemeEval(as);
+		eval->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+	}
+
+	~IsTrueUTest()
+	{
+		delete as;
+		// Erase the log file if no assertions failed.
+		if (!CxxTest::TestTracker::tracker().suiteFailed())
+			std::remove(logger().get_filename().c_str());
+	}
+
+	void setUp(void);
+	void tearDown(void);
+
+	void test_basic_is_true(void);
+};
+
+void IsTrueUTest::tearDown(void)
+{
+}
+
+void IsTrueUTest::setUp(void)
+{
+}
+
+/*
+ * Basic IsTrueLink unit test. The atomspace contains 2 atoms, one
+ * with a TRUE_TV
+ *
+ * (Concept "A" (stv 1 1))
+ *
+ * one without
+ *
+ * (Concept "B")
+ *
+ * querying such atomspace with the condition that the candidates are
+ * true should return only the first atom.
+ */
+void IsTrueUTest::test_basic_is_true(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	eval->eval("(load-from-path \"tests/query/is_true.scm\")");
+
+	Handle query = eval->eval_h("query");
+	Handle true_query = eval->eval_h("true-query");
+
+	Handle results = HandleCast(query->execute());
+	Handle true_results = HandleCast(true_query->execute());
+
+	logger().debug() << "results = " << oc_to_string(results);
+	logger().debug() << "true_results = " << oc_to_string(true_results);
+
+	TS_ASSERT_EQUALS(2, results->get_arity());
+	TS_ASSERT_EQUALS(1, true_results->get_arity());
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}

--- a/tests/query/is_false.scm
+++ b/tests/query/is_false.scm
@@ -1,0 +1,27 @@
+;
+; is_false.scm for IsFalseUTest.cxxtest
+;
+
+;; False atom
+(Concept "A" (stv 0 1))
+
+;; Non-false atom
+(Concept "B")
+
+;; Query all concepts
+(define query
+  (Get
+    (TypedVariable
+      (Variable "$C")
+      (Type 'Concept))
+    (Present (Variable "$C"))))
+
+;; Query only false concepts
+(define false-query
+  (Get
+    (TypedVariable
+      (Variable "$C")
+      (Type 'Concept))
+    (And
+     (Present (Variable "$C"))
+     (IsFalse (Variable "$C")))))

--- a/tests/query/is_true.scm
+++ b/tests/query/is_true.scm
@@ -1,0 +1,27 @@
+;
+; is_true.scm for IsTrueUTest.cxxtest
+;
+
+;; True atom
+(Concept "A" (stv 1 1))
+
+;; Non-true atom
+(Concept "B")
+
+;; Query all concepts
+(define query
+  (Get
+    (TypedVariable
+      (Variable "$C")
+      (Type 'Concept))
+    (Present (Variable "$C"))))
+
+;; Query only true concepts
+(define true-query
+  (Get
+    (TypedVariable
+      (Variable "$C")
+      (Type 'Concept))
+    (And
+     (Present (Variable "$C"))
+     (IsTrue (Variable "$C")))))


### PR DESCRIPTION
Add virtual link IsTrueLink (resp. IsFalseLink) to check if an atom has a TRUE_TV (resp. FALSE_TV).

Added wikipages as well

https://wiki.opencog.org/w/IsTrueLink
https://wiki.opencog.org/w/IsFalseLink