### PR TITLE
New utilities to set specific locations in vectors.

### DIFF
--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -239,9 +239,8 @@ ValuePtr Atom::incrementCount(const Handle& key, size_t idx, double count)
 	}
 
 	// Increment the existing value (or create a new one).
-	size_t cntsz = count.size();
-	if (new_value.size() <= cntsz)
-		new_value.resize(cntsz, 0.0);
+	if (new_value.size() <= idx)
+		new_value.resize(idx+1, 0.0);
 
 	new_value[idx] += count;
 

--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -212,7 +212,45 @@ ValuePtr Atom::incrementCount(const Handle& key, const std::vector<double>& coun
 	if (nameserver().isA(vt, TRUTH_VALUE))
 		nv = ValueCast(TruthValue::factory(vt, new_value));
 	else
-		nv = createFloatValue(new_value);
+		nv = createFloatValue(vt, new_value);
+
+	_values[key] = nv;
+	return nv;
+}
+
+ValuePtr Atom::incrementCount(const Handle& key, size_t idx, double count)
+{
+	std::vector<double> new_value;
+	Type vt = FLOAT_VALUE;
+
+	KVP_SHARED_LOCK;
+
+	// Find the existing value, if it is there.
+	auto pr = _values.find(key);
+	if (_values.end() != pr)
+	{
+		const ValuePtr& pap = pr->second;
+		vt = pap->get_type();
+		if (nameserver().isA(vt, FLOAT_VALUE))
+		{
+			FloatValuePtr fv(FloatValueCast(pap));
+			new_value = fv->value();
+		}
+	}
+
+	// Increment the existing value (or create a new one).
+	size_t cntsz = count.size();
+	if (new_value.size() <= cntsz)
+		new_value.resize(cntsz, 0.0);
+
+	new_value[idx] += count;
+
+	// Set the new value.
+	ValuePtr nv;
+	if (nameserver().isA(vt, TRUTH_VALUE))
+		nv = ValueCast(TruthValue::factory(vt, new_value));
+	else
+		nv = createFloatValue(vt, new_value);
 
 	_values[key] = nv;
 	return nv;

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -394,6 +394,7 @@ public:
     ValuePtr getValue(const Handle& key) const;
     /// Atomically increment a generic FloatValue.
     ValuePtr incrementCount(const Handle& key, const std::vector<double>&);
+    ValuePtr incrementCount(const Handle& key, size_t idx, double);
 
     /// Get the set of all keys in use for this Atom.
     HandleSet getKeys() const;

--- a/opencog/atoms/base/Link.cc
+++ b/opencog/atoms/base/Link.cc
@@ -67,7 +67,7 @@ std::string Link::to_short_string(const std::string& indent) const
     answer += "(" + nameserver().getTypeName(_type);
 
     // Print the TV only if its not the default.
-    if (not getTruthValue()->isDefaultTV())
+    if (getTruthValue() and not getTruthValue()->isDefaultTV())
         answer += " " + getTruthValue()->to_string();
 
     answer += "\n";
@@ -90,7 +90,7 @@ std::string Link::to_string(const std::string& indent) const
     answer += "(" + nameserver().getTypeName(_type);
 
     // Print the TV only if its not the default.
-    if (not getTruthValue()->isDefaultTV())
+    if (getTruthValue() and not getTruthValue()->isDefaultTV())
         answer += " " + getTruthValue()->to_string();
 
     answer += "\n";

--- a/opencog/atoms/base/Node.cc
+++ b/opencog/atoms/base/Node.cc
@@ -115,7 +115,7 @@ std::string Node::to_short_string(const std::string& indent) const
     answer += '\"';
 
     // Print the TV only if its not the default.
-    if (not getTruthValue()->isDefaultTV())
+    if (getTruthValue() and not getTruthValue()->isDefaultTV())
         answer += ' ' + getTruthValue()->to_string();
 
     answer += ')';

--- a/opencog/atoms/value/BoolValue.h
+++ b/opencog/atoms/value/BoolValue.h
@@ -46,13 +46,12 @@ protected:
 	virtual void update() const {}
 
 	BoolValue(Type t) : Value(t) {}
-public: // XXX should be protected...
-	BoolValue(Type t, const std::vector<bool>& v) : Value(t), _value(v) {}
 
 public:
 	BoolValue(bool v) : Value(BOOL_VALUE) { _value.push_back(v); }
 	BoolValue(const std::vector<bool>& v)
 		: Value(BOOL_VALUE), _value(v) {}
+	BoolValue(Type t, const std::vector<bool>& v) : Value(t), _value(v) {}
 
 	virtual ~BoolValue() {}
 

--- a/opencog/atoms/value/FloatValue.h
+++ b/opencog/atoms/value/FloatValue.h
@@ -46,13 +46,11 @@ protected:
 	virtual void update() const {}
 
 	FloatValue(Type t) : Value(t) {}
-public: // XXX should be protected...
-	FloatValue(Type t, const std::vector<double>& v) : Value(t), _value(v) {}
-
 public:
 	FloatValue(double v) : Value(FLOAT_VALUE) { _value.push_back(v); }
 	FloatValue(const std::vector<double>& v)
 		: Value(FLOAT_VALUE), _value(v) {}
+	FloatValue(Type t, const std::vector<double>& v) : Value(t), _value(v) {}
 
 	virtual ~FloatValue() {}
 

--- a/opencog/atoms/value/LinkValue.h
+++ b/opencog/atoms/value/LinkValue.h
@@ -51,6 +51,9 @@ public:
 	LinkValue(const ValueSeq& vlist)
 		: Value(LINK_VALUE), _value(vlist) {}
 
+	LinkValue(Type t, const ValueSeq& vlist)
+		: Value(t), _value(vlist) {}
+
 	LinkValue(const ValueSet& vset)
 		: Value(LINK_VALUE)
 	{ for (const ValuePtr& v: vset) _value.emplace_back(v); }

--- a/opencog/atoms/value/StringValue.h
+++ b/opencog/atoms/value/StringValue.h
@@ -49,6 +49,8 @@ public:
 		: Value(STRING_VALUE) { _value.push_back(v); }
 	StringValue(const std::vector<std::string>& v)
 		: Value(STRING_VALUE), _value(v) {}
+	StringValue(Type t, const std::vector<std::string>& v)
+		: Value(t), _value(v) {}
 
 	virtual ~StringValue() {}
 

--- a/opencog/atomspace/AtomSpace.cc
+++ b/opencog/atomspace/AtomSpace.cc
@@ -505,6 +505,14 @@ Handle AtomSpace::increment_count(const Handle& h, const Handle& key,
 	COWBOY_CODE(INCR_CNT);
 }
 
+// The increment is atomic i.e. thread-safe.
+Handle AtomSpace::increment_count(const Handle& h, const Handle& key,
+                                  size_t ref, double count)
+{
+	#define INCR_LOC(atm) atm->incrementCount(key, ref, count);
+	COWBOY_CODE(INCR_LOC);
+}
+
 std::string AtomSpace::to_string(void) const
 {
 	std::stringstream ss;

--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -406,7 +406,8 @@ public:
      *
      * If the atom is copied, then the copy is returned.
      */
-    Handle increment_count(const Handle&, const Handle& key, const std::vector<double>&);
+    Handle increment_count(const Handle&, const Handle&, const std::vector<double>&);
+    Handle increment_count(const Handle&, const Handle&, size_t, double);
     Handle increment_countTV(const Handle&, double = 1.0);
 
     /**

--- a/opencog/guile/README
+++ b/opencog/guile/README
@@ -446,13 +446,6 @@ interface.
           guile> (cog-link-type? 'FlorgleBarf)
           #f
 
-=== cog-type->int ===
-      Return the integer value corresponding to an atom type.
-
-      Example:
-          guile> (cog-type->int 'ListLink)
-          8
-
 === cog-get-subtypes type ===
       Return a list of the subtypes of the given type.  Only the
       immediate subtypes are returned; to obtain all subtypes, this

--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -346,8 +346,8 @@ void SchemeSmob::register_procs()
 	register_proc("cog-value",             2, 0, 0, C(ss_value));
 	register_proc("cog-value-type",        2, 0, 0, C(ss_value_type));
 	register_proc("cog-tv",                1, 0, 0, C(ss_tv));
-	register_proc("cog-atomspace",         0, 0, 1, C(ss_as));
-	register_proc("cog-as",                0, 0, 1, C(ss_as));
+	register_proc("cog-atomspace",         0, 1, 0, C(ss_as));
+	register_proc("cog-as",                0, 1, 0, C(ss_as));
 	register_proc("cog-mean",              1, 0, 0, C(ss_get_mean));
 	register_proc("cog-confidence",        1, 0, 0, C(ss_get_confidence));
 	register_proc("cog-count",             1, 0, 0, C(ss_get_count));

--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -317,7 +317,7 @@ void SchemeSmob::register_procs()
 
 	// Value API
 	register_proc("cog-value->list",       1, 0, 0, C(ss_value_to_list));
-	register_proc("cog-value-ref",         2, 0, 0, C(ss_value_ref));
+	register_proc("cog-value-ref",         2, 1, 0, C(ss_value_ref));
 
 	// Generic property setter on atoms
 	register_proc("cog-set-value!",        3, 0, 0, C(ss_set_value));

--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -322,6 +322,8 @@ void SchemeSmob::register_procs()
 	// Generic property setter on atoms
 	register_proc("cog-set-value!",        3, 0, 0, C(ss_set_value));
 	register_proc("cog-set-values!",       2, 0, 0, C(ss_set_values));
+	register_proc("cog-set-value-ref!",    4, 0, 0, C(ss_set_value_ref));
+	register_proc("cog-inc-value-ref!",    4, 0, 0, C(ss_inc_value_ref));
 
 	// Value property setters on atoms
 	register_proc("cog-set-tv!",           2, 0, 0, C(ss_set_tv));

--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -344,6 +344,7 @@ void SchemeSmob::register_procs()
 	register_proc("cog-keys",              1, 0, 0, C(ss_keys));
 	register_proc("cog-keys->alist",       1, 0, 0, C(ss_keys_alist));
 	register_proc("cog-value",             2, 0, 0, C(ss_value));
+	register_proc("cog-value-type",        2, 0, 0, C(ss_value_type));
 	register_proc("cog-tv",                1, 0, 0, C(ss_tv));
 	register_proc("cog-atomspace",         0, 0, 1, C(ss_as));
 	register_proc("cog-as",                0, 0, 1, C(ss_as));

--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -323,7 +323,6 @@ void SchemeSmob::register_procs()
 	register_proc("cog-set-value!",        3, 0, 0, C(ss_set_value));
 	register_proc("cog-set-values!",       2, 0, 0, C(ss_set_values));
 	register_proc("cog-set-value-ref!",    4, 0, 0, C(ss_set_value_ref));
-	register_proc("cog-inc-value-ref!",    4, 0, 0, C(ss_inc_value_ref));
 
 	// Value property setters on atoms
 	register_proc("cog-set-tv!",           2, 0, 0, C(ss_set_tv));

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -136,7 +136,6 @@ private:
 	static SCM ss_inc_value(SCM, SCM, SCM, SCM);
 	static SCM ss_update_value(SCM, SCM, SCM);
 	static SCM ss_set_value_ref(SCM, SCM, SCM, SCM);
-	static SCM ss_inc_value_ref(SCM, SCM, SCM, SCM);
 
 	// Atom properties
 	static SCM ss_name(SCM);

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -123,7 +123,8 @@ private:
 
 	// Access the list encoded in a value
 	static SCM ss_value_to_list(SCM);
-	static SCM ss_value_ref(SCM, SCM);
+	static SCM ss_value_ref(SCM, SCM, SCM);
+	static SCM value_ref(const ValuePtr&, size_t);
 
 	// Property setters on atoms
 	static SCM ss_set_tv(SCM, SCM);

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -129,6 +129,8 @@ private:
 	// Property setters on atoms
 	static SCM ss_set_tv(SCM, SCM);
 	static SCM ss_set_value(SCM, SCM, SCM);
+	static SCM set_value(const Handle&, const Handle&,
+	                     const ValuePtr&, SCM, const char*);
 	static SCM ss_set_values(SCM, SCM);
 	static SCM ss_inc_count(SCM, SCM);
 	static SCM ss_inc_value(SCM, SCM, SCM, SCM);

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -136,6 +136,7 @@ private:
 	// Atom properties
 	static SCM ss_name(SCM);
 	static SCM ss_number(SCM);
+	static SCM from_type(const ValuePtr&);
 	static SCM ss_type(SCM);
 	static SCM ss_arity(SCM);
 	static SCM ss_tv(SCM);
@@ -145,6 +146,7 @@ private:
 	static SCM ss_keys(SCM);
 	static SCM ss_keys_alist(SCM);
 	static SCM ss_value(SCM, SCM);
+	static SCM ss_value_type(SCM, SCM);
 	static SCM ss_incoming_set(SCM, SCM);
 	static SCM ss_incoming_size(SCM, SCM);
 	static SCM ss_incoming_by_type(SCM, SCM, SCM);
@@ -197,7 +199,8 @@ private:
 	static const AtomSpacePtr& get_as_from_list(SCM);
 	static Handle set_values(const Handle&, const AtomSpacePtr&, SCM);
 
-	// Logger
+	// Logger XXX TODO these do not belong here, they
+	// need to be moved to their own module.
 	static SCM logger_to_scm(Logger*);
 	static Logger* ss_to_logger(SCM);
 	static std::string logger_to_string(const Logger *);

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -133,6 +133,8 @@ private:
 	static SCM ss_inc_count(SCM, SCM);
 	static SCM ss_inc_value(SCM, SCM, SCM, SCM);
 	static SCM ss_update_value(SCM, SCM, SCM);
+	static SCM ss_set_value_ref(SCM, SCM, SCM, SCM);
+	static SCM ss_inc_value_ref(SCM, SCM, SCM, SCM);
 
 	// Atom properties
 	static SCM ss_name(SCM);
@@ -236,6 +238,8 @@ private:
 	                       const char *msg = "integer");
 	static size_t verify_size_t (SCM, const char *, int pos = 1,
 	                             const char *msg = "integer size_t");
+	static bool verify_bool (SCM, const char *, int pos = 1,
+	                         const char *msg = "boolean");
 	static double verify_real (SCM, const char *, int pos = 1,
 	                           const char *msg = "real number");
 	static Logger* verify_logger(SCM, const char *, int pos = 1);

--- a/opencog/guile/SchemeSmobAS.cc
+++ b/opencog/guile/SchemeSmobAS.cc
@@ -234,17 +234,16 @@ SCM SchemeSmob::ss_as_clear(SCM sas)
  * Return the atomspace of an atom.
  * If no atom, return the current atomspace.
  */
-SCM SchemeSmob::ss_as(SCM slist)
+SCM SchemeSmob::ss_as(SCM satom)
 {
 	// If no argument, then return the current AtomSpace.
-	if (scm_is_null(slist))
+	Handle h(scm_to_handle(satom));
+	if (nullptr == h)
 	{
 		const AtomSpacePtr& asp = ss_get_env_as("cog-atomspace");
 		return asp ? make_as(asp) : SCM_EOL;
 	}
 
-	SCM satom = scm_car(slist);
-	Handle h(verify_handle(satom, "cog-atomspace"));
 	AtomSpace* as = h->getAtomSpace();
 	return as ? make_as(AtomSpaceCast(as->shared_from_this())) : SCM_EOL;
 }

--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -201,12 +201,8 @@ SCM SchemeSmob::ss_inc_value (SCM satom, SCM skey, SCM scnt, SCM sref)
 	double cnt = verify_real(scnt, "cog-inc-value!", 3);
 	size_t ref = verify_size_t(sref, "cog-inc-value!", 4);
 
-	std::vector<double> delta;
-	delta.resize(ref+1, 0.0);
-	delta[ref] = cnt;
-
 	const AtomSpacePtr& asp = ss_get_env_as("cog-inc-value!");
-	Handle ha(asp->increment_count(h, key, delta));
+	Handle ha(asp->increment_count(h, key, ref, cnt));
 	if (ha == h)
 		return satom;
 	return handle_to_scm(ha);

--- a/opencog/guile/SchemeSmobNew.cc
+++ b/opencog/guile/SchemeSmobNew.cc
@@ -246,7 +246,6 @@ Type SchemeSmob::verify_type (SCM stype, const char *subrname, int pos)
 	return t;
 }
 
-
 /**
  * Check that the argument is an int, else throw errors.
  * Return the int.
@@ -273,6 +272,23 @@ size_t SchemeSmob::verify_size_t (SCM ssizet, const char *subrname,
 	// but it also doesn't provide a uintmax.
 	// return scm_to_size_t(ssizet);
 	return (size_t) scm_to_long(ssizet);
+}
+
+/**
+ * Check that the argument is a boolean constant, else throw errors.
+ * Return the bool.
+ */
+bool SchemeSmob::verify_bool (SCM sbool, const char *subrname,
+                              int pos, const char * msg)
+{
+	if (scm_is_bool(sbool))
+		return scm_to_bool(sbool);
+	else if (scm_is_integer(sbool))
+		return scm_to_int8(sbool);
+	else
+		scm_wrong_type_arg_msg(subrname, pos, sbool, msg);
+
+	return false; // not reached
 }
 
 /**

--- a/opencog/guile/SchemeSmobValue.cc
+++ b/opencog/guile/SchemeSmobValue.cc
@@ -41,15 +41,20 @@ using namespace opencog;
 /* ============================================================== */
 /** Return the type of a value/atom */
 
-SCM SchemeSmob::ss_type (SCM svalue)
+SCM SchemeSmob::from_type (const ValuePtr& vp)
 {
-	ValuePtr pa(verify_protom(svalue, "cog-type"));
-	Type t = pa->get_type();
+	Type t = vp->get_type();
 	const std::string &tname = nameserver().getTypeName(t);
 	SCM str = scm_from_utf8_string(tname.c_str());
 	SCM sym = scm_string_to_symbol(str);
 
 	return sym;
+}
+
+SCM SchemeSmob::ss_type (SCM svalue)
+{
+	ValuePtr vp(verify_protom(svalue, "cog-type"));
+	return from_type(vp);
 }
 
 /* ============================================================== */
@@ -476,6 +481,23 @@ SCM SchemeSmob::ss_value (SCM satom, SCM skey)
 		throw_exception(ex, "cog-value", scm_cons(satom, skey));
 	}
 	return SCM_EOL;
+}
+
+SCM SchemeSmob::ss_value_type (SCM satom, SCM skey)
+{
+	Handle atom(verify_handle(satom, "cog-value-type", 1));
+	Handle key(verify_handle(skey, "cog-value-type", 2));
+
+	try
+	{
+		ValuePtr vp = atom->getValue(key);
+		return from_type(vp);
+	}
+	catch (const std::exception& ex)
+	{
+		throw_exception(ex, "cog-value-type", scm_cons(satom, skey));
+	}
+	return SCM_BOOL_F;
 }
 
 /** Return all of the keys on the atom */

--- a/opencog/guile/SchemeSmobValue.cc
+++ b/opencog/guile/SchemeSmobValue.cc
@@ -472,15 +472,7 @@ SCM SchemeSmob::ss_value (SCM satom, SCM skey)
 	Handle atom(verify_handle(satom, "cog-value", 1));
 	Handle key(verify_handle(skey, "cog-value", 2));
 
-	try
-	{
-		return protom_to_scm(atom->getValue(key));
-	}
-	catch (const std::exception& ex)
-	{
-		throw_exception(ex, "cog-value", scm_cons(satom, skey));
-	}
-	return SCM_EOL;
+	return protom_to_scm(atom->getValue(key));
 }
 
 SCM SchemeSmob::ss_value_type (SCM satom, SCM skey)
@@ -488,16 +480,8 @@ SCM SchemeSmob::ss_value_type (SCM satom, SCM skey)
 	Handle atom(verify_handle(satom, "cog-value-type", 1));
 	Handle key(verify_handle(skey, "cog-value-type", 2));
 
-	try
-	{
-		ValuePtr vp = atom->getValue(key);
-		return from_type(vp);
-	}
-	catch (const std::exception& ex)
-	{
-		throw_exception(ex, "cog-value-type", scm_cons(satom, skey));
-	}
-	return SCM_BOOL_F;
+	ValuePtr vp = atom->getValue(key);
+	return from_type(vp);
 }
 
 /** Return all of the keys on the atom */
@@ -637,16 +621,8 @@ SCM SchemeSmob::ss_value_ref (SCM s1, SCM s2, SCM s3)
 	Handle atom(verify_handle(s1, "cog-value-ref", 1));
 	Handle key(verify_handle(s2, "cog-value-ref", 2));
 
-	try
-	{
-		ValuePtr pa(atom->getValue(key));
-		return value_ref(pa, index);
-	}
-	catch (const std::exception& ex)
-	{
-		throw_exception(ex, "cog-value-ref", scm_cons(s1, s2));
-	}
-	return SCM_BOOL_F;
+	ValuePtr pa(atom->getValue(key));
+	return value_ref(pa, index);
 }
 
 SCM SchemeSmob::value_ref (const ValuePtr& pa, size_t index)

--- a/opencog/guile/SchemeSmobValue.cc
+++ b/opencog/guile/SchemeSmobValue.cc
@@ -436,7 +436,7 @@ SCM SchemeSmob::ss_set_value_ref (SCM satom, SCM skey, SCM svalue, SCM sindex)
 		std::vector<double> v = FloatValueCast(pa)->value();
 		if (v.size() <= index) v.resize(index+1);
 		v[index] = verify_real(svalue, "cog-set-value-ref!", 3);
-		nvp = createFloatValue(v);
+		nvp = createFloatValue(t, v);
 	}
 
 	if (nameserver().isA(t, BOOL_VALUE))
@@ -444,7 +444,7 @@ SCM SchemeSmob::ss_set_value_ref (SCM satom, SCM skey, SCM svalue, SCM sindex)
 		std::vector<bool> v = BoolValueCast(pa)->value();
 		if (v.size() <= index) v.resize(index+1);
 		v[index] = verify_bool(svalue, "cog-set-value-ref!", 3);
-		nvp = createBoolValue(v);
+		nvp = createBoolValue(t, v);
 	}
 
 	if (nameserver().isA(t, STRING_VALUE))
@@ -452,7 +452,7 @@ SCM SchemeSmob::ss_set_value_ref (SCM satom, SCM skey, SCM svalue, SCM sindex)
 		std::vector<std::string> v = StringValueCast(pa)->value();
 		if (v.size() <= index) v.resize(index+1);
 		v[index] = verify_string(svalue, "cog-set-value-ref!", 3);
-		nvp = createStringValue(v);
+		nvp = createStringValue(t, v);
 	}
 
 	if (nameserver().isA(t, LINK_VALUE))
@@ -460,7 +460,7 @@ SCM SchemeSmob::ss_set_value_ref (SCM satom, SCM skey, SCM svalue, SCM sindex)
 		std::vector<ValuePtr> v = LinkValueCast(pa)->value();
 		if (v.size() <= index) v.resize(index+1);
 		v[index] = verify_protom(svalue, "cog-set-value-ref!", 3);
-		nvp = createLinkValue(v);
+		nvp = createLinkValue(t, v);
 	}
 
 	const AtomSpacePtr& asp = ss_get_env_as("cog-set-value-ref!");

--- a/opencog/guile/SchemeSmobValue.cc
+++ b/opencog/guile/SchemeSmobValue.cc
@@ -83,7 +83,7 @@ SchemeSmob::verify_bool_list (SCM svalue_list, const char * subrname, int pos)
 	// (which is rather unusual, but legit.  Allow embedded nulls
 	// as this can be convenient for writing scheme code.
 	if (!scm_is_pair(svalue_list) and !scm_is_null(svalue_list))
-		scm_wrong_type_arg_msg(subrname, pos, svalue_list, "a list of float-pt values");
+		scm_wrong_type_arg_msg(subrname, pos, svalue_list, "a list of boolean values");
 	return scm_to_bool_list(svalue_list);
 }
 
@@ -417,6 +417,41 @@ SCM SchemeSmob::ss_set_value (SCM satom, SCM skey, SCM svalue)
 	{
 		throw_exception(ex, "cog-set-value!", satom);
 	}
+}
+
+SCM SchemeSmob::ss_set_value_ref (SCM satom, SCM skey, SCM svalue, SCM sindex)
+{
+	Handle atom(verify_handle(satom, "cog-set-value-ref!", 1));
+	Handle key(verify_handle(skey, "cog-set-value-ref!", 2));
+	size_t index = verify_size_t(s2, "cog-set-value-ref!", 4);
+
+	ValuePtr pa(atom->getValue(key));
+	size_t sz = pa->size();
+	Type t = pa->get_type();
+
+	// OK. What we do next depends on the actual type of the value.
+	if (nameserver().isA(t, FLOAT_VALUE))
+	{
+		const std::vector<double>& v = FloatValueCast(pa)->value();
+		double newv = verify_real(svalue);
+	}
+
+	if (nameserver().isA(t, BOOL_VALUE))
+	{
+		const std::vector<bool>& v = BoolValueCast(pa)->value();
+	}
+
+	if (nameserver().isA(t, STRING_VALUE))
+	{
+		const std::vector<std::string>& v = StringValueCast(pa)->value();
+	}
+
+	if (nameserver().isA(t, LINK_VALUE))
+	{
+		const std::vector<ValuePtr>& v = LinkValueCast(pa)->value();
+	}
+
+xxxxxxxxxx
 }
 
 // alist is an association-list of key-value pairs.

--- a/opencog/guile/SchemeSmobValue.cc
+++ b/opencog/guile/SchemeSmobValue.cc
@@ -475,6 +475,7 @@ SCM SchemeSmob::ss_set_value_ref (SCM satom, SCM skey, SCM svalue, SCM sindex)
 }
 
 // Increment the value at the given location
+// Only works on FloatValues
 SCM SchemeSmob::ss_inc_value_ref (SCM satom, SCM skey, SCM svalue, SCM sindex)
 {
 	Handle atom(verify_handle(satom, "cog-inc-value-ref!", 1));
@@ -498,7 +499,7 @@ SCM SchemeSmob::ss_inc_value_ref (SCM satom, SCM skey, SCM svalue, SCM sindex)
 
 	std::vector<double> v = FloatValueCast(pa)->value();
 	if (v.size() <= index) v.resize(index+1);
-	v[index] += verify_real(svalue, "cog-set-value-ref!", 3);
+	v[index] += verify_real(svalue, "cog-inc-value-ref!", 3);
 	ValuePtr nvp = createFloatValue(t, v);
 
 	return set_value(atom, key, nvp, satom, "cog-inc-value-ref!");

--- a/opencog/guile/SchemeSmobValue.cc
+++ b/opencog/guile/SchemeSmobValue.cc
@@ -474,37 +474,6 @@ SCM SchemeSmob::ss_set_value_ref (SCM satom, SCM skey, SCM svalue, SCM sindex)
 	return set_value(atom, key, nvp, satom, "cog-set-value-ref!");
 }
 
-// Increment the value at the given location
-// Only works on FloatValues
-SCM SchemeSmob::ss_inc_value_ref (SCM satom, SCM skey, SCM svalue, SCM sindex)
-{
-	Handle atom(verify_handle(satom, "cog-inc-value-ref!", 1));
-	Handle key(verify_handle(skey, "cog-inc-value-ref!", 2));
-	size_t index = verify_size_t(sindex, "cog-inc-value-ref!", 4);
-
-	ValuePtr pa(atom->getValue(key));
-	Type t = pa->get_type();
-	if (not nameserver().isA(t, FLOAT_VALUE))
-	{
-		const std::string &tname = nameserver().getTypeName(t);
-		SCM ilist = scm_cons(scm_from_utf8_string(tname.c_str()), SCM_EOL);
-		scm_error_scm(
-			scm_from_utf8_symbol("wrong-type"),
-			scm_from_utf8_string("cog-inc-value-ref!"),
-			scm_from_utf8_string("Expecting a FloatValue, found ~A"),
-			ilist,
-			ilist);
-		/* scm_error_scm does not return */
-	}
-
-	std::vector<double> v = FloatValueCast(pa)->value();
-	if (v.size() <= index) v.resize(index+1);
-	v[index] += verify_real(svalue, "cog-inc-value-ref!", 3);
-	ValuePtr nvp = createFloatValue(t, v);
-
-	return set_value(atom, key, nvp, satom, "cog-inc-value-ref!");
-}
-
 // alist is an association-list of key-value pairs.
 Handle SchemeSmob::set_values(const Handle& h, const AtomSpacePtr& asp, SCM alist)
 {

--- a/opencog/guile/SchemeSmobValue.cc
+++ b/opencog/guile/SchemeSmobValue.cc
@@ -444,7 +444,12 @@ SCM SchemeSmob::ss_set_value_ref (SCM satom, SCM skey, SCM svalue, SCM sindex)
 		std::vector<double> v = FloatValueCast(pa)->value();
 		if (v.size() <= index) v.resize(index+1);
 		v[index] = verify_real(svalue, "cog-set-value-ref!", 3);
-		nvp = createFloatValue(t, v);
+
+		// Explicitly run the TruthValue factory.
+		if (nameserver().isA(t, TRUTH_VALUE))
+			nvp = ValueCast(TruthValue::factory(t, v));
+		else
+			nvp = createFloatValue(t, v);
 	}
 
 	if (nameserver().isA(t, BOOL_VALUE))

--- a/opencog/scm/opencog.scm
+++ b/opencog/scm/opencog.scm
@@ -97,6 +97,7 @@ cog-value
 cog-value?
 cog-value->list
 cog-value-ref
+cog-value-type
 )
 
 ; Print C++ exceptions so that they are readable.

--- a/opencog/scm/opencog/base/core-docs.scm
+++ b/opencog/scm/opencog/base/core-docs.scm
@@ -367,11 +367,18 @@
 
 (set-procedure-property! cog-incoming-set 'documentation
 "
- cog-incoming-set ATOM
+ cog-incoming-set ATOM [ATOMSPACE]
     Return the incoming set of ATOM.  This set is returned as an
     ordinary scheme list.
 
+    If the optional argument ATOMSPACE is given, then the lookup is
+    performed in that AtomSpace. This is useful when the Atom appears
+    in more than one AtomSpace, and it's incoming set differs in each
+    space.  If the optional argument is not given, then the current
+    AtomSpace is used.
+
     See also: cog-incoming-size, cog-incoming-by-type
+
     Example:
        ; Define two nodes and a link between them:
        guile> (define x (Concept \"abc\"))
@@ -410,8 +417,14 @@
 
 (set-procedure-property! cog-incoming-size 'documentation
 "
- cog-incoming-size ATOM
+ cog-incoming-size ATOM [ATOMSPACE]
     Return the number of atoms in the incoming set of ATOM.
+
+    If the optional argument ATOMSPACE is given, then the lookup is
+    performed in that AtomSpace. This is useful when the Atom appears
+    in more than one AtomSpace, and it's incoming set differs in each
+    space.  If the optional argument is not given, then the current
+    AtomSpace is used.
 
     See also: cog-incoming-set, cog-incoming-size-by-type
 
@@ -431,12 +444,18 @@
 
 (set-procedure-property! cog-incoming-by-type 'documentation
 "
- cog-incoming-by-type ATOM TYPE
+ cog-incoming-by-type ATOM TYPE [ATOMSPACE]
     Return the incoming set of ATOM that consists only of atoms of
     type TYPE.  This set is returned as an ordinary scheme list.
 
     Equivalent to (cog-filter TYPE (cog-incoming-set ATOM)), but
     should be faster, performance-wise.
+
+    If the optional argument ATOMSPACE is given, then the lookup is
+    performed in that AtomSpace. This is useful when the Atom appears
+    in more than one AtomSpace, and it's incoming set differs in each
+    space.  If the optional argument is not given, then the current
+    AtomSpace is used.
 
     Example:
        ; Define two nodes and two links between them:
@@ -464,8 +483,14 @@
 
 (set-procedure-property! cog-incoming-size-by-type 'documentation
 "
- cog-incoming-size-by-type ATOM TYPE
+ cog-incoming-size-by-type ATOM TYPE [ATOMSPACE]
     Return the number of atoms of type TYPE in the incoming set of ATOM.
+
+    If the optional argument ATOMSPACE is given, then the lookup is
+    performed in that AtomSpace. This is useful when the Atom appears
+    in more than one AtomSpace, and it's incoming set differs in each
+    space.  If the optional argument is not given, then the current
+    AtomSpace is used.
 
     See also: cog-incoming-by-type, cog-incoming-size
 

--- a/opencog/scm/opencog/base/core-docs.scm
+++ b/opencog/scm/opencog/base/core-docs.scm
@@ -864,7 +864,7 @@
     a history of value changes.
 
     See also:
-       cog-set-values! ATOM ALIST - Set multiple values.
+       cog-set-value! ATOM VALUE - Set a single value.
        cog-new-atomspace - Create a new AtomSpace
        cog-atomspace-cow! BOOL - Mark AtomSpace as a COW space.
        cog-atomspace-ro! - Mark AtomSpace as read-only.
@@ -937,6 +937,10 @@
     Example:
         guile> (cog-type->int 'ListLink)
         8
+
+    See also:
+        cog-type ATOM -- get the type of ATOM.
+        cog-get-types -- get all of the types in the type system.
 ")
 
 (set-procedure-property! cog-get-subtypes 'documentation

--- a/opencog/scm/opencog/base/core-docs.scm
+++ b/opencog/scm/opencog/base/core-docs.scm
@@ -957,19 +957,11 @@
 (set-procedure-property! cog-type->int 'documentation
 "
  cog-type->int TYPE
-    Return the integer value corresponding to an Atom TYPE.
-    This is unique only for the current session; it is not universally
-    unique, and may change from one session to the next. Use of this
-    function is strongly discouraged!
-
-    Example:
-        guile> (cog-type->int 'ListLink)
-        8
-
-    See also:
-        cog-type ATOM -- get the type of ATOM.
-        cog-value-type ATOM KEY -- get the type of the value at KEY on ATOM.
-        cog-get-types -- get all of the types in the type system.
+    Return the C++ internal type number assigned to an Atom TYPE.
+    This provides access to the type numbering in the current C++
+    AtomSpace session. The value is not universally unique, and may
+    change from one session to the next. This function is for
+    internal use only; do not use in general code.
 ")
 
 (set-procedure-property! cog-get-subtypes 'documentation

--- a/opencog/scm/opencog/base/core-docs.scm
+++ b/opencog/scm/opencog/base/core-docs.scm
@@ -628,6 +628,8 @@
   See also:
       cog-inc-count! -- Increment the CountTruthValue.
       cog-update-value! -- A generic atomic read-modify-write.
+      cog-set-value-ref! - Set one location in a vector.
+      cog-inc-value-ref! - Increment one location in a vector.
 ")
 
 (set-procedure-property! cog-mean 'documentation
@@ -849,6 +851,8 @@
        #f
 
     See also:
+       cog-set-value-ref! - Set one location in a vector.
+       cog-inc-value-ref! - Increment one location in a vector.
        cog-update-value! - Perform an atomic read-modify-write
        cog-set-values! - Set multiple values.
        cog-new-atomspace - Create a new AtomSpace
@@ -879,6 +883,8 @@
        cog-inc-value! -- Increment a generic FloatValue
        cog-set-value! -- Set a single value.
        cog-set-values! -- Set multiple values.
+       cog-set-value-ref! - Set one location in a vector.
+       cog-inc-value-ref! - Increment one location in a vector.
 ")
 
 (set-procedure-property! cog-set-values! 'documentation
@@ -979,6 +985,10 @@
        0.3
        guile> (cog-value-ref (Number 1 2 3) 2)
        3.0
+
+	See also:
+       cog-set-value-ref! - Set one location in a vector.
+       cog-inc-value-ref! - Increment one location in a vector.
 ")
 
 (set-procedure-property! cog-get-types 'documentation

--- a/opencog/scm/opencog/base/core-docs.scm
+++ b/opencog/scm/opencog/base/core-docs.scm
@@ -953,15 +953,26 @@
 (set-procedure-property! cog-value-ref 'documentation
 "
  cog-value-ref VALUE N
-    Return the N'th entry in the OpenCog VALUE.
-    If VALUE is a Link, this returns the N'th atom in the outgoing set.
+ cog-value-ref ATOM KEY N
+    The first form returns the N'th entry in the OpenCog VALUE.
+    The second form looks up the value om ATOM at KEY, and then returns
+    the N'th entry.
+
+    If the value is a Link, this returns the N'th atom in the outgoing set.
         That is, it returns the same atom as cog-outgoing-atom.
-    If VALUE is a Node, and N is zero, this returns the node name.
-    If VALUE is a StringValue, FloatValue or LinkValue, this returns
+    If the value is a Node, and N is zero, this returns the node name.
+    If the value is a StringValue, FloatValue or LinkValue, this returns
         the N'th entry in the value.
 
-    This returns the same result as
+    The first form returns the same result as
         (list-ref (cog-value->list VALUE) N)
+
+    The second form returns the same result as
+        (list-ref (cog-value->list (cog-value ATOM KEY)) N)
+
+    The difference is that this one call will be a lot faster than
+    either of the equivalent forms (and thus is suitable for use in
+    tight inner loops).
 
     Example:
        guile> (cog-value-ref (FloatValue 0.1 0.2 0.3) 2)

--- a/opencog/scm/opencog/base/core-docs.scm
+++ b/opencog/scm/opencog/base/core-docs.scm
@@ -337,14 +337,18 @@
 "
  cog-type EXP
     Return the type of EXP, where EXP is a Value or an Atom.
+    The returned value is a guile symbol.
 
     Example:
        ; Define a node
        guile> (define x (Concept \"abc\"))
        guile> (cog-type x)
        ConceptNode
-       guile> (eq? 'Concept (cog-type x))
+       guile> (eq? 'ConceptNode (cog-type x))
        #t
+
+    See also:
+        cog-value-type ATOM KEY -- get the type of the value at KEY on ATOM.
 ")
 
 (set-procedure-property! cog-arity 'documentation
@@ -735,6 +739,7 @@
     See also:
        cog-keys->alist ATOM - return association list of keys+values
        cog-value ATOM KEY - return a value for the given KEY
+       cog-value-type ATOM KEY -- get the type of the value at KEY on ATOM.
 ")
 
 (set-procedure-property! cog-keys->alist 'documentation
@@ -751,13 +756,13 @@
     See also:
        cog-keys ATOM - return list of all keys on ATOM
        cog-value ATOM KEY - return a value for the given KEY
+       cog-value-type ATOM KEY -- get the type of the value at KEY on ATOM.
 ")
 
 (set-procedure-property! cog-value 'documentation
 "
  cog-value ATOM KEY
-    Return the value of of KEY for ATOM. Both ATOM and KEY must be
-    atoms.
+    Return the value of KEY for ATOM. Both ATOM and KEY must be atoms.
 
     Example:
        guile> (cog-set-value!
@@ -765,6 +770,28 @@
                  (FloatValue 1 2 3))
        guile> (cog-value (Concept \"abc\") (Predicate \"key\"))
        (FloatValue 1.000000 2.000000 3.00000)
+
+   See also:
+       cog-keys ATOM - return list of all keys on ATOM
+       cog-value-type ATOM KEY -- get the type of the value at KEY on ATOM.
+")
+
+(set-procedure-property! cog-value-type 'documentation
+"
+ cog-value-type ATOM KEY
+    Return the type of the value of KEY for ATOM. Both ATOM and KEY
+    must be atoms. The returned type is a guile symbol.
+
+    Example:
+       guile> (cog-set-value!
+                 (Concept \"abc\") (Predicate \"key\")
+                 (FloatValue 1 2 3))
+       guile> (cog-value-type (Concept \"abc\") (Predicate \"key\"))
+       FloatValue
+
+   See also:
+       cog-value ATOM KEY -- get the value at KEY on ATOM.
+       cog-keys ATOM - return list of all keys on ATOM.
 ")
 
 (set-procedure-property! cog-set-value! 'documentation
@@ -931,8 +958,9 @@
 "
  cog-type->int TYPE
     Return the integer value corresponding to an Atom TYPE.
-    This is unique for the current session, only; it is not universally
-    unique, and may change from one session to the next.
+    This is unique only for the current session; it is not universally
+    unique, and may change from one session to the next. Use of this
+    function is strongly discouraged!
 
     Example:
         guile> (cog-type->int 'ListLink)
@@ -940,6 +968,7 @@
 
     See also:
         cog-type ATOM -- get the type of ATOM.
+        cog-value-type ATOM KEY -- get the type of the value at KEY on ATOM.
         cog-get-types -- get all of the types in the type system.
 ")
 

--- a/opencog/scm/opencog/base/core-docs.scm
+++ b/opencog/scm/opencog/base/core-docs.scm
@@ -629,7 +629,6 @@
       cog-inc-count! -- Increment the CountTruthValue.
       cog-update-value! -- A generic atomic read-modify-write.
       cog-set-value-ref! - Set one location in a vector.
-      cog-inc-value-ref! - Increment one location in a vector.
 ")
 
 (set-procedure-property! cog-mean 'documentation
@@ -852,12 +851,46 @@
 
     See also:
        cog-set-value-ref! - Set one location in a vector.
-       cog-inc-value-ref! - Increment one location in a vector.
+       cog-inc-value! - Increment one location in a vector.
        cog-update-value! - Perform an atomic read-modify-write
        cog-set-values! - Set multiple values.
        cog-new-atomspace - Create a new AtomSpace
        cog-atomspace-cow! - Mark AtomSpace as a COW space.
        cog-atomspace-ro! - Mark AtomSpace as read-only.
+")
+
+(set-procedure-property! cog-set-value-ref! 'documentation
+"
+  cog-set-value-ref! ATOM KEY VAL REF -- Set location REF of vector
+     locatated at KEY on ATOM to VAL.
+
+  The REF location of the vector Value at KEY is set to VAL. The type
+  of VAL must be appropriate for the Value stored there: for StringValue
+  vectors, VAL must be a string; for FloatValueV vectors, VAL must be a
+  float, and so on. The other locations in the  value are left untouched.
+
+  The reference is a zero-based offset from the start of the vector.
+
+  If the ATOM does not have any Value at KEY, then nothing is done.
+  If the existing Value is too short, it is extended until it is at
+  least (REF+1) in length.
+
+  Example usage:
+     (cog-set-value!
+         (Concept \"Question\")
+         (Predicate \"Answer\")
+         (StringValue \"a\" \"b\" \"c\" \"d\" \"e\"))
+     (cog-value (Concept \"Question\") (Predicate \"Answer\"))
+     (cog-set-value-ref!
+         (Concept \"Question\")
+         (Predicate \"Answer\")
+         \"forty-two\" 3)
+     (cog-value (Concept \"Question\") (Predicate \"Answer\"))
+
+  See also:
+      cog-inc-count! -- Increment the CountTruthValue.
+      cog-update-value! -- A generic atomic read-modify-write.
+      cog-set-value-ref! - Set one location in a vector.
 ")
 
 (set-procedure-property! cog-update-value! 'documentation
@@ -880,11 +913,10 @@
 
     See also:
        cog-inc-count! -- Increment a CountTruthValue
-       cog-inc-value! -- Increment a generic FloatValue
+       cog-inc-value! -- Increment one location in a generic FloatValue
        cog-set-value! -- Set a single value.
        cog-set-values! -- Set multiple values.
        cog-set-value-ref! - Set one location in a vector.
-       cog-inc-value-ref! - Increment one location in a vector.
 ")
 
 (set-procedure-property! cog-set-values! 'documentation
@@ -988,7 +1020,7 @@
 
 	See also:
        cog-set-value-ref! - Set one location in a vector.
-       cog-inc-value-ref! - Increment one location in a vector.
+       cog-inc-value! - Increment one location in a vector.
 ")
 
 (set-procedure-property! cog-get-types 'documentation

--- a/opencog/scm/opencog/base/types.scm
+++ b/opencog/scm/opencog/base/types.scm
@@ -60,6 +60,10 @@
     (and (cog-subtype? 'Value SYMBOL) (not (cog-subtype? 'Atom SYMBOL)))
 
     Example:
+        guile> (cog-value-type? 'FloatValue)
+        #t
+        guile> (cog-value-type? 'ConceptNode)
+        #f
         guile> (cog-type? 'ConceptNode)
         #t
         guile> (cog-type? 'FlorgleBarf)


### PR DESCRIPTION
Add various utilities to set specific locations in a vector.  These are both for 
convenience and for performance; they avoid more complex call sequences 
that are also slower.  Primary consumer to be an updated matrix API, which
should make counting less messy.

Also, assorted cleanup and additional documentation.