### PR TITLE
Atom hashes independent of type hierarchy details.

### DIFF
--- a/opencog/atoms/atom_types/NameServer.cc
+++ b/opencog/atoms/atom_types/NameServer.cc
@@ -160,6 +160,7 @@ Type NameServer::declType(const Type parent,
     _code2NameMap.resize(nTypes);
     _code2ShortMap.resize(nTypes);
     _mod.resize(nTypes);
+    _hash.resize(nTypes);
 
     for (auto& bv: inheritanceMap) bv.resize(nTypes, false);
     for (auto& bv: recursiveMap) bv.resize(nTypes, false);
@@ -170,6 +171,7 @@ Type NameServer::declType(const Type parent,
     name2CodeMap[name]           = type;
     _code2NameMap[type]          = &(name2CodeMap.find(name)->first);
     _mod[type]                   = _tmod;
+    _hash[type]                  = std::hash<std::string>{}(name);
 
     Type maxd = 1;
     setParentRecursively(parent, type, maxd);

--- a/opencog/atoms/atom_types/NameServer.h
+++ b/opencog/atoms/atom_types/NameServer.h
@@ -82,6 +82,7 @@ private:
     std::vector<const std::string*> _code2NameMap;
     std::vector<const std::string*> _code2ShortMap;
     std::vector<int> _mod;
+    std::vector<size_t> _hash;
     TypeSignal _addTypeSignal;
 
     void setParentRecursively(Type parent, Type type, Type& maxd);
@@ -305,6 +306,17 @@ public:
      */
     const std::string& getTypeName(Type type) const;
     const std::string& getTypeShortName(Type type) const;
+
+    /**
+     * Returns a hash for the atom type. The hash does not depend on
+     * the type number, and thus remains stable as types are added
+     * and removed from the type hierarchy. The hash is computed from
+     * the string name of the type.
+     *
+     * @param type Atom type code.
+     * @return A corresponding hash.
+     */
+    size_t getTypeHash(Type type) const { return _hash[type]; }
 };
 
 NameServer& nameserver();

--- a/opencog/atoms/base/Link.cc
+++ b/opencog/atoms/base/Link.cc
@@ -168,8 +168,11 @@ bool Link::operator<(const Atom& other) const
 /// chains the hash values of the child atoms, as well.
 ContentHash Link::compute_hash() const
 {
+   // The nameserver().getTypeHash() returns hash of the type string name,
+   // and is thus independent of other types in the tree.
 	// 1<<44 - 377 is prime
-	ContentHash hsh = ((1ULL<<44) - 377) * get_type();
+	ContentHash hsh = ((1ULL<<44) - 377) * nameserver().getTypeHash(get_type());
+
 	for (const Handle& h: _outgoing)
 	{
 		hsh += (hsh <<5) ^ (353 * h->get_hash()); // recursive!

--- a/opencog/atoms/base/Node.cc
+++ b/opencog/atoms/base/Node.cc
@@ -176,7 +176,9 @@ ContentHash Node::compute_hash() const
 	ContentHash hsh = std::hash<std::string>()(get_name());
 
 	// 1<<43 - 369 is a prime number.
-	hsh += (hsh<<5) + ((1ULL<<43)-369) * get_type();
+	// The nameserver().getTypeHash() returns hash of the type string name,
+	// and is thus independent of other types in the tree.
+	hsh += (hsh<<5) + ((1ULL<<43)-369) * nameserver().getTypeHash(get_type());
 
 	// Nodes will never have the MSB set.
 	ContentHash mask = ~(((ContentHash) 1ULL) << (8*sizeof(ContentHash) - 1));


### PR DESCRIPTION
Prior to this, the addition or removal of atoms to the type hierarchy alters the hashes, which makes debugging hard than it otherwise needs to be.