### PR TITLE
Enable remote execution of anything, not just queries.

### DIFF
--- a/opencog/atomspace/AtomSpace.cc
+++ b/opencog/atomspace/AtomSpace.cc
@@ -384,6 +384,8 @@ Handle AtomSpace::get_link(Type t, HandleSeq&& outgoing) const
 
 ValuePtr AtomSpace::add_atoms(const ValuePtr& vptr)
 {
+    if (nullptr == vptr) return vptr;
+
     Type t = vptr->get_type();
     if (nameserver().isA(t, ATOM))
     {

--- a/opencog/persist/api/BackingQuery.cc
+++ b/opencog/persist/api/BackingQuery.cc
@@ -138,6 +138,10 @@ IncomingSet BackingJoinCallback::get_incoming_set(const Handle& h)
 /// only those atoms that satisfy the query. (i.e. load them into the
 /// AtomSpace.)
 ///
+/// This provides a default implementation suitable for StorageNodes
+/// that fetch Atoms from "local" hard-drive storage. It is not suitable
+/// for "remote" networked StorageNodes.
+///
 /// This is currently experimental, and subject to change.
 ///
 /// The thing I don't like about this is the caching design...
@@ -146,7 +150,8 @@ IncomingSet BackingJoinCallback::get_incoming_set(const Handle& h)
 /// easily enough, but have a high cost of shipping them (i.e. over the
 /// network). The "local" backends have a low or zero cost of shipping
 /// Atoms; the main bottleneck is just obtaining the Atoms in  the first
-/// place.  The caching needs of these two backends differ.
+/// place (from the "local" hard drive).  The caching needs of these two
+/// backends differ.
 ///
 /// The caching currently works as follows:
 /// On the first call, the query is performed, and the resulting Atoms
@@ -163,16 +168,21 @@ IncomingSet BackingJoinCallback::get_incoming_set(const Handle& h)
 /// bothersome, if the user didn't need that, and was just wanted
 /// throw-away results.
 ///
-/// For the "remote storage" case, the below is much closer to ideal.
-/// Asking users to "do it themselves" for the remote case is
-/// inefficient. The query is computed on the remote server, and the
-/// result is shipped to the local server. The "do-it-yourself" cases
+/// For the "remote storage" case, the caching idea is much closer to
+/// a desirable ideal. Asking users to "do it themselves" for the remote
+/// case is inefficient. The query is computed on the remote server, and
+/// the result is shipped to the local server. The "do-it-yourself" cases
 /// would then ship the query results back to the server... which is
 /// a pointless waste of network bandwidth and risks extra latency.
 ///
-/// So, I'm thinking, ... Maybe we need two versions of this: a cached
-/// and a non-cached API... or maybe one more flag-- an "always cache
-/// remotely" flag...
+/// However, (1) remote storage will NOT use the code here; instead, on
+/// the client side, it will send a message to the server.  Also (2) it
+/// seems like a better design would be to implement caching as a
+/// storage policy (as described in the
+/// https://github.com/opencog/atomspace-agents project), rather than
+/// here, in the BackingStore API.
+///
+/// So, I'm thinking, just get rid of the caching specification ...
 ///
 /// See also the notes about meta-information. It's currently
 /// implemented to be compatible with what `cog-execute-cache!` does.

--- a/opencog/persist/api/BackingStore.h
+++ b/opencog/persist/api/BackingStore.h
@@ -171,7 +171,7 @@ class BackingStore
 		/**
 		 * Run the `query` on the remote server, and place the results
 		 * at `key` on the Atom `query`, both locally, and remotely.
-		 * The `query` must be either a JoinLink, MeetLink or QueryLink.
+		 * The `query` can be any executable or evaluatable Atom.
 		 *
 		 * It is intended that remote servers will usually cache the
 		 * query results at `key`, and so future requests for the same
@@ -203,18 +203,6 @@ class BackingStore
 		 * Only the Atoms that were the result of the search are returned.
 		 * Any Values hanging off those Atoms are not transferred from
 		 * the remote server to the local AtomSpace.
-		 *
-		 * FYI Design Note: in principle, I suppose that we could have
-		 * this method run any atom that has an `execute()` method on
-		 * it. At this time, this is not allowed, for somewhat vague
-		 * and arbitrary reasons: (1) we do not want to DDOS the remote
-		 * server with heavy CPU processing demands (you can use the
-		 * CogServer directly, if you want to do that). We also want to
-		 * limit the amount of complexity that the server implementation
-		 * must provide. For example, there's a slim chance that traditional
-		 * SQL and GraphQL servers might be able to support some of the
-		 * simpler queries.  If you want full-function hypergraph query,
-		 * just use the CogServer directly.
 		 */
 		virtual void runQuery(const Handle& query, const Handle& key,
 		                      const Handle& metadata_key = Handle::UNDEFINED,

--- a/opencog/persist/api/StorageNode.cc
+++ b/opencog/persist/api/StorageNode.cc
@@ -173,10 +173,12 @@ Handle StorageNode::fetch_query(const Handle& query, const Handle& key,
                                 const Handle& metadata, bool fresh,
                                 AtomSpace* as)
 {
-	// At this time, we restrict queries to be ... queries.
+	// Queries can be anything executable or evaluatable.
 	Type qt = query->get_type();
 	if (not nameserver().isA(qt, JOIN_LINK) and
-		not nameserver().isA(qt, PATTERN_LINK))
+		not nameserver().isA(qt, PATTERN_LINK) and
+		not nameserver().isA(qt, FUNCTION_LINK) and
+		not nameserver().isA(qt, EVALUATABLE_LINK))
 		throw RuntimeException(TRACE_INFO, "Not a Join or Meet!");
 
 	if (nullptr == as) as = getAtomSpace();

--- a/opencog/persist/api/StorageNode.cc
+++ b/opencog/persist/api/StorageNode.cc
@@ -174,12 +174,8 @@ Handle StorageNode::fetch_query(const Handle& query, const Handle& key,
                                 AtomSpace* as)
 {
 	// Queries can be anything executable or evaluatable.
-	Type qt = query->get_type();
-	if (not nameserver().isA(qt, JOIN_LINK) and
-		not nameserver().isA(qt, PATTERN_LINK) and
-		not nameserver().isA(qt, FUNCTION_LINK) and
-		not nameserver().isA(qt, EVALUATABLE_LINK))
-		throw RuntimeException(TRACE_INFO, "Not a Join or Meet!");
+	if (not query->is_executable() and not query->is_evaluatable())
+		throw RuntimeException(TRACE_INFO, "Not executable!");
 
 	if (nullptr == as) as = getAtomSpace();
 	Handle lkey = as->add_atom(key);

--- a/opencog/persist/sexpr/Commands.cc
+++ b/opencog/persist/sexpr/Commands.cc
@@ -178,8 +178,14 @@ std::string Commands::cog_execute_cache(const std::string& cmd)
 	if (nullptr != rslt and not force)
 		return Sexpr::encode_value(rslt);
 
-	// Runn the query.
-	rslt = query->execute();
+	// Run the query.
+	if (query->is_executable())
+		rslt = query->execute(_base_space.get());
+	else if (query->is_evaluatable())
+		rslt = ValueCast(query->evaluate(_base_space.get()));
+	else
+		return "#f";
+
 	_base_space->set_value(query, key, rslt);
 
 	return Sexpr::encode_value(rslt);

--- a/opencog/persist/sexpr/Commands.cc
+++ b/opencog/persist/sexpr/Commands.cc
@@ -178,12 +178,7 @@ std::string Commands::cog_execute_cache(const std::string& cmd)
 	if (nullptr != rslt and not force)
 		return Sexpr::encode_value(rslt);
 
-	// For now, prevent general execution.
-	Type qt = query->get_type();
-	if (not nameserver().isA(qt, PATTERN_LINK) and
-	    not nameserver().isA(qt, JOIN_LINK))
-		return "#f";
-
+	// Runn the query.
 	rslt = query->execute();
 	_base_space->set_value(query, key, rslt);
 


### PR DESCRIPTION
The old code only allowed for the remote execution of pattern queries. This update enables execution of anything executable.