### PR TITLE
Add support for network-distributed multi-atomspaces

### DIFF
--- a/opencog/guile/SchemeSmobAS.cc
+++ b/opencog/guile/SchemeSmobAS.cc
@@ -28,14 +28,36 @@ SCM SchemeSmob::make_as(AtomSpace *as)
 /**
  * Create a new atom space.  The parent argument might not
  * be present -- its optional.
+ * If it is present, it might be a list of one or more atomspaces.
+ * If the first in the list is a string, then it is the string name
+ * of the new AtomSpace.
  */
 SCM SchemeSmob::ss_new_as (SCM space_list)
 {
+	// The first item in the list might be the name of the AtomSpace.
+	std::string name;
+	if (not scm_is_null(space_list) and scm_is_pair(space_list))
+	{
+		SCM sname = SCM_CAR(space_list);
+		if (scm_is_string(sname))
+		{
+			char * cname = scm_to_utf8_string(sname);
+			name = cname;
+			free(cname);
+
+			space_list = SCM_CDR(space_list);
+		}
+	}
+
 	HandleSeq spaces;
 	spaces = verify_handle_list_msg(space_list, "cog-new-atomspace", 1,
 		"a list of AtomSpaces", "an AtomSpace");
 
 	AtomSpacePtr as = createAtomSpace(spaces);
+
+	if (0 < name.size())
+		as->set_name(name);
+
 	return protom_to_scm(as);
 }
 

--- a/opencog/persist/sexpr/Commands.cc
+++ b/opencog/persist/sexpr/Commands.cc
@@ -386,7 +386,6 @@ std::string Commands::interpret_command(AtomSpace* as,
 		atomspace_ptr = Sexpr::decode_frame(
 			HandleCast(asp), cmd, pos, _space_map);
 
-
 		// Hacky...
 		// _space_map.insert({sym, atomspace_ptr});
 

--- a/opencog/persist/sexpr/Commands.cc
+++ b/opencog/persist/sexpr/Commands.cc
@@ -68,8 +68,9 @@ Commands::get_opt_as(const std::string& cmd, size_t& pos, AtomSpace* as)
 	if (not _multi_space) return as;
 
 	pos = cmd.find_first_not_of(" \n\t", pos);
-	if (0 == cmd.compare(pos, sizeof("(AtomSpace")-1, "(AtomSpace"))
+	if (0 == cmd.compare(pos, 10, "(AtomSpace"))
 	{
+		_multi_space = true;
 		Handle hasp = Sexpr::decode_frame(
 			HandleCast(top_space), cmd, pos, _space_map);
 		return (AtomSpace*) hasp.get();
@@ -327,7 +328,7 @@ std::string Commands::interpret_command(AtomSpace* as,
 	}
 
 	// -----------------------------------------------
-	// (cog-set-values! (Concept "foo")
+	// (cog-set-values! (Concept "foo") (AtomSpace "foo")
 	//     (alist (cons (Predicate "bar") (stv 0.9 0.8)) ...))
 	if (svals == act)
 	{

--- a/opencog/persist/sexpr/Commands.cc
+++ b/opencog/persist/sexpr/Commands.cc
@@ -53,6 +53,7 @@ using namespace opencog;
 
 Commands::Commands(void)
 {
+	atomspace_ptr = Handle::UNDEFINED;
 }
 
 Commands::~Commands()
@@ -79,6 +80,7 @@ std::string Commands::interpret_command(AtomSpace* as,
 	static const size_t svals = std::hash<std::string>{}("cog-set-values!");
 	static const size_t settv = std::hash<std::string>{}("cog-set-tv!");
 	static const size_t value = std::hash<std::string>{}("cog-value");
+	static const size_t frame = std::hash<std::string>{}("AtomSpace");
 
 	// Find the command and dispatch
 	size_t pos = cmd.find_first_not_of(" \n\t");
@@ -327,6 +329,19 @@ std::string Commands::interpret_command(AtomSpace* as,
 		ValuePtr vp = atom->getValue(key);
 		return Sexpr::encode_value(vp);
 	}
+
+	// -----------------------------------------------
+	// (AtomSpace "foo" (AtomSpace "bar") (AtomSpace "baz"))
+	if (frame == act)
+	{
+		pos = epos + 1;
+		atomspace_ptr = Sexpr::decode_frame(
+			Handle::UNDEFINED, cmd, pos, _space_map);
+
+		return "()\n";
+	}
+
+	// -----------------------------------------------
 
 	throw SyntaxException(TRACE_INFO, "Command not supported: >>%s<<",
 		cmd.substr(pos, epos-pos).c_str());

--- a/opencog/persist/sexpr/Commands.cc
+++ b/opencog/persist/sexpr/Commands.cc
@@ -50,6 +50,15 @@ using namespace opencog;
 /// overhead of entry/exit into guile. This works because the cogserver
 /// is guaranteed to send only these commands, and no others.
 //
+
+Commands::Commands(void)
+{
+}
+
+Commands::~Commands()
+{
+}
+
 std::string Commands::interpret_command(AtomSpace* as,
                                         const std::string& cmd)
 {

--- a/opencog/persist/sexpr/Commands.cc
+++ b/opencog/persist/sexpr/Commands.cc
@@ -54,7 +54,6 @@ using namespace opencog;
 Commands::Commands(void)
 {
 	_multi_space = false;
-	atomspace_ptr = Handle::UNDEFINED;
 }
 
 Commands::~Commands()
@@ -205,7 +204,10 @@ std::string Commands::interpret_command(AtomSpace* as,
 
 		std::string rv = "(";
 		HandleSeq hset;
-		as->get_handles_by_type(hset, t, get_subtypes);
+		if (_multi_space and top_space)
+			top_space->get_handles_by_type(hset, t, get_subtypes);
+		else
+			as->get_handles_by_type(hset, t, get_subtypes);
 		for (const Handle& h: hset)
 			rv += Sexpr::encode_atom(h, _multi_space);
 		rv += ")";
@@ -389,11 +391,12 @@ std::string Commands::interpret_command(AtomSpace* as,
 
 		// Decode the AtomSpace frames
 		AtomSpacePtr asp(AtomSpaceCast(as));
-		atomspace_ptr = Sexpr::decode_frame(
+		Handle hasp = Sexpr::decode_frame(
 			HandleCast(asp), cmd, pos, _space_map);
+		top_space = AtomSpaceCast(hasp);
 
 		// Hacky...
-		// _space_map.insert({sym, atomspace_ptr});
+		// _space_map.insert({sym, top_space});
 
 		return "()\n";
 	}

--- a/opencog/persist/sexpr/Commands.cc
+++ b/opencog/persist/sexpr/Commands.cc
@@ -68,10 +68,10 @@ Commands::get_opt_as(const std::string& cmd, size_t& pos, AtomSpace* as)
 	if (not _multi_space) return as;
 
 	pos = cmd.find_first_not_of(" \n\t", pos);
-	if (0 == cmd.compare(pos, sizeof("(AtomSpace"), "(AtomSpace"))
+	if (0 == cmd.compare(pos, sizeof("(AtomSpace")-1, "(AtomSpace"))
 	{
 		Handle hasp = Sexpr::decode_frame(
-			Handle::UNDEFINED, cmd, pos, _space_map);
+			HandleCast(top_space), cmd, pos, _space_map);
 		return (AtomSpace*) hasp.get();
 	}
 	return as;
@@ -333,12 +333,12 @@ std::string Commands::interpret_command(AtomSpace* as,
 	{
 		pos = epos + 1;
 		Handle h = Sexpr::decode_atom(cmd, pos);
-		h = as->add_atom(h);
 		pos++; // skip past close-paren
-		Sexpr::decode_slist(h, cmd, pos);
 
 		// Search for optional AtomSpace argument
-		// as = get_opt_as(cmd, pos, as);
+		as = get_opt_as(cmd, pos, as);
+		h = as->add_atom(h);
+		Sexpr::decode_slist(h, cmd, pos);
 
 		return "()\n";
 	}

--- a/opencog/persist/sexpr/Commands.cc
+++ b/opencog/persist/sexpr/Commands.cc
@@ -53,6 +53,7 @@ using namespace opencog;
 
 Commands::Commands(void)
 {
+	_multi_space = false;
 	atomspace_ptr = Handle::UNDEFINED;
 }
 
@@ -60,10 +61,13 @@ Commands::~Commands()
 {
 }
 
-/// Search for optional AtomSpace argument
+/// Search for optional AtomSpace argument in `cmd` at `pos`.
+/// If none is found, then return `as`
 AtomSpace*
 Commands::get_opt_as(const std::string& cmd, size_t& pos, AtomSpace* as)
 {
+	if (not _multi_space) return as;
+
 	pos = cmd.find_first_not_of(" \n\t", pos);
 	if (0 == cmd.compare(pos, sizeof("(AtomSpace"), "(AtomSpace"))
 	{
@@ -203,7 +207,7 @@ std::string Commands::interpret_command(AtomSpace* as,
 		HandleSeq hset;
 		as->get_handles_by_type(hset, t, get_subtypes);
 		for (const Handle& h: hset)
-			rv += Sexpr::encode_atom(h);
+			rv += Sexpr::encode_atom(h, _multi_space);
 		rv += ")";
 		return rv;
 	}
@@ -299,7 +303,7 @@ std::string Commands::interpret_command(AtomSpace* as,
 			h = as->get_link(t, std::move(outgoing));
 		}
 		if (nullptr == h) return "()\n";
-		return Sexpr::encode_atom(h);
+		return Sexpr::encode_atom(h, _multi_space);
 	}
 
 	// -----------------------------------------------
@@ -374,6 +378,8 @@ std::string Commands::interpret_command(AtomSpace* as,
 	// Place the current atomspace at the bottom of the hierarchy.
 	if (dfine == act)
 	{
+		_multi_space = true;
+
 		// Extract the symbolic name after the define
 		pos = cmd.find_first_not_of(" \n\t", epos);
 		epos = cmd.find_first_of(" \n\t", pos);

--- a/opencog/persist/sexpr/Commands.cc
+++ b/opencog/persist/sexpr/Commands.cc
@@ -94,7 +94,7 @@ std::string Commands::interpret_command(AtomSpace* as,
 	static const size_t svals = std::hash<std::string>{}("cog-set-values!");
 	static const size_t settv = std::hash<std::string>{}("cog-set-tv!");
 	static const size_t value = std::hash<std::string>{}("cog-value");
-	static const size_t frame = std::hash<std::string>{}("AtomSpace");
+	static const size_t dfine = std::hash<std::string>{}("define");
 
 	// Find the command and dispatch
 	size_t pos = cmd.find_first_not_of(" \n\t");
@@ -370,14 +370,25 @@ std::string Commands::interpret_command(AtomSpace* as,
 	}
 
 	// -----------------------------------------------
-	// (AtomSpace "foo" (AtomSpace "bar") (AtomSpace "baz"))
+	// (define sym (AtomSpace "foo" (AtomSpace "bar") (AtomSpace "baz")))
 	// Place the current atomspace at the bottom of the hierarchy.
-	if (frame == act)
+	if (dfine == act)
 	{
-		pos = 0;
+		// Extract the symbolic name after the define
+		pos = cmd.find_first_not_of(" \n\t", epos);
+		epos = cmd.find_first_of(" \n\t", pos);
+		// std::string sym = cmd.substr(pos, epos-pos);
+
+		pos = epos+1;
+
+		// Decode the AtomSpace frames
 		AtomSpacePtr asp(AtomSpaceCast(as));
 		atomspace_ptr = Sexpr::decode_frame(
 			HandleCast(asp), cmd, pos, _space_map);
+
+
+		// Hacky...
+		// _space_map.insert({sym, atomspace_ptr});
 
 		return "()\n";
 	}

--- a/opencog/persist/sexpr/Commands.h
+++ b/opencog/persist/sexpr/Commands.h
@@ -80,7 +80,7 @@ public:
 
 	/// If some interpreted command specified an AtomSpace, this
 	/// will be set to that AtomSpace.
-	Handle atomspace_ptr;
+	AtomSpacePtr top_space;
 };
 
 /** @}*/

--- a/opencog/persist/sexpr/Commands.h
+++ b/opencog/persist/sexpr/Commands.h
@@ -36,6 +36,9 @@ class AtomSpace;
 class Commands
 {
 public:
+	Commands(void);
+	~Commands();
+
 	/// Interpret a very small subset of singular scheme commands.
 	/// This is an ultra-minimalistic command interpreter. It only
 	/// supports those commands needed for network I/O of AtomSpace
@@ -63,7 +66,7 @@ public:
 	/// and they MUST be followed by valid Atomese s-expressions, and
 	/// nothing else.
 	///
-	static std::string interpret_command(AtomSpace*, const std::string&);
+	std::string interpret_command(AtomSpace*, const std::string&);
 };
 
 /** @}*/

--- a/opencog/persist/sexpr/Commands.h
+++ b/opencog/persist/sexpr/Commands.h
@@ -36,6 +36,10 @@ class AtomSpace;
 class Commands
 {
 private:
+	/// True, if the _space_map below is being used, and AtomSpaces need
+	/// to be sent and received.
+	bool _multi_space;
+
 	/// Map from string AtomSpace names to the matching AtomSpacePtr's
 	std::map<std::string, Handle> _space_map;
 

--- a/opencog/persist/sexpr/Commands.h
+++ b/opencog/persist/sexpr/Commands.h
@@ -35,6 +35,10 @@ class AtomSpace;
 
 class Commands
 {
+private:
+	/// Map from string AtomSpace names to the matching AtomSpacePtr's
+	std::map<std::string, Handle> _space_map;
+
 public:
 	Commands(void);
 	~Commands();
@@ -67,6 +71,10 @@ public:
 	/// nothing else.
 	///
 	std::string interpret_command(AtomSpace*, const std::string&);
+
+	/// If some interpreted command specified an AtomSpace, this
+	/// will be set to that AtomSpace.
+	Handle atomspace_ptr;
 };
 
 /** @}*/

--- a/opencog/persist/sexpr/Commands.h
+++ b/opencog/persist/sexpr/Commands.h
@@ -39,6 +39,8 @@ private:
 	/// Map from string AtomSpace names to the matching AtomSpacePtr's
 	std::map<std::string, Handle> _space_map;
 
+	AtomSpace* get_opt_as(const std::string&, size_t&, AtomSpace*);
+
 public:
 	Commands(void);
 	~Commands();

--- a/opencog/persist/sexpr/FrameSexpr.cc
+++ b/opencog/persist/sexpr/FrameSexpr.cc
@@ -53,6 +53,11 @@ using namespace opencog;
 // Frame printers. Similar to the Atom printers, except
 // that frames can have both a name, and an outgoing set.
 // At this time, the only Frames are AtomSpaces.
+//
+// The s-expression has the form
+//    ```(AtomSpace "foo" (AtomSpace "bar") (AtomSpace "baz"))```
+// which indicates an atomspace named "foo" that is layers above two
+// other atomspaces called "bar" and "baz".
 
 static std::string prt_frame(const AtomSpace* as)
 {
@@ -79,6 +84,12 @@ std::string Sexpr::encode_frame(const AtomSpace* as)
 
 /* ================================================================== */
 // Frame decoders. Decode what the above does.
+//
+// An example of an s-expression is
+//    ```(AtomSpace "foo" (AtomSpace "bar") (AtomSpace "baz"))```
+// which indicates an atomspace named "foo" that is layers above two
+// other atomspaces called "bar" and "baz".
+
 
 /// Find some AtmSpace (frame) that has the indicated name.
 /// Both the argument, and the returned values are preseumed to be

--- a/opencog/persist/sexpr/FrameSexpr.cc
+++ b/opencog/persist/sexpr/FrameSexpr.cc
@@ -91,12 +91,10 @@ std::string Sexpr::encode_frame(const AtomSpace* as)
 // other atomspaces called "bar" and "baz".
 
 
-/// Find some AtmSpace (frame) that has the indicated name.
+/// Find some AtomSpace (frame) that has the indicated name.
 /// Both the argument, and the returned values are preseumed to be
 /// AtomSpacePtr's cast into Handles.
-//
-// XXX TODO FIXME: should also verify that the subspaces match.
-// That is, both the name matches, and also the subframes, too.
+///
 static Handle find_frame(const std::string& name, const Handle& surf)
 {
 	if (0 == name.compare(surf->get_name())) return surf;
@@ -117,14 +115,11 @@ static Handle find_frame(const std::string& name, const Handle& surf)
 ///
 /// If `surface` is null, then create a DAG of AtomSpaces, matching the
 /// structure in the s-expression `sframe`.
-//
-// XXX FIXME: this is completely broken, if the DAG has loops in it,
-// or if the same atomspace appears in multiple locations in the DAG.
-// Whoooops!
-//
-// XXX FIXME: this performs a lookup by name only. It should probably
-// perform a lookup by inheritance, too. And/or verify that these are
-// consistent.
+///
+/// The cache is used to skip parsing of long s-expressions, if the
+/// named AtomSpace is found in the cache. This assumes that all
+/// AtomSpaces have unique names.
+///
 Handle Sexpr::decode_frame(const Handle& surface,
                            const std::string& sframe, size_t& pos,
                            std::map<std::string, Handle>& cache)
@@ -154,8 +149,7 @@ Handle Sexpr::decode_frame(const Handle& surface,
 	if (surface and 0 < surface->get_arity())
 	{
 		pos = sframe.find(')', r) + 1;
-		// XXX TODO: verify that the named atomspace has the correct
-		// subframes in it, too...
+		// Perform a lookup by name only. If found, then return it.
 		return find_frame(name, surface);
 	}
 

--- a/opencog/persist/sexpr/Sexpr.h
+++ b/opencog/persist/sexpr/Sexpr.h
@@ -89,7 +89,7 @@ public:
 
 	// -------------------------------------------
 	// Encoding functions
-	static std::string encode_atom(const Handle&);
+	static std::string encode_atom(const Handle&, bool=false);
 	static std::string encode_value(const ValuePtr&);
 	static std::string encode_atom_values(const Handle&);
 	static std::string encode_frame(const Handle&);

--- a/opencog/persist/sexpr/SexprEval.cc
+++ b/opencog/persist/sexpr/SexprEval.cc
@@ -29,10 +29,10 @@
 
 using namespace opencog;
 
-SexprEval::SexprEval(AtomSpace* as)
+SexprEval::SexprEval(AtomSpacePtr& asp)
 	: GenericEval()
 {
-	_atomspace = as;
+	_atomspace = asp;
 }
 
 SexprEval::~SexprEval()
@@ -48,7 +48,8 @@ void SexprEval::eval_expr(const std::string &expr)
 	_caught_error = false;
 	try {
 		std::lock_guard<std::mutex> lock(_mtx);
-		_answer = Commands::interpret_command(_atomspace, expr);
+		_answer = _interpreter.interpret_command(
+			(AtomSpace*) _atomspace.get(), expr);
 	}
 	catch (const StandardException& ex)
 	{
@@ -93,9 +94,9 @@ void SexprEval::interrupt(void)
 	_error_string = "Caught interrupt!";
 }
 
-SexprEval* SexprEval::get_evaluator(AtomSpace* as)
+SexprEval* SexprEval::get_evaluator(AtomSpacePtr& asp)
 {
-	static thread_local SexprEval* evaluator = new SexprEval(as);
+	static thread_local SexprEval* evaluator = new SexprEval(asp);
 
 	// The eval_dtor runs when this thread is destroyed.
 	class eval_dtor {

--- a/opencog/persist/sexpr/SexprEval.h
+++ b/opencog/persist/sexpr/SexprEval.h
@@ -64,8 +64,10 @@ class SexprEval : public GenericEval
 		virtual void interrupt(void);
 
 		static SexprEval* get_evaluator(AtomSpacePtr&);
-		static SexprEval* get_evaluator(AtomSpace* as)
-			{ return get_evaluator(AtomSpaceCast(as); }
+		static SexprEval* get_evaluator(AtomSpace* as) {
+			AtomSpacePtr asp(AtomSpaceCast(as));
+			return get_evaluator(asp); }
+
 };
 
 /** @}*/

--- a/opencog/persist/sexpr/SexprEval.h
+++ b/opencog/persist/sexpr/SexprEval.h
@@ -43,6 +43,7 @@ namespace opencog {
 
 class SexprEval : public GenericEval
 {
+	friend class SexprShell;  // Cogserver needs to call ctor.
 	private:
 		AtomSpacePtr _atomspace;
 		Commands _interpreter;

--- a/opencog/persist/sexpr/SexprEval.h
+++ b/opencog/persist/sexpr/SexprEval.h
@@ -25,7 +25,9 @@
 
 #include <mutex>
 #include <string>
+#include <opencog/atomspace/AtomSpace.h>
 #include <opencog/eval/GenericEval.h>
+#include <opencog/persist/sexpr/Commands.h>
 
 /**
  * The SexprEval class implements a very simple API for s-exprssion
@@ -39,11 +41,11 @@ namespace opencog {
  *  @{
  */
 
-class AtomSpace;
 class SexprEval : public GenericEval
 {
 	private:
-		AtomSpace* _atomspace;
+		AtomSpacePtr _atomspace;
+		Commands _interpreter;
 
 		// poll_result() is called in a different thread
 		// than eval_expr() and the result is that _answer
@@ -51,7 +53,7 @@ class SexprEval : public GenericEval
 		std::mutex _mtx;
 		std::string _answer;
 
-		SexprEval(AtomSpace*);
+		SexprEval(AtomSpacePtr&);
 	public:
 		virtual ~SexprEval();
 
@@ -61,7 +63,7 @@ class SexprEval : public GenericEval
 
 		virtual void interrupt(void);
 
-		static SexprEval* get_evaluator(AtomSpace*);
+		static SexprEval* get_evaluator(AtomSpacePtr&);
 };
 
 /** @}*/

--- a/opencog/persist/sexpr/SexprEval.h
+++ b/opencog/persist/sexpr/SexprEval.h
@@ -64,6 +64,8 @@ class SexprEval : public GenericEval
 		virtual void interrupt(void);
 
 		static SexprEval* get_evaluator(AtomSpacePtr&);
+		static SexprEval* get_evaluator(AtomSpace* as)
+			{ return get_evaluator(AtomSpaceCast(as); }
 };
 
 /** @}*/

--- a/opencog/scm/opencog/base/core-docs.scm
+++ b/opencog/scm/opencog/base/core-docs.scm
@@ -948,28 +948,50 @@
 
 (set-procedure-property! cog-new-atomspace 'documentation
 "
- cog-new-atomspace [ATOMSPACE]
-    Create a new atomspace.  If the optional argument ATOMSPACE
-    is present, then the new atomspace will be an expansion (child)
-    of ATOMSPACE.  AtomSpaces are automatically deleted when no more
-    references to them remain. Returns the new atomspace.
+ cog-new-atomspace [NAME] [ATOMSPACE [ATOMSPACE2 [...]]]
+    Create a new atomspace.  If the optional argument NAME is present,
+    and it is a string, then the new AtomSpace will be given this
+    name. If a list of AtomeSpaces are present, then the new AtomSpace
+    will include these as subframes (subspaces).
+
+    Returns the new atomspace.
+
+    AtomSpaces are automatically deleted when no more references to
+    them remain.
 
     Note that this does NOT set the current atomspace to the new one;
     to do that, you need to use cog-set-atomspace!
+
+    The name of the AtomSpace can be obtained with `cog-name`.
+
+    See also:
+       cog-atomspace -- Get the current AtomSpace in this thread.
+       cog-atomspace-env -- Get the subspaces.
+       cog-atomspace-uuid -- Get the UUID of the AtomSpace.
+       cog-atomspace-ro! -- Mark the AtomSpace as read-only.
+       cog-atomspace-cow! -- Mark the AtomSpace as copy-on-write.
 ")
 
 (set-procedure-property! cog-atomspace-env 'documentation
 "
  cog-atomspace-env [ATOMSPACE]
-     Return the parent of ATOMSPACE. The ATOMSPACE argument is
-     optional; if not specified, the current atomspace is assumed.
+    Return the parent(s) of ATOMSPACE. The ATOMSPACE argument is
+    optional; if not specified, the current atomspace is assumed.
+
+    See also:
+       cog-atomspace -- Get the current AtomSpace in this thread.
+       cog-atomspace-uuid -- Get the UUID of the AtomSpace.
 ")
 
 (set-procedure-property! cog-atomspace-uuid 'documentation
 "
  cog-atomspace-uuid [ATOMSPACE]
-     Return the UUID of ATOMSPACE. The ATOMSPACE argument is
-     optional; if not specified, the current atomspace is assumed.
+    Return the UUID of ATOMSPACE. The ATOMSPACE argument is
+    optional; if not specified, the current atomspace is assumed.
+
+    See also:
+       cog-atomspace -- Get the current AtomSpace in this thread.
+       cog-atomspace-env -- Get the subspaces.
 ")
 
 (set-procedure-property! cog-atomspace-clear 'documentation

--- a/tests/persist/sexpr/CommandsUTest.cxxtest
+++ b/tests/persist/sexpr/CommandsUTest.cxxtest
@@ -69,14 +69,15 @@ void CommandsUTest::test_node()
 
 	std::string in = R"((cog-node 'Concept "foo"))";
 
-	std::string out = Commands::interpret_command(as.get(), in);
+	Commands com;
+	std::string out = com.interpret_command(as.get(), in);
 	printf("Got %s\n", out.c_str());
 
 	TS_ASSERT_EQUALS(0, as->get_size());
 	TS_ASSERT(0 == out.compare("()\n"));
 
 	as->add_node(CONCEPT_NODE, "foo");
-	out = Commands::interpret_command(as.get(), in);
+	out = com.interpret_command(as.get(), in);
 	printf("Got >>%s<<\n", out.c_str());
 	TS_ASSERT_EQUALS(1, as->get_size());
 	TS_ASSERT(0 == out.compare("(ConceptNode \"foo\")"));
@@ -94,7 +95,8 @@ void CommandsUTest::test_node_quoted()
 	std::string in = ss.str();
 	printf("Input %s\n", in.c_str());
 
-	std::string out = Commands::interpret_command(as.get(), in);
+	Commands com;
+	std::string out = com.interpret_command(as.get(), in);
 	printf("Got %s\n", out.c_str());
 
 	TS_ASSERT_EQUALS(0, as->get_size());
@@ -103,7 +105,7 @@ void CommandsUTest::test_node_quoted()
 	Handle h = as->add_node(CONCEPT_NODE, R"("f""o"""o"!!!"")");
 	printf("Added atom %s\n", h->to_short_string().c_str());
 
-	out = Commands::interpret_command(as.get(), in);
+	out = com.interpret_command(as.get(), in);
 	printf("Got    >>%s<<\n", out.c_str());
 	TS_ASSERT_EQUALS(1, as->get_size());
 
@@ -126,7 +128,8 @@ void CommandsUTest::test_link()
 
 	std::string in = R"((cog-link 'List (Concept "a") (Concept "b")))";
 
-	std::string out = Commands::interpret_command(as.get(), in);
+	Commands com;
+	std::string out = com.interpret_command(as.get(), in);
 	printf("Got %s\n", out.c_str());
 
 	TS_ASSERT_EQUALS(2, as->get_size());
@@ -134,7 +137,7 @@ void CommandsUTest::test_link()
 
 	as->add_link(LIST_LINK, ca, cb);
 
-	out = Commands::interpret_command(as.get(), in);
+	out = com.interpret_command(as.get(), in);
 	printf("Got >>%s<<\n", out.c_str());
 	TS_ASSERT_EQUALS(3, as->get_size());
 	TS_ASSERT(0 == out.compare(
@@ -150,7 +153,8 @@ void CommandsUTest::test_set_tv()
 
 	std::string in = R"((cog-set-tv! (Concept "a") (stv 1 0)))";
 
-	std::string out = Commands::interpret_command(as.get(), in);
+	Commands com;
+	std::string out = com.interpret_command(as.get(), in);
 	printf("Got %s\n", out.c_str());
 
 	TS_ASSERT_EQUALS(1, as->get_size());
@@ -165,7 +169,7 @@ void CommandsUTest::test_set_tv()
 
 	// Clobber the TV on B back to Default
 	in = R"((cog-set-tv! (Concept "b") (stv 1 0)))";
-	out = Commands::interpret_command(as.get(), in);
+	out = com.interpret_command(as.get(), in);
 
 	TruthValuePtr tv = h->getTruthValue();
 	printf("new TV is %s\n", tv->to_string().c_str());
@@ -182,7 +186,8 @@ void CommandsUTest::test_set_value()
 	std::string in =
 		R"((cog-set-value! (Concept "a") (Predicate "key") (stv 0.6 0.8)))";
 
-	std::string out = Commands::interpret_command(as.get(), in);
+	Commands com;
+	std::string out = com.interpret_command(as.get(), in);
 	printf("Got %s\n", out.c_str());
 
 	TS_ASSERT_EQUALS(2, as->get_size());
@@ -212,7 +217,8 @@ void CommandsUTest::test_set_value_quoted()
 	std::string in = ss.str();
 	printf("Input %s\n", in.c_str());
 
-	std::string out = Commands::interpret_command(as.get(), in);
+	Commands com;
+	std::string out = com.interpret_command(as.get(), in);
 	printf("Got %s\n", out.c_str());
 
 	TS_ASSERT_EQUALS(2, as->get_size());
@@ -256,17 +262,18 @@ void CommandsUTest::test_get_value()
 	h->setValue(buz, ValueCast(createSimpleTruthValue(0.3, 0.4)));
 
 	std::string in = "(cog-value (Concept \"a\") (Predicate \"key\"))";
-	std::string out = Commands::interpret_command(as.get(), in);
+	Commands com;
+	std::string out = com.interpret_command(as.get(), in);
 	printf("Got %s\n", out.c_str());
 	TS_ASSERT(0 == out.compare(0, 12, "(FloatValue "));
 
 	in = "(cog-value (Concept \"a\") (Predicate \"fiz\"))";
-	out = Commands::interpret_command(as.get(), in);
+	out = com.interpret_command(as.get(), in);
 	printf("Got %s\n", out.c_str());
 	TS_ASSERT(0 == out.compare("(StringValue \"a\" \"b\")"));
 
 	in = "(cog-value (Concept \"a\") (Predicate \"buz\"))";
-	out = Commands::interpret_command(as.get(), in);
+	out = com.interpret_command(as.get(), in);
 	printf("Got %s\n", out.c_str());
 	TS_ASSERT(0 == out.compare(0, 18, "(SimpleTruthValue "));
 
@@ -289,7 +296,8 @@ void CommandsUTest::test_get_value_quoted()
 	h->setValue(buz, ValueCast(createSimpleTruthValue(0.3, 0.4)));
 
 	std::string in = "(cog-value (Concept \"a\") (Predicate \"fiz\"))";
-	std::string out = Commands::interpret_command(as.get(), in);
+	Commands com;
+	std::string out = com.interpret_command(as.get(), in);
 	printf("Got    %s\n", out.c_str());
 
 	std::stringstream oss;
@@ -314,7 +322,8 @@ void CommandsUTest::test_set_values()
 		"(cons (Predicate \"fiz\") (FloatValue 1 2 3))"
 		"(cons (Predicate \"buz\") (StringValue \"gee\" \"golly\"))))";
 
-	std::string out = Commands::interpret_command(as.get(), in);
+	Commands com;
+	std::string out = com.interpret_command(as.get(), in);
 	printf("Got %s\n", out.c_str());
 
 	TS_ASSERT_EQUALS(5, as->get_size());
@@ -366,7 +375,8 @@ void CommandsUTest::test_get_values()
 
 	std::string in = "(cog-keys->alist (Concept \"a\"))";
 
-	std::string out = Commands::interpret_command(as.get(), in);
+	Commands com;
+	std::string out = com.interpret_command(as.get(), in);
 	printf("Got %zu %s\n", out.size(), out.c_str());
 
 	TS_ASSERT(0 == out.compare(0, 17, "(((PredicateNode "));
@@ -386,7 +396,8 @@ void CommandsUTest::test_extract()
 
 	std::string in = "(cog-extract! (Concept \"a\"))";
 
-	std::string out = Commands::interpret_command(as.get(), in);
+	Commands com;
+	std::string out = com.interpret_command(as.get(), in);
 	printf("Got %s\n", out.c_str());
 	TS_ASSERT(0 == out.compare("#f\n"));
 
@@ -395,7 +406,7 @@ void CommandsUTest::test_extract()
 
 	in = "(cog-extract-recursive! (Concept \"a\"))";
 
-	out = Commands::interpret_command(as.get(), in);
+	out = com.interpret_command(as.get(), in);
 	printf("Got %s\n", out.c_str());
 	TS_ASSERT(0 == out.compare("#t\n"));
 
@@ -422,7 +433,8 @@ void CommandsUTest::test_execute()
 		"(Present (List (Variable \"x\") (Concept \"b\"))))"
 		"(Predicate \"key\"))";
 
-	std::string out = Commands::interpret_command(as.get(), in);
+	Commands com;
+	std::string out = com.interpret_command(as.get(), in);
 	printf("Got >>%s<<\n", out.c_str());
 	TS_ASSERT(0 == out.compare("(QueueValue  (ConceptNode \"a\"))"));
 


### PR DESCRIPTION
In combination with the cogserver, this provides support for deep nested chains of atomspaces distributed over the network. 