### PR TITLE
Replace `make test` by `make check`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ jobs:
           command: cd build && make -j2 tests
       - run:
           name: Run tests
-          command: cd build && make test
+          command: cd build && make check
       - run:
           name: Install AtomSpaceRocks
           command: cd build && make -j2 install && ldconfig
@@ -160,7 +160,7 @@ jobs:
 # negatives.
 #      - run:
 #          name: Run tests
-#          command: cd build && make test ARGS="$MAKEFLAGS"
+#          command: cd build && make check ARGS="$MAKEFLAGS"
 #      - run:
 #          name: Print test log
 #          command: cat build/tests/Testing/Temporary/LastTest.log
@@ -204,7 +204,7 @@ jobs:
           command: cd build && make -j2 tests
       - run:
           name: Run tests
-          command: cd build && make -j2 test ARGS=-j2
+          command: cd build && make -j2 check ARGS=-j2
       - run:
           name: Install spacetime
           command: cd build && make -j2 install && ldconfig
@@ -249,7 +249,7 @@ jobs:
           command: cd build && make -j2 tests
       - run:
           name: Run tests
-          command: cd build && make -j2 test ARGS=-j2
+          command: cd build && make -j2 check ARGS=-j2
       - run:
           name: Install Unify
           command: cd build && make -j2 install && ldconfig
@@ -297,7 +297,7 @@ jobs:
           command: cd build && make -j2 tests
       - run:
           name: Run tests
-          command: cd build && make -j2 test ARGS=-j2
+          command: cd build && make -j2 check ARGS=-j2
       - run:
           name: Install URE
           command: cd build && make -j2 install && ldconfig
@@ -354,7 +354,7 @@ jobs:
           # Running tests in parallel seems to result in test failures.
           # I don't know why
           # command: cd build && make test ARGS="$MAKEFLAGS"
-          command: cd build && make test
+          command: cd build && make check
       - run:
           name: Install AS-MOSES
           command: cd build && make install && ldconfig
@@ -412,7 +412,7 @@ jobs:
           command: cd build && make -j2 tests
       - run:
           name: Run tests
-          command: cd build && make -j2 test ARGS=-j2
+          command: cd build && make -j2 check ARGS=-j2
       - run:
           name: Install Miner
           command: cd build && make -j2 install && ldconfig
@@ -516,7 +516,7 @@ jobs:
           command: cd build && make tests
       - run:
           name: Run tests
-          command: cd build && make test ARGS="$MAKEFLAGS"
+          command: cd build && make check ARGS="$MAKEFLAGS"
       - run:
           name: Install Attention
           command: cd build && make install && ldconfig

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -468,7 +468,7 @@ jobs:
           command: cd build && make -j2 tests
       - run:
           name: Run tests
-          command: cd build && make -j2 test ARGS=-j2
+          command: cd build && make -j2 check ARGS=-j2
       - run:
           name: Print test log
           command: cat build/tests/Testing/Temporary/LastTest.log

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,21 +8,10 @@
 # -- configure various config files.
 # -- print pretty summary
 #
-# cogutils already requires 2.8.12.2, so may as well ask for that.
+# cogutils already requires 3.12, so may as well ask for that.
 # Correct handling of guile module install requires cmake version 3.12
-# or newer, but ubuntu bionic 18.04 only has 3.10. Bummer about that.
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12.2)
-IF (COMMAND CMAKE_POLICY)
-	CMAKE_POLICY(SET CMP0003 NEW)
-ENDIF (COMMAND CMAKE_POLICY)
-
-IF(CMAKE_VERSION VERSION_GREATER 3.0.2)
-	CMAKE_POLICY(SET CMP0037 NEW)
-	CMAKE_POLICY(SET CMP0042 NEW)
-ENDIF(CMAKE_VERSION VERSION_GREATER 3.0.2)
-IF (CMAKE_VERSION VERSION_GREATER 3.9.0)
-	CMAKE_POLICY(SET CMP0068 NEW)
-ENDIF (CMAKE_VERSION VERSION_GREATER 3.9.0)
+# or newer, but Ubuntu Bionic 18.04 only has 3.10. Bummer about that.
+CMAKE_MINIMUM_REQUIRED(VERSION 3.12)
 
 PROJECT(atomspace)
 
@@ -315,10 +304,6 @@ IF (CXXTEST_FOUND)
 			COMMENT "Running tests..."
 		)
 	ENDIF (CMAKE_BUILD_TYPE STREQUAL "Coverage")
-
-	# When CMP00037 is finally turned off, just remove these two lines.
-	ADD_CUSTOM_TARGET(test)
-	ADD_DEPENDENCIES(test check)
 
 	ADD_CUSTOM_TARGET(test_atomese
 		DEPENDS tests

--- a/README.md
+++ b/README.md
@@ -713,7 +713,6 @@ Specific subsets of the unit tests can be run:
     make test_persist_sql
     make test_python
     make test_query
-    make test_sheaf
 ```
 
 ### Install


### PR DESCRIPTION
CMP0037 was deprecated in 2014. It's time to move on.