### PR TITLE
Finish implementation of promises & futures

### DIFF
--- a/examples/atomspace/README.md
+++ b/examples/atomspace/README.md
@@ -52,7 +52,8 @@ first).
 * `stream.scm`         -- Using a stream of time-varying Values.
 * `formulas.scm`       -- Representing arithmetic and computing Values.
 * `flows.scm`          -- Flowing Values around.
-* `flow-formulas.scm`  -- Dynamically updating value flows.
+* `flow-formulas.scm`  -- Dynamically updating TruthValues.
+* `flow-futures.scm`   -- Dynamically updating FloatValues.
 * `table.scm`          -- Fetching Values from a CSV/TSV table.
 * `multi-space.scm`    -- Using multiple AtomSpaces at once.
 

--- a/examples/atomspace/flow-formulas.scm
+++ b/examples/atomspace/flow-formulas.scm
@@ -17,10 +17,13 @@
 ; occurs every time the numeric value is accessed (i.e. when the
 ; strength and confidence of the TV are accessed).
 ;
-; The FormulaStream is a generalization of the FutureTruthValue, in
-; that it allows for the computation of any FloatValue. That is, the
-; SimpleTV's are just vectors of length two - the strength and
-; confidence, whereas the FloatValue is a vector of arbitrary length.
+; Note that SimpleTV's are just vectors of length two - the strength
+; and confidence. These are generalized by FloatValue, which can hold
+; a vector of arbitrary length.
+;
+; The FormulaStream generalizes the FutureTruthValue, so that it can
+; work with any FloatValue, not just TruthValues. This is demo'ed in
+; the `flow-futures.scm` file.
 
 (use-modules (opencog) (opencog exec))
 
@@ -205,39 +208,5 @@
 ; And take another look.
 (format #t "A implies B has strength ~6F and confidence ~6F\n"
 	(cog-mean a-implies-b) (cog-confidence a-implies-b))
-
-; -------------------------------------------------------------
-; The FormulaStream is the generalization of FutureTruthValue, suitable
-; for streaming a FloatValue of arbitrary length. As before, whenever it
-; is accessed, the current vector value is recomputed. The recomputation
-; forced by calling `execute()` on the Atom that the stream is created
-; with.
-;
-; Create an Atom, a key, and a random stream of five numbers.
-; The random stream is a FloatValue vector, of length 5; each of
-; the numbers are randomly distributed between 0.0 and 1.0
-(define foo (Concept "foo"))
-(define bar (Concept "bar"))
-(define akey (Predicate "some key"))
-(define bkey (Predicate "other key"))
-
-(cog-set-value! foo akey (RandomStream 5))
-
-; Take a look at what was created.
-(cog-value foo akey)
-
-; Verify that it really is a vector, and that it changes with each
-; access. The StreamValueOfLink will sample from the RandomStream.
-(cog-execute! (StreamValueOf foo akey))
-
-; Apply a formula to that stream, to get a different stream.
-(define fstream (FormulaStream (Plus (Number 10) (ValueOf foo akey))))
-
-; Place it on an atom, take a look at it, and make sure that it works.
-(cog-set-value! bar bkey fstream)
-(cog-value bar bkey)
-(cog-execute! (StreamValueOf bar bkey))
-(cog-execute! (StreamValueOf bar bkey))
-(cog-execute! (StreamValueOf bar bkey))
 
 ; ------- THE END -------

--- a/examples/atomspace/flow-formulas.scm
+++ b/examples/atomspace/flow-formulas.scm
@@ -22,8 +22,9 @@
 ; a vector of arbitrary length.
 ;
 ; The FormulaStream generalizes the FutureTruthValue, so that it can
-; work with any FloatValue, not just TruthValues. This is demo'ed in
-; the `flow-futures.scm` file.
+; work with any FloatValue, not just TruthValues. An introductory demo
+; is provided at the bottom of this file. A more complex demo is in the
+; `flow-futures.scm` file.
 
 (use-modules (opencog) (opencog exec))
 
@@ -208,5 +209,39 @@
 ; And take another look.
 (format #t "A implies B has strength ~6F and confidence ~6F\n"
 	(cog-mean a-implies-b) (cog-confidence a-implies-b))
+
+; -------------------------------------------------------------
+; The FormulaStream is the generalization of FutureTruthValue, suitable
+; for streaming a FloatValue of arbitrary length. As before, whenever it
+; is accessed, the current vector value is recomputed. The recomputation
+; forced by calling `execute()` on the Atom that the stream is created
+; with.
+;
+; Create an Atom, a key, and a random stream of five numbers.
+; The random stream is a FloatValue vector, of length 5; each of
+; the numbers are randomly distributed between 0.0 and 1.0
+(define foo (Concept "foo"))
+(define bar (Concept "bar"))
+(define akey (Predicate "some key"))
+(define bkey (Predicate "other key"))
+
+(cog-set-value! foo akey (RandomStream 5))
+
+; Take a look at what was created.
+(cog-value foo akey)
+
+; Verify that it really is a vector, and that it changes with each
+; access. The StreamValueOfLink will sample from the RandomStream.
+(cog-execute! (StreamValueOf foo akey))
+
+; Apply a formula to that stream, to get a different stream.
+(define fstream (FormulaStream (Plus (Number 10) (ValueOf foo akey))))
+
+; Place it on an atom, take a look at it, and make sure that it works.
+(cog-set-value! bar bkey fstream)
+(cog-value bar bkey)
+(cog-execute! (StreamValueOf bar bkey))
+(cog-execute! (StreamValueOf bar bkey))
+(cog-execute! (StreamValueOf bar bkey))
 
 ; ------- THE END -------

--- a/examples/atomspace/flow-futures.scm
+++ b/examples/atomspace/flow-futures.scm
@@ -19,5 +19,25 @@
 (use-modules (opencog) (opencog exec))
 
 ; -------------------------------------------------------------
+; Below is a toy pair-counting framework.  It increments counts
+; on pairs, as well as on marginals.
+
+(define (incr-counts THING-A THING-B)
+	(cog-inc-count! (List THING-A THING-B))
+	(cog-inc-count! (List (AnyNode "left wildcard") THING-B))
+	(cog-inc-count! (List THING-A (AnyNode "right wildcard")))
+	(cog-inc-count! (AnyNode "grand total")))
+
+; Same as above, but works with strings. It counts how often a pair
+; was "observed".
+(define (observe STRING-A STRING-B)
+	(incr-count (Concept STRING-A) (Concept STRING-B)))
+
+; Provide some initial data
+(observe "hello" "world")
+(observe "hello" "Sue")
+(observe "hello" "Adrian")
+(observe "goodbye" "Adrian")
+(observe "goodbye" "Mike")
 
 ; ------- THE END -------

--- a/examples/atomspace/flow-futures.scm
+++ b/examples/atomspace/flow-futures.scm
@@ -1,61 +1,23 @@
 ;
 ; flow-futures.scm -- Dynamically changing FloatValue flows.
 ;
-; The concept of a "value flow" is the idea that a Value can change
-; dynamically, recomputed from a formula that draws on it's inputs.
-; Examples of such formulas are provided below, together with the
-; code for wiring them into Atoms.
+; The `flow-formulas.scm` demo showed how to attach dynamically-updating
+; TruthValues to Atoms. This demo is similar, except that it works with
+; general FloatValues.  The specific example here computes the mutual
+; information of an ordered pair, given only counts on the pair, and
+; counts on the marginals.  This requires doing arithmetic on numbers
+; coming from four different places, and then placing the result where
+; it can be found.
 ;
-; The core implementation is in two parts: the FutureTruthValue,
-; which implements a dynamically-variable TruthValue, and the
-; FormulaPredicateLink, which specifies the formula used to compute
-; the TruthValue.
+; This is a fairly complex demo, as it attempts to be more realistic.
 ;
-; The FutureTruthValue is a kind of SimpleTruthValue, such that, every
-; time that it is accessed, the current value -- that is, the current
-; pair of floating point numbers -- is recomputed.  The recomputation
-; occurs every time the numeric value is accessed (i.e. when the
-; strength and confidence of the TV are accessed).
-;
-; The FormulaStream is a generalization of the FutureTruthValue, in
-; that it allows for the computation of any FloatValue. That is, the
-; SimpleTV's are just vectors of length two - the strength and
-; confidence, whereas the FloatValue is a vector of arbitrary length.
+; As before, the core function is provided by the FormulaStream, which
+; which wraps an arithmetic expression so that it behaves like a future.
+; See https://en.wikipedia.org/wiki/Futures_and_promises for the general
+; idea.
 
 (use-modules (opencog) (opencog exec))
 
 ; -------------------------------------------------------------
-; The FormulaStream is the generalization of FutureTruthValue, suitable
-; for streaming a FloatValue of arbitrary length. As before, whenever it
-; is accessed, the current vector value is recomputed. The recomputation
-; forced by calling `execute()` on the Atom that the stream is created
-; with.
-;
-; Create an Atom, a key, and a random stream of five numbers.
-; The random stream is a FloatValue vector, of length 5; each of
-; the numbers are randomly distributed between 0.0 and 1.0
-(define foo (Concept "foo"))
-(define bar (Concept "bar"))
-(define akey (Predicate "some key"))
-(define bkey (Predicate "other key"))
-
-(cog-set-value! foo akey (RandomStream 5))
-
-; Take a look at what was created.
-(cog-value foo akey)
-
-; Verify that it really is a vector, and that it changes with each
-; access. The StreamValueOfLink will sample from the RandomStream.
-(cog-execute! (StreamValueOf foo akey))
-
-; Apply a formula to that stream, to get a different stream.
-(define fstream (FormulaStream (Plus (Number 10) (ValueOf foo akey))))
-
-; Place it on an atom, take a look at it, and make sure that it works.
-(cog-set-value! bar bkey fstream)
-(cog-value bar bkey)
-(cog-execute! (StreamValueOf bar bkey))
-(cog-execute! (StreamValueOf bar bkey))
-(cog-execute! (StreamValueOf bar bkey))
 
 ; ------- THE END -------

--- a/examples/atomspace/flow-futures.scm
+++ b/examples/atomspace/flow-futures.scm
@@ -172,7 +172,8 @@
 (define (get-mi-scalar STRING-A STRING-B)
 	(get-computed-scalar (Concept STRING-A) (Concept STRING-B)))
 
-; Try it out
+; Try it out. Need to install it before first use.
+(install-scalar-mi "hello" "world")
 (get-mi-scalar "hello" "world")
 (get-mi "hello" "world")
 

--- a/examples/atomspace/flow-futures.scm
+++ b/examples/atomspace/flow-futures.scm
@@ -125,7 +125,7 @@
 ; Repeat some of the above, this time using the DecimateLink
 ; to pick out the desired component.
 
-; Defina a bit-mask and install it.
+; Define a bit-mask and install it.
 (cog-set-value! (Concept "someplace") (Predicate "mask key")
 	(BoolValue 0 0 1))
 

--- a/examples/atomspace/flow-futures.scm
+++ b/examples/atomspace/flow-futures.scm
@@ -40,4 +40,42 @@
 (observe "goodbye" "Adrian")
 (observe "goodbye" "Mike")
 
+; -------------------------------------------------------------
+; Set up the pipeline.
+
+; Counts are located in the third slot of the TV predicate.
+(define tvp (PredicateNode "*-TruthValueKey-*"))
+
+; We will use the formula MI(a,b) = log_2 N(a,b) N(*,*) / N(a,*) N(*,b)
+; to compute the MI of a pair.
+(DefineLink
+	(DefinedProcedure "dynamic MI")
+	(Lambda
+		(VariableList (Variable "$L") (Variable "$R"))
+		(Log2
+			(Divide
+				(Times
+					(FloatValueOf (List (Variable "$L") (Variable "$R")) tvp)
+					(FloatValueOf (AnyNode "grand total") tvp))
+				(Times
+					(FloatValueOf (List (Variable "$L") (Any "right wildcard")) tvp)
+					(FloatValueOf (List (Any "left wildcard") (Variable "$R")) tvp))))))
+
+; A utility to install the above formula on a pair.
+; The formula does no good if unless we stick it on the object.
+(define (install-formula THING-A THING-B)
+	(define pair (List THING-A THING-B))
+	(cog-set-value! pair (Predicate "MI Key")
+		(FormulaStream
+			(ExecutionOutput (DefinedProcedure "dynamic MI") pair))))
+
+; Convenience wrapper, works with strings.
+(define (install-mi STRING-A STRING-B)
+	(install-formula (Concept STRING-A) (Concept STRING-B)))
+
+; -------------------------------------------------------------
+; OK, we're done. Lets see what happens.
+
+(install-mi "hello" "world)
+
 ; ------- THE END -------

--- a/examples/atomspace/flow-futures.scm
+++ b/examples/atomspace/flow-futures.scm
@@ -1,0 +1,61 @@
+;
+; flow-futures.scm -- Dynamically changing FloatValue flows.
+;
+; The concept of a "value flow" is the idea that a Value can change
+; dynamically, recomputed from a formula that draws on it's inputs.
+; Examples of such formulas are provided below, together with the
+; code for wiring them into Atoms.
+;
+; The core implementation is in two parts: the FutureTruthValue,
+; which implements a dynamically-variable TruthValue, and the
+; FormulaPredicateLink, which specifies the formula used to compute
+; the TruthValue.
+;
+; The FutureTruthValue is a kind of SimpleTruthValue, such that, every
+; time that it is accessed, the current value -- that is, the current
+; pair of floating point numbers -- is recomputed.  The recomputation
+; occurs every time the numeric value is accessed (i.e. when the
+; strength and confidence of the TV are accessed).
+;
+; The FormulaStream is a generalization of the FutureTruthValue, in
+; that it allows for the computation of any FloatValue. That is, the
+; SimpleTV's are just vectors of length two - the strength and
+; confidence, whereas the FloatValue is a vector of arbitrary length.
+
+(use-modules (opencog) (opencog exec))
+
+; -------------------------------------------------------------
+; The FormulaStream is the generalization of FutureTruthValue, suitable
+; for streaming a FloatValue of arbitrary length. As before, whenever it
+; is accessed, the current vector value is recomputed. The recomputation
+; forced by calling `execute()` on the Atom that the stream is created
+; with.
+;
+; Create an Atom, a key, and a random stream of five numbers.
+; The random stream is a FloatValue vector, of length 5; each of
+; the numbers are randomly distributed between 0.0 and 1.0
+(define foo (Concept "foo"))
+(define bar (Concept "bar"))
+(define akey (Predicate "some key"))
+(define bkey (Predicate "other key"))
+
+(cog-set-value! foo akey (RandomStream 5))
+
+; Take a look at what was created.
+(cog-value foo akey)
+
+; Verify that it really is a vector, and that it changes with each
+; access. The StreamValueOfLink will sample from the RandomStream.
+(cog-execute! (StreamValueOf foo akey))
+
+; Apply a formula to that stream, to get a different stream.
+(define fstream (FormulaStream (Plus (Number 10) (ValueOf foo akey))))
+
+; Place it on an atom, take a look at it, and make sure that it works.
+(cog-set-value! bar bkey fstream)
+(cog-value bar bkey)
+(cog-execute! (StreamValueOf bar bkey))
+(cog-execute! (StreamValueOf bar bkey))
+(cog-execute! (StreamValueOf bar bkey))
+
+; ------- THE END -------

--- a/examples/atomspace/frame.scm
+++ b/examples/atomspace/frame.scm
@@ -1,5 +1,5 @@
 ;
-; frame.scm -- Combining StateLink with dervived AtomSpaces
+; frame.scm -- Combining StateLink with derived AtomSpaces
 ;
 ; The StateLink guarantees that only one copy of the StateLink
 ; will be present in the AtomSpace.  The cog-push-atomspace and

--- a/examples/atomspace/my_py_func.py
+++ b/examples/atomspace/my_py_func.py
@@ -10,7 +10,7 @@ from opencog.atomspace import types
 
 asp = AtomSpace()
 
-# Python function taking two atoms, converting thier string-names to
+# Python function taking two atoms, converting their string-names to
 # floats, adding the floats, and returning a new atom holding the sum.
 def my_py_func(atoma, atomb):
     print('Python received two arguments:\n' + str(atoma) + str(atomb))

--- a/examples/atomspace/persist-file.scm
+++ b/examples/atomspace/persist-file.scm
@@ -58,7 +58,7 @@
 ; loads it. For plain Atomese, this is a complete waste of time, and,
 ; for large files, it can be painfully slow. Yes, you can disable it
 ; with the GUILE_AUTO_COMPILE flag, or by loading it "raw", but that
-; still won't be enough for extrememly large files. One can do even
+; still won't be enough for extremely large files. One can do even
 ; better, by using the "fast loader".
 ;
 ; But first: you can load Atomese without compiling by doing this:

--- a/examples/atomspace/persist-multi.scm
+++ b/examples/atomspace/persist-multi.scm
@@ -9,7 +9,7 @@
 ; RocksDB backend, although any set of backends can be used. This
 ; demo requires Postgres to be configured, and the RocksDB backend
 ; to be installed. If you want to skip Postgres, then just try the
-; demo wth two different RocksDB stores.
+; demo with two different RocksDB stores.
 ;
 
 (use-modules (ice-9 readline))

--- a/examples/atomspace/persistence.scm
+++ b/examples/atomspace/persistence.scm
@@ -4,7 +4,7 @@
 ; The AtomSpace is an in-RAM database. You just might want to sometimes
 ; write some of it out to disk, and save it for later; or maybe you want
 ; to share AtomSpace contents with other AtomSpaces. This is accomplished
-; with "persistance" plug-in modules. As of this writing, there are
+; with "persistence" plug-in modules. As of this writing, there are
 ; four stable, supported modules for doing this:
 ;
 ; (persist-sql)   - Stores the AtomSpace to a PostgreSQL database.
@@ -42,7 +42,7 @@
 ; format (serialization/deserialization) takes up far more CPU time than
 ; the AtomSpace does. That is, converting Atoms/Values into key-value
 ; pairs (for no-SQL databases) or into row/column format (for SQL) or
-; even into vertexes and edges (for graph databases) is a very costly
+; even into vertices and edges (for graph databases) is a very costly
 ; proposition. It take a *lot* of CPU time! Worse, most databases are
 ; network-enabled, and thus have to create packets, send them and decode
 ; them at the other end, which adds even more overhead!  We found this

--- a/examples/atomspace/state.scm
+++ b/examples/atomspace/state.scm
@@ -117,7 +117,7 @@
 	(Evaluation (Predicate "Is A") (List (Concept "fruit") (Variable "$x")))))
 
 ; ------------------
-; The is-a relation is so very special, it get's it's own custom link
+; The is-a relation is so very special, it gets it's own custom link
 ; type. It is a bit shorter and easier to read.
 
 (Inheritance (Concept "fruit") (Concept "apple"))

--- a/opencog/atoms/atom_types/atom_types.script
+++ b/opencog/atoms/atom_types/atom_types.script
@@ -883,8 +883,9 @@ ACCUMULATE_LINK <- NUMERIC_FUNCTION_LINK
 
 // Apply a BoolValue to any other vector, knocking out all locations
 // marked with a zero, keeping all location marked with a one, thus
-// creating a shorter vector.
-DECIMATE_LINK <- FUNCTION_LINK
+// creating a shorter vector. Works on vectors of Bools, Strings, Floats,
+// etc. Declare that, so the static typechecker passes.
+DECIMATE_LINK <- FUNCTION_LINK,NUMERIC_OUTPUT_LINK,BOOLEAN_OUTPUT_LINK
 
 // TODO: perhaps create shift-left, shift-right and truncate operators?
 // Someday, they will be needed; just not yet, I guess.

--- a/opencog/atoms/atom_types/atom_types.script
+++ b/opencog/atoms/atom_types/atom_types.script
@@ -1,5 +1,5 @@
 //
-// Script for automatic "atom type" generation. For more information,
+// Script for automatic "Atom type" generation. For more information,
 // consult the `README.md` file in this directory.
 //
 // Please note: some of the types below are used only via the scheme
@@ -10,7 +10,7 @@
 //
 // ===========================================================
 
-// Special type designating that no atom type has been assigned. It is
+// Special type designating that no Atom type has been assigned. It is
 // equivalent to the bottom type in type theory, see
 // https://en.wikipedia.org/wiki/Bottom_type
 NOTYPE
@@ -21,31 +21,36 @@ NOTYPE
 TOP_TYPE
 
 // --------------------------------------------------------------
-// Values are collections of data that can be associated with atoms.
-// Think of them as decorations that can be hung on an atom.
+// Values are collections of data that can be associated with Atoms.
+// Think of them as decorations that can be hung on an Atom.
 VALUE <- TOP_TYPE
 
-VOID_VALUE <- VALUE     // singleton value holding nothing at all.
+VOID_VALUE <- VALUE     // singleton Value holding nothing at all.
 BOOL_VALUE <- VALUE     // vector of booleans
 FLOAT_VALUE <- VALUE    // vector of floats
 STRING_VALUE <- VALUE   // vector of strings
-LINK_VALUE <- VALUE     // vector of values ("link" holding values)
-VALUATION <- VALUE      // (atom,key,value) triple
+LINK_VALUE <- VALUE     // vector of Values ("link" holding Values)
+VALUATION <- VALUE      // (Atom,key,Value) triple
 
 // ===========================================================
-// A base class for time-varying floating-point values.
+// Streams aka Futures. Futures deliver a Value when asked.
+// Since they can deliver more than one, and it typically changes
+// over time, we call them "streams".  They provide wrappers for
+// any kind of time-varying data.
+
+// A base class for time-varying floating-point Values.
 STREAM_VALUE <- FLOAT_VALUE
 
-// An example of a time-varying value stream
+// An example of a time-varying Value stream
 RANDOM_STREAM <- STREAM_VALUE
 
 // A stream computed by a formula held in the AtomSpace.
 FORMULA_STREAM <- STREAM_VALUE
 
-// A base class for time-varying value sequences.
+// A base class for time-varying Value sequences.
 LINK_STREAM_VALUE <- LINK_VALUE
 
-// A thread-safe FIFO queue of value sequences.
+// A thread-safe FIFO queue of Value sequences.
 QUEUE_VALUE <- LINK_STREAM_VALUE
 
 // ===========================================================
@@ -56,7 +61,7 @@ QUEUE_VALUE <- LINK_STREAM_VALUE
 // with additional evidence associated to them. In yet other cases,
 // these resemble the truth values of "fuzzy logic", and so on.
 //
-// Many atoms and operations on atoms explicitly require truth values
+// Many Atoms and operations on Atoms explicitly require TruthValues
 // -- for example, PredicateNodes and EvaluationLinks -- and so these
 // are vital and centrally important for getting things to work.
 //
@@ -72,7 +77,7 @@ FUTURE_TRUTH_VALUE         <- TRUTH_VALUE, FORMULA_STREAM
 FORMULA_TRUTH_VALUE        <- TRUTH_VALUE, FORMULA_STREAM
 
 // ===========================================================
-// Base of the atom hierarchy. Atoms are globally unique; the AtomSpace
+// Base of the Atom hierarchy. Atoms are globally unique; the AtomSpace
 // guarantees that uniqueness. They are persistent; the AtomSpace
 // provides persistence. They are immutable (unchangeable); links and
 // nodes cannot be modified. However, the Values stored on a link/node
@@ -115,13 +120,13 @@ PREDICATE_NODE <- NODE
 // This mechanism is adequate to deal with simple user errors, but
 // isn't very strong. Issues include:
 //
-// *) By doing type-checking at atom-creation time, this is a kind-of
+// *) By doing type-checking at Atom-creation time, this is a kind-of
 //    static type-checking, and thus suffers from the typical issues
 //    of static type-checking.
 // *) Polymorphic outputs are broken.  For example, ValueOfLink
 //    can return both numbers, and not-numbers...
 // *) It fails to handle "deep types", as there should be some form
-//    of ArrowLink associated with each atom atype.
+//    of ArrowLink associated with each Atom atype.
 // *) It fails to handle connector polarities beyond just "input"
 //    and "output". That is, there are more ways of connecting things
 //    than merely saying "outputs are things that can be plugged into
@@ -130,13 +135,18 @@ PREDICATE_NODE <- NODE
 // So... deficient in many ways, but basically, it works for now, and it
 // handles most of the basic cases in a fairly straightforward fashion.
 
+// ValuableLink. Any link type which might be executed, resulting
+// in a Value, should inherit from this type.  This is a mixin-type,
+// it does nothing by itself, but is used to identify link types that
+// are executable - that is, they return Values when they are executed.
+VALUABLE_LINK <- LINK
 
 // Evaluatable link. Any link type which might be evaluated, resulting
-// in a truth-value, should inherit from this type.  This is a
+// in a TruthValue, should inherit from this type.  This is a
 // mixin-type, it does nothing by itself, but is used to identify
-// link types that are evaluatable - that is, they return truth values
+// link types that are evaluatable - that is, they return TruthValues
 // when they are evaluated.
-EVALUATABLE_LINK <- LINK
+EVALUATABLE_LINK <- VALUABLE_LINK
 
 // Crisp (scalar-valued) boolean-input link.  This link type forces
 // type-checking on it's "inputs" (it's outgoing set): they must be
@@ -152,7 +162,7 @@ CRISP_OUTPUT_LINK <- EVALUATABLE_LINK
 BOOLEAN_INPUT_LINK <- LINK
 
 // Boolean-output link. Generates BoolValues upon execution.
-BOOLEAN_OUTPUT_LINK <- LINK
+BOOLEAN_OUTPUT_LINK <- VALUABLE_LINK
 
 // Numeric-input link.  This link type forces type-checking on it's
 // "inputs" (it's outgoing set): they must be NumberNodes, or things
@@ -162,14 +172,14 @@ NUMERIC_INPUT_LINK <- LINK
 
 // Numeric-output link. Generates either NumberNodes or FloatValues
 // upon execution.
-NUMERIC_OUTPUT_LINK <- LINK
+NUMERIC_OUTPUT_LINK <- VALUABLE_LINK
 
 // Type-input link.  This link type forces type-checking on it's
 // "inputs" (it's outgoing set): they must be types.
 TYPE_INPUT_LINK <- LINK
 
 // Type-output link. Generates Types upon execution.
-TYPE_OUTPUT_LINK <- LINK
+TYPE_OUTPUT_LINK <- VALUABLE_LINK
 
 // Alpha-convertible links are those that may have multiple different
 // representations that are alpha-equivalent. This mixin helps checkers
@@ -190,7 +200,7 @@ LIST_LINK <- ORDERED_LINK,COLLECTION_LINK
 SET_LINK <- UNORDERED_LINK,COLLECTION_LINK
 
 // Measure-theoretic (probabilistic) versions of AND_LINK, OR_LINK
-// These use probabilistic formulas to compute truth values.
+// These use probabilistic formulas to compute TruthValues.
 // See issue opencog/atomspace#2814 for a discussion.
 UNION_LINK <- UNORDERED_LINK,COLLECTION_LINK
 INTERSECTION_LINK <- UNORDERED_LINK,COLLECTION_LINK
@@ -262,7 +272,7 @@ CHOICE_LINK <- ORDERED_LINK,CRISP_OUTPUT_LINK
 // Rounding out the above, we have PresentLink, which is the converse
 // of AbsentLink, and is dual to ChoiceLink, since it requires that all
 // terms are AND'ed together.  Since it does not make sense to ask if
-// the same atom is present more than once, or what order it was in, it
+// the same Atom is present more than once, or what order it was in, it
 // is an unordered link, and duplicates are eliminated.
 //
 PRESENT_LINK <- SET_LINK,CRISP_OUTPUT_LINK
@@ -450,7 +460,7 @@ VARIABLE_LIST <- CONNECTOR_SEQ
 // BindLink.
 VARIABLE_SET <- CONNECTOR_SET
 
-// A non-greedy globbing variable; matches one or more atoms in a
+// A non-greedy globbing variable; matches one or more Atoms in a
 // sequence. All this really does is to name a variable, such that
 // the default type cnstructor for it will accept multiple matches.
 GLOB_NODE <- VARIABLE_NODE
@@ -467,7 +477,7 @@ UNQUOTE_LINK <- ORDERED_LINK
 
 // Like QuoteLink but only affects the direct child, not its
 // descendants. It has the same effect as wrapping the child with a
-// QuoteLink and each atom of the its outgoing set with an UnquoteLink.
+// QuoteLink and each Atom of the its outgoing set with an UnquoteLink.
 LOCAL_QUOTE_LINK <- ORDERED_LINK
 
 // Everything under a DontExecLink is not executed. This is typically
@@ -518,7 +528,7 @@ FREE_LINK <- ORDERED_LINK
 DELETE_LINK <- FREE_LINK
 
 // Only one "closed" UniqueLink may exist (in the AtomSpace), for a
-// fixed first atom of the link.  Useful for defining state.  Additional
+// fixed first Atom of the Link.  Useful for defining state.  Additional
 // "open" links may exist; "open" links are defined as links that
 // contain free variables (see Wikipedia definition of "open term",
 // "closed term").  Kind of like DeleteLink, but allows one instead of
@@ -553,7 +563,7 @@ SCOPE_LINK <- SECTION,ALPHA_CONVERTIBLE_LINK
 
 // The RewriteLink is a ScopeLink with extra methods that perform
 // alpha conversion and beta reduction on the ScopeLink. It is a base
-// class for many kinds of atom types, most of which CANNOT be treated
+// class for many kinds of Atom types, most of which CANNOT be treated
 // as if they were lambdas!  So user beware: although RewriteLink feels
 // like LambdaLink ... it isn't.  Not everything is a Lambda.
 REWRITE_LINK <- SCOPE_LINK
@@ -604,7 +614,7 @@ MAXIMAL_JOIN_LINK <- JOIN_LINK
 PATTERN_LINK <- PRENEX_LINK
 
 // We subdivide patterns into two types: one type returns a TV when it
-// is evaluated.  The other type returns a set of atoms when it is
+// is evaluated.  The other type returns a set of Atoms when it is
 // executed.  The distinction is made for the benefit of the C++ code,
 // so that it can dispatch appropriately, based on the base type.
 
@@ -617,7 +627,7 @@ SATISFYING_LINK <- PATTERN_LINK
 // ImplicationLink, except that its imperative, not declarative.
 // Both return SetLinks holding the results.
 // QueryLink is identical to BindLink, except it returns a LinkValue
-// holding the result, instead of a SetLink. (Less atomspace pollution).
+// holding the result, instead of a SetLink. (Less AtomSpace pollution).
 MEET_LINK <- SATISFYING_LINK       // Finds all groundings, returns them
 GET_LINK <- MEET_LINK              // Finds all groundings, returns them
 QUERY_LINK <- SATISFYING_LINK      // Finds all groundings, substitutes.
@@ -633,17 +643,17 @@ DUAL_LINK <- SATISFYING_LINK
 //
 // EvaluationLinks record the result of evaluating a predicate.
 // That is, given some elements, they indicate whether the predicate is
-// true or false (or has some other truth value) on those elements.
+// true or false (or has some other TruthValue) on those elements.
 EVALUATION_LINK <- FREE_LINK,EVALUATABLE_LINK
 
 // ==============================================================
-// Types and type constructors. Variables and other atoms can be
+// Types and type constructors. Variables and other Atoms can be
 // given types.  The below describe the types.
 
 // A TypeNode holds simple, "atomic" type declarations, such as those
 // defined in this file. It cannot hold compound types (deep types),
 // because compound types are Atoms, and this is a Node, not a Link,
-// and so it cannot hold any atoms. Use DefinedTypeNode for compound
+// and so it cannot hold any Atoms. Use DefinedTypeNode for compound
 // types. Its a LexicalNode, whose lexis consists of Atom types.
 TYPE_NODE <- BOND_NODE
 
@@ -705,10 +715,10 @@ SIGNATURE_LINK <- CONNECTOR,TYPE_OUTPUT_LINK
 // The variable name is not lexical -- its a wild-card.
 TYPED_VARIABLE_LINK <- CONNECTOR,ALPHA_CONVERTIBLE_LINK
 
-// A type binder for non-variable atoms. It binds a type to an atom
+// A type binder for non-variable Atoms. It binds a type to an Atom
 // at a "global" level.  Always arity-2, the first position cannot be
-// any atom except for a VariableNode, the second must be a type.
-// A given atom can only ever have just one type, thus, this is unique.
+// any Atom except for a VariableNode, the second must be a type.
+// A given Atom can only ever have just one type, thus, this is unique.
 TYPED_ATOM_LINK <- UNIQUE_LINK
 
 // An arity-2 link, used for specifying numeric intervals, that is,
@@ -763,18 +773,18 @@ VIRTUAL_LINK <- CRISP_OUTPUT_LINK
 GREATER_THAN_LINK <- VIRTUAL_LINK,NUMERIC_INPUT_LINK
 LESS_THAN_LINK <- VIRTUAL_LINK,NUMERIC_INPUT_LINK
 
-// Test whether all outgoing atoms are closed, that is do not contain
+// Test whether all outgoing Atoms are closed, that is do not contain
 // any free variable.
 IS_CLOSED_LINK <- UNORDERED_LINK,VIRTUAL_LINK
 
-// Test whether all outgoing atoms have a TRUE_TV (resp. FALSE_TV).
+// Test whether all outgoing Atoms have a TRUE_TV (resp. FALSE_TV).
 IS_TRUE_LINK <- UNORDERED_LINK,VIRTUAL_LINK
 IS_FALSE_LINK <- UNORDERED_LINK,VIRTUAL_LINK
 
 // IdenticalLink tests for syntactic equality.  It does NOT execute its
-// arguments; it is true only if both sides are the same atom.
+// arguments; it is true only if both sides are the same Atom.
 // EqualLink tests for semantic equality: the two sides are equal, if,
-// after execution, they evaluate to the same atom.
+// after execution, they evaluate to the same Atom.
 IDENTICAL_LINK <- UNORDERED_LINK,VIRTUAL_LINK
 EQUAL_LINK <- UNORDERED_LINK,VIRTUAL_LINK
 
@@ -793,8 +803,8 @@ SATISFACTION_LINK <- SATISFYING_LINK,VIRTUAL_LINK
 // --------------------------------------------------------------
 // Functions that do NOT bind variables.
 
-// A FunctionLink is a link that can be executed, with the result of
-// execution being some atom.  FunctionLink does NOT derive from
+// A FunctionLink is a Link that can be executed, with the result of
+// execution being some Atom.  FunctionLink does NOT derive from
 // LambdaLink, which may seem counter-intuitive; here's why, so
 // listen up.  All of the explicitly-named functions (e.g. PlusLink)
 // do not need to explicitly name their arguments, and it would even
@@ -863,11 +873,19 @@ RANDOM_NUMBER_LINK <- NUMERIC_FUNCTION_LINK
 // Trigonometric Sine function
 SINE_LINK <- NUMERIC_FUNCTION_LINK
 
-// Return the sum of vector components of a number/float-value.
+// Return the sum of vector components of a NumberNode or FloatValue.
 ACCUMULATE_LINK <- NUMERIC_FUNCTION_LINK
 
+// Apply a BoolValue to any other vector, knocking out all locations
+// marked with a zero, keeping all location marked with a one, thus
+// creating a shorter vector.
+DECIMATE_LINK <- FUNCTION_LINK
+
+// TODO: perhaps create shift-left, shift-right and truncate operators?
+// Someday, they will be needed; just not yet, I guess.
+
 // Return arity of the wrapped link. If it's a NumberNode
-// of a value, return the length of the underlying vector.
+// or a Value, return the length of the underlying vector.
 // XXX FIXME .. did we mis-name this? Should it be SizeOfLink
 // or maybe LengthOfLink? (viz, the length of FloatValue...)
 ARITY_LINK <- FUNCTION_LINK,NUMERIC_OUTPUT_LINK
@@ -876,10 +894,9 @@ ARITY_LINK <- FUNCTION_LINK,NUMERIC_OUTPUT_LINK
 TIME_LINK <- FUNCTION_LINK,NUMERIC_OUTPUT_LINK
 
 // --------------------
-// Truth-value manipulating functions. Some of these return numbers,
-// some of these return truth values.
+// Value getters. Grab the current Value attached to some Atom.
 
-// Return the indicated value on the indicated atom.
+// Return the indicated Value on the indicated Atom.
 // The BoolValueOf and FloatValueOf links exist only to provide
 // creation-time type checking; otherwise, they behave just like
 // the ValueOfLink.
@@ -892,12 +909,21 @@ STRENGTH_OF_LINK <- FLOAT_VALUE_OF_LINK
 CONFIDENCE_OF_LINK <- FLOAT_VALUE_OF_LINK
 COUNT_OF_LINK <- FLOAT_VALUE_OF_LINK
 
-// Opposite of the above; attach a value to an atom.
-SET_VALUE_LINK <- FUNCTION_LINK
-SET_TV_LINK <- SET_VALUE_LINK,EVALUATABLE_LINK "SetTVLink"
+// Like the above, but this returns a promise to return a Value
+// sometime in the future. This is accomplished by returning a
+// StreamValue or a LinkStreamValue, when executed. The streams
+// will then cough up the actual Value later on, when interrogated.
+// Used to create dynamically executable computation chains.
+PROMISE_LINK <- VALUABLE_LINK
+
+// Return a FutureTruthValue when evaluated. Same as above, but for
+// TruthValues only.  This can be used to wrap any Atom that returns a
+// TruthValue. The effect is to defer to the future the evaluation of
+// that predicate. Used to create dynamically evaluatable formulas.
+PROMISE_PREDICATE_LINK <- EVALUATABLE_LINK, PROMISE_LINK
 
 // Return a SimpleTruthValue when evaluated.
-// This is used to wrap any atom that returns a FloatValue; all this
+// This is used to wrap any Atom that returns a FloatValue; all this
 // does is to provide some formatting.  It is not strictly needed,
 // because any LambdaLink returning FloatValue is enough. But this is
 // handy to have while a transition is made to a more general setting.
@@ -909,19 +935,18 @@ SET_TV_LINK <- SET_VALUE_LINK,EVALUATABLE_LINK "SetTVLink"
 // the variables.
 FORMULA_PREDICATE_LINK <- SCOPE_LINK,EVALUATABLE_LINK
 
-// Return a FormulaTruthValue when evaluated.
-// This is used to wrap any atom that returns a TruthValue. The effect
-// is to defer to the future the evaluation of that predicate. Used to
-// create dynamically evaluatable formulas.
-PROMISE_PREDICATE_LINK <- EVALUATABLE_LINK
+// Opposite of the above; attach a Value to an Atom.
+SET_VALUE_LINK <- FUNCTION_LINK
+SET_TV_LINK <- SET_VALUE_LINK,EVALUATABLE_LINK "SetTVLink"
 
 // --------------------
 // Other kinds of functions.
 
 // The ExecutionOutputLink is a specific kind of function: it must have
-// a GroundedSchemeNode as its first argument.  The other kinds of
-// FunctionLinks do not have this restriction: indeed, the actual
-// function they perform is implicit in the link type.
+// a Schema of some kind in it's first argument. Current choices include:
+// Schema, GroundedSchema, DefinedSchema and PromiseSchema. The other
+// kinds of FunctionLinks do not need this; the function they perform,
+// that is, the schema, is implcit in the link type.
 EXECUTION_OUTPUT_LINK <- FUNCTION_LINK
 
 // Return (with uniform distribution) one of the links it wraps.
@@ -938,7 +963,7 @@ COND_LINK <- FUNCTION_LINK
 SLEEP_LINK <- FUNCTION_LINK,NUMERIC_INPUT_LINK
 
 // MapLink could be named UnPutLink ... it undoes a beta-reduction,
-// by extracting values for a given set of variables.  In many ways,
+// by extracting Values for a given set of variables.  In many ways,
 // it resembles a GetLink, except that it searches only its argument
 // list, instead of the entire AtomSpace.  It is more-or-less analogous
 // to the standard functional-programming concept of "map".
@@ -948,13 +973,19 @@ MAP_LINK <- FUNCTION_LINK
 // Procedure and schema nodes.
 //
 // These form the foundation for a different way of looking at
-// values and predicates: they generalize the notion of "predicate"
-// so that any value or atom can be the result of evaluation
+// Values and Predicates: they generalize the notion of "predicate"
+// so that any Value or Atom can be the result of evaluation
 // (which is now renamed "execution", to make a distinction).
 //
 // Procedures are generic terms; when they are executed, they can
-// return any value, including Atoms, and not just TruthValues.
+// return any Value, including Atoms, and not just TruthValues.
 PROCEDURE_NODE <- NODE
+
+// DefinedProcedureNodes are used to make human-written Atomese easier
+// to read by humans. They have no other fundamental usefulness...
+// They are meant to be wrappers for more complex Atomese that return
+// some Value.
+DEFINED_PROCEDURE_NODE <- PROCEDURE_NODE
 
 // Grounded procedures/predicates/schemas are "jets", which replace
 // inefficient code with efficient implementations in an ad-hoc kind of
@@ -963,22 +994,25 @@ PROCEDURE_NODE <- NODE
 // http://lambda-the-ultimate.org/node/5482 for discussion of jets.
 GROUNDED_PROCEDURE_NODE <- PROCEDURE_NODE
 
-// SchemaNodes are similar to PredicateNodes, except they must
-// necessarily return an Atom when executed.
-SCHEMA_NODE <- PROCEDURE_NODE
-DEFINED_SCHEMA_NODE <- SCHEMA_NODE
-GROUNDED_SCHEMA_NODE <- SCHEMA_NODE,GROUNDED_PROCEDURE_NODE
+// GroundedPredicates wrap something that returns a TruthValue.
+GROUNDED_PREDICATE_NODE <- PREDICATE_NODE,GROUNDED_PROCEDURE_NODE
 
-// Special cases of PredicateNodes.
 // DefinedPredicateNodes are used to make human-written Atomese easier
 // to read by humans. They have no other fundamental usefulness...
+// They are meant to be wrappers for more complex Atomese that return
+// some TruthValue.
 DEFINED_PREDICATE_NODE <- PREDICATE_NODE
-GROUNDED_PREDICATE_NODE <- PREDICATE_NODE,GROUNDED_PROCEDURE_NODE
+
+// SchemaNodes are similar to PredicateNodes, except they must
+// necessarily return Atoms when executed.
+SCHEMA_NODE <- PROCEDURE_NODE
+DEFINED_SCHEMA_NODE <- SCHEMA_NODE,DEFINED_PROCEDURE_NODE
+GROUNDED_SCHEMA_NODE <- SCHEMA_NODE,GROUNDED_PROCEDURE_NODE
 
 // ==============================================================
 // Foreign abstrast syntax trees (AST's)
 
-// Base class for all foregin (non-atomese) language abstract syntax
+// Base class for all foregin (non-Atomese) language abstract syntax
 // trees.
 FOREIGN_AST <- LINK
 
@@ -1001,7 +1035,8 @@ PYTHON_AST <- FOREIGN_AST
 // Assorted miscellaneous link types with an unclear future.
 //
 
-// What is this? I dunno.
+// This is a marker used to avoid type-checking in the static type
+// checker. See `atoms/core/Checkers.cc`
 DIRECTLY_EVALUATABLE_LINK <- LINK
 
 // The ImplicationLink and the InheritanceLink ... these are really
@@ -1061,7 +1096,7 @@ EXECUTION_LINK <- ORDERED_LINK
 
 // Mystery link used by URE in it's unit tests. It is not documented
 // anywhere that I know of. But since URE does not define it's own
-// custom atom types ... we keep it here, for now. XXX FIXME
+// custom Atom types ... we keep it here, for now. XXX FIXME
 ATTRACTION_LINK <- ORDERED_LINK
 
 // Used in the URE unit tests. XXX FIXME the URE unit tests should

--- a/opencog/atoms/atom_types/atom_types.script
+++ b/opencog/atoms/atom_types/atom_types.script
@@ -44,14 +44,19 @@ STREAM_VALUE <- FLOAT_VALUE
 // An example of a time-varying Value stream
 RANDOM_STREAM <- STREAM_VALUE
 
-// A stream computed by a formula held in the AtomSpace.
-FORMULA_STREAM <- STREAM_VALUE
-
 // A base class for time-varying Value sequences.
 LINK_STREAM_VALUE <- LINK_VALUE
 
 // A thread-safe FIFO queue of Value sequences.
 QUEUE_VALUE <- LINK_STREAM_VALUE
+
+// A stream of Values, computed by a function held in the AtomSpace.
+// Typically computed by one of the FunctionLinks, below.
+FUTURE_STREAM <- LINK_STREAM_VALUE
+
+// A stream of FloatValues computed by a formula held in the AtomSpace.
+// Same as the FutureStream, specialized for FloatValues.
+FORMULA_STREAM <- STREAM_VALUE, FUTURE_STREAM
 
 // ===========================================================
 // TruthValues are the subobject classifiers for Atomese; they are used
@@ -910,10 +915,10 @@ CONFIDENCE_OF_LINK <- FLOAT_VALUE_OF_LINK
 COUNT_OF_LINK <- FLOAT_VALUE_OF_LINK
 
 // Like the above, but this returns a promise to return a Value
-// sometime in the future. This is accomplished by returning a
-// StreamValue or a LinkStreamValue, when executed. The streams
-// will then cough up the actual Value later on, when interrogated.
-// Used to create dynamically executable computation chains.
+// sometime in the future. This is accomplished by returning a either
+// a FutureStream or a FormulaStream when executed. This stream will
+// then cough up the actual Value later on, when interrogated. Used to
+// create dynamically executable computation chains.
 PROMISE_LINK <- VALUABLE_LINK
 
 // Return a FutureTruthValue when evaluated. Same as above, but for

--- a/opencog/atoms/atom_types/atom_types.script
+++ b/opencog/atoms/atom_types/atom_types.script
@@ -38,25 +38,25 @@ VALUATION <- VALUE      // (Atom,key,Value) triple
 // over time, we call them "streams".  They provide wrappers for
 // any kind of time-varying data.
 
+// A stream of Values, computed by a function held in the AtomSpace.
+// Typically computed by one of the FunctionLinks, below.
+FUTURE_STREAM <- VALUE
+
 // A base class for time-varying floating-point Values.
 STREAM_VALUE <- FLOAT_VALUE
 
 // An example of a time-varying Value stream
 RANDOM_STREAM <- STREAM_VALUE
 
+// A stream of FloatValues computed by a formula held in the AtomSpace.
+// Similar to the FutureStream, except it is specialized for FloatValues.
+FORMULA_STREAM <- STREAM_VALUE, FUTURE_STREAM
+
 // A base class for time-varying Value sequences.
 LINK_STREAM_VALUE <- LINK_VALUE
 
 // A thread-safe FIFO queue of Value sequences.
 QUEUE_VALUE <- LINK_STREAM_VALUE
-
-// A stream of Values, computed by a function held in the AtomSpace.
-// Typically computed by one of the FunctionLinks, below.
-FUTURE_STREAM <- LINK_STREAM_VALUE
-
-// A stream of FloatValues computed by a formula held in the AtomSpace.
-// Same as the FutureStream, specialized for FloatValues.
-FORMULA_STREAM <- STREAM_VALUE, FUTURE_STREAM
 
 // ===========================================================
 // TruthValues are the subobject classifiers for Atomese; they are used

--- a/opencog/atoms/core/DefineLink.cc
+++ b/opencog/atoms/core/DefineLink.cc
@@ -46,11 +46,12 @@ void DefineLink::init()
 	// definitions anchored with these types; other definitions won't
 	// work during execution.
 	Type dtype = _outgoing[0]->get_type();
-	if (DEFINED_SCHEMA_NODE != dtype and
+	if (DEFINED_PROCEDURE_NODE != dtype and
+	    DEFINED_SCHEMA_NODE != dtype and
 	    DEFINED_PREDICATE_NODE != dtype and
 	    DEFINED_TYPE_NODE != dtype)
 		throw SyntaxException(TRACE_INFO,
-			"Expecting Defined(Schema/Predicate/Type)Node, got %s",
+			"Expecting Defined(Procedure/Schema/Predicate/Type)Node, got %s",
 				nameserver().getTypeName(dtype).c_str());
 }
 

--- a/opencog/atoms/execution/ExecutionOutputLink.cc
+++ b/opencog/atoms/execution/ExecutionOutputLink.cc
@@ -37,7 +37,7 @@ void ExecutionOutputLink::check_schema(const Handle& schema) const
 	// Derived types do their own validation.
 	if (EXECUTION_OUTPUT_LINK != get_type()) return;
 
-	if (not nameserver().isA(schema->get_type(), SCHEMA_NODE) and
+	if (not nameserver().isA(schema->get_type(), PROCEDURE_NODE) and
 	    LAMBDA_LINK != schema->get_type() and
 	    // In case it is a pattern matcher query
 	    VARIABLE_NODE != schema->get_type() and
@@ -174,7 +174,7 @@ ValuePtr ExecutionOutputLink::execute_once(AtomSpace* as, bool silent)
 		return gsn->execute(as, args, silent);
 	}
 
-	if (DEFINED_SCHEMA_NODE == snt)
+	if (DEFINED_PROCEDURE_NODE == snt or DEFINED_SCHEMA_NODE == snt)
 		sn = DefineLink::get_definition(sn);
 
 	if (LAMBDA_LINK == sn->get_type())

--- a/opencog/atoms/flow/CMakeLists.txt
+++ b/opencog/atoms/flow/CMakeLists.txt
@@ -4,6 +4,7 @@ INCLUDE_DIRECTORIES( ${CMAKE_CURRENT_BINARY_DIR})
 
 ADD_LIBRARY (atomflow
 	FormulaPredicateLink.cc
+	PromiseLink.cc
 	SetTVLink.cc
 	SetValueLink.cc
 	StreamValueOfLink.cc
@@ -26,6 +27,7 @@ INSTALL (TARGETS atomflow EXPORT AtomSpaceTargets
 
 INSTALL (FILES
 	FormulaPredicateLink.h
+	PromiseLink.h
 	SetTVLink.h
 	SetValueLink.h
 	StreamValueOfLink.h

--- a/opencog/atoms/flow/PromiseLink.cc
+++ b/opencog/atoms/flow/PromiseLink.cc
@@ -1,0 +1,76 @@
+/*
+ * PromiseLink.cc
+ *
+ * Copyright (C) 2015, 2018, 2022 Linas Vepstas
+ *
+ * Author: Linas Vepstas <linasvepstas@gmail.com>  January 2009
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the
+ * exceptions at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/atomspace/AtomSpace.h>
+#include "PromiseLink.h"
+
+using namespace opencog;
+
+PromiseLink::PromiseLink(const HandleSeq&& oset, Type t)
+	: Link(std::move(oset), t)
+{
+	if (not nameserver().isA(t, PROMISE_LINK))
+	{
+		const std::string& tname = nameserver().getTypeName(t);
+		throw InvalidParamException(TRACE_INFO,
+			"Expecting an PromiseLink, got %s", tname.c_str());
+	}
+	init();
+}
+
+PromiseLink::PromiseLink(const Handle& valb)
+	: Link(std::move({valb}), PROMISE_LINK)
+{
+	init();
+}
+
+PromiseLink::PromiseLink(const Handle& valb, const Handle& typ)
+	: Link(std::move({valb, typ}), PROMISE_LINK)
+{
+	init();
+}
+
+void PromiseLink::init(void)
+{
+	size_t ary = _outgoing.size();
+	if (2 != ary)
+		throw SyntaxException(TRACE_INFO, "Expecting two atoms!");
+
+}
+
+// ---------------------------------------------------------------
+
+/// When executed, this will return the value at the indicated key.
+ValuePtr PromiseLink::execute(AtomSpace* as, bool silent)
+{
+	if (silent)
+		throw SilentException();
+
+	throw InvalidParamException(TRACE_INFO,
+	   "No value at key %s on atom %s",
+	   ak->to_string().c_str(), ah->to_string().c_str());
+}
+
+DEFINE_LINK_FACTORY(PromiseLink, PROMISE_LINK)
+
+/* ===================== END OF FILE ===================== */

--- a/opencog/atoms/flow/PromiseLink.cc
+++ b/opencog/atoms/flow/PromiseLink.cc
@@ -23,7 +23,7 @@
 
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/atoms/core/TypeNode.h>
-#include <opencog/atoms/value/StreamValue.h>
+#include <opencog/atoms/value/FormulaStream.h>
 #include "PromiseLink.h"
 
 using namespace opencog;

--- a/opencog/atoms/flow/PromiseLink.cc
+++ b/opencog/atoms/flow/PromiseLink.cc
@@ -22,6 +22,8 @@
  */
 
 #include <opencog/atomspace/AtomSpace.h>
+#include <opencog/atoms/core/TypeNode.h>
+#include <opencog/atoms/value/StreamValue.h>
 #include "PromiseLink.h"
 
 using namespace opencog;
@@ -52,10 +54,23 @@ PromiseLink::PromiseLink(const Handle& valb, const Handle& typ)
 
 void PromiseLink::init(void)
 {
-	size_t ary = _outgoing.size();
-	if (2 != ary)
-		throw SyntaxException(TRACE_INFO, "Expecting two atoms!");
+	// The default future.
+	_type = STREAM_VALUE;
 
+	if (1 == _outgoing.size()) return;
+
+	// The second Atom is a type specifying the kind of future
+	// we should use.
+	TypeNodePtr tnp = TypeNodeCast(_outgoing[1]);
+	if (nullptr == tnp)
+		throw SyntaxException(TRACE_INFO,
+			"Expecting a TypeNode to specify the future type!");
+
+	_type = tnp->get_kind();
+
+	if (not ((STREAM_VALUE == _type) or (LINK_STREAM_VALUE == _type)))
+		throw SyntaxException(TRACE_INFO,
+			"Expecting a Stream of some kind!");
 }
 
 // ---------------------------------------------------------------

--- a/opencog/atoms/flow/PromiseLink.h
+++ b/opencog/atoms/flow/PromiseLink.h
@@ -1,0 +1,60 @@
+/*
+ * opencog/atoms/flow/PromiseLink.h
+ *
+ * Copyright (C) 2018, 2022 Linas Vepstas
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef _OPENCOG_PROMISE_LINK_H
+#define _OPENCOG_PROMISE_LINK_H
+
+#include <opencog/atoms/base/Link.h>
+
+namespace opencog
+{
+/** \addtogroup grp_atomspace
+ *  @{
+ */
+
+/// The PromiseLink returns the provided atom wrapped with a future.
+/// The three future base clases are StreamValue, LinkStream and
+/// FutureTruthValue.
+///
+class PromiseLink : public Link
+{
+public:
+	PromiseLink(const HandleSeq&&, Type=PROMISE_LINK);
+	PromiseLink(const Handle&);
+	PromiseLink(const Handle&, const Handle&);
+
+	PromiseLink(const PromiseLink&) = delete;
+	PromiseLink& operator=(const PromiseLink&) = delete;
+
+	// Return a future
+	virtual ValuePtr execute(AtomSpace*, bool);
+
+	static Handle factory(const Handle&);
+};
+
+LINK_PTR_DECL(PromiseLink)
+#define createPromiseLink CREATE_DECL(PromiseLink)
+
+/** @}*/
+}
+
+#endif // _OPENCOG_PROMISE_LINK_H

--- a/opencog/atoms/flow/PromiseLink.h
+++ b/opencog/atoms/flow/PromiseLink.h
@@ -39,7 +39,7 @@ class PromiseLink : public Link
 {
 private:
 	void init(void);
-	Type _type;
+	Type _future_type;
 
 public:
 	PromiseLink(const HandleSeq&&, Type=PROMISE_LINK);

--- a/opencog/atoms/flow/PromiseLink.h
+++ b/opencog/atoms/flow/PromiseLink.h
@@ -37,6 +37,10 @@ namespace opencog
 ///
 class PromiseLink : public Link
 {
+private:
+	void init(void);
+	Type _type;
+
 public:
 	PromiseLink(const HandleSeq&&, Type=PROMISE_LINK);
 	PromiseLink(const Handle&);

--- a/opencog/atoms/flow/PromiseLink.h
+++ b/opencog/atoms/flow/PromiseLink.h
@@ -49,6 +49,7 @@ public:
 	PromiseLink(const PromiseLink&) = delete;
 	PromiseLink& operator=(const PromiseLink&) = delete;
 
+	virtual bool is_executable() const { return true; }
 	// Return a future
 	virtual ValuePtr execute(AtomSpace*, bool);
 

--- a/opencog/atoms/flow/SetValueLink.cc
+++ b/opencog/atoms/flow/SetValueLink.cc
@@ -51,64 +51,56 @@ SetValueLink::SetValueLink(const HandleSeq&& oset, Type t)
 /// first argument. The computed value is returned.
 ValuePtr SetValueLink::execute(AtomSpace* as, bool silent)
 {
-	// Obtain the value that we will be setting.
-	ValuePtr pap;
+	// Simple case: just set the Value. Obtain it, as needed.
 	if (3 == _outgoing.size())
 	{
+		ValuePtr pap;
 		if (_outgoing[2]->is_executable())
 			pap = _outgoing[2]->execute(as, silent);
 		else
 			pap = _outgoing[2];
-	}
-	else
-	{
-		Handle put(_outgoing[2]);
-		Type pt = put->get_type();
-		if (DEFINED_PREDICATE_NODE == pt or DEFINED_SCHEMA_NODE == pt)
-		{
-			put = DefineLink::get_definition(put);
-			pt = put->get_type();
-		}
 
-		// XXX TODO we should perform a type-check to make sure
-		// variable declarations match the args.
-		if (not nameserver().isA(pt, LAMBDA_LINK))
-			throw SyntaxException(TRACE_INFO,
-				"Expecting a LambdaLink, got %s",
-				put->to_string().c_str());
-
-		LambdaLinkPtr lamp(LambdaLinkCast(put));
-		const Handle& args(_outgoing[3]);
-		Handle reduct;
-		if (LIST_LINK == args->get_type())
-			reduct = lamp->beta_reduce(args->getOutgoingSet());
-		else
-			reduct = lamp->beta_reduce({args});
-
-		if (reduct->is_executable())
-			pap = reduct->execute(as, silent);
-		else
-			pap = reduct;
-	}
-
-	// We cannot set Values unless we are working with the unique
-	// version of the atom that sits in the AtomSpace!
-	Handle ah(as->get_atom(_outgoing[0]));
-	Handle ak(as->get_atom(_outgoing[1]));
-	if (ah and ak)
-	{
-		ah->setValue(ak, pap);
+		as->set_value(_ougoing[0], _outgoing[1], pap);
 		return pap;
 	}
 
-	// Hmm. shouldn't this be SilentException?
-	if (silent)
-		throw SilentException();
+	// Complicated Case: There are four arguments. The first two are
+	// Atom and key, as before. Then comes a lambda or function in
+	// third place, and the arguments to the function in fourth place.
+	// Wrap these two in an ExecutionOutput, and then wrap that in a
+	// PromiseLink.
 
-	throw InvalidParamException(TRACE_INFO,
-		"No atom %s or no key %s",
-		_outgoing[0]->to_string().c_str(),
-		_outgoing[1]->to_string().c_str());
+	Handle put(_outgoing[2]);
+	Type pt = put->get_type();
+	if (DEFINED_PROCEDURE_NODE == pt or DEFINED_SCHEMA_NODE == pt or
+	    DEFINED_PREDICATE_NODE == pt)
+	{
+		put = DefineLink::get_definition(put);
+		pt = put->get_type();
+	}
+
+	// XXX TODO we should perform a type-check to make sure
+	// variable declarations match the args.
+	if (not nameserver().isA(pt, LAMBDA_LINK))
+		throw SyntaxException(TRACE_INFO,
+			"Expecting a LambdaLink, got %s",
+			put->to_string().c_str());
+
+	LambdaLinkPtr lamp(LambdaLinkCast(put));
+	const Handle& args(_outgoing[3]);
+	Handle reduct;
+	if (LIST_LINK == args->get_type())
+		reduct = lamp->beta_reduce(args->getOutgoingSet());
+	else
+		reduct = lamp->beta_reduce({args});
+
+	if (reduct->is_executable())
+		pap = reduct->execute(as, silent);
+	else
+		pap = reduct;
+
+	as->set_value(_outgoing[0], _outgoing[1], pap);
+	return pap;
 }
 
 DEFINE_LINK_FACTORY(SetValueLink, SET_VALUE_LINK)

--- a/opencog/atoms/reduct/DecimateLink.h
+++ b/opencog/atoms/reduct/DecimateLink.h
@@ -33,6 +33,7 @@ public:
 	DecimateLink(const DecimateLink&) = delete;
 	DecimateLink& operator=(const DecimateLink&) = delete;
 
+	virtual bool is_executable() const { return true; }
 	virtual ValuePtr execute(AtomSpace*, bool);
 
 	static Handle factory(const Handle&);

--- a/opencog/atoms/reduct/TimesLink.cc
+++ b/opencog/atoms/reduct/TimesLink.cc
@@ -100,7 +100,7 @@ ValuePtr TimesLink::kons(AtomSpace* as, bool silent,
 		return vsum;
 	}
 
-	// Are they numbers? If so, perform vector (pointwise) subtraction.
+	// Are they numbers? If so, perform vector (pointwise) multiplication.
 	// Always lower the strength: Number+Number->Number
 	// but FloatValue+Number->FloatValue
 	try

--- a/opencog/atoms/value/CMakeLists.txt
+++ b/opencog/atoms/value/CMakeLists.txt
@@ -5,6 +5,7 @@ ADD_LIBRARY (value
 	BoolValue.cc
 	FloatValue.cc
 	FormulaStream.cc
+	FutureStream.cc
 	LinkStreamValue.cc
 	LinkValue.cc
 	QueueValue.cc
@@ -31,6 +32,7 @@ INSTALL (FILES
 	BoolValue.h
 	FloatValue.h
 	FormulaStream.h
+	FutureStream.h
 	LinkStreamValue.h
 	LinkValue.h
 	QueueValue.h

--- a/opencog/atoms/value/FloatValue.cc
+++ b/opencog/atoms/value/FloatValue.cc
@@ -28,7 +28,9 @@ using namespace opencog;
 
 bool FloatValue::operator==(const Value& other) const
 {
-	if (FLOAT_VALUE != other.get_type()) return false;
+	// Unlike Atoms, we are willing to compare othr types, as long
+	// as the type hierachy makes sence, and the values compare.
+	if (not other.is_type(FLOAT_VALUE)) return false;
 
    const FloatValue* fov = (const FloatValue*) &other;
 

--- a/opencog/atoms/value/FormulaStream.cc
+++ b/opencog/atoms/value/FormulaStream.cc
@@ -90,10 +90,17 @@ std::string FormulaStream::to_string(const std::string& indent) const
 
 bool FormulaStream::operator==(const Value& other) const
 {
-	if (FORMULA_STREAM != other.get_type()) return false;
+	// If they are both FormulaStream's, then we're good.
+	if (FORMULA_STREAM == other.get_type())
+	{
+		const FormulaStream* eso = (const FormulaStream*) &other;
+		return eso->_formula == _formula;
+	}
 
-	const FormulaStream* eso = (const FormulaStream*) &other;
-	return eso->_formula == _formula;
+	if (not other.is_type(FLOAT_VALUE)) return false;
+
+	// Value-compare
+	return FloatValue::operator==(other);
 }
 
 // ==============================================================

--- a/opencog/atoms/value/FutureStream.cc
+++ b/opencog/atoms/value/FutureStream.cc
@@ -31,16 +31,16 @@ using namespace opencog;
 // ==============================================================
 
 FutureStream::FutureStream(const Handle& h) :
-	LinkStreamValue(FUTURE_STREAM), _formula(h), _as(h->getAtomSpace())
+	Value(FUTURE_STREAM), _formula(h), _as(h->getAtomSpace())
 {
 	ValuePtr vp;
 	if (h->is_executable())
 	{
-		vp = h->execute(_as);
+		_value = h->execute(_as);
 	}
 	else if (h->is_evaluatable())
 	{
-		vp = ValueCast(h->evaluate(_as));
+		_value = ValueCast(h->evaluate(_as));
 	}
 	else
 	{
@@ -48,30 +48,20 @@ FutureStream::FutureStream(const Handle& h) :
 			"Expecting an executable/evaluatable atom, got %s",
 			h->to_string().c_str());
 	}
-
-	if (not nameserver().isA(vp->get_type(), FLOAT_VALUE))
-		throw SyntaxException(TRACE_INFO,
-			"Expecting formula to return a FloatValue, got %s",
-			vp->to_string().c_str());
-
-	_value = FloatValueCast(vp)->value();
 }
 
 // ==============================================================
 
 void FutureStream::update() const
 {
-	FloatValuePtr vp;
 	if (_formula->is_evaluatable())
 	{
-		vp = _formula->evaluate(_as);
+		_value = _formula->evaluate(_as);
 	}
 	else if (_formula->is_executable())
 	{
-		vp = FloatValueCast(_formula->execute(_as));
+		_value = FloatValueCast(_formula->execute(_as));
 	}
-
-	_value = vp->value();
 }
 
 // ==============================================================
@@ -81,7 +71,7 @@ std::string FutureStream::to_string(const std::string& indent) const
 	std::string rv = indent + "(" + nameserver().getTypeName(_type);
 	rv += "\n" + _formula->to_short_string(indent + "   ");
 	rv += "\n" + indent + "   ; Current sample:\n";
-	rv += indent + "   ; " + FloatValue::to_string("", FLOAT_VALUE);
+	rv += indent + "   ; " + _value->to_string("");
 	rv += "\n)";
 	return rv;
 }

--- a/opencog/atoms/value/FutureStream.cc
+++ b/opencog/atoms/value/FutureStream.cc
@@ -54,13 +54,13 @@ FutureStream::FutureStream(const Handle& h) :
 
 void FutureStream::update() const
 {
-	if (_formula->is_evaluatable())
+	if (_formula->is_executable())
 	{
-		_value = _formula->evaluate(_as);
+		_value = _formula->execute(_as);
 	}
-	else if (_formula->is_executable())
+	else if (_formula->is_evaluatable())
 	{
-		_value = FloatValueCast(_formula->execute(_as));
+		_value = ValueCast(_formula->evaluate(_as));
 	}
 }
 

--- a/opencog/atoms/value/FutureStream.cc
+++ b/opencog/atoms/value/FutureStream.cc
@@ -1,0 +1,102 @@
+/*
+ * opencog/atoms/value/FutureStream.cc
+ *
+ * Copyright (C) 2020, 2022 Linas Vepstas
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <stdlib.h>
+#include <opencog/atoms/value/FutureStream.h>
+#include <opencog/atoms/value/ValueFactory.h>
+#include <opencog/atoms/base/Atom.h>
+#include <opencog/atomspace/AtomSpace.h>
+
+using namespace opencog;
+
+// ==============================================================
+
+FutureStream::FutureStream(const Handle& h) :
+	LinkStreamValue(FUTURE_STREAM), _formula(h), _as(h->getAtomSpace())
+{
+	ValuePtr vp;
+	if (h->is_executable())
+	{
+		vp = h->execute(_as);
+	}
+	else if (h->is_evaluatable())
+	{
+		vp = ValueCast(h->evaluate(_as));
+	}
+	else
+	{
+		throw SyntaxException(TRACE_INFO,
+			"Expecting an executable/evaluatable atom, got %s",
+			h->to_string().c_str());
+	}
+
+	if (not nameserver().isA(vp->get_type(), FLOAT_VALUE))
+		throw SyntaxException(TRACE_INFO,
+			"Expecting formula to return a FloatValue, got %s",
+			vp->to_string().c_str());
+
+	_value = FloatValueCast(vp)->value();
+}
+
+// ==============================================================
+
+void FutureStream::update() const
+{
+	FloatValuePtr vp;
+	if (_formula->is_evaluatable())
+	{
+		vp = _formula->evaluate(_as);
+	}
+	else if (_formula->is_executable())
+	{
+		vp = FloatValueCast(_formula->execute(_as));
+	}
+
+	_value = vp->value();
+}
+
+// ==============================================================
+
+std::string FutureStream::to_string(const std::string& indent) const
+{
+	std::string rv = indent + "(" + nameserver().getTypeName(_type);
+	rv += "\n" + _formula->to_short_string(indent + "   ");
+	rv += "\n" + indent + "   ; Current sample:\n";
+	rv += indent + "   ; " + FloatValue::to_string("", FLOAT_VALUE);
+	rv += "\n)";
+	return rv;
+}
+
+// ==============================================================
+
+bool FutureStream::operator==(const Value& other) const
+{
+	if (FUTURE_STREAM != other.get_type()) return false;
+
+	const FutureStream* eso = (const FutureStream*) &other;
+	return eso->_formula == _formula;
+}
+
+// ==============================================================
+
+// Adds factor when library is loaded.
+DEFINE_VALUE_FACTORY(FUTURE_STREAM, createFutureStream, const Handle&)

--- a/opencog/atoms/value/FutureStream.h
+++ b/opencog/atoms/value/FutureStream.h
@@ -25,6 +25,7 @@
 
 #include <opencog/atoms/base/Handle.h>
 #include <opencog/atomspace/AtomSpace.h>
+#include <opencog/atoms/value/Value.h>
 
 namespace opencog
 {
@@ -35,15 +36,16 @@ namespace opencog
 
 /**
  * FutureStream will evaluate the stored Atom to obtain a fresh
- * FloatValue, every time it is queried for data.
+ * Value, every time it is queried for data.
  */
 class FutureStream
-	: public LinkStreamValue
+	: public Value
 {
 protected:
-	FutureStream(Type t, const Handle&) : LinkStreamValue(t) {}
+	FutureStream(Type t, const Handle&) : Value(t) {}
 
 	virtual void update() const;
+	ValuePtr _value;
 	Handle _formula;
 	AtomSpace* _as;
 

--- a/opencog/atoms/value/FutureStream.h
+++ b/opencog/atoms/value/FutureStream.h
@@ -45,13 +45,15 @@ protected:
 	FutureStream(Type t, const Handle&) : Value(t) {}
 
 	virtual void update() const;
-	ValuePtr _value;
 	Handle _formula;
 	AtomSpace* _as;
+	mutable ValuePtr _value;
 
 public:
 	FutureStream(const Handle&);
 	virtual ~FutureStream() {}
+
+	ValuePtr value() const { update(); return _value; }
 
 	/** Returns a string representation of the value.  */
 	virtual std::string to_string(const std::string& indent = "") const;

--- a/opencog/atoms/value/FutureStream.h
+++ b/opencog/atoms/value/FutureStream.h
@@ -1,0 +1,75 @@
+/*
+ * opencog/atoms/value/FutureStream.h
+ *
+ * Copyright (C) 2020, 2022 Linas Vepstas
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef _OPENCOG_FUTURE_STREAM_H
+#define _OPENCOG_FUTURE_STREAM_H
+
+#include <opencog/atoms/base/Handle.h>
+#include <opencog/atomspace/AtomSpace.h>
+
+namespace opencog
+{
+
+/** \addtogroup grp_atomspace
+ *  @{
+ */
+
+/**
+ * FutureStream will evaluate the stored Atom to obtain a fresh
+ * FloatValue, every time it is queried for data.
+ */
+class FutureStream
+	: public LinkStreamValue
+{
+protected:
+	FutureStream(Type t, const Handle&) : LinkStreamValue(t) {}
+
+	virtual void update() const;
+	Handle _formula;
+	AtomSpace* _as;
+
+public:
+	FutureStream(const Handle&);
+	virtual ~FutureStream() {}
+
+	/** Returns a string representation of the value.  */
+	virtual std::string to_string(const std::string& indent = "") const;
+
+	/** Returns true if two values are equal. */
+	virtual bool operator==(const Value&) const;
+};
+
+typedef std::shared_ptr<FutureStream> FutureStreamPtr;
+static inline FutureStreamPtr FutureStreamCast(ValuePtr& a)
+	{ return std::dynamic_pointer_cast<FutureStream>(a); }
+
+template<typename ... Type>
+static inline std::shared_ptr<FutureStream> createFutureStream(Type&&... args)
+{
+	return std::make_shared<FutureStream>(std::forward<Type>(args)...);
+}
+
+
+/** @}*/
+} // namespace opencog
+
+#endif // _OPENCOG_FUTURE_STREAM_H

--- a/opencog/atoms/value/LinkStreamValue.cc
+++ b/opencog/atoms/value/LinkStreamValue.cc
@@ -29,7 +29,11 @@ using namespace opencog;
 
 bool LinkStreamValue::operator==(const Value& other) const
 {
-	return &other == this;
+	// Since we're streaming, get the latest value before compare!
+	update();
+
+	// Let the base class do the hard work.
+	return LinkValue::operator==(other);
 }
 
 // ==============================================================

--- a/opencog/atoms/value/LinkValue.cc
+++ b/opencog/atoms/value/LinkValue.cc
@@ -71,8 +71,10 @@ HandleSet LinkValue::to_handle_set(void) const
 
 bool LinkValue::operator==(const Value& other) const
 {
-	// Derived classes use this, so use get_type()
-	if (get_type() != other.get_type()) return false;
+	// We do content-compare, and only loose type compare.
+	// As long as other is a derviced type, we're good if
+	// the actual values compare
+	if (not other.is_type(LINK_VALUE)) return false;
 
 	const LinkValue* lov = (const LinkValue*) &other;
 

--- a/opencog/atoms/value/StreamValue.cc
+++ b/opencog/atoms/value/StreamValue.cc
@@ -29,7 +29,11 @@ using namespace opencog;
 
 bool StreamValue::operator==(const Value& other) const
 {
-	return &other == this;
+	// Since we're streaming, get the latest value before comparing!
+	update();
+
+	// Let the base class do the hard work.
+	return FloatValue::operator==(other);
 }
 
 // ==============================================================

--- a/opencog/atoms/value/StreamValue.h
+++ b/opencog/atoms/value/StreamValue.h
@@ -40,7 +40,7 @@ namespace opencog
  * rapidly-changing data encoded as floats, including video and
  * audio feeds, or other kinds of high-bandwidth data.
  *
- * This class itself doesn't "do anything" other than to provde
+ * This class itself doesn't "do anything" other than to provide
  * a base class.
  *
  * See also LinkStreamValue when the data is encoded as Atoms or

--- a/opencog/atoms/value/StringValue.cc
+++ b/opencog/atoms/value/StringValue.cc
@@ -30,7 +30,7 @@ using namespace opencog;
 
 bool StringValue::operator==(const Value& other) const
 {
-	if (STRING_VALUE != other.get_type()) return false;
+	if (not other.is_type(STRING_VALUE)) return false;
 
 	const StringValue* sov = (const StringValue*) &other;
 

--- a/tests/atoms/flow/DynamicUTest.cxxtest
+++ b/tests/atoms/flow/DynamicUTest.cxxtest
@@ -273,6 +273,24 @@ void DynamicUTest::test_futures()
 	double vmi = fvp->value()[2];
 	TS_ASSERT(fabs(vmi - 0.7369655941662062) <= EPSI);
 
+	// Bump the numbers
+	_eval.eval("(observe \"Hey\" \"Joe\")");
+	_eval.eval("(observe \"whazzup\" \"Joe\")");
+
+	scalar = _eval.eval_v("(get-mi-scalar \"hello\" \"world\")");
+	printf("scalar: %s\n", scalar->to_string().c_str());
+	fvp = FloatValueCast(scalar);
+	TS_ASSERT(nullptr != fvp);
+	smi = fvp->value()[0];
+	TS_ASSERT(fabs(smi - 1.222392421336448) <= EPSI);
+
+	flvect = _eval.eval_v("(get-mi-stream \"hello\" \"world\")");
+	printf("flvect: %s\n", flvect->to_string().c_str());
+	fvp = FloatValueCast(flvect);
+	TS_ASSERT(nullptr != fvp);
+	vmi = fvp->value()[2];
+	TS_ASSERT(fabs(vmi - 1.222392421336448) <= EPSI);
+
 	logger().debug("END TEST: %s", __FUNCTION__);
 }
 

--- a/tests/atoms/flow/DynamicUTest.cxxtest
+++ b/tests/atoms/flow/DynamicUTest.cxxtest
@@ -40,6 +40,7 @@ public:
 	void test_dynamic_predicate();
 	void test_defined_dynamic();
 	void test_formula_stream();
+	void test_futures();
 };
 
 DynamicUTest::DynamicUTest(void) : _asp(createAtomSpace()), _eval(_asp)
@@ -247,6 +248,21 @@ void DynamicUTest::test_formula_stream()
 			TS_ASSERT(fabs(result[k] - rv[k] - 10.0) <= EPSI);
 		}
 	}
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+// ====================================================================
+// Test the flow-dutures.scm example.
+void DynamicUTest::test_futures()
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+	_eval.eval("(load-from-path \"tests/atoms/flow/futures.scm\")");
+
+	ValuePtr scalar = _eval.eval_v("(get-mi-scalar \"hello\" \"world\")");
+	printf("scalar: %s\n", scalar->to_string().c_str());
+
+	// TS_ASSERT_EQUALS(result->get_type(), FUTURE_TRUTH_VALUE);
 
 	logger().debug("END TEST: %s", __FUNCTION__);
 }

--- a/tests/atoms/flow/DynamicUTest.cxxtest
+++ b/tests/atoms/flow/DynamicUTest.cxxtest
@@ -261,8 +261,17 @@ void DynamicUTest::test_futures()
 
 	ValuePtr scalar = _eval.eval_v("(get-mi-scalar \"hello\" \"world\")");
 	printf("scalar: %s\n", scalar->to_string().c_str());
+	FloatValuePtr fvp = FloatValueCast(scalar);
+	TS_ASSERT(nullptr != fvp);
+	double smi = fvp->value()[0];
+	TS_ASSERT(fabs(smi - 0.7369655941662062) <= EPSI);
 
-	// TS_ASSERT_EQUALS(result->get_type(), FUTURE_TRUTH_VALUE);
+	ValuePtr flvect = _eval.eval_v("(get-mi-stream \"hello\" \"world\")");
+	printf("flvect: %s\n", flvect->to_string().c_str());
+	fvp = FloatValueCast(flvect);
+	TS_ASSERT(nullptr != fvp);
+	double vmi = fvp->value()[2];
+	TS_ASSERT(fabs(vmi - 0.7369655941662062) <= EPSI);
 
 	logger().debug("END TEST: %s", __FUNCTION__);
 }

--- a/tests/atoms/flow/SetValueUTest.cxxtest
+++ b/tests/atoms/flow/SetValueUTest.cxxtest
@@ -114,21 +114,21 @@ void SetValueUTest::test_triangle()
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	ValuePtr tvp = _eval.eval_v("(cog-execute! triangle)");
-
-	ValuePtr result = _eval.eval_v("tri");
+	ValuePtr tvp = _eval.eval_v("tri");
 	printf("expect: %s\n", tvp->to_string().c_str());
-	printf("result: %s\n", result->to_string().c_str());
+
+	ValuePtr result = _eval.eval_v("(cog-execute! triangle)");
+	printf("result ex-tri: %s\n", result->to_string().c_str());
 
 	TS_ASSERT(*tvp == *result);
 
 	result = _eval.eval_v("(cog-execute! (ValueOf bar kee))");
-	printf("result: %s\n", result->to_string().c_str());
+	printf("result val-of: %s\n", result->to_string().c_str());
 
 	TS_ASSERT(*tvp == *result);
 
 	result = _eval.eval_v("(cog-value bar kee)");
-	printf("result: %s\n", result->to_string().c_str());
+	printf("result cog-val: %s\n", result->to_string().c_str());
 
 	TS_ASSERT(*tvp == *result);
 

--- a/tests/atoms/flow/futures.scm
+++ b/tests/atoms/flow/futures.scm
@@ -1,21 +1,6 @@
 ;
-; flow-futures.scm -- Dynamically changing FloatValue flows.
+; futures.scm -- unit test corresponding to the demo flow-futures.scm
 ;
-; The `flow-formulas.scm` demo showed how to attach dynamically-updating
-; TruthValues to Atoms. This demo is similar, except that it works with
-; general FloatValues.  The specific example here computes the mutual
-; information of an ordered pair, given only counts on the pair, and
-; counts on the marginals.  This requires doing arithmetic on numbers
-; coming from four different places, and then placing the result where
-; it can be found.
-;
-; This is a fairly complex demo, as it attempts to be more realistic.
-;
-; As before, the core function is provided by the FormulaStream, which
-; which wraps an arithmetic expression so that it behaves like a future.
-; See https://en.wikipedia.org/wiki/Futures_and_promises for the general
-; idea.
-
 (use-modules (opencog) (opencog exec))
 
 ; -------------------------------------------------------------
@@ -81,59 +66,14 @@
 	(get-computed-value (Concept STRING-A) (Concept STRING-B)))
 
 ; -------------------------------------------------------------
-; OK, we're done. Lets see what happens.
 
 (install-mi "hello" "world")
-(get-mi-stream "hello" "world")
-
-; Well, that's messy! But it does show the full structure of
-; what was set up. Note that the formulas were applied to the
-; full vector of floats, which have the form (1 0 N) for some
-; count N. Dividing by zero and taking a log will result in a
-; NAN (Not A Number), and so the first two numbers are garbage.
-; We only want the third number.
-;
-; Instead of treating the full vector, we could have written
-; the formula to extract the third number at the beginning, and
-; then only work with that. The extraction can be done with the
-; DecimateLink. But that would make the demo too complicated, so
-; that is not done. See however, below.
-
-; We really ony want the third number. So grab that.
-(define (get-mi STRING-A STRING-B)
-	(cog-value-ref (get-mi-stream STRING-A STRING-B) 2))
-
-(get-mi "hello" "world")
-
-; And now play with the data. Observe the pair a second time.
-; The MI will change.
-(observe "hello" "world")
-(get-mi "hello" "world")
-
-; Observing other pairs will also change the MI
-(observe "hello" "Gary")
-(get-mi "hello" "world")
-
-(observe "whats" "up")
-(get-mi "hello" "world")
-
-; Dump the contents of the AtomSpace. Review to make sure the
-; demo was understood.
-(cog-prt-atomspace)
 
 ; -------------------------------------------------------------
-; Repeate some of the above, this time using the DecimateLink
-; to pick out the desired component.
 
 ; Defina a bit-mask and install it.
 (cog-set-value! (Concept "someplace") (Predicate "mask key")
 	(BoolValue 0 0 1))
-
-; Verify that masking works
-(cog-execute!
-	(Decimate
-		(BoolValueOf (Concept "someplace") (Predicate "mask key"))
-		(FloatValueOf (AnyNode "grand total") tvp)))
 
 ; Wrap it in a utility constructor
 (define (make-deci ATOM)
@@ -174,12 +114,5 @@
 
 ; Try it out. Need to install it before first use.
 (install-scalar-mi "hello" "world")
-(get-mi-scalar "hello" "world")
-(get-mi "hello" "world")
-
-(observe "Hey" "Joe")
-
-(get-mi-scalar "hello" "world")
-(get-mi "hello" "world")
 
 ; ------- THE END -------

--- a/tests/atoms/flow/futures.scm
+++ b/tests/atoms/flow/futures.scm
@@ -99,7 +99,7 @@
 ; DecimateLink. But that would make the demo too complicated, so
 ; that is not done. See however, below.
 
-; We really only want the third number. So grab that.
+; We really ony want the third number. So grab that.
 (define (get-mi STRING-A STRING-B)
 	(cog-value-ref (get-mi-stream STRING-A STRING-B) 2))
 
@@ -114,7 +114,7 @@
 (observe "hello" "Gary")
 (get-mi "hello" "world")
 
-(observe "what's" "up")
+(observe "whats" "up")
 (get-mi "hello" "world")
 
 ; Dump the contents of the AtomSpace. Review to make sure the
@@ -122,7 +122,7 @@
 (cog-prt-atomspace)
 
 ; -------------------------------------------------------------
-; Repeat some of the above, this time using the DecimateLink
+; Repeate some of the above, this time using the DecimateLink
 ; to pick out the desired component.
 
 ; Defina a bit-mask and install it.
@@ -141,7 +141,7 @@
 		(BoolValueOf (Concept "someplace") (Predicate "mask key"))
 		(FloatValueOf ATOM tvp)))
 
-; A new procedure, that works only on the one item.
+; A new proceedure, that works only on the one item.
 (DefineLink
 	(DefinedProcedure "scalar MI")
 	(Lambda

--- a/tests/atoms/flow/futures.scm
+++ b/tests/atoms/flow/futures.scm
@@ -71,7 +71,7 @@
 
 ; -------------------------------------------------------------
 
-; Defina a bit-mask and install it.
+; Define a bit-mask and install it.
 (cog-set-value! (Concept "someplace") (Predicate "mask key")
 	(BoolValue 0 0 1))
 


### PR DESCRIPTION
A few years ago, the ability to specify TruthValue formulas in Atomese was added. Basically, a formula can be specified, that takes some collection of TV's from one place, does some computation on them (using `PlusLink`, `MinusLink`, etc.) and then places that result at some other TruthValue location.

This implementation had two parts: (1) a method for hooking up formulas to their TV inputs and output, and (2) a method for updating "dynamically", so that if one of the inputs changed, the target TV did as well.  This second part is a "promise" or "future", see https://en.wikipedia.org/wiki/Futures_and_promises 

It was anticipated that PLN would use this to simplify and speed up how formulas are computed, but @ngeiswei never got around to this (that's OK). Another user is the learning subsystem,  which works with large vectors, and needs to do arithmetic and dot-products and logartihms and so on. The stuff is needed and used there.

Although TV promises & futures worked, the implementation was incomplete for float vectors. This pull req finishes that work.

FYI, a minor commemoration: it's been a little over 14 years that this has been in the making. The AtomSpace `opencog/scm/wires` directory held a proof-of-concept, it was created in September 2008. This eventually morphed into two different subsystems: the query-engine aka pattern-matcher solved the issue of how to join wires together into a coherent wiring diagram (looking at it as a constraint-satisfaction problem). The other half became Values, which more clearly represented the "fluid" that can flow along the wires. But Values didn't fully/freely flow until just now.

Looking forward, the intent is to make both audio and video processing easier.

FWIW wires was inspired by SICP sections 3.3 (constraints) and 3.5 (streams), and by *The Art of the Propagator* Alexey Radul; Gerald Jay Sussman local: MIT-CSAIL-TR-2009-002 http://dspace.mit.edu/handle/1721.1/44215

See the five demos in the examples directory:
* `stream.scm`         -- Using a stream of time-varying Values.
* `formulas.scm`       -- Representing arithmetic and computing Values.
* `flows.scm`          -- Flowing Values around.
* `flow-formulas.scm`  -- Dynamically updating TruthValues.
* `flow-futures.scm`   -- Dynamically updating FloatValues.
