### PR TITLE
Final batch of OrLink fixes.

### DIFF
--- a/opencog/atoms/core/StateLink.cc
+++ b/opencog/atoms/core/StateLink.cc
@@ -68,6 +68,14 @@ Handle StateLink::get_link(const Handle& alias, const AtomSpace* as)
 	return get_unique(alias, STATE_LINK, true, as);
 }
 
+/// Return this if not found.
+Handle StateLink::get_link(const AtomSpace* as)
+{
+	Handle shallowest(get_unique_nt(_outgoing[0], STATE_LINK, true, as));
+	if (shallowest) return shallowest;
+	return get_handle();
+}
+
 void StateLink::install()
 {
 	// If the handlset is closed (no free variables), then

--- a/opencog/atoms/core/StateLink.h
+++ b/opencog/atoms/core/StateLink.h
@@ -92,6 +92,14 @@ public:
 	 */
 	static Handle get_link(const Handle& alias, const AtomSpace*);
 
+	/**
+	 * Non-static version of the above. Uses `this->get_alias()`
+	 * and then tries to find the appropriate closed link.
+	 * Unlike the above, it won't throw, if not found. Instead,
+	 * it will just return `this`.
+	 */
+	Handle get_link(const AtomSpace*);
+
 	static Handle factory(const Handle&);
 };
 

--- a/opencog/atoms/core/UniqueLink.cc
+++ b/opencog/atoms/core/UniqueLink.cc
@@ -84,8 +84,8 @@ UniqueLink::UniqueLink(const Handle& name, const Handle& defn)
 }
 
 /// Get the unique link for this alias.
-Handle UniqueLink::get_unique(const Handle& alias, Type type,
-                              bool allow_open, const AtomSpace* as)
+Handle UniqueLink::get_unique_nt(const Handle& alias, Type type,
+                                 bool disallow_open, const AtomSpace* as)
 {
 	// Get all UniqueLinks associated with the alias. Be aware that
 	// the incoming set will also include those UniqueLinks which
@@ -101,7 +101,7 @@ Handle UniqueLink::get_unique(const Handle& alias, Type type,
 	for (const Handle& defl : defs)
 	{
 		if (defl->getOutgoingAtom(0) != alias) continue;
-		if (allow_open)
+		if (disallow_open)
 		{
 			UniqueLinkPtr ulp(UniqueLinkCast(defl));
 			if (0 < ulp->get_vars().varseq.size()) continue;
@@ -113,6 +113,13 @@ Handle UniqueLink::get_unique(const Handle& alias, Type type,
 			depth = lvl;
 		}
 	}
+	return shallowest;
+}
+
+Handle UniqueLink::get_unique(const Handle& alias, Type type,
+                              bool allow_open, const AtomSpace* as)
+{
+	Handle shallowest(get_unique_nt(alias, type, allow_open, as));
 
 	if (shallowest) return shallowest;
 

--- a/opencog/atoms/core/UniqueLink.h
+++ b/opencog/atoms/core/UniqueLink.h
@@ -47,6 +47,7 @@ class UniqueLink : public FreeLink
 {
 protected:
 	void init(bool);
+	static Handle get_unique_nt(const Handle&, Type, bool, const AtomSpace*);
 	static Handle get_unique(const Handle&, Type, bool, const AtomSpace*);
 
 public:

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -201,11 +201,16 @@ void PatternLink::init(void)
 		      to_short_string().c_str());
 	}
 
-	// A body that is an OrLink must be treated as a collection of
+	// A body that is a ChoiceLink must be treated as a collection of
 	// distinct, unrelated searches; the result is a union of the
-	// results of the parts.
+	// results of the parts. Because must users have trouble
+	// distinguishing between menu-choice and logical-or, we will
+	// allow OrLink at the top level, as well. Both of these result
+	// in the SetUnion of the search results. Of course, this only
+	// needs to be worried about, if there is more than one term in
+	// the body.  Otherwise, its a no-op.
 	Type t = _body->get_type();
-	if (OR_LINK == t)
+	if ((CHOICE_LINK == t or OR_LINK == t) and 1 < _body->get_arity())
 	{
 		disjointed_init();
 		return;

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -523,8 +523,7 @@ void AtomSpace::get_handles_by_type(HandleSeq& hseq,
     // UNIQUE_LINK.
     if (STATE_LINK == type) {
         while (tit != tend) {
-            hseq.push_back(
-                StateLink::get_link(UniqueLinkCast(*tit)->get_alias(), cas));
+            hseq.push_back(StateLinkCast(*tit)->get_link(cas));
             tit++;
         }
     } else if (DEFINE_LINK == type) {

--- a/opencog/query/SatisfyMixin.cc
+++ b/opencog/query/SatisfyMixin.cc
@@ -438,7 +438,8 @@ bool SatisfyMixin::satisfy(const PatternLinkPtr& form)
 	}
 #endif
 
-	bool have_orlink = (OR_LINK == pat.body->get_type());
+	Type patty = pat.body->get_type();
+	bool have_orlink = (OR_LINK == patty) or (CHOICE_LINK == patty);
 	GroundingMapSeqSeq comp_term_gnds;
 	GroundingMapSeqSeq comp_var_gnds;
 	const HandleSeq& comp_patterns = jit->get_component_patterns();

--- a/tests/query/CMakeLists.txt
+++ b/tests/query/CMakeLists.txt
@@ -111,6 +111,7 @@ IF (HAVE_GUILE)
 	ADD_GUILE_TEST(MeetLinkValueTest meet-link-value-test.scm)
 	ADD_GUILE_TEST(MultiSpaceQueryTest multi-space-test.scm)
 	ADD_GUILE_TEST(OrLinkTest or-link-test.scm)
+	ADD_GUILE_TEST(OrMoreTest or-more-test.scm)
 	ADD_GUILE_TEST(RecursiveTest recursive-test.scm)
 
 ENDIF (HAVE_GUILE)

--- a/tests/query/or-link-test.scm
+++ b/tests/query/or-link-test.scm
@@ -6,7 +6,7 @@
 (use-modules (opencog test-runner))
 
 (opencog-test-runner)
-(define tname "or-link-space-test")
+(define tname "or-link-test")
 (test-begin tname)
 
 ; Initial data. Note the (stv 1 1) is necessary, because the IsTrueLink

--- a/tests/query/or-more-test.scm
+++ b/tests/query/or-more-test.scm
@@ -1,0 +1,64 @@
+;
+; or-more-test.scm -- Verify more variations involving the OrLink.
+; Reflects the discussion in issue opencog/atomspace#2644
+
+(use-modules (opencog) (opencog exec))
+(use-modules (opencog test-runner))
+
+(opencog-test-runner)
+(define tname "or-more-test")
+(test-begin tname)
+
+; Some simple one or two clause choices.
+(State (List (Concept "alice") (Predicate "hungry")) (Concept "TRUE"))
+(State (Concept "alice") (Concept "at home"))
+
+(define who-is-hungry-1?
+	(Get
+		(VariableList
+			(TypedVariable (Variable "x") (Type "ConceptNode"))
+			(TypedVariable (Variable "y") (Type "ConceptNode")))
+		(Present
+			(State (Variable "x") (Variable "y"))
+			(State (List (Variable "x") (Predicate "hungry")) (Concept "TRUE"))
+		)))
+
+(test-assert "alice at home"
+	(equal? (cog-execute! who-is-hungry-1?)
+		(Set (List (Concept "alice") (Concept "at home")))))
+
+; -----------------
+(define who-is-hungry-2?
+	(Get
+		(VariableList
+			(TypedVariable (Variable "x") (Type "ConceptNode"))
+			(TypedVariable (Variable "y") (Type "ConceptNode")))
+		(Or
+			(Present (State (Variable "x") (Variable "y")))
+			(Present (State (List (Variable "x") (Predicate "hungry")) (Concept "TRUE")))
+			)))
+
+(test-assert "alice y at home"
+	(equal? (cog-execute! who-is-hungry-2?)
+		(Set
+			(List (Concept "alice") (Concept "at home"))
+			(List (Concept "alice") (Variable "y")))))
+
+; -----------------
+(define who-is-hungry-3?
+	(Get
+		(VariableList
+			(TypedVariable (Variable "x") (Type "ConceptNode"))
+			(TypedVariable (Variable "y") (Type "ConceptNode")))
+		(Choice
+			(Present (State (Variable "x") (Variable "y")))
+			(Present (State (List (Variable "x") (Predicate "hungry")) (Concept "TRUE")))
+			)))
+
+(test-assert "alice why at home"
+	(equal? (cog-execute! who-is-hungry-3?)
+		(Set
+			(List (Concept "alice") (Concept "at home"))
+			(List (Concept "alice") (Variable "y")))))
+
+(test-end tname)

--- a/tests/query/or-more-test.scm
+++ b/tests/query/or-more-test.scm
@@ -16,8 +16,8 @@
 (define who-is-hungry-1?
 	(Get
 		(VariableList
-			(TypedVariable (Variable "x") (Type "ConceptNode"))
-			(TypedVariable (Variable "y") (Type "ConceptNode")))
+			(TypedVariable (Variable "x") (Type 'Concept))
+			(TypedVariable (Variable "y") (Type 'Concept)))
 		(Present
 			(State (Variable "x") (Variable "y"))
 			(State (List (Variable "x") (Predicate "hungry")) (Concept "TRUE"))
@@ -31,13 +31,16 @@
 (define who-is-hungry-2?
 	(Get
 		(VariableList
-			(TypedVariable (Variable "x") (Type "ConceptNode"))
-			(TypedVariable (Variable "y") (Type "ConceptNode")))
+			(TypedVariable (Variable "x") (Type 'Concept))
+			(TypedVariable (Variable "y") (Type 'Concept)))
 		(Or
 			(Present (State (Variable "x") (Variable "y")))
 			(Present (State (List (Variable "x") (Predicate "hungry")) (Concept "TRUE")))
 			)))
 
+; Well, look, the naked Variable y appearing in the search results
+; is sinfully ugly, but its associated with a clause that never actually
+; grounds y. C'est la vie.
 (test-assert "alice y at home"
 	(equal? (cog-execute! who-is-hungry-2?)
 		(Set
@@ -48,17 +51,60 @@
 (define who-is-hungry-3?
 	(Get
 		(VariableList
-			(TypedVariable (Variable "x") (Type "ConceptNode"))
-			(TypedVariable (Variable "y") (Type "ConceptNode")))
+			(TypedVariable (Variable "x") (Type 'Concept))
+			(TypedVariable (Variable "y") (Type 'Concept)))
 		(Choice
 			(Present (State (Variable "x") (Variable "y")))
 			(Present (State (List (Variable "x") (Predicate "hungry")) (Concept "TRUE")))
 			)))
 
+; Well, look, the naked Variable y appearing in the search results
+; is sinfully ugly, but its associated with a clause that never actually
+; grounds y. C'est la vie.
 (test-assert "alice why at home"
 	(equal? (cog-execute! who-is-hungry-3?)
 		(Set
 			(List (Concept "alice") (Concept "at home"))
 			(List (Concept "alice") (Variable "y")))))
+
+; -----------------
+(State (List (Concept "alice") (Predicate "hungry")) (Concept "TRUE"))
+(State (List (Concept "alice") (Predicate "thirsty")) (Concept "TRUE"))
+
+(State (List (Concept "bob") (Predicate "hungry")) (Concept "FALSE"))
+(State (List (Concept "bob") (Predicate "thirsty")) (Concept "FALSE"))
+
+(State (List (Concept "charlie") (Predicate "hungry")) (Concept "FALSE"))
+(State (List (Concept "charlie") (Predicate "thirsty")) (Concept "TRUE"))
+(State (Concept "charlie") (Concept "at home"))
+(State (List (Concept "at home") (Predicate "is cozy")) (Concept "TRUE"))
+
+(define whos-on-first?
+	(Get
+		(VariableList
+			(TypedVariable (Variable "x") (Type 'Concept))
+			(TypedVariable (Variable "y") (Type 'Concept)))
+		(Choice
+			(Present
+				(State (Variable "x") (Variable "y"))
+				(State (List (Variable "y") (Predicate "is cozy")) (Concept "TRUE"))
+				(State (List (Variable "x") (Predicate "hungry")) (Concept "FALSE"))
+				(State (List (Variable "x") (Predicate "thirsty")) (Concept "TRUE")))
+			(Present
+				(State (List (Variable "x") (Predicate "hungry")) (Concept "FALSE"))
+				(State (List (Variable "x") (Predicate "thirsty")) (Concept "FALSE")))
+			(Present
+				(State (List (Variable "x") (Predicate "hungry")) (Concept "TRUE")))
+			)))
+
+; Well, look, the naked Variable y appearing in the search results
+; is sinfully ugly, but its associated with a clause that never actually
+; grounds y. C'est la vie.
+(test-assert "whats on first"
+	(equal? (cog-execute! whos-on-first?)
+		(Set
+			(List (Concept "alice") (Variable "y"))
+			(List (Concept "bob") (Variable "y"))
+			(List (Concept "charlie") (Concept "at home")))))
 
 (test-end tname)


### PR DESCRIPTION
This is the last batch of fixes for #2644 and I think it now handles all the cases. 

At the top-most level, `OrLink` and `ChoiceLink` behave exactly the same way, when the things being search for are objects, (and not truth values). In other words, picking a bunch of things off the menu (`ChoiceLink`) and making a set union out of them is the same thing as just assuming that `OrLink` applied to a bunch of stuff means 'set-union'. 

(`OrLink` applied to truth values still means 'logical-or' just as before, while `ChoiceLink` applied to truth values doesn't make sense/is undefined.)