### PR TITLE
Add support for Atom removal via JSON API

### DIFF
--- a/opencog/atoms/atom_types/NameServer.cc
+++ b/opencog/atoms/atom_types/NameServer.cc
@@ -46,7 +46,7 @@ using namespace opencog;
 NameServer::NameServer(void)
 {
 	nTypes = MAX_NUM_VALUE + 1;
-	nValues = 1;
+	nValues = 0;   // TopType is 0  Value is 1
 	_maxDepth = 0;
 	_tmod = 0;
 }

--- a/opencog/atoms/atom_types/atom_types.script
+++ b/opencog/atoms/atom_types/atom_types.script
@@ -18,11 +18,13 @@ NOTYPE
 // Supertype, equivalent to the top type of type theory. Every specific
 // type inherits from this type. See
 // https://en.wikipedia.org/wiki/Top_type
-VALUE
+TOP_TYPE
 
 // --------------------------------------------------------------
 // Values are collections of data that can be associated with atoms.
 // Think of them as decorations that can be hung on an atom.
+VALUE <- TOP_TYPE
+
 VOID_VALUE <- VALUE     // singleton value holding nothing at all.
 BOOL_VALUE <- VALUE     // vector of booleans
 FLOAT_VALUE <- VALUE    // vector of floats

--- a/opencog/persist/json/JSCommands.cc
+++ b/opencog/persist/json/JSCommands.cc
@@ -366,7 +366,7 @@ std::string JSCommands::interpret_command(AtomSpace* as,
 		GET_VALUE;
 
 		as->set_value(h, k, v);
-		return "true";
+		return "true\n";
 	}
 
 	// -----------------------------------------------
@@ -392,13 +392,13 @@ std::string JSCommands::interpret_command(AtomSpace* as,
 		GET_VALUE;
 
 		as->set_truthvalue(h, TruthValueCast(v));
-		return "true";
+		return "true\n";
 	}
 
 	// -----------------------------------------------
 	// AtomSpace.execute({ "type": "PlusLink", "outgoing":
-	//     [{ "type": "NumberNode", "value": "2" },
-	//      { "type": "NumberNode", "value": "2" }] })
+	//     [{ "type": "NumberNode", "name": "2" },
+	//      { "type": "NumberNode", "name": "2" }] })
 	if (execu == act)
 	{
 		CHK_CMD;
@@ -406,6 +406,20 @@ std::string JSCommands::interpret_command(AtomSpace* as,
 
 		ValuePtr vp = h->execute();
 		return Json::encode_value(vp);
+	}
+
+	// -----------------------------------------------
+	// AtomSpace.extract({ "type": "Concept", "name": "foo"}, true)
+	if (extra == act)
+	{
+		CHK_CMD;
+		Handle h = Json::decode_atom(cmd, pos, epos);
+		if (nullptr == h) return "false\n";
+		pos = epos;
+		GET_BOOL;
+		bool ok = as->extract_atom(h, recursive);
+		if (ok) return "true\n";
+		return "false\n";
 	}
 
 	// -----------------------------------------------

--- a/opencog/persist/json/JSCommands.cc
+++ b/opencog/persist/json/JSCommands.cc
@@ -61,11 +61,11 @@ static std::string reterr(const std::string& cmd)
 
 #define GET_BOOL \
 	pos = cmd.find_first_not_of(",) \n\t", pos); \
-	bool get_subtypes = true; \
+	bool recursive = true; \
 	if (std::string::npos != pos and ( \
 			0 == cmd.compare(pos, 1, "0") or \
 			0 == cmd.compare(pos, 5, "false"))) \
-		get_subtypes = false;
+		recursive = false;
 
 #define GET_ATOM(rv) \
 	Handle h = Json::decode_atom(cmd, pos, epos); \
@@ -159,7 +159,7 @@ std::string JSCommands::interpret_command(AtomSpace* as,
 		GET_BOOL;
 
 		std::vector<Type> vect;
-		if (get_subtypes)
+		if (recursive)
 			nameserver().getChildrenRecursive(t, std::back_inserter(vect));
 		else
 			nameserver().getChildren(t, std::back_inserter(vect));
@@ -176,7 +176,7 @@ std::string JSCommands::interpret_command(AtomSpace* as,
 		GET_BOOL;
 
 		std::vector<Type> vect;
-		if (get_subtypes)
+		if (recursive)
 			nameserver().getParentsRecursive(t, std::back_inserter(vect));
 		else
 			nameserver().getParents(t, std::back_inserter(vect));
@@ -193,7 +193,7 @@ std::string JSCommands::interpret_command(AtomSpace* as,
 
 		std::string rv = "[\n";
 		HandleSeq hset;
-		as->get_handles_by_type(hset, t, get_subtypes);
+		as->get_handles_by_type(hset, t, recursive);
 		bool first = true;
 		for (const Handle& h: hset)
 		{

--- a/opencog/persist/json/JSCommands.cc
+++ b/opencog/persist/json/JSCommands.cc
@@ -32,6 +32,7 @@
 #include <opencog/atoms/value/FloatValue.h>
 #include <opencog/atoms/truthvalue/TruthValue.h>
 #include <opencog/atomspace/AtomSpace.h>
+#include <opencog/atomspace/version.h>
 
 #include "JSCommands.h"
 #include "Json.h"
@@ -137,7 +138,7 @@ std::string JSCommands::interpret_command(AtomSpace* as,
 	if (versn == act)
 	{
 		CHK_CMD;
-		return "0.9.1";
+		return ATOMSPACE_VERSION_STRING;
 	}
 
 	// -----------------------------------------------

--- a/opencog/persist/json/JSCommands.cc
+++ b/opencog/persist/json/JSCommands.cc
@@ -61,11 +61,11 @@ static std::string reterr(const std::string& cmd)
 
 #define GET_BOOL \
 	pos = cmd.find_first_not_of(",) \n\t", pos); \
-	bool recursive = true; \
+	bool recursive = false; \
 	if (std::string::npos != pos and ( \
-			0 == cmd.compare(pos, 1, "0") or \
-			0 == cmd.compare(pos, 5, "false"))) \
-		recursive = false;
+			0 == cmd.compare(pos, 1, "1") or \
+			0 == cmd.compare(pos, 4, "true"))) \
+		recursive = true;
 
 #define GET_ATOM(rv) \
 	Handle h = Json::decode_atom(cmd, pos, epos); \
@@ -123,6 +123,7 @@ std::string JSCommands::interpret_command(AtomSpace* as,
 	static const size_t gtval = std::hash<std::string>{}("getValues");
 	static const size_t stval = std::hash<std::string>{}("setValue");
 	static const size_t execu = std::hash<std::string>{}("execute");
+	static const size_t extra = std::hash<std::string>{}("extract");
 
 	// Ignore comments, blank lines
 	if ('/' == cmd[0]) return "";

--- a/opencog/persist/json/README.md
+++ b/opencog/persist/json/README.md
@@ -11,11 +11,9 @@ just enough to interact with the AtomSpace, and nothing more.
 
 Status
 ------
-**Version 0.9.1.** There is just enough here to be usable for basic things.
-Several convenience calls are missing, as well as the ability to run
-arbitrary queries. Adding support for this is **really easy**, and just
-slightly tedious.  The hard part is writing the docs!
-Patches are solicited and will be accepted.
+**Version 0.9.2.** There is enough here to be usable for basic things.
+Support for multiple AtomSpaces is missing.  A convenience call for
+setting multiple values at the same time is missing.
 
 
 Network API

--- a/opencog/persist/json/README.md
+++ b/opencog/persist/json/README.md
@@ -152,7 +152,7 @@ AtomSpace.getSuperTypes("ListLink")
 AtomSpace.getSuperTypes("ListLink", false)
 ```
 
-* Execute an executable Atom
+* Execute an executable Atom.
 ```
 AtomSpace.execute({ "type": "PlusLink",
     "outgoing":
@@ -160,10 +160,18 @@ AtomSpace.execute({ "type": "PlusLink",
          { "type": "NumberNode", "name": "2" }] })
 ```
 
+* Remove (extract) an Atom. By default, the Atom is not removed if it
+  is contained in some Link. Setting the optional boolean flag to `true`
+  forces the recursive extraction of the Atom, and every Link that
+  contains it. Returns false is the atom was not removed or if an error
+  occured (e.g. the Atom does not exist).
+```
+AtomSpace.extract({ "type": "Concept", "name": "foo"}) // fails if not topmost
+AtomSpace.extract({ "type": "Concept", "name": "foo"}, true) // recursive
+```
 
 ### Unimplemented Commands
 * Set multiple values at once -- this would be a nice-to-have utility.
-* Extract atoms
 * Wrapper for cog-evaluate!
 * Multiple AtomSpace support
 

--- a/opencog/persist/json/README.md
+++ b/opencog/persist/json/README.md
@@ -142,10 +142,14 @@ AtomSpace.setValue({ "type": "ConceptNode", "name": "foo", "key": { "type":
 { "type": "CountTruthValue", "value": [7, 8, 9] } } } )
 ```
 
-* Get base and derived types.
+* Get base and derived types.  The optional bool flag indicates whether
+  to get all of the sub/supertypes rescursively, or not.
 ```
-AtomSpace.getSubTypes("Link")
+AtomSpace.getSubTypes("Atom")
+AtomSpace.getSubTypes("Atom", false)
+AtomSpace.getSubTypes("Atom", true)
 AtomSpace.getSuperTypes("ListLink")
+AtomSpace.getSuperTypes("ListLink", false)
 ```
 
 * Execute an executable Atom

--- a/opencog/persist/sexpr/Commands.cc
+++ b/opencog/persist/sexpr/Commands.cc
@@ -78,7 +78,7 @@ Commands::Commands(void)
 	static const size_t value = std::hash<std::string>{}("cog-value");
 	static const size_t dfine = std::hash<std::string>{}("define");
 	static const size_t ping = std::hash<std::string>{}("ping)");
-	static const size_t vers = std::hash<std::string>{}("cog-version)");
+	static const size_t versn = std::hash<std::string>{}("cog-version)");
 
 	using namespace std::placeholders;  // for _1, _2, _3...
 
@@ -102,7 +102,7 @@ Commands::Commands(void)
 	_dispatch_map.insert({value, std::bind(&Commands::cog_value, this, _1)});
 	_dispatch_map.insert({dfine, std::bind(&Commands::cog_define, this, _1)});
 	_dispatch_map.insert({ping, std::bind(&Commands::cog_ping, this, _1)});
-	_dispatch_map.insert({vers, std::bind(&Commands::cog_version, this, _1)});
+	_dispatch_map.insert({versn, std::bind(&Commands::cog_version, this, _1)});
 }
 
 Commands::~Commands()
@@ -475,7 +475,7 @@ std::string Commands::cog_ping(const std::string& cmd)
 // (cog-version) -- AtomSpace version
 std::string Commands::cog_version(const std::string& cmd)
 {
-	return "\"" ATOMSPACE_VERSION_STRING "\"";
+	return ATOMSPACE_VERSION_STRING;
 }
 
 // -----------------------------------------------


### PR DESCRIPTION
Several JSON API updates:
* Add ability to extract atoms
* Make type query optionally recursive.
* Return AtomSpace version number. 