### PR TITLE
Performance: replace reccursive calls by loops

### DIFF
--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -113,7 +113,7 @@ class AtomSpace : public Frame
     Handle add(const Handle&, bool force=false,
                bool recurse=false, bool absent = false);
     Handle check(const Handle&, bool force=false);
-    Handle lookupHide(const Handle&) const;
+    Handle lookupHide(const Handle&, bool hide=false) const;
 
     virtual ContentHash compute_hash() const;
 
@@ -412,7 +412,8 @@ public:
      * If such an atom is in the AtomSpace, or in any of it's parent
      * AtomSpaces, return that Atom. Return the shallowest such Atom.
      */
-    Handle lookupHandle(const Handle&) const;
+    Handle lookupHandle(const Handle& h) const
+    { return lookupHide(h, true); }
 
     /**
      * Get a node from the AtomSpace, if it's in there. If the atom

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -199,9 +199,10 @@ Handle AtomSpace::lookupHandle(const Handle& a) const
 
     size_t esz = _environ.size();
     if (0 == esz) return Handle::UNDEFINED;
+
+    AtomSpacePtr eas = _environ[0];
     while (1 == esz)
     {
-        AtomSpacePtr eas = _environ[0];
         const Handle& h(eas->typeIndex.findAtom(a));
         if (h) {
             if (h->isAbsent()) return Handle::UNDEFINED;
@@ -222,6 +223,8 @@ Handle AtomSpace::lookupHandle(const Handle& a) const
              }
              return Handle::UNDEFINED;
         }
+
+        eas = eas->_environ[0];
     }
 
     // In the case of multiple inheritance, check each merge, until


### PR DESCRIPTION
Improve performance by replacing recursive calls with loops
The recursive calls can go thousands deep; we cannot afford
a stack frame for each.