### PR TITLE
Implement PureExecLink

### DIFF
--- a/opencog/atoms/atom_types/atom_types.script
+++ b/opencog/atoms/atom_types/atom_types.script
@@ -1072,7 +1072,7 @@ THREAD_JOIN_LINK <- PARALLEL_LINK
 
 // Somewhat like ThreadJoinLink, except that this works with executable,
 // not evaluatable links.
-EXECUTE_THREADED_LINK <- ORDERED_LINK
+EXECUTE_THREADED_LINK <- EXECUTABLE_LINK
 
 // Everything under a PureExecLink is executed in a different AtomSpace.
 // This is used to isolate the present AtomSpace from the execution

--- a/opencog/atoms/atom_types/atom_types.script
+++ b/opencog/atoms/atom_types/atom_types.script
@@ -1077,7 +1077,7 @@ EXECUTE_THREADED_LINK <- ORDERED_LINK
 // Everything under a PureExecLink is executed in a different AtomSpace.
 // This is used to isolate the present AtomSpace from the execution
 // results. If no AtomSpace is specified, a temporary is created.
-PURE_EXEC_LINK <- ORDERED_LINK
+PURE_EXEC_LINK <- EXECUTABLE_LINK
 
 // ==============================================================
 // Procedure and schema nodes.

--- a/opencog/atoms/atom_types/atom_types.script
+++ b/opencog/atoms/atom_types/atom_types.script
@@ -1074,6 +1074,11 @@ THREAD_JOIN_LINK <- PARALLEL_LINK
 // not evaluatable links.
 EXECUTE_THREADED_LINK <- ORDERED_LINK
 
+// Everything under a PureExecLink is executed in a different AtomSpace.
+// This is used to isolate the present AtomSpace from the execution
+// results. If no AtomSpace is specified, a temporary is created.
+PURE_EXEC_LINK <- ORDERED_LINK
+
 // ==============================================================
 // Procedure and schema nodes.
 //

--- a/opencog/atoms/execution/Instantiator.cc
+++ b/opencog/atoms/execution/Instantiator.cc
@@ -631,14 +631,6 @@ ValuePtr Instantiator::instantiate(const Handle& expr,
 		return eolh->execute(_as, silent);
 	}
 
-	// ExecuteThreadedLinks
-	if (EXECUTE_THREADED_LINK == t)
-	{
-		// XXX Don't we need to plug in the vars, first!?
-		// Maybe this is just not tested?
-		return expr->execute(_as, silent);
-	}
-
 	// The thread-links are ambiguously executable/evaluatable.
 	if (nameserver().isA(t, PARALLEL_LINK))
 	{

--- a/opencog/atoms/parallel/CMakeLists.txt
+++ b/opencog/atoms/parallel/CMakeLists.txt
@@ -5,6 +5,7 @@ INCLUDE_DIRECTORIES( ${CMAKE_CURRENT_BINARY_DIR})
 ADD_LIBRARY (parallel
 	ExecuteThreadedLink.cc
 	ParallelLink.cc
+	PureExecLink.cc
 	ThreadJoinLink.cc
 )
 
@@ -23,6 +24,7 @@ INSTALL (TARGETS parallel
 INSTALL (FILES
 	ExecuteThreadedLink.h
 	ParallelLink.h
+	PureExecLink.h
 	ThreadJoinLink.h
 	DESTINATION "include/opencog/atoms/parallel"
 )

--- a/opencog/atoms/parallel/PureExecLink.cc
+++ b/opencog/atoms/parallel/PureExecLink.cc
@@ -1,0 +1,67 @@
+/*
+ * opencog/atoms/parallel/PureExecLink.cc
+ *
+ * Copyright (C) 2009, 2013-2015, 2020, 2024 Linas Vepstas
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/atoms/parallel/PureExecLink.h>
+#include <opencog/atomspace/AtomSpace.h>
+#include <opencog/atomspace/Transient.h>
+
+using namespace opencog;
+
+/// PureExecLink
+/// Perform execution in given AtomSpace, or a transient, if none given.
+///
+/// The general structure of this link is
+///
+///        PureExecLink
+///            ExecutableAtom
+///            AtomSpace (optional)
+///
+/// When this link is executed, the `ExecutableAtom` is executed in the
+/// specified AtomSpace, so that any Atoms created during execution end
+/// up there, instead of the current AtomSpace.
+
+PureExecLink::PureExecLink(const HandleSeq&& oset, Type t)
+    : Link(std::move(oset), t)
+{
+	if (0 == _outgoing.size())
+		throw InvalidParamException(TRACE_INFO,
+			"Expecting at least one argument!");
+}
+
+ValuePtr PureExecLink::execute(AtomSpace* as,
+                               bool silent)
+{
+	if (not _outgoing[0]->is_executable()) return _outgoing[0];
+
+	// Is there an AtomSpace? If so, use that.
+	// If none specified, then create a temporary.
+	AtomSpace* tas;
+	if (1 < _outgoing.size() and _outgoing[1]->get_type() == ATOM_SPACE)
+		tas = AtomSpaceCast(_outgoing[1]).get();
+	else
+		tas = grab_transient_atomspace(as);
+
+	return _outgoing[0]->execute(tas, silent);
+}
+
+DEFINE_LINK_FACTORY(PureExecLink, PURE_EXEC_LINK)

--- a/opencog/atoms/parallel/PureExecLink.h
+++ b/opencog/atoms/parallel/PureExecLink.h
@@ -1,0 +1,58 @@
+/*
+ * opencog/atoms/parallel/PureExecLink.h
+ *
+ * Copyright (C) 2020, 2024 Linas Vepstas
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef _OPENCOG_PURE_EXEC_LINK_H
+#define _OPENCOG_PURE_EXEC_LINK_H
+
+#include <opencog/atoms/base/Link.h>
+
+namespace opencog
+{
+/** \addtogroup grp_atomspace
+ *  @{
+ */
+
+class AtomSpace;
+
+class PureExecLink : public Link
+{
+protected:
+
+public:
+	PureExecLink(const HandleSeq&&, Type=PURE_EXEC_LINK);
+	PureExecLink(const PureExecLink&) = delete;
+	PureExecLink& operator=(const PureExecLink&) = delete;
+
+	virtual bool is_executable() const { return true; }
+	virtual ValuePtr execute(AtomSpace*, bool);
+
+	static Handle factory(const Handle&);
+};
+
+LINK_PTR_DECL(PureExecLink)
+#define createPureExecLink CREATE_DECL(PureExecLink)
+
+/** @}*/
+}
+
+#endif // _OPENCOG_PURE_EXEC_LINK_H


### PR DESCRIPTION
Executing some links places things into the AtomSpace. Specify the AtomSpace into which they should go (or use a temp, if not specified).