### PR TITLE
For large AtomSpaces, std::set is furiously slow.

### DIFF
--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -118,7 +118,7 @@ class AtomSpace : public Frame
     virtual ContentHash compute_hash() const;
 
     // Private helper function.
-    void shadow_by_type(HandleSet&,
+    void shadow_by_type(UnorderedHandleSet&,
                         Type type,
                         bool subclass,
                         bool parent,
@@ -480,14 +480,14 @@ public:
      * Gets a set of handles that matches with the given type
      * (subclasses optionally).
      *
-     * @param hset the HandleSet into which to insert handles.
+     * @param hseq the HandleSeq into which to insert handles.
      * @param type The desired type.
      * @param subclass Whether type subclasses should be considered.
      *
      * Example of call to this method, which would return all ConceptNodes
      * in the AtomSpace:
      * @code
-     *         HandleSet atoms;
+     *         HandleSeq atoms;
      *         atomSpace.get_handles_by_type(atoms, CONCEPT_NODE);
      * @endcode
      */
@@ -499,7 +499,7 @@ public:
                         const AtomSpace* = nullptr) const;
 
     void
-    get_handles_by_type(HandleSet&,
+    get_handles_by_type(UnorderedHandleSet&,
                         Type type,
                         bool subclass=false,
                         bool parent=true,
@@ -509,14 +509,14 @@ public:
      * Gets a set of handles that matches with the given type,
      * but ONLY if they have an empty incoming set! 
      *
-     * @param hset the HandleSet into which to insert handles.
+     * @param hset the HandleSeq into which to insert handles.
      * @param The desired type.
      * @param Whether type subclasses should be considered.
      *
      * Example of call to this method, which would return all ConceptNodes
      * in the AtomSpace:
      * @code
-     *         HandleSet atoms;
+     *         HandleSeq atoms;
      *         atomSpace.get_rootset_by_type(atoms, CONCEPT_NODE);
      * @endcode
      */

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -453,7 +453,7 @@ size_t AtomSpace::get_num_atoms_of_type(Type type, bool subclass) const
     // If the flag is set, we need to deduplicate the atoms,
     // and then count them.
     if (_copy_on_write) {
-        HandleSet hset;
+        UnorderedHandleSet hset;
         shadow_by_type(hset, type, subclass, true, this);
         return hset.size();
     }
@@ -628,7 +628,7 @@ void AtomSpace::get_handles_by_type(HandleSeq& hseq,
     // returning the shallowest version of each Atom.
     if (_copy_on_write)
     {
-        HandleSet rawset;
+        UnorderedHandleSet rawset;
         shadow_by_type(rawset, type, subclass, parent, cas);
 
         // Look for the shallowest version of each Atom.
@@ -690,7 +690,7 @@ void AtomSpace::get_handles_by_type(HandleSeq& hseq,
 // duplicate atoms due to shadowing of child spaces by parent spaces.
 // However, the returned set is NOT guaranteed to contain the shallowest
 // Atoms! These need to be obtained with a distinct step.
-void AtomSpace::shadow_by_type(HandleSet& hset,
+void AtomSpace::shadow_by_type(UnorderedHandleSet& hset,
                                Type type,
                                bool subclass,
                                bool parent,
@@ -731,7 +731,7 @@ void AtomSpace::shadow_by_type(HandleSet& hset,
     }
 }
 
-void AtomSpace::get_handles_by_type(HandleSet& hset,
+void AtomSpace::get_handles_by_type(UnorderedHandleSet& hset,
                                     Type type,
                                     bool subclass,
                                     bool parent,
@@ -741,7 +741,7 @@ void AtomSpace::get_handles_by_type(HandleSet& hset,
     // returning the shallowest version of each Atom.
     if (_copy_on_write)
     {
-        HandleSet rawset;
+        UnorderedHandleSet rawset;
         shadow_by_type(rawset, type, subclass, parent, cas);
 
         // Look for the shallowest version of each Atom.

--- a/opencog/atomspace/TypeIndex.cc
+++ b/opencog/atomspace/TypeIndex.cc
@@ -102,7 +102,7 @@ void TypeIndex::get_handles_by_type(HandleSeq& hseq,
 }
 
 // Same as above, except using an unordered set.
-void TypeIndex::get_handles_by_type(HandleSet& hset,
+void TypeIndex::get_handles_by_type(UnorderedHandleSet& hset,
                                     Type type,
                                     bool subclass) const
 {

--- a/opencog/atomspace/TypeIndex.h
+++ b/opencog/atomspace/TypeIndex.h
@@ -150,7 +150,7 @@ class TypeIndex
 		void clear(void);
 
 		void get_handles_by_type(HandleSeq&, Type, bool subclass) const;
-		void get_handles_by_type(HandleSet&, Type, bool subclass) const;
+		void get_handles_by_type(UnorderedHandleSet&, Type, bool subclass) const;
 		void get_rootset_by_type(HandleSeq&, Type, bool subclass,
 		                         const AtomSpace*) const;
 };


### PR DESCRIPTION
For 30 million atoms, this can take many many seconds.

Use `std::unordered_set` instead -- its hash-table based.