### PR TITLE
Use iterators as input for content_contains instead of HandleSeq

### DIFF
--- a/opencog/atoms/core/Context.cc
+++ b/opencog/atoms/core/Context.cc
@@ -81,7 +81,7 @@ bool Context::is_free_variable(const Handle& h) const
 	Type t = h->get_type();
 	return (t == VARIABLE_NODE or t == GLOB_NODE)
 		and quotation.is_unquoted()
-		and not contains(shadow, h);
+		and not content_contains(HandleSeq(shadow.begin(), shadow.end()), h);
 }
 
 bool Context::operator==(const Context& other) const


### PR DESCRIPTION
A `vector` is passed to `content_contains` in [FreeVariables.cc](https://github.com/opencog/atomspace/blob/5871e38ec680040a1e48a3c5a33af5408bcd1076/opencog/atoms/core/FreeVariables.cc#L226) and a `set` is passed in [Context.cc](https://github.com/opencog/atomspace/blob/5871e38ec680040a1e48a3c5a33af5408bcd1076/opencog/atoms/core/Context.cc#L84). Hence, it's better to use an `InputIterator` as an argument for it to generally work for containers.