### PR TITLE
Escape quotes in Nodes and StringValues

### DIFF
--- a/opencog/atoms/base/Node.cc
+++ b/opencog/atoms/base/Node.cc
@@ -21,6 +21,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <iomanip>
+
 #include <opencog/atoms/atom_types/NameServer.h>
 
 #include "Node.h"
@@ -38,8 +40,9 @@ void Node::init()
 }
 
 /// Return a universally-unique string for each distinct node.
-/// It needs to be fast, to be human-readable, and without any
-/// trailing newlines.
+/// It needs to be fast (because it is used in performance-critical
+/// code paths), it needs to be human-readable, and it must not have
+/// any trailing newlines.
 std::string Node::to_short_string(const std::string& indent) const
 {
     std::string answer = indent;
@@ -52,6 +55,21 @@ std::string Node::to_short_string(const std::string& indent) const
 
     answer += ")";
     return answer;
+}
+
+/// Return a universally-unique string for each distinct node.
+/// It needs to be fast (because it is used in performance-critical
+/// code paths), it needs to escape embedded quotes, and it must
+/// not have any trailing newlines.
+///
+std::string Node::to_string_esc() const
+{
+    std::stringstream ss;
+
+    ss << "(" << nameserver().getTypeName(_type) << " "
+       << std::quoted(_name) << ")";
+
+    return ss.str();
 }
 
 std::string Node::to_string(const std::string& indent) const

--- a/opencog/atoms/base/Node.h
+++ b/opencog/atoms/base/Node.h
@@ -84,6 +84,7 @@ public:
      */
     std::string to_string(const std::string& indent) const;
     std::string to_short_string(const std::string& indent) const;
+    std::string to_string_esc(void) const;
 
 	// Work around gdb's incapability to build a string on the fly,
 	// see http://stackoverflow.com/questions/16734783 and

--- a/opencog/atoms/value/StringValue.cc
+++ b/opencog/atoms/value/StringValue.cc
@@ -42,19 +42,14 @@ bool StringValue::operator==(const Value& other) const
 
 // ==============================================================
 
+/// Print the StringValue. Escape any quotes in the strings when
+/// printing. This is needed for readability, since this is an
+/// array of strings, and without the escapes, we can't tell where
+/// strings start and end.
 std::string StringValue::to_string(const std::string& indent) const
 {
-	std::string rv = indent + "(" + nameserver().getTypeName(_type);
-	for (std::string v :_value)
-		rv += std::string(" \"") + v + "\"";
-	rv += ")";
-	return rv;
-}
-
-std::string StringValue::to_string_esc(void) const
-{
 	std::stringstream ss;
-	ss << "(" << nameserver().getTypeName(_type);
+	ss << indent << "(" << nameserver().getTypeName(_type);
 	for (const std::string& v :_value)
 		ss << " " << std::quoted(v);
 	ss << ")";

--- a/opencog/atoms/value/StringValue.cc
+++ b/opencog/atoms/value/StringValue.cc
@@ -56,7 +56,7 @@ std::string StringValue::to_string_esc(void) const
 	std::stringstream ss;
 	ss << "(" << nameserver().getTypeName(_type);
 	for (const std::string& v :_value)
-		ss << "" << std::quoted(v);
+		ss << " " << std::quoted(v);
 	ss << ")";
 	return ss.str();
 }

--- a/opencog/atoms/value/StringValue.cc
+++ b/opencog/atoms/value/StringValue.cc
@@ -20,6 +20,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <iomanip>
+
 #include <opencog/atoms/value/StringValue.h>
 #include <opencog/atoms/value/ValueFactory.h>
 
@@ -47,6 +49,16 @@ std::string StringValue::to_string(const std::string& indent) const
 		rv += std::string(" \"") + v + "\"";
 	rv += ")";
 	return rv;
+}
+
+std::string StringValue::to_string_esc(void) const
+{
+	std::stringstream ss;
+	ss << "(" << nameserver().getTypeName(_type);
+	for (const std::string& v :_value)
+		ss << "" << std::quoted(v);
+	ss << ")";
+	return ss.str();
 }
 
 // Adds factory when library is loaded.

--- a/opencog/atoms/value/StringValue.h
+++ b/opencog/atoms/value/StringValue.h
@@ -57,7 +57,6 @@ public:
 
 	/** Returns a string representation of the value.  */
 	virtual std::string to_string(const std::string& indent = "") const;
-	virtual std::string to_string_esc(void) const;
 
 	/** Returns true if the two atoms are equal.  */
 	virtual bool operator==(const Value&) const;

--- a/opencog/atoms/value/StringValue.h
+++ b/opencog/atoms/value/StringValue.h
@@ -57,6 +57,7 @@ public:
 
 	/** Returns a string representation of the value.  */
 	virtual std::string to_string(const std::string& indent = "") const;
+	virtual std::string to_string_esc(void) const;
 
 	/** Returns true if the two atoms are equal.  */
 	virtual bool operator==(const Value&) const;

--- a/opencog/persist/sexpr/AtomSexpr.cc
+++ b/opencog/persist/sexpr/AtomSexpr.cc
@@ -23,6 +23,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <iomanip>
 #include <stdexcept>
 #include <string>
 
@@ -206,7 +207,11 @@ Handle Sexpr::decode_atom(const std::string& s,
 		l2 = r1;
 		if ('"' == s[l2]) l2++; // step past trailing quote.
 
-		const std::string name = s.substr(l1, r1-l1);
+		std::stringstream ss;
+		std::string name;
+		ss << s.substr(l1-1, r1-l1+2); // Pad, to pick up quotes.
+		ss >> std::quoted(name);
+
 		Handle h(createNode(atype, std::move(name)));
 
 		// There might be an stv in the content. Handle it.

--- a/opencog/persist/sexpr/AtomSexpr.cc
+++ b/opencog/persist/sexpr/AtomSexpr.cc
@@ -119,11 +119,19 @@ static Type get_typename(const std::string& s, size_t& l, size_t& r,
 /// If the node is a Type node, then `l` points at the first
 /// non-whitespace character of the type name and `r` points to the next
 /// opening parenthesis.
-void Sexpr::get_node_name(const std::string& s, size_t& l, size_t& r,
-                          size_t line_cnt, bool typeNode)
+///
+/// This function was originally written to allow in-place extraction
+/// of the node name. Unfortunately, node names containing escaped
+/// quotes need to be unescaped, which prevents in-place extraction.
+/// So, instead, this returns the unescaped node name.
+std::string Sexpr::get_node_name(const std::string& s,
+                                 size_t& l, size_t& r,
+                                 Type atype, size_t line_cnt)
 {
 	// Advance past whitespace.
 	while (l < r and (s[l] == ' ' or s[l] == '\t' or s[l] == '\n')) l++;
+
+	bool typeNode = namer.isA(atype, TYPE_NODE);
 
 	// Scheme strings start and end with double-quote.
 	// Scheme symbols start with single-quote.
@@ -142,6 +150,17 @@ void Sexpr::get_node_name(const std::string& s, size_t& l, size_t& r,
 	else
 		for (; p < r and (s[p] != '"' or ((0 < p) and (s[p - 1] == '\\'))); p++);
 	r = p;
+
+	// We use std::quoted() to unescape embedded quotes.
+	// Unescaping works ONLY if the leading character is a quote!
+	// So readjust left and right to pick those up.
+	if ('"' == s[l-1]) l--; // grab leading quote, for std::quoted().
+	if ('"' == s[r]) r++;   // step past trailing quote.
+	std::stringstream ss;
+	std::string name;
+	ss << s.substr(l, r-l);
+	ss >> std::quoted(name);
+	return name;
 }
 
 /// Extract SimpleTruthValue and return that, else throw an error.
@@ -202,24 +221,12 @@ Handle Sexpr::decode_atom(const std::string& s,
 	{
 		l1 = l;
 		r1 = r;
-		size_t l2;
-		get_node_name(s, l1, r1, line_cnt, namer.isA(atype, TYPE_NODE));
-
-		// We use std::quoted() to unescape embedded quotes.
-		// Unescaping works ONLY if the leading character is a quote!
-		// So readjust left and right to pick those up.
-		if ('"' == s[l1-1]) l1--; // grab leading quote, for std::quoted().
-		if ('"' == s[r1]) r1++; // step past trailing quote.
-		l2 = r1;
-
-		std::stringstream ss;
-		std::string name;
-		ss << s.substr(l1, r1-l1);
-		ss >> std::quoted(name);
+		const std::string name = get_node_name(s, l1, r1, atype, line_cnt);
 
 		Handle h(createNode(atype, std::move(name)));
 
 		// There might be an stv in the content. Handle it.
+		size_t l2 = r1;
 		size_t r2 = r;
 		get_next_expr(s, l2, r2, line_cnt);
 		if (l2 < r2)

--- a/opencog/persist/sexpr/AtomSexpr.cc
+++ b/opencog/persist/sexpr/AtomSexpr.cc
@@ -119,8 +119,8 @@ static Type get_typename(const std::string& s, size_t& l, size_t& r,
 /// If the node is a Type node, then `l` points at the first
 /// non-whitespace character of the type name and `r` points to the next
 /// opening parenthesis.
-static void get_node_name(const std::string& s, size_t& l, size_t& r,
-                          size_t line_cnt, bool typeNode = false)
+void Sexpr::get_node_name(const std::string& s, size_t& l, size_t& r,
+                          size_t line_cnt, bool typeNode)
 {
 	// Advance past whitespace.
 	while (l < r and (s[l] == ' ' or s[l] == '\t' or s[l] == '\n')) l++;

--- a/opencog/persist/sexpr/AtomSexpr.cc
+++ b/opencog/persist/sexpr/AtomSexpr.cc
@@ -204,12 +204,17 @@ Handle Sexpr::decode_atom(const std::string& s,
 		r1 = r;
 		size_t l2;
 		get_node_name(s, l1, r1, line_cnt, namer.isA(atype, TYPE_NODE));
+
+		// We use std::quoted() to unescape embedded quotes.
+		// Unescaping works ONLY if the leading character is a quote!
+		// So readjust left and right to pick those up.
+		if ('"' == s[l1-1]) l1--; // grab leading quote, for std::quoted().
+		if ('"' == s[r1]) r1++; // step past trailing quote.
 		l2 = r1;
-		if ('"' == s[l2]) l2++; // step past trailing quote.
 
 		std::stringstream ss;
 		std::string name;
-		ss << s.substr(l1-1, r1-l1+2); // Pad, to pick up quotes.
+		ss << s.substr(l1, r1-l1);
 		ss >> std::quoted(name);
 
 		Handle h(createNode(atype, std::move(name)));

--- a/opencog/persist/sexpr/Commands.cc
+++ b/opencog/persist/sexpr/Commands.cc
@@ -23,6 +23,7 @@
 #include <time.h>
 
 #include <functional>
+#include <iomanip>
 #include <string>
 
 #include <opencog/atoms/atom_types/NameServer.h>
@@ -225,9 +226,10 @@ std::string Commands::interpret_command(AtomSpace* as,
 		Handle h;
 		if (node == act)
 		{
-			pos = cmd.find('"', pos+1) + 1;
-			size_t nos = cmd.find('"', pos);
-			h = as->get_node(t, cmd.substr(pos, nos-pos));
+			size_t l = pos+1;
+			size_t r = cmd.size();
+			std::string name = Sexpr::get_node_name(cmd, l, r, t);
+			h = as->get_node(t, std::move(name));
 		}
 		else
 		if (link == act)

--- a/opencog/persist/sexpr/Sexpr.h
+++ b/opencog/persist/sexpr/Sexpr.h
@@ -52,8 +52,8 @@ public:
 		return decode_atom(s, junk);
 	}
 
-	static void get_node_name(const std::string&, size_t& l, size_t& r,
-	                          size_t line = 0, bool typeNode = false);
+	static std::string get_node_name(const std::string&, size_t& l, size_t& r,
+	                                 Type, size_t line = 0);
 
 	static ValuePtr decode_value(const std::string&, size_t&);
 	static Type decode_type(const std::string& s, size_t& pos);

--- a/opencog/persist/sexpr/Sexpr.h
+++ b/opencog/persist/sexpr/Sexpr.h
@@ -52,6 +52,9 @@ public:
 		return decode_atom(s, junk);
 	}
 
+	static void get_node_name(const std::string&, size_t& l, size_t& r,
+	                          size_t line = 0, bool typeNode = false);
+
 	static ValuePtr decode_value(const std::string&, size_t&);
 	static Type decode_type(const std::string& s, size_t& pos);
 

--- a/opencog/persist/sexpr/ValueSexpr.cc
+++ b/opencog/persist/sexpr/ValueSexpr.cc
@@ -342,13 +342,6 @@ std::string Sexpr::encode_value(const ValuePtr& v)
 		return fv->FloatValue::to_string();
 	}
 
-	if (nameserver().isA(v->get_type(), STRING_VALUE))
-	{
-		// The StringValue to_string() method does not escape quotes.
-		// The to_string_esc() method does.
-		StringValuePtr sv(StringValueCast(v));
-		return sv->StringValue::to_string_esc();
-	}
 	if (not v->is_atom())
 		return v->to_short_string();
 	return prt_atom(HandleCast(v));

--- a/opencog/persist/sexpr/ValueSexpr.cc
+++ b/opencog/persist/sexpr/ValueSexpr.cc
@@ -214,6 +214,7 @@ ValuePtr Sexpr::decode_value(const std::string& stv, size_t& pos)
 		if (')' != stv[p])
 			throw SyntaxException(TRACE_INFO,
 				"Missing closing paren in StringValue: %s", stv.substr(vos).c_str());
+		pos = ++p;
 		return valueserver().create(vtype, sv);
 	}
 

--- a/opencog/persist/sexpr/ValueSexpr.cc
+++ b/opencog/persist/sexpr/ValueSexpr.cc
@@ -23,8 +23,10 @@
 #include <iomanip>
 
 #include <opencog/atoms/base/Atom.h>
-#include <opencog/atoms/value/ValueFactory.h>
+#include <opencog/atoms/value/FloatValue.h>
 #include <opencog/atoms/value/LinkValue.h>
+#include <opencog/atoms/value/StringValue.h>
+#include <opencog/atoms/value/ValueFactory.h>
 #include <opencog/atomspace/AtomSpace.h>
 
 #include "Sexpr.h"
@@ -324,11 +326,19 @@ std::string Sexpr::encode_value(const ValuePtr& v)
 
 	if (nameserver().isA(v->get_type(), FLOAT_VALUE))
 	{
-		// The FloatValue to_string() print prints out a high-precision
+		// The FloatValue to_string() method prints out a high-precision
 		// form of the value, as compared to SimpleTruthValue, which
 		// only prints 6 digits and breaks the unit tests.
 		FloatValuePtr fv(FloatValueCast(v));
 		return fv->FloatValue::to_string();
+	}
+
+	if (nameserver().isA(v->get_type(), STRING_VALUE))
+	{
+		// The StringValue to_string() method does not escape quotes.
+		// The to_string_esc() method does.
+		StringValuePtr sv(StringValueCast(v));
+		return sv->StringValue::to_string_esc();
 	}
 	if (not v->is_atom())
 		return v->to_short_string();

--- a/opencog/persist/sexpr/ValueSexpr.cc
+++ b/opencog/persist/sexpr/ValueSexpr.cc
@@ -20,6 +20,8 @@
  * Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+#include <iomanip>
+
 #include <opencog/atoms/base/Atom.h>
 #include <opencog/atoms/value/ValueFactory.h>
 #include <opencog/atoms/value/LinkValue.h>
@@ -285,9 +287,11 @@ void Sexpr::decode_slist(const Handle& atom,
 
 static std::string prt_node(const Handle& h)
 {
-	std::string txt = "(" + nameserver().getTypeName(h->get_type())
-		+ " \"" + h->get_name() + "\")";
-	return txt;
+	std::stringstream ss;
+	ss << "(" << nameserver().getTypeName(h->get_type())
+		<< " " << std::quoted(h->get_name()) << ")";
+
+	return ss.str();
 }
 
 static std::string prt_atom(const Handle&);

--- a/opencog/persist/sexpr/ValueSexpr.cc
+++ b/opencog/persist/sexpr/ValueSexpr.cc
@@ -144,6 +144,14 @@ ValuePtr Sexpr::decode_value(const std::string& stv, size_t& pos)
 			while (0 < pcnt and epos < totlen)
 			{
 				char c = stv[++epos];
+
+				// Advance past escaped quotes.
+				if ('"' == c)
+				{
+					++epos;
+					for (; epos < totlen and (stv[epos] != '"' or (stv[epos-1] == '\\')); epos++);
+					continue;
+				}
 				if ('(' == c) pcnt ++;
 				else if (')' == c) pcnt--;
 			}

--- a/tests/persist/sexpr/CommandsUTest.cxxtest
+++ b/tests/persist/sexpr/CommandsUTest.cxxtest
@@ -53,6 +53,7 @@ class CommandsUTest : public CxxTest::TestSuite
 		void test_link();
 		void test_set_tv();
 		void test_set_value();
+		void test_set_value_quoted();
 		void test_get_value();
 		void test_set_values();
 		void test_get_values();
@@ -193,6 +194,48 @@ void CommandsUTest::test_set_value()
 	ValuePtr vp = h->getValue(key);
 	TS_ASSERT(nullptr != vp);
 	TS_ASSERT_EQUALS(SIMPLE_TRUTH_VALUE, vp->get_type());
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// Test cog-set-value! with nested quotes
+void CommandsUTest::test_set_value_quoted()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	std::stringstream ss;
+	ss << "(cog-set-value! (Concept \"a\") (Predicate \"key\") ";
+	ss << "(StringValue ";
+	ss << std::quoted(R"("f""o"""o"!!!"")") << " ";
+	ss << std::quoted(R"(b"""a"""r)") << "))";
+	std::string in = ss.str();
+	printf("Input %s\n", in.c_str());
+
+	std::string out = Commands::interpret_command(as, in);
+	printf("Got %s\n", out.c_str());
+
+	TS_ASSERT_EQUALS(2, as->get_size());
+	TS_ASSERT(0 == out.compare("()\n"));
+
+	Handle h = as->get_node(CONCEPT_NODE, "a");
+	TS_ASSERT(nullptr != h);
+
+	Handle key = as->add_node(PREDICATE_NODE, "key");
+	ValuePtr vp = h->getValue(key);
+	TS_ASSERT(nullptr != vp);
+	TS_ASSERT_EQUALS(STRING_VALUE, vp->get_type());
+
+	std::string vps = vp->to_string();
+	printf("Value  %s\n", vps.c_str());
+
+	std::stringstream oss;
+	oss << "(StringValue ";
+	oss << std::quoted(R"("f""o"""o"!!!"")") << " ";
+	oss << std::quoted(R"(b"""a"""r)") << ")";
+	std::string xpt = oss.str();
+	printf("Expect %s\n", xpt.c_str());
+
+	TS_ASSERT(0 == vps.compare(xpt));
 
 	logger().info("END TEST: %s", __FUNCTION__);
 }

--- a/tests/persist/sexpr/CommandsUTest.cxxtest
+++ b/tests/persist/sexpr/CommandsUTest.cxxtest
@@ -20,6 +20,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <iomanip>
+
 #include <opencog/util/Logger.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/atoms/value/FloatValue.h>
@@ -47,6 +49,7 @@ class CommandsUTest : public CxxTest::TestSuite
 		void tearDown() {}
 
 		void test_node();
+		void test_node_quoted();
 		void test_link();
 		void test_set_tv();
 		void test_set_value();
@@ -75,6 +78,38 @@ void CommandsUTest::test_node()
 	printf("Got >>%s<<\n", out.c_str());
 	TS_ASSERT_EQUALS(1, as->get_size());
 	TS_ASSERT(0 == out.compare("(ConceptNode \"foo\")"));
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// Test cog-node with quoted names
+void CommandsUTest::test_node_quoted()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	std::stringstream ss;
+	ss << "(cog-node 'Concept " << std::quoted(R"("f""o"""o"!!!"")") << ")";
+	std::string in = ss.str();
+	printf("Input %s\n", in.c_str());
+
+	std::string out = Commands::interpret_command(as, in);
+	printf("Got %s\n", out.c_str());
+
+	TS_ASSERT_EQUALS(0, as->get_size());
+	TS_ASSERT(0 == out.compare("()\n"));
+
+	Handle h = as->add_node(CONCEPT_NODE, R"("f""o"""o"!!!"")");
+	printf("Added atom %s\n", h->to_short_string().c_str());
+
+	out = Commands::interpret_command(as, in);
+	printf("Got    >>%s<<\n", out.c_str());
+	TS_ASSERT_EQUALS(1, as->get_size());
+
+	std::stringstream sso;
+	sso << "(ConceptNode " << std::quoted(R"("f""o"""o"!!!"")") << ")";
+	std::string expect = sso.str();
+	printf("Expect >>%s<<\n", expect.c_str());
+	TS_ASSERT(0 == out.compare(expect));
 
 	logger().info("END TEST: %s", __FUNCTION__);
 }

--- a/tests/persist/sexpr/CommandsUTest.cxxtest
+++ b/tests/persist/sexpr/CommandsUTest.cxxtest
@@ -55,6 +55,7 @@ class CommandsUTest : public CxxTest::TestSuite
 		void test_set_value();
 		void test_set_value_quoted();
 		void test_get_value();
+		void test_get_value_quoted();
 		void test_set_values();
 		void test_get_values();
 		void test_extract();
@@ -268,6 +269,36 @@ void CommandsUTest::test_get_value()
 	out = Commands::interpret_command(as, in);
 	printf("Got %s\n", out.c_str());
 	TS_ASSERT(0 == out.compare(0, 18, "(SimpleTruthValue "));
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// Test cog-value, with quoted string
+void CommandsUTest::test_get_value_quoted()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle h = as->add_node(CONCEPT_NODE, "a");
+	Handle key = as->add_node(PREDICATE_NODE, "key");
+	Handle fiz = as->add_node(PREDICATE_NODE, "fiz");
+	Handle buz = as->add_node(PREDICATE_NODE, "buz");
+
+	h->setValue(key, createFloatValue(std::vector<double>{4, 5, 6}));
+	h->setValue(fiz, createStringValue(std::vector<std::string>
+		{"\"f\"\"o\"\"\"o\"!!!\"\"", "b\"\"\"a\"\"\"r"}));
+	h->setValue(buz, ValueCast(createSimpleTruthValue(0.3, 0.4)));
+
+	std::string in = "(cog-value (Concept \"a\") (Predicate \"fiz\"))";
+	std::string out = Commands::interpret_command(as, in);
+	printf("Got    %s\n", out.c_str());
+
+	std::stringstream oss;
+	oss << "(StringValue ";
+	oss << std::quoted(R"("f""o"""o"!!!"")") << " ";
+	oss << std::quoted(R"(b"""a"""r)") << ")";
+	std::string xpt = oss.str();
+	printf("Expect %s\n", xpt.c_str());
+	TS_ASSERT(0 == out.compare(xpt));
 
 	logger().info("END TEST: %s", __FUNCTION__);
 }

--- a/tests/persist/sexpr/FastLoadUTest.cxxtest
+++ b/tests/persist/sexpr/FastLoadUTest.cxxtest
@@ -19,6 +19,9 @@
  * Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+
+#include <iomanip>
+
 #include <opencog/atoms/value/LinkValue.h>
 
 // Installed into opencog/persist/file/fast_load.h
@@ -43,6 +46,7 @@ public:
     void tearDown() {}
 
     void test_expr_parse();
+    void test_quoted_node();
     void test_pattern_parse();
     void test_dense_parse();
     void test_dense_loop();
@@ -62,6 +66,28 @@ void FastLoadUTest::test_expr_parse()
 
     TS_ASSERT_EQUALS(5, _as.get_size());
     TS_ASSERT_EQUALS(2, h->getOutgoingSet().size());
+
+    logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// Test parseExpression
+void FastLoadUTest::test_quoted_node()
+{
+    logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+    std::stringstream ss;
+    ss << "(Concept " << std::quoted(R"("f""o"""o"!!!"")") << ")";
+    std::string in = ss.str();
+    printf("Input string %s\n", in.c_str());
+
+    Handle h = parseExpression(in, _as);
+    printf("Parsed Atom h=%s\n", h->to_short_string().c_str());
+
+    Handle expected = _as.get_node(CONCEPT_NODE, R"("f""o"""o"!!!"")");
+    TS_ASSERT (expected != nullptr);
+
+    printf("Got %s\n", expected->to_short_string().c_str());
+    TS_ASSERT_EQUALS(h, expected);
 
     logger().info("END TEST: %s", __FUNCTION__);
 }


### PR DESCRIPTION
Quotes embedded in node names were not being correctly escaped.

This should fix issue #2817 

This also fixes the same issue for StringValues, and for the command interpreter.