### PR TITLE
Fix usage of StateLink with overlay AtomSpaces

### DIFF
--- a/examples/atomspace/README.md
+++ b/examples/atomspace/README.md
@@ -79,6 +79,7 @@ be effective.
 * `persist-multi.scm`  -- Work with multiple databases/servers at once.
 * `distributed.scm`    -- Distributed AtomSpace on multiple network nodes.
 * `copy-on-write.scm`  -- Read-only AtomSpace, with r/w overlays.
+* `frame.scm`          -- Using StateLink in overlays.
 * `gperf.scm`          -- Some very crude performance measurements.
 
 Documentation

--- a/examples/atomspace/basic.scm
+++ b/examples/atomspace/basic.scm
@@ -1,5 +1,5 @@
 ;
-; Basic guile usage example!
+; basic.scm -- Basic guile usage example!
 ;
 ; See `opencog/guile/README` or http://wiki.opencog.org/w/Scheme
 ; for additional documentation.

--- a/examples/atomspace/frame.scm
+++ b/examples/atomspace/frame.scm
@@ -1,0 +1,50 @@
+;
+; frame.scm -- Combining StateLink with dervived AtomSpaces
+;
+; The StateLink guarantees that only one copy of the StateLink
+; will be present in the AtomSpace.  The cog-push-atomspace and
+; cog-pop-atomspace maintain a stack of atomspaces, with each
+; derived AtomSpace on the stack shadowing the underlying space.
+;
+; It should be possible to set the StateLink in a derived AtomSpace
+; without affecting the state in the base AtomSpace. That's what is
+; demonstrated here.
+
+(use-modules (opencog))
+
+; Record the current atomspace, for later use.
+(define root-as (cog-atomspace))
+
+; Create a robot arm that is not holding anything.
+(State (Concept "robot arm") (Concept "empty"))
+
+; Print everything, just to check.
+(cog-prt-atomspace)
+
+; Create a new AtomSpace
+(cog-push-atomspace)
+
+; Print everything. There should be no change.
+(cog-prt-atomspace)
+
+; Change the state of the robot arm.
+(State (Concept "robot arm")
+	(Evaluation (Predicate "holding") (Concept "block 42")))
+
+; Print everything. The state should have changed.
+(cog-prt-atomspace)
+
+; Another way of printing the state.
+(cog-map-type (lambda (A) (format #t "This is the state: ~A\n" A) #f) 'State)
+
+; Print the state in the root atomspace
+(cog-prt-atomspace root-as)
+
+(cog-map-type (lambda (A) (format #t "Before, it was: ~A\n" A) #f)
+	'State root-as)
+
+; Reset back to the original AtomSpace.
+(cog-pop-atomspace)
+
+; And print, again, to make sure it went back to the original state.
+(cog-prt-atomspace)

--- a/examples/atomspace/frame.scm
+++ b/examples/atomspace/frame.scm
@@ -9,6 +9,9 @@
 ; It should be possible to set the StateLink in a derived AtomSpace
 ; without affecting the state in the base AtomSpace. That's what is
 ; demonstrated here.
+;
+; The word `frame` is used as the title of the example, as the usage
+; resembles that of Kripke frames used in forward-chaining.
 
 (use-modules (opencog))
 
@@ -48,3 +51,7 @@
 
 ; And print, again, to make sure it went back to the original state.
 (cog-prt-atomspace)
+
+; The above can also be repeated using `cog-new-atomspace` instead.
+; Up to you to explore that!
+; That's all for now -- the end!

--- a/opencog/atoms/core/DefineLink.cc
+++ b/opencog/atoms/core/DefineLink.cc
@@ -77,6 +77,11 @@ Handle DefineLink::get_definition(const Handle& alias, AtomSpace* as)
 	return uniq->getOutgoingAtom(1);
 }
 
+Handle DefineLink::get_link(const Handle& alias, AtomSpace* as)
+{
+	return get_unique(alias, DEFINE_LINK, false, as);
+}
+
 DEFINE_LINK_FACTORY(DefineLink, DEFINE_LINK)
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/core/DefineLink.cc
+++ b/opencog/atoms/core/DefineLink.cc
@@ -71,9 +71,9 @@ DefineLink::DefineLink(const Handle& name, const Handle& defn)
  * This will be the second atom of some DefineLink, where
  * `alias` is the first.
  */
-Handle DefineLink::get_definition(const Handle& alias)
+Handle DefineLink::get_definition(const Handle& alias, AtomSpace* as)
 {
-	Handle uniq(get_unique(alias, DEFINE_LINK, false));
+	Handle uniq(get_unique(alias, DEFINE_LINK, false, as));
 	return uniq->getOutgoingAtom(1);
 }
 

--- a/opencog/atoms/core/DefineLink.h
+++ b/opencog/atoms/core/DefineLink.h
@@ -81,7 +81,10 @@ public:
 	 *
 	 * return <body>
 	 */
-	static Handle get_definition(const Handle& alias);
+	static Handle get_definition(const Handle& alias, AtomSpace*);
+
+	static Handle get_definition(const Handle& alias)
+	{ return get_definition(alias, alias->getAtomSpace()); }
 
 	static Handle factory(const Handle&);
 };

--- a/opencog/atoms/core/DefineLink.h
+++ b/opencog/atoms/core/DefineLink.h
@@ -83,6 +83,17 @@ public:
 	 */
 	static Handle get_definition(const Handle& alias, AtomSpace*);
 
+	/**
+	 * Given a Handle pointing to <name> in
+	 *
+	 * DefineLink
+	 *    <name>
+	 *    <body>
+	 *
+	 * return the DefineLink for the given AtomSpace.
+	 */
+	static Handle get_link(const Handle& alias, AtomSpace*);
+
 	static Handle get_definition(const Handle& alias)
 	{ return get_definition(alias, alias->getAtomSpace()); }
 

--- a/opencog/atoms/core/DefineLink.h
+++ b/opencog/atoms/core/DefineLink.h
@@ -82,6 +82,8 @@ public:
 	 * return <body>
 	 */
 	static Handle get_definition(const Handle& alias, AtomSpace*);
+	static Handle get_definition(const Handle& alias)
+	{ return get_definition(alias, alias->getAtomSpace()); }
 
 	/**
 	 * Given a Handle pointing to <name> in
@@ -93,9 +95,6 @@ public:
 	 * return the DefineLink for the given AtomSpace.
 	 */
 	static Handle get_link(const Handle& alias, AtomSpace*);
-
-	static Handle get_definition(const Handle& alias)
-	{ return get_definition(alias, alias->getAtomSpace()); }
 
 	static Handle factory(const Handle&);
 };

--- a/opencog/atoms/core/StateLink.cc
+++ b/opencog/atoms/core/StateLink.cc
@@ -53,9 +53,9 @@ StateLink::StateLink(const Handle& name, const Handle& defn)
  * This will be the second atom of some StateLink, where
  * `alias` is the first.
  */
-Handle StateLink::get_state(const Handle& alias)
+Handle StateLink::get_state(const Handle& alias, AtomSpace* as)
 {
-	Handle uniq(get_unique(alias, STATE_LINK, true));
+	Handle uniq(get_unique(alias, STATE_LINK, true, as));
 	return uniq->getOutgoingAtom(1);
 }
 
@@ -63,9 +63,9 @@ Handle StateLink::get_state(const Handle& alias)
  * Get the link associated with the alias.  This will be the StateLink
  * which has `alias` as the first member of the outgoing set.
  */
-Handle StateLink::get_link(const Handle& alias)
+Handle StateLink::get_link(const Handle& alias, AtomSpace* as)
 {
-	return get_unique(alias, STATE_LINK, true);
+	return get_unique(alias, STATE_LINK, true, as);
 }
 
 void StateLink::install()

--- a/opencog/atoms/core/StateLink.h
+++ b/opencog/atoms/core/StateLink.h
@@ -77,6 +77,8 @@ public:
 	 * return <body>. Throws exception if there is no such StateLink.
 	 */
 	static Handle get_state(const Handle& alias, AtomSpace*);
+	static Handle get_state(const Handle& alias)
+	{ return get_state(alias, alias->getAtomSpace()); }
 
 	/**
 	 * Given a Handle pointing to <name> in

--- a/opencog/atoms/core/StateLink.h
+++ b/opencog/atoms/core/StateLink.h
@@ -36,11 +36,15 @@ namespace opencog
 /// that atom in the first position.  Adding another StateLink with
 /// the same first-atom causes the previous StateLink to be removed!
 ///
-/// This class is intended for holding single-valued state in a safe,
-/// automated fashion. Of course, a user can also store unique state
-/// simply by being careful to delete the old state after adding the
-/// new state; but this can be error prone.  Thus link type provides
-/// convenience and safety.
+/// This class is intended for holding single-valued state in a
+/// thread-safe, fully-automated fashion. Of course, a user can also
+/// store unique state simply by being careful to delete the old state
+/// after adding the new state; but this would not be thread-safe.
+///
+/// By "thread-safe", it is meant that any other thread observing the
+/// AtomSpace will only see one StateLink: either the old one, or the
+/// new one; they will never see two StateLinks, and they will never
+/// see zero StateLinks.
 ///
 class StateLink : public UniqueLink
 {
@@ -72,7 +76,7 @@ public:
 	 *
 	 * return <body>. Throws exception if there is no such StateLink.
 	 */
-	static Handle get_state(const Handle& alias);
+	static Handle get_state(const Handle& alias, AtomSpace*);
 
 	/**
 	 * Given a Handle pointing to <name> in
@@ -84,7 +88,7 @@ public:
 	 * return the whole StateLink. Throws exception if there is
 	 * no such StateLink.
 	 */
-	static Handle get_link(const Handle& alias);
+	static Handle get_link(const Handle& alias, AtomSpace*);
 
 	static Handle factory(const Handle&);
 };

--- a/opencog/atoms/core/TypedAtomLink.cc
+++ b/opencog/atoms/core/TypedAtomLink.cc
@@ -80,6 +80,11 @@ Handle TypedAtomLink::get_type(const Handle& atom, AtomSpace* as)
 	return uniq->getOutgoingAtom(1);
 }
 
+Handle TypedAtomLink::get_link(const Handle& atom, AtomSpace* as)
+{
+	return get_unique(atom, TYPED_ATOM_LINK, false, as);
+}
+
 DEFINE_LINK_FACTORY(TypedAtomLink, TYPED_ATOM_LINK);
 
 /* ===================== END OF FILE ===================== */

--- a/opencog/atoms/core/TypedAtomLink.cc
+++ b/opencog/atoms/core/TypedAtomLink.cc
@@ -74,9 +74,9 @@ TypedAtomLink::TypedAtomLink(const Handle& name, const Handle& defn)
  * This will be the second atom of some TypedAtomLink, where
  * `atom` is the first.
  */
-Handle TypedAtomLink::get_type(const Handle& atom)
+Handle TypedAtomLink::get_type(const Handle& atom, AtomSpace* as)
 {
-	Handle uniq(get_unique(atom, TYPED_ATOM_LINK, false));
+	Handle uniq(get_unique(atom, TYPED_ATOM_LINK, false, as));
 	return uniq->getOutgoingAtom(1);
 }
 

--- a/opencog/atoms/core/TypedAtomLink.h
+++ b/opencog/atoms/core/TypedAtomLink.h
@@ -68,7 +68,7 @@ public:
 	 *
 	 * return <type-specification>
 	 */
-	static Handle get_type(const Handle&);
+	static Handle get_type(const Handle&, AtomSpace*);
 
 	static Handle factory(const Handle&);
 };

--- a/opencog/atoms/core/TypedAtomLink.h
+++ b/opencog/atoms/core/TypedAtomLink.h
@@ -70,6 +70,17 @@ public:
 	 */
 	static Handle get_type(const Handle&, AtomSpace*);
 
+	/**
+	 * Given a Handle pointing to <atom> in
+	 *
+	 * TypedAtomLink
+	 *    <atom>
+	 *    <type-specification>
+	 *
+	 * return the TypedAtomLink for the given AtomSpace.
+	 */
+	static Handle get_link(const Handle&, AtomSpace*);
+
 	static Handle factory(const Handle&);
 };
 

--- a/opencog/atoms/core/UniqueLink.cc
+++ b/opencog/atoms/core/UniqueLink.cc
@@ -22,6 +22,7 @@
  */
 
 #include <opencog/atoms/base/ClassServer.h>
+#include <opencog/atomspace/AtomSpace.h>
 
 #include "UniqueLink.h"
 
@@ -53,17 +54,16 @@ void UniqueLink::init(bool allow_open)
 	IncomingSet defs = alias->getIncomingSetByType(_type);
 	for (const Handle& def : defs)
 	{
-		if (def->getOutgoingAtom(0) == alias)
+		if (def->getOutgoingAtom(0) != alias) continue;
+
+		size_t sz = _outgoing.size();
+		for (size_t i=1; i<sz; i++)
 		{
-			size_t sz = _outgoing.size();
-			for (size_t i=1; i<sz; i++)
+			if (def->getOutgoingAtom(i) != _outgoing[i])
 			{
-				if (def->getOutgoingAtom(i) != _outgoing[i])
-				{
-					throw InvalidParamException(TRACE_INFO,
-					      "Already defined: %s\n",
-					       alias->to_string().c_str());
-				}
+				throw InvalidParamException(TRACE_INFO,
+				      "Already defined: %s\n",
+				       alias->to_string().c_str());
 			}
 		}
 	}
@@ -92,24 +92,33 @@ Handle UniqueLink::get_unique(const Handle& alias, Type type,
 	// have the alias in a position other than the first.
 	IncomingSet defs = alias->getIncomingSetByType(type, as);
 
-	// Return the first (supposedly unique) definition that has no
-	// variables in it.
+	// Return the shallowest (supposedly unique) definition that
+	// has no variables in it. We look for the shallowest, since
+	// it is the one that hides any of the deeper ones, defined
+	// in deeper atomspaces.
+	Handle shallowest;
+	int depth = INT_MAX;
 	for (const Handle& defl : defs)
 	{
-		if (defl->getOutgoingAtom(0) == alias)
+		if (defl->getOutgoingAtom(0) != alias) continue;
+		if (allow_open)
 		{
-			if (allow_open)
-			{
-				UniqueLinkPtr ulp(UniqueLinkCast(defl));
-				if (0 < ulp->get_vars().varseq.size()) continue;
-			}
-			return defl;
+			UniqueLinkPtr ulp(UniqueLinkCast(defl));
+			if (0 < ulp->get_vars().varseq.size()) continue;
+		}
+		int lvl = as->depth(defl);
+		if (0 <= lvl and lvl < depth)
+		{
+			shallowest = defl;
+			depth = lvl;
 		}
 	}
 
+	if (shallowest) return shallowest;
+
 	// There is no definition for the alias.
 	throw InvalidParamException(TRACE_INFO,
-	                            "Cannot find defined hypergraph for atom %s",
+	                            "Cannot find defintion for atom %s",
 	                            alias->to_string().c_str());
 }
 

--- a/opencog/atoms/core/UniqueLink.cc
+++ b/opencog/atoms/core/UniqueLink.cc
@@ -85,12 +85,12 @@ UniqueLink::UniqueLink(const Handle& name, const Handle& defn)
 
 /// Get the unique link for this alias.
 Handle UniqueLink::get_unique(const Handle& alias, Type type,
-                              bool allow_open)
+                              bool allow_open, AtomSpace* as)
 {
 	// Get all UniqueLinks associated with the alias. Be aware that
 	// the incoming set will also include those UniqueLinks which
 	// have the alias in a position other than the first.
-	IncomingSet defs = alias->getIncomingSetByType(type);
+	IncomingSet defs = alias->getIncomingSetByType(type, as);
 
 	// Return the first (supposedly unique) definition that has no
 	// variables in it.

--- a/opencog/atoms/core/UniqueLink.h
+++ b/opencog/atoms/core/UniqueLink.h
@@ -47,7 +47,7 @@ class UniqueLink : public FreeLink
 {
 protected:
 	void init(bool);
-	static Handle get_unique(const Handle&, Type, bool);
+	static Handle get_unique(const Handle&, Type, bool, AtomSpace*);
 
 public:
 	UniqueLink(const HandleSeq&&, Type=UNIQUE_LINK);

--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -118,6 +118,14 @@ public:
         return _atom_table.in_environ(h);
     }
 
+    /// Return the depth of the Atom, relative to this AtomSpace.
+    /// The depth is zero, if the Atom is in this space; it is one
+    /// if it is in the parent, and so on. It is -1 if it is not
+    /// in the chain.
+    int depth(const Handle& h) const {
+        return _atom_table.depth(h);
+    }
+
     /**
      * Compare atomspaces for equality. Useful during testing.
      */

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -505,11 +505,22 @@ void AtomTable::getRootSetByType(HandleSet& hset,
     std::shared_lock<std::shared_mutex> lck(_mtx);
     auto tit = typeIndex.begin(type, subclass);
     auto tend = typeIndex.end();
-    while (tit != tend) {
-        if (0 == (*tit)->getIncomingSetSize())
-             hset.insert(*tit);
-        tit++;
+
+    if (STATE_LINK == type) {
+        while (tit != tend) {
+            if (0 == (*tit)->getIncomingSetSize(cas))
+                hset.insert(
+                    StateLink::get_link(StateLinkCast(*tit)->get_alias(), cas));
+            tit++;
+        }
+    } else {
+        while (tit != tend) {
+            if (0 == (*tit)->getIncomingSetSize(cas))
+                hset.insert(*tit);
+            tit++;
+        }
     }
+
     // If an atom is already in the set, it will hide any duplicate
     // atom in the parent.
     if (parent and _environ)

--- a/opencog/atomspace/AtomTable.h
+++ b/opencog/atomspace/AtomTable.h
@@ -138,6 +138,26 @@ public:
     AtomSpace* getAtomSpace(void) const { return _as; }
 
     /**
+     * Return the depth of the Atom, relative to this AtomTable.
+     * The depth is zero, if the Atom is in this table; it is one
+     * if it is in the parent, and so on. It is -1 if it is not
+     * in the chain.
+     */
+    int depth(const Handle& atom) const
+    {
+        if (nullptr == atom) return -1;
+        AtomTable* atab = atom->getAtomTable();
+        const AtomTable* env = this;
+        int count = 0;
+        while (env) {
+            if (atab == env) return count;
+            env = env->_environ;
+            count ++;
+        }
+        return -1;
+    }
+
+    /**
      * Return true if the atom is in this atomtable, or if it is
      * in the environment of this atomtable.
      *

--- a/tests/atoms/StateLinkUTest.cxxtest
+++ b/tests/atoms/StateLinkUTest.cxxtest
@@ -50,6 +50,7 @@ public:
 	void test_putting();
 	void test_list();
 	void test_scope();
+	void test_spaces();
 };
 
 #define N _as.add_node
@@ -437,5 +438,79 @@ void StateLinkUTest::test_scope()
 	// The result of the get should be correct.
 	TS_ASSERT_EQUALS(regotten, empty_set);
 
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+// Test to make sure that there is only ever one StateLink,
+// even as child AtomSpaces are used. That is, the StateLink
+// in each child overloads the one in it's parent.
+#define N2 as2->add_node
+#define L2 as2->add_link
+#define N3 as3->add_node
+#define L3 as3->add_link
+void StateLinkUTest::test_spaces()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Empty robot gripper.
+	Handle robot = N(CONCEPT_NODE, "robot arm");
+	Handle empty = N(CONCEPT_NODE, "empty");
+
+	// Set the gripper to empty.
+	Handle rempty = L(STATE_LINK, robot, empty);
+
+	AtomSpace* as2 = new AtomSpace(&_as);
+	Handle b42 =
+		L2(EVALUATION_LINK,
+			N2(PREDICATE_NODE, "holding"),
+			N2(CONCEPT_NODE, "block 42"));
+
+	Handle r42 = L2(STATE_LINK, robot, b42);
+
+	AtomSpace* as3 = new AtomSpace(as2);
+	Handle b43 =
+		L3(EVALUATION_LINK,
+			N3(PREDICATE_NODE, "holding"),
+			N3(CONCEPT_NODE, "block 43"));
+
+	Handle r43 = L3(STATE_LINK, robot, b43);
+
+	Handle gempty = StateLink::get_link(robot, &_as);
+	TS_ASSERT_EQUALS(gempty, rempty)
+	Handle g42 = StateLink::get_link(robot, as2);
+	TS_ASSERT_EQUALS(g42, r42)
+	Handle g43 = StateLink::get_link(robot, as3);
+	TS_ASSERT_EQUALS(g43, r43)
+
+	// -----------------------
+	// Test atmospace-dependent incoming sets.
+	TS_ASSERT_EQUALS(1, robot->getIncomingSetSize(&_as));
+	TS_ASSERT_EQUALS(2, robot->getIncomingSetSize(as2));
+	TS_ASSERT_EQUALS(3, robot->getIncomingSetSize(as3));
+
+	Handle iempty = *robot->getIncomingSet(&_as).begin();
+	TS_ASSERT_EQUALS(iempty, rempty)
+
+	// -----------------------
+	Handle full = N(CONCEPT_NODE, "full");
+	Handle rfull = L(STATE_LINK, robot, full);
+
+	Handle gfull = StateLink::get_link(robot, &_as);
+	TS_ASSERT_EQUALS(gfull, rfull)
+	g42 = StateLink::get_link(robot, as2);
+	TS_ASSERT_EQUALS(g42, r42)
+	g43 = StateLink::get_link(robot, as3);
+	TS_ASSERT_EQUALS(g43, r43)
+
+	// Verify no change to atmospace-dependent incoming sets.
+	TS_ASSERT_EQUALS(1, robot->getIncomingSetSize(&_as));
+	TS_ASSERT_EQUALS(2, robot->getIncomingSetSize(as2));
+	TS_ASSERT_EQUALS(3, robot->getIncomingSetSize(as3));
+
+	Handle ifull = *robot->getIncomingSet(&_as).begin();
+	TS_ASSERT_EQUALS(ifull, rfull)
+
+	delete as3;
+	delete as2;
 	logger().info("END TEST: %s", __FUNCTION__);
 }

--- a/tests/atoms/StateLinkUTest.cxxtest
+++ b/tests/atoms/StateLinkUTest.cxxtest
@@ -238,7 +238,7 @@ void StateLinkUTest::test_putting()
 
 	Handle strawberry = N(CONCEPT_NODE, "strawberry");
 
-	Handle state = StateLink::get_state(N(ANCHOR_NODE, "fruit"));
+	Handle state = StateLink::get_state(N(ANCHOR_NODE, "fruit"), &_as);
 
 	// The incoming set should be simple.
 	TS_ASSERT_EQUALS(state, strawberry);

--- a/tests/atoms/StateLinkUTest.cxxtest
+++ b/tests/atoms/StateLinkUTest.cxxtest
@@ -475,12 +475,29 @@ void StateLinkUTest::test_spaces()
 
 	Handle r43 = L3(STATE_LINK, robot, b43);
 
+	// Verify static methods
 	Handle gempty = StateLink::get_link(robot, &_as);
 	TS_ASSERT_EQUALS(gempty, rempty)
 	Handle g42 = StateLink::get_link(robot, as2);
 	TS_ASSERT_EQUALS(g42, r42)
 	Handle g43 = StateLink::get_link(robot, as3);
 	TS_ASSERT_EQUALS(g43, r43)
+
+	// Verify AtomTable getter
+	HandleSet hset;
+	_as.get_handleset_by_type(hset, STATE_LINK);
+	Handle tempty = *hset.begin();
+	TS_ASSERT_EQUALS(tempty, rempty)
+
+	hset.clear();
+	as2->get_handleset_by_type(hset, STATE_LINK);
+	Handle t42 = *hset.begin();
+	TS_ASSERT_EQUALS(t42, r42)
+
+	hset.clear();
+	as3->get_handleset_by_type(hset, STATE_LINK);
+	Handle t43 = *hset.begin();
+	TS_ASSERT_EQUALS(t43, r43)
 
 	// -----------------------
 	// Test atmospace-dependent incoming sets.
@@ -510,6 +527,23 @@ void StateLinkUTest::test_spaces()
 	Handle ifull = *robot->getIncomingSet(&_as).begin();
 	TS_ASSERT_EQUALS(ifull, rfull)
 
+	hset.clear();
+	_as.get_handleset_by_type(hset, STATE_LINK);
+	Handle tfull = *hset.begin();
+	TS_ASSERT_EQUALS(tfull, rfull)
+
+	hset.clear();
+	as2->get_handleset_by_type(hset, STATE_LINK);
+	t42 = *hset.begin();
+	TS_ASSERT_EQUALS(t42, r42)
+
+	hset.clear();
+	as3->get_handleset_by_type(hset, STATE_LINK);
+	t43 = *hset.begin();
+	TS_ASSERT_EQUALS(t43, r43)
+
+	// ------------------------------------------------------------
+	// We are done.
 	delete as3;
 	delete as2;
 	logger().info("END TEST: %s", __FUNCTION__);

--- a/tests/query/SequenceUTest.cxxtest
+++ b/tests/query/SequenceUTest.cxxtest
@@ -316,7 +316,7 @@ void SequenceUTest::test_or_put(void)
 	// Check the state.
 	Handle not_viz = eval->eval_h("(ConceptNode \"not-vis\")");
 	Handle stateh = eval->eval_h("(AnchorNode \"state\")");
-	Handle state = StateLink::get_state(stateh, stateh->getAtomSpace());
+	Handle state = StateLink::get_state(stateh);
 	TS_ASSERT_EQUALS(state, not_viz);
 
 	// ----

--- a/tests/query/SequenceUTest.cxxtest
+++ b/tests/query/SequenceUTest.cxxtest
@@ -316,7 +316,7 @@ void SequenceUTest::test_or_put(void)
 	// Check the state.
 	Handle not_viz = eval->eval_h("(ConceptNode \"not-vis\")");
 	Handle stateh = eval->eval_h("(AnchorNode \"state\")");
-	Handle state = StateLink::get_state(stateh);
+	Handle state = StateLink::get_state(stateh, stateh->getAtomSpace());
 	TS_ASSERT_EQUALS(state, not_viz);
 
 	// ----


### PR DESCRIPTION
Per email discussion, it appears that StateLink was a bit broken in it's interaction with overlay AtomSpaces.  This is fixed in this pull req. Includes a demo, and a unit test. 