### PR TITLE
Covering links should shadow values on covered links

### DIFF
--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -313,6 +313,13 @@ Handle AtomSpace::add(const Handle& orig, bool force)
             atom->copyValues(orig);
         } else {
             atom->unsetRemovalFlag();
+
+            // If we are shadowing a deeper atom, copy it's values.
+            if (_transient or _copy_on_write)
+            {
+                Handle covered(lookupHandle(atom));
+                if (covered) atom->copyValues(covered);
+            }
         }
     }
     else if (atom->getAtomSpace())
@@ -322,7 +329,16 @@ Handle AtomSpace::add(const Handle& orig, bool force)
         atom->copyValues(orig);
     }
     else
+    {
         atom->unsetRemovalFlag();
+
+        // If we are shadowing a deeper atom, copy it's values.
+        if (_transient or _copy_on_write)
+        {
+            Handle covered(lookupHandle(atom));
+            if (covered) atom->copyValues(covered);
+        }
+    }
 
     // Must set atomspace before insertion. This must be done before the
     // atom becomes visible at the typeIndex insert.  Likewise for setting

--- a/tests/atomspace/cover-space-test.scm
+++ b/tests/atomspace/cover-space-test.scm
@@ -8,6 +8,8 @@
 
 (opencog-test-runner)
 
+(define (get-cnt ATOM) (inexact->exact (cog-count ATOM)))
+
 ; -------------------------------------------------------------------
 ; Common setup, used by all tests.
 
@@ -15,12 +17,6 @@
 (define mid1-space (cog-new-atomspace base-space))
 (define mid2-space (cog-new-atomspace mid1-space))
 (define surface-space (cog-new-atomspace mid2-space))
-
-; -------------------------------------------------------------------
-; Test that deep links are found correctly.
-
-(define deep-link "test deep links")
-(test-begin deep-link)
 
 ; Splatter some atoms into the various spaces.
 (cog-set-atomspace! base-space)
@@ -32,6 +28,12 @@
 (cog-set-atomspace! mid2-space)
 (ListLink (Concept "foo") (Concept "bar") (ctv 1 0 5))
 
+; -------------------------------------------------------------------
+; Test that deep links are found correctly.
+
+(define deep-link "test deep links")
+(test-begin deep-link)
+
 ; Even though we work on the current surface, we expect to find
 ; the deeper ListLink.
 (cog-set-atomspace! surface-space)
@@ -42,6 +44,39 @@
 (test-equal "bar-space" mid1-space (cog-atomspace (gdr lilly)))
 
 (test-end deep-link)
+
+; -------------------------------------------------------------------
+; Test that deep links are covered correctly.
+
+(define deep-cover "test deep links")
+(test-begin deep-cover)
+
+; Alter counts in the outgoing set.
+; The new ListLink should pick up the counts on the deeper one.
+(Concept "foo" (ctv 1 0 9))
+(define litop (ListLink (Concept "foo") (Concept "bar")))
+
+; The mid-grade ListLink should be unchanged.
+(test-equal "link-space" mid2-space (cog-atomspace lilly))
+(test-equal "foo-space" base-space (cog-atomspace (gar lilly)))
+(test-equal "bar-space" mid1-space (cog-atomspace (gdr lilly)))
+
+; TV should be as before.
+(test-equal "link-tv" 5 (get-cnt lilly))
+(test-equal "foo-tv" 3 (get-cnt (gar lilly)))
+(test-equal "bar-tv" 4 (get-cnt (gdr lilly)))
+
+; The top-most ListLink should be different.
+(test-equal "link-top" surface-space (cog-atomspace litop))
+(test-equal "foo-top" surface-space (cog-atomspace (gar litop)))
+(test-equal "bar-top" mid1-space (cog-atomspace (gdr litop)))
+
+; Verify that the count on ListLink was copied over correctly
+(test-equal "top-link-tv" 5 (get-cnt litop))
+(test-equal "top-foo-tv" 9 (get-cnt (gar litop)))
+(test-equal "top-bar-tv" 4 (get-cnt (gdr litop)))
+
+(test-end deep-cover)
 
 ; -------------------------------------------------------------------
 (opencog-test-end)


### PR DESCRIPTION
When an atom is added to an atom space, and it shadows a deeper atom, it should inherit values from the deeper atom.