### PR TITLE
Set thread names for AtomSpace threads

### DIFF
--- a/opencog/atoms/parallel/ExecuteThreadedLink.cc
+++ b/opencog/atoms/parallel/ExecuteThreadedLink.cc
@@ -21,6 +21,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <sys/prctl.h>
 #include <thread>
 
 #include <opencog/util/concurrent_queue.h>
@@ -91,6 +92,7 @@ static void thread_exec(AtomSpace* as, bool silent,
                         QueueValuePtr qvp,
                         std::exception_ptr* returned_ex)
 {
+	prctl(PR_SET_NAME, "atoms:execlink", 0, 0, 0);
 	while (true)
 	{
 		Handle h;

--- a/opencog/atoms/parallel/ParallelLink.cc
+++ b/opencog/atoms/parallel/ParallelLink.cc
@@ -21,7 +21,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-
+#include <sys/prctl.h>
 #include <thread>
 
 #include <opencog/atoms/execution/EvaluationLink.h>
@@ -41,6 +41,7 @@ static void thread_eval(AtomSpace* as,
                         const Handle& evelnk, AtomSpace* scratch,
                         bool silent)
 {
+	prctl(PR_SET_NAME, "atoms:parallel", 0, 0, 0);
 	try
 	{
 		EvaluationLink::do_eval_scratch(as, evelnk, scratch, silent);

--- a/opencog/atoms/parallel/ThreadJoinLink.cc
+++ b/opencog/atoms/parallel/ThreadJoinLink.cc
@@ -21,6 +21,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <sys/prctl.h>
 #include <thread>
 
 #include <opencog/atoms/core/NumberNode.h>
@@ -43,6 +44,7 @@ static void thread_eval_tv(AtomSpace* as,
                            bool silent, TruthValuePtr* tv,
                            std::exception_ptr* returned_ex)
 {
+	prctl(PR_SET_NAME, "atoms:joinlink", 0, 0, 0);
 	try
 	{
 		*tv = EvaluationLink::do_eval_scratch(as, evelnk, scratch, silent);

--- a/opencog/guile/SchemeEval.cc
+++ b/opencog/guile/SchemeEval.cc
@@ -27,6 +27,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
+#include <sys/prctl.h>
 #include <termios.h>
 
 #include <cstddef>
@@ -271,6 +272,7 @@ static volatile bool done_with_init = false;
 static void immortal_thread(void)
 {
 	scm_with_guile(c_wrap_init_only_once, NULL);
+	prctl(PR_SET_NAME, "atoms:immortal", 0, 0, 0);
 
 	// Tell compiler to set flag dead-last, after above has executed.
 	asm volatile("": : :"memory");

--- a/opencog/persist/sql/multi-driver/llapi.cc
+++ b/opencog/persist/sql/multi-driver/llapi.cc
@@ -34,6 +34,7 @@
 
 #ifdef HAVE_SQL_STORAGE
 
+#include <sys/prctl.h>
 #include <stack>
 #include <string>
 
@@ -49,6 +50,7 @@
 
 LLConnection::LLConnection(void)
 {
+    prctl(PR_SET_NAME, "atoms:pgconn", 0, 0, 0);
     is_connected = false;
 }
 


### PR DESCRIPTION
This should simplify debugging with gdb. The thread name will be printed when you say `info threads`.