### PR TITLE
Replace boilerplate code by cpp macro defn.

### DIFF
--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -529,6 +529,15 @@ public:
     virtual bool operator<(const Atom&) const = 0;
 };
 
+#define ATOM_PTR_DECL(CNAME)                                \
+    typedef std::shared_ptr<CNAME> CNAME##Ptr;              \
+    static inline CNAME##Ptr CNAME##Cast(const Handle& h)   \
+        { return std::dynamic_pointer_cast<CNAME>(h); }     \
+    static inline CNAME##Ptr CNAME##Cast(const AtomPtr& a)  \
+        { return std::dynamic_pointer_cast<CNAME>(a); }
+
+#define CREATE_DECL(CNAME)  std::make_shared<CNAME>
+
 static inline AtomPtr AtomCast(const ValuePtr& pa)
     { return std::dynamic_pointer_cast<Atom>(pa); }
 

--- a/opencog/atoms/base/Link.h
+++ b/opencog/atoms/base/Link.h
@@ -200,11 +200,16 @@ public:
     virtual bool operator<(const Atom&) const;
 };
 
-typedef std::shared_ptr<Link> LinkPtr;
-static inline LinkPtr LinkCast(const Handle& h)
-    { return std::dynamic_pointer_cast<Link>(h); }
-static inline LinkPtr LinkCast(const AtomPtr& a)
-    { return std::dynamic_pointer_cast<Link>(a); }
+#define LINK_PTR_DECL(CNAME)                                \
+    typedef std::shared_ptr<CNAME> CNAME##Ptr;              \
+    static inline CNAME##Ptr CNAME##Cast(const Handle& h)   \
+        { return std::dynamic_pointer_cast<CNAME>(h); }     \
+    static inline CNAME##Ptr CNAME##Cast(const AtomPtr& a)  \
+        { return std::dynamic_pointer_cast<CNAME>(a); }
+
+#define CREATE_DECL(CNAME)  std::make_shared<CNAME>
+
+LINK_PTR_DECL(Link);
 
 template< class... Args >
 Handle createLink( Args&&... args )

--- a/opencog/atoms/base/Link.h
+++ b/opencog/atoms/base/Link.h
@@ -200,14 +200,7 @@ public:
     virtual bool operator<(const Atom&) const;
 };
 
-#define LINK_PTR_DECL(CNAME)                                \
-    typedef std::shared_ptr<CNAME> CNAME##Ptr;              \
-    static inline CNAME##Ptr CNAME##Cast(const Handle& h)   \
-        { return std::dynamic_pointer_cast<CNAME>(h); }     \
-    static inline CNAME##Ptr CNAME##Cast(const AtomPtr& a)  \
-        { return std::dynamic_pointer_cast<CNAME>(a); }
-
-#define CREATE_DECL(CNAME)  std::make_shared<CNAME>
+#define LINK_PTR_DECL(CNAME)  ATOM_PTR_DECL(CNAME)
 
 LINK_PTR_DECL(Link);
 

--- a/opencog/atoms/base/Node.h
+++ b/opencog/atoms/base/Node.h
@@ -112,11 +112,8 @@ public:
 	virtual bool operator<(const Atom&) const;
 };
 
-typedef std::shared_ptr<Node> NodePtr;
-// static inline NodePtr NodeCast(const Handle& h)
-//    { return std::dynamic_pointer_cast<Node>(AtomCast(h)); }
-static inline NodePtr NodeCast(const AtomPtr& a)
-    { return std::dynamic_pointer_cast<Node>(a); }
+#define NODE_PTR_DECL(CNAME) ATOM_PTR_DECL(CNAME)
+NODE_PTR_DECL(Node)
 
 template< class... Args >
 Handle createNode( Args&&... args )

--- a/opencog/atoms/core/AbsentLink.h
+++ b/opencog/atoms/core/AbsentLink.h
@@ -76,13 +76,8 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<AbsentLink> AbsentLinkPtr;
-static inline AbsentLinkPtr AbsentLinkCast(const Handle& h)
-	{ return std::dynamic_pointer_cast<AbsentLink>(h); }
-static inline AbsentLinkPtr AbsentLinkCast(const AtomPtr& a)
-	{ return std::dynamic_pointer_cast<AbsentLink>(a); }
-
-#define createAbsentLink std::make_shared<AbsentLink>
+LINK_PTR_DECL(AbsentLink)
+#define createAbsentLink CREATE_DECL(AbsentLink)
 
 /** @}*/
 }

--- a/opencog/atoms/core/ArityLink.h
+++ b/opencog/atoms/core/ArityLink.h
@@ -57,12 +57,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<ArityLink> ArityLinkPtr;
-static inline ArityLinkPtr ArityLinkCast(const Handle& h)
-	{ return std::dynamic_pointer_cast<ArityLink>(h); }
-static inline ArityLinkPtr ArityLinkCast(const AtomPtr& a)
-	{ return std::dynamic_pointer_cast<ArityLink>(a); }
-
+LINK_PTR_DECL(ArityLink)
 #define createArityLink std::make_shared<ArityLink>
 
 /** @}*/

--- a/opencog/atoms/core/ArityLink.h
+++ b/opencog/atoms/core/ArityLink.h
@@ -58,7 +58,7 @@ public:
 };
 
 LINK_PTR_DECL(ArityLink)
-#define createArityLink std::make_shared<ArityLink>
+#define createArityLink CREATE_DECL(ArityLink)
 
 /** @}*/
 }

--- a/opencog/atoms/core/CondLink.h
+++ b/opencog/atoms/core/CondLink.h
@@ -49,7 +49,7 @@ public:
 };
 
 LINK_PTR_DECL(CondLink)
-#define createCondLink std::make_shared<CondLink>
+#define createCondLink CREATE_DECL(CondLink)
 
 /** @}*/
 }

--- a/opencog/atoms/core/CondLink.h
+++ b/opencog/atoms/core/CondLink.h
@@ -48,12 +48,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<CondLink> CondLinkPtr;
-static inline CondLinkPtr CondLinkCast(const Handle& h)
-	{ AtomPtr a(h); return std::dynamic_pointer_cast<CondLink>(a); }
-static inline CondLinkPtr CondLinkCast(AtomPtr a)
-	{ return std::dynamic_pointer_cast<CondLink>(a); }
-
+LINK_PTR_DECL(CondLink)
 #define createCondLink std::make_shared<CondLink>
 
 /** @}*/

--- a/opencog/atoms/core/DefineLink.h
+++ b/opencog/atoms/core/DefineLink.h
@@ -100,7 +100,7 @@ public:
 };
 
 LINK_PTR_DECL(DefineLink)
-#define createDefineLink std::make_shared<DefineLink>
+#define createDefineLink CREATE_DECL(DefineLink)
 
 /** @}*/
 }

--- a/opencog/atoms/core/DefineLink.h
+++ b/opencog/atoms/core/DefineLink.h
@@ -99,12 +99,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<DefineLink> DefineLinkPtr;
-static inline DefineLinkPtr DefineLinkCast(const Handle& h)
-	{ return std::dynamic_pointer_cast<DefineLink>(h); }
-static inline DefineLinkPtr DefineLinkCast(const AtomPtr& a)
-	{ return std::dynamic_pointer_cast<DefineLink>(a); }
-
+LINK_PTR_DECL(DefineLink)
 #define createDefineLink std::make_shared<DefineLink>
 
 /** @}*/

--- a/opencog/atoms/core/DeleteLink.h
+++ b/opencog/atoms/core/DeleteLink.h
@@ -58,7 +58,7 @@ public:
 };
 
 LINK_PTR_DECL(DeleteLink)
-#define createDeleteLink std::make_shared<DeleteLink>
+#define createDeleteLink CREATE_DECL(DeleteLink)
 
 /** @}*/
 }

--- a/opencog/atoms/core/DeleteLink.h
+++ b/opencog/atoms/core/DeleteLink.h
@@ -57,12 +57,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<DeleteLink> DeleteLinkPtr;
-static inline DeleteLinkPtr DeleteLinkCast(const Handle& h)
-	{ return std::dynamic_pointer_cast<DeleteLink>(h); }
-static inline DeleteLinkPtr DeleteLinkCast(const AtomPtr& a)
-	{ return std::dynamic_pointer_cast<DeleteLink>(a); }
-
+LINK_PTR_DECL(DeleteLink)
 #define createDeleteLink std::make_shared<DeleteLink>
 
 /** @}*/

--- a/opencog/atoms/core/FreeLink.h
+++ b/opencog/atoms/core/FreeLink.h
@@ -57,7 +57,7 @@ public:
 };
 
 LINK_PTR_DECL(FreeLink)
-#define createFreeLink std::make_shared<FreeLink>
+#define createFreeLink CREATE_DECL(FreeLink)
 
 /** @}*/
 }

--- a/opencog/atoms/core/FreeLink.h
+++ b/opencog/atoms/core/FreeLink.h
@@ -56,12 +56,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<FreeLink> FreeLinkPtr;
-static inline FreeLinkPtr FreeLinkCast(const Handle& h)
-   { return std::dynamic_pointer_cast<FreeLink>(h); }
-static inline FreeLinkPtr FreeLinkCast(const AtomPtr& a)
-   { return std::dynamic_pointer_cast<FreeLink>(a); }
-
+LINK_PTR_DECL(FreeLink)
 #define createFreeLink std::make_shared<FreeLink>
 
 /** @}*/

--- a/opencog/atoms/core/FunctionLink.h
+++ b/opencog/atoms/core/FunctionLink.h
@@ -82,7 +82,7 @@ LINK_PTR_DECL(FunctionLink)
 static inline FunctionLinkPtr FunctionLinkCast(const ValuePtr& a)
    { return std::dynamic_pointer_cast<FunctionLink>(a); }
 
-#define createFunctionLink std::make_shared<FunctionLink>
+#define createFunctionLink CREATE_DECL(FunctionLink)
 
 /** @}*/
 }

--- a/opencog/atoms/core/FunctionLink.h
+++ b/opencog/atoms/core/FunctionLink.h
@@ -78,11 +78,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<FunctionLink> FunctionLinkPtr;
-static inline FunctionLinkPtr FunctionLinkCast(const Handle& h)
-   { return std::dynamic_pointer_cast<FunctionLink>(h); }
-static inline FunctionLinkPtr FunctionLinkCast(const AtomPtr& a)
-   { return std::dynamic_pointer_cast<FunctionLink>(a); }
+LINK_PTR_DECL(FunctionLink)
 static inline FunctionLinkPtr FunctionLinkCast(const ValuePtr& a)
    { return std::dynamic_pointer_cast<FunctionLink>(a); }
 

--- a/opencog/atoms/core/ImplicationScopeLink.h
+++ b/opencog/atoms/core/ImplicationScopeLink.h
@@ -61,12 +61,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<ImplicationScopeLink> ImplicationScopeLinkPtr;
-static inline ImplicationScopeLinkPtr ImplicationScopeLinkCast(const Handle& h)
-	{ return std::dynamic_pointer_cast<ImplicationScopeLink>(h); }
-static inline ImplicationScopeLinkPtr ImplicationScopeLinkCast(AtomPtr a)
-	{ return std::dynamic_pointer_cast<ImplicationScopeLink>(a); }
-
+LINK_PTR_DECL(ImplicationScopeLink)
 #define createImplicationScopeLink std::make_shared<ImplicationScopeLink>
 
 /** @}*/

--- a/opencog/atoms/core/ImplicationScopeLink.h
+++ b/opencog/atoms/core/ImplicationScopeLink.h
@@ -62,7 +62,7 @@ public:
 };
 
 LINK_PTR_DECL(ImplicationScopeLink)
-#define createImplicationScopeLink std::make_shared<ImplicationScopeLink>
+#define createImplicationScopeLink CREATE_DECL(ImplicationScopeLink)
 
 /** @}*/
 }

--- a/opencog/atoms/core/LambdaLink.h
+++ b/opencog/atoms/core/LambdaLink.h
@@ -66,7 +66,7 @@ public:
 };
 
 LINK_PTR_DECL(LambdaLink)
-#define createLambdaLink std::make_shared<LambdaLink>
+#define createLambdaLink CREATE_DECL(LambdaLink)
 
 /** @}*/
 }

--- a/opencog/atoms/core/LambdaLink.h
+++ b/opencog/atoms/core/LambdaLink.h
@@ -65,12 +65,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<LambdaLink> LambdaLinkPtr;
-static inline LambdaLinkPtr LambdaLinkCast(const Handle& h)
-	{ return std::dynamic_pointer_cast<LambdaLink>(h); }
-static inline LambdaLinkPtr LambdaLinkCast(const AtomPtr& a)
-	{ return std::dynamic_pointer_cast<LambdaLink>(a); }
-
+LINK_PTR_DECL(LambdaLink)
 #define createLambdaLink std::make_shared<LambdaLink>
 
 /** @}*/

--- a/opencog/atoms/core/MapLink.h
+++ b/opencog/atoms/core/MapLink.h
@@ -76,12 +76,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<MapLink> MapLinkPtr;
-static inline MapLinkPtr MapLinkCast(const Handle& h)
-	{ AtomPtr a(h); return std::dynamic_pointer_cast<MapLink>(a); }
-static inline MapLinkPtr MapLinkCast(AtomPtr a)
-	{ return std::dynamic_pointer_cast<MapLink>(a); }
-
+LINK_PTR_DECL(MapLink);
 #define createMapLink std::make_shared<MapLink>
 
 /** @}*/

--- a/opencog/atoms/core/MapLink.h
+++ b/opencog/atoms/core/MapLink.h
@@ -77,7 +77,7 @@ public:
 };
 
 LINK_PTR_DECL(MapLink);
-#define createMapLink std::make_shared<MapLink>
+#define createMapLink CREATE_DECL(MapLink)
 
 /** @}*/
 }

--- a/opencog/atoms/core/NumberNode.h
+++ b/opencog/atoms/core/NumberNode.h
@@ -81,15 +81,11 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<NumberNode> NumberNodePtr;
-static inline NumberNodePtr NumberNodeCast(const Handle& h)
-	{ return std::dynamic_pointer_cast<NumberNode>(h); }
-static inline NumberNodePtr NumberNodeCast(const AtomPtr& a)
-	{ return std::dynamic_pointer_cast<NumberNode>(a); }
-static inline NumberNodePtr NumberNodeCast(const ValuePtr& a)
-	{ return std::dynamic_pointer_cast<NumberNode>(a); }
+NODE_PTR_DECL(NumberNode)
+#define createNumberNode CREATE_DECL(NumberNode)
 
-#define createNumberNode std::make_shared<NumberNode>
+static inline NumberNodePtr NumberNodeCast(const ValuePtr& vp)
+    { return std::dynamic_pointer_cast<NumberNode>(vp); }
 
 // --------------------
 // Scalar multiplication and addition

--- a/opencog/atoms/core/PrenexLink.h
+++ b/opencog/atoms/core/PrenexLink.h
@@ -58,12 +58,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<PrenexLink> PrenexLinkPtr;
-static inline PrenexLinkPtr PrenexLinkCast(const Handle& h)
-	{ return std::dynamic_pointer_cast<PrenexLink>(h); }
-static inline PrenexLinkPtr PrenexLinkCast(const AtomPtr& a)
-	{ return std::dynamic_pointer_cast<PrenexLink>(a); }
-
+LINK_PTR_DECL(PrenexLink)
 #define createPrenexLink std::make_shared<PrenexLink>
 
 /** @}*/

--- a/opencog/atoms/core/PrenexLink.h
+++ b/opencog/atoms/core/PrenexLink.h
@@ -59,7 +59,7 @@ public:
 };
 
 LINK_PTR_DECL(PrenexLink)
-#define createPrenexLink std::make_shared<PrenexLink>
+#define createPrenexLink CREATE_DECL(PrenexLink)
 
 /** @}*/
 }

--- a/opencog/atoms/core/PresentLink.h
+++ b/opencog/atoms/core/PresentLink.h
@@ -76,12 +76,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<PresentLink> PresentLinkPtr;
-static inline PresentLinkPtr PresentLinkCast(const Handle& h)
-	{ return std::dynamic_pointer_cast<PresentLink>(h); }
-static inline PresentLinkPtr PresentLinkCast(const AtomPtr& a)
-	{ return std::dynamic_pointer_cast<PresentLink>(a); }
-
+LINK_PTR_DECL(PresentLink)
 #define createPresentLink std::make_shared<PresentLink>
 
 /** @}*/

--- a/opencog/atoms/core/PresentLink.h
+++ b/opencog/atoms/core/PresentLink.h
@@ -77,7 +77,7 @@ public:
 };
 
 LINK_PTR_DECL(PresentLink)
-#define createPresentLink std::make_shared<PresentLink>
+#define createPresentLink CREATE_DECL(PresentLink)
 
 /** @}*/
 }

--- a/opencog/atoms/core/PutLink.h
+++ b/opencog/atoms/core/PutLink.h
@@ -96,12 +96,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<PutLink> PutLinkPtr;
-static inline PutLinkPtr PutLinkCast(const Handle& h)
-   { return std::dynamic_pointer_cast<PutLink>(h); }
-static inline PutLinkPtr PutLinkCast(const AtomPtr& a)
-   { return std::dynamic_pointer_cast<PutLink>(a); }
-
+LINK_PTR_DECL(PutLink)
 #define createPutLink std::make_shared<PutLink>
 
 /** @}*/

--- a/opencog/atoms/core/PutLink.h
+++ b/opencog/atoms/core/PutLink.h
@@ -97,7 +97,7 @@ public:
 };
 
 LINK_PTR_DECL(PutLink)
-#define createPutLink std::make_shared<PutLink>
+#define createPutLink CREATE_DECL(PutLink)
 
 /** @}*/
 }

--- a/opencog/atoms/core/RandomChoice.h
+++ b/opencog/atoms/core/RandomChoice.h
@@ -72,13 +72,8 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<RandomChoiceLink> RandomChoiceLinkPtr;
-static inline RandomChoiceLinkPtr RandomChoiceLinkCast(const Handle& h)
-	{ return std::dynamic_pointer_cast<RandomChoiceLink>(h); }
-static inline RandomChoiceLinkPtr RandomChoiceLinkCast(const AtomPtr& a)
-	{ return std::dynamic_pointer_cast<RandomChoiceLink>(a); }
-
-#define createRandomChoiceLink std::make_shared<RandomChoiceLink>
+LINK_PTR_DECL(RandomChoiceLink)
+#define createRandomChoiceLink CREATE_DECL(RandomChoiceLink)
 
 /** @}*/
 }

--- a/opencog/atoms/core/RewriteLink.h
+++ b/opencog/atoms/core/RewriteLink.h
@@ -43,8 +43,6 @@ namespace opencog
 /// edit and create PatternLinks on the fly, thus allowing different
 /// kinds of queries to be generated and run as chaining proceeds.
 ///
-class RewriteLink;
-typedef std::shared_ptr<RewriteLink> RewriteLinkPtr;
 class RewriteLink : public ScopeLink
 {
 protected:
@@ -245,11 +243,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-static inline RewriteLinkPtr RewriteLinkCast(const Handle& h)
-	{ return std::dynamic_pointer_cast<RewriteLink>(h); }
-static inline RewriteLinkPtr RewriteLinkCast(const AtomPtr& a)
-	{ return std::dynamic_pointer_cast<RewriteLink>(a); }
-
+LINK_PTR_DECL(RewriteLink)
 #define createRewriteLink std::make_shared<RewriteLink>
 
 /** @}*/

--- a/opencog/atoms/core/RewriteLink.h
+++ b/opencog/atoms/core/RewriteLink.h
@@ -244,7 +244,7 @@ public:
 };
 
 LINK_PTR_DECL(RewriteLink)
-#define createRewriteLink std::make_shared<RewriteLink>
+#define createRewriteLink CREATE_DECL(RewriteLink)
 
 /** @}*/
 }

--- a/opencog/atoms/core/ScopeLink.h
+++ b/opencog/atoms/core/ScopeLink.h
@@ -46,8 +46,6 @@ namespace opencog
 /// the point of unpacked variables is to act as a memo or cache,
 /// speeding up later calculations.
 ///
-class ScopeLink;
-typedef std::shared_ptr<ScopeLink> ScopeLinkPtr;
 class ScopeLink : public Link
 {
 protected:
@@ -111,11 +109,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-static inline ScopeLinkPtr ScopeLinkCast(const Handle& h)
-	{ return std::dynamic_pointer_cast<ScopeLink>(h); }
-static inline ScopeLinkPtr ScopeLinkCast(const AtomPtr& a)
-	{ return std::dynamic_pointer_cast<ScopeLink>(a); }
-
+LINK_PTR_DECL(ScopeLink)
 #define createScopeLink std::make_shared<ScopeLink>
 
 /** @}*/

--- a/opencog/atoms/core/ScopeLink.h
+++ b/opencog/atoms/core/ScopeLink.h
@@ -110,7 +110,7 @@ public:
 };
 
 LINK_PTR_DECL(ScopeLink)
-#define createScopeLink std::make_shared<ScopeLink>
+#define createScopeLink CREATE_DECL(ScopeLink)
 
 /** @}*/
 }

--- a/opencog/atoms/core/SleepLink.h
+++ b/opencog/atoms/core/SleepLink.h
@@ -49,7 +49,7 @@ public:
 };
 
 LINK_PTR_DECL(SleepLink)
-#define createSleepLink std::make_shared<SleepLink>
+#define createSleepLink CREATE_DECL(SleepLink)
 
 /** @}*/
 }

--- a/opencog/atoms/core/SleepLink.h
+++ b/opencog/atoms/core/SleepLink.h
@@ -48,12 +48,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<SleepLink> SleepLinkPtr;
-static inline SleepLinkPtr SleepLinkCast(const Handle& h)
-	{ return std::dynamic_pointer_cast<SleepLink>(h); }
-static inline SleepLinkPtr SleepLinkCast(AtomPtr a)
-	{ return std::dynamic_pointer_cast<SleepLink>(a); }
-
+LINK_PTR_DECL(SleepLink)
 #define createSleepLink std::make_shared<SleepLink>
 
 /** @}*/

--- a/opencog/atoms/core/StateLink.h
+++ b/opencog/atoms/core/StateLink.h
@@ -105,12 +105,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<StateLink> StateLinkPtr;
-static inline StateLinkPtr StateLinkCast(const Handle& h)
-	{ return std::dynamic_pointer_cast<StateLink>(h); }
-static inline StateLinkPtr StateLinkCast(const AtomPtr& a)
-	{ return std::dynamic_pointer_cast<StateLink>(a); }
-
+LINK_PTR_DECL(StateLink)
 #define createStateLink std::make_shared<StateLink>
 
 /** @}*/

--- a/opencog/atoms/core/StateLink.h
+++ b/opencog/atoms/core/StateLink.h
@@ -106,7 +106,7 @@ public:
 };
 
 LINK_PTR_DECL(StateLink)
-#define createStateLink std::make_shared<StateLink>
+#define createStateLink CREATE_DECL(StateLink)
 
 /** @}*/
 }

--- a/opencog/atoms/core/TimeLink.h
+++ b/opencog/atoms/core/TimeLink.h
@@ -48,7 +48,7 @@ public:
 };
 
 LINK_PTR_DECL(TimeLink)
-#define createTimeLink std::make_shared<TimeLink>
+#define createTimeLink CREATE_DECL(TimeLink)
 
 /** @}*/
 }

--- a/opencog/atoms/core/TimeLink.h
+++ b/opencog/atoms/core/TimeLink.h
@@ -47,12 +47,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<TimeLink> TimeLinkPtr;
-static inline TimeLinkPtr TimeLinkCast(const Handle& h)
-	{ return std::dynamic_pointer_cast<TimeLink>(h); }
-static inline TimeLinkPtr TimeLinkCast(AtomPtr a)
-	{ return std::dynamic_pointer_cast<TimeLink>(a); }
-
+LINK_PTR_DECL(TimeLink)
 #define createTimeLink std::make_shared<TimeLink>
 
 /** @}*/

--- a/opencog/atoms/core/TypeChoice.h
+++ b/opencog/atoms/core/TypeChoice.h
@@ -33,7 +33,7 @@ namespace opencog
 
 typedef std::pair<size_t, size_t> GlobInterval;
 class TypeChoice;
-typedef std::shared_ptr<TypeChoice> TypeChoicePtr;
+LINK_PTR_DECL(TypeChoice)
 typedef std::set<TypeChoicePtr> TypeChoiceSet;
 
 /// The TypeChoice link is used to hold a type description; it is
@@ -97,13 +97,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<TypeChoice> TypeChoicePtr;
-static inline TypeChoicePtr TypeChoiceCast(const Handle& h)
-	{ return std::dynamic_pointer_cast<TypeChoice>(h); }
-static inline TypeChoicePtr TypeChoiceCast(AtomPtr a)
-	{ return std::dynamic_pointer_cast<TypeChoice>(a); }
-
-#define createTypeChoice std::make_shared<TypeChoice>
+#define createTypeChoice CREATE_DECL(TypeChoice)
 
 std::string oc_to_string(const TypeChoiceSet&,
                          const std::string& indent=empty_string);

--- a/opencog/atoms/core/TypeIntersectionLink.h
+++ b/opencog/atoms/core/TypeIntersectionLink.h
@@ -57,7 +57,7 @@ public:
 };
 
 LINK_PTR_DECL(TypeIntersectionLink)
-#define createTypeIntersectionLink std::make_shared<TypeIntersectionLink>
+#define createTypeIntersectionLink CREATE_DECL(TypeIntersectionLink)
 
 /** @}*/
 }

--- a/opencog/atoms/core/TypeIntersectionLink.h
+++ b/opencog/atoms/core/TypeIntersectionLink.h
@@ -56,12 +56,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<TypeIntersectionLink> TypeIntersectionLinkPtr;
-static inline TypeIntersectionLinkPtr TypeIntersectionLinkCast(const Handle& h)
-	{ return std::dynamic_pointer_cast<TypeIntersectionLink>(h); }
-static inline TypeIntersectionLinkPtr TypeIntersectionLinkCast(AtomPtr a)
-	{ return std::dynamic_pointer_cast<TypeIntersectionLink>(a); }
-
+LINK_PTR_DECL(TypeIntersectionLink)
 #define createTypeIntersectionLink std::make_shared<TypeIntersectionLink>
 
 /** @}*/

--- a/opencog/atoms/core/TypeNode.h
+++ b/opencog/atoms/core/TypeNode.h
@@ -94,13 +94,8 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<TypeNode> TypeNodePtr;
-static inline TypeNodePtr TypeNodeCast(const Handle& h)
-	{ return std::dynamic_pointer_cast<TypeNode>(h); }
-static inline TypeNodePtr TypeNodeCast(AtomPtr a)
-	{ return std::dynamic_pointer_cast<TypeNode>(a); }
-
-#define createTypeNode std::make_shared<TypeNode>
+NODE_PTR_DECL(TypeNode)
+#define createTypeNode CREATE_DECL(TypeNode)
 
 /** @}*/
 }

--- a/opencog/atoms/core/TypedAtomLink.h
+++ b/opencog/atoms/core/TypedAtomLink.h
@@ -84,12 +84,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<TypedAtomLink> TypedAtomLinkPtr;
-static inline TypedAtomLinkPtr TypedAtomLinkCast(const Handle& h)
-	{ return std::dynamic_pointer_cast<TypedAtomLink>(h); }
-static inline TypedAtomLinkPtr TypedAtomLinkCast(AtomPtr a)
-	{ return std::dynamic_pointer_cast<TypedAtomLink>(a); }
-
+LINK_PTR_DECL(TypedAtomLink)
 #define createTypedAtomLink std::make_shared<TypedAtomLink>
 
 /** @}*/

--- a/opencog/atoms/core/TypedAtomLink.h
+++ b/opencog/atoms/core/TypedAtomLink.h
@@ -85,7 +85,7 @@ public:
 };
 
 LINK_PTR_DECL(TypedAtomLink)
-#define createTypedAtomLink std::make_shared<TypedAtomLink>
+#define createTypedAtomLink CREATE_DECL(TypedAtomLink)
 
 /** @}*/
 }

--- a/opencog/atoms/core/TypedVariableLink.h
+++ b/opencog/atoms/core/TypedVariableLink.h
@@ -103,7 +103,7 @@ public:
 };
 
 LINK_PTR_DECL(TypedVariableLink)
-#define createTypedVariableLink std::make_shared<TypedVariableLink>
+#define createTypedVariableLink CREATE_DECL(TypedVariableLink)
 
 /** @}*/
 }

--- a/opencog/atoms/core/TypedVariableLink.h
+++ b/opencog/atoms/core/TypedVariableLink.h
@@ -102,12 +102,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<TypedVariableLink> TypedVariableLinkPtr;
-static inline TypedVariableLinkPtr TypedVariableLinkCast(const Handle& h)
-	{ return std::dynamic_pointer_cast<TypedVariableLink>(h); }
-static inline TypedVariableLinkPtr TypedVariableLinkCast(AtomPtr a)
-	{ return std::dynamic_pointer_cast<TypedVariableLink>(a); }
-
+LINK_PTR_DECL(TypedVariableLink)
 #define createTypedVariableLink std::make_shared<TypedVariableLink>
 
 /** @}*/

--- a/opencog/atoms/core/UniqueLink.h
+++ b/opencog/atoms/core/UniqueLink.h
@@ -63,7 +63,7 @@ public:
 };
 
 LINK_PTR_DECL(UniqueLink)
-#define createUniqueLink std::make_shared<UniqueLink>
+#define createUniqueLink CREATE_DECL(UniqueLink)
 
 /** @}*/
 }

--- a/opencog/atoms/core/UniqueLink.h
+++ b/opencog/atoms/core/UniqueLink.h
@@ -62,12 +62,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<UniqueLink> UniqueLinkPtr;
-static inline UniqueLinkPtr UniqueLinkCast(const Handle& h)
-	{ return std::dynamic_pointer_cast<UniqueLink>(h); }
-static inline UniqueLinkPtr UniqueLinkCast(const AtomPtr& a)
-	{ return std::dynamic_pointer_cast<UniqueLink>(a); }
-
+LINK_PTR_DECL(UniqueLink)
 #define createUniqueLink std::make_shared<UniqueLink>
 
 /** @}*/

--- a/opencog/atoms/core/UnorderedLink.h
+++ b/opencog/atoms/core/UnorderedLink.h
@@ -64,7 +64,7 @@ public:
 };
 
 LINK_PTR_DECL(UnorderedLink)
-#define createUnorderedLink std::make_shared<UnorderedLink>
+#define createUnorderedLink CREATE_DECL(UnorderedLink)
 
 /** @}*/
 }

--- a/opencog/atoms/core/UnorderedLink.h
+++ b/opencog/atoms/core/UnorderedLink.h
@@ -63,12 +63,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<UnorderedLink> UnorderedLinkPtr;
-static inline UnorderedLinkPtr UnorderedLinkCast(const Handle& h)
-	{ return std::dynamic_pointer_cast<UnorderedLink>(h); }
-static inline UnorderedLinkPtr UnorderedLinkCast(const AtomPtr& a)
-	{ return std::dynamic_pointer_cast<UnorderedLink>(a); }
-
+LINK_PTR_DECL(UnorderedLink)
 #define createUnorderedLink std::make_shared<UnorderedLink>
 
 /** @}*/

--- a/opencog/atoms/core/VariableList.h
+++ b/opencog/atoms/core/VariableList.h
@@ -88,13 +88,8 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<VariableList> VariableListPtr;
-static inline VariableListPtr VariableListCast(const Handle& h)
-	{ return std::dynamic_pointer_cast<VariableList>(h); }
-static inline VariableListPtr VariableListCast(const AtomPtr& a)
-	{ return std::dynamic_pointer_cast<VariableList>(a); }
-
-#define createVariableList std::make_shared<VariableList>
+LINK_PTR_DECL(VariableList)
+#define createVariableList CREATE_DECL(VariableList)
 
 // Debugging helpers see
 // http://wiki.opencog.org/w/Development_standards#Print_OpenCog_Objects

--- a/opencog/atoms/core/VariableSet.h
+++ b/opencog/atoms/core/VariableSet.h
@@ -56,13 +56,8 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<VariableSet> VariableSetPtr;
-static inline VariableSetPtr VariableSetCast(const Handle& h)
-	{ return std::dynamic_pointer_cast<VariableSet>(h); }
-static inline VariableSetPtr VariableSetCast(const AtomPtr& a)
-	{ return std::dynamic_pointer_cast<VariableSet>(a); }
-
-#define createVariableSet std::make_shared<VariableSet>
+LINK_PTR_DECL(VariableSet)
+#define createVariableSet CREATE_DECL(VariableSet)
 
 // Debugging helpers see
 // http://wiki.opencog.org/w/Development_standards#Print_OpenCog_Objects

--- a/opencog/atoms/execution/EvaluationLink.h
+++ b/opencog/atoms/execution/EvaluationLink.h
@@ -55,12 +55,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<EvaluationLink> EvaluationLinkPtr;
-static inline EvaluationLinkPtr EvaluationLinkCast(const Handle& h)
-   { AtomPtr a(h); return std::dynamic_pointer_cast<EvaluationLink>(a); }
-static inline EvaluationLinkPtr EvaluationLinkCast(AtomPtr a)
-   { return std::dynamic_pointer_cast<EvaluationLink>(a); }
-
+LINK_PTR_DECL(EvaluationLink)
 #define createEvaluationLink std::make_shared<EvaluationLink>
 
 /** @}*/

--- a/opencog/atoms/execution/EvaluationLink.h
+++ b/opencog/atoms/execution/EvaluationLink.h
@@ -56,7 +56,7 @@ public:
 };
 
 LINK_PTR_DECL(EvaluationLink)
-#define createEvaluationLink std::make_shared<EvaluationLink>
+#define createEvaluationLink CREATE_DECL(EvaluationLink)
 
 /** @}*/
 }

--- a/opencog/atoms/execution/ExecutionOutputLink.h
+++ b/opencog/atoms/execution/ExecutionOutputLink.h
@@ -62,7 +62,7 @@ public:
 };
 
 LINK_PTR_DECL(ExecutionOutputLink)
-#define createExecutionOutputLink std::make_shared<ExecutionOutputLink>
+#define createExecutionOutputLink CREATE_DECL(ExecutionOutputLink)
 
 /** @}*/
 }

--- a/opencog/atoms/execution/ExecutionOutputLink.h
+++ b/opencog/atoms/execution/ExecutionOutputLink.h
@@ -61,12 +61,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<ExecutionOutputLink> ExecutionOutputLinkPtr;
-static inline ExecutionOutputLinkPtr ExecutionOutputLinkCast(const Handle& h)
-   { AtomPtr a(h); return std::dynamic_pointer_cast<ExecutionOutputLink>(a); }
-static inline ExecutionOutputLinkPtr ExecutionOutputLinkCast(AtomPtr a)
-   { return std::dynamic_pointer_cast<ExecutionOutputLink>(a); }
-
+LINK_PTR_DECL(ExecutionOutputLink)
 #define createExecutionOutputLink std::make_shared<ExecutionOutputLink>
 
 /** @}*/

--- a/opencog/atoms/execution/GroundedProcedureNode.h
+++ b/opencog/atoms/execution/GroundedProcedureNode.h
@@ -47,11 +47,7 @@ public:
 	virtual ValuePtr execute(AtomSpace*, const Handle&, bool silent=false) = 0;
 };
 
-typedef std::shared_ptr<GroundedProcedureNode> GroundedProcedureNodePtr;
-static inline GroundedProcedureNodePtr GroundedProcedureNodeCast(const Handle& h)
-   { AtomPtr a(h); return std::dynamic_pointer_cast<GroundedProcedureNode>(a); }
-static inline GroundedProcedureNodePtr GroundedProcedureNodeCast(AtomPtr a)
-   { return std::dynamic_pointer_cast<GroundedProcedureNode>(a); }
+NODE_PTR_DECL(GroundedProcedureNode)
 
 /** @}*/
 }

--- a/opencog/atoms/flow/PredicateFormulaLink.h
+++ b/opencog/atoms/flow/PredicateFormulaLink.h
@@ -61,7 +61,7 @@ public:
 };
 
 LINK_PTR_DECL(PredicateFormulaLink)
-#define createPredicateFormulaLink std::make_shared<PredicateFormulaLink>
+#define createPredicateFormulaLink CREATE_DECL(PredicateFormulaLink)
 
 /** @}*/
 }

--- a/opencog/atoms/flow/PredicateFormulaLink.h
+++ b/opencog/atoms/flow/PredicateFormulaLink.h
@@ -60,12 +60,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<PredicateFormulaLink> PredicateFormulaLinkPtr;
-static inline PredicateFormulaLinkPtr PredicateFormulaLinkCast(const Handle& h)
-	{ return std::dynamic_pointer_cast<PredicateFormulaLink>(h); }
-static inline PredicateFormulaLinkPtr PredicateFormulaLinkCast(AtomPtr a)
-	{ return std::dynamic_pointer_cast<PredicateFormulaLink>(a); }
-
+LINK_PTR_DECL(PredicateFormulaLink)
 #define createPredicateFormulaLink std::make_shared<PredicateFormulaLink>
 
 /** @}*/

--- a/opencog/atoms/flow/SetTVLink.h
+++ b/opencog/atoms/flow/SetTVLink.h
@@ -53,12 +53,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<SetTVLink> SetTVLinkPtr;
-static inline SetTVLinkPtr SetTVLinkCast(const Handle& h)
-	{ return std::dynamic_pointer_cast<SetTVLink>(h); }
-static inline SetTVLinkPtr SetTVLinkCast(AtomPtr a)
-	{ return std::dynamic_pointer_cast<SetTVLink>(a); }
-
+LINK_PTR_DECL(SetTVLink)
 #define createSetTVLink std::make_shared<SetTVLink>
 
 /** @}*/

--- a/opencog/atoms/flow/SetTVLink.h
+++ b/opencog/atoms/flow/SetTVLink.h
@@ -54,7 +54,7 @@ public:
 };
 
 LINK_PTR_DECL(SetTVLink)
-#define createSetTVLink std::make_shared<SetTVLink>
+#define createSetTVLink CREATE_DECL(SetTVLink)
 
 /** @}*/
 }

--- a/opencog/atoms/flow/SetValueLink.h
+++ b/opencog/atoms/flow/SetValueLink.h
@@ -49,12 +49,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<SetValueLink> SetValueLinkPtr;
-static inline SetValueLinkPtr SetValueLinkCast(const Handle& h)
-	{ return std::dynamic_pointer_cast<SetValueLink>(h); }
-static inline SetValueLinkPtr SetValueLinkCast(AtomPtr a)
-	{ return std::dynamic_pointer_cast<SetValueLink>(a); }
-
+LINK_PTR_DECL(SetValueLink)
 #define createSetValueLink std::make_shared<SetValueLink>
 
 /** @}*/

--- a/opencog/atoms/flow/SetValueLink.h
+++ b/opencog/atoms/flow/SetValueLink.h
@@ -50,7 +50,7 @@ public:
 };
 
 LINK_PTR_DECL(SetValueLink)
-#define createSetValueLink std::make_shared<SetValueLink>
+#define createSetValueLink CREATE_DECL(SetValueLink)
 
 /** @}*/
 }

--- a/opencog/atoms/flow/StreamValueOfLink.h
+++ b/opencog/atoms/flow/StreamValueOfLink.h
@@ -47,12 +47,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<StreamValueOfLink> StreamValueOfLinkPtr;
-static inline StreamValueOfLinkPtr StreamValueOfLinkCast(const Handle& h)
-	{ return std::dynamic_pointer_cast<StreamValueOfLink>(h); }
-static inline StreamValueOfLinkPtr StreamValueOfLinkCast(AtomPtr a)
-	{ return std::dynamic_pointer_cast<StreamValueOfLink>(a); }
-
+LINK_PTR_DECL(StreamValueOfLink)
 #define createStreamValueOfLink std::make_shared<StreamValueOfLink>
 
 /** @}*/

--- a/opencog/atoms/flow/StreamValueOfLink.h
+++ b/opencog/atoms/flow/StreamValueOfLink.h
@@ -48,7 +48,7 @@ public:
 };
 
 LINK_PTR_DECL(StreamValueOfLink)
-#define createStreamValueOfLink std::make_shared<StreamValueOfLink>
+#define createStreamValueOfLink CREATE_DECL(StreamValueOfLink)
 
 /** @}*/
 }

--- a/opencog/atoms/flow/TruthValueOfLink.h
+++ b/opencog/atoms/flow/TruthValueOfLink.h
@@ -134,7 +134,7 @@ public:
 };
 
 LINK_PTR_DECL(CountOfLink)
-#define createCountOfLink std::make_shared<CountOfLink>
+#define createCountOfLink CREATE_DECL(CountOfLink)
 
 /** @}*/
 }

--- a/opencog/atoms/flow/TruthValueOfLink.h
+++ b/opencog/atoms/flow/TruthValueOfLink.h
@@ -133,12 +133,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<CountOfLink> CountOfLinkPtr;
-static inline CountOfLinkPtr CountOfLinkCast(const Handle& h)
-	{ return std::dynamic_pointer_cast<CountOfLink>(h); }
-static inline CountOfLinkPtr CountOfLinkCast(AtomPtr a)
-	{ return std::dynamic_pointer_cast<CountOfLink>(a); }
-
+LINK_PTR_DECL(CountOfLink)
 #define createCountOfLink std::make_shared<CountOfLink>
 
 /** @}*/

--- a/opencog/atoms/flow/TruthValueOfLink.h
+++ b/opencog/atoms/flow/TruthValueOfLink.h
@@ -52,13 +52,8 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<TruthValueOfLink> TruthValueOfLinkPtr;
-static inline TruthValueOfLinkPtr TruthValueOfLinkCast(const Handle& h)
-	{ return std::dynamic_pointer_cast<TruthValueOfLink>(h); }
-static inline TruthValueOfLinkPtr TruthValueOfLinkCast(AtomPtr a)
-	{ return std::dynamic_pointer_cast<TruthValueOfLink>(a); }
-
-#define createTruthValueOfLink std::make_shared<TruthValueOfLink>
+LINK_PTR_DECL(TruthValueOfLink)
+#define createTruthValueOfLink CREATE_DECL(TruthValueOfLink)
 
 // ====================================================================
 
@@ -79,13 +74,8 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<StrengthOfLink> StrengthOfLinkPtr;
-static inline StrengthOfLinkPtr StrengthOfLinkCast(const Handle& h)
-	{ return std::dynamic_pointer_cast<StrengthOfLink>(h); }
-static inline StrengthOfLinkPtr StrengthOfLinkCast(AtomPtr a)
-	{ return std::dynamic_pointer_cast<StrengthOfLink>(a); }
-
-#define createStrengthOfLink std::make_shared<StrengthOfLink>
+LINK_PTR_DECL(StrengthOfLink)
+#define createStrengthOfLink CREATE_DECL(StrengthOfLink)
 
 // ====================================================================
 
@@ -106,13 +96,8 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<ConfidenceOfLink> ConfidenceOfLinkPtr;
-static inline ConfidenceOfLinkPtr ConfidenceOfLinkCast(const Handle& h)
-	{ return std::dynamic_pointer_cast<ConfidenceOfLink>(h); }
-static inline ConfidenceOfLinkPtr ConfidenceOfLinkCast(AtomPtr a)
-	{ return std::dynamic_pointer_cast<ConfidenceOfLink>(a); }
-
-#define createConfidenceOfLink std::make_shared<ConfidenceOfLink>
+LINK_PTR_DECL(ConfidenceOfLink)
+#define createConfidenceOfLink CREATE_DECL(ConfidenceOfLink)
 
 // ====================================================================
 

--- a/opencog/atoms/flow/ValueOfLink.h
+++ b/opencog/atoms/flow/ValueOfLink.h
@@ -48,12 +48,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<ValueOfLink> ValueOfLinkPtr;
-static inline ValueOfLinkPtr ValueOfLinkCast(const Handle& h)
-	{ return std::dynamic_pointer_cast<ValueOfLink>(h); }
-static inline ValueOfLinkPtr ValueOfLinkCast(AtomPtr a)
-	{ return std::dynamic_pointer_cast<ValueOfLink>(a); }
-
+LINK_PTR_DECL(ValueOfLink)
 #define createValueOfLink std::make_shared<ValueOfLink>
 
 /** @}*/

--- a/opencog/atoms/flow/ValueOfLink.h
+++ b/opencog/atoms/flow/ValueOfLink.h
@@ -49,7 +49,7 @@ public:
 };
 
 LINK_PTR_DECL(ValueOfLink)
-#define createValueOfLink std::make_shared<ValueOfLink>
+#define createValueOfLink CREATE_DECL(ValueOfLink)
 
 /** @}*/
 }

--- a/opencog/atoms/foreign/ForeignAST.h
+++ b/opencog/atoms/foreign/ForeignAST.h
@@ -47,12 +47,7 @@ public:
 	virtual const std::string& get_name() const { return _name; }
 };
 
-typedef std::shared_ptr<ForeignAST> ForeignASTPtr;
-static inline ForeignASTPtr ForeignASTCast(const Handle& h)
-	{ return std::dynamic_pointer_cast<ForeignAST>(h); }
-static inline ForeignASTPtr ForeignASTCast(const AtomPtr& a)
-	{ return std::dynamic_pointer_cast<ForeignAST>(a); }
-
+LINK_PTR_DECL(ForeignAST)
 
 template< class... Args >
 Handle createForeignAST( Args&&... args )

--- a/opencog/atoms/foreign/SexprAST.h
+++ b/opencog/atoms/foreign/SexprAST.h
@@ -57,13 +57,8 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<SexprAST> SexprASTPtr;
-static inline SexprASTPtr SexprASTCast(const Handle& h)
-	{ return std::dynamic_pointer_cast<SexprAST>(h); }
-static inline SexprASTPtr SexprASTCast(const AtomPtr& a)
-	{ return std::dynamic_pointer_cast<SexprAST>(a); }
-
-#define createSexprAST std::make_shared<SexprAST>
+LINK_PTR_DECL(SexprAST)
+#define createSexprAST CREATE_DECL(SexprAST)
 
 /** @}*/
 }

--- a/opencog/atoms/grounded/GroundedPredicateNode.h
+++ b/opencog/atoms/grounded/GroundedPredicateNode.h
@@ -53,13 +53,8 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<GroundedPredicateNode> GroundedPredicateNodePtr;
-static inline GroundedPredicateNodePtr GroundedPredicateNodeCast(const Handle& h)
-   { AtomPtr a(h); return std::dynamic_pointer_cast<GroundedPredicateNode>(a); }
-static inline GroundedPredicateNodePtr GroundedPredicateNodeCast(AtomPtr a)
-   { return std::dynamic_pointer_cast<GroundedPredicateNode>(a); }
-
-#define createGroundedPredicateNode std::make_shared<GroundedPredicateNode>
+NODE_PTR_DECL(GroundedPredicateNode)
+#define createGroundedPredicateNode CREATE_DECL(GroundedPredicateNode)
 
 /** @}*/
 }

--- a/opencog/atoms/grounded/GroundedSchemaNode.cc
+++ b/opencog/atoms/grounded/GroundedSchemaNode.cc
@@ -24,7 +24,7 @@
 #include <opencog/atoms/atom_types/atom_types.h>
 #include <opencog/atomspace/AtomSpace.h>
 
-#include <opencog/atoms/grounded/GroundedSchemaNode.h>
+#include "GroundedSchemaNode.h"
 #include "LibraryRunner.h"
 #include "PythonRunner.h"
 #include "SCMRunner.h"

--- a/opencog/atoms/grounded/GroundedSchemaNode.h
+++ b/opencog/atoms/grounded/GroundedSchemaNode.h
@@ -53,7 +53,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-NODE_PTR_DEL(GroundedSchemaNode)
+NODE_PTR_DECL(GroundedSchemaNode)
 #define createGroundedSchemaNode CREATE_DECL(GroundedSchemaNode)
 
 /** @}*/

--- a/opencog/atoms/grounded/GroundedSchemaNode.h
+++ b/opencog/atoms/grounded/GroundedSchemaNode.h
@@ -53,13 +53,8 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<GroundedSchemaNode> GroundedSchemaNodePtr;
-static inline GroundedSchemaNodePtr GroundedSchemaNodeCast(const Handle& h)
-   { AtomPtr a(h); return std::dynamic_pointer_cast<GroundedSchemaNode>(a); }
-static inline GroundedSchemaNodePtr GroundedSchemaNodeCast(AtomPtr a)
-   { return std::dynamic_pointer_cast<GroundedSchemaNode>(a); }
-
-#define createGroundedSchemaNode std::make_shared<GroundedSchemaNode>
+NODE_PTR_DEL(GroundedSchemaNode)
+#define createGroundedSchemaNode CREATE_DECL(GroundedSchemaNode)
 
 /** @}*/
 }

--- a/opencog/atoms/join/JoinLink.h
+++ b/opencog/atoms/join/JoinLink.h
@@ -113,12 +113,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<JoinLink> JoinLinkPtr;
-static inline JoinLinkPtr JoinLinkCast(const Handle& h)
-	{ AtomPtr a(h); return std::dynamic_pointer_cast<JoinLink>(a); }
-static inline JoinLinkPtr JoinLinkCast(AtomPtr a)
-	{ return std::dynamic_pointer_cast<JoinLink>(a); }
-
+LINK_PTR_DECL(JoinLink)
 #define createJoinLink std::make_shared<JoinLink>
 
 /** @}*/

--- a/opencog/atoms/join/JoinLink.h
+++ b/opencog/atoms/join/JoinLink.h
@@ -114,7 +114,7 @@ public:
 };
 
 LINK_PTR_DECL(JoinLink)
-#define createJoinLink std::make_shared<JoinLink>
+#define createJoinLink CREATE_DECL(JoinLink)
 
 /** @}*/
 }

--- a/opencog/atoms/parallel/ExecuteThreadedLink.h
+++ b/opencog/atoms/parallel/ExecuteThreadedLink.h
@@ -52,7 +52,7 @@ public:
 };
 
 LINK_PTR_DECL(ExecuteThreadedLink)
-#define createExecuteThreadedLink std::make_shared<ExecuteThreadedLink>
+#define createExecuteThreadedLink CREATE_DECL(ExecuteThreadedLink)
 
 /** @}*/
 }

--- a/opencog/atoms/parallel/ExecuteThreadedLink.h
+++ b/opencog/atoms/parallel/ExecuteThreadedLink.h
@@ -51,10 +51,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<ExecuteThreadedLink> ExecuteThreadedLinkPtr;
-static inline ExecuteThreadedLinkPtr ExecuteThreadedLinkCast(const Handle& h)
-   { AtomPtr a(h); return std::dynamic_pointer_cast<ExecuteThreadedLink>(a); }
-
+LINK_PTR_DECL(ExecuteThreadedLink)
 #define createExecuteThreadedLink std::make_shared<ExecuteThreadedLink>
 
 /** @}*/

--- a/opencog/atoms/parallel/ParallelLink.h
+++ b/opencog/atoms/parallel/ParallelLink.h
@@ -48,10 +48,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<ParallelLink> ParallelLinkPtr;
-static inline ParallelLinkPtr ParallelLinkCast(const Handle& h)
-   { AtomPtr a(h); return std::dynamic_pointer_cast<ParallelLink>(a); }
-
+LINK_PTR_DECL(ParallelLink)
 #define createParallelLink std::make_shared<ParallelLink>
 
 /** @}*/

--- a/opencog/atoms/parallel/ParallelLink.h
+++ b/opencog/atoms/parallel/ParallelLink.h
@@ -49,7 +49,7 @@ public:
 };
 
 LINK_PTR_DECL(ParallelLink)
-#define createParallelLink std::make_shared<ParallelLink>
+#define createParallelLink CREATE_DECL(ParallelLink)
 
 /** @}*/
 }

--- a/opencog/atoms/parallel/ThreadJoinLink.h
+++ b/opencog/atoms/parallel/ThreadJoinLink.h
@@ -48,7 +48,7 @@ public:
 };
 
 LINK_PTR_DECL(ThreadJoinLink)
-#define createThreadJoinLink std::make_shared<ThreadJoinLink>
+#define createThreadJoinLink CREATE_DECL(ThreadJoinLink)
 
 /** @}*/
 }

--- a/opencog/atoms/parallel/ThreadJoinLink.h
+++ b/opencog/atoms/parallel/ThreadJoinLink.h
@@ -47,10 +47,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<ThreadJoinLink> ThreadJoinLinkPtr;
-static inline ThreadJoinLinkPtr ThreadJoinLinkCast(const Handle& h)
-   { AtomPtr a(h); return std::dynamic_pointer_cast<ThreadJoinLink>(a); }
-
+LINK_PTR_DECL(ThreadJoinLink)
 #define createThreadJoinLink std::make_shared<ThreadJoinLink>
 
 /** @}*/

--- a/opencog/atoms/pattern/BindLink.h
+++ b/opencog/atoms/pattern/BindLink.h
@@ -49,7 +49,7 @@ public:
 };
 
 LINK_PTR_DECL(BindLink)
-#define createBindLink std::make_shared<BindLink>
+#define createBindLink CREATE_DECL(BindLink)
 
 /** @}*/
 }

--- a/opencog/atoms/pattern/BindLink.h
+++ b/opencog/atoms/pattern/BindLink.h
@@ -48,12 +48,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<BindLink> BindLinkPtr;
-static inline BindLinkPtr BindLinkCast(const Handle& h)
-	{ AtomPtr a(h); return std::dynamic_pointer_cast<BindLink>(a); }
-static inline BindLinkPtr BindLinkCast(AtomPtr a)
-	{ return std::dynamic_pointer_cast<BindLink>(a); }
-
+LINK_PTR_DECL(BindLink)
 #define createBindLink std::make_shared<BindLink>
 
 /** @}*/

--- a/opencog/atoms/pattern/DualLink.h
+++ b/opencog/atoms/pattern/DualLink.h
@@ -44,12 +44,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<DualLink> DualLinkPtr;
-static inline DualLinkPtr DualLinkCast(const Handle& h)
-	{ AtomPtr a(h); return std::dynamic_pointer_cast<DualLink>(a); }
-static inline DualLinkPtr DualLinkCast(AtomPtr a)
-	{ return std::dynamic_pointer_cast<DualLink>(a); }
-
+LINK_PTR_DECL(DualLink)
 #define createDualLink std::make_shared<DualLink>
 
 /** @}*/

--- a/opencog/atoms/pattern/DualLink.h
+++ b/opencog/atoms/pattern/DualLink.h
@@ -45,7 +45,7 @@ public:
 };
 
 LINK_PTR_DECL(DualLink)
-#define createDualLink std::make_shared<DualLink>
+#define createDualLink CREATE_DECL(DualLink)
 
 /** @}*/
 }

--- a/opencog/atoms/pattern/GetLink.h
+++ b/opencog/atoms/pattern/GetLink.h
@@ -45,12 +45,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<GetLink> GetLinkPtr;
-static inline GetLinkPtr GetLinkCast(const Handle& h)
-	{ AtomPtr a(h); return std::dynamic_pointer_cast<GetLink>(a); }
-static inline GetLinkPtr GetLinkCast(AtomPtr a)
-	{ return std::dynamic_pointer_cast<GetLink>(a); }
-
+LINK_PTR_DECL(GetLink)
 #define createGetLink std::make_shared<GetLink>
 
 /** @}*/

--- a/opencog/atoms/pattern/GetLink.h
+++ b/opencog/atoms/pattern/GetLink.h
@@ -46,7 +46,7 @@ public:
 };
 
 LINK_PTR_DECL(GetLink)
-#define createGetLink std::make_shared<GetLink>
+#define createGetLink CREATE_DECL(GetLink)
 
 /** @}*/
 }

--- a/opencog/atoms/pattern/MeetLink.h
+++ b/opencog/atoms/pattern/MeetLink.h
@@ -47,12 +47,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<MeetLink> MeetLinkPtr;
-static inline MeetLinkPtr MeetLinkCast(const Handle& h)
-	{ AtomPtr a(h); return std::dynamic_pointer_cast<MeetLink>(a); }
-static inline MeetLinkPtr MeetLinkCast(AtomPtr a)
-	{ return std::dynamic_pointer_cast<MeetLink>(a); }
-
+LINK_PTR_DECL(MeetLink)
 #define createMeetLink std::make_shared<MeetLink>
 
 /** @}*/

--- a/opencog/atoms/pattern/MeetLink.h
+++ b/opencog/atoms/pattern/MeetLink.h
@@ -48,7 +48,7 @@ public:
 };
 
 LINK_PTR_DECL(MeetLink)
-#define createMeetLink std::make_shared<MeetLink>
+#define createMeetLink CREATE_DECL(MeetLink)
 
 /** @}*/
 }

--- a/opencog/atoms/pattern/PatternLink.h
+++ b/opencog/atoms/pattern/PatternLink.h
@@ -71,7 +71,7 @@ namespace opencog
 /// virtual links.
 ///
 class PatternLink;
-typedef std::shared_ptr<PatternLink> PatternLinkPtr;
+LINK_PTR_DECL(PatternLink)
 class PatternLink : public PrenexLink
 {
 protected:
@@ -201,11 +201,6 @@ public:
 	// C++ attributes
 	std::string to_long_string(const std::string& indent) const;
 };
-
-static inline PatternLinkPtr PatternLinkCast(const Handle& h)
-	{ AtomPtr a(h); return std::dynamic_pointer_cast<PatternLink>(a); }
-static inline PatternLinkPtr PatternLinkCast(AtomPtr a)
-	{ return std::dynamic_pointer_cast<PatternLink>(a); }
 
 #define createPatternLink std::make_shared<PatternLink>
 

--- a/opencog/atoms/pattern/PatternLink.h
+++ b/opencog/atoms/pattern/PatternLink.h
@@ -202,7 +202,7 @@ public:
 	std::string to_long_string(const std::string& indent) const;
 };
 
-#define createPatternLink std::make_shared<PatternLink>
+#define createPatternLink CREATE_DECL(PatternLink)
 
 // For gdb, see
 // http://wiki.opencog.org/w/Development_standards#Print_OpenCog_Objects

--- a/opencog/atoms/pattern/QueryLink.h
+++ b/opencog/atoms/pattern/QueryLink.h
@@ -62,7 +62,7 @@ public:
 };
 
 LINK_PTR_DECL(QueryLink)
-#define createQueryLink std::make_shared<QueryLink>
+#define createQueryLink CREATE_DECL(QueryLink)
 
 /** @}*/
 }

--- a/opencog/atoms/pattern/QueryLink.h
+++ b/opencog/atoms/pattern/QueryLink.h
@@ -61,12 +61,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<QueryLink> QueryLinkPtr;
-static inline QueryLinkPtr QueryLinkCast(const Handle& h)
-	{ AtomPtr a(h); return std::dynamic_pointer_cast<QueryLink>(a); }
-static inline QueryLinkPtr QueryLinkCast(AtomPtr a)
-	{ return std::dynamic_pointer_cast<QueryLink>(a); }
-
+LINK_PTR_DECL(QueryLink)
 #define createQueryLink std::make_shared<QueryLink>
 
 /** @}*/

--- a/opencog/atoms/pattern/SatisfactionLink.h
+++ b/opencog/atoms/pattern/SatisfactionLink.h
@@ -50,12 +50,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<SatisfactionLink> SatisfactionLinkPtr;
-static inline SatisfactionLinkPtr SatisfactionLinkCast(const Handle& h)
-	{ AtomPtr a(h); return std::dynamic_pointer_cast<SatisfactionLink>(a); }
-static inline SatisfactionLinkPtr SatisfactionLinkCast(AtomPtr a)
-	{ return std::dynamic_pointer_cast<SatisfactionLink>(a); }
-
+LINK_PTR_DECL(SatisfactionLink)
 #define createSatisfactionLink std::make_shared<SatisfactionLink>
 
 /** @}*/

--- a/opencog/atoms/pattern/SatisfactionLink.h
+++ b/opencog/atoms/pattern/SatisfactionLink.h
@@ -51,7 +51,7 @@ public:
 };
 
 LINK_PTR_DECL(SatisfactionLink)
-#define createSatisfactionLink std::make_shared<SatisfactionLink>
+#define createSatisfactionLink CREATE_DECL(SatisfactionLink)
 
 /** @}*/
 }

--- a/opencog/atoms/reduct/AccumulateLink.h
+++ b/opencog/atoms/reduct/AccumulateLink.h
@@ -40,7 +40,7 @@ public:
 };
 
 LINK_PTR_DECL(AccumulateLink)
-#define createAccumulateLink std::make_shared<AccumulateLink>
+#define createAccumulateLink CREATE_DECL(AccumulateLink)
 
 /** @}*/
 }

--- a/opencog/atoms/reduct/AccumulateLink.h
+++ b/opencog/atoms/reduct/AccumulateLink.h
@@ -39,12 +39,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<AccumulateLink> AccumulateLinkPtr;
-static inline AccumulateLinkPtr AccumulateLinkCast(const Handle& h)
-   { AtomPtr a(h); return std::dynamic_pointer_cast<AccumulateLink>(a); }
-static inline AccumulateLinkPtr AccumulateLinkCast(AtomPtr a)
-   { return std::dynamic_pointer_cast<AccumulateLink>(a); }
-
+LINK_PTR_DECL(AccumulateLink)
 #define createAccumulateLink std::make_shared<AccumulateLink>
 
 /** @}*/

--- a/opencog/atoms/reduct/ArithmeticLink.h
+++ b/opencog/atoms/reduct/ArithmeticLink.h
@@ -56,7 +56,7 @@ public:
 };
 
 LINK_PTR_DECL(ArithmeticLink)
-#define createArithmeticLink std::make_shared<ArithmeticLink>
+#define createArithmeticLink CREATE_DECL(ArithmeticLink)
 
 /** @}*/
 }

--- a/opencog/atoms/reduct/ArithmeticLink.h
+++ b/opencog/atoms/reduct/ArithmeticLink.h
@@ -55,12 +55,7 @@ public:
 	virtual ValuePtr execute(void) { return execute(_atom_space, false); }
 };
 
-typedef std::shared_ptr<ArithmeticLink> ArithmeticLinkPtr;
-static inline ArithmeticLinkPtr ArithmeticLinkCast(const Handle& h)
-   { AtomPtr a(h); return std::dynamic_pointer_cast<ArithmeticLink>(a); }
-static inline ArithmeticLinkPtr ArithmeticLinkCast(AtomPtr a)
-   { return std::dynamic_pointer_cast<ArithmeticLink>(a); }
-
+LINK_PTR_DECL(ArithmeticLink)
 #define createArithmeticLink std::make_shared<ArithmeticLink>
 
 /** @}*/

--- a/opencog/atoms/reduct/DivideLink.h
+++ b/opencog/atoms/reduct/DivideLink.h
@@ -37,7 +37,7 @@ public:
 };
 
 LINK_PTR_DECL(DivideLink)
-#define createDivideLink std::make_shared<DivideLink>
+#define createDivideLink CREATE_DECL(DivideLink)
 
 /** @}*/
 }

--- a/opencog/atoms/reduct/DivideLink.h
+++ b/opencog/atoms/reduct/DivideLink.h
@@ -36,12 +36,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<DivideLink> DivideLinkPtr;
-static inline DivideLinkPtr DivideLinkCast(const Handle& h)
-   { AtomPtr a(h); return std::dynamic_pointer_cast<DivideLink>(a); }
-static inline DivideLinkPtr DivideLinkCast(AtomPtr a)
-   { return std::dynamic_pointer_cast<DivideLink>(a); }
-
+LINK_PTR_DECL(DivideLink)
 #define createDivideLink std::make_shared<DivideLink>
 
 /** @}*/

--- a/opencog/atoms/reduct/FoldLink.h
+++ b/opencog/atoms/reduct/FoldLink.h
@@ -37,8 +37,6 @@ namespace opencog
  * http://en.wikipedia.org/wiki/Fold_(higher-order_function)
  * for a general discussion.
  */
-class FoldLink;
-typedef std::shared_ptr<FoldLink> FoldLinkPtr;
 class FoldLink : public FunctionLink
 {
 protected:
@@ -58,11 +56,7 @@ public:
    virtual ValuePtr delta_reduce(AtomSpace*, bool) const;
 };
 
-static inline FoldLinkPtr FoldLinkCast(const Handle& h)
-   { AtomPtr a(h); return std::dynamic_pointer_cast<FoldLink>(a); }
-static inline FoldLinkPtr FoldLinkCast(AtomPtr a)
-   { return std::dynamic_pointer_cast<FoldLink>(a); }
-
+LINK_PTR_DECL(FoldLink)
 #define createFoldLink std::make_shared<FoldLink>
 
 /** @}*/

--- a/opencog/atoms/reduct/FoldLink.h
+++ b/opencog/atoms/reduct/FoldLink.h
@@ -57,7 +57,7 @@ public:
 };
 
 LINK_PTR_DECL(FoldLink)
-#define createFoldLink std::make_shared<FoldLink>
+#define createFoldLink CREATE_DECL(FoldLink)
 
 /** @}*/
 }

--- a/opencog/atoms/reduct/HeavisideLink.h
+++ b/opencog/atoms/reduct/HeavisideLink.h
@@ -41,7 +41,7 @@ public:
 };
 
 LINK_PTR_DECL(HeavisideLink)
-#define createHeavisideLink std::make_shared<HeavisideLink>
+#define createHeavisideLink CREATE_DECL(HeavisideLink)
 
 /** @}*/
 }

--- a/opencog/atoms/reduct/HeavisideLink.h
+++ b/opencog/atoms/reduct/HeavisideLink.h
@@ -40,12 +40,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<HeavisideLink> HeavisideLinkPtr;
-static inline HeavisideLinkPtr HeavisideLinkCast(const Handle& h)
-   { AtomPtr a(h); return std::dynamic_pointer_cast<HeavisideLink>(a); }
-static inline HeavisideLinkPtr HeavisideLinkCast(AtomPtr a)
-   { return std::dynamic_pointer_cast<HeavisideLink>(a); }
-
+LINK_PTR_DECL(HeavisideLink)
 #define createHeavisideLink std::make_shared<HeavisideLink>
 
 /** @}*/

--- a/opencog/atoms/reduct/Log2Link.h
+++ b/opencog/atoms/reduct/Log2Link.h
@@ -40,7 +40,7 @@ public:
 };
 
 LINK_PTR_DECL(Log2Link)
-#define createLog2Link std::make_shared<Log2Link>
+#define createLog2Link CREATE_DECL(Log2Link)
 
 /** @}*/
 }

--- a/opencog/atoms/reduct/Log2Link.h
+++ b/opencog/atoms/reduct/Log2Link.h
@@ -39,12 +39,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<Log2Link> Log2LinkPtr;
-static inline Log2LinkPtr Log2LinkCast(const Handle& h)
-   { AtomPtr a(h); return std::dynamic_pointer_cast<Log2Link>(a); }
-static inline Log2LinkPtr Log2LinkCast(AtomPtr a)
-   { return std::dynamic_pointer_cast<Log2Link>(a); }
-
+LINK_PTR_DECL(Log2Link)
 #define createLog2Link std::make_shared<Log2Link>
 
 /** @}*/

--- a/opencog/atoms/reduct/MaxLink.h
+++ b/opencog/atoms/reduct/MaxLink.h
@@ -38,7 +38,7 @@ public:
 };
 
 LINK_PTR_DECL(MaxLink)
-#define createMaxLink std::make_shared<MaxLink>
+#define createMaxLink CREATE_DECL(MaxLink)
 
 /** @}*/
 }

--- a/opencog/atoms/reduct/MaxLink.h
+++ b/opencog/atoms/reduct/MaxLink.h
@@ -37,12 +37,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<MaxLink> MaxLinkPtr;
-static inline MaxLinkPtr MaxLinkCast(const Handle& h)
-   { AtomPtr a(h); return std::dynamic_pointer_cast<MaxLink>(a); }
-static inline MaxLinkPtr MaxLinkCast(AtomPtr a)
-   { return std::dynamic_pointer_cast<MaxLink>(a); }
-
+LINK_PTR_DECL(MaxLink)
 #define createMaxLink std::make_shared<MaxLink>
 
 /** @}*/

--- a/opencog/atoms/reduct/MinLink.h
+++ b/opencog/atoms/reduct/MinLink.h
@@ -37,12 +37,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<MinLink> MinLinkPtr;
-static inline MinLinkPtr MinLinkCast(const Handle& h)
-   { AtomPtr a(h); return std::dynamic_pointer_cast<MinLink>(a); }
-static inline MinLinkPtr MinLinkCast(AtomPtr a)
-   { return std::dynamic_pointer_cast<MinLink>(a); }
-
+LINK_PTR_DECL(MinLink)
 #define createMinLink std::make_shared<MinLink>
 
 /** @}*/

--- a/opencog/atoms/reduct/MinLink.h
+++ b/opencog/atoms/reduct/MinLink.h
@@ -38,7 +38,7 @@ public:
 };
 
 LINK_PTR_DECL(MinLink)
-#define createMinLink std::make_shared<MinLink>
+#define createMinLink CREATE_DECL(MinLink)
 
 /** @}*/
 }

--- a/opencog/atoms/reduct/MinusLink.h
+++ b/opencog/atoms/reduct/MinusLink.h
@@ -37,7 +37,7 @@ public:
 };
 
 LINK_PTR_DECL(MinusLink)
-#define createMinusLink std::make_shared<MinusLink>
+#define createMinusLink CREATE_DECL(MinusLink)
 
 /** @}*/
 }

--- a/opencog/atoms/reduct/MinusLink.h
+++ b/opencog/atoms/reduct/MinusLink.h
@@ -36,12 +36,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<MinusLink> MinusLinkPtr;
-static inline MinusLinkPtr MinusLinkCast(const Handle& h)
-   { AtomPtr a(h); return std::dynamic_pointer_cast<MinusLink>(a); }
-static inline MinusLinkPtr MinusLinkCast(AtomPtr a)
-   { return std::dynamic_pointer_cast<MinusLink>(a); }
-
+LINK_PTR_DECL(MinusLink)
 #define createMinusLink std::make_shared<MinusLink>
 
 /** @}*/

--- a/opencog/atoms/reduct/NumericFunctionLink.h
+++ b/opencog/atoms/reduct/NumericFunctionLink.h
@@ -57,7 +57,7 @@ public:
 };
 
 LINK_PTR_DECL(NumericFunctionLink)
-#define createNumericFunctionLink std::make_shared<NumericFunctionLink>
+#define createNumericFunctionLink CREATE_DECL(NumericFunctionLink)
 
 /** @}*/
 }

--- a/opencog/atoms/reduct/NumericFunctionLink.h
+++ b/opencog/atoms/reduct/NumericFunctionLink.h
@@ -56,12 +56,7 @@ public:
 	static ValuePtr get_value(AtomSpace*, bool, ValuePtr);
 };
 
-typedef std::shared_ptr<NumericFunctionLink> NumericFunctionLinkPtr;
-static inline NumericFunctionLinkPtr NumericFunctionLinkCast(const Handle& h)
-   { AtomPtr a(h); return std::dynamic_pointer_cast<NumericFunctionLink>(a); }
-static inline NumericFunctionLinkPtr NumericFunctionLinkCast(AtomPtr a)
-   { return std::dynamic_pointer_cast<NumericFunctionLink>(a); }
-
+LINK_PTR_DECL(NumericFunctionLink)
 #define createNumericFunctionLink std::make_shared<NumericFunctionLink>
 
 /** @}*/

--- a/opencog/atoms/reduct/PlusLink.h
+++ b/opencog/atoms/reduct/PlusLink.h
@@ -39,12 +39,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<PlusLink> PlusLinkPtr;
-static inline PlusLinkPtr PlusLinkCast(const Handle& h)
-   { AtomPtr a(h); return std::dynamic_pointer_cast<PlusLink>(a); }
-static inline PlusLinkPtr PlusLinkCast(AtomPtr a)
-   { return std::dynamic_pointer_cast<PlusLink>(a); }
-
+LINK_PTR_DECL(PlusLink)
 #define createPlusLink std::make_shared<PlusLink>
 
 /** @}*/

--- a/opencog/atoms/reduct/PlusLink.h
+++ b/opencog/atoms/reduct/PlusLink.h
@@ -40,7 +40,7 @@ public:
 };
 
 LINK_PTR_DECL(PlusLink)
-#define createPlusLink std::make_shared<PlusLink>
+#define createPlusLink CREATE_DECL(PlusLink)
 
 /** @}*/
 }

--- a/opencog/atoms/reduct/PowLink.h
+++ b/opencog/atoms/reduct/PowLink.h
@@ -44,12 +44,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<PowLink> PowLinkPtr;
-static inline PowLinkPtr PowLinkCast(const Handle& h)
-   { AtomPtr a(h); return std::dynamic_pointer_cast<PowLink>(a); }
-static inline PowLinkPtr PowLinkCast(AtomPtr a)
-   { return std::dynamic_pointer_cast<PowLink>(a); }
-
+LINK_PTR_DECL(PowLink)
 #define createPowLink std::make_shared<PowLink>
 
 /** @}*/

--- a/opencog/atoms/reduct/PowLink.h
+++ b/opencog/atoms/reduct/PowLink.h
@@ -45,7 +45,7 @@ public:
 };
 
 LINK_PTR_DECL(PowLink)
-#define createPowLink std::make_shared<PowLink>
+#define createPowLink CREATE_DECL(PowLink)
 
 /** @}*/
 }

--- a/opencog/atoms/reduct/RandomNumber.h
+++ b/opencog/atoms/reduct/RandomNumber.h
@@ -58,13 +58,8 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<RandomNumberLink> RandomNumberLinkPtr;
-static inline RandomNumberLinkPtr RandomNumberLinkCast(const Handle& h)
-	{ return std::dynamic_pointer_cast<RandomNumberLink>(h); }
-static inline RandomNumberLinkPtr RandomNumberLinkCast(AtomPtr a)
-	{ return std::dynamic_pointer_cast<RandomNumberLink>(a); }
-
-#define createRandomNumberLink std::make_shared<RandomNumberLink>
+LINK_PTR_DECL(RandomNumberLink)
+#define createRandomNumberLink CREATE_DECL(RandomNumberLink)
 
 /** @}*/
 }

--- a/opencog/atoms/reduct/TimesLink.h
+++ b/opencog/atoms/reduct/TimesLink.h
@@ -39,12 +39,7 @@ public:
 	static Handle factory(const Handle&);
 };
 
-typedef std::shared_ptr<TimesLink> TimesLinkPtr;
-static inline TimesLinkPtr TimesLinkCast(const Handle& h)
-   { AtomPtr a(h); return std::dynamic_pointer_cast<TimesLink>(a); }
-static inline TimesLinkPtr TimesLinkCast(AtomPtr a)
-   { return std::dynamic_pointer_cast<TimesLink>(a); }
-
+LINK_PTR_DECL(TimesLink)
 #define createTimesLink std::make_shared<TimesLink>
 
 /** @}*/

--- a/opencog/atoms/reduct/TimesLink.h
+++ b/opencog/atoms/reduct/TimesLink.h
@@ -40,7 +40,7 @@ public:
 };
 
 LINK_PTR_DECL(TimesLink)
-#define createTimesLink std::make_shared<TimesLink>
+#define createTimesLink CREATE_DECL(TimesLink)
 
 /** @}*/
 }


### PR DESCRIPTION
All of the node and link definition files have repeated, regularly-structured boilerplate code.
Replace these by two macros.  This is wanted for other, related maintenance tasks.