### PR TITLE
Escape quotes for the postgres storage node

### DIFF
--- a/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
@@ -893,7 +893,7 @@ void ValueSaveUTest::do_test_link_by_type_quoted()
 	// Start it up again.
 
 	as = new AtomSpace();
-	hsn = as->add_node(ROCKS_STORAGE_NODE, std::string(uri));
+	hsn = as->add_node(POSTGRES_STORAGE_NODE, std::string(uri));
 	store = StorageNodeCast(hsn);
 	store->open();
 	TS_ASSERT(store->connected())
@@ -914,9 +914,8 @@ void ValueSaveUTest::do_test_link_by_type_quoted()
 	store->fetch_all_atoms_of_type(LIST_LINK);
 	store->barrier();
 
-	// We created 9 new atoms above, so expect 15 from before plus 9
-	printf ("fetched %lu atoms, expecting 24\n", as->get_size());
-	TSM_ASSERT("Wrong number of Atoms fetched!", as->get_size() == 24);
+	printf ("fetched %lu atoms, expecting 15\n", as->get_size());
+	TSM_ASSERT("Wrong number of Atoms fetched!", as->get_size() == 15);
 
 	Handle gbf = as->add_node(CONCEPT_NODE, "b float node");
 	Handle gbt = as->add_node(CONCEPT_NODE, "b string node");

--- a/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
@@ -843,7 +843,7 @@ void ValueSaveUTest::do_test_link_by_type_quoted()
 
 	// --------------------
 	ValuePtr pvt = createStringValue(
-		std::vector<std::string>({"a\"a\"a", "bb) (bb) (bb", "ccc \")(\"ccc))\" ccc"}));
+		std::vector<std::string>({"a\"a\"a", "bb}, {bb}, {bb", "ccc \"},{\"ccc}},}\"{ c,c,c"}));
 	at->setValue(key, pvt);
 	bt->setValue(key, pvt);
 	ct->setValue(key, pvt);

--- a/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
@@ -124,6 +124,7 @@ class ValueSaveUTest :  public CxxTest::TestSuite
         void check_one(ValuePtr, bool);
         void do_test_load_by_type();
         void do_test_link_by_type();
+        void do_test_link_by_type_quoted();
         void do_test_incoming();
 
         void test_odbc_single_atom_save();
@@ -137,6 +138,9 @@ class ValueSaveUTest :  public CxxTest::TestSuite
 
         void test_odbc_link_by_type();
         void test_pq_link_by_type();
+
+        void test_odbc_link_by_type_quoted();
+        void test_pq_link_by_type_quoted();
 
         void test_odbc_incoming();
         void test_pq_incoming();
@@ -232,6 +236,26 @@ void ValueSaveUTest::test_pq_link_by_type(void)
 #if HAVE_PGSQL_STORAGE
 	uri = mkuri("postgres", dbname, username, passwd);
 	do_test_link_by_type();
+#endif // HAVE_PGSQL_STORAGE
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+void ValueSaveUTest::test_odbc_link_by_type_quoted(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+#if HAVE_ODBC_STORAGE
+	uri = mkuri("odbc", dbname, username, passwd);
+	do_test_link_by_type_quoted();
+#endif
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+void ValueSaveUTest::test_pq_link_by_type_quoted(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+#if HAVE_PGSQL_STORAGE
+	uri = mkuri("postgres", dbname, username, passwd);
+	do_test_link_by_type_quoted();
 #endif // HAVE_PGSQL_STORAGE
 	logger().debug("END TEST: %s", __FUNCTION__);
 }
@@ -771,6 +795,217 @@ void ValueSaveUTest::do_test_link_by_type()
 	// --------------------
 	kill_data(store);
 	delete as;
+}
+
+// ============================================================
+
+// Same as do_test_link_by_type() except that the StringValue
+// has some nasties intended to confuse parsing.
+void ValueSaveUTest::do_test_link_by_type_quoted()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	AtomSpace* as = new AtomSpace();
+	Handle hsn = as->add_node(POSTGRES_STORAGE_NODE, std::string(uri));
+	StorageNodePtr store = StorageNodeCast(hsn);
+	store->open();
+	TS_ASSERT(store->connected())
+
+	Handle key = as->add_node(PREDICATE_NODE, "some (\"pred\"))) key");
+	Handle af = as->add_node(CONCEPT_NODE, "x \"float\" node");
+	Handle at = as->add_node(CONCEPT_NODE, "x \"string\" node");
+	Handle al = as->add_node(CONCEPT_NODE, "x \"depth-1\" node");
+	Handle av = as->add_node(CONCEPT_NODE, "x \"depth-2\" node");
+
+	Handle bf = as->add_node(CONCEPT_NODE, "b float node");
+	Handle bt = as->add_node(CONCEPT_NODE, "b string node");
+	Handle bl = as->add_node(CONCEPT_NODE, "b depth-1 node");
+	Handle bv = as->add_node(CONCEPT_NODE, "b depth-2 node");
+
+	Handle cf = as->add_link(LIST_LINK, {af, bf});
+	Handle ct = as->add_link(LIST_LINK, {at, bt});
+	Handle cl = as->add_link(LIST_LINK, {al, bl});
+	Handle cv = as->add_link(LIST_LINK, {av, bv});
+
+	// --------------------
+	// Now set some values
+	ValuePtr pvf = createFloatValue(
+		std::vector<double>({1.1098765432109876, 2.1234567890123456e37,
+		                     3.2109876543210987e-250}));
+	af->setValue(key, pvf);
+	bf->setValue(key, pvf);
+	cf->setValue(key, pvf);
+
+	TruthValuePtr tf(SimpleTruthValue::createTV(0.11, 100));
+	af->setTruthValue(tf);
+	bf->setTruthValue(tf);
+	cf->setTruthValue(tf);
+
+	// --------------------
+	ValuePtr pvt = createStringValue(
+		std::vector<std::string>({"a\"a\"a", "bb) (bb) (bb", "ccc \")(\"ccc))\" ccc"}));
+	at->setValue(key, pvt);
+	bt->setValue(key, pvt);
+	ct->setValue(key, pvt);
+
+	TruthValuePtr tt(SimpleTruthValue::createTV(0.22, 200));
+	at->setTruthValue(tt);
+	bt->setTruthValue(tt);
+	ct->setTruthValue(tt);
+
+	// --------------------
+	ValuePtr pvl = createLinkValue(
+		std::vector<ValuePtr>({pvf, pvt}));
+	al->setValue(key, pvl);
+	bl->setValue(key, pvl);
+	cl->setValue(key, pvl);
+
+	TruthValuePtr tl(SimpleTruthValue::createTV(0.33, 300));
+	al->setTruthValue(tl);
+	bl->setTruthValue(tl);
+	cl->setTruthValue(tl);
+
+	// --------------------
+	ValuePtr pvv = createLinkValue(
+		std::vector<ValuePtr>({pvl, pvl, pvf, pvt}));
+	av->setValue(key, pvv);
+	bv->setValue(key, pvv);
+	cv->setValue(key, pvv);
+
+	TruthValuePtr tv(SimpleTruthValue::createTV(0.44, 400));
+	av->setTruthValue(tv);
+	bv->setTruthValue(tv);
+	cv->setTruthValue(tv);
+
+	// --------------------
+	// Save, and close things down.
+	// Note that this store will also *recursively* store the
+	// values on the outgoing atoms, as well.
+	store->store_atom(cf);
+	store->store_atom(ct);
+	store->store_atom(cl);
+	store->store_atom(cv);
+	store->barrier();
+
+	delete as;
+
+	// --------------------
+	// Start it up again.
+
+	as = new AtomSpace();
+	hsn = as->add_node(ROCKS_STORAGE_NODE, std::string(uri));
+	store = StorageNodeCast(hsn);
+	store->open();
+	TS_ASSERT(store->connected())
+
+	// --------------------
+	// Fetch by type. This is what we are testing.
+
+	Handle gkey = as->add_node(PREDICATE_NODE, "some (\"pred\"))) key");
+	Handle gaf = as->add_node(CONCEPT_NODE, "x \"float\" node");
+	Handle gat = as->add_node(CONCEPT_NODE, "x \"string\" node");
+	Handle gal = as->add_node(CONCEPT_NODE, "x \"depth-1\" node");
+	Handle gav = as->add_node(CONCEPT_NODE, "x \"depth-2\" node");
+
+	// Note that the A-nodes above are added *before* the fetch;
+	// The B-nodes are added after the fetch. In either case,
+	// there should not be any values fetched for either A or B;
+	// only the values on the C-links should be fetched.
+	store->fetch_all_atoms_of_type(LIST_LINK);
+	store->barrier();
+
+	// We created 9 new atoms above, so expect 15 from before plus 9
+	printf ("fetched %lu atoms, expecting 24\n", as->get_size());
+	TSM_ASSERT("Wrong number of Atoms fetched!", as->get_size() == 24);
+
+	Handle gbf = as->add_node(CONCEPT_NODE, "b float node");
+	Handle gbt = as->add_node(CONCEPT_NODE, "b string node");
+	Handle gbl = as->add_node(CONCEPT_NODE, "b depth-1 node");
+	Handle gbv = as->add_node(CONCEPT_NODE, "b depth-2 node");
+
+	Handle gcf = as->add_link(LIST_LINK, {gaf, gbf});
+	Handle gct = as->add_link(LIST_LINK, {gat, gbt});
+	Handle gcl = as->add_link(LIST_LINK, {gal, gbl});
+	Handle gcv = as->add_link(LIST_LINK, {gav, gbv});
+
+	TS_ASSERT(*gcf == *cf);
+	TS_ASSERT(*gct == *ct);
+	TS_ASSERT(*gcl == *cl);
+	TS_ASSERT(*gcv == *cv);
+
+	TruthValuePtr gtf = gaf->getTruthValue();
+	TruthValuePtr gtt = gat->getTruthValue();
+	TruthValuePtr gtl = gal->getTruthValue();
+	TruthValuePtr gtv = gav->getTruthValue();
+
+	TS_ASSERT(gtf == TruthValue::DEFAULT_TV());
+	TS_ASSERT(gtt == TruthValue::DEFAULT_TV());
+	TS_ASSERT(gtl == TruthValue::DEFAULT_TV());
+	TS_ASSERT(gtv == TruthValue::DEFAULT_TV());
+
+	gtf = gbf->getTruthValue();
+	gtt = gbt->getTruthValue();
+	gtl = gbl->getTruthValue();
+	gtv = gbv->getTruthValue();
+
+	TS_ASSERT(gtf == TruthValue::DEFAULT_TV());
+	TS_ASSERT(gtt == TruthValue::DEFAULT_TV());
+	TS_ASSERT(gtl == TruthValue::DEFAULT_TV());
+	TS_ASSERT(gtv == TruthValue::DEFAULT_TV());
+
+	gtf = gcf->getTruthValue();
+	gtt = gct->getTruthValue();
+	gtl = gcl->getTruthValue();
+	gtv = gcv->getTruthValue();
+
+	printf("Expecting %s\n", tf->to_string().c_str());
+	printf("Got %s\n", gtf->to_string().c_str());
+	TS_ASSERT(*gtf == *tf);
+	TS_ASSERT(*gtt == *tt);
+	TS_ASSERT(*gtl == *tl);
+	TS_ASSERT(*gtv == *tv);
+
+	// --------------------
+
+	ValuePtr gpf;
+	ValuePtr gpt;
+	ValuePtr gpl;
+	ValuePtr gpv;
+
+	try { gpf = gaf->getValue(gkey); } catch(const RuntimeException&) {}
+	try { gpt = gat->getValue(gkey); } catch(const RuntimeException&) {}
+	try { gpl = gal->getValue(gkey); } catch(const RuntimeException&) {}
+	try { gpv = gav->getValue(gkey); } catch(const RuntimeException&) {}
+
+	TS_ASSERT(gpf == nullptr);
+	TS_ASSERT(gpt == nullptr);
+	TS_ASSERT(gpl == nullptr);
+	TS_ASSERT(gpv == nullptr);
+
+	try { gpf = gbf->getValue(gkey); } catch(const RuntimeException&) {}
+	try { gpt = gbt->getValue(gkey); } catch(const RuntimeException&) {}
+	try { gpl = gbl->getValue(gkey); } catch(const RuntimeException&) {}
+	try { gpv = gbv->getValue(gkey); } catch(const RuntimeException&) {}
+
+	TS_ASSERT(gpf == nullptr);
+	TS_ASSERT(gpt == nullptr);
+	TS_ASSERT(gpl == nullptr);
+	TS_ASSERT(gpv == nullptr);
+
+	gpf = gcf->getValue(gkey);
+	gpt = gct->getValue(gkey);
+	gpl = gcl->getValue(gkey);
+	gpv = gcv->getValue(gkey);
+
+	TS_ASSERT(*gpf == *pvf);
+	TS_ASSERT(*gpt == *pvt);
+	TS_ASSERT(*gpl == *pvl);
+	TS_ASSERT(*gpv == *pvv);
+
+	// --------------------
+	delete as;
+
+	logger().info("END TEST: %s", __FUNCTION__);
 }
 
 // ============================================================


### PR DESCRIPTION
Similar to #2818, but specific to Postgres.

Extend unit test as well.