### PR TITLE
Use association lists not lists for key-value pairs

### DIFF
--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -52,6 +52,7 @@ using namespace opencog;
 scm_t_bits SchemeSmob::cog_misc_tag;
 std::atomic_flag SchemeSmob::is_inited = ATOMIC_FLAG_INIT;
 SCM SchemeSmob::_radix_ten;
+SCM SchemeSmob::_alist;
 
 void SchemeSmob::init()
 {
@@ -74,6 +75,7 @@ void SchemeSmob::init()
 	atomspace_fluid = scm_make_fluid();
 	atomspace_fluid = scm_permanent_object(atomspace_fluid);
 	_radix_ten = scm_from_int8(10);
+	_alist = scm_from_utf8_symbol("alist");
 
 	// Tell compiler to set flag dead-last, after above has executed.
 	asm volatile("": : :"memory");

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -112,6 +112,7 @@ private:
 	static SCM ss_node_p(SCM);
 	static SCM ss_link_p(SCM);
 	static SCM _radix_ten;
+	static SCM _alist;
 
 	// Return the hash value of the atom.
 	static SCM ss_handle(SCM);

--- a/opencog/guile/SchemeSmobValue.cc
+++ b/opencog/guile/SchemeSmobValue.cc
@@ -355,7 +355,7 @@ Handle SchemeSmob::set_values(const Handle& h, AtomSpace* as, SCM alist)
 		{
 			Handle key(scm_to_handle(SCM_CAR(kvp)));
 			ValuePtr pa(scm_to_protom(SCM_CDR(kvp)));
-			atom = as->set_value(atom, key, pa);
+			if (key) atom = as->set_value(atom, key, pa);
 		}
 		kvpli = SCM_CDR(kvpli);
 	}

--- a/opencog/persist/sexpr/AtomSexpr.cc
+++ b/opencog/persist/sexpr/AtomSexpr.cc
@@ -237,7 +237,7 @@ Handle Sexpr::decode_atom(const std::string& s,
 		get_next_expr(s, l2, r2, line_cnt);
 		if (l2 < r2)
 		{
-			if (s.compare(l2, 5, "(list "))
+			if (s.compare(l2, 6, "(alist "))
 				decode_slist(h, s, l2);
 			else
 				h->setTruthValue(get_stv(s, l2, r2, line_cnt));

--- a/opencog/persist/sexpr/Commands.cc
+++ b/opencog/persist/sexpr/Commands.cc
@@ -282,7 +282,7 @@ std::string Commands::interpret_command(AtomSpace* as,
 
 	// -----------------------------------------------
 	// (cog-set-values! (Concpet "foo")
-	//     (list (cons (Predicate "bar") (stv 0.9 0.8)) ...))
+	//     (alist (cons (Predicate "bar") (stv 0.9 0.8)) ...))
 	if (svals == act)
 	{
 		pos = epos + 1;

--- a/opencog/persist/sexpr/FileStorage.h
+++ b/opencog/persist/sexpr/FileStorage.h
@@ -37,7 +37,6 @@ class FileStorageNode : public StorageNode
 {
 	private:
 		FILE* _fh;
-		void connect(const char *);
 
 	public:
 		FileStorageNode(Type t, const std::string& uri);

--- a/opencog/persist/sexpr/ValueSexpr.cc
+++ b/opencog/persist/sexpr/ValueSexpr.cc
@@ -271,7 +271,7 @@ void Sexpr::decode_alist(const Handle& atom,
 /**
  * Decode a Valuation association list.
  * This list has the format
- * (list (cons KEY VALUE)(cons KEY2 VALUE2)...)
+ *    (alist (cons KEY VALUE)(cons KEY2 VALUE2)...)
  * Store the results as values on the atom.
  */
 void Sexpr::decode_slist(const Handle& atom,
@@ -281,7 +281,7 @@ void Sexpr::decode_slist(const Handle& atom,
 
 	pos = alist.find_first_not_of(" \n\t", pos);
 	if (std::string::npos == pos) return;
-	if (alist.compare(pos, 5, "(list"))
+	if (alist.compare(pos, 6, "(alist"))
 		throw SyntaxException(TRACE_INFO, "Badly formed alist: %s",
 			alist.substr(pos).c_str());
 
@@ -371,7 +371,7 @@ std::string Sexpr::encode_atom_values(const Handle& h)
 {
 	std::stringstream rv;
 
-	rv << "(list ";
+	rv << "(alist ";
 	for (const Handle& k: h->getKeys())
 	{
 		ValuePtr p = h->getValue(k);
@@ -435,7 +435,7 @@ static std::string dump_vnode(const Handle& h, const Handle& key)
 
 	ValuePtr p = h->getValue(key);
 	if (nullptr != p)
-		ss << " (list (cons " << prt_atom(key) << Sexpr::encode_value(p) << ")))";
+		ss << " (alist (cons " << prt_atom(key) << Sexpr::encode_value(p) << ")))";
 
 	return ss.str();
 }
@@ -448,7 +448,7 @@ static std::string dump_vlink(const Handle& h, const Handle& key)
 
 	ValuePtr p = h->getValue(key);
 	if (nullptr != p)
-		txt += " (list (cons " + prt_atom(key) + Sexpr::encode_value(p) + ")))";
+		txt += " (alist (cons " + prt_atom(key) + Sexpr::encode_value(p) + ")))";
 
 	return txt;
 }

--- a/opencog/scm/opencog.scm
+++ b/opencog/scm/opencog.scm
@@ -117,6 +117,9 @@ cog-value-ref
 (define-public (cog-extract-recursive ATOM)
 	"See cog-extract-recursive!" (cog-extract-recursive! ATOM))
 
+; A very special association-list ctor.
+(define-public (alist . x) (list 'alist x))
+
 ; Load core atom types.
 (include-from-path "opencog/base/core_types.scm")
 

--- a/tests/persist/sexpr/CommandsUTest.cxxtest
+++ b/tests/persist/sexpr/CommandsUTest.cxxtest
@@ -308,7 +308,7 @@ void CommandsUTest::test_set_values()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
-	std::string in = "(cog-set-values! (Concept \"a\") (list "
+	std::string in = "(cog-set-values! (Concept \"a\") (alist "
 		"(cons (Predicate \"*-TruthValueKey-*\") (stv 0.3 0.5))"
 		"(cons (Predicate \"key\") (stv 0.6 0.8))"
 		"(cons (Predicate \"fiz\") (FloatValue 1 2 3))"

--- a/tests/scm/inline-values.scm
+++ b/tests/scm/inline-values.scm
@@ -10,7 +10,7 @@
 (test-begin tname)
 
 ; Specify an in-line key-value pair.
-(Number 42 43 44 (list (cons (Predicate "p") (FloatValue 1 2 3))))
+(Number 42 43 44 (alist (cons (Predicate "p") (FloatValue 1 2 3))))
 
 ; Verify that it got recorded.
 (define nu (Number 42 43 44))
@@ -21,7 +21,7 @@
 ; ----------
 ; Do it again.  Note that Numbers above and Concepts follow
 ; a different code path.
-(Concept "a" (list (cons (Predicate "p") (FloatValue 1 2 3))))
+(Concept "a" (alist (cons (Predicate "p") (FloatValue 1 2 3))))
 
 (define ca (Concept "a"))
 
@@ -30,7 +30,7 @@
 	(equal? (cog-value ca (Predicate "p")) (FloatValue 1 2 3)))
 
 ; Add another, and modify.
-(Concept "a" (list
+(Concept "a" (alist
 	(cons (Predicate "p") (FloatValue 11 22 33))
 	(cons (Predicate "q") (StringValue "p" "q" "r"))))
 
@@ -44,15 +44,15 @@
 ; Like above, but for links.
 ;
 (Link (Concept "foo") (Concept "bar")
-	(list
+	(alist
 		(cons (Predicate "num") (FloatValue 4 5 6))
 		(cons (Predicate "str") (StringValue "x" "y" "z"))))
 
 (define rli (Link (Concept "foo") (Concept "bar")))
-;;;(test-assert "List Keys" (equal? 2 (length (cog-keys rli))))
-;;;(test-assert "List Num"
-;;;	(equal? (cog-value rli (Predicate "num")) (FloatValue 4 5 6)))
-;;;(test-assert "List Str"
-;;;	(equal? (cog-value rli (Predicate "str")) (StringValue "x" "y" "z")))
+(test-assert "List Keys" (equal? 2 (length (cog-keys rli))))
+(test-assert "List Num"
+	(equal? (cog-value rli (Predicate "num")) (FloatValue 4 5 6)))
+(test-assert "List Str"
+	(equal? (cog-value rli (Predicate "str")) (StringValue "x" "y" "z")))
 
 (test-end tname)


### PR DESCRIPTION
This refactors the code in #2839 to use an explicit association-list
type for storing key-value pairs. It's a more robust design.