### PR TITLE
Change AtomSpace to default copy-on-write

### DIFF
--- a/examples/atomspace/copy-on-write.scm
+++ b/examples/atomspace/copy-on-write.scm
@@ -19,6 +19,23 @@
 ; perform read-write operations) without corrupting the underlying
 ; shared read-only database.
 ;
+; A more advanced use is to use deep stacks of AtomSpaces to hold
+; partial results arising from long computations. These can be thought
+; of as a historical record or a collection of Kripke frames of the
+; calculations, with each level consisting of all changes between that
+; and the previous level: a "changeset", similar to that in git.
+; Multiple branches are also allowed, and so fancy algorithms can
+; perform "many-worlds" computations, and directly compare AtomSpaces
+; in different branches.
+;
+; By default, whenever a new AtomSpace is created as a layer on top of
+; another, it is marked as a copy-on-write space. This flag can be
+; cleared: in this case, the overlay becomes a write-through AtomSpace.
+; Newly-created Atoms will still be created in the overlay, but changes
+; to Values and TruthValues of Atoms in the base space will pass through,
+; to the base space. This demo does not show the write-through ability;
+; the user is encourage to explore this themselves.
+;
 (use-modules (opencog))
 
 ; Create atoms in the base AtomSpace.

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -110,6 +110,9 @@ AtomSpace::AtomSpace(AtomSpacePtr& parent) :
     _nameserver(nameserver())
 {
     if (nullptr != parent) {
+        // Set the COW flag by default; it seems like a simpler
+        // default than setting it to be write-through.
+        _copy_on_write = true;
         _environ.push_back(parent);
         _outgoing.push_back(HandleCast(parent));
     }
@@ -132,6 +135,8 @@ AtomSpace::AtomSpace(const HandleSeq& bases) :
             throw RuntimeException(TRACE_INFO,
                     "AtomSpace - bases must be AtomSpaces!");
     }
+
+    if (0 < bases.size()) _copy_on_write = true;
     init();
 }
 

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -92,12 +92,10 @@ AtomSpace::AtomSpace(AtomSpace* parent, bool transient) :
     _nameserver(nameserver())
 {
     if (parent) {
-        // It would be nice to set the COW flag by default, for any
-        // Atomspace that sits on top of another one.
-        // _copy_on_write = true;
-        // However the URE ForwardChainerUTest and BackwardChainerUTest
-        // fail if we do this. The root cause of this failure is not
-        // known. Perhaps the URE should be amended to NOT use COW?
+        // Set the COW flag by default, for any Atomspace that sits on
+        // top of another one. This provides a "common-sense" behavior
+        // that most users would expect.
+        _copy_on_write = true;
         _environ.push_back(AtomSpaceCast(parent->shared_from_this()));
         _outgoing.push_back(HandleCast(parent->shared_from_this()));
     }

--- a/opencog/atomspace/README-DeepSpace.md
+++ b/opencog/atomspace/README-DeepSpace.md
@@ -52,11 +52,9 @@ in order.
 
 ; Create a covering space
 (define base-space (cog-atomspace))
-(cog-atomspace-cow! #t base-space)
 
 (define cover-space (cog-new-atomspace base-space))
 (cog-set-atomspace! cover-space)
-(cog-atomspace-cow! #t cover-space)
 
 ; Hide the atom "foo" in the base-space.
 (Concept "foo" (ctv 1 0 42))

--- a/tests/atomspace/RemoveUTest.cxxtest
+++ b/tests/atomspace/RemoveUTest.cxxtest
@@ -45,6 +45,9 @@ public:
 	{
 		asp1 = createAtomSpace();
 		asp2 = createAtomSpace(asp1);
+
+		// Testing is performed on a write-through configuration.
+		asp2->clear_copy_on_write();
 	}
 
 	void tearDown() {}

--- a/tests/atomspace/cover-delete-test.scm
+++ b/tests/atomspace/cover-delete-test.scm
@@ -12,19 +12,10 @@
 ; Common setup, used by all tests.
 
 (define base-space (cog-atomspace))
-(cog-atomspace-cow! #t base-space)
-
 (define mid1-space (cog-new-atomspace base-space))
-(cog-atomspace-cow! #t mid1-space)
-
 (define mid2-space (cog-new-atomspace mid1-space))
-(cog-atomspace-cow! #t mid2-space)
-
 (define mid3-space (cog-new-atomspace mid2-space))
-(cog-atomspace-cow! #t mid3-space)
-
 (define surface-space (cog-new-atomspace mid3-space))
-(cog-atomspace-cow! #t surface-space)
 
 ; ===================================================================
 ; Test that deep deletions work correctly.

--- a/tests/atomspace/cover-space-test.scm
+++ b/tests/atomspace/cover-space-test.scm
@@ -12,16 +12,9 @@
 ; Common setup, used by all tests.
 
 (define base-space (cog-atomspace))
-(cog-atomspace-cow! #t base-space)
-
 (define mid1-space (cog-new-atomspace base-space))
-(cog-atomspace-cow! #t mid1-space)
-
 (define mid2-space (cog-new-atomspace mid1-space))
-(cog-atomspace-cow! #t mid2-space)
-
 (define surface-space (cog-new-atomspace mid2-space))
-(cog-atomspace-cow! #t surface-space)
 
 ; -------------------------------------------------------------------
 ; Test that deep links are found correctly.

--- a/tests/atomspace/deep-space-test.scm
+++ b/tests/atomspace/deep-space-test.scm
@@ -12,14 +12,12 @@
 ; Creates a stack of AtomSpaces, each a child of the last.
 
 (define base-space (cog-atomspace))
-(cog-atomspace-cow! #t base-space)
 
 ; Create a list of atomspaces, each a child of the last.
 (define (make-space-list LST NUM)
 	(if (<= NUM 0) LST
 		(let ((newspace (cog-new-atomspace (cog-atomspace))))
 			(cog-set-atomspace! newspace)
-			(cog-atomspace-cow! #t newspace)
 			(make-space-list (cons newspace LST) (- NUM 1)))))
 
 ; Twenty of them, the base space first in the list.

--- a/tests/query/FiniteStateMachineUTest.cxxtest
+++ b/tests/query/FiniteStateMachineUTest.cxxtest
@@ -147,6 +147,9 @@ void FiniteStateMachineUTest::test_basic_overlay(void)
 	SchemeEval* seval = eval;
 	eval = new SchemeEval(as);
 
+	// Testing is peformed in a write-through mode.
+	as->clear_copy_on_write();
+
 	do_test_basic();
 
 	delete eval;


### PR DESCRIPTION
Previous AtomSpace used a write-through strategy, when using an overlay space, and updating existing atoms. This changes the default to be copy-on-write: if any TruthValue is changed, a copy of the Atom will be created in the overlay AtomSpace. This seems like a more reasonable default.