### PR TITLE
Encode and decode AtomSpace DAGs (as s-expressions)

### DIFF
--- a/opencog/atoms/atom_types/atom_types.script
+++ b/opencog/atoms/atom_types/atom_types.script
@@ -77,9 +77,14 @@ FORMULA_TRUTH_VALUE        <- TRUTH_VALUE, FORMULA_STREAM
 // avoid conflict with the python Atom object.
 ATOM <- VALUE
 
+// Frames are experimental: Atoms that are both Nodes and Links,
+// having both a name and an outgoing set. Used as a base class for
+// AtomSpaces. Currently, no other use.
+FRAME <- ATOM
+
 // The AtomSpace is kind of like a Link, kind of like a SetLink, except
 // that it is mutable. The contents of the AtomSpace *can* be changed!
-ATOM_SPACE <- ATOM
+ATOM_SPACE <- FRAME
 
 NODE <- ATOM
 LINK <- ATOM

--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -147,6 +147,7 @@ public:
     AtomSpace(const HandleSeq&);
     ~AtomSpace();
 
+    bool is_atom(void) const { return true; }
     UUID get_uuid(void) const { return _uuid; }
 
     /// Transient atomspaces are lighter-weight, faster, but are missing

--- a/opencog/persist/sexpr/AtomSexpr.cc
+++ b/opencog/persist/sexpr/AtomSexpr.cc
@@ -123,7 +123,7 @@ static Type get_typename(const std::string& s, size_t& l, size_t& r,
 /// This function was originally written to allow in-place extraction
 /// of the node name. Unfortunately, node names containing escaped
 /// quotes need to be unescaped, which prevents in-place extraction.
-/// So, instead, this returns the unescaped node name.
+/// So, instead, this returns a copy of the name string.
 std::string Sexpr::get_node_name(const std::string& s,
                                  size_t& l, size_t& r,
                                  Type atype, size_t line_cnt)

--- a/opencog/persist/sexpr/CMakeLists.txt
+++ b/opencog/persist/sexpr/CMakeLists.txt
@@ -3,6 +3,7 @@
 ADD_LIBRARY (sexpr
 	AtomSexpr.cc
 	Commands.cc
+	FrameSexpr.cc
 	SexprEval.cc
 	ValueSexpr.cc
 )

--- a/opencog/persist/sexpr/FrameSexpr.cc
+++ b/opencog/persist/sexpr/FrameSexpr.cc
@@ -1,0 +1,90 @@
+/*
+ * FrameSexpr.cc
+ * Encode/decode S-Expressions for Atomese Frames (AtomSpaces).
+ *
+ * Copyright (c) 2021 Linas Vepstas <linas@linas.org>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#include <iomanip>
+
+#include <opencog/atomspace/AtomSpace.h>
+
+#include "Sexpr.h"
+
+using namespace opencog;
+
+/* ================================================================== */
+// Frame printers. Similar to the Atom printers, except
+// that frames can have both a name, and an outgoing set.
+// At this time, the only Frames are AtomSpaces.
+
+static std::string prt_frame(const AtomSpace* as)
+{
+	std::stringstream ss;
+	ss << std::quoted(as->get_name());
+
+	std::string txt = "(" + nameserver().getTypeName(as->get_type()) + " ";
+	txt += ss.str() + " ";
+	for (const Handle& ho : as->getOutgoingSet())
+		txt += prt_frame((AtomSpace*) ho.get());
+	txt += ")";
+	return txt;
+}
+
+std::string Sexpr::encode_frame(const Handle& h)
+{
+	return prt_frame((AtomSpace*) h.get());
+}
+
+std::string Sexpr::encode_frame(const AtomSpace* as)
+{
+	return prt_frame(as);
+}
+
+/* ================================================================== */
+// Frame decoders. Decode what the above does.
+
+/// Decode an s-expression that encodes a frame. Search for the result
+/// in the surface frame. If it can be found there, then return a
+/// pointer to it. If not found, throw an exception.  This allows the
+/// caller to figure out what to do... XXX Maybe we should just create
+/// it?
+AtomSpace* Sexpr::decode_frame(AtomSpace* surface,
+                               const std::string& sframe, size_t& pos)
+{
+	// Skip past whitespace
+	pos = sframe.find_first_not_of(" \n\t", pos);
+
+	// Increment pos by one to point just after the open-paren.
+	size_t vos = sframe.find_first_of(" \n\t", ++pos);
+	if (std::string::npos == vos
+	    or sframe.compare(pos, vos-pos, "AtomSpace"))
+		throw SyntaxException(TRACE_INFO, "Badly formatted Frame %s",
+			sframe.substr(pos).c_str());
+
+	// Get the AtomSpace name.
+	if ('"' != sframe[vos])
+		throw SyntaxException(TRACE_INFO, "Badly formatted Frame %s",
+			sframe.substr(pos).c_str());
+printf("duuuude vosv=%s<<\n", sframe.substr(vos).c_str());
+
+
+	return nullptr;
+}
+
+/* ============================= END OF FILE ================= */

--- a/opencog/persist/sexpr/Sexpr.h
+++ b/opencog/persist/sexpr/Sexpr.h
@@ -65,6 +65,12 @@ public:
 		decode_alist(h, s, junk);
 	}
 
+	static AtomSpace* decode_frame(AtomSpace*, const std::string&, size_t&);
+	static AtomSpace* decode_frame(AtomSpace* as, const std::string& fs) {
+		size_t junk = 0;
+		return decode_frame(as, fs, junk);
+	}
+
 	// -------------------------------------------
 	// API more suitable to very long, file-driven I/O.
 	static int get_next_expr(const std::string&,

--- a/opencog/persist/sexpr/Sexpr.h
+++ b/opencog/persist/sexpr/Sexpr.h
@@ -79,6 +79,8 @@ public:
 	static std::string encode_atom(const Handle&);
 	static std::string encode_value(const ValuePtr&);
 	static std::string encode_atom_values(const Handle&);
+	static std::string encode_frame(const Handle&);
+	static std::string encode_frame(const AtomSpace*);
 
 	static std::string dump_atom(const Handle&);
 	static std::string dump_vatom(const Handle&, const Handle&);

--- a/opencog/persist/sexpr/ValueSexpr.cc
+++ b/opencog/persist/sexpr/ValueSexpr.cc
@@ -481,4 +481,45 @@ ValuePtr Sexpr::add_atoms(AtomSpace* as, const ValuePtr& vptr)
 	return as->add_atoms(vptr);
 }
 
+/* ================================================================== */
+// Frame printers. Similar to the Atom printers, except
+// that frames can have both a name, and an outgoing set.
+// At this time, the only Frames are AtomSpaces.
+
+static std::string prt_frame(const Handle& asp)
+{
+	std::stringstream ss;
+	ss << std::quoted(asp->get_name());
+
+	std::string txt = "(" + nameserver().getTypeName(asp->get_type()) + " ";
+	txt += ss.str() + " ";
+	for (const Handle& ho : asp->getOutgoingSet())
+		txt += prt_frame(ho);
+	txt += ")";
+	return txt;
+}
+
+static std::string prt_frame(const AtomSpace* as)
+{
+	std::stringstream ss;
+	ss << std::quoted(as->get_name());
+
+	std::string txt = "(" + nameserver().getTypeName(as->get_type()) + " ";
+	txt += ss.str() + " ";
+	for (const Handle& ho : as->getOutgoingSet())
+		txt += prt_frame(ho);
+	txt += ")";
+	return txt;
+}
+
+std::string Sexpr::encode_frame(const Handle& h)
+{
+	return prt_frame(h);
+}
+
+std::string Sexpr::encode_frame(const AtomSpace* as)
+{
+	return prt_frame(as);
+}
+
 /* ============================= END OF FILE ================= */

--- a/opencog/persist/sexpr/ValueSexpr.cc
+++ b/opencog/persist/sexpr/ValueSexpr.cc
@@ -481,45 +481,4 @@ ValuePtr Sexpr::add_atoms(AtomSpace* as, const ValuePtr& vptr)
 	return as->add_atoms(vptr);
 }
 
-/* ================================================================== */
-// Frame printers. Similar to the Atom printers, except
-// that frames can have both a name, and an outgoing set.
-// At this time, the only Frames are AtomSpaces.
-
-static std::string prt_frame(const Handle& asp)
-{
-	std::stringstream ss;
-	ss << std::quoted(asp->get_name());
-
-	std::string txt = "(" + nameserver().getTypeName(asp->get_type()) + " ";
-	txt += ss.str() + " ";
-	for (const Handle& ho : asp->getOutgoingSet())
-		txt += prt_frame(ho);
-	txt += ")";
-	return txt;
-}
-
-static std::string prt_frame(const AtomSpace* as)
-{
-	std::stringstream ss;
-	ss << std::quoted(as->get_name());
-
-	std::string txt = "(" + nameserver().getTypeName(as->get_type()) + " ";
-	txt += ss.str() + " ";
-	for (const Handle& ho : as->getOutgoingSet())
-		txt += prt_frame(ho);
-	txt += ")";
-	return txt;
-}
-
-std::string Sexpr::encode_frame(const Handle& h)
-{
-	return prt_frame(h);
-}
-
-std::string Sexpr::encode_frame(const AtomSpace* as)
-{
-	return prt_frame(as);
-}
-
 /* ============================= END OF FILE ================= */

--- a/tests/atoms/atom_types/NameServerUTest.cxxtest
+++ b/tests/atoms/atom_types/NameServerUTest.cxxtest
@@ -50,7 +50,7 @@ public:
             if (t > ATOM) {
                 TS_ASSERT(nameserver().isA(t, NODE) or
                           nameserver().isA(t, LINK) or
-                          nameserver().isA(t, ATOM_SPACE));
+                          nameserver().isA(t, FRAME));
             }
             else {
                 TS_ASSERT(nameserver().isA(t, VALUE));


### PR DESCRIPTION
In order to store complex kripke frames to the RocksDB backend, there needs to be some way of representing the nesting structure of the AtomSpaces as s-expressions. This adds initial support for that ability.