### PR TITLE
Attempt to decouple scheme evaluator from atomspace

### DIFF
--- a/opencog/cython/opencog/PyScheme.cc
+++ b/opencog/cython/opencog/PyScheme.cc
@@ -55,6 +55,7 @@ std::string opencog::eval_scheme(AtomSpace* as, const std::string &s)
 	OC_ASSERT(nullptr != as, "Cython failed to specify an atomspace!");
 	SchemeEval* evaluator = SchemeEval::get_evaluator(as);
 	evaluator->clear_pending();
+	evaluator->set_scheme_as(as);
 	std::string scheme_return_value = evaluator->eval(s);
 
 	// If there's an error, the scheme_return_value will contain
@@ -83,6 +84,7 @@ ValuePtr opencog::eval_scheme_v(AtomSpace* as, const std::string &s)
 
 	SchemeEval* evaluator = SchemeEval::get_evaluator(as);
 	evaluator->clear_pending();
+	evaluator->set_scheme_as(as);
 	ValuePtr scheme_return_value = evaluator->eval_v(s);
 
 	if (evaluator->eval_error())
@@ -104,6 +106,7 @@ Handle opencog::eval_scheme_h(AtomSpace* as, const std::string &s)
 
 	SchemeEval* evaluator = SchemeEval::get_evaluator(as);
 	evaluator->clear_pending();
+	evaluator->set_scheme_as(as);
 	Handle scheme_return_value = evaluator->eval_h(s);
 
 	if (evaluator->eval_error())

--- a/opencog/guile/SchemeEval.cc
+++ b/opencog/guile/SchemeEval.cc
@@ -92,6 +92,13 @@ void SchemeEval::init(void)
 	_rc = scm_gc_protect_object(_rc);
 
 	_gc_ctr = 0;
+
+	// We expect one evaluator per thread, so set that up now.
+	// More complicated possibilities are too hard to deal with:
+	// evaluated expressions might themselves be setting the
+	// AtomSpace of the thread.
+	if (_atomspace)
+		SchemeSmob::ss_set_env_as(_atomspace);
 }
 
 /// When the user is using the guile shell from within the cogserver,

--- a/opencog/guile/SchemeEval.cc
+++ b/opencog/guile/SchemeEval.cc
@@ -197,6 +197,9 @@ void * SchemeEval::c_wrap_init(void *p)
 
 void SchemeEval::finish(void)
 {
+	// Unset the AtomSpace for this thread.
+	SchemeSmob::ss_set_env_as(nullptr);
+
 	std::lock_guard<std::mutex> lck(init_mtx);
 	scm_gc_unprotect_object(_rc);
 
@@ -625,7 +628,7 @@ void SchemeEval::do_eval(const std::string &expr)
 
 	_input_line += expr;
 
-	if (_atomspace)
+	if (_atomspace and nullptr == SchemeSmob::ss_get_env_as("do_eval"))
 		SchemeSmob::ss_set_env_as(_atomspace);
 
 	redirect_output();
@@ -821,7 +824,7 @@ SCM SchemeEval::do_scm_eval(SCM sexpr, SCM (*evo)(void *))
 	per_thread_init();
 
 	// Set per-thread atomspace variable in the execution environment.
-	if (_atomspace)
+	if (_atomspace) // and nullptr == SchemeSmob::ss_get_env_as("do_scm_eval"))
 		SchemeSmob::ss_set_env_as(_atomspace);
 
 	// If we are running from the cogserver shell, capture all output

--- a/opencog/guile/SchemeEval.cc
+++ b/opencog/guile/SchemeEval.cc
@@ -1216,6 +1216,7 @@ SchemeEval* SchemeEval::get_evaluator(const AtomSpacePtr& asp)
 	SchemeEval* evaluator = get_from_pool();
 	evaluator->_atomspace = asp;
 	issued[asp] = evaluator;
+
 	return evaluator;
 }
 
@@ -1265,7 +1266,7 @@ void SchemeEval::set_scheme_as(AtomSpace* as)
 	scm_with_guile(c_wrap_set_atomspace, as);
 }
 
-void SchemeEval::set_scheme_as(AtomSpacePtr& as)
+void SchemeEval::set_scheme_as(const AtomSpacePtr& as)
 {
 	scm_with_guile(c_wrap_set_atomspace, as.get());
 }

--- a/opencog/guile/SchemeEval.h
+++ b/opencog/guile/SchemeEval.h
@@ -160,7 +160,7 @@ class SchemeEval : public GenericEval
 
 		// Set per-thread global
 		static void set_scheme_as(AtomSpace*);
-		static void set_scheme_as(AtomSpacePtr&);
+		static void set_scheme_as(const AtomSpacePtr&);
 		AtomSpacePtr get_scheme_as(void);
 
 		SchemeEval(AtomSpace* = NULL);

--- a/tests/persist/sql/multi-driver/FetchUTest.cxxtest
+++ b/tests/persist/sql/multi-driver/FetchUTest.cxxtest
@@ -104,6 +104,7 @@ void FetchUTest::setUp(void)
 {
 	_as = createAtomSpace();
 	eval = SchemeEval::get_evaluator(_as);
+	eval->set_scheme_as(_as);
 	kill_data();
 
 	// eval->eval(R"((add-to-load-path "/usr/local/share/opencog/scm"))");
@@ -203,6 +204,7 @@ void FetchUTest::test_stuff(void)
 
 	_as = createAtomSpace();
 	eval = SchemeEval::get_evaluator(_as);
+	eval->set_scheme_as(_as);
 	eval->eval(sql_open);
 	eval->eval(R"((fetch-atom (List (Concept "AAA") (Concept "BBB"))))");
 	eval->eval("(barrier)");
@@ -233,6 +235,7 @@ void FetchUTest::test_stuff(void)
 
 	_as = createAtomSpace();
 	eval = SchemeEval::get_evaluator(_as);
+	eval->set_scheme_as(_as);
 	eval->eval(sql_open);
 
 	// AAA should have been updated, as above.
@@ -273,6 +276,7 @@ void FetchUTest::test_readonly(void)
 
 	_as = createAtomSpace();
 	eval = SchemeEval::get_evaluator(_as);
+	eval->set_scheme_as(_as);
 	eval->eval(sql_open);
 	_as->set_read_only();
 


### PR DESCRIPTION
The old code tied the scheme evaluator to the atomspace. This patch-set attempts to decouple it (so that the use can manage it themselves). The decoupling is incomplete; there's a lot of tricky corner cases that make this hard to do.But it is, perhaps, steps in the right direction.