### PR TITLE
Create a direct sum object

### DIFF
--- a/opencog/matrix/CMakeLists.txt
+++ b/opencog/matrix/CMakeLists.txt
@@ -3,6 +3,7 @@ ADD_GUILE_MODULE (FILES
 	bin-count.scm
 	compute-mi.scm
 	cosine.scm
+	direct-sum.scm
 	dynamic.scm
 	entropy.scm
 	eval-pairs.scm

--- a/opencog/matrix/README.md
+++ b/opencog/matrix/README.md
@@ -19,12 +19,12 @@ and so on. Vectors are buried in essentially all neural-net type
 algorithms.  But - this is key: a collection of vectors can be viewed
 as a matrix. Entries in the matrix are (row, column) pairs.
 
-The code in this directory exposes portions of the atomspace as pairs,
+The code in this directory exposes portions of the AtomSpace as pairs,
 or as a matrix, or as a collection of vectors, depending on how you want
 to think about it.  It implements the low-level code for this access,
 so that high-level algorithms can be implemented on top of it: so that
 they can grab that data, do things with it, and write it back.  It
-provides a "window" onto a portion of the atomspace, and everything
+provides a "window" onto a portion of the AtomSpace, and everything
 seen through that "window" looks like vectors, like one big matrix.
 
 That is, the structure of interest are ordered pairs `(x,y)` of atoms
@@ -40,7 +40,7 @@ might do with such a matrix.  That's what the code in this directory
 does.
 
 The prototypical example is that of word-pairs. These are stored in the
-atomspace as
+AtomSpace as
 ```
     EvaluationLink   (count=6789)
         PredicateNode "word-pair"
@@ -56,8 +56,8 @@ in relations between, say, `ConceptNodes` and `ContextLink`s. For
 biology, the left side might be a GeneNode, and the right side a
 ProteinNode.
 
-The core idea is that the atomspace can hold sparse matrix data; in a
-certain sense, the atomspace was designed from the get-go to do exactly
+The core idea is that the AtomSpace can hold sparse matrix data; in a
+certain sense, the AtomSpace was designed from the get-go to do exactly
 that. Once you realize that your data can be seen as a kind of matrix,
 you can then apply a variety of generic matrix analysis tools to it.
 
@@ -79,7 +79,7 @@ a Value, some Value, any Value, holding a floating-point number for each
 pair. This number is called `N(x,y)`. This number can represent any
 numeric data at all.  In the prototypical usage, this number is an
 observation count obtained by sensory data flowing in from the outside
-world. It dosn't have to be - the matrix toolset provided here is
+world. It doesn't have to be - the matrix toolset provided here is
 generic, intended to be useful for any AtomSpace data that meets the
 requirement of having a numeric value attached to a collection of pairs.
 
@@ -128,7 +128,7 @@ FAQ
 **Q:** Really, C++ is sooo fast...
 
 **A:** Yes, but since the data is stored in values associated with
-   atoms in the atomspace, adding numbers together is NOT the
+   atoms in the AtomSpace, adding numbers together is NOT the
    bottleneck. Accessing Atom Values *is* the bottleneck. Finding
    a good performance optimization for the atom values framework
    is a lot harder.
@@ -343,7 +343,7 @@ Direct sums
 -----------
 If one has a collection of things that can be vectors in two different
 ways, then the direct sum can be used to create a single vector out of
-the two.  It can be thought of as a concatentation of the two vectors,
+the two.  It can be thought of as a concatenation of the two vectors,
 appending one to the other to create a single vector.
 
 For example, a word "foo" can be associated with a vector of disjuncts.
@@ -371,7 +371,7 @@ no "overlap".  The total number of non-zero entries in the combined
 matrix is the sum of the number of non-zero entries in each component.
 
 (Caution: this is not the conventional definition of a direct sum, which
-results in block-diagonal matrix. The conventional defintion takes the
+results in block-diagonal matrix. The conventional definition takes the
 disjoint-union of the indexes (the basis), whereas here, we take the
 set-union of the basis. The set-union makes more sense in the current
 context, because the rows and columns have explicit labels, and it is
@@ -388,7 +388,7 @@ element-by-element min or max of a set of columns, counting the number
 of entries that are simultaneously non-zero in sets of columns, etc.
 
 The class works by defining a new matrix, whose rows or columns
-are tuples (pairs, triples, etc) of the underlying matix. For example,
+are tuples (pairs, triples, etc) of the underlying matrix. For example,
 one can ask for the matrix entry `(x, [y,z,w])`.  The value returned
 will be `(x, f((x,y), (x,z), (x,w)))` where the user-defined function
 `f` was used to create the `x` row.
@@ -433,7 +433,7 @@ TODO
 ----
 To-do list items.
  * The "star" objects need to be redesigned. They fetch wild-card counts
-   and other marginal values straight out of the atomspace.  But those
+   and other marginal values straight out of the AtomSpace.  But those
    marginal values are correct only if no filtering is applied. If there
    are pre-filters, then the returned marginals are garbage. Yucko.  Can
    we fail-safe this for now?
@@ -443,6 +443,6 @@ To-do list items.
    handled in an ad hoc manner.
 
  * Need a more consistent/coherent API for interacting with storage.
-   Currently, the `fetch` mathods do this, and there is a scattering
+   Currently, the `fetch` methods do this, and there is a scattering
    of other store methods provided in an ad hoc, as-needed basis. All
    this should be made prettier.

--- a/opencog/matrix/README.md
+++ b/opencog/matrix/README.md
@@ -343,25 +343,40 @@ Direct sums
 -----------
 If one has a collection of things that can be vectors in two different
 ways, then the direct sum can be used to create a single vector out of
-the two.  For example, a word "foo" can be associated with a vector of
-disjuncts. It can also be associated with a vector of connectors that
-it appears in (a "shape"). These are two completely different kinds of
-vectors; all they have in common is that both are associated with the
-word "foo". As martices, one consists of (word,disjunct) pairs, while
-the other consists of (word,shape) pairs. The left-side of the matrix
-(the rows of the matrix) all have the same type (i.e. words) while the
-right side (the columns) are two different types (and are completely
-disjoint, as sets).
+the two.  It can be thought of as a concatentation of the two vectors,
+appending one to the other to create a single vector.
+
+For example, a word "foo" can be associated with a vector of disjuncts.
+It can also be associated with a vector of connectors that it appears
+in (a "shape"). These are two completely different kinds of vectors;
+all they have in common is that both are associated with the word "foo".
+As matrices, one consists of (word,disjunct) pairs, while the other
+consists of (word,shape) pairs. The left-side of the matrix (the rows
+of the matrix) all have the same type (i.e. words) while the right
+side (the columns) are two different types (and are completely disjoint,
+as sets). Concatenating these two matrices, placing one after the other,
+results in a single matrix where the rows are result of appending the
+rows of the second matrix to the first. If the dimensions of the two
+matrices are N x M and N x K, then the dimensions of the combined matrix
+would be N x (M + K).
 
 The `direct-sum` class will combine these two matrices to provide an
 object that behaves like a single matrix. The left and right basis
 elements will be the set-union of the left and right basis elts of each
-component matrix. By assumption, the types of either the left basis or
-the right basis are distinct, and so one of these sets is disjoint.
-Thus, the union is unambiguous; there is no concern with double-counting
-or any kind of "overlap". The total number of non-zero entries in the
-combined matrix is the sum of the number of non-zero entries in each
-component.
+component matrix. By assumption, the types of either the columns or
+the rows are distinct, and so one of these sets is disjoint.  Thus, the
+union is unambiguous; the matrices are either placed side-by-side by
+concatenating rows, or above-below, by concatenating columns. There is
+no "overlap".  The total number of non-zero entries in the combined
+matrix is the sum of the number of non-zero entries in each component.
+
+(Caution: this is not the conventional definition of a direct sum, which
+results in block-diagonal matrix. The conventional defintion takes the
+disjoint-union of the indexes (the basis), whereas here, we take the
+set-union of the basis. The set-union makes more sense in the current
+context, because the rows and columns have explicit labels, and it is
+the labels that are important. The set union is obtained from the
+disjoint union by means of a projection.)
 
 
 Working with rows and columns

--- a/opencog/matrix/concatenate.scm
+++ b/opencog/matrix/concatenate.scm
@@ -157,11 +157,34 @@
 		(define (right-basis-size)
 			(+ (a-stars 'right-basis-size) (b-stars 'right-basis-size)))
 
+		; Delegate left stars and duals according to the type
+		; of the right-atom.
+		(define (left-stars R-ATOM)
+			(init-ra)
+			(if (r-type-a? R-ATOM)
+				(a-stars 'left-stars R-ATOM)
+				(b-stars 'left-stars R-ATOM)))
+
+		(define (left-duals R-ATOM)
+			(init-ra)
+			(if (r-type-a? R-ATOM)
+				(a-stars 'left-duals R-ATOM)
+				(b-stars 'left-duals R-ATOM)))
+
+		; Right stars and duals are a simple concatenaition
+		(define (right-stars L-ATOM)
+			(append
+				(a-stars 'right-stars L-ATOM)
+				(b-stars 'right-stars L-ATOM)))
+
+		(define (right-duals L-ATOM)
+			(append
+				(a-stars 'right-duals L-ATOM)
+				(b-stars 'right-duals L-ATOM)))
+
 		; Just get all the parts, and append them.
 		(define (get-all-elts)
 			(append (a-stars 'get-all-elts) (b-stars 'get-all-elts)))
-
-
 
 		; XXX Uh, is this neeed/correct?
 		(define (clobber)

--- a/opencog/matrix/concatenate.scm
+++ b/opencog/matrix/concatenate.scm
@@ -43,7 +43,8 @@
   left-concatenation
 "
 
-	(let ((x 0)
+	(let ((l-basis '())
+			(l-size 0)
 		)
 
 		; ---------------
@@ -66,6 +67,54 @@
 		(define (get-id)
 			(string-append (LLA 'id) "." (LLB 'id)))
 
+		; ===================================================
+		; Overloaded stars functions
+
+		; Left basis must be the union of the two.
+		(define (compute-left-basis)
+			(define atom-set (make-atom-set))
+			(for-each atom-set (LLA 'left-basis))
+			(for-each atom-set (LLB 'left-basis))
+			(atom-set #f)
+		)
+
+		(define (left-basis)
+			(if (null? l-basis) (set! l-basis (compute-left-basis)))
+			l-basis)
+
+		(define (left-basis-size)
+			(if (eq? 0 l-size) (set! l-size (length (get-left-basis))))
+			l-size)
+
+		; The right basis is easy: since the items are completely
+		; different, all we have to do is to append them.
+		(define (right-basis)
+			(append (LLA 'right-basis) (LLB 'right-basis)))
+
+		(define (right-basis-size)
+			(+ (LLA 'right-basis-size) (LLB 'right-basis-size)))
+
+		; Just get all the parts, and append them.
+		(define (get-all-elts)
+			(append (LLA 'get-all-elts) (LLB 'get-all-elts)))
+
+		; XXX Uh, is this neeed/correct?
+		(define (clobber)
+			(LLA 'clobber)
+			(LLB 'clobber))
+
+		; -------------
+		; Return a pointer to each method that this class overloads.
+		(define (provides meth)
+			(case meth
+				((left-basis)       left-basis)
+				((right-basis)      right-basis)
+				((left-basis-size)  left-basis-size)
+				((right-basis-size) right-basis-size)
+				((get-all-elts)     get-all-elts)
+				((clobber)          clobber)
+			))
+
 		; -------------
 		; Methods on this class.
 		(lambda (message . args)
@@ -84,7 +133,16 @@
 				; ((right-wildcard) get-right-wildcard)
 				; ((wild-wild) get-wild-wild)
 				((fetch-pairs)      (fetch-all-pairs))
-				; ((provides) (lambda (symb) #f))
+
+				; Overloaded stars functions
+				((left-basis)       (left-basis))
+				((right-basis)      (right-basis))
+				((left-basis-size)  (left-basis-size))
+				((right-basis-size) (right-basis-size))
+				((get-all-elts)     (get-all-elts))
+				((clobber)          (clobber))
+
+				((provides)         (apply provides args))
 				((filters?)         #f)
 
 				; Block anything that we can't handle.

--- a/opencog/matrix/concatenate.scm
+++ b/opencog/matrix/concatenate.scm
@@ -192,6 +192,22 @@
 			(b-stars 'clobber))
 
 		; -------------
+		(define (help)
+			(format #t
+				(string-append
+"This is the `left-concatentation` of \"~A\" and \"~A\"\n"
+"It allows these two objects to share a common left-basis\n"
+"while concatenating the right-basis. For more information,\n"
+"say `,d left-concatentation` or `,describe left-concatentation`\n"
+"at the guile prompt, or just use the 'describe method on this\n"
+"object.\n"
+)
+				(LLA 'id) (LLB 'id)))
+
+		(define (describe)
+			(display (procedure-property left-concatenation 'documentation)))
+
+		; -------------
 		; Return a pointer to each method that this class overloads.
 		(define (provides meth)
 			(case meth
@@ -240,6 +256,9 @@
 
 				((provides)         (apply provides args))
 				((filters?)         #t)
+
+				((help)             (help))
+				((describe)         (describe))
 
 				; Block anything that we can't handle.
 				(else               (throw 'bad-use 'make-concatenation

--- a/opencog/matrix/concatenate.scm
+++ b/opencog/matrix/concatenate.scm
@@ -43,7 +43,9 @@
   left-concatenation
 "
 
-	(let ((l-basis '())
+	(let ((a-stars (add-pair-stars LLA))
+			(b-stars (add-pair-stars LLB))
+			(l-basis '())
 			(l-size 0)
 		)
 
@@ -73,8 +75,8 @@
 		; Left basis must be the union of the two.
 		(define (compute-left-basis)
 			(define atom-set (make-atom-set))
-			(for-each atom-set (LLA 'left-basis))
-			(for-each atom-set (LLB 'left-basis))
+			(for-each atom-set (a-stars 'left-basis))
+			(for-each atom-set (b-stars 'left-basis))
 			(atom-set #f)
 		)
 
@@ -89,19 +91,19 @@
 		; The right basis is easy: since the items are completely
 		; different, all we have to do is to append them.
 		(define (right-basis)
-			(append (LLA 'right-basis) (LLB 'right-basis)))
+			(append (a-stars 'right-basis) (b-stars 'right-basis)))
 
 		(define (right-basis-size)
-			(+ (LLA 'right-basis-size) (LLB 'right-basis-size)))
+			(+ (a-stars 'right-basis-size) (b-stars 'right-basis-size)))
 
 		; Just get all the parts, and append them.
 		(define (get-all-elts)
-			(append (LLA 'get-all-elts) (LLB 'get-all-elts)))
+			(append (a-stars 'get-all-elts) (b-stars 'get-all-elts)))
 
 		; XXX Uh, is this neeed/correct?
 		(define (clobber)
-			(LLA 'clobber)
-			(LLB 'clobber))
+			(a-stars 'clobber)
+			(b-stars 'clobber))
 
 		; -------------
 		; Return a pointer to each method that this class overloads.

--- a/opencog/matrix/concatenate.scm
+++ b/opencog/matrix/concatenate.scm
@@ -47,6 +47,15 @@
 		)
 
 		; ---------------
+		; Right type can be either one of two things...
+		; This is a provisional hack, for now. Not sure if it makes sense.
+		(define (get-right-type)
+			(ChoiceLink (LLA 'right-type) (LLB 'right-type)))
+		(define (get-pair-type)
+			(ChoiceLink (LLA 'pair-type) (LLB 'pair-type)))
+
+		; ---------------
+		; Delegate the pair fetching to each subobject.
 		(define (fetch-all-pairs)
 			(LLA 'fetch-pairs)
 			(LLB 'fetch-pairs))
@@ -63,10 +72,10 @@
 			(case message
 				((name)             (get-name))
 				((id)               (get-id))
-				((left-type)        (apply LLA (cons message args)))
+				((left-type)        (apply LLA message))
+				((right-type)       (get-right-type))
+				((pair-type)        (get-pair-type))
 
-				; ((right-type) get-right-type)
-				; ((pair-type) get-pair-type)
 				; ((pair-count) get-pair-count)
 				; ((get-pair) get-pair)
 				; ((get-count) get-count)

--- a/opencog/matrix/concatenate.scm
+++ b/opencog/matrix/concatenate.scm
@@ -38,11 +38,11 @@
 
 ; ---------------------------------------------------------------------
 
-(define-public (make-concatenation LLA LLB)
+(define-public (make-left-concatenation LLA LLB)
 "
   left-concatenation
 "
-	(let (id-string (string-append "(" (LLA 'id) "." (LLB 'id) ")"))
+	(let ((id-string (string-append "(" (LLA 'id) "." (LLB 'id) ")"))
 			(a-stars (add-pair-stars LLA))
 			(b-stars (add-pair-stars LLB))
 			(l-basis '())
@@ -146,7 +146,7 @@
 			l-basis)
 
 		(define (left-basis-size)
-			(if (eq? 0 l-size) (set! l-size (length (get-left-basis))))
+			(if (eq? 0 l-size) (set! l-size (length (left-basis))))
 			l-size)
 
 		; The right basis is easy: since the items are completely
@@ -205,7 +205,7 @@
 				(LLA 'id) (LLB 'id)))
 
 		(define (describe)
-			(display (procedure-property left-concatenation 'documentation)))
+			(display (procedure-property make-left-concatenation 'documentation)))
 
 		; -------------
 		; Return a pointer to each method that this class overloads.
@@ -237,7 +237,7 @@
 				((pair-count)       (apply get-pair-count args))
 				((get-count)        (apply get-count args))
 				((make-pair)        (apply make-pair args))
-				((left-wildcard)    (apply get-left-wildcard args))
+				((left-wildcard)    (apply left-wildcard args))
 				; ((right-wildcard) get-right-wildcard)
 				; ((wild-wild) get-wild-wild)
 				((fetch-pairs)      (fetch-all-pairs))

--- a/opencog/matrix/concatenate.scm
+++ b/opencog/matrix/concatenate.scm
@@ -1,0 +1,39 @@
+;
+; concatenate.scm
+;
+; Define API's for concatenating two matrices. These can be concatenated
+; left-right, or above-below.
+;
+; Copyright (c) 2021 Linas Vepstas
+;
+; ---------------------------------------------------------------------
+; OVERVIEW
+; --------
+; Two matrices may share the same rows (row types), but have completely
+; different columns (column types); it can be useful to work with a
+; matrix that is the concatenation of these two, so that the combined
+; matrix has rows that have entries from one, and from the other, as if
+; the two matrices were stacked side-by-side. Alternately, if the have
+; the same column labels, but different rows, they can be stacked one
+; above the other.
+;
+; In diagrams, if [A] and [B] are two matrices, then thier left-
+; concatenation is [L] = [AB] and the right-concatenation is 
+; [R] = [A]
+;       [B]
+;
+; In index notation, if matrix A has n columns, then L_ij = A_ij if j<n
+; and L_ij = B_i(j-n) if j>n. Likewise for R, transposing rows and
+; columns.
+;
+; The code here takes two matrix-API objects, and creates a single
+; matrix API. Note that there can be some difficulties with the API,
+; as the row or column types might not be consistenst across the whole
+; matrix.
+;
+; ---------------------------------------------------------------------
+
+(use-modules (srfi srfi-1))
+(use-modules (ice-9 optargs)) ; for define*-public
+
+; ---------------------------------------------------------------------

--- a/opencog/matrix/concatenate.scm
+++ b/opencog/matrix/concatenate.scm
@@ -42,11 +42,11 @@
 "
   left-concatenation
 "
-
 	(let ((a-stars (add-pair-stars LLA))
 			(b-stars (add-pair-stars LLB))
 			(l-basis '())
 			(l-size 0)
+			(is-from-a? #f)
 		)
 
 		; ---------------
@@ -68,6 +68,32 @@
 			(string-append (LLA 'name) " . " (LLB 'name)))
 		(define (get-id)
 			(string-append (LLA 'id) "." (LLB 'id)))
+
+		; ---------------
+
+		; Return the pair, if it exists.
+		; Brute force; try A, then B.
+		(define (get-pair L-ATOM R-ATOM)
+			(define maybe-a (LLA 'get-pair L-ATOM R-ATOM))
+			(if (not (nil? maybe-a)) maybe-a
+				(LLB 'get-pair L-ATOM R-ATOM)))
+
+		; Return the count on the pair, if it exists.
+		(define (get-pair-count L-ATOM R-ATOM)
+			(define maybe-a (LLA 'get-pair L-ATOM R-ATOM))
+			(if (not (nil? maybe-a))
+				(LLA 'get-count maybe-a)
+				(LLB 'pair-count L-ATOM R-ATOM)))
+
+		; Return the count on the pair, by delgating.
+		; Maintains a cache of all atoms in LLA, and uses that
+		; to delegate.
+		(define (get-count PAIR)
+			(if (not is-from-a?) ; initialize if not initialized.
+				(set! is-from-a?
+					(make-aset-predicate (a-stars 'get-all-elts))))
+			(if (is-from-a? PAIR)
+				(LLA 'get-count PAIR) (LLB 'get-count PAIR)))
 
 		; ===================================================
 		; Overloaded stars functions
@@ -127,9 +153,9 @@
 				((right-type)       (get-right-type))
 				((pair-type)        (get-pair-type))
 
-				; ((pair-count) get-pair-count)
-				; ((get-pair) get-pair)
-				; ((get-count) get-count)
+				((get-pair)         (apply get-pair args))
+				((pair-count)       (apply get-pair-count args))
+				((get-count)        (apply get-count args))
 				; ((make-pair) make-pair)
 				; ((left-wildcard) get-left-wildcard)
 				; ((right-wildcard) get-right-wildcard)

--- a/opencog/matrix/concatenate.scm
+++ b/opencog/matrix/concatenate.scm
@@ -37,3 +37,51 @@
 (use-modules (ice-9 optargs)) ; for define*-public
 
 ; ---------------------------------------------------------------------
+
+(define-public (make-concatenation LLA LLB)
+"
+  left-concatenation
+"
+
+	(let ((x 0)
+		)
+
+		; ---------------
+		(define (fetch-all-pairs)
+			(LLA 'fetch-pairs)
+			(LLB 'fetch-pairs))
+
+		; ---------------
+		(define (get-name)
+			(string-append (LLA 'name) " . " (LLB 'name)))
+		(define (get-id)
+			(string-append (LLA 'id) "." (LLB 'id)))
+
+		; -------------
+		; Methods on this class.
+		(lambda (message . args)
+			(case message
+				((name)             (get-name))
+				((id)               (get-id))
+				((left-type)        (apply LLA (cons message args)))
+
+				; ((right-type) get-right-type)
+				; ((pair-type) get-pair-type)
+				; ((pair-count) get-pair-count)
+				; ((get-pair) get-pair)
+				; ((get-count) get-count)
+				; ((make-pair) make-pair)
+				; ((left-wildcard) get-left-wildcard)
+				; ((right-wildcard) get-right-wildcard)
+				; ((wild-wild) get-wild-wild)
+				((fetch-pairs)      (fetch-all-pairs))
+				; ((provides) (lambda (symb) #f))
+				((filters?)         #f)
+
+				; Block anything that we can't handle.
+				(else               (throw 'bad-use 'make-concatenation
+					(format #f "Sorry, method ~A not available!" message)))
+	)))
+)
+
+; ---------------------------------------------------------------------

--- a/opencog/matrix/direct-sum.scm
+++ b/opencog/matrix/direct-sum.scm
@@ -120,8 +120,8 @@
 		; ---------------
 		; Name and id of this object.
 		(define (get-name)
-			(string-append "Direct sum of \"" (LLA 'name)
-				 "\" and \"" (LLB 'name) "\""))
+			(string-append "Direct sum of '" (LLA 'name)
+				 "' and '" (LLB 'name) "'"))
 
 		; Caution: other objects, e.g. those that access marginals,
 		; use the id as part of the marginal label. This happens
@@ -288,7 +288,7 @@
 		(define (help)
 			(format #t
 				(string-append
-"This is the `direct sum` of \"~A\" and \"~A\"\n"
+"This is the `direct sum` of '~A' and '~A'\n"
 "It takes the union of the left-basis of both objects, and likewise\n"
 "the right-basis. For more information, say `,d diect-sum` or\n"
 "`,describe direct-sum` at the guile prompt, or just use the 'describe\n"

--- a/opencog/matrix/direct-sum.scm
+++ b/opencog/matrix/direct-sum.scm
@@ -55,9 +55,18 @@
 
 (define-public (direct-sum LLA LLB)
 "
-  direct-sum LLA LLB -- concatenate/append/sum A and B
+  direct-sum LLA LLB -- provide a matrix API for the 'sum' of A and B.
 
-  Given objects LLA and LLB
+  This has aspects of being a concatenation of A and B, of being an
+  'ordinary' sum of A and B, and of being a direct sum, .. kind-of.
+
+  Given objects LLA and LLB, this presents a new object whose
+  left-basis is the set-union of the left-basis of A and B, and
+  likewise the right basis. The matrix elements are likewise the
+  set-union; it is assumed that the matrix elements of A and B are
+  *disjoint sets*, so that the union is well-defined. If they are
+  not disjoint, then the behavior is ill-defined (i.e. it is not
+  currently specified.)
 "
 	(let ((id-string (string-append "(" (LLA 'id) "⊕" (LLB 'id) ")"))
 			(a-stars (add-pair-stars LLA))
@@ -127,6 +136,8 @@
 		; type to create. This assumes the user is only trying to
 		; create wild-cards with this function; it breaks down
 		; utterly for anything else.
+xxxx
+this is wrong.
 		(define (make-pair L-ATOM R-ATOM)
 			(init-ra)
 			(if (r-type-a? R-ATOM)
@@ -140,7 +151,7 @@
 				(LLA 'get-count maybe-a)
 				(LLB 'pair-count L-ATOM R-ATOM)))
 
-		; Return the count on the pair, by delgating.
+		; Return the count on the pair, by delegating.
 		; Maintains a cache of all atoms in LLA, and uses that
 		; to delegate.
 		(define (get-count PAIR)
@@ -222,17 +233,16 @@
 		(define (help)
 			(format #t
 				(string-append
-"This is the `left-concatentation` of \"~A\" and \"~A\"\n"
-"It allows these two objects to share a common left-basis\n"
-"while concatenating the right-basis. For more information,\n"
-"say `,d left-concatentation` or `,describe left-concatentation`\n"
-"at the guile prompt, or just use the 'describe method on this\n"
-"object.\n"
+"This is the `direct sum` of \"~A\" and \"~A\"\n"
+"It takes the union of the left-basis of both objects, and likewise\n"
+"the right-basis. For more information, say `,d diect-sum` or\n"
+"`,describe direct-sum` at the guile prompt, or just use the 'describe\n"
+"method on this object.\n"
 )
 				(LLA 'id) (LLB 'id)))
 
 		(define (describe)
-			(display (procedure-property make-left-concatenation 'documentation)))
+			(display (procedure-property direct-sum 'documentation)))
 
 		; -------------
 		; Return a pointer to each method that this class overloads.

--- a/opencog/matrix/direct-sum.scm
+++ b/opencog/matrix/direct-sum.scm
@@ -164,66 +164,52 @@
 		; ===================================================
 		; Overloaded stars functions
 
-		; Left basis must be the union of the two.
-		(define (compute-left-basis)
+		(define (union MSG)
 			(define atom-set (make-atom-set))
-			(for-each atom-set (a-stars 'left-basis))
-			(for-each atom-set (b-stars 'left-basis))
-			(atom-set #f)
-		)
+			(for-each atom-set (a-stars MSG))
+			(for-each atom-set (b-stars MSG))
+			(atom-set #f))
 
 		(define (left-basis)
-			(if (null? l-basis) (set! l-basis (compute-left-basis)))
+			(if (null? l-basis) (set! l-basis (union 'left-basis)))
 			l-basis)
 
 		(define (left-basis-size)
 			(if (eq? 0 l-size) (set! l-size (length (left-basis))))
 			l-size)
 
-		; In the prototypical example, the right basis is a union
-		; of two disjoint sets, so the below is overkill. But the
-		; general case requires this.
-		(define (compute-right-basis)
-			(define atom-set (make-atom-set))
-			(for-each atom-set (a-stars 'right-basis))
-			(for-each atom-set (b-stars 'right-basis))
-			(atom-set #f)
-		)
-
 		(define (right-basis)
-			(if (null? r-basis) (set! r-basis (compute-right-basis)))
+			(if (null? r-basis) (set! r-basis (union 'right-basis)))
 			r-basis)
 
 		(define (right-basis-size)
 			(if (eq? 0 r-size) (set! r-size (length (right-basis))))
 			r-size)
 
-		; Delegate left stars and duals according to the type
-		; of the right-atom.
+		(define (gunion MSG ARG)
+			(define atom-set (make-atom-set))
+			(for-each atom-set (a-stars MSG ARG))
+			(for-each atom-set (b-stars MSG ARG))
+			(atom-set #f))
+
+		; Stars and duals are unions.
 		(define (left-stars R-ATOM)
-			(init-ra)
-			(if (r-type-a? R-ATOM)
-				(a-stars 'left-stars R-ATOM)
-				(b-stars 'left-stars R-ATOM)))
+			(gunion 'left-stars R-ATOM))
 
 		(define (left-duals R-ATOM)
-			(init-ra)
-			(if (r-type-a? R-ATOM)
-				(a-stars 'left-duals R-ATOM)
-				(b-stars 'left-duals R-ATOM)))
+			(gunion 'left-duals R-ATOM))
 
-		; Right stars and duals are a simple concatenaition
 		(define (right-stars L-ATOM)
-			(append
-				(a-stars 'right-stars L-ATOM)
-				(b-stars 'right-stars L-ATOM)))
+			(gunion 'right-stars L-ATOM))
 
 		(define (right-duals L-ATOM)
-			(append
-				(a-stars 'right-duals L-ATOM)
-				(b-stars 'right-duals L-ATOM)))
+			(gunion 'right-duals L-ATOM))
 
 		; Just get all the parts, and append them.
+		; Avoid a cpu-sucking union. Thus, any elts appearing in
+		; both will be dpulicated. This may or may not be what the
+		; user expects. It's up to the user to de-dupe if that's
+		; what they want.
 		(define (get-all-elts)
 			(append (a-stars 'get-all-elts) (b-stars 'get-all-elts)))
 

--- a/opencog/matrix/dynamic.scm
+++ b/opencog/matrix/dynamic.scm
@@ -11,6 +11,9 @@
 (use-modules (opencog persist))
 
 ; ---------------------------------------------------------------------
+; TODO: this class sort-of works for the simplest case, but is
+; incomplete. Support for duals is missing. It also won't work
+; for pairs that have a non-trivial structure.
 
 (define-public (add-dynamic-stars LLOBJ)
 "
@@ -95,6 +98,8 @@
 		(define (get-right-stars ITEM)
 			(get-incoming ITEM)
 			(stars-obj 'right-stars ITEM))
+
+		; XXX TODO: implement left and right duals.
 
 		;-------------------------------------------
 		; Release (extract) row or column. No specific check is made

--- a/opencog/matrix/matrix.scm
+++ b/opencog/matrix/matrix.scm
@@ -43,4 +43,5 @@
 (include-from-path "opencog/matrix/trans-batch.scm")
 (include-from-path "opencog/matrix/filter.scm")
 (include-from-path "opencog/matrix/similarity-api.scm")
+(include-from-path "opencog/matrix/direct-sum.scm")
 (include-from-path "opencog/matrix/thresh-pca.scm")

--- a/opencog/matrix/object-api.scm
+++ b/opencog/matrix/object-api.scm
@@ -75,6 +75,7 @@
 ; Most users will find it easiest to use the `make-evaluation-pair-api`
 ; to provide the low-level API.  It is ideal, when counts are stored
 ; in the form of `EvaluationLink PredicateNode "..." ListLink ...`.
+; See `eval-pair.scm` for details.
 ;
 ; The `add-pair-freq-api` class, below, is a typical user of this
 ; class; it provides getters and setters for the frequencies.

--- a/opencog/matrix/trans-batch.scm
+++ b/opencog/matrix/trans-batch.scm
@@ -15,7 +15,7 @@
 ;
 ; This file precomputes the various partial sums (marginals) that occur
 ; in the definition of the symmetric MI.  It assumes that the vectors
-; (i.e. observation counts) are in an SQL database; it fetches those,
+; (i.e. observation counts) are in an open database; it fetches those,
 ; computes the assorted marginals, and writes those marginals back to
 ; disk. Specifically, the marginals are those needed for the
 ; `transpose-api`, which is used to compute the symmetric MI.


### PR DESCRIPTION
If one has a collection of things that can be vectors in two different
ways, then the direct sum can be used to create a single vector out of
the two. It is a concatenation the two vectors. If the vectors are the rows
of a matrix, then the result is a concatenation of the two matrices (by
concatenating the individual rows).

As always, this can be applied to *any* collection of pairs of Atoms in the 
AtomSpace, no matter what form they may be in.
