### PR TITLE
Move atomspace lock to typeindex

### DIFF
--- a/opencog/atoms/core/StateLink.cc
+++ b/opencog/atoms/core/StateLink.cc
@@ -117,9 +117,7 @@ void StateLink::install()
 		_outgoing[1]->insert_atom(new_state);
 
 		// Remove the old StateLink too. It must be no more.
-		// Ths is all happening under a recursive lock. So don't
-		// double-clock.
-		as->extract_atom(defl, true, false);
+		as->extract_atom(defl, true);
 		swapped = true;
 	}
 

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -294,13 +294,16 @@ Handle AtomSpace::add(const Handle& orig, bool force)
     else
         atom->unsetRemovalFlag();
 
+    // Must set atomspace before insertion. This is harmless, because
+    // if someone else raced us and inserted first, this atom will never
+    // be visible.
+    atom->setAtomSpace(this);
+
     // Between the time that we last checked, and here, some other thread
     // may have raced and inserted this atom already. So the insert does
     // have to be an atomic test-n-set.
     Handle oldh(typeIndex.insertAtom(atom));
     if (oldh) return oldh;
-
-    atom->setAtomSpace(this);
 
     atom->keep_incoming_set();
 

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -384,7 +384,7 @@ bool AtomSpace::extract_atom(const Handle& h, bool recursive)
     // deleting it.
     Handle handle(get_atom(h));
 
-    if (nullptr == handle or handle->isMarkedForRemoval()) return false;
+    if (nullptr == handle) return false;
 
     // User asked for a non-recursive remove, and the
     // atom is still referenced. So, do nothing.

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -449,8 +449,9 @@ bool AtomSpace::extract_atom(const Handle& h, bool recursive)
     // Remove handle from other incoming sets.
     handle->remove();
 
-    handle->setAtomSpace(nullptr);
     typeIndex.removeAtom(handle);
+
+    handle->setAtomSpace(nullptr);
     return true;
 }
 

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -294,8 +294,13 @@ Handle AtomSpace::add(const Handle& orig, bool force)
     else
         atom->unsetRemovalFlag();
 
+    // Between the time that we last checked, and here, some other thread
+    // may have raced and inserted this atom already. So the insert does
+    // have to be an atomic test-n-set.
+    Handle oldh(typeIndex.insertAtom(atom));
+    if (oldh) return oldh;
+
     atom->setAtomSpace(this);
-    typeIndex.insertAtom(atom);
 
     atom->keep_incoming_set();
 

--- a/opencog/atomspace/TypeIndex.cc
+++ b/opencog/atomspace/TypeIndex.cc
@@ -33,6 +33,7 @@ TypeIndex::TypeIndex(void) :
 void TypeIndex::resize(void)
 {
 	_num_types = nameserver().getNumberOfClasses();
+	std::unique_lock<std::shared_mutex> lck(_mtx);
 	_idx.resize(_num_types + 1);
 }
 
@@ -53,6 +54,7 @@ void TypeIndex::get_handles_by_type(HandleSeq& hseq,
 	// allocations and copies whenever the allocated size is exceeded.
 	hseq.reserve(initial_size + size_of_append);
 
+	std::unique_lock<std::shared_mutex> lck(_mtx);
 	const AtomSet& s(_idx.at(type));
 	for (const Handle& h : s)
 		hseq.push_back(h);
@@ -88,6 +90,7 @@ void TypeIndex::get_rootset_by_type(HandleSeq& hseq,
 	// allocations and copies whenever the allocated size is exceeded.
 	hseq.reserve(initial_size + size_of_append);
 
+	std::unique_lock<std::shared_mutex> lck(_mtx);
 	const AtomSet& s(_idx.at(type));
 	for (const Handle& h : s)
 	{

--- a/opencog/atomspace/TypeIndex.h
+++ b/opencog/atomspace/TypeIndex.h
@@ -22,6 +22,7 @@
 #ifndef _OPENCOG_TYPEINDEX_H
 #define _OPENCOG_TYPEINDEX_H
 
+#include <mutex>
 #include <set>
 #include <vector>
 
@@ -57,22 +58,29 @@ class TypeIndex
 		std::vector<AtomSet> _idx;
 		size_t _num_types;
 		NameServer& _nameserver;
+
+		// Single, global mutex for locking the index.
+		mutable std::shared_mutex _mtx;
 	public:
 		TypeIndex(void);
 		void resize(void);
 		void insertAtom(const Handle& h)
 		{
+			std::unique_lock<std::shared_mutex> lck(_mtx);
 			AtomSet& s(_idx.at(h->get_type()));
 			s.insert(h);
 		}
 		void removeAtom(const Handle& h)
 		{
+			std::unique_lock<std::shared_mutex> lck(_mtx);
 			AtomSet& s(_idx.at(h->get_type()));
 			s.erase(h);
 		}
 
 		Handle findAtom(const Handle& h) const
 		{
+			std::unique_lock<std::shared_mutex> lck(_mtx);
+
 			const AtomSet& s(_idx.at(h->get_type()));
 			auto iter = s.find(h);
 			if (s.end() == iter) return Handle::UNDEFINED;
@@ -82,6 +90,7 @@ class TypeIndex
 		// How many atoms are ther of type t?
 		size_t size(Type t) const
 		{
+			std::unique_lock<std::shared_mutex> lck(_mtx);
 			const AtomSet& s(_idx.at(t));
 			return s.size();
 		}
@@ -89,6 +98,7 @@ class TypeIndex
 		// How many atoms, grand total?
 		size_t size(void) const
 		{
+			std::unique_lock<std::shared_mutex> lck(_mtx);
 			size_t cnt = 0;
 			for (const auto& s : _idx)
 				cnt += s.size();
@@ -100,6 +110,8 @@ class TypeIndex
 		{
 			size_t result = size(type);
 			if (not subclass) return result;
+
+			std::unique_lock<std::shared_mutex> lck(_mtx);
 			for (Type t = ATOM; t<_num_types; t++)
 			{
 				if (t != type and _nameserver.isA(t, type))
@@ -110,6 +122,7 @@ class TypeIndex
 
 		void clear(void)
 		{
+			std::unique_lock<std::shared_mutex> lck(_mtx);
 			for (auto& s : _idx)
 			{
 				for (auto& h : s)

--- a/opencog/atomspace/TypeIndex.h
+++ b/opencog/atomspace/TypeIndex.h
@@ -111,7 +111,6 @@ class TypeIndex
 			size_t result = size(type);
 			if (not subclass) return result;
 
-			std::unique_lock<std::shared_mutex> lck(_mtx);
 			for (Type t = ATOM; t<_num_types; t++)
 			{
 				if (t != type and _nameserver.isA(t, type))

--- a/opencog/atomspace/TypeIndex.h
+++ b/opencog/atomspace/TypeIndex.h
@@ -64,12 +64,19 @@ class TypeIndex
 	public:
 		TypeIndex(void);
 		void resize(void);
-		void insertAtom(const Handle& h)
+
+		// Return a Handle, if it's already in the set.
+		// Else, return nullptr
+		Handle insertAtom(const Handle& h)
 		{
 			std::unique_lock<std::shared_mutex> lck(_mtx);
 			AtomSet& s(_idx.at(h->get_type()));
+			auto iter = s.find(h);
+			if (s.end() != iter) return *iter;
 			s.insert(h);
+			return Handle::UNDEFINED;
 		}
+
 		void removeAtom(const Handle& h)
 		{
 			std::unique_lock<std::shared_mutex> lck(_mtx);

--- a/tests/atomspace/AtomSpaceAsyncUTest.cxxtest
+++ b/tests/atomspace/AtomSpaceAsyncUTest.cxxtest
@@ -188,45 +188,6 @@ public:
     }
 
     // =================================================================
-
-    // return true if it looks OK.
-    bool checkOutgoingSet(const Handle& h)
-    {
-        for (const Handle& ho: h->getOutgoingSet())
-        {
-            bool found = false;
-            HandleSeq oset = ho->getIncomingSet();
-            for (const Handle& hi : oset)
-                if (*hi == *h) { found = true; break; }
-            if (not found)
-            {
-                printf("Fail: atom\n%s\nnot in incoming set of\n%s\n",
-                    h->to_string().c_str(), ho->to_string().c_str());
-                TSM_ASSERT("Badly structured incoming set!", found)
-                return false;
-            }
-        }
-        return true;
-    }
-
-    bool checkIncoming(Type t)
-    {
-        HandleSeq all;
-        atomSpace->get_handles_by_type(all, t, false);
-        for (const Handle& h : all)
-            checkOutgoingSet(h);
-        return true;
-    }
-
-    bool checkAllIncoming(void)
-    {
-        TypeSet ts = nameserver().getChildrenRecursive(LINK);
-        for (Type t: ts)
-             checkIncoming(t);
-        return true;
-    }
-
-    // =================================================================
     // Test multi-threaded addition of nodes to atomspace.
 
     Type randomType(Type t)
@@ -278,8 +239,6 @@ public:
 
         // we should get num_atoms * n_threads distinct atoms
         TS_ASSERT_EQUALS(size, num_atoms * n_threads);
-
-        checkAllIncoming();
     }
 
     void testThreadedDuplicateAdd()
@@ -295,8 +254,6 @@ public:
 
         // We should get only num_atoms, because all threads are creating duplicates.
         TS_ASSERT_EQUALS(size, num_atoms);
-
-        checkAllIncoming();
     }
 
     // =================================================================
@@ -447,6 +404,56 @@ public:
         }
         n_threads = n_threads_save;
         num_atoms = num_atoms_save;
+    }
+
+    // =================================================================
+
+    size_t _nchecks;
+
+    // Verify that h appears in the incoming set of every evey
+    // atom in h's outgoing set.  i.e. that outgoing/incoming
+    // is a symmetric relation.
+    // Return true if it looks OK.
+    bool checkOutgoingSet(const Handle& h)
+    {
+        for (const Handle& ho: h->getOutgoingSet())
+        {
+            bool found = false;
+            HandleSeq oset = ho->getIncomingSet();
+            for (const Handle& hi : oset)
+            {
+                _nchecks ++;
+                if (*hi == *h) { found = true; break; }
+            }
+            if (not found)
+            {
+                printf("Fail: atom\n%s\nnot in incoming set of\n%s\n",
+                    h->to_string().c_str(), ho->to_string().c_str());
+                TSM_ASSERT("Badly structured incoming set!", found)
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool checkIncoming(Type t)
+    {
+        HandleSeq all;
+        atomSpace->get_handles_by_type(all, t, false);
+        for (const Handle& h : all)
+            checkOutgoingSet(h);
+        return true;
+    }
+
+    bool checkAllIncoming(void)
+    {
+        _nchecks = 0;
+        TypeSet ts = nameserver().getChildrenRecursive(LINK);
+        for (Type t: ts)
+             checkIncoming(t);
+
+        printf("Checked %zu outgoing/incoming set matches\n", _nchecks);
+        return true;
     }
 
     // =================================================================

--- a/tests/atomspace/AtomSpaceAsyncUTest.cxxtest
+++ b/tests/atomspace/AtomSpaceAsyncUTest.cxxtest
@@ -188,6 +188,45 @@ public:
     }
 
     // =================================================================
+
+    // return true if it looks OK.
+    bool checkOutgoingSet(const Handle& h)
+    {
+        for (const Handle& ho: h->getOutgoingSet())
+        {
+            bool found = false;
+            HandleSeq oset = ho->getIncomingSet();
+            for (const Handle& hi : oset)
+                if (*hi == *h) { found = true; break; }
+            if (not found)
+            {
+                printf("Fail: atom\n%s\nnot in incoming set of\n%s\n",
+                    h->to_string().c_str(), ho->to_string().c_str());
+                TSM_ASSERT("Badly structured incoming set!", found)
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool checkIncoming(Type t)
+    {
+        HandleSeq all;
+        atomSpace->get_handles_by_type(all, t, false);
+        for (const Handle& h : all)
+            checkOutgoingSet(h);
+        return true;
+    }
+
+    bool checkAllIncoming(void)
+    {
+        TypeSet ts = nameserver().getChildrenRecursive(LINK);
+        for (Type t: ts)
+             checkIncoming(t);
+        return true;
+    }
+
+    // =================================================================
     // Test multi-threaded addition of nodes to atomspace.
 
     Type randomType(Type t)
@@ -239,6 +278,8 @@ public:
 
         // we should get num_atoms * n_threads distinct atoms
         TS_ASSERT_EQUALS(size, num_atoms * n_threads);
+
+        checkAllIncoming();
     }
 
     void testThreadedDuplicateAdd()
@@ -254,6 +295,8 @@ public:
 
         // We should get only num_atoms, because all threads are creating duplicates.
         TS_ASSERT_EQUALS(size, num_atoms);
+
+        checkAllIncoming();
     }
 
     // =================================================================
@@ -322,11 +365,9 @@ public:
     void testThreadedSignals()
     {
         // connect signals
-        // int add =
-            atomSpace->atomAddedSignal().connect(std::bind(&AtomSpaceAsyncUTest::countAtomAdded, this, _1));
+        atomSpace->atomAddedSignal().connect(std::bind(&AtomSpaceAsyncUTest::countAtomAdded, this, _1));
 
-        // int chg =
-            atomSpace->TVChangedSignal().connect(std::bind(&AtomSpaceAsyncUTest::countAtomChanged, this, _1, _2, _3));
+        atomSpace->TVChangedSignal().connect(std::bind(&AtomSpaceAsyncUTest::countAtomChanged, this, _1, _2, _3));
 
         __totalAdded = 0;
         __totalChanged = 0;
@@ -467,6 +508,7 @@ public:
 
         TS_ASSERT_EQUALS((int) __totalAdded, num_atoms);
         TS_ASSERT_EQUALS((int) __totalChanged, num_atoms * n_threads); // lots!
+        checkAllIncoming();
     }
 
     // =================================================================
@@ -521,6 +563,7 @@ public:
         // n_thread, because all threads created duplicate ListLinks,
         // duplicate PredicateNodes, but unique EvaluationLinks.
         TS_ASSERT_EQUALS(size, (n_threads+2)*num_atoms + n_threads);
+        checkAllIncoming();
     }
 
     // =================================================================


### PR DESCRIPTION
This moves all locking from the AtomSpace to the type index. It simplifies control flow, narrows down the critical sections, and finally enables solving #2553 in a reasonable manner.