### PR TITLE
Support deletion in deeply-stacked atomspaces

### DIFF
--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -237,6 +237,27 @@ bool Atom::setUnchecked(void)
     return _checked.exchange(false);
 }
 
+bool Atom::isAbsent() const
+{
+    return _absent.load();
+}
+
+/// Marking an Atom as being absent makes it invisible, as if it
+/// were deleted. We reclaim the "impossible-to-access" storage on
+/// it, as well. (Is this really needed? I dunno. Seems like a good
+/// idea.)
+bool Atom::setAbsent(void)
+{
+    KVP_SHARED_LOCK;
+    _values.clear();
+    return _absent.exchange(true);
+}
+
+bool Atom::setPresent(void)
+{
+    return _absent.exchange(false);
+}
+
 // ==============================================================
 
 void Atom::setAtomSpace(AtomSpace *tb)

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -192,17 +192,18 @@ class Atom
     friend class StateLink;       // Needs to call swap_atom()
 
 protected:
-    //! Sets the AtomSpace in which this Atom is inserted.
-    virtual void setAtomSpace(AtomSpace *);
-
     // Each atomic_flag chews up a byte.
     // Place this first, so that these share a word with Type.
+    mutable std::atomic_bool _absent;
     mutable std::atomic_bool _marked_for_removal;
     mutable std::atomic_bool _checked;
 
     /// Merkle-tree hash of the atom contents. Generically useful
     /// for indexing and comparison operations.
     mutable ContentHash _content_hash;
+
+    //! Sets the AtomSpace in which this Atom is inserted.
+    virtual void setAtomSpace(AtomSpace *);
 
     AtomSpace *_atom_space;
 
@@ -224,6 +225,7 @@ protected:
      */
     Atom(Type t)
       : Value(t),
+        _absent(false),
         _marked_for_removal(false),
         _checked(false),
         _content_hash(Handle::INVALID_HASH),
@@ -287,10 +289,7 @@ protected:
     virtual ContentHash compute_hash() const = 0;
 
 private:
-    /** Returns whether this atom is marked for removal.
-     *
-     * @return Whether this atom is marked for removal.
-     */
+    //! Returns whether this atom is marked for removal.
     bool isMarkedForRemoval() const;
 
     //! Marks the atom for removal. Returns old value.
@@ -303,6 +302,11 @@ private:
     bool isChecked() const;
     bool setChecked();
     bool setUnchecked();
+
+    /** Returns whether this atom is marked absent. */
+    bool isAbsent() const;
+    bool setAbsent();
+    bool setPresent();
 
 public:
 

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -92,6 +92,12 @@ AtomSpace::AtomSpace(AtomSpace* parent, bool transient) :
     _nameserver(nameserver())
 {
     if (parent) {
+        // It would be nice to set the COW flag by default, for any
+        // Atomspace that sits on top of another one.
+        // _copy_on_write = true;
+        // However the URE ForwardChainerUTest and BackwardChainerUTest
+        // fail if we do this. The root cause of this failure is not
+        // known. Perhaps the URE should be amended to NOT use COW?
         _environ.push_back(AtomSpaceCast(parent->shared_from_this()));
         _outgoing.push_back(HandleCast(parent->shared_from_this()));
     }

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -390,15 +390,15 @@ bool AtomSpace::extract_atom(const Handle& h, bool recursive)
     if (not recursive and not handle->isIncomingSetEmpty())
         return false;
 
-    // If the Atom is in some other AtomSpace that is not in our
-    // environment, then it is a user error.
-    // If we are in a COW space, we hide it instead of removing it.
+    // Atom seems to reside somewhere else.
     AtomSpace* other = handle->getAtomSpace();
     if (other != this)
     {
-        if (not in_environ(handle)) // return false;
-            throw RuntimeException(TRACE_INFO,
-                    "AtomSpace - extracting unknown Atom");
+        // If the Atom is in some other AtomSpace that is not in our
+        // environment, then it is a user error. ... Except that this
+        // can be hit during multi-threaded racing of add-delete, as
+        // witnessed by UseCountUTest.
+        if (not in_environ(handle)) return false;
 
         // If this is a COW space, then force-add it, so that it
         // can hide the atom in the deeper space.

--- a/opencog/atomspace/README-DeepSpace.md
+++ b/opencog/atomspace/README-DeepSpace.md
@@ -31,9 +31,62 @@ A "change-set" is meant to convey the same idea as in git: a single,
 coherent set of changes to many Atoms, rather than some piecemeal,
 uncoordinated changes to individual Atoms.
 
+Implementation
+--------------
+Atom deletion in an overaly is implemented by adding the atom to the
+overlay, but then marking it as "absent". That way, the atom is still
+there in the base space, while quieries for it in the cover space return
+"no such atom".
+
+Incoming set traversal
+----------------------
+The current design does NOT duplicate the incoming set of a covering
+atom. This can lead to confusion for the unwary user.  Some examples are
+in order.
+```
+(use-modules (opencog))
+
+; Place Atom in the base-space.
+(Concept "foo" (ctv 1 0 3))
+(ListLink (Concept "foo") (Concept "bar"))
+
+; Create a covering space
+(define base-space (cog-atomspace))
+(cog-atomspace-cow! #t base-space)
+
+(define cover-space (cog-new-atomspace base-space))
+(cog-set-atomspace! cover-space)
+(cog-atomspace-cow! #t cover-space)
+
+; Hide the atom "foo" in the base-space.
+(Concept "foo" (ctv 1 0 42))
+
+; Surprise! It has an empty incoming set!
+(cog-incoming-set (Concept "foo"))
+
+; Go back to the base space ... we see it is still there.
+(cog-set-atomspace! base-space)
+(cog-incoming-set (Concept "foo"))
+```
+
+Traversal is problematic, as well.
+```
+; Go back to the covering space
+(cog-set-atomspace! cover-space)
+
+; Surprise! There's a ListLink, but it contains the base-space
+; version of (Concept "foo") and not the covering-space version,
+; even though we are explicitly working in the covering space.
+(cog-incoming-set (Concept "bar"))
+```
+
+These two surprises could be "fixed" in the code, but all of the
+obvious fixes pay a hefty performance penalty. Thus, the current
+implementation leaves it to the user to decide what to do.
+
+
 TODO
 ----
-* Support atom deletion.
 * Make the `AtomSpace::in_environ()` call, and related calls, run fast,
   instead of being a recursive walk on the C stack.  In general, lookups
   should be O(1) in stack depth, and not O(N).

--- a/opencog/atomspace/README.md
+++ b/opencog/atomspace/README.md
@@ -166,9 +166,16 @@ Alter the atom's `getIncomingSet()` method, so that it returns not only
 it's own strict incoming set, but also that of any atoms that it's
 hiding. The cost here seems to be minimal.
 
-Add a "masked" bit-flag to the atom, indicating that there's another
-atom in an overlay that is covering it. This can be used to avoid
-traversing covered/masked atoms.
+However, this now presents a problem for traversing back down again:
+following the outgoing set back down will return the atom in the base
+space, and not it's cover. This would require performance-sapping checks
+of atoms in outgoing sets, to always return the version in the current
+atomspace. This cost seems excessive.
+
+#### Design A3)
+Do nothing. This is the easiest to implement: no additional code
+required. User-beware, though. Things might not work as the user
+expects.
 
 ### Design B)
 Each Atom holds an atomspace, key, value triple, so that, to find the
@@ -188,10 +195,9 @@ all existing applications, the majority of atoms have either TV's or
 AV's or both.
 
 ------
-Conclusion: Design A2 seems like the best, for now.
+Conclusion: Design A3 seems like the best, for now. See the
+[DeepSpace README](README-DeepSpace.md) for a mor detailed discussion.
 
-However, see also the [DeepSpace README](README-DeepSpace.md) for more
-info.
 
 -------------------------
 Garbage Collection Design

--- a/tests/atomspace/CMakeLists.txt
+++ b/tests/atomspace/CMakeLists.txt
@@ -22,3 +22,4 @@ ADD_CXXTEST(RemoveUTest)
 
 ADD_GUILE_TEST(DeepSpace deep-space-test.scm)
 ADD_GUILE_TEST(CoverSpace cover-space-test.scm)
+ADD_GUILE_TEST(CoverDelete cover-delete-test.scm)

--- a/tests/atomspace/cover-delete-test.scm
+++ b/tests/atomspace/cover-delete-test.scm
@@ -1,0 +1,53 @@
+;
+; cover-space-test.scm
+; Verify that links are correctly covered/uncovered in deeply nested
+; atomspaces.
+;
+(use-modules (srfi srfi-1))
+(use-modules (opencog) (opencog test-runner))
+
+(opencog-test-runner)
+
+; -------------------------------------------------------------------
+; Common setup, used by all tests.
+
+(define base-space (cog-atomspace))
+(cog-atomspace-cow! #t base-space)
+
+(define mid1-space (cog-new-atomspace base-space))
+(cog-atomspace-cow! #t mid1-space)
+
+(define mid2-space (cog-new-atomspace mid1-space))
+(cog-atomspace-cow! #t mid2-space)
+
+(define mid3-space (cog-new-atomspace mid2-space))
+(cog-atomspace-cow! #t mid3-space)
+
+(define surface-space (cog-new-atomspace mid3-space))
+(cog-atomspace-cow! #t surface-space)
+
+; -------------------------------------------------------------------
+; Test that deep links are found correctly.
+
+(define deep-delete "test deep delete")
+(test-begin deep-delete)
+
+; Repeatedly add and remove the same atom
+(cog-set-atomspace! base-space)
+(Concept "foo" (ctv 1 0 3))
+
+(cog-set-atomspace! mid1-space)
+(cog-extract! (Concept "foo"))
+
+; Should be present in the base space.
+(cog-set-atomspace! base-space)
+(test-assert "base-space" (cog-atom? (cog-node 'Concept "foo")))
+
+; Should be absent in the next level.
+(cog-set-atomspace! mid1-space)
+(test-assert "mid1-space" (nil? (cog-node 'Concept "foo")))
+
+(test-end deep-delete)
+
+; -------------------------------------------------------------------
+(opencog-test-end)

--- a/tests/atomspace/cover-delete-test.scm
+++ b/tests/atomspace/cover-delete-test.scm
@@ -39,13 +39,35 @@
 (cog-set-atomspace! mid1-space)
 (cog-extract! (Concept "foo"))
 
+(cog-set-atomspace! mid2-space)
+(Concept "foo" (ctv 1 0 5))
+
+(cog-set-atomspace! mid3-space)
+(cog-extract! (Concept "foo"))
+
+(cog-set-atomspace! surface-space)
+(Concept "foo" (ctv 1 0 7))
+
+; -----------------------------------
 ; Should be present in the base space.
 (cog-set-atomspace! base-space)
 (test-assert "base-space" (cog-atom? (cog-node 'Concept "foo")))
+(test-equal "base-tv" 3 (inexact->exact (cog-count (cog-node 'Concept "foo"))))
 
 ; Should be absent in the next level.
 (cog-set-atomspace! mid1-space)
 (test-assert "mid1-space" (nil? (cog-node 'Concept "foo")))
+
+(cog-set-atomspace! mid2-space)
+(test-assert "mid2-space" (cog-atom? (cog-node 'Concept "foo")))
+(test-equal "mid2-tv" 5 (inexact->exact (cog-count (cog-node 'Concept "foo"))))
+
+(cog-set-atomspace! mid3-space)
+(test-assert "mid3-space" (nil? (cog-node 'Concept "foo")))
+
+(cog-set-atomspace! surface-space)
+(test-assert "surface-space" (cog-atom? (cog-node 'Concept "foo")))
+(test-equal "surface-tv" 7 (inexact->exact (cog-count (cog-node 'Concept "foo"))))
 
 (test-end deep-delete)
 

--- a/tests/atomspace/cover-delete-test.scm
+++ b/tests/atomspace/cover-delete-test.scm
@@ -27,7 +27,7 @@
 (cog-atomspace-cow! #t surface-space)
 
 ; ===================================================================
-; Test that deep links are found correctly.
+; Test that deep deletions work correctly.
 
 (define deep-delete "test deep delete")
 (test-begin deep-delete)
@@ -109,6 +109,58 @@
 (test-equal "surface-tv" 6 (inexact->exact (cog-count (cog-node 'Concept "foo"))))
 
 (test-end deep-change)
+
+; ===================================================================
+; Test that deep link deletions work correctly.
+
+(define deep-link-delete "test deep link-delete")
+(test-begin deep-link-delete)
+
+; Repeatedly add and remove the same atom
+(cog-set-atomspace! base-space)
+(Concept "bar")
+(ListLink (Concept "foo") (Concept "bar") (ctv 1 0 10))
+
+(cog-set-atomspace! mid1-space)
+(cog-extract-recursive! (Concept "foo"))
+
+(cog-set-atomspace! mid2-space)
+(ListLink (Concept "foo") (Concept "bar") (ctv 1 0 20))
+
+(cog-set-atomspace! mid3-space)
+(cog-extract-recursive! (Concept "foo"))
+
+(cog-set-atomspace! surface-space)
+(ListLink (Concept "foo") (Concept "bar") (ctv 1 0 30))
+
+; -----------------------------------
+; Should be present in the base space.
+(cog-set-atomspace! base-space)
+(test-assert "base-space" (cog-atom? (cog-node 'Concept "foo")))
+(test-equal "base-tv" 2 (inexact->exact (cog-count (Concept "foo"))))
+(test-equal "base-litv" 10 (inexact->exact (cog-count
+    (ListLink (Concept "foo") (Concept "bar")))))
+
+; Should be absent in the next level.
+(cog-set-atomspace! mid1-space)
+(test-assert "mid1-space" (nil? (cog-node 'Concept "foo")))
+
+(cog-set-atomspace! mid2-space)
+(test-assert "mid2-space" (cog-atom? (cog-node 'Concept "foo")))
+(test-equal "mid2-tv" 4 (inexact->exact (cog-count (Concept "foo"))))
+(test-equal "mid2-litv" 20 (inexact->exact (cog-count
+    (ListLink (Concept "foo") (Concept "bar")))))
+
+(cog-set-atomspace! mid3-space)
+(test-assert "mid3-space" (nil? (cog-node 'Concept "foo")))
+
+(cog-set-atomspace! surface-space)
+(test-assert "surface-space" (cog-atom? (cog-node 'Concept "foo")))
+(test-equal "surface-tv" 6 (inexact->exact (cog-count (Concept "foo"))))
+(test-equal "surface-litv" 30 (inexact->exact (cog-count
+    (ListLink (Concept "foo") (Concept "bar")))))
+
+(test-end deep-link-delete)
 
 ; ===================================================================
 (opencog-test-end)

--- a/tests/atomspace/cover-delete-test.scm
+++ b/tests/atomspace/cover-delete-test.scm
@@ -26,7 +26,7 @@
 (define surface-space (cog-new-atomspace mid3-space))
 (cog-atomspace-cow! #t surface-space)
 
-; -------------------------------------------------------------------
+; ===================================================================
 ; Test that deep links are found correctly.
 
 (define deep-delete "test deep delete")
@@ -71,5 +71,44 @@
 
 (test-end deep-delete)
 
-; -------------------------------------------------------------------
+; ===================================================================
+; Building on the above, verify that values work
+
+(define deep-change "test deep change-delete")
+(test-begin deep-change)
+
+; Repeatedly add and remove the same atom
+(cog-set-atomspace! base-space)
+(cog-set-tv! (Concept "foo") (ctv 1 0 2))
+
+(cog-set-atomspace! mid2-space)
+(cog-set-tv! (Concept "foo") (ctv 1 0 4))
+
+(cog-set-atomspace! surface-space)
+(cog-set-tv! (Concept "foo") (ctv 1 0 6))
+
+; -----------------------------------
+; Should be present in the base space.
+(cog-set-atomspace! base-space)
+(test-assert "base-space" (cog-atom? (cog-node 'Concept "foo")))
+(test-equal "base-tv" 2 (inexact->exact (cog-count (cog-node 'Concept "foo"))))
+
+; Should be absent in the next level.
+(cog-set-atomspace! mid1-space)
+(test-assert "mid1-space" (nil? (cog-node 'Concept "foo")))
+
+(cog-set-atomspace! mid2-space)
+(test-assert "mid2-space" (cog-atom? (cog-node 'Concept "foo")))
+(test-equal "mid2-tv" 4 (inexact->exact (cog-count (cog-node 'Concept "foo"))))
+
+(cog-set-atomspace! mid3-space)
+(test-assert "mid3-space" (nil? (cog-node 'Concept "foo")))
+
+(cog-set-atomspace! surface-space)
+(test-assert "surface-space" (cog-atom? (cog-node 'Concept "foo")))
+(test-equal "surface-tv" 6 (inexact->exact (cog-count (cog-node 'Concept "foo"))))
+
+(test-end deep-change)
+
+; ===================================================================
 (opencog-test-end)


### PR DESCRIPTION
Part two to pull req #2925: When there is a stack of atomspaces, and the atom is deleted at the top of the stack, it is marked as being invisible, so that it will remain present deeper in the stack.  That is, AtomSpaces with "deleted" atoms behave as if that atom really is gone, while still being present and accessible if shifting the viewpoint to other atomspaces.

FYI: This means that AtomSpaces now behave like "Context TV" and "Hypothetical TV" from the old, old, atomspace design from a decade ago. Different AtomSpace expose different TV's and atoms: they provide the "context" for some particular truth/world-view.