### PR TITLE
Fix unlikely lock-order inversion

### DIFF
--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -419,7 +419,13 @@ Handle AtomSpace::add(const Handle& orig, bool force,
     // may have raced and inserted this atom already. So the insert does
     // have to be an atomic test-n-set.
     const Handle& oldh(typeIndex.insertAtom(atom));
-    if (oldh) return oldh;
+    if (oldh)
+    {
+        // If it was already in the index, then undo the install above.
+        atom->setAtomSpace(nullptr);
+        atom->remove();
+        return oldh;
+    }
     return atom;
 }
 

--- a/opencog/atomspace/Transient.cc
+++ b/opencog/atomspace/Transient.cc
@@ -92,6 +92,8 @@ AtomSpace* opencog::grab_transient_atomspace(AtomSpace* parent)
 	if (!tranny)
 	{
 		tranny = createAtomSpace(parent, TRANSIENT_SPACE);
+
+		std::unique_lock<std::mutex> cache_lock(s_transient_cache_mutex);
 		s_issued.insert(tranny);
 		num_issued ++;
 	}

--- a/opencog/atomspace/TypeIndex.h
+++ b/opencog/atomspace/TypeIndex.h
@@ -147,21 +147,7 @@ class TypeIndex
 			return result;
 		}
 
-		void clear(void)
-		{
-			TYPE_INDEX_UNIQUE_LOCK;
-			for (auto& s : _idx)
-			{
-				for (auto& h : s)
-				{
-					h->_atom_space = nullptr;
-
-					// We installed the incoming set; we remove it too.
-					h->remove();
-				}
-				s.clear();
-			}
-		}
+		void clear(void);
 
 		void get_handles_by_type(HandleSeq&, Type, bool subclass) const;
 		void get_handles_by_type(HandleSet&, Type, bool subclass) const;


### PR DESCRIPTION
This allows one thread to add atoms to the AtomSpace while another
thread is clearing the entire AtomSpace. Certainly a very unlikely
scenario, but it was flagged as a lock order inversion by tsan.
The fix is fast and simple, so go for it.
