### PR TITLE
Split out command dispatcher from interpreter.

### DIFF
--- a/opencog/persist/file/fast_load.cc
+++ b/opencog/persist/file/fast_load.cc
@@ -29,7 +29,7 @@
 #include <string>
 
 #include <opencog/atomspace/AtomSpace.h>
-#include <opencog/persist/sexpr/Commands.h>
+#include <opencog/persist/sexpr/Dispatcher.h>
 #include <opencog/persist/sexpr/Sexpr.h>
 
 #include "fast_load.h"
@@ -38,7 +38,7 @@ using namespace opencog;
 
 Handle opencog::parseStream(std::istream& in, AtomSpacePtr asp)
 {
-    Commands cmd;
+    Dispatcher cmd;
     cmd.set_base_space(asp);
     static std::unordered_map<std::string, Handle> ascache; // empty, not currently used.
     Handle h;

--- a/opencog/persist/sexpr/CMakeLists.txt
+++ b/opencog/persist/sexpr/CMakeLists.txt
@@ -3,6 +3,7 @@
 ADD_LIBRARY (sexpr
 	AtomSexpr.cc
 	Commands.cc
+	Dispatcher.cc
 	FrameSexpr.cc
 	SexprEval.cc
 	ValueSexpr.cc
@@ -23,6 +24,7 @@ INSTALL (TARGETS sexpr EXPORT AtomSpaceTargets
 
 INSTALL (FILES
 	Commands.h
+	Dispatcher.h
 	Sexpr.h
 	SexprEval.h
 	DESTINATION "include/opencog/persist/sexpr"

--- a/opencog/persist/sexpr/Commands.cc
+++ b/opencog/persist/sexpr/Commands.cc
@@ -55,54 +55,6 @@ using namespace opencog;
 Commands::Commands(void)
 {
 	_multi_space = false;
-
-	// Fast dispatch. There should be zero hash collisions
-	// here. If there are, we are in trouble. (Well, if there
-	// are collisions, pre-pend the paren, post-pend the space.)
-	static const size_t space = std::hash<std::string>{}("cog-atomspace)");
-	static const size_t clear = std::hash<std::string>{}("cog-atomspace-clear)");
-	static const size_t cache = std::hash<std::string>{}("cog-execute-cache!");
-	static const size_t extra = std::hash<std::string>{}("cog-extract!");
-	static const size_t recur = std::hash<std::string>{}("cog-extract-recursive!");
-
-	static const size_t gtatm = std::hash<std::string>{}("cog-get-atoms");
-	static const size_t incty = std::hash<std::string>{}("cog-incoming-by-type");
-	static const size_t incom = std::hash<std::string>{}("cog-incoming-set");
-	static const size_t keys = std::hash<std::string>{}("cog-keys->alist");
-	static const size_t link = std::hash<std::string>{}("cog-link");
-	static const size_t node = std::hash<std::string>{}("cog-node");
-
-	static const size_t stval = std::hash<std::string>{}("cog-set-value!");
-	static const size_t svals = std::hash<std::string>{}("cog-set-values!");
-	static const size_t settv = std::hash<std::string>{}("cog-set-tv!");
-	static const size_t value = std::hash<std::string>{}("cog-value");
-	static const size_t dfine = std::hash<std::string>{}("define");
-	static const size_t ping = std::hash<std::string>{}("ping)");
-	static const size_t versn = std::hash<std::string>{}("cog-version)");
-
-	using namespace std::placeholders;  // for _1, _2, _3...
-
-	// Hash map to look up method to call
-	_dispatch_map.insert({space, std::bind(&Commands::cog_atomspace, this, _1)});
-	_dispatch_map.insert({clear, std::bind(&Commands::cog_atomspace_clear, this, _1)});
-	_dispatch_map.insert({cache, std::bind(&Commands::cog_execute_cache, this, _1)});
-	_dispatch_map.insert({extra, std::bind(&Commands::cog_extract, this, _1)});
-	_dispatch_map.insert({recur, std::bind(&Commands::cog_extract_recursive, this, _1)});
-
-	_dispatch_map.insert({gtatm, std::bind(&Commands::cog_get_atoms, this, _1)});
-	_dispatch_map.insert({incty, std::bind(&Commands::cog_incoming_by_type, this, _1)});
-	_dispatch_map.insert({incom, std::bind(&Commands::cog_incoming_set, this, _1)});
-	_dispatch_map.insert({keys, std::bind(&Commands::cog_keys_alist, this, _1)});
-	_dispatch_map.insert({link, std::bind(&Commands::cog_link, this, _1)});
-	_dispatch_map.insert({node, std::bind(&Commands::cog_node, this, _1)});
-
-	_dispatch_map.insert({stval, std::bind(&Commands::cog_set_value, this, _1)});
-	_dispatch_map.insert({svals, std::bind(&Commands::cog_set_values, this, _1)});
-	_dispatch_map.insert({settv, std::bind(&Commands::cog_set_tv, this, _1)});
-	_dispatch_map.insert({value, std::bind(&Commands::cog_value, this, _1)});
-	_dispatch_map.insert({dfine, std::bind(&Commands::cog_define, this, _1)});
-	_dispatch_map.insert({ping, std::bind(&Commands::cog_ping, this, _1)});
-	_dispatch_map.insert({versn, std::bind(&Commands::cog_version, this, _1)});
 }
 
 Commands::~Commands()
@@ -112,12 +64,6 @@ Commands::~Commands()
 void Commands::set_base_space(const AtomSpacePtr& asp)
 {
 	_base_space = asp;
-}
-
-void Commands::install_handler(const std::string& idstr, Meth handler)
-{
-	size_t idhash = std::hash<std::string>{}(idstr);
-	_dispatch_map.insert_or_assign(idhash, handler);
 }
 
 /// Search for optional AtomSpace argument in `cmd` at `pos`.
@@ -476,44 +422,6 @@ std::string Commands::cog_ping(const std::string& cmd)
 std::string Commands::cog_version(const std::string& cmd)
 {
 	return ATOMSPACE_VERSION_STRING;
-}
-
-// -----------------------------------------------
-std::string Commands::interpret_command(const std::string& cmd)
-{
-	// Find the command and dispatch
-	size_t pos = cmd.find_first_not_of(" \n\t");
-	if (std::string::npos == pos) return "";
-
-	// Ignore comments
-	if (';' == cmd[pos]) return "";
-
-	if ('(' != cmd[pos])
-		throw SyntaxException(TRACE_INFO, "Badly formed command: %s",
-			cmd.c_str());
-
-	pos ++; // Skip over the open-paren
-
-	size_t epos = cmd.find_first_of(" \n\t", pos);
-	if (std::string::npos == epos)
-		throw SyntaxException(TRACE_INFO, "Not a command: %s",
-			cmd.c_str());
-
-	// Look up the method to call, based on the hash of the command string.
-	size_t action = std::hash<std::string>{}(cmd.substr(pos, epos-pos));
-	const auto& disp = _dispatch_map.find(action);
-
-	if (_dispatch_map.end() != disp)
-	{
-		Meth f = disp->second;
-		pos = cmd.find_first_not_of(" \n\t", epos);
-		if (cmd.npos != pos)
-			return f(cmd.substr(pos));
-		return f(""); // no arguments available.
-	}
-
-	throw SyntaxException(TRACE_INFO, "Command not supported: >>%s<<",
-		cmd.substr(pos, epos-pos).c_str());
 }
 
 // ===================================================================

--- a/opencog/persist/sexpr/Commands.cc
+++ b/opencog/persist/sexpr/Commands.cc
@@ -311,7 +311,7 @@ std::string Commands::cog_set_value(const std::string& cmd, CB_HHV cb)
 // -----------------------------------------------
 // (cog-set-values! (Concept "foo") (AtomSpace "foo")
 //     (alist (cons (Predicate "bar") (stv 0.9 0.8)) ...))
-std::string Commands::cog_set_values(const std::string& cmd)
+std::string Commands::cog_set_values(const std::string& cmd, CB_H cb)
 {
 	size_t pos = 0;
 	Handle h = Sexpr::decode_atom(cmd, pos, _space_map);
@@ -324,6 +324,8 @@ std::string Commands::cog_set_values(const std::string& cmd)
 		h = as->add_atom(h);
 	}
 	Sexpr::decode_slist(h, cmd, pos);
+
+	if (cb) cb(h);
 
 	return "()";
 }

--- a/opencog/persist/sexpr/Commands.cc
+++ b/opencog/persist/sexpr/Commands.cc
@@ -142,22 +142,28 @@ std::string Commands::cog_execute_cache(const std::string& cmd)
 
 // -----------------------------------------------
 // (cog-extract! (Concept "foo"))
-std::string Commands::cog_extract(const std::string& cmd)
+std::string Commands::cog_extract(const std::string& cmd, CB_HB cb)
 {
 	size_t pos = 0;
 	Handle h = _base_space->get_atom(Sexpr::decode_atom(cmd, pos, _space_map));
 	if (nullptr == h) return "#t";
+
+	if (cb) cb(h, false);
+
 	if (_base_space->extract_atom(h, false)) return "#t";
 	return "#f";
 }
 
 // -----------------------------------------------
 // (cog-extract-recursive! (Concept "foo"))
-std::string Commands::cog_extract_recursive(const std::string& cmd)
+std::string Commands::cog_extract_recursive(const std::string& cmd, CB_HB cb)
 {
 	size_t pos = 0;
 	Handle h = _base_space->get_atom(Sexpr::decode_atom(cmd, pos, _space_map));
 	if (nullptr == h) return "#t";
+
+	if (cb) cb(h, true);
+
 	if (_base_space->extract_atom(h, true)) return "#t";
 	return "#f";
 }

--- a/opencog/persist/sexpr/Commands.cc
+++ b/opencog/persist/sexpr/Commands.cc
@@ -333,18 +333,23 @@ std::string Commands::cog_set_values(const std::string& cmd, CB_H cb)
 // -----------------------------------------------
 // (cog-set-tv! (Concept "foo") (stv 1 0))
 // (cog-set-tv! (Concept "foo") (stv 1 0) (AtomSpace "foo"))
-std::string Commands::cog_set_tv(const std::string& cmd)
+std::string Commands::cog_set_tv(const std::string& cmd, CB_HT cb)
 {
 	size_t pos = 0;
 	Handle h = Sexpr::decode_atom(cmd, pos, _space_map);
-	ValuePtr tv = Sexpr::decode_value(cmd, ++pos);
+	ValuePtr vp = Sexpr::decode_value(cmd, ++pos);
 
 	// Search for optional AtomSpace argument
 	AtomSpace* as = get_opt_as(cmd, pos);
 
 	Handle ha = as->add_atom(h);
 	if (nullptr == ha) return "()"; // read-only atomspace.
-	as->set_truthvalue(ha, TruthValueCast(tv));
+
+	TruthValuePtr tvp(TruthValueCast(vp));
+	ha = as->set_truthvalue(ha, tvp);
+
+	if (cb) cb(ha, tvp);
+
 	return "()";
 }
 

--- a/opencog/persist/sexpr/Commands.cc
+++ b/opencog/persist/sexpr/Commands.cc
@@ -196,7 +196,7 @@ std::string Commands::cog_get_atoms(const std::string& cmd)
 
 // -----------------------------------------------
 // (cog-incoming-by-type (Concept "foo") 'ListLink)
-std::string Commands::cog_incoming_by_type(const std::string& cmd)
+std::string Commands::cog_incoming_by_type(const std::string& cmd, CB_HY cb)
 {
 	size_t pos = 0;
 	Handle h = Sexpr::decode_atom(cmd, pos, _space_map);
@@ -205,6 +205,8 @@ std::string Commands::cog_incoming_by_type(const std::string& cmd)
 
 	AtomSpace* as = get_opt_as(cmd, pos);
 	h = as->add_atom(h);
+
+	if (cb) cb(h, t);
 
 	std::string alist = "(";
 	for (const Handle& hi : h->getIncomingSetByType(t))
@@ -216,12 +218,15 @@ std::string Commands::cog_incoming_by_type(const std::string& cmd)
 
 // -----------------------------------------------
 // (cog-incoming-set (Concept "foo"))
-std::string Commands::cog_incoming_set(const std::string& cmd)
+std::string Commands::cog_incoming_set(const std::string& cmd, CB_H cb)
 {
 	size_t pos = 0;
 	Handle h = Sexpr::decode_atom(cmd, pos, _space_map);
 	AtomSpace* as = get_opt_as(cmd, pos);
 	h = as->add_atom(h);
+
+	if (cb) cb(h);
+
 	std::string alist = "(";
 	for (const Handle& hi : h->getIncomingSet())
 		alist += Sexpr::encode_atom(hi);

--- a/opencog/persist/sexpr/Commands.cc
+++ b/opencog/persist/sexpr/Commands.cc
@@ -355,7 +355,7 @@ std::string Commands::cog_set_tv(const std::string& cmd, CB_HT cb)
 
 // -----------------------------------------------
 // (cog-update-value! (Concept "foo") (Predicate "key") (FloatValue 1 2 3))
-std::string Commands::cog_update_value(const std::string& cmd)
+std::string Commands::cog_update_value(const std::string& cmd, CB_HHV cb)
 {
 	size_t pos = 0;
 	Handle atom = Sexpr::decode_atom(cmd, pos, _space_map);
@@ -371,6 +371,8 @@ std::string Commands::cog_update_value(const std::string& cmd)
 
 	FloatValuePtr fvp = FloatValueCast(vp);
 	as->increment_count(atom, key, fvp->value());
+
+	if (cb) cb(atom, key, vp);
 
 	// Return the new value. XXX Why? This just wastes CPU?
 	// ValuePtr vp = atom->getValue(key);

--- a/opencog/persist/sexpr/Commands.cc
+++ b/opencog/persist/sexpr/Commands.cc
@@ -289,7 +289,7 @@ std::string Commands::cog_link(const std::string& cmd)
 
 // -----------------------------------------------
 // (cog-set-value! (Concept "foo") (Predicate "key") (FloatValue 1 2 3))
-std::string Commands::cog_set_value(const std::string& cmd)
+std::string Commands::cog_set_value(const std::string& cmd, CB_HHV cb)
 {
 	size_t pos = 0;
 	Handle atom = Sexpr::decode_atom(cmd, pos, _space_map);
@@ -302,6 +302,9 @@ std::string Commands::cog_set_value(const std::string& cmd)
 	if (vp)
 		vp = Sexpr::add_atoms(as, vp);
 	as->set_value(atom, key, vp);
+
+	if (cb) cb(atom, key, vp);
+
 	return "()";
 }
 

--- a/opencog/persist/sexpr/Commands.h
+++ b/opencog/persist/sexpr/Commands.h
@@ -36,6 +36,9 @@ namespace opencog
 
 class Commands
 {
+public:
+	typedef std::function<void (const Handle&, const Handle&, const ValuePtr&)> CB_HHV;
+
 protected:
 	/// True, if the _space_map below is being used, and AtomSpaces need
 	/// to be sent and received.
@@ -75,7 +78,7 @@ public:
 	std::string cog_link(const std::string&);
 	std::string cog_node(const std::string&);
 
-	std::string cog_set_value(const std::string&);
+	std::string cog_set_value(const std::string&, CB_HHV=nullptr);
 	std::string cog_set_values(const std::string&);
 	std::string cog_set_tv(const std::string&);
 	std::string cog_value(const std::string&);

--- a/opencog/persist/sexpr/Commands.h
+++ b/opencog/persist/sexpr/Commands.h
@@ -23,7 +23,7 @@
 #ifndef _COMMANDS_H
 #define _COMMANDS_H
 
-#include <functional>
+#include <map>
 #include <string>
 
 namespace opencog
@@ -36,9 +36,6 @@ class AtomSpace;
 
 class Commands
 {
-public:
-	typedef std::function<std::string (const std::string&)> Meth;
-
 protected:
 	/// True, if the _space_map below is being used, and AtomSpaces need
 	/// to be sent and received.
@@ -46,9 +43,6 @@ protected:
 
 	/// Map from string AtomSpace names to the matching AtomSpacePtr's
 	std::unordered_map<std::string, Handle> _space_map;
-
-	/// Map to dispatch table
-	std::unordered_map<size_t, Meth> _dispatch_map;
 
 	AtomSpace* get_opt_as(const std::string&, size_t&);
 
@@ -60,7 +54,14 @@ protected:
 	/// not free the frame immediattely after it is created.
 	AtomSpacePtr top_space;
 
-	/// Methods that implement each of the interpreted commands, below.
+public:
+	Commands(void);
+	~Commands();
+
+	// Indicate which AtomSpace to use
+	void set_base_space(const AtomSpacePtr&);
+
+	/// Methods that implement each of the interpreted commands.
 	std::string cog_atomspace(const std::string&);
 	std::string cog_atomspace_clear(const std::string&);
 	std::string cog_execute_cache(const std::string&);
@@ -82,50 +83,6 @@ protected:
 	std::string cog_define(const std::string&);
 	std::string cog_ping(const std::string&);
 	std::string cog_version(const std::string&);
-
-public:
-	Commands(void);
-	~Commands();
-
-	// Indicate which AtomSpace to use
-	void set_base_space(const AtomSpacePtr&);
-
-	/// Interpret a very small subset of singular scheme commands.
-	/// This is an ultra-minimalistic command interpreter. It only
-	/// supports those commands needed for network I/O of AtomSpace
-	/// contents (The cogserver uses this to provide peer AtomSpace
-	/// network services). The goal is to provide much higher
-	/// performance than what is possible through the guile interfaces.
-	///
-	/// The supported commands are:
-	///    cog-atomspace-clear
-	///    cog-execute-cache!
-	///    cog-extract!
-	///    cog-extract-recursive!
-	///    cog-get-atoms
-	///    cog-incoming-by-type
-	///    cog-incoming-set
-	///    cog-keys->alist
-	///    cog-link
-	///    cog-node
-	///    cog-set-value!
-	///    cog-set-values!
-	///    cog-set-tv!
-	///    cog-update-value!
-	///    cog-value
-	///    ping
-	///
-	/// They MUST appear only once in the string, at the very beginning,
-	/// and they MUST be followed by valid Atomese s-expressions, and
-	/// nothing else.
-	///
-	std::string interpret_command(const std::string&);
-
-	/// Install a callback handler, over-riding the default behavior for
-	/// the command interpreter. This allows proxy agents to over-ride the
-	/// default interpretation of any message that is received, so as to do
-	/// ... something different. Anything different.
-	void install_handler(const std::string&, Meth);
 };
 
 /** @}*/

--- a/opencog/persist/sexpr/Commands.h
+++ b/opencog/persist/sexpr/Commands.h
@@ -83,8 +83,8 @@ public:
 	std::string cog_set_value(const std::string&, CB_HHV=nullptr);
 	std::string cog_set_values(const std::string&, CB_H=nullptr);
 	std::string cog_set_tv(const std::string&, CB_HT=nullptr);
+	std::string cog_update_value(const std::string&, CB_HHV=nullptr);
 	std::string cog_value(const std::string&);
-	std::string cog_update_value(const std::string&);
 	std::string cog_define(const std::string&);
 	std::string cog_ping(const std::string&);
 	std::string cog_version(const std::string&);

--- a/opencog/persist/sexpr/Commands.h
+++ b/opencog/persist/sexpr/Commands.h
@@ -38,6 +38,7 @@ class Commands
 {
 public:
 	typedef std::function<void (const Handle&)> CB_H;
+	typedef std::function<void (const Handle&, bool)> CB_HB;
 	typedef std::function<void (const Handle&, const TruthValuePtr&)> CB_HT;
 	typedef std::function<void (const Handle&, const Handle&, const ValuePtr&)> CB_HHV;
 
@@ -70,8 +71,8 @@ public:
 	std::string cog_atomspace(const std::string&);
 	std::string cog_atomspace_clear(const std::string&);
 	std::string cog_execute_cache(const std::string&);
-	std::string cog_extract(const std::string&);
-	std::string cog_extract_recursive(const std::string&);
+	std::string cog_extract(const std::string&, CB_HB=nullptr);
+	std::string cog_extract_recursive(const std::string&, CB_HB=nullptr);
 
 	std::string cog_get_atoms(const std::string&);
 	std::string cog_incoming_by_type(const std::string&);

--- a/opencog/persist/sexpr/Commands.h
+++ b/opencog/persist/sexpr/Commands.h
@@ -40,6 +40,7 @@ public:
 	typedef std::function<void (const Handle&)> CB_H;
 	typedef std::function<void (const Handle&, bool)> CB_HB;
 	typedef std::function<void (const Handle&, const TruthValuePtr&)> CB_HT;
+	typedef std::function<void (const Handle&, Type)> CB_HY;
 	typedef std::function<void (const Handle&, const Handle&, const ValuePtr&)> CB_HHV;
 
 protected:
@@ -75,8 +76,8 @@ public:
 	std::string cog_extract_recursive(const std::string&, CB_HB=nullptr);
 
 	std::string cog_get_atoms(const std::string&);
-	std::string cog_incoming_by_type(const std::string&);
-	std::string cog_incoming_set(const std::string&);
+	std::string cog_incoming_by_type(const std::string&, CB_HY=nullptr);
+	std::string cog_incoming_set(const std::string&, CB_H=nullptr);
 	std::string cog_keys_alist(const std::string&);
 	std::string cog_link(const std::string&);
 	std::string cog_node(const std::string&);

--- a/opencog/persist/sexpr/Commands.h
+++ b/opencog/persist/sexpr/Commands.h
@@ -38,6 +38,7 @@ class Commands
 {
 public:
 	typedef std::function<void (const Handle&)> CB_H;
+	typedef std::function<void (const Handle&, const TruthValuePtr&)> CB_HT;
 	typedef std::function<void (const Handle&, const Handle&, const ValuePtr&)> CB_HHV;
 
 protected:
@@ -81,7 +82,7 @@ public:
 
 	std::string cog_set_value(const std::string&, CB_HHV=nullptr);
 	std::string cog_set_values(const std::string&, CB_H=nullptr);
-	std::string cog_set_tv(const std::string&);
+	std::string cog_set_tv(const std::string&, CB_HT=nullptr);
 	std::string cog_value(const std::string&);
 	std::string cog_update_value(const std::string&);
 	std::string cog_define(const std::string&);

--- a/opencog/persist/sexpr/Commands.h
+++ b/opencog/persist/sexpr/Commands.h
@@ -26,13 +26,13 @@
 #include <map>
 #include <string>
 
+#include <opencog/atomspace/AtomSpace.h>
+
 namespace opencog
 {
 /** \addtogroup grp_persist
  *  @{
  */
-
-class AtomSpace;
 
 class Commands
 {

--- a/opencog/persist/sexpr/Commands.h
+++ b/opencog/persist/sexpr/Commands.h
@@ -37,6 +37,7 @@ namespace opencog
 class Commands
 {
 public:
+	typedef std::function<void (const Handle&)> CB_H;
 	typedef std::function<void (const Handle&, const Handle&, const ValuePtr&)> CB_HHV;
 
 protected:
@@ -79,7 +80,7 @@ public:
 	std::string cog_node(const std::string&);
 
 	std::string cog_set_value(const std::string&, CB_HHV=nullptr);
-	std::string cog_set_values(const std::string&);
+	std::string cog_set_values(const std::string&, CB_H=nullptr);
 	std::string cog_set_tv(const std::string&);
 	std::string cog_value(const std::string&);
 	std::string cog_update_value(const std::string&);

--- a/opencog/persist/sexpr/Dispatcher.cc
+++ b/opencog/persist/sexpr/Dispatcher.cc
@@ -1,0 +1,291 @@
+/*
+ * Dispatcher.cc
+ * Dispatcher for a command interpreter for basic AtomSpace commands.
+ *
+ * Copyright (C) 2020, 2022 Linas Vepstas
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <time.h>
+
+#include <functional>
+#include <iomanip>
+#include <string>
+
+#include "Dispatcher.h"
+#include "Commands.h"
+
+using namespace opencog;
+
+/// The cogserver provides a network API to send/receive Atoms over
+/// the internet. The actual API is that of the StorageNode (see the
+/// wiki page https://wiki.opencog.org/w/StorageNode for details.)
+/// The cogserver supports the full `StorageNode` API, and it uses
+/// the code in this directory in order to make it fast.
+///
+/// To aid in performance, a very special set of about 15 scheme
+/// functions have been hard-coded in C++, in the static function
+/// `Commands::interpret_command()` below.  The goal is to avoid the
+/// overhead of entry/exit into guile. This works because the cogserver
+/// is guaranteed to send only these commands, and no others.
+//
+
+Dispatcher::Dispatcher(void)
+{
+	// Fast dispatch. There should be zero hash collisions
+	// here. If there are, we are in trouble. (Well, if there
+	// are collisions, pre-pend the paren, post-pend the space.)
+	static const size_t space = std::hash<std::string>{}("cog-atomspace)");
+	static const size_t clear = std::hash<std::string>{}("cog-atomspace-clear)");
+	static const size_t cache = std::hash<std::string>{}("cog-execute-cache!");
+	static const size_t extra = std::hash<std::string>{}("cog-extract!");
+	static const size_t recur = std::hash<std::string>{}("cog-extract-recursive!");
+
+	static const size_t gtatm = std::hash<std::string>{}("cog-get-atoms");
+	static const size_t incty = std::hash<std::string>{}("cog-incoming-by-type");
+	static const size_t incom = std::hash<std::string>{}("cog-incoming-set");
+	static const size_t keys = std::hash<std::string>{}("cog-keys->alist");
+	static const size_t link = std::hash<std::string>{}("cog-link");
+	static const size_t node = std::hash<std::string>{}("cog-node");
+
+	static const size_t stval = std::hash<std::string>{}("cog-set-value!");
+	static const size_t svals = std::hash<std::string>{}("cog-set-values!");
+	static const size_t settv = std::hash<std::string>{}("cog-set-tv!");
+	static const size_t value = std::hash<std::string>{}("cog-value");
+	static const size_t dfine = std::hash<std::string>{}("define");
+	static const size_t ping = std::hash<std::string>{}("ping)");
+	static const size_t versn = std::hash<std::string>{}("cog-version)");
+
+	using namespace std::placeholders;  // for _1, _2, _3...
+
+	// Hash map to look up method to call
+	_dispatch_map.insert({space, std::bind(&Dispatcher::cog_atomspace, this, _1)});
+	_dispatch_map.insert({clear, std::bind(&Dispatcher::cog_atomspace_clear, this, _1)});
+	_dispatch_map.insert({cache, std::bind(&Dispatcher::cog_execute_cache, this, _1)});
+	_dispatch_map.insert({extra, std::bind(&Dispatcher::cog_extract, this, _1)});
+	_dispatch_map.insert({recur, std::bind(&Dispatcher::cog_extract_recursive, this, _1)});
+
+	_dispatch_map.insert({gtatm, std::bind(&Dispatcher::cog_get_atoms, this, _1)});
+	_dispatch_map.insert({incty, std::bind(&Dispatcher::cog_incoming_by_type, this, _1)});
+	_dispatch_map.insert({incom, std::bind(&Dispatcher::cog_incoming_set, this, _1)});
+	_dispatch_map.insert({keys, std::bind(&Dispatcher::cog_keys_alist, this, _1)});
+	_dispatch_map.insert({link, std::bind(&Dispatcher::cog_link, this, _1)});
+	_dispatch_map.insert({node, std::bind(&Dispatcher::cog_node, this, _1)});
+
+	_dispatch_map.insert({stval, std::bind(&Dispatcher::cog_set_value, this, _1)});
+	_dispatch_map.insert({svals, std::bind(&Dispatcher::cog_set_values, this, _1)});
+	_dispatch_map.insert({settv, std::bind(&Dispatcher::cog_set_tv, this, _1)});
+	_dispatch_map.insert({value, std::bind(&Dispatcher::cog_value, this, _1)});
+	_dispatch_map.insert({dfine, std::bind(&Dispatcher::cog_define, this, _1)});
+	_dispatch_map.insert({ping, std::bind(&Dispatcher::cog_ping, this, _1)});
+	_dispatch_map.insert({versn, std::bind(&Dispatcher::cog_version, this, _1)});
+}
+
+Dispatcher::~Dispatcher()
+{
+}
+
+void Dispatcher::install_handler(const std::string& idstr, Meth handler)
+{
+	size_t idhash = std::hash<std::string>{}(idstr);
+	_dispatch_map.insert_or_assign(idhash, handler);
+}
+
+// -----------------------------------------------
+
+std::string Dispatcher::interpret_command(const std::string& cmd)
+{
+	// Find the command and dispatch
+	size_t pos = cmd.find_first_not_of(" \n\t");
+	if (std::string::npos == pos) return "";
+
+	// Ignore comments
+	if (';' == cmd[pos]) return "";
+
+	if ('(' != cmd[pos])
+		throw SyntaxException(TRACE_INFO, "Badly formed command: %s",
+			cmd.c_str());
+
+	pos ++; // Skip over the open-paren
+
+	size_t epos = cmd.find_first_of(" \n\t", pos);
+	if (std::string::npos == epos)
+		throw SyntaxException(TRACE_INFO, "Not a command: %s",
+			cmd.c_str());
+
+	// Look up the method to call, based on the hash of the command string.
+	size_t action = std::hash<std::string>{}(cmd.substr(pos, epos-pos));
+	const auto& disp = _dispatch_map.find(action);
+
+	if (_dispatch_map.end() != disp)
+	{
+		Meth f = disp->second;
+		pos = cmd.find_first_not_of(" \n\t", epos);
+		if (cmd.npos != pos)
+			return f(cmd.substr(pos));
+		return f(""); // no arguments available.
+	}
+
+	throw SyntaxException(TRACE_INFO, "Command not supported: >>%s<<",
+		cmd.substr(pos, epos-pos).c_str());
+}
+
+// -----------------------------------------------
+// Frame support
+void Dispatcher::set_base_space(const AtomSpacePtr& asp)
+{
+	_default.set_base_space(asp);
+}
+
+// -----------------------------------------------
+// (cog-atomspace)
+std::string Dispatcher::cog_atomspace(const std::string& arg)
+{
+	return _default.cog_atomspace(arg);
+}
+
+// -----------------------------------------------
+// (cog-atomspace-clear)
+std::string Dispatcher::cog_atomspace_clear(const std::string& arg)
+{
+	return _default.cog_atomspace_clear(arg);
+}
+
+// -----------------------------------------------
+// (cog-execute-cache! (GetLink ...) (Predicate "key") ...)
+// This is complicated, and subject to change...
+std::string Dispatcher::cog_execute_cache(const std::string& cmd)
+{
+	return _default.cog_execute_cache(cmd);
+}
+
+// -----------------------------------------------
+// (cog-extract! (Concept "foo"))
+std::string Dispatcher::cog_extract(const std::string& cmd)
+{
+	return _default.cog_extract(cmd);
+}
+
+// -----------------------------------------------
+// (cog-extract-recursive! (Concept "foo"))
+std::string Dispatcher::cog_extract_recursive(const std::string& cmd)
+{
+	return _default.cog_extract_recursive(cmd);
+}
+
+// -----------------------------------------------
+// (cog-get-atoms 'Node #t)
+std::string Dispatcher::cog_get_atoms(const std::string& cmd)
+{
+	return _default.cog_get_atoms(cmd);
+}
+
+// -----------------------------------------------
+// (cog-incoming-by-type (Concept "foo") 'ListLink)
+std::string Dispatcher::cog_incoming_by_type(const std::string& cmd)
+{
+	return _default.cog_incoming_by_type(cmd);
+}
+
+// -----------------------------------------------
+// (cog-incoming-set (Concept "foo"))
+std::string Dispatcher::cog_incoming_set(const std::string& cmd)
+{
+	return _default.cog_incoming_set(cmd);
+}
+
+// -----------------------------------------------
+// (cog-keys->alist (Concept "foo"))
+std::string Dispatcher::cog_keys_alist(const std::string& cmd)
+{
+	return _default.cog_keys_alist(cmd);
+}
+
+// -----------------------------------------------
+// (cog-node 'Concept "foobar")
+std::string Dispatcher::cog_node(const std::string& cmd)
+{
+	return _default.cog_node(cmd);
+}
+
+// -----------------------------------------------
+// (cog-link 'ListLink (Atom) (Atom) (Atom))
+std::string Dispatcher::cog_link(const std::string& cmd)
+{
+	return _default.cog_link(cmd);
+}
+
+// -----------------------------------------------
+// (cog-set-value! (Concept "foo") (Predicate "key") (FloatValue 1 2 3))
+std::string Dispatcher::cog_set_value(const std::string& cmd)
+{
+	return _default.cog_set_value(cmd);
+}
+
+// -----------------------------------------------
+// (cog-set-values! (Concept "foo") (AtomSpace "foo")
+//     (alist (cons (Predicate "bar") (stv 0.9 0.8)) ...))
+std::string Dispatcher::cog_set_values(const std::string& cmd)
+{
+	return _default.cog_set_values(cmd);
+}
+
+// -----------------------------------------------
+// (cog-set-tv! (Concept "foo") (stv 1 0))
+// (cog-set-tv! (Concept "foo") (stv 1 0) (AtomSpace "foo"))
+std::string Dispatcher::cog_set_tv(const std::string& cmd)
+{
+	return _default.cog_set_tv(cmd);
+}
+
+// -----------------------------------------------
+// (cog-update-value! (Concept "foo") (Predicate "key") (FloatValue 1 2 3))
+std::string Dispatcher::cog_update_value(const std::string& cmd)
+{
+	return _default.cog_update_value(cmd);
+}
+
+// -----------------------------------------------
+// (cog-value (Concept "foo") (Predicate "key"))
+std::string Dispatcher::cog_value(const std::string& cmd)
+{
+	return _default.cog_value(cmd);
+}
+
+// -----------------------------------------------
+// (define sym (AtomSpace "foo" (AtomSpace "bar") (AtomSpace "baz")))
+// Place the current atomspace at the bottom of the hierarchy.
+std::string Dispatcher::cog_define(const std::string& cmd)
+{
+	return _default.cog_define(cmd);
+}
+
+// -----------------------------------------------
+// (ping) -- network ping
+std::string Dispatcher::cog_ping(const std::string& cmd)
+{
+	return _default.cog_ping(cmd);
+}
+
+// -----------------------------------------------
+// (cog-version) -- AtomSpace version
+std::string Dispatcher::cog_version(const std::string& cmd)
+{
+	return _default.cog_version(cmd);
+}
+
+// ===================================================================

--- a/opencog/persist/sexpr/Dispatcher.h
+++ b/opencog/persist/sexpr/Dispatcher.h
@@ -26,6 +26,8 @@
 #include <functional>
 #include <string>
 
+#include <opencog/persist/sexpr/Commands.h>
+
 namespace opencog
 {
 /** \addtogroup grp_persist

--- a/opencog/persist/sexpr/Dispatcher.h
+++ b/opencog/persist/sexpr/Dispatcher.h
@@ -1,0 +1,119 @@
+/*
+ * Dispatcher.h
+ * Dispatcher for command interpreter.
+ *
+ * Copyright (C) 2020, 2022 Linas Vepstas
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef _DISPATCHER_H
+#define _DISPATCHER_H
+
+#include <functional>
+#include <string>
+
+namespace opencog
+{
+/** \addtogroup grp_persist
+ *  @{
+ */
+
+class AtomSpace;
+
+class Dispatcher
+{
+public:
+	typedef std::function<std::string (const std::string&)> Meth;
+
+protected:
+	Commands _default;
+
+	/// Map to dispatch table
+	std::unordered_map<size_t, Meth> _dispatch_map;
+
+	/// Methods that implement each of the interpreted commands, below.
+	std::string cog_atomspace(const std::string&);
+	std::string cog_atomspace_clear(const std::string&);
+	std::string cog_execute_cache(const std::string&);
+	std::string cog_extract(const std::string&);
+	std::string cog_extract_recursive(const std::string&);
+
+	std::string cog_get_atoms(const std::string&);
+	std::string cog_incoming_by_type(const std::string&);
+	std::string cog_incoming_set(const std::string&);
+	std::string cog_keys_alist(const std::string&);
+	std::string cog_link(const std::string&);
+	std::string cog_node(const std::string&);
+
+	std::string cog_set_value(const std::string&);
+	std::string cog_set_values(const std::string&);
+	std::string cog_set_tv(const std::string&);
+	std::string cog_value(const std::string&);
+	std::string cog_update_value(const std::string&);
+	std::string cog_define(const std::string&);
+	std::string cog_ping(const std::string&);
+	std::string cog_version(const std::string&);
+
+public:
+	Dispatcher(void);
+	~Dispatcher();
+
+	// Indicate which AtomSpace to use
+	void set_base_space(const AtomSpacePtr&);
+
+	/// Interpret a very small subset of singular scheme commands.
+	/// This is an ultra-minimalistic command interpreter. It only
+	/// supports those commands needed for network I/O of AtomSpace
+	/// contents (The cogserver uses this to provide peer AtomSpace
+	/// network services). The goal is to provide much higher
+	/// performance than what is possible through the guile interfaces.
+	///
+	/// The supported commands are:
+	///    cog-atomspace-clear
+	///    cog-execute-cache!
+	///    cog-extract!
+	///    cog-extract-recursive!
+	///    cog-get-atoms
+	///    cog-incoming-by-type
+	///    cog-incoming-set
+	///    cog-keys->alist
+	///    cog-link
+	///    cog-node
+	///    cog-set-value!
+	///    cog-set-values!
+	///    cog-set-tv!
+	///    cog-update-value!
+	///    cog-value
+	///    ping
+	///
+	/// They MUST appear only once in the string, at the very beginning,
+	/// and they MUST be followed by valid Atomese s-expressions, and
+	/// nothing else.
+	///
+	std::string interpret_command(const std::string&);
+
+	/// Install a callback handler, over-riding the default behavior for
+	/// the command interpreter. This allows proxy agents to over-ride the
+	/// default interpretation of any message that is received, so as to do
+	/// ... something different. Anything different.
+	void install_handler(const std::string&, Meth);
+};
+
+/** @}*/
+} // namespace opencog
+
+#endif // _DISPATCHER_H

--- a/opencog/persist/sexpr/README.md
+++ b/opencog/persist/sexpr/README.md
@@ -138,11 +138,12 @@ needs to be written to or read from disk. The proxy agent determines
 what is to be done.
 
 To implement the proxy, one needs to intercept network commands, as they
-come in. This spot is the `interpret_command()` method in `Commands.cc`.
-The `class Command` maintains a table of functions to be called, one for
+come in. This spot is the `interpret_command()` method in `Dispatcher.cc`.
+The `class Dispatcher` maintains a table of functions to be called, one for
 each network command.  By altering this table and installing command
 handlers other than the default handlers, the proxy agent can respond
-in some custom fashion.
+in some custom fashion. The `class Commands` provides some default
+decoders.
 
 For example, if the CogServer receives a command to put an Atom into the
 AtomSpace, it can then immediately push it out to any open `StorageNode`s,
@@ -154,7 +155,7 @@ For details, see https://github.com/opencog/atomspace-agents
 
 Status & TODO
 -------------
-***Version 1.0.1*** -- Everything works, has withstood the test of time.
+***Version 1.0.2*** -- Everything works, has withstood the test of time.
 
 However -- multi-atomspace (frame) support is missing. Some basic work
 in this direction has been done, but it is not been completed.  The

--- a/opencog/persist/sexpr/SexprEval.cc
+++ b/opencog/persist/sexpr/SexprEval.cc
@@ -23,14 +23,14 @@
 
 #include <opencog/util/Logger.h>
 #include <opencog/atomspace/AtomSpace.h>
-#include <opencog/persist/sexpr/Commands.h>
+#include <opencog/persist/sexpr/Dispatcher.h>
 
 #include "SexprEval.h"
 
 using namespace opencog;
 
 // Single shared instance holding single shared frame cache.
-Commands SexprEval::_interpreter;
+Dispatcher SexprEval::_interpreter;
 
 SexprEval::SexprEval(const AtomSpacePtr& asp)
 	: GenericEval()

--- a/opencog/persist/sexpr/SexprEval.h
+++ b/opencog/persist/sexpr/SexprEval.h
@@ -27,7 +27,7 @@
 #include <string>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/eval/GenericEval.h>
-#include <opencog/persist/sexpr/Commands.h>
+#include <opencog/persist/sexpr/Dispatcher.h>
 
 /**
  * The SexprEval class implements a very simple API for s-exprssion
@@ -50,7 +50,7 @@ class SexprEval : public GenericEval
 		// Static, so that there is a singleton instance shared by
 		// by all threads. Specifically, the frame cache needs to
 		// be shared by all.
-		static Commands _interpreter;
+		static Dispatcher _interpreter;
 
 		// poll_result() is called in a different thread
 		// than eval_expr() and the result is that _answer
@@ -73,7 +73,7 @@ class SexprEval : public GenericEval
 			AtomSpacePtr asp(AtomSpaceCast(as));
 			return get_evaluator(asp); }
 
-		void install_handler(const std::string& cmd, Commands::Meth impl) {
+		void install_handler(const std::string& cmd, Dispatcher::Meth impl) {
 			_interpreter.install_handler(cmd, impl);
 		}
 };

--- a/tests/persist/sexpr/CommandsUTest.cxxtest
+++ b/tests/persist/sexpr/CommandsUTest.cxxtest
@@ -29,7 +29,7 @@
 #include <opencog/atoms/truthvalue/SimpleTruthValue.h>
 #include <opencog/atoms/truthvalue/CountTruthValue.h>
 
-#include "opencog/persist/sexpr/Commands.h"
+#include "opencog/persist/sexpr/Dispatcher.h"
 
 using namespace opencog;
 
@@ -69,7 +69,7 @@ void CommandsUTest::test_node()
 
 	std::string in = R"((cog-node 'Concept "foo"))";
 
-	Commands com;
+	Dispatcher com;
 	com.set_base_space(as);
 	std::string out = com.interpret_command(in);
 	printf("Got %s\n", out.c_str());
@@ -96,7 +96,7 @@ void CommandsUTest::test_node_quoted()
 	std::string in = ss.str();
 	printf("Input %s\n", in.c_str());
 
-	Commands com;
+	Dispatcher com;
 	com.set_base_space(as);
 	std::string out = com.interpret_command(in);
 	printf("Got %s\n", out.c_str());
@@ -130,7 +130,7 @@ void CommandsUTest::test_link()
 
 	std::string in = R"((cog-link 'List (Concept "a") (Concept "b")))";
 
-	Commands com;
+	Dispatcher com;
 	com.set_base_space(as);
 	std::string out = com.interpret_command(in);
 	printf("Got %s\n", out.c_str());
@@ -156,7 +156,7 @@ void CommandsUTest::test_set_tv()
 
 	std::string in = R"((cog-set-tv! (Concept "a") (stv 1 0)))";
 
-	Commands com;
+	Dispatcher com;
 	com.set_base_space(as);
 	std::string out = com.interpret_command(in);
 	printf("Got %s\n", out.c_str());
@@ -190,7 +190,7 @@ void CommandsUTest::test_set_value()
 	std::string in =
 		R"((cog-set-value! (Concept "a") (Predicate "key") (stv 0.6 0.8)))";
 
-	Commands com;
+	Dispatcher com;
 	com.set_base_space(as);
 	std::string out = com.interpret_command(in);
 	printf("Got %s\n", out.c_str());
@@ -222,7 +222,7 @@ void CommandsUTest::test_set_value_quoted()
 	std::string in = ss.str();
 	printf("Input %s\n", in.c_str());
 
-	Commands com;
+	Dispatcher com;
 	com.set_base_space(as);
 	std::string out = com.interpret_command(in);
 	printf("Got %s\n", out.c_str());
@@ -268,7 +268,7 @@ void CommandsUTest::test_get_value()
 	h->setValue(buz, ValueCast(createSimpleTruthValue(0.3, 0.4)));
 
 	std::string in = "(cog-value (Concept \"a\") (Predicate \"key\"))";
-	Commands com;
+	Dispatcher com;
 	com.set_base_space(as);
 	std::string out = com.interpret_command(in);
 	printf("Got %s\n", out.c_str());
@@ -303,7 +303,7 @@ void CommandsUTest::test_get_value_quoted()
 	h->setValue(buz, ValueCast(createSimpleTruthValue(0.3, 0.4)));
 
 	std::string in = "(cog-value (Concept \"a\") (Predicate \"fiz\"))";
-	Commands com;
+	Dispatcher com;
 	com.set_base_space(as);
 	std::string out = com.interpret_command(in);
 	printf("Got    %s\n", out.c_str());
@@ -330,7 +330,7 @@ void CommandsUTest::test_set_values()
 		"(cons (Predicate \"fiz\") (FloatValue 1 2 3))"
 		"(cons (Predicate \"buz\") (StringValue \"gee\" \"golly\"))))";
 
-	Commands com;
+	Dispatcher com;
 	com.set_base_space(as);
 	std::string out = com.interpret_command(in);
 	printf("Got %s\n", out.c_str());
@@ -384,7 +384,7 @@ void CommandsUTest::test_get_values()
 
 	std::string in = "(cog-keys->alist (Concept \"a\"))";
 
-	Commands com;
+	Dispatcher com;
 	com.set_base_space(as);
 	std::string out = com.interpret_command(in);
 	printf("Got %zu %s\n", out.size(), out.c_str());
@@ -406,7 +406,7 @@ void CommandsUTest::test_extract()
 
 	std::string in = "(cog-extract! (Concept \"a\"))";
 
-	Commands com;
+	Dispatcher com;
 	com.set_base_space(as);
 	std::string out = com.interpret_command(in);
 	printf("Got %s\n", out.c_str());
@@ -444,7 +444,7 @@ void CommandsUTest::test_execute()
 		"(Present (List (Variable \"x\") (Concept \"b\"))))"
 		"(Predicate \"key\"))";
 
-	Commands com;
+	Dispatcher com;
 	com.set_base_space(as);
 	std::string out = com.interpret_command(in);
 	printf("Got >>%s<<\n", out.c_str());

--- a/tests/persist/sexpr/DispatchUTest.cxxtest
+++ b/tests/persist/sexpr/DispatchUTest.cxxtest
@@ -29,11 +29,11 @@
 #include <opencog/atoms/truthvalue/SimpleTruthValue.h>
 #include <opencog/atoms/truthvalue/CountTruthValue.h>
 
-#include "opencog/persist/sexpr/Commands.h"
+#include "opencog/persist/sexpr/Dispatcher.h"
 
 using namespace opencog;
 
-class MyDispatch : public Commands
+class MyDispatch : public Dispatcher
 {
 public:
 	MyDispatch();


### PR DESCRIPTION
The command interpreter is used to process atomspace commands that come in over the network. The command dispatcher calls the appropriate handler for a given command.

The write-thru and read-thru poxies use the command dispatcher to overload received commands which re-distribute them to other (networked) atomspaces. The changes here simplify the design of the proxies, by factoring out common code.