### PR TITLE
fix MultiUserUTest regression

### DIFF
--- a/opencog/atomspaceutils/TLB.h
+++ b/opencog/atomspaceutils/TLB.h
@@ -122,6 +122,7 @@ public:
     }
     void removeAtom(const Handle&);
     void removeAtom(UUID);
+    void purgeAtom(UUID);
 };
 
 } // namespace opencog

--- a/opencog/persist/sql/multi-driver/SQLAtomStore.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStore.cc
@@ -142,7 +142,9 @@ void SQLAtomStorage::vdo_store_atom(const Handle& h)
 bool SQLAtomStorage::not_yet_stored(const Handle& h)
 {
 	std::lock_guard<std::mutex> create_lock(_store_mutex);
-	return TLB::INVALID_UUID == _tlbuf.getUUID(h);
+	UUID uuid = _tlbuf.getUUID(h);
+	return (TLB::INVALID_UUID == uuid) and
+	       (Handle::UNDEFINED == _tlbuf.getAtom(uuid));
 }
 
 /**
@@ -157,10 +159,12 @@ void SQLAtomStorage::do_store_single_atom(const Handle& h, int aheight)
 	std::unique_lock<std::mutex> create_lock(_store_mutex);
 
 	UUID uuid = check_uuid(h);
-	if (TLB::INVALID_UUID != uuid) return;
+	if ((TLB::INVALID_UUID != uuid) and
+	    (Handle::UNDEFINED != _tlbuf.getAtom(uuid))) return;
 
 	// If it was not found, then issue a brand-spankin new UUID.
-	uuid = _tlbuf.addAtom(h, TLB::INVALID_UUID);
+	if (TLB::INVALID_UUID == uuid)
+		uuid = _tlbuf.addAtom(h, TLB::INVALID_UUID);
 
 	std::string uuidbuff = std::to_string(uuid);
 

--- a/opencog/persist/sql/multi-driver/SQLAtomStore.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStore.cc
@@ -275,7 +275,7 @@ void SQLAtomStorage::do_store_single_atom(const Handle& h, int aheight)
 	}
 	catch (const SilentException& ex)
 	{
-		_tlbuf.removeAtom(uuid);
+		_tlbuf.purgeAtom(uuid);
 		create_lock.unlock();
 		do_store_single_atom(h, aheight);
 	}

--- a/opencog/persist/sql/multi-driver/SQLAtomStore.cc
+++ b/opencog/persist/sql/multi-driver/SQLAtomStore.cc
@@ -162,9 +162,8 @@ void SQLAtomStorage::do_store_single_atom(const Handle& h, int aheight)
 	if ((TLB::INVALID_UUID != uuid) and
 	    (Handle::UNDEFINED != _tlbuf.getAtom(uuid))) return;
 
-	// If it was not found, then issue a brand-spankin new UUID.
-	if (TLB::INVALID_UUID == uuid)
-		uuid = _tlbuf.addAtom(h, TLB::INVALID_UUID);
+	// Make sure the Atom in the the TLB.
+	uuid = _tlbuf.addAtom(h, uuid);
 
 	std::string uuidbuff = std::to_string(uuid);
 

--- a/opencog/persist/sql/multi-driver/SQLUUID.cc
+++ b/opencog/persist/sql/multi-driver/SQLUUID.cc
@@ -117,8 +117,8 @@ UUID SQLAtomStorage::check_uuid(const Handle& h)
 	}
 
 	// If it was found in the database, then the TLB got updated.
-	// If it was not found in the databse, we might still be
-	// recreating a previously known atom.
+	// If it was not found, we might still be recreating a
+	// a previously known atom, and so should reuse that uuid.
 	return _tlbuf.getUUID(h);
 }
 

--- a/opencog/persist/sql/multi-driver/SQLUUID.cc
+++ b/opencog/persist/sql/multi-driver/SQLUUID.cc
@@ -97,7 +97,8 @@ void SQLAtomStorage::extract_callback(const AtomPtr& atom)
 UUID SQLAtomStorage::check_uuid(const Handle& h)
 {
 	UUID uuid = _tlbuf.getUUID(h);
-	if (TLB::INVALID_UUID != uuid) return uuid;
+	if ((TLB::INVALID_UUID != uuid) and
+	    (Handle::UNDEFINED != _tlbuf.getAtom(uuid))) return uuid;
 
 	// Optimize for bulk stores. That is, we know for a fact that
 	// the database cannot possibly contain this atom yet, so do
@@ -127,7 +128,8 @@ UUID SQLAtomStorage::check_uuid(const Handle& h)
 UUID SQLAtomStorage::get_uuid(const Handle& h)
 {
 	UUID uuid = check_uuid(h);
-	if (TLB::INVALID_UUID != uuid) return uuid;
+	if ((TLB::INVALID_UUID != uuid) and
+	    (Handle::UNDEFINED != _tlbuf.getAtom(uuid))) return uuid;
 
 	// Throw a silent exception; don't clutter log-files with this!
 	throw NotFoundException(TRACE_INFO, "");

--- a/opencog/persist/sql/multi-driver/SQLUUID.cc
+++ b/opencog/persist/sql/multi-driver/SQLUUID.cc
@@ -115,11 +115,11 @@ UUID SQLAtomStorage::check_uuid(const Handle& h)
 	{
 		dbh = doGetLink(h->get_type(), h->getOutgoingSet());
 	}
-	// If it was found in the database, then the TLB got updated.
-	if (dbh) return _tlbuf.getUUID(h);
 
-	// If it was not found in the database, then say so.
-	return TLB::INVALID_UUID;
+	// If it was found in the database, then the TLB got updated.
+	// If it was not found in the databse, we might still be
+	// recreating a previously known atom.
+	return _tlbuf.getUUID(h);
 }
 
 /// Return the UUID of the handle, if it is known, else throw exception.

--- a/tests/persist/sql/multi-driver/BasicDeleteUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/BasicDeleteUTest.cxxtest
@@ -210,7 +210,7 @@ void BasicDeleteUTest::test_recursive(void)
 	TS_ASSERT_EQUALS(as->get_size(), 5);
 
 	// Remove (Concept "a"). Since this appears twice, recursion
-	// will hit it twice, in stange ways, and maybe crash.
+	// will hit it twice, in strange ways, and maybe crash.
 	store->remove_atom(ha, true);
 	as->extract_atom(ha);
 


### PR DESCRIPTION
The pull req #2807 introduced a regression in the `MultiUserUTest`; 
it would fail one out of three runs.  This pull req fixes the failure.
Both unit tests can be run in excess of 100 times with no failures.