### PR TITLE
convert int->size_t where it makes sense

### DIFF
--- a/opencog/guile/SchemeEval.cc
+++ b/opencog/guile/SchemeEval.cc
@@ -1067,7 +1067,7 @@ SCM SchemeEval::do_apply_scm(const std::string& func, const Handle& varargs )
 
 		// Iterate in reverse, because cons chains in reverse.
 		size_t sz = oset.size();
-		for (int i=sz-1; i>=0; i--)
+		for (size_t i=sz-1; i>=0; i--)
 		{
 			SCM sh = SchemeSmob::handle_to_scm(oset[i]);
 			expr = scm_cons(sh, expr);

--- a/opencog/guile/SchemeEval.cc
+++ b/opencog/guile/SchemeEval.cc
@@ -1067,9 +1067,9 @@ SCM SchemeEval::do_apply_scm(const std::string& func, const Handle& varargs )
 
 		// Iterate in reverse, because cons chains in reverse.
 		size_t sz = oset.size();
-		for (size_t i=sz-1; i>=0; i--)
+		for (size_t i=sz; i>0; i--)
 		{
-			SCM sh = SchemeSmob::handle_to_scm(oset[i]);
+			SCM sh = SchemeSmob::handle_to_scm(oset[i-1]);
 			expr = scm_cons(sh, expr);
 		}
 	}

--- a/opencog/guile/SchemePrimitive.h
+++ b/opencog/guile/SchemePrimitive.h
@@ -103,7 +103,7 @@ protected:
 	size_t scm_to(SCM args, size_t idx, size_t) const
 	{
 		SCM arg = scm_list_ref(args, scm_from_size_t(idx));
-		return SchemeSmob::verify_size(arg, scheme_name, idx);
+		return SchemeSmob::verify_size_t(arg, scheme_name, idx);
 	}
 	int scm_to(SCM args, size_t idx, int) const
 	{

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -222,8 +222,8 @@ private:
 	                                  const char *msg = "string");
 	static int verify_int (SCM, const char *, int pos = 1,
 	                       const char *msg = "integer");
-	static size_t verify_size (SCM, const char *, int pos = 1,
-	                           const char *msg = "size integer");
+	static size_t verify_size_t (SCM, const char *, int pos = 1,
+	                             const char *msg = "integer size_t");
 	static double verify_real (SCM, const char *, int pos = 1,
 	                           const char *msg = "real number");
 	static Logger* verify_logger(SCM, const char *, int pos = 1);

--- a/opencog/guile/SchemeSmobAS.cc
+++ b/opencog/guile/SchemeSmobAS.cc
@@ -216,11 +216,11 @@ AtomSpace* SchemeSmob::ss_to_atomspace(SCM sas)
 
 AtomSpace* SchemeSmob::verify_atomspace(SCM sas, const char * subrname, int pos)
 {
-   AtomSpace* as = ss_to_atomspace(sas);
-   if (nullptr == as)
-      scm_wrong_type_arg_msg(subrname, pos, sas, "opencog atomspace");
+	AtomSpace* as = ss_to_atomspace(sas);
+	if (nullptr == as)
+		scm_wrong_type_arg_msg(subrname, pos, sas, "opencog atomspace");
 
-   return as;
+	return as;
 }
 
 /* ============================================================== */
@@ -449,8 +449,8 @@ void SchemeSmob::ss_set_env_as(AtomSpace *nas)
 
 AtomSpace* SchemeSmob::ss_get_env_as(const char* subr)
 {
-   // There are weird test-case scenarios where the fluid is not
-   // initalized. Those will crash-n-burn without this test.
+	// There are weird test-case scenarios where the fluid is not
+	// initalized. Those will crash-n-burn without this test.
 	if (0x0 == atomspace_fluid) return nullptr;
 
 	SCM ref = scm_fluid_ref(atomspace_fluid);

--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -253,7 +253,7 @@ SCM SchemeSmob::ss_outgoing_set (SCM satom)
 	const HandleSeq& oset = h->getOutgoingSet();
 
 	SCM list = SCM_EOL;
-	for (int i = oset.size()-1; i >= 0; i--)
+	for (size_t i = oset.size()-1; i >= 0; i--)
 	{
 		SCM smob = handle_to_scm(oset[i]);
 		list = scm_cons (smob, list);
@@ -277,7 +277,7 @@ SCM SchemeSmob::ss_outgoing_by_type (SCM satom, SCM stype)
 	const HandleSeq& oset = h->getOutgoingSet();
 
 	SCM list = SCM_EOL;
-	for (int i = oset.size()-1; i >= 0; i--)
+	for (size_t i = oset.size()-1; i >= 0; i--)
 	{
 		if (oset[i]->get_type() != t) continue;
 		SCM smob = handle_to_scm(oset[i]);

--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -253,9 +253,9 @@ SCM SchemeSmob::ss_outgoing_set (SCM satom)
 	const HandleSeq& oset = h->getOutgoingSet();
 
 	SCM list = SCM_EOL;
-	for (size_t i = oset.size()-1; i >= 0; i--)
+	for (size_t i = oset.size(); i > 0; i--)
 	{
-		SCM smob = handle_to_scm(oset[i]);
+		SCM smob = handle_to_scm(oset[i-1]);
 		list = scm_cons (smob, list);
 	}
 
@@ -277,10 +277,10 @@ SCM SchemeSmob::ss_outgoing_by_type (SCM satom, SCM stype)
 	const HandleSeq& oset = h->getOutgoingSet();
 
 	SCM list = SCM_EOL;
-	for (size_t i = oset.size()-1; i >= 0; i--)
+	for (size_t i = oset.size(); i > 0; i--)
 	{
-		if (oset[i]->get_type() != t) continue;
-		SCM smob = handle_to_scm(oset[i]);
+		if (oset[i-1]->get_type() != t) continue;
+		SCM smob = handle_to_scm(oset[i-1]);
 		list = scm_cons (smob, list);
 	}
 

--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -213,7 +213,7 @@ SCM SchemeSmob::ss_inc_value (SCM satom, SCM skey, SCM scnt, SCM sref)
 	Handle h = verify_handle(satom, "cog-inc-value!");
 	Handle key = verify_handle(skey, "cog-inc-value!", 2);
 	double cnt = verify_real(scnt, "cog-inc-value!", 3);
-	int ref = verify_int(sref, "cog-inc-value!", 4);
+	size_t ref = verify_size_t(sref, "cog-inc-value!", 4);
 
 	std::vector<double> new_value;
 
@@ -225,7 +225,7 @@ SCM SchemeSmob::ss_inc_value (SCM satom, SCM skey, SCM scnt, SCM sref)
 	{
 		FloatValuePtr fv(FloatValueCast(v));
 		new_value = fv->value();
-		if (new_value.size() <= (size_t) ref) new_value.resize(ref+1, 0.0);
+		if (new_value.size() <= ref) new_value.resize(ref+1, 0.0);
 	}
 	else
 	{

--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -294,7 +294,7 @@ SCM SchemeSmob::ss_outgoing_by_type (SCM satom, SCM stype)
 SCM SchemeSmob::ss_outgoing_atom (SCM satom, SCM spos)
 {
 	Handle h = verify_handle(satom, "cog-outgoing-atom");
-	size_t pos = verify_size(spos, "cog-outgoing-atom", 2);
+	size_t pos = verify_size_t(spos, "cog-outgoing-atom", 2);
 
 	if (not h->is_link()) return SCM_EOL;
 

--- a/opencog/guile/SchemeSmobNew.cc
+++ b/opencog/guile/SchemeSmobNew.cc
@@ -260,16 +260,15 @@ double SchemeSmob::verify_real (SCM sreal, const char *subrname,
 }
 
 /**
- * Check that the argument is an int, else throw errors.
- * Use C++ casting to convert the int to size_t. Return the size_t.
+ * Check that the argument is a size_t, else throw errors.
  */
-size_t SchemeSmob::verify_size (SCM sint, const char *subrname,
+size_t SchemeSmob::verify_size (SCM ssizet, const char *subrname,
                                 int pos, const char * msg)
 {
-	if (scm_is_false(scm_integer_p(sint)))
-		scm_wrong_type_arg_msg(subrname, pos, sint, msg);
+	if (scm_is_false(scm_integer_p(ssizet)))
+		scm_wrong_type_arg_msg(subrname, pos, ssizet, msg);
 
-	return (size_t) scm_to_int(sint);
+	return scm_to_size_t(ssizet);
 }
 
 /**

--- a/opencog/guile/SchemeSmobNew.cc
+++ b/opencog/guile/SchemeSmobNew.cc
@@ -247,6 +247,18 @@ int SchemeSmob::verify_int (SCM sint, const char *subrname,
 }
 
 /**
+ * Check that the argument is a size_t, else throw errors.
+ */
+size_t SchemeSmob::verify_size_t (SCM ssizet, const char *subrname,
+                                  int pos, const char * msg)
+{
+	if (scm_is_false(scm_integer_p(ssizet)))
+		scm_wrong_type_arg_msg(subrname, pos, ssizet, msg);
+
+	return scm_to_size_t(ssizet);
+}
+
+/**
  * Check that the argument is convertible to a real, else throw errors.
  * Return as a float.
  */
@@ -257,18 +269,6 @@ double SchemeSmob::verify_real (SCM sreal, const char *subrname,
 		scm_wrong_type_arg_msg(subrname, pos, sreal, msg);
 
 	return scm_to_double(sreal);
-}
-
-/**
- * Check that the argument is a size_t, else throw errors.
- */
-size_t SchemeSmob::verify_size (SCM ssizet, const char *subrname,
-                                int pos, const char * msg)
-{
-	if (scm_is_false(scm_integer_p(ssizet)))
-		scm_wrong_type_arg_msg(subrname, pos, ssizet, msg);
-
-	return scm_to_size_t(ssizet);
 }
 
 /**

--- a/opencog/guile/SchemeSmobValue.cc
+++ b/opencog/guile/SchemeSmobValue.cc
@@ -452,8 +452,8 @@ SCM SchemeSmob::ss_keys_alist (SCM satom)
 
 #define CPPL_TO_SCML(VAL, FN) \
 	SCM list = SCM_EOL; \
-	for (size_t i = VAL.size()-1; i >= 0; i--) { \
-		SCM smob = FN(VAL[i]); \
+	for (size_t i = VAL.size(); i > 0; i--) { \
+		SCM smob = FN(VAL[i-1]); \
 		list = scm_cons (smob, list); \
 	} \
 	return list;

--- a/opencog/guile/SchemeSmobValue.cc
+++ b/opencog/guile/SchemeSmobValue.cc
@@ -452,7 +452,7 @@ SCM SchemeSmob::ss_keys_alist (SCM satom)
 
 #define CPPL_TO_SCML(VAL, FN) \
 	SCM list = SCM_EOL; \
-	for (int i = VAL.size()-1; i >= 0; i--) { \
+	for (size_t i = VAL.size()-1; i >= 0; i--) { \
 		SCM smob = FN(VAL[i]); \
 		list = scm_cons (smob, list); \
 	} \

--- a/opencog/guile/SchemeSmobValue.cc
+++ b/opencog/guile/SchemeSmobValue.cc
@@ -509,7 +509,7 @@ SCM SchemeSmob::ss_value_to_list (SCM svalue)
 SCM SchemeSmob::ss_value_ref (SCM svalue, SCM sindex)
 {
 	ValuePtr pa(verify_protom(svalue, "cog-value-ref"));
-   size_t index = verify_size(sindex, "cog-value-ref", 2);
+	size_t index = verify_size_t(sindex, "cog-value-ref", 2);
 	Type t = pa->get_type();
 
 	if (nameserver().isA(t, FLOAT_VALUE))


### PR DESCRIPTION
Assorted std::c++ templates expect size_t not int, so use size_t for those.