### PR TITLE
Balanced quotes during pattern compilation

### DIFF
--- a/opencog/atoms/core/Quotation.cc
+++ b/opencog/atoms/core/Quotation.cc
@@ -23,6 +23,7 @@
  */
 
 #include <sstream>
+#include <opencog/util/exceptions.h>
 #include "Quotation.h"
 
 namespace opencog {
@@ -70,9 +71,22 @@ void Quotation::update(Type t)
 	_local_quote = is_unquoted and LOCAL_QUOTE_LINK == t;
 
 	// Increment or decrement quotation level if locally unquoted
-	if (is_locally_unquoted) {
+	if (is_locally_unquoted)
+	{
 		if (QUOTE_LINK == t) _quotation_level++;
-	    else if (UNQUOTE_LINK == t) _quotation_level--;
+		else if (UNQUOTE_LINK == t)
+		{
+			// Well, it would make sense to check for unbalanced quotes,
+			// in theory. In practice, this does not quite work, because
+			// this triggers when quoted FunctionLinks are inserted into
+			// the AtomSpace. FunctionLinks are built on FreeLink which
+			// searches for free variables, which often sees one unquote
+			// too many during atomspace insertion. I don't see any easy
+			// fixes at this time.
+			// if (0 == _quotation_level)
+			// 	throw RuntimeException(TRACE_INFO, "Unbalanced quotes!");
+			_quotation_level--;
+		}
     }
 }
 

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -395,7 +395,7 @@ bool PatternLink::record_literal(const PatternTermPtr& clause, bool reverse)
 	{
 		for (const PatternTermPtr& term : clause->getOutgoingSet())
 		{
-			const Handle& ph = term->getHandle();
+			const Handle& ph = term->getQuote();
 			if (is_constant(_variables.varset, ph)) continue;
 			record_mandatory(term);
 		}
@@ -612,7 +612,7 @@ void PatternLink::locate_defines(const PatternTermSeq& clauses)
 {
 	for (const PatternTermPtr& ptm: clauses)
 	{
-		const Handle& clause = ptm->getHandle();
+		const Handle& clause = ptm->getQuote();
 		FindAtoms fdpn(DEFINED_PREDICATE_NODE, DEFINED_SCHEMA_NODE, true);
 		fdpn.stopset.insert(SCOPE_LINK);
 		fdpn.search_set(clause);
@@ -645,11 +645,13 @@ void PatternLink::locate_cacheable(const PatternTermSeq& clauses)
 		if (not ptm->isLiteral() and not ptm->isPresent() and
 		    not ptm->isChoice() and not ptm->isAbsent()) continue;
 
-		const Handle& claw = ptm->getHandle();
+		const Handle& claw = ptm->getQuote();
 
 		if (1 == num_unquoted_unscoped_in_tree(claw, _variables.varset))
 		{
-			_pat.cacheable_clauses.insert(claw);
+			// XXX Needs work??? I think we need to cache the unquoted
+			// clause, not the quoted one. Right? This might be wrong...
+			_pat.cacheable_clauses.insert(ptm->getHandle());
 			continue;
 		}
 
@@ -674,7 +676,7 @@ void PatternLink::locate_cacheable(const PatternTermSeq& clauses)
 /// grounded (or not).
 void PatternLink::get_clause_variables(const PatternTermPtr& ptm)
 {
-	const Handle& hcl = ptm->getHandle();
+	const Handle& hcl = ptm->getQuote();
 	HandleSet vset = get_free_variables(hcl);
 
 	// Put them into a sequence; any fixed sequence will do.

--- a/tests/query/PresentUTest.cxxtest
+++ b/tests/query/PresentUTest.cxxtest
@@ -61,9 +61,7 @@ public:
 
 	void test_literal(void);
 	void test_virtual(void);
-	// TODO: re-enable test_monotonicity as soon as
-	// https://github.com/opencog/atomspace/issues/2886 is fixed.
-	void xtest_monotonicity(void);
+	void test_monotonicity(void);
 };
 
 void PresentUTest::tearDown(void)
@@ -122,9 +120,9 @@ void PresentUTest::test_virtual(void)
 /**
  * Test the monotonicity of PresentLink.  This is for issue
  * https://github.com/opencog/atomspace/issues/2886
- *
+ * (This turned out to be an unbalanced-quotation issue.)
  */
-void PresentUTest::xtest_monotonicity(void)
+void PresentUTest::test_monotonicity(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 


### PR DESCRIPTION
Make sure that quoted terms are treated properly during pattern compilation. This fixes issue #2886