### PR TITLE
Provide atomic increment in the AtomSpace

### DIFF
--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -35,6 +35,8 @@
 #include <opencog/atoms/base/Atom.h>
 #include <opencog/atoms/base/Link.h>
 #include <opencog/atoms/base/Node.h>
+#include <opencog/atoms/truthvalue/CountTruthValue.h>
+#include <opencog/atoms/value/FloatValue.h>
 
 #include <opencog/atomspace/AtomSpace.h>
 
@@ -96,7 +98,7 @@ TruthValuePtr Atom::getTruthValue() const
     return TruthValueCast(pap);
 }
 
-TruthValuePtr Atom::incrementCount(double cnt) const
+TruthValuePtr Atom::incrementCountTV(double cnt)
 {
 	ValuePtr pap;
 
@@ -106,11 +108,18 @@ TruthValuePtr Atom::incrementCount(double cnt) const
 	auto pr = _values.find(truth_key());
 	if (_values.end() != pr) pap = pr->second;
 
-	if (nullptr != pap and COUNT_TRUTH_VALUE == pap->get_type())
-		cnt += TruthValueCast(pap)->get_count();
+	double mean = 1.0;
+	double conf = 0.0;
+	if (nullptr != pap)
+	{
+		const TruthValuePtr& tvp = TruthValueCast(pap);
+		if (COUNT_TRUTH_VALUE == pap->get_type())
+			cnt += tvp->get_count();
+		mean = tvp->get_mean();
+		conf = tvp->get_confidence();
+	}
 
-	TruthValuePtr newTV = CountTruthValue::createTV(
-		tv->get_mean(), tv->get_confidence(), cnt);
+	TruthValuePtr newTV = CountTruthValue::createTV(mean, conf, cnt);
 
 	_values[truth_key()] = ValueCast(newTV);
 	return newTV;

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -380,6 +380,10 @@ public:
     //! Sets the TruthValue object of the atom.
     void setTruthValue(const TruthValuePtr&);
 
+    /// Increment the CountTruthValue atomically.
+    /// Return the new TruthValue
+    TruthValuePtr incrementCount(double);
+
     /// Associate `value` to `key` for this atom.
     void setValue(const Handle& key, const ValuePtr& value);
     /// Get value at `key` for this atom.

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -382,12 +382,14 @@ public:
 
     /// Increment the CountTruthValue atomically.
     /// Return the new TruthValue
-    TruthValuePtr incrementCount(double);
+    TruthValuePtr incrementCountTV(double);
 
     /// Associate `value` to `key` for this atom.
     void setValue(const Handle& key, const ValuePtr& value);
     /// Get value at `key` for this atom.
     ValuePtr getValue(const Handle& key) const;
+    /// Increment a generic FloatValue.
+    ValuePtr incrementCount(const Handle& key, const std::vector<double>);
 
     /// Get the set of all keys in use for this Atom.
     HandleSet getKeys() const;

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -389,7 +389,7 @@ public:
     /// Get value at `key` for this atom.
     ValuePtr getValue(const Handle& key) const;
     /// Increment a generic FloatValue.
-    ValuePtr incrementCount(const Handle& key, const std::vector<double>);
+    ValuePtr incrementCount(const Handle& key, const std::vector<double>&);
 
     /// Get the set of all keys in use for this Atom.
     HandleSet getKeys() const;

--- a/opencog/atomspace/AtomSpace.cc
+++ b/opencog/atomspace/AtomSpace.cc
@@ -460,15 +460,15 @@ Handle AtomSpace::set_truthvalue(const Handle& h, const TruthValuePtr& tvp)
 // Copy-on-write for incrementing truth values.
 Handle AtomSpace::increment_countTV(const Handle& h, double cnt)
 {
-	#define INC_TV(atom) atm->incrementCountTV(cnt);
-	COWBOY_CODE(SET_TV);
+	#define INC_TV(atm) atm->incrementCountTV(cnt);
+	COWBOY_CODE(INC_TV);
 }
 
 Handle AtomSpace::increment_count(const Handle& h, const Handle& key,
                                   const std::vector<double>& count)
 {
 	#define INCR_CNT(atm) atm->incrementCount(key, count);
-	COWBOY_CODE(SET_TV);
+	COWBOY_CODE(INCR_CNT);
 }
 
 std::string AtomSpace::to_string(void) const

--- a/opencog/atomspace/AtomSpace.cc
+++ b/opencog/atomspace/AtomSpace.cc
@@ -403,143 +403,72 @@ ValuePtr AtomSpace::add_atoms(const ValuePtr& vptr)
     return vptr;
 }
 
+// COW == Copy On Write
+#define COWBOY_CODE(DO_STUFF)                                            \
+    AtomSpace* has = h->getAtomSpace();                                  \
+                                                                         \
+    /* Hmm. It's kind-of a user-error, if they give us a naked atom.  */ \
+    /* We could throw here, and force them to fix their code, or we   */ \
+    /* can silently do what they wanted!? Which will probably expose  */ \
+    /* other hard-to-debug bugs in the user's code ...                */ \
+    /* if (nullptr == has)                                            */ \
+    /*     throw opencog::RuntimeException(TRACE_INFO,                */ \
+    /*            "Your atom is needs to be placed in an atomspace!") */ \
+                                                                         \
+    /* If the atom is in a read-only atomspace (i.e. if the parent    */ \
+    /* is read-only) and this atomspace is read-write, then make      */ \
+    /* a copy of the atom, and then set the value.                    */ \
+    /* If this is a COW space, then always copy, no matter what.      */ \
+    if (nullptr == has or has->_read_only or _copy_on_write) {           \
+        if (has != this and (_copy_on_write or not _read_only)) {        \
+            /* Copy the atom into this atomspace                      */ \
+            Handle copy(add(h, true));                                   \
+            DO_STUFF(copy);                                              \
+            return copy;                                                 \
+        }                                                                \
+                                                                         \
+        /* No copy needed. Safe to just update.                       */ \
+        if (has == this and not _read_only) {                            \
+            DO_STUFF(h);                                                 \
+            return h;                                                    \
+        }                                                                \
+    } else {                                                             \
+        DO_STUFF(h);                                                     \
+        return h;                                                        \
+    }                                                                    \
+    throw opencog::RuntimeException(TRACE_INFO,                          \
+         "Value not changed; AtomSpace is readonly");                    \
+    return Handle::UNDEFINED;
+
+
 // Copy-on-write for setting values.
 Handle AtomSpace::set_value(const Handle& h,
                             const Handle& key,
                             const ValuePtr& value)
 {
-    AtomSpace* has = h->getAtomSpace();
-
-    // Hmm. It's kind-of a user-error, if they give us a naked atom.
-    // We could throw here, and force them to fix their code, or we
-    // can silently do what they wanted!? Which will probably expose
-    // other hard-to-debug bugs in the user's code ...
-    // if (nullptr == has)
-    //     throw opencog::RuntimeException(TRACE_INFO,
-    //            "Your atom is needs to be placed in an atomspace!")
-
-    // If the atom is in a read-only atomspace (i.e. if the parent
-    // is read-only) and this atomspace is read-write, then make
-    // a copy of the atom, and then set the value.
-    // If this is a COW space, then always copy, no matter what.
-    if (nullptr == has or has->_read_only or _copy_on_write) {
-        if (has != this and (_copy_on_write or not _read_only)) {
-            // Copy the atom into this atomspace
-            Handle copy(add(h, true));
-            copy->setValue(key, value);
-            return copy;
-        }
-
-        // No copy needed. Safe to just update.
-        if (has == this and not _read_only) {
-            h->setValue(key, value);
-            return h;
-        }
-    } else {
-        h->setValue(key, value);
-        return h;
-    }
-    throw opencog::RuntimeException(TRACE_INFO,
-         "Value not changed; AtomSpace is readonly");
-    return Handle::UNDEFINED;
+   #define SETV(atm) atm->setValue(key, value);
+	COWBOY_CODE(SETV);
 }
 
 // Copy-on-write for setting truth values.
 Handle AtomSpace::set_truthvalue(const Handle& h, const TruthValuePtr& tvp)
 {
-    AtomSpace* has = h->getAtomSpace();
-    // Hmm. It's kind-of a user-error, if they give us a naked atom.
-    // We could throw here, and force them to fix their code, or we
-    // can silently do what they wanted!? Which will probably expose
-    // other hard-to-debug bugs in the user's code ...
-    // if (nullptr == has)
-    //     throw opencog::RuntimeException(TRACE_INFO,
-    //            "Your atom is needs to be placed in an atomspace!")
-
-    // If the atom is in a read-only atomspace (i.e. if the parent
-    // is read-only) and this atomspace is read-write, then make
-    // a copy of the atom, and then set the value.
-    // If this is a COW space, then always copy, no matter what.
-    if (nullptr == has or has->_read_only or _copy_on_write) {
-        if (has != this and (_copy_on_write or not _read_only)) {
-            // Copy the atom into this atomspace
-            Handle copy(add(h, true));
-            copy->setTruthValue(tvp);
-            return copy;
-        }
-
-        // No copy needed. Safe to just update.
-        if (has == this and not _read_only) {
-            h->setTruthValue(tvp);
-            return h;
-        }
-    } else {
-        h->setTruthValue(tvp);
-        return h;
-    }
-    throw opencog::RuntimeException(TRACE_INFO,
-         "TruthValue not changed; AtomSpace is readonly");
-    return Handle::UNDEFINED;
+   #define SET_TV(atm) atm->setTruthValue(tvp);
+	COWBOY_CODE(SET_TV);
 }
 
 // Copy-on-write for incrementing truth values.
 Handle AtomSpace::increment_countTV(const Handle& h, double cnt)
 {
-    AtomSpace* has = h->getAtomSpace();
-    // If the atom is in a read-only atomspace (i.e. if the parent
-    // is read-only) and this atomspace is read-write, then make
-    // a copy of the atom, and then set the value.
-    // If this is a COW space, then always copy, no matter what.
-    if (nullptr == has or has->_read_only or _copy_on_write) {
-        if (has != this and (_copy_on_write or not _read_only)) {
-            // Copy the atom into this atomspace
-            Handle copy(add(h, true));
-            copy->incrementCountTV(cnt);
-            return copy;
-        }
-
-        // No copy needed. Safe to just update.
-        if (has == this and not _read_only) {
-            h->incrementCountTV(cnt);
-            return h;
-        }
-    } else {
-        h->incrementCountTV(cnt);
-        return h;
-    }
-    throw opencog::RuntimeException(TRACE_INFO,
-         "TruthValue not changed; AtomSpace is readonly");
-    return Handle::UNDEFINED;
+	#define INC_TV(atom) atm->incrementCountTV(cnt);
+	COWBOY_CODE(SET_TV);
 }
 
-Handle AtomSpace::increment_count(const Handle&, const Handle& key,
+Handle AtomSpace::increment_count(const Handle& h, const Handle& key,
                                   const std::vector<double>& count)
 {
-    AtomSpace* has = h->getAtomSpace();
-    // If the atom is in a read-only atomspace (i.e. if the parent
-    // is read-only) and this atomspace is read-write, then make
-    // a copy of the atom, and then set the value.
-    // If this is a COW space, then always copy, no matter what.
-    if (nullptr == has or has->_read_only or _copy_on_write) {
-        if (has != this and (_copy_on_write or not _read_only)) {
-            // Copy the atom into this atomspace
-            Handle copy(add(h, true));
-            copy->incrementCount(key, count);
-            return copy;
-        }
-
-        // No copy needed. Safe to just update.
-        if (has == this and not _read_only) {
-            h->incrementCount(key, count);
-            return h;
-        }
-    } else {
-        h->incrementCount(key, count);
-        return h;
-    }
-    throw opencog::RuntimeException(TRACE_INFO,
-         "TruthValue not changed; AtomSpace is readonly");
-    return Handle::UNDEFINED;
+	#define INCR_CNT(atm) atm->incrementCount(key, count);
+	COWBOY_CODE(SET_TV);
 }
 
 std::string AtomSpace::to_string(void) const

--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -394,6 +394,17 @@ public:
     Handle set_truthvalue(const Handle&, const TruthValuePtr&);
 
     /**
+     * Increment the count on a CountTrutheValue, or increment the count
+     * on a general Value. The increment is performed atomically, so that
+     * there are no races in the update. Atomspaces that are read-only, COW,
+     * or frames are handled as described above, for `set_value()`.
+     *
+     * If the atom is copied, then the copy is returned.
+     */
+    Handle increment_count(const Handle&, const Handle& key, const std::vector<double>&);
+    Handle increment_countTV(const Handle&, double);
+
+    /**
      * Find an equivalent Atom that is exactly the same as the arg.
      * If such an atom is in the AtomSpace, or in any of it's parent
      * AtomSpaces, return that Atom. Return the shallowest such Atom.

--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -183,18 +183,8 @@ SCM SchemeSmob::ss_inc_count (SCM satom, SCM scnt)
 	Handle h = verify_handle(satom, "cog-inc-count!");
 	double cnt = verify_real(scnt, "cog-inc-count!", 2);
 
-	// Lock so that count updates are atomic!
-	std::lock_guard<std::mutex> lck(count_mtx);
-	TruthValuePtr tv = h->getTruthValue();
-	if (COUNT_TRUTH_VALUE == tv->get_type())
-	{
-		cnt += tv->get_count();
-	}
-	tv = CountTruthValue::createTV(
-		tv->get_mean(), tv->get_confidence(), cnt);
-
 	const AtomSpacePtr& asp = ss_get_env_as("cog-inc-count!");
-	Handle ha(asp->set_truthvalue(h, tv));
+	Handle ha(asp->increment_countTV(h, cnt));
 	if (ha == h)
 		return satom;
 	return handle_to_scm(ha);


### PR DESCRIPTION
The old code provided atomic increment only in the guile layer.
Move that to the AtomSpace C++ code proper (where it should
have been, from the beginning.)