### PR TITLE
Check shadowed copy

### DIFF
--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -310,6 +310,16 @@ Handle AtomSpace::add(const Handle& orig, bool force)
                 closet.emplace_back(add(h, false));
             }
             atom = createLink(std::move(closet), atom->get_type());
+
+            // Now that the outgoing set is correct, check again to
+            // see if we already have this atom in the atomspace.
+            const Handle& hc(check(atom, force));
+            if (hc) {
+                hc->copyValues(orig);
+                return hc;
+            }
+
+            // Don't have it. Copy values, and then add it.
             atom->copyValues(orig);
         } else {
             atom->unsetRemovalFlag();

--- a/opencog/scm/opencog/persist.scm
+++ b/opencog/scm/opencog/persist.scm
@@ -313,6 +313,14 @@
     If the optional STORAGE argument is provided, then it will be
     used as the target of the store. It must be a StorageNode.
 
+    If the current AtomSpace sits on top of a stack of AtomSpaces, then
+    only the shallowest visible Atoms in the current AtomSpace will be
+    stored. Atoms that have been deleted in the current Atomspaces but
+    are present in deeper AtomSpaces will NOT be stored. Values in
+    deeper AtomSpaces that are hidden/changed in the current AtomSpace
+    will NOT be stored. In other words, the only Atoms and Values that
+    are stored are those that are visible in the current AtomSpace.
+
     See also:
     load-atomspace -- load all Atoms in the AtomSpace.
     store-atom ATOM -- store one ATOM and all of the values on it.


### PR DESCRIPTION
During link add, after adjusting outgoing set, check again to see if we already have this atom.