### PR TITLE
Provide better fix for determining when dummies are needed

### DIFF
--- a/opencog/atoms/pattern/PatternLink.h
+++ b/opencog/atoms/pattern/PatternLink.h
@@ -133,8 +133,9 @@ protected:
 
 	void locate_cacheable(const PatternTermSeq& clauses);
 
-	void add_dummies(const PatternTermPtr&);
+	bool need_dummies(const PatternTermPtr&);
 	bool add_unaries(const PatternTermPtr&);
+	void add_dummies(const PatternTermPtr&);
 
 	void make_connectivity_map(void);
 	void make_map_recursive(const Handle&, const PatternTermPtr&);


### PR DESCRIPTION
All variables must appear somewhere, in order for the pattern engine to find them. This provides a better check for that.