### PR TITLE
Multi-atomspace API fixes

### DIFF
--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -532,7 +532,12 @@ void AtomSpace::get_handles_by_type(HandleSeq& hseq,
 
         // Look for the shallowest version of each Atom.
         for (const Handle& h: rawset)
-            hseq.push_back(lookupHandle(h));
+        {
+            // hshallow might be null, if h is mask-deleted
+            // in this AtomSpace (h->isAbsent() == true)
+            const Handle& hshallow(lookupHandle(h));
+            if (hshallow) hseq.push_back(hshallow);
+        }
         return;
     }
 

--- a/opencog/persist/api/PersistSCM.cc
+++ b/opencog/persist/api/PersistSCM.cc
@@ -23,6 +23,7 @@
 
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/guile/SchemePrimitive.h>
+#include <opencog/guile/SchemeSmob.h>
 #include "PersistSCM.h"
 
 using namespace opencog;
@@ -243,19 +244,22 @@ void PersistSCM::sn_store_value(Handle h, Handle key, Handle hsn)
 void PersistSCM::sn_load_type(Type t, Handle hsn)
 {
 	GET_STNP;
-	stnp->fetch_all_atoms_of_type(t);
+	AtomSpace* as = SchemeSmob::ss_get_env_as("load-atoms-of-type");
+	stnp->fetch_all_atoms_of_type(t, as);
 }
 
 void PersistSCM::sn_load_atomspace(Handle hsn)
 {
 	GET_STNP;
-	stnp->load_atomspace();
+	AtomSpace* as = SchemeSmob::ss_get_env_as("load-atomspace");
+	stnp->load_atomspace(as);
 }
 
 void PersistSCM::sn_store_atomspace(Handle hsn)
 {
 	GET_STNP;
-	stnp->store_atomspace();
+	AtomSpace* as = SchemeSmob::ss_get_env_as("store-atomspace");
+	stnp->store_atomspace(as);
 }
 
 Handle PersistSCM::sn_load_frames(Handle hsn)
@@ -358,19 +362,22 @@ void PersistSCM::dflt_store_value(Handle h, Handle key)
 void PersistSCM::dflt_load_type(Type t)
 {
 	CHECK;
-	_sn->fetch_all_atoms_of_type(t);
+	AtomSpace* as = SchemeSmob::ss_get_env_as("load-atoms-of-type");
+	_sn->fetch_all_atoms_of_type(t, as);
 }
 
 void PersistSCM::dflt_load_atomspace(void)
 {
 	CHECK;
-	_sn->load_atomspace();
+	AtomSpace* as = SchemeSmob::ss_get_env_as("load-atomspace");
+	_sn->load_atomspace(as);
 }
 
 void PersistSCM::dflt_store_atomspace(void)
 {
 	CHECK;
-	_sn->store_atomspace();
+	AtomSpace* as = SchemeSmob::ss_get_env_as("store-atomspace");
+	_sn->store_atomspace(as);
 }
 
 Handle PersistSCM::dflt_load_frames(void)

--- a/opencog/persist/api/PersistSCM.cc
+++ b/opencog/persist/api/PersistSCM.cc
@@ -205,7 +205,7 @@ Handle PersistSCM::sn_fetch_incoming_set(Handle h, Handle hsn)
 	GET_STNP;
 	AtomSpace* as = SchemeSmob::ss_get_env_as("fetch-incoming-set");
 	// The "false" flag here means that the fetch is NOT recursive.
-	return stnp->fetch_incoming_set(h, as, false);
+	return stnp->fetch_incoming_set(h, false, as);
 }
 
 Handle PersistSCM::sn_fetch_incoming_by_type(Handle h, Type t, Handle hsn)
@@ -219,7 +219,7 @@ Handle PersistSCM::sn_fetch_query2(Handle query, Handle key, Handle hsn)
 {
 	GET_STNP;
 	AtomSpace* as = SchemeSmob::ss_get_env_as("fetch-query");
-	return stnp->fetch_query(query, key, as, Handle::UNDEFINED, false);
+	return stnp->fetch_query(query, key, Handle::UNDEFINED, false, as);
 }
 
 Handle PersistSCM::sn_fetch_query4(Handle query, Handle key,
@@ -227,7 +227,7 @@ Handle PersistSCM::sn_fetch_query4(Handle query, Handle key,
 {
 	GET_STNP;
 	AtomSpace* as = SchemeSmob::ss_get_env_as("fetch-query");
-	return stnp->fetch_query(query, key, as, meta, fresh);
+	return stnp->fetch_query(query, key, meta, fresh, as);
 }
 
 /**
@@ -330,7 +330,7 @@ Handle PersistSCM::dflt_fetch_incoming_set(Handle h)
 	CHECK;
 	AtomSpace* as = SchemeSmob::ss_get_env_as("fetch-incoming-set");
 	// The "false" flag here means that the fetch is NOT recursive.
-	return _sn->fetch_incoming_set(h, as, false);
+	return _sn->fetch_incoming_set(h, false, as);
 }
 
 Handle PersistSCM::dflt_fetch_incoming_by_type(Handle h, Type t)
@@ -344,7 +344,7 @@ Handle PersistSCM::dflt_fetch_query2(Handle query, Handle key)
 {
 	CHECK;
 	AtomSpace* as = SchemeSmob::ss_get_env_as("fetch-query");
-	return _sn->fetch_query(query, key, as, Handle::UNDEFINED, false);
+	return _sn->fetch_query(query, key, Handle::UNDEFINED, false, as);
 }
 
 Handle PersistSCM::dflt_fetch_query4(Handle query, Handle key,
@@ -352,7 +352,7 @@ Handle PersistSCM::dflt_fetch_query4(Handle query, Handle key,
 {
 	CHECK;
 	AtomSpace* as = SchemeSmob::ss_get_env_as("fetch-query");
-	return _sn->fetch_query(query, key, as, meta, fresh);
+	return _sn->fetch_query(query, key, meta, fresh, as);
 }
 
 /**

--- a/opencog/persist/api/PersistSCM.cc
+++ b/opencog/persist/api/PersistSCM.cc
@@ -189,39 +189,45 @@ bool PersistSCM::connected(Handle hsn)
 Handle PersistSCM::sn_fetch_atom(Handle h, Handle hsn)
 {
 	GET_STNP;
-	return stnp->fetch_atom(h);
+	AtomSpace* as = SchemeSmob::ss_get_env_as("fetch-atom");
+	return stnp->fetch_atom(h, as);
 }
 
 Handle PersistSCM::sn_fetch_value(Handle h, Handle key, Handle hsn)
 {
 	GET_STNP;
-	return stnp->fetch_value(h, key);
+	AtomSpace* as = SchemeSmob::ss_get_env_as("fetch-value");
+	return stnp->fetch_value(h, key, as);
 }
 
 Handle PersistSCM::sn_fetch_incoming_set(Handle h, Handle hsn)
 {
 	GET_STNP;
+	AtomSpace* as = SchemeSmob::ss_get_env_as("fetch-incoming-set");
 	// The "false" flag here means that the fetch is NOT recursive.
-	return stnp->fetch_incoming_set(h, false);
+	return stnp->fetch_incoming_set(h, as, false);
 }
 
 Handle PersistSCM::sn_fetch_incoming_by_type(Handle h, Type t, Handle hsn)
 {
 	GET_STNP;
-	return stnp->fetch_incoming_by_type(h, t);
+	AtomSpace* as = SchemeSmob::ss_get_env_as("fetch-incoming-by-type");
+	return stnp->fetch_incoming_by_type(h, t, as);
 }
 
 Handle PersistSCM::sn_fetch_query2(Handle query, Handle key, Handle hsn)
 {
 	GET_STNP;
-	return stnp->fetch_query(query, key, Handle::UNDEFINED, false);
+	AtomSpace* as = SchemeSmob::ss_get_env_as("fetch-query");
+	return stnp->fetch_query(query, key, as, Handle::UNDEFINED, false);
 }
 
 Handle PersistSCM::sn_fetch_query4(Handle query, Handle key,
                                 Handle meta, bool fresh, Handle hsn)
 {
 	GET_STNP;
-	return stnp->fetch_query(query, key, meta, fresh);
+	AtomSpace* as = SchemeSmob::ss_get_env_as("fetch-query");
+	return stnp->fetch_query(query, key, as, meta, fresh);
 }
 
 /**
@@ -289,7 +295,8 @@ bool PersistSCM::sn_delete_recursive(Handle h, Handle hsn)
 void PersistSCM::sn_barrier(Handle hsn)
 {
 	GET_STNP;
-	stnp->barrier();
+	AtomSpace* as = SchemeSmob::ss_get_env_as("barrier");
+	stnp->barrier(as);
 }
 
 std::string PersistSCM::sn_monitor(Handle hsn)
@@ -307,39 +314,45 @@ std::string PersistSCM::sn_monitor(Handle hsn)
 Handle PersistSCM::dflt_fetch_atom(Handle h)
 {
 	CHECK;
-	return _sn->fetch_atom(h);
+	AtomSpace* as = SchemeSmob::ss_get_env_as("fetch-atom");
+	return _sn->fetch_atom(h, as);
 }
 
 Handle PersistSCM::dflt_fetch_value(Handle h, Handle key)
 {
 	CHECK;
-	return _sn->fetch_value(h, key);
+	AtomSpace* as = SchemeSmob::ss_get_env_as("fetch-value");
+	return _sn->fetch_value(h, key, as);
 }
 
 Handle PersistSCM::dflt_fetch_incoming_set(Handle h)
 {
 	CHECK;
+	AtomSpace* as = SchemeSmob::ss_get_env_as("fetch-incoming-set");
 	// The "false" flag here means that the fetch is NOT recursive.
-	return _sn->fetch_incoming_set(h, false);
+	return _sn->fetch_incoming_set(h, as, false);
 }
 
 Handle PersistSCM::dflt_fetch_incoming_by_type(Handle h, Type t)
 {
 	CHECK;
-	return _sn->fetch_incoming_by_type(h, t);
+	AtomSpace* as = SchemeSmob::ss_get_env_as("fetch-incoming-by-type");
+	return _sn->fetch_incoming_by_type(h, t, as);
 }
 
 Handle PersistSCM::dflt_fetch_query2(Handle query, Handle key)
 {
 	CHECK;
-	return _sn->fetch_query(query, key, Handle::UNDEFINED, false);
+	AtomSpace* as = SchemeSmob::ss_get_env_as("fetch-query");
+	return _sn->fetch_query(query, key, as, Handle::UNDEFINED, false);
 }
 
 Handle PersistSCM::dflt_fetch_query4(Handle query, Handle key,
                                 Handle meta, bool fresh)
 {
 	CHECK;
-	return _sn->fetch_query(query, key, meta, fresh);
+	AtomSpace* as = SchemeSmob::ss_get_env_as("fetch-query");
+	return _sn->fetch_query(query, key, as, meta, fresh);
 }
 
 /**
@@ -407,7 +420,8 @@ bool PersistSCM::dflt_delete_recursive(Handle h)
 void PersistSCM::dflt_barrier(void)
 {
 	CHECK;
-	_sn->barrier();
+	AtomSpace* as = SchemeSmob::ss_get_env_as("barrier");
+	_sn->barrier(as);
 }
 
 std::string PersistSCM::dflt_monitor(void)

--- a/opencog/persist/api/StorageNode.cc
+++ b/opencog/persist/api/StorageNode.cc
@@ -128,8 +128,8 @@ Handle StorageNode::fetch_value(const Handle& h, const Handle& key,
 	return lh;
 }
 
-Handle StorageNode::fetch_incoming_set(const Handle& h, AtomSpace* as,
-                                       bool recursive)
+Handle StorageNode::fetch_incoming_set(const Handle& h, bool recursive,
+                                       AtomSpace* as)
 {
 	if (nullptr == as) as = getAtomSpace();
 	Handle lh = as->get_atom(h);
@@ -142,7 +142,7 @@ Handle StorageNode::fetch_incoming_set(const Handle& h, AtomSpace* as,
 
 	IncomingSet vh(h->getIncomingSet());
 	for (const Handle& lp : vh)
-		fetch_incoming_set(lp, as, true);
+		fetch_incoming_set(lp, true, as);
 
 	return lh;
 }
@@ -161,8 +161,8 @@ Handle StorageNode::fetch_incoming_by_type(const Handle& h, Type t,
 }
 
 Handle StorageNode::fetch_query(const Handle& query, const Handle& key,
-                                AtomSpace* as,
-                                const Handle& metadata, bool fresh)
+                                const Handle& metadata, bool fresh,
+                                AtomSpace* as)
 {
 	// At this time, we restrict queries to be ... queries.
 	Type qt = query->get_type();

--- a/opencog/persist/api/StorageNode.cc
+++ b/opencog/persist/api/StorageNode.cc
@@ -187,22 +187,22 @@ Handle StorageNode::fetch_query(const Handle& query, const Handle& key,
 	return lq;
 }
 
-void StorageNode::load_atomspace(void)
+void StorageNode::load_atomspace(AtomSpace* as)
 {
-	loadAtomSpace(getAtomSpace());
+	loadAtomSpace(as);
 }
 
 /**
  * Use the backing store to store entire AtomSpace.
  */
-void StorageNode::store_atomspace(void)
+void StorageNode::store_atomspace(AtomSpace* as)
 {
-	storeAtomSpace(getAtomSpace());
+	storeAtomSpace(as);
 }
 
-void StorageNode::fetch_all_atoms_of_type(Type t)
+void StorageNode::fetch_all_atoms_of_type(Type t, AtomSpace* as)
 {
-	loadType(getAtomSpace(), t);
+	loadType(as, t);
 }
 
 Handle StorageNode::load_frames(void)

--- a/opencog/persist/api/StorageNode.cc
+++ b/opencog/persist/api/StorageNode.cc
@@ -51,6 +51,7 @@ std::string StorageNode::monitor(void)
 
 void StorageNode::barrier(AtomSpace* as)
 {
+	if (nullptr == as) as = getAtomSpace();
 	as->barrier();
 }
 
@@ -104,6 +105,7 @@ bool StorageNode::remove_atom(Handle h, bool recursive)
 Handle StorageNode::fetch_atom(const Handle& h, AtomSpace* as)
 {
 	if (nullptr == h) return Handle::UNDEFINED;
+	if (nullptr == as) as = getAtomSpace();
 
 	// Now, get the latest values from the backing store.
 	// The operation here is to CLOBBER the values, NOT to merge them!
@@ -129,6 +131,7 @@ Handle StorageNode::fetch_value(const Handle& h, const Handle& key,
 Handle StorageNode::fetch_incoming_set(const Handle& h, AtomSpace* as,
                                        bool recursive)
 {
+	if (nullptr == as) as = getAtomSpace();
 	Handle lh = as->get_atom(h);
 	if (nullptr == lh) return lh;
 
@@ -147,6 +150,7 @@ Handle StorageNode::fetch_incoming_set(const Handle& h, AtomSpace* as,
 Handle StorageNode::fetch_incoming_by_type(const Handle& h, Type t,
                                            AtomSpace* as)
 {
+	if (nullptr == as) as = getAtomSpace();
 	Handle lh = as->get_atom(h);
 	if (nullptr == lh) return lh;
 
@@ -166,10 +170,7 @@ Handle StorageNode::fetch_query(const Handle& query, const Handle& key,
 		not nameserver().isA(qt, PATTERN_LINK))
 		throw RuntimeException(TRACE_INFO, "Not a Join or Meet!");
 
-	// Make sure we are working with Atoms in this Atomspace.
-	// Not clear if we really have to do this, or if it's enough
-	// to just assume  that they are. Could save a few CPU cycles,
-	// here, by trading efficiency for safety.
+	if (nullptr == as) as = getAtomSpace();
 	Handle lkey = as->add_atom(key);
 	Handle lq = as->add_atom(query);
 	Handle lmeta = metadata;
@@ -181,6 +182,7 @@ Handle StorageNode::fetch_query(const Handle& query, const Handle& key,
 
 void StorageNode::load_atomspace(AtomSpace* as)
 {
+	if (nullptr == as) as = getAtomSpace();
 	loadAtomSpace(as);
 }
 
@@ -189,16 +191,19 @@ void StorageNode::load_atomspace(AtomSpace* as)
  */
 void StorageNode::store_atomspace(AtomSpace* as)
 {
+	if (nullptr == as) as = getAtomSpace();
 	storeAtomSpace(as);
 }
 
 void StorageNode::fetch_all_atoms_of_type(Type t, AtomSpace* as)
 {
+	if (nullptr == as) as = getAtomSpace();
 	loadType(as, t);
 }
 
-Handle StorageNode::load_frames(void)
+Handle StorageNode::load_frames(AtomSpace* as)
 {
+	if (nullptr == as) as = getAtomSpace();
 	return loadFrameDAG(getAtomSpace());
 }
 

--- a/opencog/persist/api/StorageNode.h
+++ b/opencog/persist/api/StorageNode.h
@@ -129,17 +129,17 @@ public:
 	/**
 	 * Use the backing store to load all atoms of the given atom type.
 	 */
-	void fetch_all_atoms_of_type(Type t);
+	void fetch_all_atoms_of_type(Type t, AtomSpace*);
 
 	/**
 	 * Use the backing store to load entire AtomSpace.
 	 */
-	void load_atomspace(void);
+	void load_atomspace(AtomSpace*);
 
 	/**
 	 * Use the backing store to store entire AtomSpace.
 	 */
-	void store_atomspace(void);
+	void store_atomspace(AtomSpace*);
 
 	/**
 	 * Return the DAG of all AtomSpaces in the backing store.

--- a/opencog/persist/api/StorageNode.h
+++ b/opencog/persist/api/StorageNode.h
@@ -172,7 +172,7 @@ public:
 	 * See also `fetch_query` which can be used with a JoinLink to
 	 * obtain a custom-tailored incoming set.
 	 */
-	Handle fetch_incoming_set(const Handle&, AtomSpace* = nullptr, bool=false);
+	Handle fetch_incoming_set(const Handle&, bool = false, AtomSpace* = nullptr);
 
 	/**
 	 * Use the backing store to load the incoming set of the
@@ -216,9 +216,9 @@ public:
 	 * remote server to the local AtomSpace.
 	 */
 	Handle fetch_query(const Handle& query, const Handle& key,
-	                   AtomSpace* = nullptr,
 	                   const Handle& metadata_key = Handle::UNDEFINED,
-	                   bool fresh = false);
+	                   bool fresh = false,
+	                   AtomSpace* = nullptr);
 
 	/**
 	 * Recursively store the atom to the backing store.

--- a/opencog/persist/api/StorageNode.h
+++ b/opencog/persist/api/StorageNode.h
@@ -98,7 +98,7 @@ public:
 	 * operations have completed.
 	 * NB: at this time, we don't distinguish barrier and flush.
 	 */
-	void barrier(void);
+	void barrier(AtomSpace*);
 
 	/**
 	 * Unconditionally fetch an atom from the backingstore.
@@ -113,7 +113,7 @@ public:
 	 * To avoid a fetch if the atom already is in the atomtable, use
 	 * the get_atom() method instead.
 	 */
-	Handle fetch_atom(const Handle&);
+	Handle fetch_atom(const Handle&, AtomSpace*);
 
 	/**
 	 * Fetch the Value located at `key` on `atom` from the remote
@@ -124,7 +124,7 @@ public:
 	 * This method is more granular than `fetch_atom()`, as it
 	 * operates only on one particular key.
 	 */
-	Handle fetch_value(const Handle& atom, const Handle& key);
+	Handle fetch_value(const Handle& atom, const Handle& key, AtomSpace*);
 
 	/**
 	 * Use the backing store to load all atoms of the given atom type.
@@ -171,7 +171,7 @@ public:
 	 * See also `fetch_query` which can be used with a JoinLink to
 	 * obtain a custom-tailored incoming set.
 	 */
-	Handle fetch_incoming_set(const Handle&, bool=false);
+	Handle fetch_incoming_set(const Handle&, AtomSpace*, bool=false);
 
 	/**
 	 * Use the backing store to load the incoming set of the
@@ -182,7 +182,7 @@ public:
 	 * See also `fetch_query` which can be used with a JoinLink to
 	 * obtain a custom-tailored incoming set.
 	 */
-	Handle fetch_incoming_by_type(const Handle&, Type);
+	Handle fetch_incoming_by_type(const Handle&, Type, AtomSpace*);
 
 	/**
 	 * Run the `query` on the remote server, and place the query
@@ -215,6 +215,7 @@ public:
 	 * remote server to the local AtomSpace.
 	 */
 	Handle fetch_query(const Handle& query, const Handle& key,
+	                   AtomSpace*,
 	                   const Handle& metadata_key = Handle::UNDEFINED,
 	                   bool fresh = false);
 
@@ -229,7 +230,7 @@ public:
 	 * Store the Value located at `key` on `atom` to the remote
 	 * server. If the `atom` does not yet exist on the remote
 	 * server, it is created there.  This method is more granular
-	 * than `store_attom` above, as it works with only one value,
+	 * than `store_atom` above, as it works with only one value,
 	 * instead of all of them.
 	 *
 	 * Note that Values can be deleted merely by having a null

--- a/opencog/persist/api/StorageNode.h
+++ b/opencog/persist/api/StorageNode.h
@@ -98,7 +98,7 @@ public:
 	 * operations have completed.
 	 * NB: at this time, we don't distinguish barrier and flush.
 	 */
-	void barrier(AtomSpace*);
+	void barrier(AtomSpace* = nullptr);
 
 	/**
 	 * Unconditionally fetch an atom from the backingstore.
@@ -113,7 +113,7 @@ public:
 	 * To avoid a fetch if the atom already is in the atomtable, use
 	 * the get_atom() method instead.
 	 */
-	Handle fetch_atom(const Handle&, AtomSpace*);
+	Handle fetch_atom(const Handle&, AtomSpace* = nullptr);
 
 	/**
 	 * Fetch the Value located at `key` on `atom` from the remote
@@ -124,22 +124,23 @@ public:
 	 * This method is more granular than `fetch_atom()`, as it
 	 * operates only on one particular key.
 	 */
-	Handle fetch_value(const Handle& atom, const Handle& key, AtomSpace*);
+	Handle fetch_value(const Handle& atom, const Handle& key,
+	                   AtomSpace* = nullptr);
 
 	/**
 	 * Use the backing store to load all atoms of the given atom type.
 	 */
-	void fetch_all_atoms_of_type(Type t, AtomSpace*);
+	void fetch_all_atoms_of_type(Type t, AtomSpace* = nullptr);
 
 	/**
 	 * Use the backing store to load entire AtomSpace.
 	 */
-	void load_atomspace(AtomSpace*);
+	void load_atomspace(AtomSpace* = nullptr);
 
 	/**
 	 * Use the backing store to store entire AtomSpace.
 	 */
-	void store_atomspace(AtomSpace*);
+	void store_atomspace(AtomSpace* = nullptr);
 
 	/**
 	 * Return the DAG of all AtomSpaces in the backing store.
@@ -148,7 +149,7 @@ public:
 	 *
 	 * The returned Handle is an AtomSpacePtr to the top of the DAG.
 	 */
-	Handle load_frames(void);
+	Handle load_frames(AtomSpace* = nullptr);
 
 	/**
 	 * Store the DAG of all AtomSpaces to the backing store.
@@ -171,7 +172,7 @@ public:
 	 * See also `fetch_query` which can be used with a JoinLink to
 	 * obtain a custom-tailored incoming set.
 	 */
-	Handle fetch_incoming_set(const Handle&, AtomSpace*, bool=false);
+	Handle fetch_incoming_set(const Handle&, AtomSpace* = nullptr, bool=false);
 
 	/**
 	 * Use the backing store to load the incoming set of the
@@ -182,7 +183,7 @@ public:
 	 * See also `fetch_query` which can be used with a JoinLink to
 	 * obtain a custom-tailored incoming set.
 	 */
-	Handle fetch_incoming_by_type(const Handle&, Type, AtomSpace*);
+	Handle fetch_incoming_by_type(const Handle&, Type, AtomSpace* = nullptr);
 
 	/**
 	 * Run the `query` on the remote server, and place the query
@@ -215,7 +216,7 @@ public:
 	 * remote server to the local AtomSpace.
 	 */
 	Handle fetch_query(const Handle& query, const Handle& key,
-	                   AtomSpace*,
+	                   AtomSpace* = nullptr,
 	                   const Handle& metadata_key = Handle::UNDEFINED,
 	                   bool fresh = false);
 

--- a/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/ValueSaveUTest.cxxtest
@@ -119,6 +119,7 @@ void ValueSaveUTest::tearDown(void) {}
 void ValueSaveUTest::kill_data(const StorageNodePtr& store)
 {
 	store->erase();
+	store->barrier();
 }
 
 void ValueSaveUTest::test_odbc_single_atom_save(void)
@@ -305,7 +306,9 @@ void ValueSaveUTest::do_test_single_atom_save()
 	store->barrier();
 
 	// --------------------
+	store->fetch_atom(atom);
 	store->erase();
+	store->close();
 
 	delete as;
 }


### PR DESCRIPTION
When storing multiple AtomSpaces to disk storage or network storage, that actual AtomSpace to store needs to be explicitly specified.   Update the API to pass this as a parameter.