### PR TITLE
Release an atom if it's already in the atomspace.

### DIFF
--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -419,7 +419,13 @@ Handle AtomSpace::add(const Handle& orig, bool force,
     // may have raced and inserted this atom already. So the insert does
     // have to be an atomic test-n-set.
     const Handle& oldh(typeIndex.insertAtom(atom));
-    if (oldh) return oldh;
+    if (oldh)
+    {
+        // If it was already in the index, then undo the install above.
+        atom->setAtomSpace(nullptr);
+        atom->remove();
+        return oldh;
+    }
     return atom;
 }
 

--- a/opencog/atomspace/Transient.cc
+++ b/opencog/atomspace/Transient.cc
@@ -92,6 +92,8 @@ AtomSpace* opencog::grab_transient_atomspace(AtomSpace* parent)
 	if (!tranny)
 	{
 		tranny = createAtomSpace(parent, TRANSIENT_SPACE);
+
+		std::unique_lock<std::mutex> cache_lock(s_transient_cache_mutex);
 		s_issued.insert(tranny);
 		num_issued ++;
 	}


### PR DESCRIPTION
This covers an extremely unlikely race condition, where the same
atom is being both inserted and removed from the same AtomSpace
at the same time. Otherwise this change should be invisible.
