### PR TITLE
Revert "Two-stage atom remove"

### DIFF
--- a/opencog/persist/api/StorageNode.h
+++ b/opencog/persist/api/StorageNode.h
@@ -318,28 +318,6 @@ public:
 	bool remove_atom(AtomSpace*, Handle h, bool recursive=false);
 	bool remove_atom(const AtomSpacePtr& as, Handle h, bool recursive=false)
 		{ return remove_atom(as.get(), h, recursive); }
-
-	/**
-	 * comment 
-	*/
-	virtual void preRemoveAtom(AtomSpace* as, const Handle& h,
-		                           bool recursive)
-	{
-		removeAtom(as, h, recursive);
-	}
-
-	/**
-	 * comment 
-	*/
-	virtual void postRemoveAtom(AtomSpace* as, const Handle& h,
-		                            bool recursive, bool extracted)
-	{}
-
-	/**
-	 * Wrapper neccessary for RocksStorage
-	*/
-	bool isAtomAbsent(const Handle& atom)
-		{ return atom->isAbsent(); }
 };
 
 NODE_PTR_DECL(StorageNode)


### PR DESCRIPTION
Reverts opencog/atomspace#3049

I had completely forgotten about #3044 when I merged this. Upon closer inspection, it is not at all obvious that this is correct or needed. So I'm reverting, for now. If/when it becomes clear that this or something like this is needed, well, we can try again at that time.