### PR TITLE
Stop using weak pointers

### DIFF
--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -361,12 +361,6 @@ void Atom::swap_atom(const Handle& old, const Handle& neu)
 void Atom::install() {}
 void Atom::remove() {}
 
-#if USE_BARE_BACKPOINTER
-	#define WEAKLY_DO(HA,WP,STMT) Handle HA(WP); STMT;
-#else  // USE_BARE_BACKPOINTER
-	#define WEAKLY_DO(HA,WP,STMT) Handle HA(WP.lock()); if (HA) { STMT; }
-#endif // USE_BARE_BACKPOINTER
-
 bool Atom::isIncomingSetEmpty(const AtomSpace* as) const
 {
     if (nullptr == _incoming_set) return true;

--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -256,6 +256,12 @@ void Atom::setAtomSpace(AtomSpace *tb)
 // ==============================================================
 // Incoming set stuff
 
+#if USE_BARE_BACKPOINTER
+	#define GET_PTR(a) a.const_atom_ptr()
+#else // USE_BARE_BACKPOINTER
+	#define GET_PTR(a) a
+#endif // USE_BARE_BACKPOINTER
+
 /// Start tracking the incoming set for this atom.
 /// An atom can't know what it's incoming set is, until this method
 /// is called.  If this atom is added to any links before this call
@@ -298,7 +304,7 @@ void Atom::insert_atom(const Handle& a)
                    std::make_pair(at, WincomingSet()));
         bucket = pr.first;
     }
-    bucket->second.insert(a);
+    bucket->second.insert(GET_PTR(a));
 
 #ifdef INCOMING_SET_SIGNALS
     _incoming_set->_addAtomSignal(shared_from_this(), a);
@@ -318,7 +324,7 @@ void Atom::remove_atom(const Handle& a)
     const auto bucket = _incoming_set->_iset.find(at);
 
     OC_ASSERT(bucket != _incoming_set->_iset.end(), "No bucket!");
-    size_t erc = bucket->second.erase(a);
+    size_t erc = bucket->second.erase(GET_PTR(a));
 
     // std::set is a "true set", in that it either contains something,
     // or it does not.  Therefore, the erase count is either 1 (the
@@ -341,7 +347,7 @@ void Atom::swap_atom(const Handle& old, const Handle& neu)
 #endif /* INCOMING_SET_SIGNALS */
     Type ot = old->get_type();
     auto bucket = _incoming_set->_iset.find(ot);
-    bucket->second.erase(old);
+    bucket->second.erase(GET_PTR(old));
 
     Type nt = neu->get_type();
     bucket = _incoming_set->_iset.find(nt);
@@ -351,7 +357,7 @@ void Atom::swap_atom(const Handle& old, const Handle& neu)
                    std::make_pair(nt, WincomingSet()));
         bucket = pr.first;
     }
-    bucket->second.insert(neu);
+    bucket->second.insert(GET_PTR(neu));
 
 #ifdef INCOMING_SET_SIGNALS
     _incoming_set->_addAtomSignal(shared_from_this(), neu);

--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -371,8 +371,13 @@ bool Atom::isIncomingSetEmpty(const AtomSpace* as) const
     {
         for (const WinkPtr& w : bucket.second)
         {
+#if USE_BARE_BACKPOINTER
+            Handle l(w);
+            if (not as or as->in_environ(l)) return false;
+#else // USE_BARE_BACKPOINTER
             Handle l(w.lock());
             if (l and (not as or as->in_environ(l))) return false;
+#endif // USE_BARE_BACKPOINTER
         }
     }
     return true;
@@ -391,8 +396,13 @@ size_t Atom::getIncomingSetSize(const AtomSpace* as) const
         {
             for (const WinkPtr& w : bucket.second)
             {
+#if USE_BARE_BACKPOINTER
+                Handle l(w);
+                if (as->in_environ(l)) cnt++;
+#else // USE_BARE_BACKPOINTER
                 Handle l(w.lock());
                 if (l and as->in_environ(l)) cnt++;
+#endif // USE_BARE_BACKPOINTER
             }
         }
         return cnt;
@@ -420,9 +430,15 @@ IncomingSet Atom::getIncomingSet(const AtomSpace* as) const
         {
             for (const WinkPtr& w : bucket.second)
             {
+#if USE_BARE_BACKPOINTER
+                Handle l(w);
+                if (as->in_environ(l))
+                    iset.emplace_back(l);
+#else // USE_BARE_BACKPOINTER
                 Handle l(w.lock());
                 if (l and as->in_environ(l))
                     iset.emplace_back(l);
+#endif // USE_BARE_BACKPOINTER
             }
         }
         return iset;
@@ -435,8 +451,13 @@ IncomingSet Atom::getIncomingSet(const AtomSpace* as) const
     {
         for (const WinkPtr& w : bucket.second)
         {
+#if USE_BARE_BACKPOINTER
+            Handle l(w);
+            iset.emplace_back(l);
+#else // USE_BARE_BACKPOINTER
             Handle l(w.lock());
             if (l) iset.emplace_back(l);
+#endif // USE_BARE_BACKPOINTER
         }
     }
     return iset;
@@ -457,17 +478,28 @@ IncomingSet Atom::getIncomingSetByType(Type type, const AtomSpace* as) const
     if (as) {
         for (const WinkPtr& w : bucket->second)
         {
+#if USE_BARE_BACKPOINTER
+            Handle l(w);
+            if (as->in_environ(l))
+                result.emplace_back(l);
+#else // USE_BARE_BACKPOINTER
             Handle l(w.lock());
             if (l and as->in_environ(l))
                 result.emplace_back(l);
+#endif // USE_BARE_BACKPOINTER
         }
         return result;
     }
 
     for (const WinkPtr& w : bucket->second)
     {
+#if USE_BARE_BACKPOINTER
+        Handle l(w);
+        result.emplace_back(l);
+#else // USE_BARE_BACKPOINTER
         Handle l(w.lock());
         if (l) result.emplace_back(l);
+#endif // USE_BARE_BACKPOINTER
     }
     return result;
 }
@@ -485,16 +517,26 @@ size_t Atom::getIncomingSetSizeByType(Type type, const AtomSpace* as) const
     if (as) {
         for (const WinkPtr& w : bucket->second)
         {
+#if USE_BARE_BACKPOINTER
+            Handle l(w);
+            if (as->in_environ(l)) cnt++;
+#else // USE_BARE_BACKPOINTER
             Handle l(w.lock());
             if (l and as->in_environ(l)) cnt++;
+#endif // USE_BARE_BACKPOINTER
         }
         return cnt;
     }
 
     for (const WinkPtr& w : bucket->second)
     {
+#if USE_BARE_BACKPOINTER
+        Handle l(w);
+        cnt++;
+#else // USE_BARE_BACKPOINTER
         Handle l(w.lock());
         if (l) cnt++;
+#endif // USE_BARE_BACKPOINTER
     }
     return cnt;
 }

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -34,7 +34,7 @@
 #include <string>
 #include <unordered_set>
 
-#if XHAVE_FOLLY
+#if HAVE_FOLLY
 #include <folly/container/F14Set.h>
 #define USE_HASHABLE_WEAK_PTR 1
 #endif
@@ -88,8 +88,15 @@ typedef hashable_weak_ptr<Atom> WinkPtr;
 
 #else // USE_HASHABLE_WEAK_PTR
 
-// See discussion in README, explaining why using a bar pointer is safe.
-#define USE_BARE_BACKPOINTER 1
+// See discussion in README, explaining why using a bare pointer is safe.
+//
+// Based on current measurements (March 2022, benchmark/query-loop/diary.txt)
+// there is no performance advantage to useing bare pointers. In addition,
+// it appears that AtomSpaceAsyncUTest fails, probably due to "trivial"
+// reasons. Thus, there does not seem to be any advantage to enabling bare
+// pointers, and perhaps some minor disadvantages.
+// #define USE_BARE_BACKPOINTER 1
+//
 #if USE_BARE_BACKPOINTER
 typedef const Atom* WinkPtr;
 #else // USE_BARE_BACKPOINTER
@@ -162,7 +169,7 @@ typedef std::size_t Arity;
 typedef HandleSeq IncomingSet;
 typedef SigSlot<Handle, Handle> AtomPairSignal;
 
-#if XHAVE_FOLLY
+#if HAVE_FOLLY
 // typedef folly::F14ValueSet<WinkPtr, std::owner_hash<WinkPtr> > WincomingSet;
 typedef folly::F14ValueSet<WinkPtr> WincomingSet;
 #else

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -34,7 +34,7 @@
 #include <string>
 #include <unordered_set>
 
-#if HAVE_FOLLY
+#if XHAVE_FOLLY
 #include <folly/container/F14Set.h>
 #define USE_HASHABLE_WEAK_PTR 1
 #endif
@@ -91,7 +91,7 @@ typedef hashable_weak_ptr<Atom> WinkPtr;
 // See discussion in README, explaining why using a bar pointer is safe.
 #define USE_BARE_BACKPOINTER 1
 #if USE_BARE_BACKPOINTER
-typedef Atom* WinkPtr;
+typedef const Atom* WinkPtr;
 #else // USE_BARE_BACKPOINTER
 typedef std::weak_ptr<Atom> WinkPtr;
 #endif // USE_BARE_BACKPOINTER
@@ -128,13 +128,10 @@ template<class T> struct hash<opencog::hashable_weak_ptr<T>>
 #else // USE_HASHABLE_WEAK_PTR
 
 #if USE_BARE_BACKPOINTER
-
-// Some but not all versions of the compiler require std::owner_less
-// to be explicitly declared.
-template <> struct owner_less<opencog::Atom*>
+template <> struct owner_less<const opencog::Atom*>
 {
-	bool operator()(const opencog::Atom*& lhs,
-	                const opencog::Atom*& rhs) const noexcept
+	bool operator()(const opencog::Atom* const& lhs,
+	                const opencog::Atom* const& rhs) const noexcept
 	{
 		return lhs < rhs;
 	}
@@ -165,7 +162,7 @@ typedef std::size_t Arity;
 typedef HandleSeq IncomingSet;
 typedef SigSlot<Handle, Handle> AtomPairSignal;
 
-#if HAVE_FOLLY
+#if XHAVE_FOLLY
 // typedef folly::F14ValueSet<WinkPtr, std::owner_hash<WinkPtr> > WincomingSet;
 typedef folly::F14ValueSet<WinkPtr> WincomingSet;
 #else

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -98,6 +98,12 @@ typedef std::weak_ptr<Atom> WinkPtr;
 #endif // USE_HASHABLE_WEAK_PTR
 }
 
+#if USE_BARE_BACKPOINTER
+	#define WEAKLY_DO(HA,WP,STMT) Handle HA(WP); STMT;
+#else  // USE_BARE_BACKPOINTER
+	#define WEAKLY_DO(HA,WP,STMT) Handle HA(WP.lock()); if (HA) { STMT; }
+#endif // USE_BARE_BACKPOINTER
+
 namespace std
 {
 
@@ -411,13 +417,7 @@ public:
         {
             for (const WinkPtr& w : bucket.second)
             {
-#if USE_BARE_BACKPOINTER
-                *result = std::static_pointer_cast<Atom>(w);
-                result ++;
-#else //  USE_BARE_BACKPOINTER
-                Handle h(std::static_pointer_cast<Atom>(w.lock()));
-                if (h) { *result = h; result ++; }
-#endif //  USE_BARE_BACKPOINTER
+                WEAKLY_DO(h, w, { *result = h; result ++; })
             }
         }
         return result;
@@ -458,13 +458,7 @@ public:
 
         for (const WinkPtr& w : bucket->second)
         {
-#if USE_BARE_BACKPOINTER
-            *result = std::static_pointer_cast<Atom>(w);
-            result ++;
-#else //  USE_BARE_BACKPOINTER
-            Handle h(std::static_pointer_cast<Atom>(w.lock()));
-            if (h) { *result = h; result ++; }
-#endif //  USE_BARE_BACKPOINTER
+            WEAKLY_DO(h, w, { *result = h; result ++; })
         }
         return result;
     }

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -88,6 +88,7 @@ typedef hashable_weak_ptr<Atom> WinkPtr;
 
 #else // USE_HASHABLE_WEAK_PTR
 
+// See discussion in README, explaining why using a bar pointer is safe.
 #define USE_BARE_BACKPOINTER 1
 #if USE_BARE_BACKPOINTER
 typedef Atom* WinkPtr;

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -87,7 +87,14 @@ struct hashable_weak_ptr : public std::weak_ptr<T>
 typedef hashable_weak_ptr<Atom> WinkPtr;
 
 #else // USE_HASHABLE_WEAK_PTR
+
+#define USE_BARE_BACKPOINTER 1
+#if USE_BARE_BACKPOINTER
+typedef Atom* WinkPtr;
+#else // USE_BARE_BACKPOINTER
 typedef std::weak_ptr<Atom> WinkPtr;
+#endif // USE_BARE_BACKPOINTER
+
 #endif // USE_HASHABLE_WEAK_PTR
 }
 
@@ -404,8 +411,13 @@ public:
         {
             for (const WinkPtr& w : bucket.second)
             {
+#if USE_BARE_BACKPOINTER
+                *result = std::static_pointer_cast<Atom>(w);
+                result ++;
+#else //  USE_BARE_BACKPOINTER
                 Handle h(std::static_pointer_cast<Atom>(w.lock()));
                 if (h) { *result = h; result ++; }
+#endif //  USE_BARE_BACKPOINTER
             }
         }
         return result;
@@ -446,8 +458,13 @@ public:
 
         for (const WinkPtr& w : bucket->second)
         {
+#if USE_BARE_BACKPOINTER
+            *result = std::static_pointer_cast<Atom>(w);
+            result ++;
+#else //  USE_BARE_BACKPOINTER
             Handle h(std::static_pointer_cast<Atom>(w.lock()));
             if (h) { *result = h; result ++; }
+#endif //  USE_BARE_BACKPOINTER
         }
         return result;
     }

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -131,7 +131,7 @@ template<class T> struct hash<opencog::hashable_weak_ptr<T>>
 
 // Some but not all versions of the compiler require std::owner_less
 // to be explicitly declared.
-struct owner_less<opencog::Atom*>
+template <> struct owner_less<opencog::Atom*>
 {
 	bool operator()(const opencog::Atom*& lhs,
 	                const opencog::Atom*& rhs) const noexcept

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -125,6 +125,22 @@ template<class T> struct hash<opencog::hashable_weak_ptr<T>>
 		return w.get_hash();
 	}
 };
+#else // USE_HASHABLE_WEAK_PTR
+
+#if USE_BARE_BACKPOINTER
+
+// Some but not all versions of the compiler require std::owner_less
+// to be explicitly declared.
+struct owner_less<opencog::Atom*>
+{
+	bool operator()(const opencog::Atom*& lhs,
+	                const opencog::Atom*& rhs) const noexcept
+	{
+		return lhs < rhs;
+	}
+};
+#endif //USE_BARE_BACKPOINTER
+
 #endif // USE_HASHABLE_WEAK_PTR
 
 

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -100,7 +100,7 @@ typedef std::weak_ptr<Atom> WinkPtr;
 }
 
 #if USE_BARE_BACKPOINTER
-	#define WEAKLY_DO(HA,WP,STMT) Handle HA(WP); STMT;
+	#define WEAKLY_DO(HA,WP,STMT) Handle HA(WP->get_handle()); STMT;
 #else  // USE_BARE_BACKPOINTER
 	#define WEAKLY_DO(HA,WP,STMT) Handle HA(WP.lock()); if (HA) { STMT; }
 #endif // USE_BARE_BACKPOINTER

--- a/opencog/atoms/base/README.md
+++ b/opencog/atoms/base/README.md
@@ -34,3 +34,29 @@ runs these validators, before calling the factory itself. This
 validation helps avoid the need to have lots of repetitive checking
 in the constructors for the various C++ atom classes; they also work
 for atoms that do not have any C++ class behind them.
+
+Weak Pointers
+=============
+Handles are reference-counted pointers to Atoms, guaranteeing that the
+memory for an Atom is never released, as long as there is *some* Handle
+pointing to it.  Links are vectors of Handles, and thus for a reference-
+counted tree of all the Atoms underneath.
+
+The Incoming Set points in the *opposite direction*, back up the tree.
+One cannot use a regular "strong" (reference-counted) pointer for this,
+as this would create a loop with a cycle, and thus could never decrement
+itself back down to zero if there are no external references to the cycle.
+
+The conventional wisdom here is to use weak pointers, as these will not
+interfere with reference counting, while stil enabling safe memory access.
+The code for the incoming set was originally written to use weak pointers.
+
+However ... they are not really needed, and, instead, naked, bare pointers
+can be used for the incoming set. This is because the incoming set is
+always valid, when an Atom is in the AtomSpace... because incoming sets
+are kept *only* when an Atom is in an AtomSpace, and are *never* kept when
+an Atom is *not* in an AtomSpace!
+
+The use of naked, bare backpointers in the incoming set allows for faster
+dereferencing, avoiding the lock and the overhead of conveting weak pointers
+into strong pointers. The `#define USE_BARE_BACKPOINTER 1` is set.

--- a/opencog/atoms/base/README.md
+++ b/opencog/atoms/base/README.md
@@ -57,6 +57,9 @@ always valid, when an Atom is in the AtomSpace... because incoming sets
 are kept *only* when an Atom is in an AtomSpace, and are *never* kept when
 an Atom is *not* in an AtomSpace!
 
-The use of naked, bare backpointers in the incoming set allows for faster
-dereferencing, avoiding the lock and the overhead of conveting weak pointers
-into strong pointers. The `#define USE_BARE_BACKPOINTER 1` is set.
+The use of naked, bare backpointers in the incoming set should have allowed
+for faster dereferencing, avoiding the lock and the overhead of conveting
+weak pointers into strong pointers.  Unfortunately, nothing is gained, as
+the need to convert bare pointers into Handles appears to offset any gains.
+In fact, this conversion might even slow things down slightly.
+The `#define USE_BARE_BACKPOINTER 1` is *NOT* set.

--- a/opencog/atomspace/TypeIndex.h
+++ b/opencog/atomspace/TypeIndex.h
@@ -43,7 +43,6 @@ namespace opencog
 
 // Facebook Folly
 // https://github.com/facebook/folly/blob/main/folly/container/F14.md
-// promises a faster and more compact hash table. Just one problem:
 // promises a faster and more compact hash table. Just two problems:
 // 1) It does not make any difference in the "real world" benchmark
 //    I tried (the `bio-loop3.scm` benchmark from opencog/benchmark)


### PR DESCRIPTION
They're overkill, and are not needed, and are an overall drag on performance.

The AtomSpace guarantees that the incoming set will be valid.