### PR TITLE
Virtualize sexpr commands

### DIFF
--- a/opencog/persist/sexpr/Commands.cc
+++ b/opencog/persist/sexpr/Commands.cc
@@ -209,7 +209,15 @@ std::string Commands::interpret_command(AtomSpace* as,
 		throw SyntaxException(TRACE_INFO, "Not a command: %s",
 			cmd.c_str());
 
+	// Look up the method to call, based on the hash of the command string.
 	size_t act = std::hash<std::string>{}(cmd.substr(pos, epos-pos));
+	const auto& disp = _dispatch_map.find(act);
+
+	if (_dispatch_map.end() != disp)
+	{
+		pos = cmd.find_first_not_of(" \n\t", epos);
+		return (this->*(disp->second))(cmd.substr(pos));
+	}
 
 	// -----------------------------------------------
 	// (cog-get-atoms 'Node #t)

--- a/opencog/persist/sexpr/Commands.cc
+++ b/opencog/persist/sexpr/Commands.cc
@@ -434,8 +434,7 @@ std::string Commands::cog_ping(const std::string& cmd)
 }
 
 // -----------------------------------------------
-std::string Commands::interpret_command(AtomSpace* as,
-                                        const std::string& cmd)
+std::string Commands::interpret_command(const std::string& cmd)
 {
 	// Find the command and dispatch
 	size_t pos = cmd.find_first_not_of(" \n\t");

--- a/opencog/persist/sexpr/Commands.cc
+++ b/opencog/persist/sexpr/Commands.cc
@@ -271,7 +271,7 @@ std::string Commands::cog_incoming_set(const std::string& cmd)
 // (cog-keys->alist (Concept "foo"))
 std::string Commands::cog_keys_alist(const std::string& cmd)
 {
-	size_t pos;
+	size_t pos = 0;
 	Handle h = Sexpr::decode_atom(cmd, pos, _space_map);
 	AtomSpace* as = get_opt_as(cmd, pos);
 	h = as->add_atom(h);

--- a/opencog/persist/sexpr/Commands.cc
+++ b/opencog/persist/sexpr/Commands.cc
@@ -61,6 +61,11 @@ Commands::Commands(void)
 	_dispatch_map.insert({clear, &Commands::cog_atomspace_clear});
 }
 
+void Commands::set_base_space(const AtomSpacePtr& asp)
+{
+	_base_space = asp;
+}
+
 Commands::~Commands()
 {
 }
@@ -93,7 +98,7 @@ std::string Commands::cog_atomspace(const std::string& arg)
 // (cog-atomspace-clear)
 std::string Commands::cog_atomspace_clear(const std::string& arg)
 {
-	// as->clear();
+	_base_space->clear();
 	return "#t";
 }
 

--- a/opencog/persist/sexpr/Commands.h
+++ b/opencog/persist/sexpr/Commands.h
@@ -35,13 +35,17 @@ class AtomSpace;
 
 class Commands
 {
-private:
+protected:
 	/// True, if the _space_map below is being used, and AtomSpaces need
 	/// to be sent and received.
 	bool _multi_space;
 
 	/// Map from string AtomSpace names to the matching AtomSpacePtr's
 	std::unordered_map<std::string, Handle> _space_map;
+
+	/// Map to dispatch table
+	typedef std::string (Commands::*Meth)(const std::string&);
+	std::unordered_map<size_t, Meth> _dispatch_map;
 
 	AtomSpace* get_opt_as(const std::string&, size_t&, AtomSpace*);
 
@@ -82,6 +86,9 @@ public:
 	/// If some interpreted command specified an AtomSpace, this
 	/// will be set to that AtomSpace.
 	AtomSpacePtr top_space;
+
+	std::string cog_atomspace(const std::string&);
+	std::string cog_atomspace_clear(const std::string&);
 };
 
 /** @}*/

--- a/opencog/persist/sexpr/Commands.h
+++ b/opencog/persist/sexpr/Commands.h
@@ -47,7 +47,7 @@ protected:
 	typedef std::string (Commands::*Meth)(const std::string&);
 	std::unordered_map<size_t, Meth> _dispatch_map;
 
-	AtomSpace* get_opt_as(const std::string&, size_t&, AtomSpace*);
+	AtomSpace* get_opt_as(const std::string&, size_t&);
 
 	/// AtomSpace to which all commands apply.
 	AtomSpacePtr _base_space;
@@ -99,6 +99,13 @@ public:
 	std::string cog_execute_cache(const std::string&);
 	std::string cog_extract(const std::string&);
 	std::string cog_extract_recursive(const std::string&);
+	std::string cog_get_atoms(const std::string&);
+	std::string cog_incoming_by_type(const std::string&);
+	std::string cog_incoming_set(const std::string&);
+	std::string cog_keys_alist(const std::string&);
+	std::string cog_link(const std::string&);
+	std::string cog_node(const std::string&);
+	// std::string cog_(const std::string&);
 };
 
 /** @}*/

--- a/opencog/persist/sexpr/Commands.h
+++ b/opencog/persist/sexpr/Commands.h
@@ -49,9 +49,20 @@ protected:
 
 	AtomSpace* get_opt_as(const std::string&, size_t&, AtomSpace*);
 
+	/// AtomSpace to which all commands apply.
+	AtomSpacePtr _base_space;
+
+	/// If some interpreted command specified an AtomSpace, this
+	/// will be set to that AtomSpace.
+	// XXX FIXME is this really neededd???
+	AtomSpacePtr top_space;
+
 public:
 	Commands(void);
 	~Commands();
+
+	// Indicate which AtomSpace to use
+	void set_base_space(const AtomSpacePtr&);
 
 	/// Interpret a very small subset of singular scheme commands.
 	/// This is an ultra-minimalistic command interpreter. It only
@@ -82,10 +93,6 @@ public:
 	/// nothing else.
 	///
 	std::string interpret_command(AtomSpace*, const std::string&);
-
-	/// If some interpreted command specified an AtomSpace, this
-	/// will be set to that AtomSpace.
-	AtomSpacePtr top_space;
 
 	std::string cog_atomspace(const std::string&);
 	std::string cog_atomspace_clear(const std::string&);

--- a/opencog/persist/sexpr/Commands.h
+++ b/opencog/persist/sexpr/Commands.h
@@ -92,8 +92,9 @@ public:
 	/// and they MUST be followed by valid Atomese s-expressions, and
 	/// nothing else.
 	///
-	std::string interpret_command(AtomSpace*, const std::string&);
+	std::string interpret_command(const std::string&);
 
+	/// Methods that implement each of the interpreted commands, above.
 	std::string cog_atomspace(const std::string&);
 	std::string cog_atomspace_clear(const std::string&);
 	std::string cog_execute_cache(const std::string&);

--- a/opencog/persist/sexpr/Commands.h
+++ b/opencog/persist/sexpr/Commands.h
@@ -96,6 +96,9 @@ public:
 
 	std::string cog_atomspace(const std::string&);
 	std::string cog_atomspace_clear(const std::string&);
+	std::string cog_execute_cache(const std::string&);
+	std::string cog_extract(const std::string&);
+	std::string cog_extract_recursive(const std::string&);
 };
 
 /** @}*/

--- a/opencog/persist/sexpr/Commands.h
+++ b/opencog/persist/sexpr/Commands.h
@@ -52,9 +52,9 @@ protected:
 	/// AtomSpace to which all commands apply.
 	AtomSpacePtr _base_space;
 
-	/// If some interpreted command specified an AtomSpace, this
-	/// will be set to that AtomSpace.
-	// XXX FIXME is this really neededd???
+	/// If AtomSpace frames are in use, this points at the top-most
+	/// frame. It is needed so that the automatic use-counting does
+	/// not free the frame immediattely after it is created.
 	AtomSpacePtr top_space;
 
 public:
@@ -99,13 +99,20 @@ public:
 	std::string cog_execute_cache(const std::string&);
 	std::string cog_extract(const std::string&);
 	std::string cog_extract_recursive(const std::string&);
+
 	std::string cog_get_atoms(const std::string&);
 	std::string cog_incoming_by_type(const std::string&);
 	std::string cog_incoming_set(const std::string&);
 	std::string cog_keys_alist(const std::string&);
 	std::string cog_link(const std::string&);
 	std::string cog_node(const std::string&);
-	// std::string cog_(const std::string&);
+
+	std::string cog_set_value(const std::string&);
+	std::string cog_set_values(const std::string&);
+	std::string cog_set_tv(const std::string&);
+	std::string cog_value(const std::string&);
+	std::string cog_define(const std::string&);
+	std::string cog_ping(const std::string&);
 };
 
 /** @}*/

--- a/opencog/persist/sexpr/README.md
+++ b/opencog/persist/sexpr/README.md
@@ -117,8 +117,8 @@ Here's an example of reading back what was stored above:
 ```
 
 
-Network API
------------
+Network API, Command Dispatching
+--------------------------------
 The CogServer provides a network API to send/receive Atoms over the
 internet. The actual API is that of the StorageNode (see the wiki page
 https://wiki.opencog.org/w/StorageNode for details.) The cogserver
@@ -130,3 +130,24 @@ have been hard-coded in C++. These are implemented in `Commands.cc`
 The goal is to avoid the overhead of entry/exit into guile. This works
 because the cogserver is guaranteed to send only these commands, and no
 others.
+
+Network-distributed AtomSpaces need to have proxy agents that know what
+to do with the data being passed around.  Besides just workig with the
+attached AtomSpace, maybe something more needs to be done: maybe data
+needs to be written to or read from disk. The proxy agent determines
+what is to be done.
+
+To implement the proxy, one needs to intercept network commands, as they
+come in. This spot is the `interpret_command()` method in `Commands.cc`.
+The `class Command` maintains a table of functions to be called, one for
+each network command.  By altering this table and installing command
+handlers other than the default handlers, the proxy agent can respond
+in some custom fashion.
+
+For example, if the CogServer receives a command to put an Atom into the
+AtomSpace, it can then immediately push it out to any open `StorageNode`s,
+for example, to disk storage. This becomes an easy way to implement a
+write-through proxy, which just listens to connections on the net, and,
+whenever it receives some Atom, it just pushes it to disk.`
+
+For details, see https://github.com/opencog/atomspace-agents

--- a/opencog/persist/sexpr/SexprEval.cc
+++ b/opencog/persist/sexpr/SexprEval.cc
@@ -36,6 +36,7 @@ SexprEval::SexprEval(AtomSpacePtr& asp)
 	: GenericEval()
 {
 	_atomspace = asp;
+	_interpreter.set_base_space(asp);
 }
 
 SexprEval::~SexprEval()

--- a/opencog/persist/sexpr/SexprEval.cc
+++ b/opencog/persist/sexpr/SexprEval.cc
@@ -52,8 +52,7 @@ void SexprEval::eval_expr(const std::string &expr)
 	_caught_error = false;
 	try {
 		std::lock_guard<std::mutex> lock(_mtx);
-		_answer = _interpreter.interpret_command(
-			(AtomSpace*) _atomspace.get(), expr);
+		_answer = _interpreter.interpret_command(expr);
 
 		// CogStorageNode expects all responses to be terminated
 		// by exactly one newline char. It is the end-of-message

--- a/tests/persist/sexpr/CommandsUTest.cxxtest
+++ b/tests/persist/sexpr/CommandsUTest.cxxtest
@@ -70,14 +70,15 @@ void CommandsUTest::test_node()
 	std::string in = R"((cog-node 'Concept "foo"))";
 
 	Commands com;
-	std::string out = com.interpret_command(as.get(), in);
+	com.set_base_space(as);
+	std::string out = com.interpret_command(in);
 	printf("Got %s\n", out.c_str());
 
 	TS_ASSERT_EQUALS(0, as->get_size());
 	TS_ASSERT(0 == out.compare("()"));
 
 	as->add_node(CONCEPT_NODE, "foo");
-	out = com.interpret_command(as.get(), in);
+	out = com.interpret_command(in);
 	printf("Got >>%s<<\n", out.c_str());
 	TS_ASSERT_EQUALS(1, as->get_size());
 	TS_ASSERT(0 == out.compare("(ConceptNode \"foo\")"));
@@ -96,7 +97,8 @@ void CommandsUTest::test_node_quoted()
 	printf("Input %s\n", in.c_str());
 
 	Commands com;
-	std::string out = com.interpret_command(as.get(), in);
+	com.set_base_space(as);
+	std::string out = com.interpret_command(in);
 	printf("Got %s\n", out.c_str());
 
 	TS_ASSERT_EQUALS(0, as->get_size());
@@ -105,7 +107,7 @@ void CommandsUTest::test_node_quoted()
 	Handle h = as->add_node(CONCEPT_NODE, R"("f""o"""o"!!!"")");
 	printf("Added atom %s\n", h->to_short_string().c_str());
 
-	out = com.interpret_command(as.get(), in);
+	out = com.interpret_command(in);
 	printf("Got    >>%s<<\n", out.c_str());
 	TS_ASSERT_EQUALS(1, as->get_size());
 
@@ -129,7 +131,8 @@ void CommandsUTest::test_link()
 	std::string in = R"((cog-link 'List (Concept "a") (Concept "b")))";
 
 	Commands com;
-	std::string out = com.interpret_command(as.get(), in);
+	com.set_base_space(as);
+	std::string out = com.interpret_command(in);
 	printf("Got %s\n", out.c_str());
 
 	TS_ASSERT_EQUALS(2, as->get_size());
@@ -137,7 +140,7 @@ void CommandsUTest::test_link()
 
 	as->add_link(LIST_LINK, ca, cb);
 
-	out = com.interpret_command(as.get(), in);
+	out = com.interpret_command(in);
 	printf("Got >>%s<<\n", out.c_str());
 	TS_ASSERT_EQUALS(3, as->get_size());
 	TS_ASSERT(0 == out.compare(
@@ -154,7 +157,8 @@ void CommandsUTest::test_set_tv()
 	std::string in = R"((cog-set-tv! (Concept "a") (stv 1 0)))";
 
 	Commands com;
-	std::string out = com.interpret_command(as.get(), in);
+	com.set_base_space(as);
+	std::string out = com.interpret_command(in);
 	printf("Got %s\n", out.c_str());
 
 	TS_ASSERT_EQUALS(1, as->get_size());
@@ -169,7 +173,7 @@ void CommandsUTest::test_set_tv()
 
 	// Clobber the TV on B back to Default
 	in = R"((cog-set-tv! (Concept "b") (stv 1 0)))";
-	out = com.interpret_command(as.get(), in);
+	out = com.interpret_command(in);
 
 	TruthValuePtr tv = h->getTruthValue();
 	printf("new TV is %s\n", tv->to_string().c_str());
@@ -187,7 +191,8 @@ void CommandsUTest::test_set_value()
 		R"((cog-set-value! (Concept "a") (Predicate "key") (stv 0.6 0.8)))";
 
 	Commands com;
-	std::string out = com.interpret_command(as.get(), in);
+	com.set_base_space(as);
+	std::string out = com.interpret_command(in);
 	printf("Got %s\n", out.c_str());
 
 	TS_ASSERT_EQUALS(2, as->get_size());
@@ -218,7 +223,8 @@ void CommandsUTest::test_set_value_quoted()
 	printf("Input %s\n", in.c_str());
 
 	Commands com;
-	std::string out = com.interpret_command(as.get(), in);
+	com.set_base_space(as);
+	std::string out = com.interpret_command(in);
 	printf("Got %s\n", out.c_str());
 
 	TS_ASSERT_EQUALS(2, as->get_size());
@@ -263,17 +269,18 @@ void CommandsUTest::test_get_value()
 
 	std::string in = "(cog-value (Concept \"a\") (Predicate \"key\"))";
 	Commands com;
-	std::string out = com.interpret_command(as.get(), in);
+	com.set_base_space(as);
+	std::string out = com.interpret_command(in);
 	printf("Got %s\n", out.c_str());
 	TS_ASSERT(0 == out.compare(0, 12, "(FloatValue "));
 
 	in = "(cog-value (Concept \"a\") (Predicate \"fiz\"))";
-	out = com.interpret_command(as.get(), in);
+	out = com.interpret_command(in);
 	printf("Got %s\n", out.c_str());
 	TS_ASSERT(0 == out.compare("(StringValue \"a\" \"b\")"));
 
 	in = "(cog-value (Concept \"a\") (Predicate \"buz\"))";
-	out = com.interpret_command(as.get(), in);
+	out = com.interpret_command(in);
 	printf("Got %s\n", out.c_str());
 	TS_ASSERT(0 == out.compare(0, 18, "(SimpleTruthValue "));
 
@@ -297,7 +304,8 @@ void CommandsUTest::test_get_value_quoted()
 
 	std::string in = "(cog-value (Concept \"a\") (Predicate \"fiz\"))";
 	Commands com;
-	std::string out = com.interpret_command(as.get(), in);
+	com.set_base_space(as);
+	std::string out = com.interpret_command(in);
 	printf("Got    %s\n", out.c_str());
 
 	std::stringstream oss;
@@ -323,7 +331,8 @@ void CommandsUTest::test_set_values()
 		"(cons (Predicate \"buz\") (StringValue \"gee\" \"golly\"))))";
 
 	Commands com;
-	std::string out = com.interpret_command(as.get(), in);
+	com.set_base_space(as);
+	std::string out = com.interpret_command(in);
 	printf("Got %s\n", out.c_str());
 
 	TS_ASSERT_EQUALS(5, as->get_size());
@@ -376,7 +385,8 @@ void CommandsUTest::test_get_values()
 	std::string in = "(cog-keys->alist (Concept \"a\"))";
 
 	Commands com;
-	std::string out = com.interpret_command(as.get(), in);
+	com.set_base_space(as);
+	std::string out = com.interpret_command(in);
 	printf("Got %zu %s\n", out.size(), out.c_str());
 
 	TS_ASSERT(0 == out.compare(0, 17, "(((PredicateNode "));
@@ -397,7 +407,8 @@ void CommandsUTest::test_extract()
 	std::string in = "(cog-extract! (Concept \"a\"))";
 
 	Commands com;
-	std::string out = com.interpret_command(as.get(), in);
+	com.set_base_space(as);
+	std::string out = com.interpret_command(in);
 	printf("Got %s\n", out.c_str());
 	TS_ASSERT(0 == out.compare("#f"));
 
@@ -406,7 +417,7 @@ void CommandsUTest::test_extract()
 
 	in = "(cog-extract-recursive! (Concept \"a\"))";
 
-	out = com.interpret_command(as.get(), in);
+	out = com.interpret_command(in);
 	printf("Got %s\n", out.c_str());
 	TS_ASSERT(0 == out.compare("#t"));
 
@@ -434,7 +445,8 @@ void CommandsUTest::test_execute()
 		"(Predicate \"key\"))";
 
 	Commands com;
-	std::string out = com.interpret_command(as.get(), in);
+	com.set_base_space(as);
+	std::string out = com.interpret_command(in);
 	printf("Got >>%s<<\n", out.c_str());
 	TS_ASSERT(0 == out.compare("(QueueValue  (ConceptNode \"a\"))"));
 


### PR DESCRIPTION
Network-distributed AtomSpaces need to have proxy agents that know what to do with incoming data.  One obvious location to put that proxy is at the point where network commands are received, decoded and then dispatched to handlers. This reorganizes the network dispatcher code, so that proxies will be able to plug in different handlers for different commands. For example, if the cogserver receives a command to put an Atom into the AtomSpace, it can then immediately push it out to any open `StorageNode`s, for example to disk storage. This becomes an easy way to implement a write-through proxy, which just listens to connections on the next, and whenever it receives some Atom, it just pushed it to disk.`

For details, see https://github.com/opencog/atomspace-agents