### PR TITLE
Change the frame-loading DAG API

### DIFF
--- a/opencog/persist/api/BackingStore.h
+++ b/opencog/persist/api/BackingStore.h
@@ -225,19 +225,14 @@ class BackingStore
 
 		/**
 		 * Return the DAG of all of the AtomSpaces held in storage.
-		 * If storage holds only one AtomSpace, then the argument is
-		 * returned. If storage holds more than one AtomSpace, and
-		 * the argument is not a null pointer, then an automatic merge
-		 * of the argument DAG and the in-storage DAG is attempted.
-		 * This merge might result in name of the argument AtomSpace being
-		 * changed!
 		 *
-		 * The returned Handle is an AtomSpacePtr to the top of the DAG.
+		 * The returned HandleSet consists of AtomSpacePtr's to the
+		 * tops of all of the AtomSpaces in the DAG.
 		 */
-		virtual Handle loadFrameDAG(AtomSpace* as = nullptr)
+		virtual HandleSeq loadFrameDAG(void)
 		{
 			throw IOException(TRACE_INFO, "Not implemented!");
-			// return as->shared_from_this();
+			// return HandleSet();
 		}
 
 		/**

--- a/opencog/persist/api/PersistSCM.cc
+++ b/opencog/persist/api/PersistSCM.cc
@@ -268,7 +268,7 @@ void PersistSCM::sn_store_atomspace(Handle hsn)
 	stnp->store_atomspace(as);
 }
 
-Handle PersistSCM::sn_load_frames(Handle hsn)
+HandleSeq PersistSCM::sn_load_frames(Handle hsn)
 {
 	GET_STNP;
 	return stnp->load_frames();
@@ -395,7 +395,7 @@ void PersistSCM::dflt_store_atomspace(void)
 	_sn->store_atomspace(as);
 }
 
-Handle PersistSCM::dflt_load_frames(void)
+HandleSeq PersistSCM::dflt_load_frames(void)
 {
 	CHECK;
 	return _sn->load_frames();

--- a/opencog/persist/api/PersistSCM.h
+++ b/opencog/persist/api/PersistSCM.h
@@ -52,7 +52,7 @@ private:
 	static void sn_load_type(Type, Handle);
 	static void sn_load_atomspace(Handle);
 	static void sn_store_atomspace(Handle);
-	static Handle sn_load_frames(Handle);
+	static HandleSeq sn_load_frames(Handle);
 	static void sn_store_frames(Handle, Handle);
 	static bool sn_delete(Handle, Handle);
 	static bool sn_delete_recursive(Handle, Handle);
@@ -78,7 +78,7 @@ private:
 	void dflt_load_type(Type);
 	void dflt_load_atomspace(void);
 	void dflt_store_atomspace(void);
-	Handle dflt_load_frames(void);
+	HandleSeq dflt_load_frames(void);
 	void dflt_store_frames(Handle);
 	bool dflt_delete(Handle);
 	bool dflt_delete_recursive(Handle);

--- a/opencog/persist/api/StorageNode.cc
+++ b/opencog/persist/api/StorageNode.cc
@@ -201,10 +201,9 @@ void StorageNode::fetch_all_atoms_of_type(Type t, AtomSpace* as)
 	loadType(as, t);
 }
 
-Handle StorageNode::load_frames(AtomSpace* as)
+HandleSeq StorageNode::load_frames(void)
 {
-	if (nullptr == as) as = getAtomSpace();
-	return loadFrameDAG(as);
+	return loadFrameDAG();
 }
 
 void StorageNode::store_frames(const Handle& has)

--- a/opencog/persist/api/StorageNode.h
+++ b/opencog/persist/api/StorageNode.h
@@ -154,9 +154,10 @@ public:
 	 * The AtomSpaces themselves will not be populated; use the
 	 * `load_atomspace` method above to accomplish that.
 	 *
-	 * The returned Handle is an AtomSpacePtr to the top of the DAG.
+	 * The returned HandleSeq consists of AtomSpacePtr's to the
+	 * AtomSpaces at the top of the DAG.
 	 */
-	Handle load_frames(AtomSpace* = nullptr);
+	HandleSeq load_frames(void);
 
 	/**
 	 * Store the DAG of all AtomSpaces to the backing store.


### PR DESCRIPTION
Change the API so that it returns all of the different branches of the AtomSpace (all of the tops of the DAG of atomspaces).

This makes things simpler, when there are lots of different branches going at the same time.