### PR TITLE
Convert nakes AtomSpace* usage to AtomSpacePtr

### DIFF
--- a/opencog/cython/PythonSCM.cc
+++ b/opencog/cython/PythonSCM.cc
@@ -100,7 +100,7 @@ void* PythonSCM::init_in_guile(void* self)
 	PythonEval& pev = PythonEval::instance();
   	// Make sure that guile and python are using the same atomspace.
 	// This will avoid assorted confusion.
-	AtomSpace* as = SchemeSmob::ss_get_env_as("python-eval");
+	const AtomSpacePtr& asp = SchemeSmob::ss_get_env_as("python-eval");
 
 	// This feels hacky, I guess, but I cannot figure out any other
 	// way of telling python which atomspace it is supposed to use
@@ -108,7 +108,7 @@ void* PythonSCM::init_in_guile(void* self)
 	pev.eval("from opencog.atomspace import AtomSpace");
 	pev.eval("from opencog.type_constructors import set_default_atomspace");
 	pev.eval("set_default_atomspace(AtomSpace(" +
-            std::to_string((uint64_t) as) + "))\n");
+            std::to_string((uint64_t) asp.get()) + "))\n");
 
 	return NULL;
 }

--- a/opencog/cython/opencog/PyScheme.cc
+++ b/opencog/cython/opencog/PyScheme.cc
@@ -123,9 +123,9 @@ AtomSpace* opencog::eval_scheme_as(const std::string &s)
 	do_init();
 	SchemeEval* evaluator = SchemeEval::get_evaluator(nullptr);
 	evaluator->clear_pending();
-	AtomSpace* as = evaluator->eval_as(s);
+	const AtomSpacePtr& asp = evaluator->eval_as(s);
 
-	if (nullptr == as)
+	if (nullptr == asp)
 		throw RuntimeException(TRACE_INFO,
 		       "Python-Scheme Wrapper: Null atomspace for '%s'", s.c_str());
 
@@ -133,7 +133,7 @@ AtomSpace* opencog::eval_scheme_as(const std::string &s)
 		throw RuntimeException(TRACE_INFO,
 		       "Python-Scheme Wrapper: Failed to execute '%s'", s.c_str());
 
-	return as;
+	return asp.get();
 #else // HAVE_GUILE
 	return nullptr;
 #endif // HAVE_GUILE

--- a/opencog/guile/SchemeEval.cc
+++ b/opencog/guile/SchemeEval.cc
@@ -308,7 +308,12 @@ static void init_only_once(void)
 SchemeEval::SchemeEval(AtomSpace* as)
 {
 	init_only_once();
-	_atomspace = AtomSpaceCast(as->shared_from_this());
+
+	// If it is coming from the pool, the as will be null.
+	if (as)
+		_atomspace = AtomSpaceCast(as->shared_from_this());
+	else
+		_atomspace = nullptr;
 
 	scm_with_guile(c_wrap_init, this);
 }

--- a/opencog/guile/SchemeEval.cc
+++ b/opencog/guile/SchemeEval.cc
@@ -308,15 +308,15 @@ static void init_only_once(void)
 SchemeEval::SchemeEval(AtomSpace* as)
 {
 	init_only_once();
-	_atomspace = as;
+	_atomspace = AtomSpaceCast(as->shared_from_this());
 
 	scm_with_guile(c_wrap_init, this);
 }
 
-SchemeEval::SchemeEval(AtomSpacePtr& as)
+SchemeEval::SchemeEval(AtomSpacePtr& asp)
 {
 	init_only_once();
-	_atomspace = (AtomSpace*) as.get();
+	_atomspace = asp;
 
 	scm_with_guile(c_wrap_init, this);
 }
@@ -620,7 +620,7 @@ void SchemeEval::do_eval(const std::string &expr)
 
 	// Set the execution environment atomspace (i.e. for this thread)
 	// to the evaluator _atomspace variable.
-	AtomSpace* saved_as = nullptr;
+	AtomSpacePtr saved_as;
 	if (_atomspace)
 	{
 		saved_as = SchemeSmob::ss_get_env_as("do_eval");
@@ -828,14 +828,14 @@ SCM SchemeEval::do_scm_eval(SCM sexpr, SCM (*evo)(void *))
 	per_thread_init();
 
 	// Set per-thread atomspace variable in the execution environment.
-	AtomSpace* saved_as = NULL;
+	AtomSpacePtr saved_as;
 	if (_atomspace)
 	{
 		saved_as = SchemeSmob::ss_get_env_as("do_scm_eval");
 		if (saved_as != _atomspace)
 			SchemeSmob::ss_set_env_as(_atomspace);
 		else
-			saved_as = NULL;
+			saved_as = nullptr;
 	}
 
 	// If we are running from the cogserver shell, capture all output
@@ -1006,7 +1006,7 @@ ValuePtr SchemeEval::eval_v(const std::string &expr)
  * If an evaluation error occurs, an exception is thrown, and the stack
  * trace is logged to the log file.
  */
-AtomSpace* SchemeEval::eval_as(const std::string &expr)
+AtomSpacePtr SchemeEval::eval_as(const std::string &expr)
 {
 	// If we are recursing, then we already are in the guile
 	// environment, and don't need to do any additional setup.
@@ -1190,9 +1190,9 @@ static void return_to_pool(SchemeEval* ev)
 /// Use thread-local storage (TLS) in order to avoid repeatedly
 /// creating and destroying the evaluator.
 ///
-SchemeEval* SchemeEval::get_evaluator(AtomSpace* as)
+SchemeEval* SchemeEval::get_evaluator(const AtomSpacePtr& asp)
 {
-	static thread_local std::map<AtomSpace*,SchemeEval*> issued;
+	static thread_local std::map<AtomSpacePtr,SchemeEval*> issued;
 
 	// The eval_dtor runs when this thread is destroyed.
 	class eval_dtor {
@@ -1209,26 +1209,28 @@ SchemeEval* SchemeEval::get_evaluator(AtomSpace* as)
 				// calling delete will lead to a crash in c_wrap_finish().
 				// It would be nice if we got called before guile did, but
 				// there is no way in TLS to control execution order...
-				evaluator->_atomspace = NULL;
+				evaluator->_atomspace = nullptr;
 				return_to_pool(evaluator);
 			}
 		}
 	};
 	static thread_local eval_dtor killer;
 
-	auto ev = issued.find(as);
+	auto ev = issued.find(asp);
 	if (ev != issued.end())
 		return ev->second;
 
 	SchemeEval* evaluator = get_from_pool();
-	evaluator->_atomspace = as;
-	issued[as] = evaluator;
+	evaluator->_atomspace = asp;
+	issued[asp] = evaluator;
 	return evaluator;
 }
 
-SchemeEval* SchemeEval::get_evaluator(AtomSpacePtr& as)
+SchemeEval* SchemeEval::get_evaluator(AtomSpace* as)
 {
-	return get_evaluator((AtomSpace*) as.get());
+	OC_ASSERT(as, "Expected aan AtomSpace");
+	const AtomSpacePtr& asp = AtomSpaceCast(as->shared_from_this());
+	return get_evaluator(asp);
 }
 
 /* ============================================================== */
@@ -1236,7 +1238,8 @@ SchemeEval* SchemeEval::get_evaluator(AtomSpacePtr& as)
 void* SchemeEval::c_wrap_set_atomspace(void * vas)
 {
 	AtomSpace* as = (AtomSpace*) vas;
-	SchemeSmob::ss_set_env_as(as);
+	const AtomSpacePtr& asp = AtomSpaceCast(as->shared_from_this());
+	SchemeSmob::ss_set_env_as(asp);
 	return vas;
 }
 

--- a/opencog/guile/SchemeEval.cc
+++ b/opencog/guile/SchemeEval.cc
@@ -1233,7 +1233,12 @@ SchemeEval* SchemeEval::get_evaluator(const AtomSpacePtr& asp)
 
 SchemeEval* SchemeEval::get_evaluator(AtomSpace* as)
 {
-	OC_ASSERT(as, "Expected aan AtomSpace");
+	// A null AtomSpace is passed from the cython initialization
+	// code. That code scramble to create an AtomSpace, after
+	// guile is initialized.
+	static AtomSpacePtr nullasp;
+	if (nullptr == as) return get_evaluator(nullasp);
+
 	const AtomSpacePtr& asp = AtomSpaceCast(as->shared_from_this());
 	return get_evaluator(asp);
 }

--- a/opencog/guile/SchemeEval.h
+++ b/opencog/guile/SchemeEval.h
@@ -130,7 +130,7 @@ class SchemeEval : public GenericEval
 		// Apply function to arguments, returning Handle or TV
 		Handle _hargs;
 		ValuePtr _retval;
-		AtomSpace* _retas;
+		AtomSpacePtr _retas;
 		SCM do_apply_scm(const std::string& func, const Handle& varargs);
 		static void * c_wrap_apply_v(void *);
 
@@ -149,7 +149,7 @@ class SchemeEval : public GenericEval
 		static std::string prt(SCM);
 
 		static void * c_wrap_set_atomspace(void *);
-		AtomSpace* _atomspace;
+		AtomSpacePtr _atomspace;
 		int _gc_ctr;
 		bool _in_eval;
 
@@ -166,8 +166,8 @@ class SchemeEval : public GenericEval
 		~SchemeEval();
 
 		// Return per-thread, per-atomspace singleton
-		static SchemeEval* get_evaluator(AtomSpace* = NULL);
-		static SchemeEval* get_evaluator(AtomSpacePtr&);
+		static SchemeEval* get_evaluator(AtomSpace*);
+		static SchemeEval* get_evaluator(const AtomSpacePtr&);
 
 		// The async-output interface.
 		void begin_eval(void);
@@ -194,7 +194,7 @@ class SchemeEval : public GenericEval
 		TruthValuePtr eval_tv(const std::stringstream& ss) { return eval_tv(ss.str()); }
 
 		// Evaluate expression, returning AtomSpace.
-		AtomSpace* eval_as(const std::string&);
+		AtomSpacePtr eval_as(const std::string&);
 
 		// Apply expression to args, returning Handle or TV
 		virtual ValuePtr apply_v(const std::string& func, Handle varargs);

--- a/opencog/guile/SchemeModule.cc
+++ b/opencog/guile/SchemeModule.cc
@@ -58,28 +58,32 @@ FunctionWrap::FunctionWrap(ValuePtr (p)(AtomSpace*, const Handle&),
 Handle FunctionWrap::as_wrapper_h_h(Handle h)
 {
 	// XXX we should also allow opt-args to be a list of handles
-	AtomSpace *as = SchemeSmob::ss_get_env_as(_name);
+	const AtomSpacePtr& asp = SchemeSmob::ss_get_env_as(_name);
+	AtomSpace* as = asp.get();
 	return _func_h_ah(as, h);
 }
 
 Handle FunctionWrap::as_wrapper_h_hz(Handle h, size_t sz)
 {
 	// XXX we should also allow opt-args to be a list of handles
-	AtomSpace *as = SchemeSmob::ss_get_env_as(_name);
+	const AtomSpacePtr& asp = SchemeSmob::ss_get_env_as(_name);
+	AtomSpace* as = asp.get();
 	return _func_h_ahz(as, h, sz);
 }
 
 TruthValuePtr FunctionWrap::as_wrapper_p_h(Handle h)
 {
 	// XXX we should also allow opt-args to be a list of handles
-	AtomSpace *as = SchemeSmob::ss_get_env_as(_name);
+	const AtomSpacePtr& asp = SchemeSmob::ss_get_env_as(_name);
+	AtomSpace* as = asp.get();
 	return _pred_ah(as, h);
 }
 
 ValuePtr FunctionWrap::as_wrapper_v_h(Handle h)
 {
 	// XXX we should also allow opt-args to be a list of handles
-	AtomSpace *as = SchemeSmob::ss_get_env_as(_name);
+	const AtomSpacePtr& asp = SchemeSmob::ss_get_env_as(_name);
+	AtomSpace* as = asp.get();
 	return _proto_ah(as, h);
 }
 

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -177,8 +177,8 @@ private:
 	static SCM ss_as_readonly_p(SCM);
 	static SCM ss_as_mark_cow(SCM, SCM);
 	static SCM ss_as_cow_p(SCM);
-	static SCM make_as(AtomSpace *);
-	static AtomSpace* ss_to_atomspace(SCM);
+	static SCM make_as(const AtomSpacePtr&);
+	static const AtomSpacePtr& ss_to_atomspace(SCM);
 
 	// Free variables
 	static SCM ss_get_free_variables(SCM);
@@ -231,7 +231,7 @@ private:
 	static Logger* verify_logger(SCM, const char *, int pos = 1);
 
 	static SCM atomspace_fluid;
-	static void ss_set_env_as(AtomSpace *);
+	static void ss_set_env_as(const AtomSpacePtr&);
 
 	SchemeSmob();
 public:
@@ -240,7 +240,7 @@ public:
 
 	// This allows other users to get the atomspace that scheme is
 	// using.
-	static AtomSpace* ss_get_env_as(const char *);
+	static const AtomSpacePtr& ss_get_env_as(const char *);
 };
 
 // This assumes that sizeof(ValuePtr) == 16. If it ever changes

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -190,8 +190,8 @@ private:
 	static std::string protom_to_server_string(SCM);
 	static std::string misc_to_string(SCM);
 	static TruthValuePtr get_tv_from_list(SCM);
-	static AtomSpace* get_as_from_list(SCM);
-	static Handle set_values(const Handle&, AtomSpace*, SCM);
+	static const AtomSpacePtr& get_as_from_list(SCM);
+	static Handle set_values(const Handle&, const AtomSpacePtr&, SCM);
 
 	// Logger
 	static SCM logger_to_scm(Logger*);
@@ -247,6 +247,7 @@ public:
 // to 24, then this macro has to be changed to SCM_SMOB_OBJECT_1_LOC
 // and if it ever gets larger than 24, then we are SOL.
 #define SCM_SMOB_VALUE_PTR_LOC(x) ((ValuePtr*) SCM_SMOB_OBJECT_2_LOC(x))
+#define SCM_SMOB_AS_PTR_LOC(x) ((AtomSpacePtr*) SCM_SMOB_OBJECT_2_LOC(x))
 
 /** @}*/
 } // namespace opencog

--- a/opencog/guile/SchemeSmobAS.cc
+++ b/opencog/guile/SchemeSmobAS.cc
@@ -82,7 +82,15 @@ SCM SchemeSmob::ss_as_p (SCM s)
 
 const AtomSpacePtr& SchemeSmob::ss_to_atomspace(SCM sas)
 {
-	return AtomSpaceCast(scm_to_protom(sas));
+	static AtomSpacePtr nullasp;
+	if (not SCM_SMOB_PREDICATE(SchemeSmob::cog_misc_tag, sas))
+		return nullasp;
+
+	scm_t_bits misctype = SCM_SMOB_FLAGS(sas);
+	if (COG_PROTOM != misctype) // Should this be a wrong-type-arg?
+		return nullasp;
+
+	return *(SCM_SMOB_AS_PTR_LOC(sas));
 }
 
 /* ============================================================== */
@@ -293,17 +301,18 @@ const AtomSpacePtr& SchemeSmob::ss_get_env_as(const char* subr)
  * Return the atomspace if found, else return null.
  * Throw errors if the list is not stictly just key-value pairs.
  */
-AtomSpace* SchemeSmob::get_as_from_list(SCM slist)
+const AtomSpacePtr& SchemeSmob::get_as_from_list(SCM slist)
 {
 	while (scm_is_pair(slist))
 	{
 		SCM sval = SCM_CAR(slist);
 		const AtomSpacePtr& asp = ss_to_atomspace(sval);
-		if (asp) return asp.get();
+		if (asp) return asp;
 		slist = SCM_CDR(slist);
 	}
 
-	return NULL;
+	static AtomSpacePtr nullasp;
+	return nullasp;
 }
 
 /* ===================== END OF FILE ============================ */

--- a/opencog/guile/SchemeSmobAS.cc
+++ b/opencog/guile/SchemeSmobAS.cc
@@ -19,9 +19,9 @@ using namespace opencog;
 /**
  * Create SCM object wrapping the atomspace.
  */
-SCM SchemeSmob::make_as(AtomSpace *as)
+SCM SchemeSmob::make_as(const AtomSpacePtr& asp)
 {
-	return protom_to_scm(as->shared_from_this());
+	return protom_to_scm(asp);
 }
 
 /* ============================================================== */
@@ -80,24 +80,20 @@ SCM SchemeSmob::ss_as_p (SCM s)
 /* ============================================================== */
 /* Cast SCM to atomspace */
 
-AtomSpace* SchemeSmob::ss_to_atomspace(SCM sas)
+const AtomSpacePtr& SchemeSmob::ss_to_atomspace(SCM sas)
 {
-	ValuePtr vp(scm_to_protom(sas));
-	if (nullptr == vp or ATOM_SPACE != vp->get_type())
-		return nullptr;
-
-	return (AtomSpace*) vp.get();
+	return AtomSpaceCast(scm_to_protom(sas));
 }
 
 /* ============================================================== */
 
 AtomSpace* SchemeSmob::verify_atomspace(SCM sas, const char * subrname, int pos)
 {
-	AtomSpace* as = ss_to_atomspace(sas);
+	const AtomSpacePtr& asp = ss_to_atomspace(sas);
 	if (nullptr == as)
 		scm_wrong_type_arg_msg(subrname, pos, sas, "opencog atomspace");
 
-	return as;
+	return asp.get();
 }
 
 /* ============================================================== */
@@ -106,10 +102,10 @@ AtomSpace* SchemeSmob::verify_atomspace(SCM sas, const char * subrname, int pos)
  */
 SCM SchemeSmob::ss_as_uuid(SCM sas)
 {
-	AtomSpace* as = ss_to_atomspace(sas);
-	if (nullptr == as) as = ss_get_env_as("cog-atomspace-uuid");
+	const AtomSpacePtr& asp = ss_to_atomspace(sas);
+	if (nullptr == asp) asp = ss_get_env_as("cog-atomspace-uuid");
 
-	UUID uuid = as->get_uuid();
+	UUID uuid = asp->get_uuid();
 	scm_remember_upto_here_1(sas);
 
 	return scm_from_ulong(uuid);
@@ -121,10 +117,10 @@ SCM SchemeSmob::ss_as_uuid(SCM sas)
  */
 SCM SchemeSmob::ss_as_env(SCM sas)
 {
-	AtomSpace* as = ss_to_atomspace(sas);
-	if (nullptr == as) as = ss_get_env_as("cog-atomspace-env");
+	const AtomSpacePtr& asp = ss_to_atomspace(sas);
+	if (nullptr == asp) asp = ss_get_env_as("cog-atomspace-env");
 
-	const HandleSeq& oset = as->getOutgoingSet();
+	const HandleSeq& oset = asp->getOutgoingSet();
 	SCM list = SCM_EOL;
 	for (size_t i = oset.size(); i > 0; i--)
 	{
@@ -142,11 +138,11 @@ SCM SchemeSmob::ss_as_env(SCM sas)
  */
 SCM SchemeSmob::ss_as_readonly_p(SCM sas)
 {
-	AtomSpace* as = ss_to_atomspace(sas);
+	const AtomSpacePtr& asp = ss_to_atomspace(sas);
 	scm_remember_upto_here_1(sas);
-	if (nullptr == as) as = ss_get_env_as("cog-atomspace-readonly?");
+	if (nullptr == asp) asp = ss_get_env_as("cog-atomspace-readonly?");
 
-	if (as->get_read_only()) return SCM_BOOL_T;
+	if (asp->get_read_only()) return SCM_BOOL_T;
 	return SCM_BOOL_F;
 }
 
@@ -156,9 +152,9 @@ SCM SchemeSmob::ss_as_readonly_p(SCM sas)
  */
 SCM SchemeSmob::ss_as_cow_p(SCM sas)
 {
-	AtomSpace* as = ss_to_atomspace(sas);
+	const AtomSpacePtr& asp = ss_to_atomspace(sas);
 	scm_remember_upto_here_1(sas);
-	if (nullptr == as) as = ss_get_env_as("cog-atomspace-cow?");
+	if (nullptr == asp) asp = ss_get_env_as("cog-atomspace-cow?");
 
 	if (as->get_copy_on_write()) return SCM_BOOL_T;
 	return SCM_BOOL_F;
@@ -172,33 +168,33 @@ SCM SchemeSmob::ss_as_cow_p(SCM sas)
  */
 SCM SchemeSmob::ss_as_mark_readonly(SCM sas)
 {
-	AtomSpace* as = ss_to_atomspace(sas);
+	const AtomSpacePtr& asp = ss_to_atomspace(sas);
 	scm_remember_upto_here_1(sas);
-	if (nullptr == as) as = ss_get_env_as("cog-atomspace-ro!");
+	if (nullptr == asp) asp = ss_get_env_as("cog-atomspace-ro!");
 
-	as->set_read_only();
+	asp->set_read_only();
 	return SCM_BOOL_T;
 }
 
 SCM SchemeSmob::ss_as_mark_readwrite(SCM sas)
 {
-	AtomSpace* as = ss_to_atomspace(sas);
+	const AtomSpacePtr& asp = ss_to_atomspace(sas);
 	scm_remember_upto_here_1(sas);
-	if (nullptr == as) as = ss_get_env_as("cog-atomspace-rw!");
+	if (nullptr == asp) asp = ss_get_env_as("cog-atomspace-rw!");
 
-	as->set_read_write();
+	asp->set_read_write();
 	return SCM_BOOL_T;
 }
 
 SCM SchemeSmob::ss_as_mark_cow(SCM scow, SCM sas)
 {
-	AtomSpace* as = ss_to_atomspace(sas);
+	const AtomSpacePtr& asp = ss_to_atomspace(sas);
 	scm_remember_upto_here_1(sas);
-	if (nullptr == as) as = ss_get_env_as("cog-atomspace-cow!");
+	if (nullptr == asp) asp = ss_get_env_as("cog-atomspace-cow!");
 
 	bool cow = scm_to_bool(scow);
-	if (cow) as->set_copy_on_write();
-	else as->clear_copy_on_write();
+	if (cow) asp->set_copy_on_write();
+	else asp->clear_copy_on_write();
 	return SCM_BOOL_T;
 }
 
@@ -208,10 +204,10 @@ SCM SchemeSmob::ss_as_mark_cow(SCM scow, SCM sas)
  */
 SCM SchemeSmob::ss_as_clear(SCM sas)
 {
-	AtomSpace* as = ss_to_atomspace(sas);
-	if (nullptr == as) as = ss_get_env_as("cog-atomspace-clear");
+	const AtomSpacePtr& asp = ss_to_atomspace(sas);
+	if (nullptr == asp) asp = ss_get_env_as("cog-atomspace-clear");
 
-	as->clear();
+	asp->clear();
 
 	scm_remember_upto_here_1(sas);
 	return SCM_BOOL_T;
@@ -227,14 +223,14 @@ SCM SchemeSmob::ss_as(SCM slist)
 	// If no argument, then return the current AtomSpace.
 	if (scm_is_null(slist))
 	{
-		AtomSpace* as = ss_get_env_as("cog-atomspace");
-		return as ? make_as(as) : SCM_EOL;
+		const AtomSpacePtr& asp = ss_get_env_as("cog-atomspace");
+		return asp ? make_as(asp) : SCM_EOL;
 	}
 
 	SCM satom = scm_car(slist);
 	Handle h(verify_handle(satom, "cog-atomspace"));
 	AtomSpace* as = h->getAtomSpace();
-	return as ? make_as(as) : SCM_EOL;
+	return as ? make_as(as->make_shared_from_this()) : SCM_EOL;
 }
 
 /* ============================================================== */
@@ -249,7 +245,7 @@ SCM SchemeSmob::atomspace_fluid;
  */
 SCM SchemeSmob::ss_set_as (SCM new_as)
 {
-	AtomSpace* nas = ss_to_atomspace(new_as);
+	const AtomSpacePtr& nas = ss_to_atomspace(new_as);
 	if (!nas)
 		return SCM_BOOL_F;
 
@@ -267,22 +263,23 @@ SCM SchemeSmob::ss_set_as (SCM new_as)
  * thread, so that different threads can use different atomspaces,
  * all at the same time.
  */
-void SchemeSmob::ss_set_env_as(AtomSpace *nas)
+void SchemeSmob::ss_set_env_as(const AtomSpacePtr& nas)
 {
 	scm_fluid_set_x(atomspace_fluid, make_as(nas));
 }
 
-AtomSpace* SchemeSmob::ss_get_env_as(const char* subr)
+const AtomSpacePtr& SchemeSmob::ss_get_env_as(const char* subr)
 {
 	// There are weird test-case scenarios where the fluid is not
 	// initialized. Those will crash-n-burn without this test.
-	if (0x0 == atomspace_fluid) return nullptr;
+	static AtomSpacePtr nullasp;
+	if (0x0 == atomspace_fluid) return nullasp;
 
 	SCM ref = scm_fluid_ref(atomspace_fluid);
-	AtomSpace* as = ss_to_atomspace(ref);
+	const AtomSpacePtr& asp = ss_to_atomspace(ref);
 	// if (nullptr == as)
 	//	scm_misc_error(subr, "No atomspace was specified!", SCM_BOOL_F);
-	return as;
+	return asp;
 }
 
 /* ============================================================== */
@@ -297,8 +294,8 @@ AtomSpace* SchemeSmob::get_as_from_list(SCM slist)
 	while (scm_is_pair(slist))
 	{
 		SCM sval = SCM_CAR(slist);
-		AtomSpace* as = ss_to_atomspace(sval);
-		if (as) return as;
+		const AtomSpacePtr& asp = ss_to_atomspace(sval);
+		if (asp) return asp.get();
 		slist = SCM_CDR(slist);
 	}
 

--- a/opencog/guile/SchemeSmobAS.cc
+++ b/opencog/guile/SchemeSmobAS.cc
@@ -90,7 +90,11 @@ const AtomSpacePtr& SchemeSmob::ss_to_atomspace(SCM sas)
 	if (COG_PROTOM != misctype) // Should this be a wrong-type-arg?
 		return nullasp;
 
-	return *(SCM_SMOB_AS_PTR_LOC(sas));
+	const AtomSpacePtr& asp = *(SCM_SMOB_AS_PTR_LOC(sas));
+	if (ATOM_SPACE != asp->get_type())
+		return nullasp;
+
+	return asp;
 }
 
 /* ============================================================== */

--- a/opencog/guile/SchemeSmobAS.cc
+++ b/opencog/guile/SchemeSmobAS.cc
@@ -90,7 +90,7 @@ const AtomSpacePtr& SchemeSmob::ss_to_atomspace(SCM sas)
 AtomSpace* SchemeSmob::verify_atomspace(SCM sas, const char * subrname, int pos)
 {
 	const AtomSpacePtr& asp = ss_to_atomspace(sas);
-	if (nullptr == as)
+	if (nullptr == asp)
 		scm_wrong_type_arg_msg(subrname, pos, sas, "opencog atomspace");
 
 	return asp.get();
@@ -102,8 +102,9 @@ AtomSpace* SchemeSmob::verify_atomspace(SCM sas, const char * subrname, int pos)
  */
 SCM SchemeSmob::ss_as_uuid(SCM sas)
 {
-	const AtomSpacePtr& asp = ss_to_atomspace(sas);
-	if (nullptr == asp) asp = ss_get_env_as("cog-atomspace-uuid");
+	const AtomSpacePtr& asg = ss_to_atomspace(sas);
+	const AtomSpacePtr& asp = asg ? asg :
+		ss_get_env_as("cog-atomspace-uuid");
 
 	UUID uuid = asp->get_uuid();
 	scm_remember_upto_here_1(sas);
@@ -117,8 +118,9 @@ SCM SchemeSmob::ss_as_uuid(SCM sas)
  */
 SCM SchemeSmob::ss_as_env(SCM sas)
 {
-	const AtomSpacePtr& asp = ss_to_atomspace(sas);
-	if (nullptr == asp) asp = ss_get_env_as("cog-atomspace-env");
+	const AtomSpacePtr& asg = ss_to_atomspace(sas);
+	const AtomSpacePtr& asp = asg ? asg :
+		ss_get_env_as("cog-atomspace-env");
 
 	const HandleSeq& oset = asp->getOutgoingSet();
 	SCM list = SCM_EOL;
@@ -138,9 +140,10 @@ SCM SchemeSmob::ss_as_env(SCM sas)
  */
 SCM SchemeSmob::ss_as_readonly_p(SCM sas)
 {
-	const AtomSpacePtr& asp = ss_to_atomspace(sas);
+	const AtomSpacePtr& asg = ss_to_atomspace(sas);
+	const AtomSpacePtr& asp = asg ? asg :
+		ss_get_env_as("cog-atomspace-readonly?");
 	scm_remember_upto_here_1(sas);
-	if (nullptr == asp) asp = ss_get_env_as("cog-atomspace-readonly?");
 
 	if (asp->get_read_only()) return SCM_BOOL_T;
 	return SCM_BOOL_F;
@@ -152,11 +155,11 @@ SCM SchemeSmob::ss_as_readonly_p(SCM sas)
  */
 SCM SchemeSmob::ss_as_cow_p(SCM sas)
 {
-	const AtomSpacePtr& asp = ss_to_atomspace(sas);
-	scm_remember_upto_here_1(sas);
-	if (nullptr == asp) asp = ss_get_env_as("cog-atomspace-cow?");
+	const AtomSpacePtr& asg = ss_to_atomspace(sas);
+	const AtomSpacePtr& asp = asg ? asg :
+		ss_get_env_as("cog-atomspace-cow?");
 
-	if (as->get_copy_on_write()) return SCM_BOOL_T;
+	if (asp->get_copy_on_write()) return SCM_BOOL_T;
 	return SCM_BOOL_F;
 }
 
@@ -168,9 +171,9 @@ SCM SchemeSmob::ss_as_cow_p(SCM sas)
  */
 SCM SchemeSmob::ss_as_mark_readonly(SCM sas)
 {
-	const AtomSpacePtr& asp = ss_to_atomspace(sas);
-	scm_remember_upto_here_1(sas);
-	if (nullptr == asp) asp = ss_get_env_as("cog-atomspace-ro!");
+	const AtomSpacePtr& asg = ss_to_atomspace(sas);
+	const AtomSpacePtr& asp = asg ? asg :
+		ss_get_env_as("cog-atomspace-ro!");
 
 	asp->set_read_only();
 	return SCM_BOOL_T;
@@ -178,9 +181,9 @@ SCM SchemeSmob::ss_as_mark_readonly(SCM sas)
 
 SCM SchemeSmob::ss_as_mark_readwrite(SCM sas)
 {
-	const AtomSpacePtr& asp = ss_to_atomspace(sas);
-	scm_remember_upto_here_1(sas);
-	if (nullptr == asp) asp = ss_get_env_as("cog-atomspace-rw!");
+	const AtomSpacePtr& asg = ss_to_atomspace(sas);
+	const AtomSpacePtr& asp = asg ? asg :
+		ss_get_env_as("cog-atomspace-rw!");
 
 	asp->set_read_write();
 	return SCM_BOOL_T;
@@ -188,9 +191,9 @@ SCM SchemeSmob::ss_as_mark_readwrite(SCM sas)
 
 SCM SchemeSmob::ss_as_mark_cow(SCM scow, SCM sas)
 {
-	const AtomSpacePtr& asp = ss_to_atomspace(sas);
-	scm_remember_upto_here_1(sas);
-	if (nullptr == asp) asp = ss_get_env_as("cog-atomspace-cow!");
+	const AtomSpacePtr& asg = ss_to_atomspace(sas);
+	const AtomSpacePtr& asp = asg ? asg :
+		ss_get_env_as("cog-atomspace-cow!");
 
 	bool cow = scm_to_bool(scow);
 	if (cow) asp->set_copy_on_write();
@@ -204,8 +207,9 @@ SCM SchemeSmob::ss_as_mark_cow(SCM scow, SCM sas)
  */
 SCM SchemeSmob::ss_as_clear(SCM sas)
 {
-	const AtomSpacePtr& asp = ss_to_atomspace(sas);
-	if (nullptr == asp) asp = ss_get_env_as("cog-atomspace-clear");
+	const AtomSpacePtr& asg = ss_to_atomspace(sas);
+	const AtomSpacePtr& asp = asg ? asg :
+		ss_get_env_as("cog-atomspace-clear");
 
 	asp->clear();
 
@@ -230,7 +234,7 @@ SCM SchemeSmob::ss_as(SCM slist)
 	SCM satom = scm_car(slist);
 	Handle h(verify_handle(satom, "cog-atomspace"));
 	AtomSpace* as = h->getAtomSpace();
-	return as ? make_as(as->make_shared_from_this()) : SCM_EOL;
+	return as ? make_as(AtomSpaceCast(as->shared_from_this())) : SCM_EOL;
 }
 
 /* ============================================================== */

--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -312,13 +312,13 @@ SCM SchemeSmob::ss_incoming_set (SCM satom, SCM aspace)
 {
 	Handle h = verify_handle(satom, "cog-incoming-set");
 
-	const AtomSpacePtr& asp = ss_to_atomspace(aspace);
-	if (nullptr == asp)
-		asp = ss_get_env_as("cog-incoming-set");
+	const AtomSpacePtr& asg = ss_to_atomspace(aspace);
+	const AtomSpacePtr& asp = asg ? asg :
+		ss_get_env_as("cog-incoming-set");
 
 	// This reverses the order of the incoming set, but so what ...
 	SCM head = SCM_EOL;
-	IncomingSet iset = h->getIncomingSet(asp);
+	IncomingSet iset = h->getIncomingSet(asp.get());
 	for (const Handle& l : iset)
 	{
 		SCM smob = handle_to_scm(l);
@@ -337,11 +337,11 @@ SCM SchemeSmob::ss_incoming_by_type (SCM satom, SCM stype, SCM aspace)
 	Handle h = verify_handle(satom, "cog-incoming-by-type");
 	Type t = verify_type(stype, "cog-incoming-by-type", 2);
 
-	const AtomSpacePtr& asp = ss_to_atomspace(aspace);
-	if (nullptr == asp)
-		asp = ss_get_env_as("cog-incoming-by-type");
+	const AtomSpacePtr& asg = ss_to_atomspace(aspace);
+	const AtomSpacePtr& asp = asg ? asg :
+		ss_get_env_as("cog-incoming-by-type");
 
-	IncomingSet iset = h->getIncomingSetByType(t, asp);
+	IncomingSet iset = h->getIncomingSetByType(t, asp.get());
 	SCM head = SCM_EOL;
 	for (const Handle& ih : iset)
 	{
@@ -359,11 +359,11 @@ SCM SchemeSmob::ss_incoming_by_type (SCM satom, SCM stype, SCM aspace)
 SCM SchemeSmob::ss_incoming_size (SCM satom, SCM aspace)
 {
 	Handle h = verify_handle(satom, "cog-incoming-size");
-	const AtomSpacePtr& asp = ss_to_atomspace(aspace);
-	if (nullptr == asp)
-		asp = ss_get_env_as("cog-incoming-size");
+	const AtomSpacePtr& asg = ss_to_atomspace(aspace);
+	const AtomSpacePtr& asp = asg ? asg :
+		ss_get_env_as("cog-incoming-size");
 
-	size_t sz = h->getIncomingSetSize(asp);
+	size_t sz = h->getIncomingSetSize(asp.get());
 	return scm_from_size_t(sz);
 }
 
@@ -377,11 +377,11 @@ SCM SchemeSmob::ss_incoming_size_by_type (SCM satom, SCM stype, SCM aspace)
 	Handle h = verify_handle(satom, "cog-incoming-size-by-type");
 	Type t = verify_type(stype, "cog-incoming-size-by-type", 2);
 
-	const AtomSpacePtr& asp = ss_to_atomspace(aspace);
-	if (nullptr == asp)
-		asp = ss_get_env_as("cog-incoming-size-by-type");
+	const AtomSpacePtr& asg = ss_to_atomspace(aspace);
+	const AtomSpacePtr& asp = asg ? asg :
+		ss_get_env_as("cog-incoming-size-by-type");
 
-	size_t sz = h->getIncomingSetSizeByType(t, asp);
+	size_t sz = h->getIncomingSetSizeByType(t, asp.get());
 	return scm_from_size_t(sz);
 }
 
@@ -397,9 +397,9 @@ SCM SchemeSmob::ss_map_type (SCM proc, SCM stype, SCM aspace)
 {
 	Type t = verify_type (stype, "cog-map-type");
 
-	const AtomSpacePtr& asp = ss_to_atomspace(aspace);
-	if (nullptr == asp)
-		asp = ss_get_env_as("cog-map-type");
+	const AtomSpacePtr& asg = ss_to_atomspace(aspace);
+	const AtomSpacePtr& asp = asg ? asg :
+		ss_get_env_as("cog-map-type");
 
 	// Get all of the handles of the indicated type
 	HandleSeq hset;
@@ -534,9 +534,9 @@ SCM SchemeSmob::ss_count (SCM stype, SCM aspace)
 {
 	Type t = verify_type(stype, "cog-count-atoms");
 
-	const AtomSpacePtr& asp = ss_to_atomspace(aspace);
-	if (nullptr == asp)
-		asp = ss_get_env_as("cog-count-atoms");
+	const AtomSpacePtr& asg = ss_to_atomspace(aspace);
+	const AtomSpacePtr& asp = asg ? asg :
+		ss_get_env_as("cog-count-atoms");
 
 	size_t cnt = asp->get_num_atoms_of_type(t);
 	return scm_from_size_t(cnt);

--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -160,10 +160,10 @@ SCM SchemeSmob::ss_set_tv (SCM satom, SCM stv)
 	TruthValuePtr tv = verify_tv(stv, "cog-set-tv!", 2);
 	scm_remember_upto_here_1(stv);
 
-	AtomSpace* as = ss_get_env_as("cog-set-tv!");
+	const AtomSpacePtr& asp = ss_get_env_as("cog-set-tv!");
 	try
 	{
-		Handle newh = as->set_truthvalue(h, tv);
+		Handle newh = asp->set_truthvalue(h, tv);
 
 		if (h == newh) return satom;
 		return handle_to_scm(newh);
@@ -193,8 +193,8 @@ SCM SchemeSmob::ss_inc_count (SCM satom, SCM scnt)
 	tv = CountTruthValue::createTV(
 		tv->get_mean(), tv->get_confidence(), cnt);
 
-	AtomSpace* as = ss_get_env_as("cog-inc-count!");
-	Handle ha(as->set_truthvalue(h, tv));
+	const AtomSpacePtr& asp = ss_get_env_as("cog-inc-count!");
+	Handle ha(asp->set_truthvalue(h, tv));
 	if (ha == h)
 		return satom;
 	return handle_to_scm(ha);
@@ -233,8 +233,8 @@ SCM SchemeSmob::ss_inc_value (SCM satom, SCM skey, SCM scnt, SCM sref)
 	}
 	new_value[ref] += cnt;
 
-	AtomSpace* as = ss_get_env_as("cog-inc-value!");
-	Handle ha(as->set_value(h, key, createFloatValue(new_value)));
+	const AtomSpacePtr& asp = ss_get_env_as("cog-inc-value!");
+	Handle ha(asp->set_value(h, key, createFloatValue(new_value)));
 	if (ha == h)
 		return satom;
 	return handle_to_scm(ha);
@@ -312,13 +312,13 @@ SCM SchemeSmob::ss_incoming_set (SCM satom, SCM aspace)
 {
 	Handle h = verify_handle(satom, "cog-incoming-set");
 
-	AtomSpace* as = ss_to_atomspace(aspace);
-	if (nullptr == as)
-		as = ss_get_env_as("cog-incoming-set");
+	const AtomSpacePtr& asp = ss_to_atomspace(aspace);
+	if (nullptr == asp)
+		asp = ss_get_env_as("cog-incoming-set");
 
 	// This reverses the order of the incoming set, but so what ...
 	SCM head = SCM_EOL;
-	IncomingSet iset = h->getIncomingSet(as);
+	IncomingSet iset = h->getIncomingSet(asp);
 	for (const Handle& l : iset)
 	{
 		SCM smob = handle_to_scm(l);
@@ -337,11 +337,11 @@ SCM SchemeSmob::ss_incoming_by_type (SCM satom, SCM stype, SCM aspace)
 	Handle h = verify_handle(satom, "cog-incoming-by-type");
 	Type t = verify_type(stype, "cog-incoming-by-type", 2);
 
-	AtomSpace* as = ss_to_atomspace(aspace);
-	if (nullptr == as)
-		as = ss_get_env_as("cog-incoming-by-type");
+	const AtomSpacePtr& asp = ss_to_atomspace(aspace);
+	if (nullptr == asp)
+		asp = ss_get_env_as("cog-incoming-by-type");
 
-	IncomingSet iset = h->getIncomingSetByType(t, as);
+	IncomingSet iset = h->getIncomingSetByType(t, asp);
 	SCM head = SCM_EOL;
 	for (const Handle& ih : iset)
 	{
@@ -359,11 +359,11 @@ SCM SchemeSmob::ss_incoming_by_type (SCM satom, SCM stype, SCM aspace)
 SCM SchemeSmob::ss_incoming_size (SCM satom, SCM aspace)
 {
 	Handle h = verify_handle(satom, "cog-incoming-size");
-	AtomSpace* as = ss_to_atomspace(aspace);
-	if (nullptr == as)
-		as = ss_get_env_as("cog-incoming-size");
+	const AtomSpacePtr& asp = ss_to_atomspace(aspace);
+	if (nullptr == asp)
+		asp = ss_get_env_as("cog-incoming-size");
 
-	size_t sz = h->getIncomingSetSize(as);
+	size_t sz = h->getIncomingSetSize(asp);
 	return scm_from_size_t(sz);
 }
 
@@ -377,11 +377,11 @@ SCM SchemeSmob::ss_incoming_size_by_type (SCM satom, SCM stype, SCM aspace)
 	Handle h = verify_handle(satom, "cog-incoming-size-by-type");
 	Type t = verify_type(stype, "cog-incoming-size-by-type", 2);
 
-	AtomSpace* as = ss_to_atomspace(aspace);
-	if (nullptr == as)
-		as = ss_get_env_as("cog-incoming-size-by-type");
+	const AtomSpacePtr& asp = ss_to_atomspace(aspace);
+	if (nullptr == asp)
+		asp = ss_get_env_as("cog-incoming-size-by-type");
 
-	size_t sz = h->getIncomingSetSizeByType(t, as);
+	size_t sz = h->getIncomingSetSizeByType(t, asp);
 	return scm_from_size_t(sz);
 }
 
@@ -397,13 +397,13 @@ SCM SchemeSmob::ss_map_type (SCM proc, SCM stype, SCM aspace)
 {
 	Type t = verify_type (stype, "cog-map-type");
 
-	AtomSpace* atomspace = ss_to_atomspace(aspace);
-	if (nullptr == atomspace)
-		atomspace = ss_get_env_as("cog-map-type");
+	const AtomSpacePtr& asp = ss_to_atomspace(aspace);
+	if (nullptr == asp)
+		asp = ss_get_env_as("cog-map-type");
 
 	// Get all of the handles of the indicated type
 	HandleSeq hset;
-	atomspace->get_handles_by_type(hset, t);
+	asp->get_handles_by_type(hset, t);
 
 	// Loop over all handles in the handle set.
 	// Call proc on each handle, in turn.
@@ -534,11 +534,11 @@ SCM SchemeSmob::ss_count (SCM stype, SCM aspace)
 {
 	Type t = verify_type(stype, "cog-count-atoms");
 
-	AtomSpace* as = ss_to_atomspace(aspace);
-	if (nullptr == as)
-		as = ss_get_env_as("cog-count-atoms");
+	const AtomSpacePtr& asp = ss_to_atomspace(aspace);
+	if (nullptr == asp)
+		asp = ss_get_env_as("cog-count-atoms");
 
-	size_t cnt = as->get_num_atoms_of_type(t);
+	size_t cnt = asp->get_num_atoms_of_type(t);
 	return scm_from_size_t(cnt);
 }
 

--- a/opencog/guile/SchemeSmobValue.cc
+++ b/opencog/guile/SchemeSmobValue.cc
@@ -251,15 +251,15 @@ ValuePtr SchemeSmob::make_value (Type t, SCM svalue_list)
 		// XXX FIXME... at this time, nodes have a single name.
 		SCM sname = SCM_CAR(svalue_list);
 		std::string name = verify_string(sname, "cog-new-value", 2);
-		AtomSpace* atomspace = ss_get_env_as("cog-new-value");
-		return atomspace->add_node(t, std::move(name));
+		const AtomSpacePtr& asp = ss_get_env_as("cog-new-value");
+		return asp->add_node(t, std::move(name));
 	}
 
 	if (nameserver().isA(t, LINK))
 	{
 		HandleSeq oset = verify_handle_list(svalue_list, "cog-new-value", 2);
-		AtomSpace* atomspace = ss_get_env_as("cog-new-value");
-		return atomspace->add_link(t, std::move(oset));
+		const AtomSpacePtr& asp = ss_get_env_as("cog-new-value");
+		return asp->add_link(t, std::move(oset));
 	}
 
 	scm_wrong_type_arg_msg("cog-new-value", 1, svalue_list, "value type");
@@ -349,10 +349,10 @@ SCM SchemeSmob::ss_set_value (SCM satom, SCM skey, SCM svalue)
 
 	// Note that pa might be a null pointer, if svalue is '() or #f
 	// In this case, the key is removed.
-	AtomSpace* as = ss_get_env_as("cog-set-value!");
+	const AtomSpacePtr& asp = ss_get_env_as("cog-set-value!");
 	try
 	{
-		Handle newh = as->set_value(atom, key, pa);
+		Handle newh = asp->set_value(atom, key, pa);
 		if (atom == newh) return satom;
 		return handle_to_scm(newh);
 	}
@@ -363,7 +363,7 @@ SCM SchemeSmob::ss_set_value (SCM satom, SCM skey, SCM svalue)
 }
 
 // alist is an association-list of key-value pairs.
-Handle SchemeSmob::set_values(const Handle& h, AtomSpace* as, SCM alist)
+Handle SchemeSmob::set_values(const Handle& h, const AtomSpacePtr& asp, SCM alist)
 {
 	Handle atom = h;
 	SCM kvpli = alist;
@@ -375,7 +375,7 @@ Handle SchemeSmob::set_values(const Handle& h, AtomSpace* as, SCM alist)
 		{
 			Handle key(scm_to_handle(SCM_CAR(kvp)));
 			ValuePtr pa(scm_to_protom(SCM_CDR(kvp)));
-			if (key) atom = as->set_value(atom, key, pa);
+			if (key) atom = asp->set_value(atom, key, pa);
 		}
 		kvpli = SCM_CDR(kvpli);
 	}
@@ -386,7 +386,7 @@ Handle SchemeSmob::set_values(const Handle& h, AtomSpace* as, SCM alist)
 // alist is an association-list of key-value pairs.
 SCM SchemeSmob::ss_set_values(SCM satom, SCM alist)
 {
-	AtomSpace* as = ss_get_env_as("cog-set-values!");
+	const AtomSpacePtr& asp = ss_get_env_as("cog-set-values!");
 
 	Handle atom(verify_handle(satom, "cog-set-values!", 1));
 	if (not scm_is_true(scm_list_p(alist)))
@@ -397,7 +397,7 @@ SCM SchemeSmob::ss_set_values(SCM satom, SCM alist)
 	// Atomspace may be read-only. Respect that.
 	try
 	{
-		atom = set_values(atom, as, alist);
+		atom = set_values(atom, asp, alist);
 	}
 	catch (const std::exception& ex)
 	{

--- a/opencog/guile/modules/UuidSCM.cc
+++ b/opencog/guile/modules/UuidSCM.cc
@@ -81,8 +81,8 @@ void UuidSCM::init(void)
 	// atomspaces, and really, we should have nested hierarchical TLB
 	// resolvers for nested atomspaces. But for now, no one uses this so
 	// what the heck. I'm gonna punt. XXX FIXME.
-	AtomSpace* as = SchemeSmob::ss_get_env_as("uuid");
-	_tlb.set_resolver(as);
+	const AtomSpacePtr& asp = SchemeSmob::ss_get_env_as("uuid");
+	_tlb.set_resolver(asp.get());
 
 	define_scheme_primitive("cog-add-uuid",
 		&UuidSCM::add_atom, this, "uuid");

--- a/opencog/persist/api/PersistSCM.cc
+++ b/opencog/persist/api/PersistSCM.cc
@@ -189,45 +189,45 @@ bool PersistSCM::connected(Handle hsn)
 Handle PersistSCM::sn_fetch_atom(Handle h, Handle hsn)
 {
 	GET_STNP;
-	AtomSpace* as = SchemeSmob::ss_get_env_as("fetch-atom");
-	return stnp->fetch_atom(h, as);
+	const AtomSpacePtr& asp = SchemeSmob::ss_get_env_as("fetch-atom");
+	return stnp->fetch_atom(h, asp.get());
 }
 
 Handle PersistSCM::sn_fetch_value(Handle h, Handle key, Handle hsn)
 {
 	GET_STNP;
-	AtomSpace* as = SchemeSmob::ss_get_env_as("fetch-value");
-	return stnp->fetch_value(h, key, as);
+	const AtomSpacePtr& asp = SchemeSmob::ss_get_env_as("fetch-value");
+	return stnp->fetch_value(h, key, asp.get());
 }
 
 Handle PersistSCM::sn_fetch_incoming_set(Handle h, Handle hsn)
 {
 	GET_STNP;
-	AtomSpace* as = SchemeSmob::ss_get_env_as("fetch-incoming-set");
+	const AtomSpacePtr& asp = SchemeSmob::ss_get_env_as("fetch-incoming-set");
 	// The "false" flag here means that the fetch is NOT recursive.
-	return stnp->fetch_incoming_set(h, false, as);
+	return stnp->fetch_incoming_set(h, false, asp.get());
 }
 
 Handle PersistSCM::sn_fetch_incoming_by_type(Handle h, Type t, Handle hsn)
 {
 	GET_STNP;
-	AtomSpace* as = SchemeSmob::ss_get_env_as("fetch-incoming-by-type");
-	return stnp->fetch_incoming_by_type(h, t, as);
+	const AtomSpacePtr& asp = SchemeSmob::ss_get_env_as("fetch-incoming-by-type");
+	return stnp->fetch_incoming_by_type(h, t, asp.get());
 }
 
 Handle PersistSCM::sn_fetch_query2(Handle query, Handle key, Handle hsn)
 {
 	GET_STNP;
-	AtomSpace* as = SchemeSmob::ss_get_env_as("fetch-query");
-	return stnp->fetch_query(query, key, Handle::UNDEFINED, false, as);
+	const AtomSpacePtr& asp = SchemeSmob::ss_get_env_as("fetch-query");
+	return stnp->fetch_query(query, key, Handle::UNDEFINED, false, asp.get());
 }
 
 Handle PersistSCM::sn_fetch_query4(Handle query, Handle key,
                                 Handle meta, bool fresh, Handle hsn)
 {
 	GET_STNP;
-	AtomSpace* as = SchemeSmob::ss_get_env_as("fetch-query");
-	return stnp->fetch_query(query, key, meta, fresh, as);
+	const AtomSpacePtr& asp = SchemeSmob::ss_get_env_as("fetch-query");
+	return stnp->fetch_query(query, key, meta, fresh, asp.get());
 }
 
 /**
@@ -250,22 +250,22 @@ void PersistSCM::sn_store_value(Handle h, Handle key, Handle hsn)
 void PersistSCM::sn_load_type(Type t, Handle hsn)
 {
 	GET_STNP;
-	AtomSpace* as = SchemeSmob::ss_get_env_as("load-atoms-of-type");
-	stnp->fetch_all_atoms_of_type(t, as);
+	const AtomSpacePtr& asp = SchemeSmob::ss_get_env_as("load-atoms-of-type");
+	stnp->fetch_all_atoms_of_type(t, asp.get());
 }
 
 void PersistSCM::sn_load_atomspace(Handle hsn)
 {
 	GET_STNP;
-	AtomSpace* as = SchemeSmob::ss_get_env_as("load-atomspace");
-	stnp->load_atomspace(as);
+	const AtomSpacePtr& asp = SchemeSmob::ss_get_env_as("load-atomspace");
+	stnp->load_atomspace(asp.get());
 }
 
 void PersistSCM::sn_store_atomspace(Handle hsn)
 {
 	GET_STNP;
-	AtomSpace* as = SchemeSmob::ss_get_env_as("store-atomspace");
-	stnp->store_atomspace(as);
+	const AtomSpacePtr& asp = SchemeSmob::ss_get_env_as("store-atomspace");
+	stnp->store_atomspace(asp.get());
 }
 
 HandleSeq PersistSCM::sn_load_frames(Handle hsn)
@@ -283,22 +283,22 @@ void PersistSCM::sn_store_frames(Handle hsn, Handle has)
 bool PersistSCM::sn_delete(Handle h, Handle hsn)
 {
 	GET_STNP;
-	AtomSpace* as = SchemeSmob::ss_get_env_as("cog-delete!");
+	const AtomSpacePtr& as = SchemeSmob::ss_get_env_as("cog-delete!");
 	return stnp->remove_atom(as, h, false);
 }
 
 bool PersistSCM::sn_delete_recursive(Handle h, Handle hsn)
 {
 	GET_STNP;
-	AtomSpace* as = SchemeSmob::ss_get_env_as("cog-delete-recursive!");
+	const AtomSpacePtr& as = SchemeSmob::ss_get_env_as("cog-delete-recursive!");
 	return stnp->remove_atom(as, h, true);
 }
 
 void PersistSCM::sn_barrier(Handle hsn)
 {
 	GET_STNP;
-	AtomSpace* as = SchemeSmob::ss_get_env_as("barrier");
-	stnp->barrier(as);
+	const AtomSpacePtr& asp = SchemeSmob::ss_get_env_as("barrier");
+	stnp->barrier(asp.get());
 }
 
 std::string PersistSCM::sn_monitor(Handle hsn)
@@ -316,45 +316,45 @@ std::string PersistSCM::sn_monitor(Handle hsn)
 Handle PersistSCM::dflt_fetch_atom(Handle h)
 {
 	CHECK;
-	AtomSpace* as = SchemeSmob::ss_get_env_as("fetch-atom");
-	return _sn->fetch_atom(h, as);
+	const AtomSpacePtr& asp = SchemeSmob::ss_get_env_as("fetch-atom");
+	return _sn->fetch_atom(h, asp.get());
 }
 
 Handle PersistSCM::dflt_fetch_value(Handle h, Handle key)
 {
 	CHECK;
-	AtomSpace* as = SchemeSmob::ss_get_env_as("fetch-value");
-	return _sn->fetch_value(h, key, as);
+	const AtomSpacePtr& asp = SchemeSmob::ss_get_env_as("fetch-value");
+	return _sn->fetch_value(h, key, asp.get());
 }
 
 Handle PersistSCM::dflt_fetch_incoming_set(Handle h)
 {
 	CHECK;
-	AtomSpace* as = SchemeSmob::ss_get_env_as("fetch-incoming-set");
+	const AtomSpacePtr& asp = SchemeSmob::ss_get_env_as("fetch-incoming-set");
 	// The "false" flag here means that the fetch is NOT recursive.
-	return _sn->fetch_incoming_set(h, false, as);
+	return _sn->fetch_incoming_set(h, false, asp.get());
 }
 
 Handle PersistSCM::dflt_fetch_incoming_by_type(Handle h, Type t)
 {
 	CHECK;
-	AtomSpace* as = SchemeSmob::ss_get_env_as("fetch-incoming-by-type");
-	return _sn->fetch_incoming_by_type(h, t, as);
+	const AtomSpacePtr& asp = SchemeSmob::ss_get_env_as("fetch-incoming-by-type");
+	return _sn->fetch_incoming_by_type(h, t, asp.get());
 }
 
 Handle PersistSCM::dflt_fetch_query2(Handle query, Handle key)
 {
 	CHECK;
-	AtomSpace* as = SchemeSmob::ss_get_env_as("fetch-query");
-	return _sn->fetch_query(query, key, Handle::UNDEFINED, false, as);
+	const AtomSpacePtr& asp = SchemeSmob::ss_get_env_as("fetch-query");
+	return _sn->fetch_query(query, key, Handle::UNDEFINED, false, asp.get());
 }
 
 Handle PersistSCM::dflt_fetch_query4(Handle query, Handle key,
                                 Handle meta, bool fresh)
 {
 	CHECK;
-	AtomSpace* as = SchemeSmob::ss_get_env_as("fetch-query");
-	return _sn->fetch_query(query, key, meta, fresh, as);
+	const AtomSpacePtr& asp = SchemeSmob::ss_get_env_as("fetch-query");
+	return _sn->fetch_query(query, key, meta, fresh, asp.get());
 }
 
 /**
@@ -377,22 +377,22 @@ void PersistSCM::dflt_store_value(Handle h, Handle key)
 void PersistSCM::dflt_load_type(Type t)
 {
 	CHECK;
-	AtomSpace* as = SchemeSmob::ss_get_env_as("load-atoms-of-type");
-	_sn->fetch_all_atoms_of_type(t, as);
+	const AtomSpacePtr& asp = SchemeSmob::ss_get_env_as("load-atoms-of-type");
+	_sn->fetch_all_atoms_of_type(t, asp.get());
 }
 
 void PersistSCM::dflt_load_atomspace(void)
 {
 	CHECK;
-	AtomSpace* as = SchemeSmob::ss_get_env_as("load-atomspace");
-	_sn->load_atomspace(as);
+	const AtomSpacePtr& asp = SchemeSmob::ss_get_env_as("load-atomspace");
+	_sn->load_atomspace(asp.get());
 }
 
 void PersistSCM::dflt_store_atomspace(void)
 {
 	CHECK;
-	AtomSpace* as = SchemeSmob::ss_get_env_as("store-atomspace");
-	_sn->store_atomspace(as);
+	const AtomSpacePtr& asp = SchemeSmob::ss_get_env_as("store-atomspace");
+	_sn->store_atomspace(asp.get());
 }
 
 HandleSeq PersistSCM::dflt_load_frames(void)
@@ -410,22 +410,22 @@ void PersistSCM::dflt_store_frames(Handle has)
 bool PersistSCM::dflt_delete(Handle h)
 {
 	CHECK;
-	AtomSpace* as = SchemeSmob::ss_get_env_as("cog-delete!");
+	const AtomSpacePtr& as = SchemeSmob::ss_get_env_as("cog-delete!");
 	return _sn->remove_atom(as, h, false);
 }
 
 bool PersistSCM::dflt_delete_recursive(Handle h)
 {
 	CHECK;
-	AtomSpace* as = SchemeSmob::ss_get_env_as("cog-delete-recursive!");
+	const AtomSpacePtr& as = SchemeSmob::ss_get_env_as("cog-delete-recursive!");
 	return _sn->remove_atom(as, h, true);
 }
 
 void PersistSCM::dflt_barrier(void)
 {
 	CHECK;
-	AtomSpace* as = SchemeSmob::ss_get_env_as("barrier");
-	_sn->barrier(as);
+	const AtomSpacePtr& asp = SchemeSmob::ss_get_env_as("barrier");
+	_sn->barrier(asp.get());
 }
 
 std::string PersistSCM::dflt_monitor(void)

--- a/opencog/persist/gearman/DistSCM.cc
+++ b/opencog/persist/gearman/DistSCM.cc
@@ -173,13 +173,13 @@ std::string DistSCM::start_work_handler(const std::string& ipaddr_string,
 	gearman_function_t worker_fn = gearman_function_create(worker_function);
 
 	// Get the atomspace for this thread.
-	AtomSpace* atomspace = SchemeSmob::ss_get_env_as("start-work-handler");
+	const AtomSpacePtr& asp = SchemeSmob::ss_get_env_as("start-work-handler");
 
 	rc = gearman_worker_define_function(worker,
 	                                    gearman_literal_param("make_call"),
 	                                    worker_fn,
 	                                    0,
-	                                    atomspace);
+	                                    asp.get());
 
 	if (gearman_failed(rc))
 	{

--- a/opencog/persist/sexpr/PersistFileSCM.cc
+++ b/opencog/persist/sexpr/PersistFileSCM.cc
@@ -81,8 +81,8 @@ void PersistFileSCM::init(void)
 
 void PersistFileSCM::load_file(const std::string& path)
 {
-	AtomSpace *as = SchemeSmob::ss_get_env_as("load-file");
-	opencog::load_file(path, *as);
+	const AtomSpacePtr& as = SchemeSmob::ss_get_env_as("load-file");
+	opencog::load_file(path, *as.get());
 }
 
 void opencog_persist_file_init(void)

--- a/opencog/persist/sql/multi-driver/SQLPersistSCM.cc
+++ b/opencog/persist/sql/multi-driver/SQLPersistSCM.cc
@@ -90,8 +90,8 @@ void SQLPersistSCM::do_open(const std::string& uri)
              "sql-open: Error: Already connected to a database!");
 
     // Unconditionally use the current atomspace, until the next close.
-    AtomSpace *as = SchemeSmob::ss_get_env_as("sql-open");
-    if (nullptr != as) _as = as;
+    const AtomSpacePtr& asp = SchemeSmob::ss_get_env_as("sql-open");
+    if (nullptr != asp) _as = asp.get();
 
     if (nullptr == _as)
         throw RuntimeException(TRACE_INFO,

--- a/opencog/persist/sql/multi-driver/SQLPersistSCM.h
+++ b/opencog/persist/sql/multi-driver/SQLPersistSCM.h
@@ -46,7 +46,7 @@ private:
     void init(void);
 
     PostgresStorageNodePtr _storage;
-    AtomSpace *_as;
+    AtomSpace* _as;
 
 public:
     SQLPersistSCM(AtomSpace*);

--- a/tests/scm/MultiAtomSpaceUTest.cxxtest
+++ b/tests/scm/MultiAtomSpaceUTest.cxxtest
@@ -569,7 +569,7 @@ void MultiAtomSpace::test_as_of_atom_scm(void)
 	std::string rs = evaluator->eval("(load-from-path \"tests/scm/as-of-atom.scm\")");
 	logger().debug() << "rs = " << rs;
 	Handle A = evaluator->eval_h("A");
-	AtomSpace* A_as = evaluator->eval_as("A-as");
+	AtomSpacePtr A_as = evaluator->eval_as("A-as");
 
 	TS_ASSERT_DIFFERS(A, Handle::UNDEFINED);
 	TS_ASSERT_DIFFERS(A_as, nullptr);


### PR DESCRIPTION
This conversion makes the guile subsystem ever so slightly safer, 
but otherwise has no practical effects.