### PR TITLE
Inserting FloatValue, resolves #3026

### DIFF
--- a/examples/atomspace/recursive-loop.scm
+++ b/examples/atomspace/recursive-loop.scm
@@ -23,7 +23,7 @@
 
 ; Define a predicate that tests to see if the sum of three random
 ; values is less than 2.5 or not.
-(define uniform (ValueOfLink someplace key))
+(define uniform (FloatValueOfLink someplace key))
 (Define (DefinedPredicate "keep going?")
    (GreaterThan (Number 2.5) (Plus uniform uniform uniform)))
 

--- a/examples/pattern-matcher/fsm-mealy.scm
+++ b/examples/pattern-matcher/fsm-mealy.scm
@@ -10,7 +10,8 @@
 ;
 ; Then, scroll to the bottom, and try some of the commented-out examples.
 
-(use-modules (opencog))
+(use-modules (opencog)(opencog exec))
+(use-modules (opencog persist))
 
 (define my-trans (Concept "My FSM's Transition Rule"))
 (define my-state (Anchor  "My FSM's Current State"))

--- a/examples/pattern-matcher/type-signature.scm
+++ b/examples/pattern-matcher/type-signature.scm
@@ -8,6 +8,7 @@
 ; groundings must respect the variable type.
 ;
 (use-modules (opencog) (opencog exec))
+(use-modules (opencog type-utils))
 
 ; Populate the atomspace with some nonsense atoms.
 (Inheritance (Concept "foo") (Concept "bingo"))

--- a/examples/pattern-matcher/value-of.scm
+++ b/examples/pattern-matcher/value-of.scm
@@ -51,7 +51,7 @@
 			; Divide by twelve, then see if its more than 3.
 			(GreaterThan
 				(Divide
-					(ValueOf (Variable "$X") key)
+					(FloatValueOf (Variable "$X") key)
 					(Number 12))
 				(Number 3)))
 		(Variable "$X")))


### PR DESCRIPTION
This PR relates to #3026.   
In order to avoid an exception, Value has to be replaced with FloatValue in two places.   
Apart from that, missing modules were included in two places.