### PR TITLE
Atomic update for the network-distributed AtomSpace.

### DIFF
--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -186,6 +186,13 @@ ValuePtr Atom::incrementCount(const Handle& key, const std::vector<double>& coun
 
 	KVP_SHARED_LOCK;
 
+	// XXX FIXME. The code below should be changed to do
+	// if (nameserver().isA(vt, FLOAT_VALUE))
+	// and then to use a factory to create a new value of
+	// the same type... we're not doing this right now, because
+	// it's not obvious how the derived types should respond to
+	// an increment request. More work would need to be done here.
+
 	// Find the existing value, if it is there.
 	auto pr = _values.find(key);
 	if (_values.end() != pr)

--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -305,12 +305,13 @@ void SchemeSmob::register_procs()
 	register_proc("cog-set-value!",        3, 0, 0, C(ss_set_value));
 	register_proc("cog-set-values!",       2, 0, 0, C(ss_set_values));
 
-	// TV property setters on atoms
+	// Value property setters on atoms
 	register_proc("cog-set-tv!",           2, 0, 0, C(ss_set_tv));
 	register_proc("cog-inc-count!",        2, 0, 0, C(ss_inc_count));
 	register_proc("cog-inc-value!",        4, 0, 0, C(ss_inc_value));
+	register_proc("cog-update-value!",     3, 0, 0, C(ss_update_value));
 
-	// property getters on atoms
+	// Property getters on atoms
 	register_proc("cog-name",              1, 0, 0, C(ss_name));
 	register_proc("cog-number",            1, 0, 0, C(ss_number));
 	register_proc("cog-type",              1, 0, 0, C(ss_type));

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -128,6 +128,7 @@ private:
 	static SCM ss_set_values(SCM, SCM);
 	static SCM ss_inc_count(SCM, SCM);
 	static SCM ss_inc_value(SCM, SCM, SCM, SCM);
+	static SCM ss_update_value(SCM, SCM, SCM);
 
 	// Atom properties
 	static SCM ss_name(SCM);

--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -174,8 +174,8 @@ SCM SchemeSmob::ss_set_tv (SCM satom, SCM stv)
 	}
 }
 
-// Increment the count, keeping mean and confidence as-is.
-// Converts existing truth value to a CountTruthValue.
+/// Increment the count, keeping mean and confidence as-is.
+/// Converts existing truth value to a CountTruthValue.
 SCM SchemeSmob::ss_inc_count (SCM satom, SCM scnt)
 {
 	Handle h = verify_handle(satom, "cog-inc-count!");
@@ -189,11 +189,11 @@ SCM SchemeSmob::ss_inc_count (SCM satom, SCM scnt)
 }
 
 /* ============================================================== */
-// Increment the count of some generic FloatValue.
-// Just like ss_inc_count but generic.
-// key == key for value
-// cnt == how much to increment
-// ref == list-ref, which location to increment.
+/// Increment the count of some generic FloatValue.
+/// Just like ss_inc_count but generic.
+/// key == key for value
+/// cnt == how much to increment
+/// ref == list-ref, which location to increment.
 SCM SchemeSmob::ss_inc_value (SCM satom, SCM skey, SCM scnt, SCM sref)
 {
 	Handle h = verify_handle(satom, "cog-inc-value!");
@@ -207,6 +207,32 @@ SCM SchemeSmob::ss_inc_value (SCM satom, SCM skey, SCM scnt, SCM sref)
 
 	const AtomSpacePtr& asp = ss_get_env_as("cog-inc-value!");
 	Handle ha(asp->increment_count(h, key, delta));
+	if (ha == h)
+		return satom;
+	return handle_to_scm(ha);
+}
+
+/* ============================================================== */
+
+/// Generic atomic read-modify-write update
+SCM SchemeSmob::ss_update_value (SCM satom, SCM skey, SCM sdelta)
+{
+	Handle h = verify_handle(satom, "cog-update-value!");
+	Handle key = verify_handle(skey, "cog-update-value!", 2);
+	ValuePtr vp = verify_protom(sdelta, "cog-update-value!", 3);
+
+	// Only FloatValues are supported at this time.
+	if (not nameserver().isA(vp->get_type(), FLOAT_VALUE))
+	{
+		static std::exception ex = RuntimeException(TRACE_INFO,
+			"Expecting a FloatValue!");
+		throw_exception(ex, "cog-update-value!", sdelta);
+	}
+
+	FloatValuePtr fvp = FloatValueCast(vp);
+
+	const AtomSpacePtr& asp = ss_get_env_as("cog-update-value!");
+	Handle ha(asp->increment_count(h, key, fvp->value()));
 	if (ha == h)
 		return satom;
 	return handle_to_scm(ha);

--- a/opencog/persist/api/BackingStore.h
+++ b/opencog/persist/api/BackingStore.h
@@ -139,24 +139,19 @@ class BackingStore
 		}
 
 		/**
-		 * Increment the count on the CountTruthValue. The increment is
-		 * done atomically, so that different writers do not race with a
-		 * read-modify-write operation. The count on the local atom is
-		 * updated with the new count; however, it might not reflect the
-		 * true count at the remote destination, if there are other writers.
-		 * Thus, it behaves like storeValue() above: if there are other
-		 * writers, this backend is not automatically aware of those updates.
+		 * Perform an atomic read-modify-write of the Value located at
+		 * `key` on `atom`.  The existing Value at that location is
+		 * modified by `delta`. The goal of this method is to provide
+		 * an atomic operation for that multiple racing updators can
+		 * safely use.
+		 *
+		 * At this time, the only workable/working updates are the atomic
+		 * increment of FloatValues (usually, of CountTruthValues). The
+		 * API here is generic, though, so can be used to provide other
+		 * kinds of atomic delta-changes.
 		 */
-		virtual void incrementCountTV(const Handle& atom, double delta)
-		{
-			throw IOException(TRACE_INFO, "Not implemented!");
-		}
-
-		/**
-		 * Same as above, but for generic FloatValues.
-		 */
-		virtual void incrementCount(const Handle& atom, const Handle& key,
-		                            const std::vector<double>& delta)
+		virtual void updateValue(const Handle& atom, const Handle& key,
+		                         const ValuePtr& delta)
 		{
 			throw IOException(TRACE_INFO, "Not implemented!");
 		}

--- a/opencog/persist/api/BackingStore.h
+++ b/opencog/persist/api/BackingStore.h
@@ -139,6 +139,29 @@ class BackingStore
 		}
 
 		/**
+		 * Increment the count on the CountTruthValue. The increment is
+		 * done atomically, so that different writers do not race with a
+		 * read-modify-write operation. The count on the local atom is
+		 * updated with the new count; however, it might not reflect the
+		 * true count at the remote destination, if there are other writers.
+		 * Thus, it behaves like storeValue() above: if there are other
+		 * writers, this backend is not automatically aware of those updates.
+		 */
+		virtual void incrementCountTV(const Handle& atom, double delta)
+		{
+			throw IOException(TRACE_INFO, "Not implemented!");
+		}
+
+		/**
+		 * Same as above, but for generic FloatValues.
+		 */
+		virtual void incrementCount(const Handle& atom, const Handle& key,
+		                            const std::vector<double>& delta)
+		{
+			throw IOException(TRACE_INFO, "Not implemented!");
+		}
+
+		/**
 		 * Fetch the Value located at `key` on `atom` from the remote
 		 * server, and place it on `key` on `atom` in this AtomSpace.
 		 *

--- a/opencog/persist/api/PersistSCM.cc
+++ b/opencog/persist/api/PersistSCM.cc
@@ -67,6 +67,8 @@ void PersistSCM::init(void)
 	             &PersistSCM::sn_store_atom, "persist", false);
 	define_scheme_primitive("sn-store-value",
 	             &PersistSCM::sn_store_value, "persist", false);
+	define_scheme_primitive("sn-update-value",
+	             &PersistSCM::sn_update_value, "persist", false);
 	define_scheme_primitive("sn-load-atoms-of-type",
 	             &PersistSCM::sn_load_type, "persist", false);
 	define_scheme_primitive("sn-load-atomspace",
@@ -102,6 +104,8 @@ void PersistSCM::init(void)
 	             &PersistSCM::dflt_store_atom, this, "persist", false);
 	define_scheme_primitive("dflt-store-value",
 	             &PersistSCM::dflt_store_value, this, "persist", false);
+	define_scheme_primitive("dflt-update-value",
+	             &PersistSCM::dflt_update_value, this, "persist", false);
 	define_scheme_primitive("dflt-load-atoms-of-type",
 	             &PersistSCM::dflt_load_type, this, "persist", false);
 	define_scheme_primitive("dflt-load-atomspace",
@@ -247,6 +251,12 @@ void PersistSCM::sn_store_value(Handle h, Handle key, Handle hsn)
 	stnp->store_value(h, key);
 }
 
+void PersistSCM::sn_update_value(Handle h, Handle key, ValuePtr delta, Handle hsn)
+{
+	GET_STNP;
+	stnp->update_value(h, key, delta);
+}
+
 void PersistSCM::sn_load_type(Type t, Handle hsn)
 {
 	GET_STNP;
@@ -372,6 +382,12 @@ void PersistSCM::dflt_store_value(Handle h, Handle key)
 {
 	CHECK;
 	_sn->store_value(h, key);
+}
+
+void PersistSCM::dflt_update_value(Handle h, Handle key, ValuePtr delta)
+{
+	CHECK;
+	_sn->update_value(h, key, delta);
 }
 
 void PersistSCM::dflt_load_type(Type t)

--- a/opencog/persist/api/PersistSCM.h
+++ b/opencog/persist/api/PersistSCM.h
@@ -49,6 +49,7 @@ private:
 	static Handle sn_fetch_query4(Handle, Handle, Handle, bool, Handle);
 	static Handle sn_store_atom(Handle, Handle);
 	static void sn_store_value(Handle, Handle, Handle);
+	static void sn_update_value(Handle, Handle, ValuePtr, Handle);
 	static void sn_load_type(Type, Handle);
 	static void sn_load_atomspace(Handle);
 	static void sn_store_atomspace(Handle);
@@ -75,6 +76,7 @@ private:
 	Handle dflt_fetch_query4(Handle, Handle, Handle, bool);
 	Handle dflt_store_atom(Handle);
 	void dflt_store_value(Handle, Handle);
+	void dflt_update_value(Handle, Handle, ValuePtr);
 	void dflt_load_type(Type);
 	void dflt_load_atomspace(void);
 	void dflt_store_atomspace(void);

--- a/opencog/persist/api/StorageNode.cc
+++ b/opencog/persist/api/StorageNode.cc
@@ -71,6 +71,29 @@ void StorageNode::store_value(const Handle& h, const Handle& key)
 	storeValue(h, key);
 }
 
+void StorageNode::update_value(const Handle& h, const Handle& key,
+                               const ValuePtr& value)
+{
+	if (_atom_space->get_read_only())
+		throw RuntimeException(TRACE_INFO, "Read-only AtomSpace!");
+
+	if (nullptr == value) return;
+	Type vt = value->get_type();
+	if (not nameserver().isA(vt, FLOAT_VALUE))
+		throw RuntimeException(TRACE_INFO, "Can only update FloatValues!");
+
+	const FloatValuePtr& fv = FloatValueCast(value);
+	incrementCount(h, key, fv->value());
+}
+
+void StorageNode::update_count(const Handle& h, double count)
+{
+	if (_atom_space->get_read_only())
+		throw RuntimeException(TRACE_INFO, "Read-only AtomSpace!");
+
+	incrementCountTV(h, count);
+}
+
 bool StorageNode::remove_atom(AtomSpace* as, Handle h, bool recursive)
 {
 	// Removal is ... tricky. We need to remove Atoms from storage first,

--- a/opencog/persist/api/StorageNode.cc
+++ b/opencog/persist/api/StorageNode.cc
@@ -72,26 +72,12 @@ void StorageNode::store_value(const Handle& h, const Handle& key)
 }
 
 void StorageNode::update_value(const Handle& h, const Handle& key,
-                               const ValuePtr& value)
+                               const ValuePtr& delta)
 {
 	if (_atom_space->get_read_only())
 		throw RuntimeException(TRACE_INFO, "Read-only AtomSpace!");
 
-	if (nullptr == value) return;
-	Type vt = value->get_type();
-	if (not nameserver().isA(vt, FLOAT_VALUE))
-		throw RuntimeException(TRACE_INFO, "Can only update FloatValues!");
-
-	const FloatValuePtr& fv = FloatValueCast(value);
-	incrementCount(h, key, fv->value());
-}
-
-void StorageNode::update_count(const Handle& h, double count)
-{
-	if (_atom_space->get_read_only())
-		throw RuntimeException(TRACE_INFO, "Read-only AtomSpace!");
-
-	incrementCountTV(h, count);
+	updateValue(h, key, delta);
 }
 
 bool StorageNode::remove_atom(AtomSpace* as, Handle h, bool recursive)

--- a/opencog/persist/api/StorageNode.h
+++ b/opencog/persist/api/StorageNode.h
@@ -250,6 +250,30 @@ public:
 	void store_value(const Handle& atom, const Handle& key);
 
 	/**
+	 * Update the Value located at `key` on `atom` at the remote
+	 * server, incorporating a delta-change `delta`. This is an
+	 * atomic read-modify-write update at the server end. The goal
+	 * of this method is to allow multiple clients perform delta
+	 * changes to values, without race conditions.
+	 *
+	 * At this time, the only supported updates are increments of
+	 * counts: i.e. incremenets of FloatValues. Perhaps other kinds
+	 * of updates might be implemented in the future?
+	 *
+	 * If the `atom` does not yet exist on the remote server, it is
+	 * created there.
+	 */
+	void update_value(const Handle& atom, const Handle& key,
+	                  const ValuePtr& delta);
+
+	/**
+	 * Same as above, but for a CountTruthValue only.
+	 * XXX This might be a bad idea; CountTruthValues should
+	 * probably be made obsolete!?
+	 */
+	void update_count(const Handle& atom, double);
+
+	/**
 	 * Removes an atom from the atomspace, and any attached storage.
 	 * The atom remains valid as long as there are Handles that
 	 * reference it; it is deleted only when the last reference

--- a/opencog/persist/api/StorageNode.h
+++ b/opencog/persist/api/StorageNode.h
@@ -267,13 +267,6 @@ public:
 	                  const ValuePtr& delta);
 
 	/**
-	 * Same as above, but for a CountTruthValue only.
-	 * XXX This might be a bad idea; CountTruthValues should
-	 * probably be made obsolete!?
-	 */
-	void update_count(const Handle& atom, double);
-
-	/**
 	 * Removes an atom from the atomspace, and any attached storage.
 	 * The atom remains valid as long as there are Handles that
 	 * reference it; it is deleted only when the last reference

--- a/opencog/persist/sexpr/Commands.cc
+++ b/opencog/persist/sexpr/Commands.cc
@@ -394,14 +394,41 @@ std::string Commands::cog_set_tv(const std::string& cmd)
 }
 
 // -----------------------------------------------
+// (cog-update-value! (Concept "foo") (Predicate "key") (FloatValue 1 2 3))
+std::string Commands::cog_update_value(const std::string& cmd)
+{
+	size_t pos = 0;
+	Handle atom = Sexpr::decode_atom(cmd, pos, _space_map);
+	Handle key = Sexpr::decode_atom(cmd, ++pos, _space_map);
+	ValuePtr vp = Sexpr::decode_value(cmd, ++pos);
+
+	AtomSpace* as = get_opt_as(cmd, pos);
+	atom = as->add_atom(atom);
+	key = as->add_atom(key);
+
+	if (not nameserver().isA(vp->get_type(), FLOAT_VALUE))
+		return "()";
+
+	FloatValuePtr fvp = FloatValueCast(vp);
+	as->increment_count(atom, key, fvp->value());
+
+	// Return the new value. XXX Why? This just wastes CPU?
+	// ValuePtr vp = atom->getValue(key);
+	// return Sexpr::encode_value(vp);
+	return "()";
+}
+
+// -----------------------------------------------
 // (cog-value (Concept "foo") (Predicate "key"))
 std::string Commands::cog_value(const std::string& cmd)
 {
 	size_t pos = 0;
 	Handle atom = Sexpr::decode_atom(cmd, pos, _space_map);
-	atom = _base_space->add_atom(atom);
 	Handle key = Sexpr::decode_atom(cmd, ++pos, _space_map);
-	key = _base_space->add_atom(key);
+
+	AtomSpace* as = get_opt_as(cmd, pos);
+	atom = as->add_atom(atom);
+	key = as->add_atom(key);
 
 	ValuePtr vp = atom->getValue(key);
 	return Sexpr::encode_value(vp);

--- a/opencog/persist/sexpr/Commands.h
+++ b/opencog/persist/sexpr/Commands.h
@@ -60,6 +60,28 @@ protected:
 	/// not free the frame immediattely after it is created.
 	AtomSpacePtr top_space;
 
+	/// Methods that implement each of the interpreted commands, below.
+	std::string cog_atomspace(const std::string&);
+	std::string cog_atomspace_clear(const std::string&);
+	std::string cog_execute_cache(const std::string&);
+	std::string cog_extract(const std::string&);
+	std::string cog_extract_recursive(const std::string&);
+
+	std::string cog_get_atoms(const std::string&);
+	std::string cog_incoming_by_type(const std::string&);
+	std::string cog_incoming_set(const std::string&);
+	std::string cog_keys_alist(const std::string&);
+	std::string cog_link(const std::string&);
+	std::string cog_node(const std::string&);
+
+	std::string cog_set_value(const std::string&);
+	std::string cog_set_values(const std::string&);
+	std::string cog_set_tv(const std::string&);
+	std::string cog_value(const std::string&);
+	std::string cog_update_value(const std::string&);
+	std::string cog_define(const std::string&);
+	std::string cog_ping(const std::string&);
+
 public:
 	Commands(void);
 	~Commands();
@@ -88,6 +110,7 @@ public:
 	///    cog-set-value!
 	///    cog-set-values!
 	///    cog-set-tv!
+	///    cog-update-value!
 	///    cog-value
 	///    ping
 	///
@@ -97,27 +120,10 @@ public:
 	///
 	std::string interpret_command(const std::string&);
 
-	/// Methods that implement each of the interpreted commands, above.
-	std::string cog_atomspace(const std::string&);
-	std::string cog_atomspace_clear(const std::string&);
-	std::string cog_execute_cache(const std::string&);
-	std::string cog_extract(const std::string&);
-	std::string cog_extract_recursive(const std::string&);
-
-	std::string cog_get_atoms(const std::string&);
-	std::string cog_incoming_by_type(const std::string&);
-	std::string cog_incoming_set(const std::string&);
-	std::string cog_keys_alist(const std::string&);
-	std::string cog_link(const std::string&);
-	std::string cog_node(const std::string&);
-
-	std::string cog_set_value(const std::string&);
-	std::string cog_set_values(const std::string&);
-	std::string cog_set_tv(const std::string&);
-	std::string cog_value(const std::string&);
-	std::string cog_define(const std::string&);
-	std::string cog_ping(const std::string&);
-
+	/// Install a callback handler, over-riding the default behavior for
+	/// the command interpreter. This allows proxy agents to over-ride the
+	/// default interpretation of any message that is received, so as to do
+	/// ... something different. Anything different.
 	void install_handler(const std::string&, Meth);
 };
 

--- a/opencog/scm/opencog.scm
+++ b/opencog/scm/opencog.scm
@@ -91,6 +91,7 @@ cog-tv-merge
 cog-tv-merge-hi-conf
 cog-type
 cog-type->int
+cog-update-value!
 cog-value
 cog-value?
 cog-value->list

--- a/opencog/scm/opencog/base/core-docs.scm
+++ b/opencog/scm/opencog/base/core-docs.scm
@@ -543,8 +543,9 @@
      (cog-inc-count! (Concept \"Answer\") 42.0)
 
   See also:
-      cog-count to fetch the current count
-      cog-inc-value! for a generic version
+      cog-count -- Fetch the current count.
+      cog-inc-value! -- Increment an arbitrary FloatValue.
+      cog-update-value! -- A generic atomic read-modify-write.
 ")
 
 (set-procedure-property! cog-inc-value! 'documentation
@@ -560,13 +561,18 @@
   created. If the existing FloatValue is too short, it is extended
   until it is at least (REF+1) in length.
 
+  To increment several locations at once, use the cog-update-value!
+  function.
+
   Example usage:
      (cog-inc-value!
          (Concept \"Question\")
          (Predicate \"Answer\")
          42.0  0)
 
-  See also: cog-inc-count! for a version that increments the count TV.
+  See also:
+      cog-inc-count! -- Increment the CountTruthValue.
+      cog-update-value! -- A generic atomic read-modify-write.
 ")
 
 (set-procedure-property! cog-mean 'documentation
@@ -765,10 +771,34 @@
        #f
 
     See also:
-       cog-set-values! ATOM ALIST - Set multiple values.
+       cog-update-value! - Perform an atomic read-modify-write
+       cog-set-values! - Set multiple values.
        cog-new-atomspace - Create a new AtomSpace
-       cog-atomspace-cow! BOOL - Mark AtomSpace as a COW space.
+       cog-atomspace-cow! - Mark AtomSpace as a COW space.
        cog-atomspace-ro! - Mark AtomSpace as read-only.
+")
+
+(set-procedure-property! cog-update-value! 'documentation
+"
+ cog-update-value! ATOM KEY DELTA
+    Perform an atomic read-modify-write update of the value at KEY
+    on ATOM, using DELTA to modify the original value.
+
+    At this time, the only updates that are implemented are the
+    increment of floating-point Values, such as FloatValues and
+    TruthValues. The intended use is for the safe update of counts
+    from multiple threads.
+
+    This function is similar to the `cog-inc-value!` function, except
+    that it allows a full-vector update. When DELTA is a vector, with
+    multiple non-zero entries, all of them are added to the matching
+    entries in the Value at KEY. This is a vector-increment.
+
+    See also:
+       cog-inc-count! -- Increment a CountTruthValue
+       cog-inc-value! -- Increment a generic FloatValue
+       cog-set-value! -- Set a single value.
+       cog-set-values! -- Set multiple values.
 ")
 
 (set-procedure-property! cog-set-values! 'documentation

--- a/opencog/scm/opencog/persist.scm
+++ b/opencog/scm/opencog/persist.scm
@@ -26,6 +26,7 @@
 	fetch-query
 	store-atom
 	store-value
+	update-value
 	load-atoms-of-type
 	cog-delete!
 	cog-delete-recursive!
@@ -213,10 +214,36 @@
     used as the target of the store. It must be a StorageNode.
 
     See also:
+       `update-value` to perform an atomic read-modify-write.
        `store-atom` to store all values on an Atom.
        `fetch-value` to fetch just one Value.
 "
 	(if STORAGE (sn-store-value ATOM KEY STORAGE) (dflt-store-value ATOM KEY))
+)
+
+(define*-public (update-value ATOM KEY DELTA #:optional (STORAGE #f))
+"
+ update-value ATOM KEY DELTA [STORAGE]
+
+    Update the Value located at KEY on ATOM, folding in DELTA. This
+    performs an atomic read-modify-write of the Value located at KEY.
+
+    At this time, the only implemented updates are atomic increments
+    of floating-point values stored in a FloatValue or in a TruthValue.
+    The intended use is to allow lots of clients to simultaneously
+    update counts on ATOM, without having them clobber each-other with
+    a non-atomic update.
+
+    If the optional STORAGE argument is provided, then it will be
+    used as the target of the store. It must be a StorageNode.
+
+    See also:
+       `store-value` to store a single value on an Atom.
+       `store-atom` to store all values on an Atom.
+       `fetch-value` to fetch just one Value.
+"
+	(if STORAGE (sn-update-value ATOM KEY DELTA STORAGE)
+		(dflt-update-value ATOM KEY DELTA))
 )
 
 (define*-public (load-atoms-of-type TYPE #:optional (STORAGE #f))


### PR DESCRIPTION
Allow multiple network clients to perform atomic read-modify-write updates to Values (basically, to increment CountTruthValues or other FloatValue vectors).  The read-modify-write is performed at the server, under a lock, so that multiple writers will not clobber one-another. Also, network traffic is reduced, since only the update is sent out.

At this time, only vectors of floating points are supported. The network remote `cog-execute-cache!` could handle the general case, but adding this seems like it would be pointless complication, just right now. Vectors of floats are enough.