### PR TITLE
Provide scheme API for inserting AtomSpaces into other AtomSpaces

### DIFF
--- a/cmake/OpenCogGenScmTypes.cmake
+++ b/cmake/OpenCogGenScmTypes.cmake
@@ -77,9 +77,10 @@ MACRO(OPENCOG_SCM_WRITE_DEFS SCM_FILE)
 		ENDIF (NOT SHORT_NAME STREQUAL "")
 	ENDIF (ISLINK STREQUAL "LINK")
 
+	# Create and then add.
 	IF (ISATOMSPACE STREQUAL "ATOM_SPACE")
 		FILE(APPEND "${SCM_FILE}"
-			"(define-public AtomSpace cog-new-atomspace)\n"
+			"(define-public (AtomSpace . x) (cog-add-atomspace (cog-new-atomspace x)))\n"
 		)
 	ENDIF (ISATOMSPACE STREQUAL "ATOM_SPACE")
 

--- a/cmake/OpenCogGenScmTypes.cmake
+++ b/cmake/OpenCogGenScmTypes.cmake
@@ -80,7 +80,7 @@ MACRO(OPENCOG_SCM_WRITE_DEFS SCM_FILE)
 	# Create and then add.
 	IF (ISATOMSPACE STREQUAL "ATOM_SPACE")
 		FILE(APPEND "${SCM_FILE}"
-			"(define-public (AtomSpace . x) (cog-add-atomspace (cog-new-atomspace x)))\n"
+			"(define-public (AtomSpace . x) (cog-add-atomspace (apply cog-new-atomspace x)))\n"
 		)
 	ENDIF (ISATOMSPACE STREQUAL "ATOM_SPACE")
 

--- a/opencog/atomspace/AtomSpace.cc
+++ b/opencog/atomspace/AtomSpace.cc
@@ -241,7 +241,13 @@ bool AtomSpace::operator<(const Atom& other) const
 
 ContentHash AtomSpace::compute_hash() const
 {
-	return _uuid;
+	if (_name.empty()) return _uuid;
+	ContentHash hsh = std::hash<std::string>()(get_name());
+
+	// Nodes will never have the MSB set.
+	ContentHash mask = ~(((ContentHash) 1ULL) << (8*sizeof(ContentHash) - 1));
+	hsh &= mask;
+	return hsh;
 }
 
 // ====================================================================
@@ -258,6 +264,7 @@ const std::string& AtomSpace::get_name() const
 void AtomSpace::set_name(const std::string& newna)
 {
 	_name = newna;
+	_content_hash = compute_hash();
 }
 
 Handle AtomSpace::getOutgoingAtom(Arity n) const

--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -296,6 +296,21 @@ void SchemeSmob::module_init(void*)
 
 void SchemeSmob::register_procs()
 {
+	// The three numbers are these:
+	// First, the number of mandatory arguments,
+	// Next, the number of fixed optional arguments,
+	// Finally, boolean t/f if API allows a variable-length list
+	// of additional arguments.
+	//
+	// For example, ss_new_value takes a type (mandatory) followed
+	// by a variable length list of values (its a vector). So, 1,0,1.
+	//
+	// Compare to cog-incoming-set, which takes an atom, followed by
+	// exactly one optional argument. Thus, 1,1,0.
+	//
+	// Note cog-atomspace, which takes zero mandatory args, and one
+	// optional arg: thus, 0,1,0.
+	//
 	register_proc("cog-version",           0, 0, 0, C(ss_version));
 	register_proc("cog-set-server-mode!",  1, 0, 0, C(ss_set_server_mode));
 
@@ -367,6 +382,7 @@ void SchemeSmob::register_procs()
 
 	// Atom Spaces
 	register_proc("cog-new-atomspace",     0, 0, 1, C(ss_new_as));
+	register_proc("cog-add-atomspace",     1, 0, 0, C(ss_add_as));
 	register_proc("cog-atomspace?",        1, 0, 0, C(ss_as_p));
 	register_proc("cog-set-atomspace!",    1, 0, 0, C(ss_set_as));
 	register_proc("cog-atomspace-env",     0, 1, 0, C(ss_as_env));

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -176,6 +176,7 @@ private:
 
 	// Atom Spaces
 	static SCM ss_new_as(SCM);
+	static SCM ss_add_as(SCM);
 	static SCM ss_as_p(SCM);
 	static SCM ss_as(SCM);
 	static SCM ss_set_as(SCM);

--- a/opencog/guile/SchemeSmobAS.cc
+++ b/opencog/guile/SchemeSmobAS.cc
@@ -63,6 +63,35 @@ SCM SchemeSmob::ss_new_as (SCM space_list)
 
 /* ============================================================== */
 /**
+ * Add an AtomSpace to the current AtomSpace. Unlike ss_new_node,
+ * the ss_new_as() call above does NOT add the new AtomSpace to any
+ * existing AtomSpace. It just ... hangs there in the void. This is
+ * usually just fine, and is the historic behavior. But in order to
+ * get naming uniqueness guarantees, it has to be actually inserted
+ * somewhere, where naming uniqueness is provided. So that's what this
+ * method does.
+ *
+ * Note that this might be crazy-making for a naive user: if two
+ * atomspaces are created with exactly the same name, and both are
+ * inserted, the second insert will return the first atomspace.
+ * Which is exactly the whole point of this function; but it also
+ * means that the second atomspace might be garbage-collected, which
+ * might come as a surprise to the user, esp. if it isn't empty.
+ */
+SCM SchemeSmob::ss_add_as (SCM sas)
+{
+	Handle hasp(verify_handle(sas, "cog-add-atomspace"));
+
+	if (hasp->get_type() != ATOM_SPACE)
+		scm_wrong_type_arg_msg("cog-add-atomspace", 1, sas, "opencog atomspace");
+
+	const AtomSpacePtr& asp = ss_get_env_as("cog-add-atomspace");
+	Handle h(asp->add_atom(hasp));
+	return handle_to_scm(h);
+}
+
+/* ============================================================== */
+/**
  * Return true if the scm is an AtomSpace
  */
 SCM SchemeSmob::ss_as_p (SCM s)

--- a/opencog/scm/opencog.scm
+++ b/opencog/scm/opencog.scm
@@ -30,6 +30,7 @@
 ; as otherwise guile generates warnings about "possibly unbound variable"
 ; when these are touched in the various scm files.
 (export
+cog-add-atomspace
 cog-arity
 cog-atom
 cog-atom?

--- a/opencog/scm/opencog/base/core-docs.scm
+++ b/opencog/scm/opencog/base/core-docs.scm
@@ -1132,19 +1132,94 @@
     Returns the new atomspace.
 
     AtomSpaces are automatically deleted when no more references to
-    them remain.
+    them remain. To prevent this, either keep a guile variable pointing
+    to it, or insert it into a Link, or insert it directly into another
+    AtomSpace (using `cog-add-atomspace`).
 
     Note that this does NOT set the current atomspace to the new one;
     to do that, you need to use cog-set-atomspace!
 
     The name of the AtomSpace can be obtained with `cog-name`.
 
+    Most users will want to call `cog-add-atomspace` on the returned
+    space. The function `AtomSpace` is a wrapper for these two combined;
+    so `(AtomSpace x)` is equivalent to (is defined as)
+    `(cog-add-atomspace (cog-new-atomspace x))`
+
     See also:
+       AtomSpace -- create an AtomSpace and insert it into this one.
        cog-atomspace -- Get the current AtomSpace in this thread.
+       cog-add-atomspace -- Insert an AtomSpace reference into this one.
        cog-atomspace-env -- Get the subspaces.
        cog-atomspace-uuid -- Get the UUID of the AtomSpace.
        cog-atomspace-ro! -- Mark the AtomSpace as read-only.
        cog-atomspace-cow! -- Mark the AtomSpace as copy-on-write.
+")
+
+(set-procedure-property! cog-add-atomspace 'documentation
+"
+ cog-add-atomspace ATOMSPACE
+    Insert ATOMSPACE into the current AtomSpace. This inserts a
+    reference (a pointer) to ATOMSPACE into the current AtomSpace.
+    The behavior is similar to creating a Node, except that Nodes
+    are always automatically inserted. The string name of ATOMSPACE
+    will be used to index the reference; thus, AtomSpaces can be found
+    by name.
+
+    This is not the same thing as subframes (subspaces). The inserted
+    ATOMSPACE is neither a superspace, subspace or copy (although it
+    could be, that's up to you.) The contents of ATOMSPACE are NOT
+    merged into the current AtomSpace, nor are they otherwise shared or
+    unified. The only goal of this function is to add a reference, and
+    have it be kept.
+
+    If the current AtomSpace does not contain some AtomSpace having the
+    same string name as ATOMSPACE, then ATOMSPACE is inserted, and
+    ATOMPSACE is returned. Otherwise, the existing AtomSpace having the
+    same name is returned.
+
+    The name of the AtomSpace can be obtained with `cog-name`.
+    The uuid the AtomSpace can be obtained with `cog-atomspace-uuid`.
+
+    Example:
+        guile> (define x (cog-new-atomspace \"foo\"))
+        guile> (cog-atomspace-uuid x)
+        13
+        guile> (define y (cog-add-atomspace x))
+        guile> (cog-atomspace-uuid y)
+        13
+        guile> (equal? x y)
+        #t
+        guile> (define z (cog-new-atomspace \"foo\"))
+        guile> (cog-atomspace-uuid z)
+        14
+        guile> (equal? z x)
+        #f
+        guile> (define w (cog-add-atomspace z))
+        guile> (cog-atomspace-uuid w)
+        13
+        guile> (equal? w x)
+        #t
+
+    See also:
+       AtomSpace -- create an AtomSpace and insert it into this one.
+       cog-atomspace -- Get the current AtomSpace in this thread.
+       cog-new-atomspace -- Create a new AtomSpace.
+       cog-atomspace-uuid -- Get the UUID of the AtomSpace.
+")
+
+(set-procedure-property! AtomSpace 'documentation
+"
+ AtomSpace [NAME]
+    Create a new AtomSpace; optionally give it the name NAME, and
+    insert it into the current AtomSpace. This is shorthand for
+    `(cog-add-atomspace (cog-new-atomspace NAME))`
+
+    See also:
+       cog-new-atomspace -- Create a new AtomSpace.
+       cog-add-atomspace -- Insert an AtomSpace reference into this one.
+       cog-atomspace -- Get the current AtomSpace in this thread.
+       cog-atomspace-uuid -- Get the UUID of the AtomSpace.
 ")
 
 (set-procedure-property! cog-atomspace-env 'documentation


### PR DESCRIPTION
The goal here is to have easy and simple episodic memory: by storing one AtomSpace in another, This has many benefits over other solutions:

* One can retain a handle to it (by name), which can be found at any time (the same way you'd find any other Atom.)
* The contents are not merged, and so its containerized, This allows:
-- Easy deletion
-- No worries about naming collisions or other cross-talk.
-- Episodic memory can be treated as Context.
-- Searches can be limited to the episodic space, and so can go much faster than searches on a larger space.

So this is like the old ContextLink, but cleaner, easier, more manageable.

This is not the same thing as frames/subspaces. The frames/subspaces are layers or version of the current Atomspace, and are used for versioning. Frames allow spaces to be virtually merged; (multiple inheritance) whereas insertion does no merging, inheritance, layering or any of that.

Basically, after this change, and AtomSpace acts both like a Node (it has a name) and an UnorderedLink (its got a bunch of stuff inside it) Note that AtomSpaces are mutable, but UnorderedLinks are not.