### PR TITLE
Load/store: allow optional AtomSpace argument

### DIFF
--- a/opencog/persist/api/PersistSCM.cc
+++ b/opencog/persist/api/PersistSCM.cc
@@ -292,18 +292,28 @@ void PersistSCM::sn_load_type(Type t, Handle hsn)
 	stnp->fetch_all_atoms_of_type(t, asp.get());
 }
 
-void PersistSCM::sn_load_atomspace(Handle hsn)
+void PersistSCM::sn_load_atomspace(Handle space, Handle hsn)
 {
 	GET_STNP;
-	const AtomSpacePtr& asp = SchemeSmob::ss_get_env_as("load-atomspace");
-	stnp->load_atomspace(asp.get());
+	if (space and space->get_type() == ATOM_SPACE)
+		stnp->load_atomspace(AtomSpaceCast(space).get());
+	else
+	{
+		const AtomSpacePtr& asp = SchemeSmob::ss_get_env_as("load-atomspace");
+		stnp->load_atomspace(asp.get());
+	}
 }
 
-void PersistSCM::sn_store_atomspace(Handle hsn)
+void PersistSCM::sn_store_atomspace(Handle space, Handle hsn)
 {
 	GET_STNP;
-	const AtomSpacePtr& asp = SchemeSmob::ss_get_env_as("store-atomspace");
-	stnp->store_atomspace(asp.get());
+	if (space and space->get_type() == ATOM_SPACE)
+		stnp->store_atomspace(AtomSpaceCast(space).get());
+	else
+	{
+		const AtomSpacePtr& asp = SchemeSmob::ss_get_env_as("store-atomspace");
+		stnp->store_atomspace(asp.get());
+	}
 }
 
 HandleSeq PersistSCM::sn_load_frames(Handle hsn)
@@ -455,18 +465,28 @@ void PersistSCM::dflt_load_type(Type t)
 	_sn->fetch_all_atoms_of_type(t, asp.get());
 }
 
-void PersistSCM::dflt_load_atomspace(void)
+void PersistSCM::dflt_load_atomspace(Handle space)
 {
 	CHECK;
-	const AtomSpacePtr& asp = SchemeSmob::ss_get_env_as("load-atomspace");
-	_sn->load_atomspace(asp.get());
+	if (space and space->get_type() == ATOM_SPACE)
+		_sn->load_atomspace(AtomSpaceCast(space).get());
+	else
+	{
+		const AtomSpacePtr& asp = SchemeSmob::ss_get_env_as("load-atomspace");
+		_sn->load_atomspace(asp.get());
+	}
 }
 
-void PersistSCM::dflt_store_atomspace(void)
+void PersistSCM::dflt_store_atomspace(Handle space)
 {
 	CHECK;
-	const AtomSpacePtr& asp = SchemeSmob::ss_get_env_as("store-atomspace");
-	_sn->store_atomspace(asp.get());
+	if (space and space->get_type() == ATOM_SPACE)
+		_sn->store_atomspace(AtomSpaceCast(space).get());
+	else
+	{
+		const AtomSpacePtr& asp = SchemeSmob::ss_get_env_as("store-atomspace");
+		_sn->store_atomspace(asp.get());
+	}
 }
 
 HandleSeq PersistSCM::dflt_load_frames(void)

--- a/opencog/persist/api/PersistSCM.h
+++ b/opencog/persist/api/PersistSCM.h
@@ -51,8 +51,8 @@ private:
 	static void sn_store_value(Handle, Handle, Handle);
 	static void sn_update_value(Handle, Handle, ValuePtr, Handle);
 	static void sn_load_type(Type, Handle);
-	static void sn_load_atomspace(Handle);
-	static void sn_store_atomspace(Handle);
+	static void sn_load_atomspace(Handle, Handle);
+	static void sn_store_atomspace(Handle, Handle);
 	static HandleSeq sn_load_frames(Handle);
 	static void sn_store_frames(Handle, Handle);
 	static void sn_delete_frame(Handle, Handle);
@@ -83,8 +83,8 @@ private:
 	void dflt_store_value(Handle, Handle);
 	void dflt_update_value(Handle, Handle, ValuePtr);
 	void dflt_load_type(Type);
-	void dflt_load_atomspace(void);
-	void dflt_store_atomspace(void);
+	void dflt_load_atomspace(Handle);
+	void dflt_store_atomspace(Handle);
 	HandleSeq dflt_load_frames(void);
 	void dflt_store_frames(Handle);
 	void dflt_delete_frame(Handle);

--- a/opencog/persist/api/opencog/persist.scm
+++ b/opencog/persist/api/opencog/persist.scm
@@ -416,15 +416,18 @@
 	(if STORAGE (sn-monitor STORAGE) (dflt-monitor))
 )
 
-(define*-public (load-atomspace #:optional (STORAGE #f))
+(define*-public (load-atomspace #:optional (ATOMSPACE #f) (STORAGE #f))
 "
- load-atomspace [STORAGE] - load all atoms from storage.
+ load-atomspace [ATOMSPACE] [STORAGE] - load all atoms from storage.
 
     This will cause ALL of the atoms in the open storage server to be
     loaded into the current AtomSpace. This can be a very time-consuming
     operation.  In normal operation, it is rarely necessary to load all
     atoms; there are several ways to fetch subsets of atoms, or even one
     at a time, when needed.
+
+    If the optional ATOMSPACE argument is provided, then the data will
+    be restored to that AtomSpace, instead of the current AtomSpace.
 
     If the optional STORAGE argument is provided, then it will be
     used as the source of the load. It must be a StorageNode.
@@ -439,18 +442,23 @@
     load-frames -- load DAG of AtomSpaces.
     store-atomspace -- store all Atoms in the AtomSpace.
 "
-	(if STORAGE (sn-load-atomspace STORAGE) (dflt-load-atomspace))
+	(if (not ATOMSPACE) (set! ATOMSPACE (cog-atomspace)))
+	(if STORAGE (sn-load-atomspace ATOMSPACE STORAGE)
+		(dflt-load-atomspace ATOMSPACE))
 )
 
-(define*-public (store-atomspace #:optional (STORAGE #f))
+(define*-public (store-atomspace #:optional (ATOMSPACE #f) (STORAGE #f))
 "
- store-atomspace [STORAGE] - Store all atoms in the AtomSpace to storage.
+ store-atomspace [ATOMSPACE] [STORAGE] - Store all atoms to storage.
 
     This will dump the ENTIRE contents of the current AtomSpace to the
     the currently-open storage.  Depending on the size of the AtomSpace,
     this may take a lot of time.  During normal operation, a bulk-save
     is rarely required, as individual atoms can always be stored, one
     at a time.
+
+    If the optional ATOMSPACE argument is provided, then it will be
+    stored, instead of the current AtomSpace.
 
     If the optional STORAGE argument is provided, then it will be
     used as the target of the store. It must be a StorageNode.
@@ -468,7 +476,9 @@
     store-atom ATOM -- store one ATOM and all of the values on it.
     store-referrers ATOM -- store all graphs that contain ATOM.
 "
-	(if STORAGE (sn-store-atomspace STORAGE) (dflt-store-atomspace))
+	(if (not ATOMSPACE) (set! ATOMSPACE (cog-atomspace)))
+	(if STORAGE (sn-store-atomspace ATOMSPACE STORAGE)
+		(dflt-store-atomspace ATOMSPACE))
 )
 
 (define*-public (load-frames #:optional (STORAGE #f))


### PR DESCRIPTION
It can be convenient to load/store to the named AtomSpace, directly.