### PR TITLE
Add new object for trimming down the size of the AtomSpace

### DIFF
--- a/opencog/matrix/CMakeLists.txt
+++ b/opencog/matrix/CMakeLists.txt
@@ -20,5 +20,6 @@ ADD_GUILE_MODULE (FILES
 	thresh-pca.scm
 	transpose.scm
 	trans-batch.scm
+	trim.scm
 	MODULE_DESTINATION "${GUILE_SITE_DIR}/opencog/matrix"
 )

--- a/opencog/matrix/README.md
+++ b/opencog/matrix/README.md
@@ -156,6 +156,8 @@ The tools implemented here include:
  * Concatenating dissimilar matrices.
  * Performing PCA (principal component analysis) in the matrix.
  * Performing cuts, to remove unwanted rows, columns and individual entries.
+   This includes both filtering (to hide those entries) and removing
+   (deleting) them from the AtomSpace.
 
 To use these tools, all you need to do is to specify a low-level
 object that describes the matrix. If the matrix is in the form of an
@@ -192,12 +194,12 @@ FAQ
 **Q:** Really, C++ is sooo fast...
 
 **A:** Yes, but since the data is stored in Values associated with
-   Atoms in the AtomSpace, adding numbers together is NOT the
-   bottleneck. Accessing Atom Values *is* the bottleneck. For this case,
-   the overhead of using scheme, compared to C++, is not outrageous.
+   Atoms in the AtomSpace, adding numbers together is NOT the bottleneck.
+   Accessing Atom Values *is* the bottleneck. For this case, the overhead
+   of using scheme, compared to C++, is not outrageous.
 
-**Q:** Why don't you just export all your data to SciPy or to Gnu R, or to
-   Octave, or MatLab, for that matter, and just do your data analytics
+**Q:** Why don't you just export all your data to SciPy or to Gnu R, or
+   to Octave, or MatLab, for that matter, and just do your data analytics
    there?  That way, you don't need to re-implement all these basic
    statistical algorithms!
 
@@ -220,15 +222,16 @@ FAQ
    to work with different cuts and filters, where you discard much of
    the data, or average together different parts: can you really afford
    the RAM needed to export all of these different cut and filtered
-   datasets?  Maybe you can, its just not trivial. (In my datasets,
-   petabytes of RAM would be needed for non-sparse representations.)
+   datasets?  Maybe you can; its just not trivial. (In my datasets,
+   petabytes of RAM would be needed for non-sparse representations.
+   The AtomSpace is all about sparse representations of data.)
 
 **Q:** But if I did want to do it for Gnu R, how could I do it?
 
 **A:** You would use Rcpp at http://dirk.eddelbuettel.com/code/rcpp.html
    Quote:
    *The Rcpp package provides C++ classes that greatly facilitate
-   interfacing C or C++ code in R packages using the .Call() interface
+   interfacing C or C++ code in R packages using the `.Call()` interface
    provided by R. Rcpp provides matching C++ classes for a large
    number of basic R data types. Hence, a package author can keep his
    data in normal R data structures without having to worry about
@@ -488,12 +491,20 @@ a filter that masks out rows, columns and entries that have counts
 below a threshold.  Another filter can mask out explicitly-named rows
 and columns.
 
+Unfortunately, filtering can be slow, and loading a large matrix only
+to access small subsets of it is wasteful of RAM, and can add CPU
+overhead.  Thus, a similar set of interfaces is provided in `trim.scm`,
+which will remove (delete) rows, columns and matrix entries from both
+the AtomSpace, and from attached storage. With appopropriate trimming,
+noisy datasets can be reduced in size by factors of two, ten or a
+hundred. This can have a huge impact on processing.
+
 
 Tensors, in general
 -------------------
 Suppose you have more than just pairs. Suppose you have triples that
 you want to work with. Then what?  Answer: use the network analysis
-tools in the (opencog network) module.
+tools in the `(opencog network)` module.
 
 
 TODO

--- a/opencog/matrix/matrix.scm
+++ b/opencog/matrix/matrix.scm
@@ -51,6 +51,7 @@
 (include-from-path "opencog/matrix/compute-mi.scm")
 (include-from-path "opencog/matrix/trans-batch.scm")
 (include-from-path "opencog/matrix/filter.scm")
+(include-from-path "opencog/matrix/trim.scm")
 (include-from-path "opencog/matrix/similarity-api.scm")
 (include-from-path "opencog/matrix/direct-sum.scm")
 (include-from-path "opencog/matrix/thresh-pca.scm")

--- a/opencog/matrix/object-api.scm
+++ b/opencog/matrix/object-api.scm
@@ -517,8 +517,8 @@
 			; The basis may have changed, too.
 			(set! l-basis #f)
 			(set! r-basis #f)
-			(set! l-basis-size 0)
-			(set! r-basis-size 0)
+			(set! l-size 0)
+			(set! r-size 0)
 
 			; Pass it on to the LLOBJ, too.
 			(if (LLOBJ 'provides 'clobber) (LLOBJ 'clobber))

--- a/opencog/matrix/trim.scm
+++ b/opencog/matrix/trim.scm
@@ -22,23 +22,30 @@
 
   LLOBJ should be an object with the conventional matrix methods on it.
 
-"
-	LEFT-BASIS-PRED RIGHT-BASIS-PRED PAIR-PRED)
-  trim-matrix LLOBJ LEFT-BASIS-PRED RIGHT-BASIS-PRED ELEMENT-PRED
-  Remove (delete) Atoms from the AtomSpace that pass the predicates.
-  If storage is connected, then these are removed from storage too.
+  The methods on this object provide functions that resemble those of
+  the `add-generic-filter`, `add-subtotal-filter`, and
+  `add-zero-filter`, except that this object simply deletes those atoms,
+  instead of filtering them out of the object API. By using the trimmer,
+  the total size of the dataset will in general be smaller, and the
+  access to the matrix entries will be faster.  This is the primary
+  advantage of using the trimmer over use the filters.
 
-  LLOBJ should be an object with the conventional matrix methods on it.
+  The provided methods are:
 
-  LEFT-BASIS-PRED should be a function taking a ROW as an argument; it
-      should return #t if that row is to be deleted, else it returns #f.
+  'generic-trim LEFT-BASIS-PRED RIGHT-BASIS-PRED ELEMENT-PRED
+      Remove (delete) Atoms from the AtomSpace that pass the predicates.
+      If storage is connected, then these are removed from storage too.
 
-  RIGHT-BASIS-PRED should be a function taking a COL as an argument; it
-      should return #t if that column is to be deleted, else it returns #f.
+      LEFT-BASIS-PRED should be a function taking a ROW as an argument;
+      it should return #t if that row is to be deleted, else it returns #f.
 
-  ELEMENT-PRED should be a function taking a matrix element as an
+      RIGHT-BASIS-PRED should be a function taking a COL as an argument;
+      it should return #t if that column is to be deleted, else it
+      returns #f.
+
+      ELEMENT-PRED should be a function taking a matrix element as an
       argument; it should return #t if that matrix element should be
-      deleted, else should returns #f.
+      deleted, else it should return #f.
 "
 	(define star-obj (add-pair-stars LLOBJ))
 
@@ -120,6 +127,8 @@
 	; Methods on this class.
 	(lambda (message . args)
 		(case message
+			((generic-trim)     (apply trim-generic args))
+
 			((help)             (help))
 			((describe)         (describe))
 			((obj)              "add-trimmer")

--- a/opencog/matrix/trim.scm
+++ b/opencog/matrix/trim.scm
@@ -2,10 +2,7 @@
 ; trim.scm
 ;
 ; Like filter.scm, but removes Atoms outright from the AtomSpace.
-; The goal is to be a bit more CPU and storage efficient.
-;
-; XXX TODO
-; -- finish writing documentation
+; The goal is to be more CPU and storage efficient.
 ;
 ; ---------------------------------------------------------------------
 

--- a/opencog/matrix/trim.scm
+++ b/opencog/matrix/trim.scm
@@ -137,7 +137,7 @@
 	; ------------------------------------------------------------
 
 	(define (subtotal-trim LEFT-CUT RIGHT-CUT PAIR-CUT)
-		(define sup-obj (add-support-api stars-obj))
+		(define sup-obj (add-support-api star-obj))
 
 		; Remove rows and columns that are below-count.
 		;
@@ -159,7 +159,7 @@
 	; ------------------------------------------------------------
 
 	(define (support-trim LEFT-CUT RIGHT-CUT PAIR-CUT)
-		(define sup-obj (add-support-api stars-obj))
+		(define sup-obj (add-support-api star-obj))
 
 		; Remove rows and columns that are below-count.
 		;

--- a/opencog/matrix/trim.scm
+++ b/opencog/matrix/trim.scm
@@ -1,0 +1,172 @@
+;
+; trim.scm
+;
+; Like filter.scm, but removes Atoms outright from the AtomSpace.
+; The goal is to be a bit more CPU and storage efficient.
+;
+; XXX TODO
+; -- finish writing documentation
+; -- move to the (opencog matrix) module
+;
+; ---------------------------------------------------------------------
+
+(use-modules (srfi srfi-1))
+
+; ---------------------------------------------------------------------
+
+(define (make-elapsed-secs)
+   (define start-time (current-time))
+   (lambda ()
+      (define now (current-time))
+      (define diff (- now start-time))
+      (set! start-time now)
+      diff)
+)
+
+; ---------------------------------------------------------------------
+
+(define-public (trim-matrix LLOBJ
+	LEFT-BASIS-PRED RIGHT-BASIS-PRED PAIR-PRED)
+"
+  trim-matrix LLOBJ LEFT-BASIS-PRED RIGHT-BASIS-PRED ELEMENT-PRED
+  Remove (delete) Atoms from the AtomSpace that pass the predicates.
+  If storage is connected, then these are removed from storage too.
+
+  LLOBJ should be an object with the conventional matrix methods on it.
+
+  LEFT-BASIS-PRED should be a function taking a ROW as an argument; it
+      should return #t if that row is to be deleted, else it returns #f.
+
+  RIGHT-BASIS-PRED should be a function taking a COL as an argument; it
+      should return #t if that column is to be deleted, else it returns #f.
+
+  ELEMENT-PRED should be a function taking a matrix element as an
+      argument; it should return #t if that matrix element should be
+      deleted, else should returns #f.
+"
+	(define star-obj (add-pair-stars LLOBJ))
+	(define elapsed-secs (make-elapsed-secs))
+
+	; After removing pairs, it may now happen that there are left
+	; and right basis elements that are no longer in any pairs.
+	; Remove these too.
+	(define (trim-type BASIS-LIST)
+		(define party (star-obj 'pair-type))
+		(for-each
+			(lambda (base)
+				(if (and (cog-atom? base)
+						(equal? 0 (cog-incoming-size-by-type base party)))
+					(cog-delete! base)))
+			BASIS-LIST))
+
+	; Walk over the left and right basis.
+	; The use of cog-delete-recursive! may knock out other
+	; elements in the matrix, and so `cog-atom?` is used
+	; to see if that particular entry still exists.
+	(for-each
+		(lambda (base)
+			(if (and (cog-atom? base) (not (LEFT-BASIS-PRED base)))
+				(cog-delete-recursive! base)))
+		(star-obj 'left-basis))
+
+	(format #t "Trimmed left basis in ~A seconds.\n" (elapsed-secs))
+
+	(for-each
+		(lambda (base)
+			(if (and (cog-atom? base) (not (RIGHT-BASIS-PRED base)))
+				(cog-delete-recursive! base)))
+		(star-obj 'right-basis))
+
+	(format #t "Trimmed right basis in ~A seconds.\n" (elapsed-secs))
+
+	; Walk over the list of all entries and just delete them.
+	(for-each
+		(lambda (atom)
+			(if (and (cog-atom? atom) (not (PAIR-PRED atom)))
+				(cog-delete-recursive! atom)))
+		(star-obj 'get-all-elts))
+
+	; After removing pairs, it may now happen that there are left
+	; and right basis elements that are no longer in any pairs.
+	; Remove these too.
+	(trim-type (star-obj 'left-basis))
+	(trim-type (star-obj 'right-basis))
+
+	; Trimming has commited violence to the matrix. Let it know.
+	(if (LLOBJ 'provides 'clobber) (LLOBJ 'clobber))
+
+	(format #t "Trimmed all pairs in ~A seconds.\n" (elapsed-secs))
+)
+
+
+(define-public (subtotal-trim LLOBJ LEFT-CUT RIGHT-CUT PAIR-CUT)
+"
+  subtotal-trim LLOBJ LEFT-CUT RIGHT-CUT PAIR-CUT
+  Remove (delete) Atoms from the AtomSpace whose counts are at or below
+  the indicated cutoffs. If storage is connected, then these are removed
+  from storage too.
+
+  This function will fail to work correctly, if support marginals have
+  not been computed on LLOBJ. That is because the support marginals are
+  used to obtain subtotal counts for rows and columns.  To compute
+  support marginals, say `((add-support-compute LLOBJ) 'cache-all)`
+
+  LLOBJ should be an object with the conventional matrix methods on it.
+
+  LEFT-CUT should be a number; if the count on that row is equal or less
+      than this number, then the entire row (including marginals) will
+      be deleted.
+"
+	(define stars-obj (add-pair-stars LLOBJ))
+	(define sup-obj (add-support-api stars-obj))
+
+	; ---------------
+	; Remove rows and columns that are below-count.
+	;
+	; Yes, we want LEFT-CUT < right-wild-count this looks weird,
+	; but is correct: as LEFT-CUT gets larger, the size of the
+	; left-basis shrinks.
+	(define (left-basis-pred ITEM)
+		(< LEFT-CUT (sup-obj 'right-count ITEM)))
+
+	(define (right-basis-pred ITEM)
+		(< RIGHT-CUT (sup-obj 'left-count ITEM)))
+
+	(define (pair-pred PAIR)
+		(< PAIR-CUT (LLOBJ 'get-count PAIR)))
+
+	; ---------------
+	(trim-matrix stars-obj
+		left-basis-pred right-basis-pred pair-pred)
+)
+
+
+(define-public (support-trim LLOBJ LEFT-CUT RIGHT-CUT PAIR-CUT)
+"
+  support-trim LLOBJ LEFT-CUT RIGHT-CUT PAIR-CUT
+
+  Almost exactly identical to subtotal-trim, except that the cuts apply
+  to the size of the support, rather than to the count.
+"
+	(define stars-obj (add-pair-stars LLOBJ))
+	(define sup-obj (add-support-api stars-obj))
+
+	; ---------------
+	; Remove rows and columns that are below-count.
+	;
+	; Yes, we want LEFT-CUT < right-support this looks weird,
+	; but is correct: as LEFT-CUT gets larger, the size of the
+	; left-basis shrinks.
+	(define (left-basis-pred ITEM)
+		(< LEFT-CUT (sup-obj 'right-support ITEM)))
+
+	(define (right-basis-pred ITEM)
+		(< RIGHT-CUT (sup-obj 'left-support ITEM)))
+
+	(define (pair-pred PAIR)
+		(< PAIR-CUT (LLOBJ 'get-count PAIR)))
+
+	; ---------------
+	(trim-matrix stars-obj
+		left-basis-pred right-basis-pred pair-pred)
+)

--- a/opencog/matrix/trim.scm
+++ b/opencog/matrix/trim.scm
@@ -156,7 +156,7 @@
 		(define (pair-pred PAIR)
 			(< PAIR-CUT (LLOBJ 'get-count PAIR)))
 
-		(trim-generic supp-obj left-basis-pred right-basis-pred pair-pred)
+		(trim-generic sup-obj left-basis-pred right-basis-pred pair-pred)
 	)
 
 	; ------------------------------------------------------------
@@ -178,7 +178,7 @@
 		(define (pair-pred PAIR)
 			(< PAIR-CUT (LLOBJ 'get-count PAIR)))
 
-		(trim-generic supp-obj left-basis-pred right-basis-pred pair-pred)
+		(trim-generic sup-obj left-basis-pred right-basis-pred pair-pred)
 	)
 
 	; -------------


### PR DESCRIPTION
My datasets are getting way too large and too unwieldy. The trimmer object is great at removing unwanted Atoms from the AtomSpace.