### PR TITLE
Change GroundedPredicates/Schema to lazy evaluation

### DIFF
--- a/opencog/atoms/grounded/GroundedPredicateNode.h
+++ b/opencog/atoms/grounded/GroundedPredicateNode.h
@@ -40,6 +40,7 @@ class GroundedPredicateNode : public GroundedProcedureNode
 {
 	void init();
 	Runner* _runner;
+	bool _eager;
 
 public:
 	GroundedPredicateNode(Type, const std::string);

--- a/opencog/atoms/grounded/GroundedSchemaNode.h
+++ b/opencog/atoms/grounded/GroundedSchemaNode.h
@@ -39,6 +39,7 @@ class Runner;
 class GroundedSchemaNode : public GroundedProcedureNode
 {
 	Runner* _runner;
+	bool _eager;
 	void init();
 
 public:

--- a/opencog/atoms/grounded/LibraryRunner.cc
+++ b/opencog/atoms/grounded/LibraryRunner.cc
@@ -22,7 +22,6 @@
  */
 
 #include <opencog/atoms/atom_types/atom_types.h>
-#include <opencog/atoms/execution/Force.h>
 #include <opencog/atoms/truthvalue/TruthValue.h>
 #include <opencog/atoms/value/Value.h>
 #include <opencog/atomspace/AtomSpace.h>
@@ -61,21 +60,11 @@ static void throwSyntaxException(bool silent, const char* message...)
 /// Expects "args" to be a ListLink. These arguments will be
 ///     substituted into the predicate.
 ///
-/// The arguments are "eager-evaluated", because it is assumed that
-/// the GPN is unaware of the concept of lazy evaluation, and can't
-/// do it itself. The arguments are then inserted into the predicate,
-/// and the predicate as a whole is then evaluated.
-///
 ValuePtr LibraryRunner::execute(AtomSpace* as,
                                const Handle& cargs,
                                bool silent)
 {
-	// Force execution of the arguments. We have to do this, because
-	// the user-defined functions are black-boxes, and cannot be trusted
-	// to do lazy execution correctly. Right now, forcing is the policy.
-	// We could add "scm-lazy:" and "py-lazy:" URI's for user-defined
-	// functions smart enough to do lazy evaluation.
-	Handle args(force_execute(as, cargs, silent));
+	Handle args(as->add_atom(cargs));
 
 	// Convert the void* pointer to the correct function type.
 	Handle* (*func)(AtomSpace*, Handle*);
@@ -104,12 +93,7 @@ ValuePtr LibraryRunner::evaluate(AtomSpace* as,
                                 const Handle& cargs,
                                 bool silent)
 {
-	// Force execution of the arguments. We have to do this, because
-	// the user-defined functions are black-boxes, and cannot be trusted
-	// to do lazy execution correctly. Right now, forcing is the policy.
-	// We could add "scm-lazy:" and "py-lazy:" URI's for user-defined
-	// functions smart enough to do lazy evaluation.
-	Handle args(force_execute(as, cargs, silent));
+	Handle args(as->add_atom(cargs));
 
 	// Convert the void* pointer to the correct function type.
 	TruthValuePtr* (*func)(AtomSpace*, Handle*);

--- a/opencog/atoms/grounded/PythonRunner.cc
+++ b/opencog/atoms/grounded/PythonRunner.cc
@@ -21,9 +21,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/atoms/atom_types/atom_types.h>
-#include <opencog/atoms/execution/Force.h>
-#include <opencog/atoms/truthvalue/TruthValue.h>
 #include <opencog/atoms/value/Value.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/cython/PythonEval.h>
@@ -45,39 +42,30 @@ PythonRunner::PythonRunner(std::string s)
 /// Expects "args" to be a ListLink. These arguments will be
 ///     substituted into the predicate.
 ///
-/// The arguments are "eager-evaluated", because it is assumed that
-/// the GPN is unaware of the concept of lazy evaluation, and can't
-/// do it itself. The arguments are then inserted into the predicate,
-/// and the predicate as a whole is then evaluated.
-///
 ValuePtr PythonRunner::execute(AtomSpace* as,
                                const Handle& cargs,
                                bool silent)
 {
-	// Force execution of the arguments. We have to do this, because
-	// the user-defined functions are black-boxes, and cannot be trusted
-	// to do lazy execution correctly. Right now, forcing is the policy.
-	// We could add "scm-lazy:" and "py-lazy:" URI's for user-defined
-	// functions smart enough to do lazy evaluation.
-	Handle args(force_execute(as, cargs, silent));
+	// If we arrive here from queries or other places, the
+	// argument will not be (in general) in any atomspace.
+	// That's because it was constructed on the fly, and
+	// we're trying to stick to lazy evaluation. But we have
+	// draw the line here: the callee necesssarily expects
+	// arguments to be in the atomspace. So we add now.
+	Handle asargs = as->add_atom(cargs);
 
 	PythonEval* applier = get_evaluator_for_python(as);
 
-	return applier->apply_v(as, _fname, args);
+	return applier->apply_v(as, _fname, asargs);
 }
 
 ValuePtr PythonRunner::evaluate(AtomSpace* as,
                                 const Handle& cargs,
                                 bool silent)
 {
-	// Force execution of the arguments. We have to do this, because
-	// the user-defined functions are black-boxes, and cannot be trusted
-	// to do lazy execution correctly. Right now, forcing is the policy.
-	// We could add "scm-lazy:" and "py-lazy:" URI's for user-defined
-	// functions smart enough to do lazy evaluation.
-	Handle args(force_execute(as, cargs, silent));
+	Handle asargs = as->add_atom(cargs);
 
 	PythonEval* applier = get_evaluator_for_python(as);
 
-	return CastToValue(applier->apply_tv(as, _fname, args));
+	return CastToValue(applier->apply_tv(as, _fname, asargs));
 }

--- a/opencog/atoms/grounded/SCMRunner.cc
+++ b/opencog/atoms/grounded/SCMRunner.cc
@@ -22,7 +22,6 @@
  */
 
 #include <opencog/atoms/atom_types/atom_types.h>
-#include <opencog/atoms/execution/Force.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/guile/SchemeEval.h>
 

--- a/opencog/atoms/grounded/SCMRunner.cc
+++ b/opencog/atoms/grounded/SCMRunner.cc
@@ -62,8 +62,16 @@ ValuePtr SCMRunner::execute(AtomSpace* as,
                             const Handle& cargs,
                             bool silent)
 {
+	// If we arrive here from queries or other places, the
+	// argument will not be (in general) in any atomspace.
+	// That's because it was constructed on the fly, and
+	// we're trying to stick to lazy evaluation. But we have
+	// draw the line here: the callee necesssarily expects
+	// arguments to be in the atomspace. So we add now.
+	Handle asargs = as->add_atom(cargs);
+
 	SchemeEval* applier = get_evaluator_for_scheme(as);
-	ValuePtr vp = applier->apply_v(_fname, cargs);
+	ValuePtr vp = applier->apply_v(_fname, asargs);
 
 	// Hmmm... well, a bad scheme function can end up returning a
 	// null pointer. We can convert this to a VoidValue... or we

--- a/opencog/atoms/grounded/SCMRunner.cc
+++ b/opencog/atoms/grounded/SCMRunner.cc
@@ -62,15 +62,8 @@ ValuePtr SCMRunner::execute(AtomSpace* as,
                             const Handle& cargs,
                             bool silent)
 {
-	// Force execution of the arguments. We have to do this, because
-	// the user-defined functions are black-boxes, and cannot be trusted
-	// to do lazy execution correctly. Right now, forcing is the policy.
-	// We could add "scm-lazy:" and "py-lazy:" URI's for user-defined
-	// functions smart enough to do lazy evaluation.
-	Handle args(force_execute(as, cargs, silent));
-
 	SchemeEval* applier = get_evaluator_for_scheme(as);
-	ValuePtr vp = applier->apply_v(_fname, args);
+	ValuePtr vp = applier->apply_v(_fname, cargs);
 
 	// Hmmm... well, a bad scheme function can end up returning a
 	// null pointer. We can convert this to a VoidValue... or we

--- a/tests/query/ill-put.scm
+++ b/tests/query/ill-put.scm
@@ -29,7 +29,7 @@
   (And
     (Variable "$P")
     (Evaluation
-      (GroundedPredicate "scm: well-formed?")
+      (GroundedPredicate "scm-eager: well-formed?")
       (Variable "$P"))))
 )
 

--- a/tests/query/implication-introduction.scm
+++ b/tests/query/implication-introduction.scm
@@ -25,7 +25,7 @@
          )
       )
       (ExecutionOutputLink
-         (GroundedSchemaNode "scm: dummy")
+         (GroundedSchemaNode "scm-eager: dummy")
          (ListLink
             (QuoteLink
                (LambdaLink
@@ -71,7 +71,7 @@
          )
       )
       (ExecutionOutputLink
-         (GroundedSchemaNode "scm: dummy")
+         (GroundedSchemaNode "scm-eager: dummy")
          (ListLink
             (ImplicationLink
                (VariableNode "$P")

--- a/tests/scm/SCMExecutionOutputUTest.cxxtest
+++ b/tests/scm/SCMExecutionOutputUTest.cxxtest
@@ -329,7 +329,7 @@ void SCMExecutionOutputUTest::test_recursive(void)
 //
 // The following should work:
 //   ExecutionOutputLink
-//       "scm: *"
+//       "scm-eager: *"
 //       ListLink
 //            ExecutionOutputLink
 //                 "scm: +"
@@ -361,7 +361,7 @@ void SCMExecutionOutputUTest::test_nested(void)
 	eval->eval(
 		"(define nestor"
 		"   (ExecutionOutputLink "
-		"      (GroundedSchemaNode \"scm: oc-times\")"
+		"      (GroundedSchemaNode \"scm-eager: oc-times\")"
 		"      (ListLink "
 		"         (ExecutionOutputLink "
 		"            (GroundedSchemaNode \"scm: oc-plus\")"
@@ -622,7 +622,7 @@ void SCMExecutionOutputUTest::test_execute_single_arg(void)
 	result = eval->eval_h(
 	   "(cog-execute!"
 	   "   (ExecutionOutputLink"
-	   "      (GroundedSchema \"scm: single-arg-fun\")"
+	   "      (GroundedSchema \"scm-eager: single-arg-fun\")"
 	   "      (ExecutionOutputLink"
 	   "         (GroundedSchema \"scm: single-arg-fun\")"
 	   "         (Concept \"B\"))))"


### PR DESCRIPTION
Eager Evaluation of grounded scheme has been a thorn in the side for too long.
Get rid of it. Provide a backwards-compat mode, just in case its needed.