### PR TITLE
Add missing cfloat include for DBL_MAX

### DIFF
--- a/opencog/atoms/reduct/MaxLink.cc
+++ b/opencog/atoms/reduct/MaxLink.cc
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include <cfloat>
+
 #include <opencog/atoms/atom_types/atom_types.h>
 #include <opencog/atoms/base/ClassServer.h>
 #include <opencog/atoms/core/NumberNode.h>

--- a/opencog/atoms/reduct/MinLink.cc
+++ b/opencog/atoms/reduct/MinLink.cc
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+#include <cfloat>
+
 #include <opencog/atoms/atom_types/atom_types.h>
 #include <opencog/atoms/base/ClassServer.h>
 #include <opencog/atoms/core/NumberNode.h>


### PR DESCRIPTION
Otherwise gcc complains with

```
MinLink.cc: In member function ‘virtual opencog::ValuePtr opencog::MinLink::execute(opencog::AtomSpace*, bool)’:
MinLink.cc:49:44: error: ‘DBL_MAX’ was not declared in this scope
   49 |                         result.resize(len, DBL_MAX);
      |                                            ^~~~~~~
```