### PR TITLE
Track down and fix more unbalanced QuoteLinks.

### DIFF
--- a/opencog/atoms/core/FreeLink.cc
+++ b/opencog/atoms/core/FreeLink.cc
@@ -22,6 +22,7 @@
 
 #include <opencog/atoms/atom_types/atom_types.h>
 #include <opencog/atoms/base/ClassServer.h>
+#include <opencog/atoms/core/Quotation.h>
 #include "FreeLink.h"
 
 using namespace opencog;
@@ -45,6 +46,7 @@ FreeLink::FreeLink(const HandleSeq&& oset, Type t)
 
 void FreeLink::init(void)
 {
+	if (unquoted_below(get_handle())) return;
 	_vars.find_variables(_outgoing, true);
 }
 

--- a/opencog/atoms/core/FreeLink.cc
+++ b/opencog/atoms/core/FreeLink.cc
@@ -46,7 +46,7 @@ FreeLink::FreeLink(const HandleSeq&& oset, Type t)
 
 void FreeLink::init(void)
 {
-	if (unquoted_below(get_handle())) return;
+	if (unquoted_below(_outgoing)) return;
 	_vars.find_variables(_outgoing, true);
 }
 

--- a/opencog/atoms/core/Quotation.cc
+++ b/opencog/atoms/core/Quotation.cc
@@ -78,14 +78,12 @@ void Quotation::update(Type t)
 		else if (UNQUOTE_LINK == t)
 		{
 			// Well, it would make sense to check for unbalanced quotes,
-			// in theory. In practice, this does not quite work, because
-			// this triggers when quoted FunctionLinks are inserted into
-			// the AtomSpace. FunctionLinks are built on FreeLink which
-			// searches for free variables, which often sees one unquote
-			// too many during atomspace insertion. I don't see any easy
-			// fixes at this time.
-			if (0 == _quotation_level)
-				throw RuntimeException(TRACE_INFO, "Unbalanced quotes!");
+			// in theory. In practice, this does not quite work, as there
+			// are an assortment of places where update() is called with
+			// unbalanced quotes. It appears to be tedious to track all of
+			// them down and fix them.
+			// if (0 == _quotation_level)
+			// 	throw RuntimeException(TRACE_INFO, "Unbalanced quotes!");
 			_quotation_level--;
 		}
     }

--- a/opencog/atoms/core/Quotation.cc
+++ b/opencog/atoms/core/Quotation.cc
@@ -133,6 +133,13 @@ bool unquoted_below(const Handle& h)
 	return unquoted_below_rec(h, skip, skiplo);
 }
 
+bool unquoted_below(const HandleSeq& hs)
+{
+	for (const Handle& h: hs)
+		if (unquoted_below(h)) return true;
+	return false;
+}
+
 bool Quotation::operator<(const Quotation& quotation) const
 {
 	return (_quotation_level < quotation._quotation_level)

--- a/opencog/atoms/core/Quotation.cc
+++ b/opencog/atoms/core/Quotation.cc
@@ -118,15 +118,13 @@ static bool unquoted_below_rec(const Handle& h, bool skip, bool skiplo)
 
 bool unquoted_below(const Handle& h)
 {
-	bool skip = false;
-	bool skiplo = false;
-	return unquoted_below_rec(h, skip, skiplo);
+	return unquoted_below_rec(h, false, false);
 }
 
 bool unquoted_below(const HandleSeq& hs)
 {
 	for (const Handle& h: hs)
-		if (unquoted_below(h)) return true;
+		if (unquoted_below_rec(h, false, false)) return true;
 	return false;
 }
 

--- a/opencog/atoms/core/Quotation.cc
+++ b/opencog/atoms/core/Quotation.cc
@@ -78,12 +78,13 @@ void Quotation::update(Type t)
 		else if (UNQUOTE_LINK == t)
 		{
 			// Well, it would make sense to check for unbalanced quotes,
-			// in theory. In practice, this does not quite work, as there
-			// are an assortment of places where update() is called with
-			// unbalanced quotes. It appears to be tedious to track all of
-			// them down and fix them.
-			// if (0 == _quotation_level)
-			// 	throw RuntimeException(TRACE_INFO, "Unbalanced quotes!");
+			// in theory. In practice, QuoteUTest builds a weird unbalanced
+			// quote, on purpose. Enabling the exception also causes half
+			// the URE unit tests to fail. So this strict check is disabled.
+#ifdef STRICT_QUOTATION_LEVEL
+			if (0 == _quotation_level)
+				throw RuntimeException(TRACE_INFO, "Unbalanced quotes!");
+#endif
 			_quotation_level--;
 		}
     }

--- a/opencog/atoms/core/Quotation.cc
+++ b/opencog/atoms/core/Quotation.cc
@@ -101,25 +101,16 @@ static bool unquoted_below_rec(const Handle& h, bool skip, bool skiplo)
 	{
 		if (not skip and not skiplo) return true;
 		skip = false;
+		skiplo = false;
 	}
+	else if (QUOTE_LINK == t)
+		skip = true;
+	else if (LOCAL_QUOTE_LINK == t)
+		skiplo = true;
 
 	for (const Handle& ho: h->getOutgoingSet())
 	{
-		bool unq;
-		Type to = ho->get_type();
-		if (QUOTE_LINK == to)
-		{
-			unq = unquoted_below_rec(ho, true, false);
-		}
-		else if (LOCAL_QUOTE_LINK == to)
-		{
-			unq = unquoted_below_rec(ho, skip, true);
-		}
-		else
-		{
-			unq = unquoted_below_rec(ho, skip, false);
-		}
-		if (unq) return true;
+		if (unquoted_below_rec(ho, skip, skiplo)) return true;
 	}
 	return false;
 }

--- a/opencog/atoms/core/Quotation.h
+++ b/opencog/atoms/core/Quotation.h
@@ -28,7 +28,7 @@
 #include <string>
 
 #include <opencog/util/empty_string.h>
-#include <opencog/atoms/atom_types/atom_types.h>
+#include <opencog/atoms/base/Handle.h>
 
 namespace opencog
 {
@@ -91,6 +91,11 @@ public:
 
 	std::string to_string(const std::string& indent) const;
 };
+
+/// Return true if there are unquotes below the given atom. From this,
+/// we can infer that the Atom itself is quoted.  Roughly speaking,
+/// this performs the 'opposite' of `class Quotation` above.
+bool unquoted_below(const Handle&);
 
 // Debugging helpers see
 // http://wiki.opencog.org/w/Development_standards#Print_OpenCog_Objects

--- a/opencog/atoms/core/Quotation.h
+++ b/opencog/atoms/core/Quotation.h
@@ -96,6 +96,7 @@ public:
 /// we can infer that the Atom itself is quoted.  Roughly speaking,
 /// this performs the 'opposite' of `class Quotation` above.
 bool unquoted_below(const Handle&);
+bool unquoted_below(const HandleSeq&);
 
 // Debugging helpers see
 // http://wiki.opencog.org/w/Development_standards#Print_OpenCog_Objects

--- a/opencog/atoms/core/RewriteLink.cc
+++ b/opencog/atoms/core/RewriteLink.cc
@@ -300,11 +300,11 @@ Handle RewriteLink::consume_quotations(const Variables& variables,
 		// any quotation or special executable links is clearly
 		// useless, regardless of whether it has been determined
 		// needless or not.
-		if (is_closed(child) and
+		if (not contains_atomtype(child, UNQUOTE_LINK) and
 		    not contains_atomtype(child, PUT_LINK) and
 		    not contains_atomtype(child, QUOTE_LINK) and
-		    not contains_atomtype(child, UNQUOTE_LINK) and
-		    not contains_atomtype(child, LOCAL_QUOTE_LINK))
+		    not contains_atomtype(child, LOCAL_QUOTE_LINK) and
+		    is_closed(child))
 		{
 			return consume_quotations(variables, child,
 			                          quotation, needless_quotation,

--- a/opencog/atoms/core/ScopeLink.cc
+++ b/opencog/atoms/core/ScopeLink.cc
@@ -47,8 +47,9 @@ void ScopeLink::init(void)
 }
 
 ScopeLink::ScopeLink(const Handle& vars, const Handle& body)
-	: Link({vars, body}, SCOPE_LINK), _quoted(false)
+	: Link({vars, body}, SCOPE_LINK)
 {
+	_quoted = unquoted_below(_outgoing);
 	init();
 }
 

--- a/opencog/atoms/core/ScopeLink.cc
+++ b/opencog/atoms/core/ScopeLink.cc
@@ -40,9 +40,9 @@ using namespace opencog;
 
 void ScopeLink::init(void)
 {
-	// If unquoted_below() returnes true, that means we are quoted,
+	// _quoted is true, that means we are inside a quote,
 	// and so nothing to be done. Skip variable extraction.
-	if (unquoted_below(_outgoing)) return;
+	if (_quoted) return;
 	extract_variables(_outgoing);
 }
 
@@ -54,6 +54,10 @@ ScopeLink::ScopeLink(const Handle& vars, const Handle& body)
 
 bool ScopeLink::skip_init(Type t)
 {
+	// If unquoted_below() returnes true, that means we are quoted,
+	// and so nothing to be done. Skip variable extraction.
+	_quoted = unquoted_below(_outgoing);
+
 	// Type must be as expected.
 #if 0
 	// ScopeLinks are created directly in unit tests, so this safety
@@ -320,10 +324,8 @@ bool ScopeLink::is_equal(const Handle& other, bool silent) const
 
 ContentHash ScopeLink::compute_hash() const
 {
-	// If there are no variables, it's likely that we are quoted,
-	// and so nothing to be done. Skip the complicated computations.
-	if (0 == _variables.varseq.size())
-		return Link::compute_hash();
+	// If we are quoted, skip the complicated computations.
+	if (_quoted) return Link::compute_hash();
 
 	return scope_hash(_variables.index);
 }

--- a/opencog/atoms/core/ScopeLink.cc
+++ b/opencog/atoms/core/ScopeLink.cc
@@ -40,6 +40,9 @@ using namespace opencog;
 
 void ScopeLink::init(void)
 {
+	// If unquoted_below() returnes true, that means we are quoted,
+	// and so nothing to be done. Skip variable extraction.
+	if (unquoted_below(_outgoing)) return;
 	extract_variables(_outgoing);
 }
 
@@ -317,6 +320,11 @@ bool ScopeLink::is_equal(const Handle& other, bool silent) const
 
 ContentHash ScopeLink::compute_hash() const
 {
+	// If there are no variables, it's likely that we are quoted,
+	// and so nothing to be done. Skip the complicated computations.
+	if (0 == _variables.varseq.size())
+		return Link::compute_hash();
+
 	return scope_hash(_variables.index);
 }
 

--- a/opencog/atoms/core/ScopeLink.cc
+++ b/opencog/atoms/core/ScopeLink.cc
@@ -47,7 +47,7 @@ void ScopeLink::init(void)
 }
 
 ScopeLink::ScopeLink(const Handle& vars, const Handle& body)
-	: Link({vars, body}, SCOPE_LINK)
+	: Link({vars, body}, SCOPE_LINK), _quoted(false)
 {
 	init();
 }

--- a/opencog/atoms/core/ScopeLink.h
+++ b/opencog/atoms/core/ScopeLink.h
@@ -59,6 +59,8 @@ protected:
 	/// Variables bound in the body.
 	Variables _variables;
 
+	bool _quoted;
+
 	void init(void);
 	void extract_variables(const HandleSeq& oset);
 	void init_scoped_variables(const Handle& vardecl);

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -1131,6 +1131,7 @@ void PatternLink::make_term_tree_recursive(const PatternTermPtr& root,
 		bool chk_const =
 			(PRESENT_LINK == t or ABSENT_LINK == t or ALWAYS_LINK == t);
 		chk_const = chk_const and not parent->hasAnyEvaluatable();
+		chk_const = chk_const and not ptm->isQuoted();
 
 		for (const Handle& ho: h->getOutgoingSet())
 		{

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -183,7 +183,7 @@ void PatternLink::disjointed_init(void)
 void PatternLink::init(void)
 {
 	// If we are quoted, don't bother to try to do anything.
-	if (unquoted_below(_outgoing)) return;
+	if (_quoted) return;
 
 	_pat.redex_name = "anonymous PatternLink";
 	ScopeLink::extract_variables(_outgoing);

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -182,6 +182,9 @@ void PatternLink::disjointed_init(void)
 
 void PatternLink::init(void)
 {
+	// If we are quoted, don't bother to try to do anything.
+	if (unquoted_below(_outgoing)) return;
+
 	_pat.redex_name = "anonymous PatternLink";
 	ScopeLink::extract_variables(_outgoing);
 

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -785,13 +785,13 @@ bool PatternLink::need_dummies(const PatternTermPtr& ptm)
 	// Do they already appear in some existing mandatory term?
 	// If not, then we have to go fishing for fixed terms,
 	// or add dummies.
-	HandleSet vset = get_free_variables(ptm->getHandle());
+	HandleSet vset = get_free_variables(ptm->getQuote());
 	for (const Handle& v: vset)
 	{
 		bool found_this_v = false;
 		for (const PatternTermPtr& man : _pat.pmandatory)
 		{
-			HandleSet vman = get_free_variables(man->getHandle());
+			HandleSet vman = get_free_variables(man->getQuote());
 			if (vman.end() != vman.find(v))
 			{
 				found_this_v = true;

--- a/opencog/atoms/pattern/QueryLink.cc
+++ b/opencog/atoms/pattern/QueryLink.cc
@@ -44,7 +44,7 @@ void QueryLink::init(void)
 	}
 
 	// If we are quoted, don't bother to try to do anything.
-	if (unquoted_below(_outgoing)) return;
+	if (_quoted) return;
 
 	extract_variables(_outgoing);
 	unbundle_clauses(_body);

--- a/opencog/atoms/pattern/QueryLink.cc
+++ b/opencog/atoms/pattern/QueryLink.cc
@@ -43,6 +43,9 @@ void QueryLink::init(void)
 			"Expecting a QueryLink, got %s", tname.c_str());
 	}
 
+	// If we are quoted, don't bother to try to do anything.
+	if (unquoted_below(_outgoing)) return;
+
 	extract_variables(_outgoing);
 	unbundle_clauses(_body);
 	common_init();


### PR DESCRIPTION
This fixes all of them, except for on that is intentionally unbalanced in a unit test.

@ngeiswei There are still many unbalanced QuoteLinks in the URE code base. These can be found by stopping the debugger at `STRICT_QUOTATION_LEVEL` in `Quotation.cc` I don't know that it matters very much. The unbalanced quotes might be hiding more serious bugs .. ore maybe not.  The unit tests do pass...