### PR TITLE
Implement atom deletion from storage

### DIFF
--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -138,8 +138,7 @@ public:
         { return _atom_table.getNumAtomsOfType(type, subclass); }
     inline UUID get_uuid(void) const { return _atom_table.get_uuid(); }
 
-    //! Clear the atomspace, extract all atoms. Does NOT clear the
-    //! attached backingstore.
+    //! Clear the atomspace, extract all atoms.
     void clear()
         { _atom_table.clear(); }
 
@@ -249,12 +248,8 @@ public:
     /**
      * Extract an atom from the atomspace.  This only removes the atom
      * from the (local, in-RAM) AtomSpace (in this process); any copies
-     * of the atom in persistent storage orin other address spaces are
-     * unaffected.  To also delete from persistant storage, use the
-     * remove_atom() method. Of course, the AtomSpace must be connected
-     * to storage in order for remove_atom() to reach out that far; if
-     * the AtomSpace is not connected to a backend, there is no
-     * difference between remove and extract.
+     * of the atom in persistent storage or in other address spaces are
+     * unaffected.
      *
      * The atom itself remains valid as long as there are Handles
      * that reference it; the RAM associated with the atom is
@@ -291,11 +286,8 @@ public:
     Handle set_truthvalue(const Handle&, const TruthValuePtr&);
 
     /**
-     * Get a node from the AtomTable, if it's in there. If its not found
-     * in the AtomTable, and there's a backing store, then the atom will
-     * be fetched from the backingstore (and added to the AtomTable). If
-     * the atom can't be found in either place, Handle::UNDEFINED will be
-     * returned.
+     * Get a node from the AtomTable, if it's in there. If the atom
+     * can't be found, Handle::UNDEFINED will be returned.
      *
      * @param t     Type of the node
      * @param str   Name of the node
@@ -306,11 +298,8 @@ public:
     }
 
     /**
-     * Get a link from the AtomTable, if it's in there. If its not found
-     * in the AtomTable, and there's a backing store, then the atom will
-     * be fetched from the backingstore (and added to the AtomTable). If
-     * the atom can't be found in either place, Handle::UNDEFINED will be
-     * returned.
+     * Get a link from the AtomTable, if it's in there. If the atom
+     * can't be found, Handle::UNDEFINED will be returned.
      *
      * See also the get_atom() method.
      *

--- a/opencog/guile/README
+++ b/opencog/guile/README
@@ -186,12 +186,12 @@ interface.
           )
 
 
-=== cog-delete atom ===
+=== cog-extract atom ===
       Delete the indicated atom, but only if it has no incoming links.
 
       Returns #t if the atom was deleted, else returns #f if not deleted.
 
-=== cog-delete-recursive atom ===
+=== cog-extract-recursive atom ===
       Delete the indicated atom, and all atoms that point at it.
 
       Both functions return #t on success, else they return #f.
@@ -212,12 +212,12 @@ interface.
 
          ; Try to delete x. This should fail, since there's a link
          ; containing x.
-         guile> (cog-delete x)
+         guile> (cog-extract x)
          #f
 
          ; Delete x, and everything pointing to it. This should delete
          ; both x, and the link l.
-         guile> (cog-delete-recursive x)
+         guile> (cog-extract-recursive x)
          #t
 
          ; Verify that the link l is gone:
@@ -565,7 +565,7 @@ in a list.
   (define (killall lst)
      (if (null? lst)
          '()
-         (cons (cog-delete (car lst))
+         (cons (cog-extract (car lst))
                (killall (cdr lst)))))
 
 

--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -267,9 +267,6 @@ void SchemeSmob::register_procs()
 	register_proc("cog-atom",              1, 0, 1, C(ss_atom));
 	register_proc("cog-node",              2, 0, 1, C(ss_node));
 	register_proc("cog-link",              1, 0, 1, C(ss_link));
-	register_proc("cog-delete!",           1, 0, 1, C(ss_delete));
-	register_proc("cog-delete",            1, 0, 1, C(ss_delete));
-	register_proc("cog-delete-recursive!", 1, 0, 1, C(ss_delete_recursive));
 	register_proc("cog-extract!",          1, 0, 1, C(ss_extract));
 	register_proc("cog-extract-recursive!",1, 0, 1, C(ss_extract_recursive));
 

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -103,8 +103,6 @@ private:
 	static SCM ss_node(SCM, SCM, SCM);
 	static SCM ss_new_link(SCM, SCM);
 	static SCM ss_link(SCM, SCM);
-	static SCM ss_delete(SCM, SCM);
-	static SCM ss_delete_recursive(SCM, SCM);
 	static SCM ss_extract(SCM, SCM);
 	static SCM ss_extract_recursive(SCM, SCM);
 	static SCM ss_value_p(SCM);

--- a/opencog/persist/api/PersistSCM.cc
+++ b/opencog/persist/api/PersistSCM.cc
@@ -68,6 +68,10 @@ void PersistSCM::init(void)
 	             &PersistSCM::sn_load_atomspace, "persist", false);
 	define_scheme_primitive("sn-store-atomspace",
 	             &PersistSCM::sn_store_atomspace, "persist", false);
+	define_scheme_primitive("sn-delete",
+	             &PersistSCM::sn_delete, "persist", false);
+	define_scheme_primitive("sn-delete-rec",
+	             &PersistSCM::sn_delete_recursive, "persist", false);
 	define_scheme_primitive("sn-barrier",
 	             &PersistSCM::sn_barrier, "persist", false);
 
@@ -93,6 +97,10 @@ void PersistSCM::init(void)
 	             &PersistSCM::dflt_load_atomspace, this, "persist", false);
 	define_scheme_primitive("dflt-store-atomspace",
 	             &PersistSCM::dflt_store_atomspace, this, "persist", false);
+	define_scheme_primitive("dflt-delete",
+	             &PersistSCM::dflt_delete, this, "persist", false);
+	define_scheme_primitive("dflt-delete-rec",
+	             &PersistSCM::dflt_delete_recursive, this, "persist", false);
 	define_scheme_primitive("dflt-barrier",
 	             &PersistSCM::dflt_barrier, this, "persist", false);
 }
@@ -209,6 +217,18 @@ void PersistSCM::sn_store_atomspace(Handle hsn)
 	stnp->store_atomspace();
 }
 
+bool PersistSCM::sn_delete(Handle h, Handle hsn)
+{
+	GET_STNP;
+	return stnp->remove_atom(h, false);
+}
+
+bool PersistSCM::sn_delete_recursive(Handle h, Handle hsn)
+{
+	GET_STNP;
+	return stnp->remove_atom(h, true);
+}
+
 void PersistSCM::sn_barrier(Handle hsn)
 {
 	GET_STNP;
@@ -292,6 +312,18 @@ void PersistSCM::dflt_store_atomspace(void)
 {
 	CHECK;
 	_sn->store_atomspace();
+}
+
+bool PersistSCM::dflt_delete(Handle h)
+{
+	CHECK;
+	return _sn->remove_atom(h, false);
+}
+
+bool PersistSCM::dflt_delete_recursive(Handle h)
+{
+	CHECK;
+	return _sn->remove_atom(h, true);
 }
 
 void PersistSCM::dflt_barrier(void)

--- a/opencog/persist/api/PersistSCM.h
+++ b/opencog/persist/api/PersistSCM.h
@@ -52,6 +52,8 @@ private:
 	static void sn_load_type(Type, Handle);
 	static void sn_load_atomspace(Handle);
 	static void sn_store_atomspace(Handle);
+	static bool sn_delete(Handle, Handle);
+	static bool sn_delete_recursive(Handle, Handle);
 	static void sn_barrier(Handle);
 
 	// Single global default storage node,
@@ -72,6 +74,8 @@ private:
 	void dflt_load_type(Type);
 	void dflt_load_atomspace(void);
 	void dflt_store_atomspace(void);
+	bool dflt_delete(Handle);
+	bool dflt_delete_recursive(Handle);
 	void dflt_barrier(void);
 
 public:

--- a/opencog/persist/api/StorageNode.cc
+++ b/opencog/persist/api/StorageNode.cc
@@ -1,5 +1,5 @@
 /*
- * opencog/persist/ati/StorageNode.cc
+ * opencog/persist/api/StorageNode.cc
  *
  * Copyright (c) 2008-2010 OpenCog Foundation
  * Copyright (c) 2009,2013,2020 Linas Vepstas

--- a/opencog/persist/storage/README.md
+++ b/opencog/persist/storage/README.md
@@ -6,7 +6,15 @@ how to connect up to storage. There are currently three types:
 
 * `PostgresStorageNode` -- connect to a Postgres backend
 * `RocksDBStorageNode` -- connect to a RocksDB backend
-* `CogserverStorageNode` -- connect to a CogServer backend
+* `CogStorageNode` -- connect to a CogServer backend
+
+`RocksDBStorageNode` is implemented in the
+[opencog/atomspace-rocks](https://github.com/opncog/atomspace-rocks)
+git repo.
+
+`CogStorageNode` is implemented in the
+[opencog/atomspace-cog](https://github.com/opncog/atomspace-cog)
+git repo.
 
 General information about the `storage_types.script` file can be found
 in the `opencog/atoms/atom_types` directory.

--- a/opencog/scm/opencog.scm
+++ b/opencog/scm/opencog.scm
@@ -40,8 +40,6 @@ cog-atomspace-uuid
 cog-confidence
 cog-count
 cog-count-atoms
-cog-delete!
-cog-delete-recursive!
 cog-extract!
 cog-extract-recursive!
 cog-get-subtypes
@@ -115,9 +113,6 @@ cog-value-ref
 
 ; Renamed functions
 (define-public (cog-as ATOM) "See cog-atomspace" (cog-atomspace ATOM))
-(define-public (cog-delete ATOM) "See cog-delete!" (cog-delete! ATOM))
-(define-public (cog-delete-recursive ATOM)
-	"See cog-delete-recursive!" (cog-delete-recursive! ATOM))
 (define-public (cog-extract ATOM) "See cog-extract!" (cog-extract! ATOM))
 (define-public (cog-extract-recursive ATOM)
 	"See cog-extract-recursive!" (cog-extract-recursive! ATOM))

--- a/opencog/scm/opencog/base/core-docs.scm
+++ b/opencog/scm/opencog/base/core-docs.scm
@@ -184,72 +184,6 @@
         )
 ")
 
-(set-procedure-property! cog-delete! 'documentation
-"
- cog-delete! ATOM [ATOMSPACE]
-    Remove the indicated ATOM, but only if it has no incoming links.
-    If it has incoming links, the remove fails.  If storage is attached,
-    the ATOM is also removed from the storage.
-
-    Returns #t if the atom was removed, else returns #f if not removed.
-
-    Use cog-extract! to remove from the AtomSpace only, leaving storage
-    unaffected.
-
-    Use cog-delete-recursive! to force removal of this atom, together
-    with any links that might be holding this atom.
-
-    If the optional ATOMSPACE argument is provided, then the ATOM is
-    removed from that AtomSpace; otherwise, it is removed from the
-    current AtomSpace for this thread.
-
-    Example:
-       ; Define two nodes and a link between them:
-       guile> (define x (Concept \"abc\"))
-       guile> (define y (Concept \"def\"))
-       guile> (define l (Link x y))
-
-       ; Verify that there's an atom called x:
-       guile> x
-       (ConceptNode \"abc\")
-
-       ; Try to delete x. This should fail, since there's a link
-       ; containing x.
-       guile> (cog-delete! x)
-       #f
-
-       ; Delete x, and everything pointing to it. This should delete
-       ; both x, and the link l.
-       guile> (cog-delete-recursive! x)
-       #t
-
-       ; Verify that the link l is gone:
-       guile> l
-       Invalid handle
-
-       ; Verify that the node x is gone:
-       guile> x
-       Invalid handle
-
-       ; Verify that the node y still exists:
-       guile> y
-       (ConceptNode \"def\")
-")
-
-(set-procedure-property! cog-delete-recursive! 'documentation
-"
- cog-delete-recursive! ATOM [ATOMSPACE]
-    Remove the indicated ATOM, and all atoms that point at it.
-    If SQL or other data storage is attached, the ATOM is also removed
-    from the storage.
-
-    Return #t on success, else return #f if not removed.
-
-    If the optional ATOMSPACE argument is provided, then the ATOM is
-    removed from that AtomSpace; otherwise, it is removed from the
-    current AtomSpace for this thread.
-")
-
 (set-procedure-property! cog-extract! 'documentation
 "
  cog-extract! ATOM [ATOMSPACE]
@@ -258,8 +192,9 @@
 
     Returns #t if the atom was removed, else returns #f if not removed.
 
-    This does NOT remove the atom from any attached storage (e.g. SQL
-    storage).  Use cog-delete! to remove from atoms from storage.
+    This does NOT remove the atom from any attached persistant storage.
+    Use cog-delete! from the (opencog persist) module to remove atoms
+    from storage.
 
     Use cog-extract-recursive! to force removal of this atom, together
     with any links that might be holding this atom.
@@ -307,13 +242,15 @@
     Remove the indicated ATOM, and all atoms that point at it.
     Return #t on success, else return #f if not removed.
 
-    The atom is NOT removed from SQL or other attached data storage.
-    If you need to delete from storage, use cog-delete! and
-    cog-delete-recursive!.
+    This does NOT remove the atom from any attached persistant storage.
+    Use cog-delete-recursive! from the (opencog persist) module to
+    remove atoms from storage.
 
     If the optional ATOMSPACE argument is provided, then the ATOM is
     removed from that AtomSpace; otherwise, it is removed from the
     current AtomSpace for this thread.
+
+    See also: cog-extract!
 ")
 
 (set-procedure-property! cog-atom? 'documentation

--- a/opencog/scm/opencog/persist.scm
+++ b/opencog/scm/opencog/persist.scm
@@ -383,12 +383,12 @@
     the current StorageNode attached to this thread.
 
     Example usage:
-       (cog-delete! (Concept "foo"))
-       (cog-delete! (Concept "foo")
+       (cog-delete! (Concept \"foo\"))
+       (cog-delete! (Concept \"foo\")
               (RocksStorage \"rocks:///tmp/my-rocks-db\"))
-       (cog-delete! (Concept "foo")
+       (cog-delete! (Concept \"foo\")
               (PostgresStorage \"postgres://USER:PASSWORD@HOST/DBNAME\"))
-       (cog-delete! (Concept "foo")
+       (cog-delete! (Concept \"foo\")
               (CogStorage \"cog://cogserver.example.com\"))
 
 "

--- a/opencog/scm/opencog/persist.scm
+++ b/opencog/scm/opencog/persist.scm
@@ -25,6 +25,8 @@
 	store-atom
 	store-value
 	load-atoms-of-type
+	cog-delete!
+	cog-delete-recursive!
 	barrier
 	load-atomspace
 	store-atomspace)
@@ -353,5 +355,77 @@
 		)
 	)
 )
+
+; --------------------------------------------------------------------
+; Renamed functions
+(define-public (cog-delete ATOM) "See cog-delete!" (cog-delete! ATOM))
+(define-public (cog-delete-recursive ATOM)
+	"See cog-delete-recursive!" (cog-delete-recursive! ATOM))
+
+
+(set-procedure-property! cog-delete! 'documentation
+"
+ cog-delete! ATOM [ATOMSPACE]
+    Remove the indicated ATOM, but only if it has no incoming links.
+    If it has incoming links, the remove fails.  If storage is attached,
+    the ATOM is also removed from the storage.
+
+    Returns #t if the atom was removed, else returns #f if not removed.
+
+    Use cog-extract! to remove from the AtomSpace only, leaving storage
+    unaffected.
+
+    Use cog-delete-recursive! to force removal of this atom, together
+    with any links that might be holding this atom.
+
+    If the optional ATOMSPACE argument is provided, then the ATOM is
+    removed from that AtomSpace; otherwise, it is removed from the
+    current AtomSpace for this thread.
+
+    Example:
+       ; Define two nodes and a link between them:
+       guile> (define x (Concept \"abc\"))
+       guile> (define y (Concept \"def\"))
+       guile> (define l (Link x y))
+
+       ; Verify that there's an atom called x:
+       guile> x
+       (ConceptNode \"abc\")
+
+       ; Try to delete x. This should fail, since there's a link
+       ; containing x.
+       guile> (cog-delete! x)
+       #f
+
+       ; Delete x, and everything pointing to it. This should delete
+       ; both x, and the link l.
+       guile> (cog-delete-recursive! x)
+       #t
+
+       ; Verify that the link l is gone:
+       guile> l
+       Invalid handle
+
+       ; Verify that the node x is gone:
+       guile> x
+       Invalid handle
+
+       ; Verify that the node y still exists:
+       guile> y
+       (ConceptNode \"def\")
+")
+
+(set-procedure-property! cog-delete-recursive! 'documentation
+"
+ cog-delete-recursive! ATOM [ATOMSPACE]
+    Remove the indicated ATOM, and all atoms that point at it.
+    If storage is attached, the ATOM is also removed from storage.
+
+    Return #t on success, else return #f if not removed.
+
+    If the optional ATOMSPACE argument is provided, then the ATOM is
+    removed from that AtomSpace; otherwise, it is removed from the
+    current AtomSpace for this thread.
+")
 
 ; --------------------------------------------------------------------

--- a/opencog/scm/opencog/persist.scm
+++ b/opencog/scm/opencog/persist.scm
@@ -363,9 +363,9 @@
 	"See cog-delete-recursive!" (cog-delete-recursive! ATOM))
 
 
-(set-procedure-property! cog-delete! 'documentation
+(define*-public (cog-delete! ATOM #:optional (STORAGE #f))
 "
- cog-delete! ATOM [ATOMSPACE]
+ cog-delete! ATOM [STORAGE]
     Remove the indicated ATOM, but only if it has no incoming links.
     If it has incoming links, the remove fails.  If storage is attached,
     the ATOM is also removed from the storage.
@@ -378,54 +378,36 @@
     Use cog-delete-recursive! to force removal of this atom, together
     with any links that might be holding this atom.
 
-    If the optional ATOMSPACE argument is provided, then the ATOM is
-    removed from that AtomSpace; otherwise, it is removed from the
-    current AtomSpace for this thread.
+    If the optional STORAGE argument is provided, then it will be
+    removed from that StorageNode; otherwise it will be removed from
+    the current StorageNode attached to this thread.
 
-    Example:
-       ; Define two nodes and a link between them:
-       guile> (define x (Concept \"abc\"))
-       guile> (define y (Concept \"def\"))
-       guile> (define l (Link x y))
+    Example usage:
+       (cog-delete! (Concept "foo"))
+       (cog-delete! (Concept "foo")
+              (RocksStorage \"rocks:///tmp/my-rocks-db\"))
+       (cog-delete! (Concept "foo")
+              (PostgresStorage \"postgres://USER:PASSWORD@HOST/DBNAME\"))
+       (cog-delete! (Concept "foo")
+              (CogStorage \"cog://cogserver.example.com\"))
 
-       ; Verify that there's an atom called x:
-       guile> x
-       (ConceptNode \"abc\")
-
-       ; Try to delete x. This should fail, since there's a link
-       ; containing x.
-       guile> (cog-delete! x)
-       #f
-
-       ; Delete x, and everything pointing to it. This should delete
-       ; both x, and the link l.
-       guile> (cog-delete-recursive! x)
-       #t
-
-       ; Verify that the link l is gone:
-       guile> l
-       Invalid handle
-
-       ; Verify that the node x is gone:
-       guile> x
-       Invalid handle
-
-       ; Verify that the node y still exists:
-       guile> y
-       (ConceptNode \"def\")
-")
-
-(set-procedure-property! cog-delete-recursive! 'documentation
 "
- cog-delete-recursive! ATOM [ATOMSPACE]
+	(if STORAGE (sn-delete ATOM STORAGE) (dflt-delete ATOM))
+)
+
+(define*-public (cog-delete-recursive! ATOM #:optional (STORAGE #f))
+"
+ cog-delete-recursive! ATOM [STORAGE]
     Remove the indicated ATOM, and all atoms that point at it.
     If storage is attached, the ATOM is also removed from storage.
 
     Return #t on success, else return #f if not removed.
 
-    If the optional ATOMSPACE argument is provided, then the ATOM is
-    removed from that AtomSpace; otherwise, it is removed from the
-    current AtomSpace for this thread.
-")
+    If the optional STORAGE argument is provided, then it will be
+    removed from that StorageNode; otherwise it will be removed from
+    the current StorageNode attached to this thread.
+"
+	(if STORAGE (sn-delete-rec ATOM STORAGE) (dflt-delete-rec ATOM))
+)
 
 ; --------------------------------------------------------------------

--- a/tests/scm/SCMPrimitiveUTest.cxxtest
+++ b/tests/scm/SCMPrimitiveUTest.cxxtest
@@ -233,7 +233,7 @@ void SCMPrimitiveUTest::test_parallel(void)
 	                 12
 	                 (lambda (n)
 	                     (tango (mango (cog-new-node 'ConceptNode (number->string n))))
-	                     (cog-delete! (mango (cog-new-node 'ConceptNode (number->string (+ n 1)))))
+	                     (cog-extract! (mango (cog-new-node 'ConceptNode (number->string (+ n 1)))))
 	                 )
 	                 (iota 30000)
 	             )


### PR DESCRIPTION
The storage refactoring done in #2760 forgot to handle the case of atom deletion from storage. This implements that forgotten step.