### PR TITLE
Remove HandleIterator  (deprecated in C++17)

### DIFF
--- a/opencog/atoms/base/Handle.h
+++ b/opencog/atoms/base/Handle.h
@@ -241,9 +241,6 @@ typedef HandleMap GroundingMap;
 typedef std::vector<GroundingMap> GroundingMapSeq;
 typedef std::vector<GroundingMapSeq> GroundingMapSeqSeq;
 
-//! a handle iterator
-typedef std::iterator<std::forward_iterator_tag, Handle> HandleIterator;
-
 bool content_eq(const opencog::HandleSeq& lhs,
                 const opencog::HandleSeq& rhs);
 


### PR DESCRIPTION
This now generates a compiler warning. Seems like no one uses
it anyway, from what I can tell...