### PR TITLE
Use `shared_lock` in AtomTable for concurrency

### DIFF
--- a/opencog/atoms/core/StateLink.cc
+++ b/opencog/atoms/core/StateLink.cc
@@ -109,7 +109,9 @@ void StateLink::install()
 		_outgoing[1]->insert_atom(new_state);
 
 		// Remove the old StateLink too. It must be no more.
-		as->extract_atom(defl, true);
+		// Ths is all happening under a recursive lock. So don't
+		// double-clock.
+		as->extract_atom(defl, true, false);
 		swapped = true;
 	}
 

--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -265,8 +265,8 @@ public:
      * @return True if the Atom for the given Handle was successfully
      *         removed. False, otherwise.
      */
-    bool extract_atom(Handle h, bool recursive=false) {
-        return 0 < _atom_table.extract(h, recursive).size();
+    bool extract_atom(Handle h, bool recursive=false, bool do_lock=true) {
+        return 0 < _atom_table.extract(h, recursive, do_lock).size();
     }
     bool remove_atom(Handle h, bool recursive=false) {
         return extract_atom(h, recursive);

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -86,7 +86,7 @@ AtomTable::AtomTable(AtomTable* parent, AtomSpace* holder, bool transient) :
 
 AtomTable::~AtomTable()
 {
-    std::lock_guard<std::recursive_mutex> lck(_mtx);
+    std::unique_lock<std::shared_mutex> lck(_mtx);
 
     if (_environ) _environ->_num_nested--;
     _nameserver.typeAddedSignal().disconnect(addedTypeConnection);
@@ -117,7 +117,7 @@ void AtomTable::clear_transient()
         throw opencog::RuntimeException(TRACE_INFO,
                 "AtomTable - clear_transient called on non-transient atom table.");
 
-    std::lock_guard<std::recursive_mutex> lck(_mtx);
+    std::unique_lock<std::shared_mutex> lck(_mtx);
 
     // Clear all the atoms
     clear_all_atoms();
@@ -135,7 +135,7 @@ void AtomTable::clear_all_atoms()
 
 void AtomTable::clear()
 {
-    std::lock_guard<std::recursive_mutex> lck(_mtx);
+    std::unique_lock<std::shared_mutex> lck(_mtx);
     clear_all_atoms();
 }
 
@@ -157,7 +157,7 @@ Handle AtomTable::lookupHandle(const Handle& a) const
 {
     if (nullptr == a) return Handle::UNDEFINED;
 
-    std::lock_guard<std::recursive_mutex> lck(_mtx);
+    std::shared_lock<std::shared_mutex> lck(_mtx);
     Handle h(typeIndex.findAtom(a));
     if (h) return h;
 
@@ -179,25 +179,6 @@ Handle AtomTable::getHandle(const Handle& a) const
     return lookupHandle(a);
 }
 
-#if 0
-static void prt_diag(Handle atom, size_t i, size_t arity, const HandleSeq& ogs)
-{
-    Logger::Level save = logger().getBackTraceLevel();
-    logger().setBackTraceLevel(Logger::Level::NONE);
-    logger().error() << "AtomTable - Insert link with "
-               "invalid outgoing members";
-    logger().error() << "Failing index i=" << i
-                    << " and arity=" << arity;
-    logger().error() << "Failing outset is this:";
-    for (unsigned int fk=0; fk<arity; fk++)
-        logger().error() << "outset i=" << fk;
-
-    logger().error() << "link is " << atom->to_string();
-    logger().flush();
-    logger().setBackTraceLevel(save);
-}
-#endif
-
 Handle AtomTable::add(const Handle& orig, bool force)
 {
     // Can be null, if its a Value
@@ -213,20 +194,23 @@ Handle AtomTable::add(const Handle& orig, bool force)
     // Lock before checking to see if this kind of atom is already in
     // the atomspace.  Lock, to prevent two different threads from
     // trying to add exactly the same atom.
-    std::unique_lock<std::recursive_mutex> lck(_mtx);
+    std::unique_lock<std::shared_mutex> lck(_mtx);
     if (not force) {
-        Handle hcheck(getHandle(orig));
+        if (in_environ(orig)) return orig;
+
+        Handle hcheck(typeIndex.findAtom(orig));
+        if (nullptr == hcheck and _environ)
+            hcheck = _environ->lookupHandle(orig);
         if (hcheck) {
             // Oh we have it already. Update the values, as needed.
             hcheck->copyValues(orig);
             return hcheck;
         }
     } else {
-
         // If force-adding, we have to be more careful.  We're looking
         // for the atom in this table, and not some other table.
-        Handle hcheck(lookupHandle(orig));
-        if (hcheck and hcheck->getAtomSpace() == _as) {
+        Handle hcheck(typeIndex.findAtom(orig));
+        if (hcheck) {
             hcheck->copyValues(orig);
             return hcheck;
         }
@@ -308,7 +292,7 @@ size_t AtomTable::getNumLinks() const
 
 size_t AtomTable::getNumAtomsOfType(Type type, bool subclass) const
 {
-    std::lock_guard<std::recursive_mutex> lck(_mtx);
+    std::shared_lock<std::shared_mutex> lck(_mtx);
 
     size_t result = typeIndex.size(type);
     if (subclass)
@@ -368,11 +352,10 @@ HandleSet AtomTable::extract(Handle& handle, bool recursive)
         return other->extract(handle, recursive);
     }
 
-    // Lock before fetching the incoming set. Since getting the
-    // incoming set also grabs a lock, we need this mutex to be
-    // recursive. We need to lock here to avoid confusion if multiple
-    // threads are trying to delete the same atom.
-    std::unique_lock<std::recursive_mutex> lck(_mtx);
+    // Lock before fetching the incoming set. (Why, exactly??)
+    // Because if multiple threads are trying to delete the same
+    // atom, then ... ???
+    std::unique_lock<std::shared_mutex> lck(_mtx);
 
     if (handle->isMarkedForRemoval()) return result;
     handle->markForRemoval();
@@ -453,6 +436,6 @@ HandleSet AtomTable::extract(Handle& handle, bool recursive)
 /// This is the resize callback, when a new type is dynamically added.
 void AtomTable::typeAdded(Type t)
 {
-    std::lock_guard<std::recursive_mutex> lck(_mtx);
+    std::unique_lock<std::shared_mutex> lck(_mtx);
     typeIndex.resize();
 }

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -422,12 +422,9 @@ HandleSet AtomTable::extract(Handle& handle, bool recursive, bool do_lock)
     // removed.  This is needed so that certain subsystems, e.g. the
     // Agent system activity table, can correctly manage the atom;
     // it needs info that gets blanked out during removal.
-    // Pfft. Give up the pretension. This is a recursive lock;
-    // unlocking it once is not enough, because it can still be
-    // recurisvely locked.
-    // lck.unlock();
+    if (do_lock) lck.unlock();
     _removeAtomSignal.emit(handle);
-    // lck.lock();
+    if (do_lock) lck.lock();
 
     typeIndex.removeAtom(handle);
 

--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -343,7 +343,7 @@ public:
      * @param The new atom to be added.
      * @return The handle of the newly added atom.
      */
-    Handle add(const Handle&, bool force=false);
+    Handle add(const Handle&, bool force=false, bool do_lock=true);
 
     /**
      * Read-write synchronization barrier fence.  When called, this

--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -73,7 +73,7 @@ private:
     // Its recursive because we need to lock twice during atom insertion
     // and removal: we need to keep the indexes stable while we search
     // them during add/remove.
-    mutable std::recursive_mutex _mtx;
+    mutable std::shared_mutex _mtx;
 
     //! Index of atoms.
     TypeIndex typeIndex;
@@ -194,7 +194,7 @@ public:
                        bool subclass=false,
                        bool parent=true) const
     {
-        std::lock_guard<std::recursive_mutex> lck(_mtx);
+        std::shared_lock<std::shared_mutex> lck(_mtx);
         auto tit = typeIndex.begin(type, subclass);
         auto tend = typeIndex.end();
         while (tit != tend) { hset.insert(*tit); tit++; }
@@ -220,7 +220,7 @@ public:
                      bool subclass=false,
                      bool parent=true) const
     {
-        std::lock_guard<std::recursive_mutex> lck(_mtx);
+        std::shared_lock<std::shared_mutex> lck(_mtx);
         auto tit = typeIndex.begin(type, subclass);
         auto tend = typeIndex.end();
         while (tit != tend) {
@@ -257,7 +257,7 @@ public:
         }
 
         // No parent ... avoid the copy above.
-        std::lock_guard<std::recursive_mutex> lck(_mtx);
+        std::shared_lock<std::shared_mutex> lck(_mtx);
         return std::copy(typeIndex.begin(type, subclass),
                          typeIndex.end(), result);
     }
@@ -284,7 +284,7 @@ public:
 
         // No parent ... avoid the copy above.
         // This can (will) deadlock if func touches the table.
-        std::lock_guard<std::recursive_mutex> lck(_mtx);
+        std::shared_lock<std::shared_mutex> lck(_mtx);
         std::for_each(typeIndex.begin(type, subclass),
                       typeIndex.end(),
              [&](const Handle& h)->void {
@@ -320,7 +320,7 @@ public:
 
         // No parent ... avoid the copy above.
         // This can (will) deadlock if func touches the table.
-        std::lock_guard<std::recursive_mutex> lck(_mtx);
+        std::shared_lock<std::shared_mutex> lck(_mtx);
         // Parallelize, always, no matter what!
         opencog::setting_omp(opencog::num_threads(), 1);
 

--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -374,7 +374,7 @@ public:
      *        incoming set will also be extracted.
      * @return A set of the extracted atoms.
      */
-    HandleSet extract(Handle& handle, bool recursive=true);
+    HandleSet extract(Handle& handle, bool recursive=true, bool do_lock=true);
 
     /**
      * Return a random atom in the AtomTable.

--- a/tests/atomspace/AtomTableUTest.cxxtest
+++ b/tests/atomspace/AtomTableUTest.cxxtest
@@ -177,7 +177,7 @@ public:
     void testRecursiveAdd()
     {
         // Once for an ordered link type, and again for an unordered
-        // type.   Unordered links get spcial handling.
+        // type.   Unordered links get special handling.
         doRecursiveAdd(LIST_LINK);
         doRecursiveAdd(SET_LINK);
         doRecursiveAdd(SIMILARITY_LINK);


### PR DESCRIPTION
Using `std::shared_lock` should improve AtomSpace concurency.