### PR TITLE
Remove c++ builtin GroundedPredicates

### DIFF
--- a/opencog/atoms/grounded/GroundedPredicateNode.cc
+++ b/opencog/atoms/grounded/GroundedPredicateNode.cc
@@ -100,96 +100,6 @@ void GroundedPredicateNode::init()
 
 // ----------------------------------------------------------
 
-static void throwSyntaxException(bool silent, const char* message...)
-{
-   if (silent)
-      throw NotEvaluatableException();
-   va_list args;
-   va_start(args, message);
-   throw SyntaxException(TRACE_INFO, message, args);
-   va_end(args);
-}
-
-// ----------------------------------------------------------
-
-/// Extract a single floating-point double out of an atom, that,
-/// when executed, should yield a value containing a number.
-/// Viz, either a NumberNode, or a FloatValue.
-static double get_numeric_value(AtomSpace* as, bool silent,
-                                Handle h)
-{
-	Type t = h->get_type();
-	if (DEFINED_SCHEMA_NODE == t)
-	{
-		h = DefineLink::get_definition(h);
-		t = h->get_type();
-	}
-
-	ValuePtr pap(h);
-	if (h->is_executable())
-	{
-		pap = h->execute(as, silent);
-		t = pap->get_type();
-
-		// Pattern matching hack. The pattern matcher returns sets of
-		// atoms; if that set contains a single number, then unwrap it.
-		// See issue #1502 which proposes to eliminate this SetLink hack.
-		if (SET_LINK == t)
-		{
-			h = HandleCast(pap);
-			if (1 != h->get_arity())
-				throw SyntaxException(TRACE_INFO,
-					"Don't know how to unwrap this: %s",
-					h->to_string().c_str());
-			pap = h->getOutgoingAtom(0);
-			t = pap->get_type();
-		}
-	}
-
-	if (NUMBER_NODE == t)
-	{
-		NumberNodePtr n(NumberNodeCast(pap));
-		return n->get_value();
-	}
-
-	if (nameserver().isA(t, FLOAT_VALUE))
-	{
-		FloatValuePtr fv(FloatValueCast(pap));
-		if (fv->value().empty())
-			throw RuntimeException(TRACE_INFO, "FloatValue is empty!");
-		return fv->value()[0];
-	}
-
-	throwSyntaxException(silent,
-		"Don't know how to do arithmetic with this: %s",
-		pap->to_string().c_str());
-
-	return std::nan("");
-}
-
-
-/// Perform a GreaterThan check
-static bool greater(AtomSpace* as, const Handle& h, bool silent)
-{
-	const HandleSeq& oset = h->getOutgoingSet();
-	if (2 != oset.size())
-		throw SyntaxException(TRACE_INFO,
-			  "GreaterThankLink expects two arguments");
-
-	double v0 = get_numeric_value(as, silent, oset[0]);
-	double v1 = get_numeric_value(as, silent, oset[1]);
-
-	return (v0 > v1);
-}
-
-static TruthValuePtr bool_to_tv(bool truf)
-{
-   if (truf) return TruthValue::TRUE_TV();
-   return TruthValue::FALSE_TV();
-}
-
-// ----------------------------------------------------------
-
 /// `execute()` -- evaluate a GroundedPredicateNode with arguments.
 ///
 /// Expects "args" to be a ListLink. These arguments will be
@@ -206,48 +116,10 @@ ValuePtr GroundedPredicateNode::execute(AtomSpace* as,
 {
 	if (_runner) return _runner->evaluate(as, cargs, silent);
 
-	// XXX FIXME -- can we get rid of the stuff from here on down?
-	// Does anybody actually use any of this?
-
-	// Force execution of the arguments. We have to do this, because
-	// the user-defined functions are black-boxes, and cannot be trusted
-	// to do lazy execution correctly. Right now, forcing is the policy.
-	// We could add "scm-lazy:" and "py-lazy:" URI's for user-defined
-	// functions smart enough to do lazy evaluation.
-	Handle args(force_execute(as, cargs, silent));
-
-	// Get the schema name.
-	const std::string& schema = get_name();
-	// printf ("Grounded schema name: %s\n", schema.c_str());
-
-	// A very special-case C++ comparison.
-	// This compares two NumberNodes, by their numeric value.
-	// Hard-coded in C++ for speed. (well, and for convenience ...)
-	if (0 == schema.compare("c++:greater"))
-	{
-		return CastToValue(bool_to_tv(greater(as, args, silent)));
-	}
-
-	// A very special-case C++ comparison.
-	// This compares a set of atoms, verifying that they are all different.
-	// Hard-coded in C++ for speed. (well, and for convenience ...)
-	if (0 == schema.compare("c++:exclusive"))
-	{
-		Arity sz = args->get_arity();
-		for (Arity i=0; i<sz-1; i++) {
-			Handle h1(args->getOutgoingAtom(i));
-			for (Arity j=i+1; j<sz; j++) {
-				Handle h2(args->getOutgoingAtom(j));
-				if (h1 == h2) return CastToValue(TruthValue::FALSE_TV());
-			}
-		}
-		return CastToValue(TruthValue::TRUE_TV());
-	}
-
 	// Unknown procedure type.
 	throw RuntimeException(TRACE_INFO,
 	     "Cannot evaluate unknown GroundedPredicateNode: %s",
-	      schema.c_str());
+	      get_name().c_str());
 }
 
 DEFINE_NODE_FACTORY(GroundedPredicateNode, GROUNDED_PREDICATE_NODE)

--- a/tests/atoms/core/condlink.scm
+++ b/tests/atoms/core/condlink.scm
@@ -1,4 +1,6 @@
-
+;
+; condlink.scm
+;
 (use-modules (opencog) (opencog exec))
 
 (define single

--- a/tests/query/GreaterThanUTest.cxxtest
+++ b/tests/query/GreaterThanUTest.cxxtest
@@ -54,7 +54,6 @@ public:
 	void setUp(void);
 	void tearDown(void);
 
-	void test_numeric_greater(void);
 	void test_scm_greater(void);
 	void test_builtin_greater(void);
 };
@@ -74,41 +73,7 @@ void GreaterThanUTest::setUp(void)
  * involving NumberNodes, and then verifies that the GreaterThanLink
  * is actually performing the numeric comparison correctly.
  */
-void GreaterThanUTest::test_numeric_greater(void)
-{
-	logger().debug("BEGIN TEST: %s", __FUNCTION__);
-
-	eval->eval("(load-from-path \"tests/query/greater_than.scm\")");
-
-	Handle richer_than_george = eval->eval_h("(richer-than-george)");
-	Handle richer_than_susan = eval->eval_h("(richer-than-susan)");
-	Handle richer_than_obama = eval->eval_h("(richer-than-obama)");
-	Handle richer_than_gates = eval->eval_h("(richer-than-gates)");
-
-	TSM_ASSERT("Failed to load test data", richer_than_george);
-	TSM_ASSERT("Failed to load test data", richer_than_susan);
-	TSM_ASSERT("Failed to load test data", richer_than_obama);
-	TSM_ASSERT("Failed to load test data", richer_than_gates);
-
-	Handle people_richer_than_george = bindlink(as, richer_than_george);
-	Handle people_richer_than_susan = bindlink(as, richer_than_susan);
-	Handle people_richer_than_obama = bindlink(as, richer_than_obama);
-	Handle people_richer_than_gates = bindlink(as, richer_than_gates);
-
-	TSM_ASSERT("Failed to run test", people_richer_than_george);
-	TSM_ASSERT("Failed to run test", people_richer_than_susan);
-	TSM_ASSERT("Failed to run test", people_richer_than_obama);
-	TSM_ASSERT("Failed to run test", people_richer_than_gates);
-
-	TS_ASSERT_EQUALS(0, getarity(people_richer_than_gates));
-	TS_ASSERT_EQUALS(1, getarity(people_richer_than_obama));
-	TS_ASSERT_EQUALS(2, getarity(people_richer_than_george));
-	TS_ASSERT_EQUALS(3, getarity(people_richer_than_susan));
-
-	logger().debug("END TEST: %s", __FUNCTION__);
-}
-
-// Same test as above, but using a scheme func for the compares
+// Uses a scheme func for the compares
 void GreaterThanUTest::test_scm_greater(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);

--- a/tests/query/deduct-rules.scm
+++ b/tests/query/deduct-rules.scm
@@ -16,6 +16,24 @@
 ;; Define simple truth value
 (define (stv mean conf) (cog-new-stv mean conf))
 
+(define (not-same atom-a atom-b)
+	(define ne (not (equal? atom-a atom-b)))
+	(if ne (stv 1 1) (stv 0 1)))
+
+(define (none-same atom-a atom-b atom-c atom-d atom-e)
+	(define ne (and
+		(not (equal? atom-a atom-b))
+		(not (equal? atom-a atom-c))
+		(not (equal? atom-a atom-d))
+		(not (equal? atom-a atom-e))
+		(not (equal? atom-b atom-c))
+		(not (equal? atom-b atom-d))
+		(not (equal? atom-b atom-e))
+		(not (equal? atom-c atom-d))
+		(not (equal? atom-c atom-e))
+		(not (equal? atom-d atom-e))))
+	(if ne (stv 1 1) (stv 0 1)))
+
 ;; Shorthand for the node types
 (define VN VariableNode)
 (define PN PredicateNode)
@@ -47,7 +65,7 @@
 ;; Predicate clause, asserting that v2 and v3 are different atoms.
 (define (differ t2 v2 t3 v3)
 	(EvaluationLink
-		(GroundedPredicateNode "c++:exclusive")
+		(GroundedPredicateNode "scm:not-same")
 		(ListLink
 			(t2 v2)
 			(t3 v3)
@@ -184,7 +202,7 @@
 			(InheritanceLink (VN "$attr_e") (VN "$attr_type"))
 			;; and attributes a,b,c,d,e are all different from one-another
 			(EvaluationLink
-				(GroundedPredicateNode "c++:exclusive")
+				(GroundedPredicateNode "scm:none-same")
 				(ListLink
 					(VN "$attr_a")
 					(VN "$attr_b")

--- a/tests/query/greater_than.scm
+++ b/tests/query/greater_than.scm
@@ -102,34 +102,6 @@
 
 
 ;; -----------------------------------------------------
-;; This variant uses the built-in c++ greater-than code.
-(define cpp-cmp
-	(EvaluationLink
-		(GroundedPredicateNode "c++:greater")
-		(ListLink
-			(VariableNode "$more-wealth")
-			(VariableNode "$less-wealth")
-		)
-	)
-)
-
-(define (richer-than-person-x person-x)
-	(richer-than-person-x-cmp person-x cpp-cmp))
-
-(define (richer-than-gates)
-	(richer-than-person-x (ConceptNode "Bill Gates")))
-
-(define (richer-than-obama)
-	(richer-than-person-x (ConceptNode "Obama")))
-
-(define (richer-than-george)
-	(richer-than-person-x (ConceptNode "George P. from Waxahachie")))
-
-(define (richer-than-susan)
-	(richer-than-person-x (ConceptNode "Susan M. from Peoria")))
-
-
-;; -----------------------------------------------------
 ;; This variant uses a hand-rolled scm compare function
 (define (richer a b)
 	(if (> (cog-number a) (cog-number b))


### PR DESCRIPTION
The C++ grounded predicates are unused except in unit tests. Get rid of them. They're just using up oxygen.