### PR TITLE
Bugfix goofy caching bug; simplify caching logic.

### DIFF
--- a/opencog/atoms/pattern/Pattern.h
+++ b/opencog/atoms/pattern/Pattern.h
@@ -107,12 +107,8 @@ struct Pattern
 	/// Clauses that can be grounded in only one way; thus the
 	/// result of that grounding can be cached, to avoid rechecking.
 	/// These clauses cannot contain evaluatable elements (as these
-	/// have context-dependent valuations), and can only contain one
-	/// variable (for lookup performance.)
+	/// have context-dependent valuations).
 	HandleSet cacheable_clauses;
-
-	/// As above, but clauses that hold two or more variables.
-	HandleSet cacheable_multi;
 
 	/// For each clause, the list of variables that appear in that clause.
 	/// Used in conjunction with the `cacheable_multi` above.

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -654,15 +654,7 @@ void PatternLink::locate_cacheable(const PatternTermSeq& clauses)
 		if (not ptm->isLiteral() and not ptm->isPresent() and
 		    not ptm->isChoice() and not ptm->isAbsent()) continue;
 
-		const Handle& claw = ptm->getQuote();
-
-		if (1 == num_unquoted_unscoped_in_tree(claw, _variables.varset))
-		{
-			// The cache uses getHandle() not getQuote()
-			// and so we must as well.
-			_pat.cacheable_clauses.insert(ptm->getHandle());
-			continue;
-		}
+		const Handle& claw = ptm->getHandle();
 
 		// Caching works fine, if there are UnorderedLinks. However,
 		// if there is a lot of them, so that the engine is exploring
@@ -674,7 +666,7 @@ void PatternLink::locate_cacheable(const PatternTermSeq& clauses)
 		// that most ussers will surely almost never do :-)
 		if (4 < contains_atomtype_count(claw, UNORDERED_LINK)) continue;
 
-		_pat.cacheable_multi.insert(claw);
+		_pat.cacheable_clauses.insert(claw);
 	}
 }
 

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -2500,38 +2500,23 @@ bool PatternMatchEngine::clause_accept(const PatternTermPtr& clause,
 
 		// Cache the result, so that it can be reused.
 		// See commentary on `explore_clause()` for more info.
-		HandleSeq key;
-		const HandleSeq& clvars(_pat->clause_variables.at(clause));
-		size_t cvsz = clvars.size();
-
-		// Clause contains just a single variable
-		if (1 == cvsz and
-			 _pat->cacheable_clauses.find(clause_root) !=
+		if (_pat->cacheable_clauses.find(clause_root) !=
 		    _pat->cacheable_clauses.end())
 		{
-			const Handle& jgnd(var_grounding.at(clvars[0]));
-			key = HandleSeq({clause_root, jgnd});
-		}
-
-		// Clause contains two or more variables.
-		if (1 < cvsz and
-			 _pat->cacheable_multi.find(clause_root) !=
-		    _pat->cacheable_multi.end())
-		{
-			key = clause_grounding_key(clause_root, clvars);
-		}
-
-		if (0 < key.size())
-		{
+			const HandleSeq& clvars(_pat->clause_variables.at(clause));
+			HandleSeq key = clause_grounding_key(clause_root, clvars);
+			if (0 < key.size())
+			{
 #ifdef QDEBUG
-			// The same clause can sometimes be grounded multiple
-			// times, but if the caching is valid, then it should
-			// always be grounded exactly the same way.
-			const auto& prev = _gnd_cache.find(key);
-			if (_gnd_cache.end() != prev)
-				OC_ASSERT(prev->second == hg, "Internal Error");
+				// The same clause can sometimes be grounded multiple
+				// times, but if the caching is valid, then it should
+				// always be grounded exactly the same way.
+				const auto& prev = _gnd_cache.find(key);
+				if (_gnd_cache.end() != prev)
+					OC_ASSERT(prev->second == hg, "Internal Error");
 #endif
-			_gnd_cache.insert({key, hg});
+				_gnd_cache.insert({key, hg});
+			}
 		}
 	}
 
@@ -3096,22 +3081,13 @@ bool PatternMatchEngine::explore_clause(const PatternTermPtr& term,
 	if (pclause->isChoice())
 		return explore_clause_direct(term, grnd, pclause);
 
-	// Build the cache lookup key
-	HandleSeq key;
-
-	// Single-variable cache. Due to the way we are called, `term`
-	// is a subterm of the clause that contains a variable, and
-	// `grnd` is the grounding of that variable.
 	const Handle& clause = pclause->getHandle();
-	if (_pat->cacheable_clauses.find(clause) != _pat->cacheable_clauses.end())
-		key = HandleSeq({clause, grnd});
+	if (_pat->cacheable_clauses.find(clause) == _pat->cacheable_clauses.end())
+		return explore_clause_direct(term, grnd, pclause);
 
-	// Multi-variable cache.
-	if (_pat->cacheable_multi.find(clause) != _pat->cacheable_multi.end())
-	{
-		const HandleSeq& varseq = _pat->clause_variables.at(pclause);
-		key = clause_grounding_key(clause, varseq);
-	}
+	// Build the cache lookup key
+	const HandleSeq& varseq = _pat->clause_variables.at(pclause);
+	HandleSeq key = clause_grounding_key(clause, varseq);
 
 	// No key, nothing to look up.
 	if (0 == key.size())

--- a/opencog/query/PatternMatchEngine.cc
+++ b/opencog/query/PatternMatchEngine.cc
@@ -3081,9 +3081,17 @@ bool PatternMatchEngine::explore_clause(const PatternTermPtr& term,
 	if (pclause->isChoice())
 		return explore_clause_direct(term, grnd, pclause);
 
+	// If its not cacheable, then we must search directly.
 	const Handle& clause = pclause->getHandle();
 	if (_pat->cacheable_clauses.find(clause) == _pat->cacheable_clauses.end())
 		return explore_clause_direct(term, grnd, pclause);
+
+	// If we are here, then we *might* be able to find a previous grounding
+	// in the cache. Here's how it works. We look to see if we have groundings
+	// for ALL of the variables in the clause. If we do, then those groundings,
+	// plus the clause itself, form a key for the cache. If we find that key,
+	// then we are done with this clause. Every term in within the clause
+	// is uniquely determined by the variable groundings.
 
 	// Build the cache lookup key
 	const HandleSeq& varseq = _pat->clause_variables.at(pclause);

--- a/opencog/query/PatternMatchEngine.h
+++ b/opencog/query/PatternMatchEngine.h
@@ -251,6 +251,7 @@ private:
 		CALL_UNORDER,
 		CALL_PRESENT,
 		CALL_CHOICE,
+		CALL_CACHE,
 		CALL_SOLN
 	} Caller;   // debug-print call-tracing.
 


### PR DESCRIPTION
The old caching code made a bad assumption about what was being passed in to it. This resulted in a spurious cache hit when none should have ocurred. This fixes it; it simplifies the code in the process.
