### PR TITLE
Add debug printing

### DIFF
--- a/opencog/atoms/pattern/MeetLink.cc
+++ b/opencog/atoms/pattern/MeetLink.cc
@@ -51,10 +51,22 @@ QueueValuePtr MeetLink::do_execute(AtomSpace* as, bool silent)
 {
 	if (nullptr == as) as = _atom_space;
 
-	SatisfyingSet sater(as);
-	sater.satisfy(PatternLinkCast(get_handle()));
-
-	return sater.get_result_queue();
+	try
+	{
+		SatisfyingSet sater(as);
+		sater.satisfy(PatternLinkCast(get_handle()));
+		return sater.get_result_queue();
+	}
+	catch(const StandardException& ex)
+	{
+		std::string msg =
+			"Exception during pattern execution! Patterns was\n";
+		msg += to_string();
+		msg += "\nException was:\n";
+		msg += ex.get_message();
+		ex.set_message(msg.c_str());
+		throw;
+	}
 }
 
 ValuePtr MeetLink::execute(AtomSpace* as, bool silent)

--- a/opencog/atoms/pattern/QueryLink.cc
+++ b/opencog/atoms/pattern/QueryLink.cc
@@ -169,7 +169,21 @@ QueueValuePtr QueryLink::do_execute(AtomSpace* as, bool silent)
 
 	Implicator impl(as);
 	impl.implicand = this->get_implicand();
-	impl.satisfy(PatternLinkCast(get_handle()));
+
+	try
+	{
+		impl.satisfy(PatternLinkCast(get_handle()));
+	}
+	catch(const StandardException& ex)
+	{
+		std::string msg =
+			"Exception during pattern execution! Patterns was\n";
+		msg += to_string();
+		msg += "\nException was:\n";
+		msg += ex.get_message();
+		ex.set_message(msg.c_str());
+		throw;
+	}
 
 	// If we got a non-empty answer, just return it.
 	QueueValuePtr qv(impl.get_result_queue());

--- a/opencog/guile/SchemeEval.cc
+++ b/opencog/guile/SchemeEval.cc
@@ -1129,7 +1129,7 @@ ValuePtr SchemeEval::apply_v(const std::string &func, Handle varargs)
 	_hargs = nullptr;
 
 	if (eval_error())
-		throw RuntimeException(TRACE_INFO, "Unable to apply %s to\n%s\n%s",
+		throw RuntimeException(TRACE_INFO, "Unable to apply `%s` to\n%s\n%s",
 			func.c_str(), varargs->to_string().c_str(), _error_msg.c_str());
 
 	// We do not want this->_retval to point at anything after we return.


### PR DESCRIPTION
This modifies exceptions to change the error message to be more informative.

This requires the latest version of `cogutil`, as otherwise, it won't compile. Seems that `cogutil` did not anticipate this use.