### PR TITLE
Make it easier to manage deleted matrix entries

### DIFF
--- a/opencog/matrix/object-api.scm
+++ b/opencog/matrix/object-api.scm
@@ -318,8 +318,8 @@
   'filters - Used in filtering out certain rows, columns or individual
       entries.
 "
-	(let ((l-basis '())
-			(r-basis '())
+	(let ((l-basis #f)
+			(r-basis #f)
 			(l-size 0)
 			(r-size 0)
 
@@ -369,11 +369,11 @@
 		; items x from the pair (x,y) for any y.
 		;
 		(define (get-left-basis)
-			(if (null? l-basis) (set! l-basis (do-get-basis #t)))
+			(if (not l-basis) (set! l-basis (do-get-basis #t)))
 			l-basis)
 
 		(define (get-right-basis)
-			(if (null? r-basis) (set! r-basis (do-get-basis #f)))
+			(if (not r-basis) (set! r-basis (do-get-basis #f)))
 			r-basis)
 
 		(define (get-left-size)
@@ -513,6 +513,12 @@
 			(atomic-box-set! dual-l-miss '())
 			(atomic-box-set! dual-r-hit '())
 			(atomic-box-set! dual-r-miss '())
+
+			; The basis may have changed, too.
+			(set! l-basis #f)
+			(set! r-basis #f)
+			(set! l-basis-size 0)
+			(set! r-basis-size 0)
 
 			; Pass it on to the LLOBJ, too.
 			(if (LLOBJ 'provides 'clobber) (LLOBJ 'clobber))

--- a/opencog/matrix/support.scm
+++ b/opencog/matrix/support.scm
@@ -212,7 +212,7 @@
 		(cog-tv-count (cog-tv (LLOBJ 'wild-wild))))
 
 	;-------------------------------------------
-	; Force data to be recomputed, but clobbering any
+	; Force data to be recomputed, by clobbering any
 	; existing data.
 	(define (clobber)
 		(for-each (lambda (ATOM)
@@ -357,13 +357,13 @@
   be more convenient, if the right-marginal sums are not available
   (and v.v. if the other marginals are not available.)
 
-  The 'set-left-marginals ITEM requires an argument ITEM from the
-  right basis. It computes the marginals for that ITEM and caches
+  The 'set-left-marginals COL requires an argument COL from the
+  right basis. It computes the marginals for that COL and caches
   them.  This is useful when some algorithm has modified the matrix,
   and the marginals for a specific column need to be recomputed.
 
-  The 'set-right-marginals ITEM requires an argument ITEM from the
-  left basis. It computes the marginals for that ITEM and caches them.
+  The 'set-right-marginals ROW requires an argument ROW from the
+  left basis. It computes the marginals for that ROW and caches them.
   This is useful when some algorithm has modified the matrix, and the
   marginals for a specific row need to be recomputed.
 
@@ -563,21 +563,21 @@
 		(define (sum-right-norms ITEM)
 			(sum-norms (star-obj 'right-stars ITEM)))
 
-		(define (set-left-marginals ITEM)
-			(define sums (sum-left-norms ITEM))
+		(define (set-left-marginals COL)
+			(define sums (sum-left-norms COL))
 			(define l0 (first sums))
 			(define l1 (second sums))
 			(define l2 (sqrt (third sums)))
 			(define lq (* (fourth sums) (fourth sums)))
-			(api-obj 'set-left-norms ITEM l0 l1 l2 lq))
+			(api-obj 'set-left-norms COL l0 l1 l2 lq))
 
-		(define (set-right-marginals ITEM)
-			(define sums (sum-right-norms ITEM))
+		(define (set-right-marginals ROW)
+			(define sums (sum-right-norms ROW))
 			(define l0 (first sums))
 			(define l1 (second sums))
 			(define l2 (sqrt (third sums)))
 			(define lq (* (fourth sums) (fourth sums)))
-			(api-obj 'set-right-norms ITEM l0 l1 l2 lq))
+			(api-obj 'set-right-norms ROW l0 l1 l2 lq))
 
 		; ----------------------------------------------------
 


### PR DESCRIPTION
Deleting matrix entries requires recalculating subtotals. Make that simpler.