### PR TITLE
Implement LinkSignatureLink

### DIFF
--- a/examples/pattern-matcher/filter.scm
+++ b/examples/pattern-matcher/filter.scm
@@ -354,3 +354,9 @@
 ; This example is currently broken, because lazy evaluation does not
 ; work!
 (cog-execute! summation)
+
+; Another (as yet unimplemented) design choice would be to use
+; AccumulateLink. But this also is currently unsupported (because
+; its not clear if Accumulate should act in parallel on Link contents,
+; or if it should accumulate everything in the Link.)
+; (cog-execute! (Accumulate summation))

--- a/opencog/atoms/atom_types/atom_types.script
+++ b/opencog/atoms/atom_types/atom_types.script
@@ -759,6 +759,15 @@ SIGNATURE_LINK <- CONNECTOR,TYPE_OUTPUT_LINK
 // a variable without a name binding.
 SIGN_NODE <- TYPE_NODE
 
+// Signature for a typed link. This is needed for encoding signatures
+// involving LinkValue and similar. It also simplifies polymorphsm.
+// Thus, for example, the siggnature of
+// (LinkValue (FloatValue...) (Concept ...)) cannot be encoded with
+// a regular SignatureLink, because the LinkValue blocks this. However,
+// it can be encoded as
+// (LinkSignature (Type 'LinkValue) (Type 'FloatValue) (Type 'Concept))
+LINK_SIGNATURE_LINK <- SIGNATURE_LINK
+
 // A type binder: it binds a type to a VariableNode. Always arity-2,
 // the first position must be a VariableNode, the second must be a type.
 // Note that this is always scoped, i.e. used in lambdas and places

--- a/opencog/atoms/core/TypeUtils.cc
+++ b/opencog/atoms/core/TypeUtils.cc
@@ -85,6 +85,10 @@ bool value_is_type(const Handle& spec, const ValuePtr& val)
 		return TypeChoiceCast(deep)->is_type(val);
 	}
 
+	// From here on, we prepae to compare Links. The next if block
+	// deals with what's left of nodes, and preps for link compare.
+	size_t sz;
+	size_t off;
 	if (LINK_SIGNATURE_LINK != dpt)
 	{
 		// If it is not a link, then it is a type-constant,
@@ -95,7 +99,14 @@ bool value_is_type(const Handle& spec, const ValuePtr& val)
 		// If it is a link, then both must be same link type.
 		if (valtype != dpt) return false;
 
-		// Fall-thru and do link compares, below.
+		// Unordered links are harder to handle...
+		if (deep->is_unordered_link())
+			throw RuntimeException(TRACE_INFO,
+				"Not implemented! TODO XXX FIXME");
+
+		// Fall-thru and do link compares, below. Setup first.
+		sz = spec->get_arity();
+		off = 0;
 	}
 	else
 	{
@@ -117,36 +128,24 @@ bool value_is_type(const Handle& spec, const ValuePtr& val)
 		if ((islink or islnkv) and not nameserver().isA(valtype, deeptype))
 			return false;
 
-		// Arities must match, for now. I guess we could someday do
-		// globbing here, if someone ever needs this.
-		size_t sz = spec->get_arity() - 1;
-		if (sz != val->size()) return false;
-
-		// Loop over the rest. Off-by-one requires a regular counter.
-		for (uint i=0; i<sz; i++)
-		{
-		}
-
-		return true;
+		// Fall-thru and do link compares, below. Setup first.
+		sz = spec->get_arity() - 1;
+		off = 1;
 	}
 
-	const HandleSeq& vlo = HandleCast(val)->getOutgoingSet();
-	const HandleSeq& dpo = deep->getOutgoingSet();
-	size_t sz = dpo.size();
+	// Arities must match, for now. I guess we could someday do
+	// globbing here, if someone ever needs this.
+	if (sz != val->size()) return false;
 
-	// Both must be the same size...
-	if (vlo.size() != sz) return false;
-
-	// Unordered links are harder to handle...
-	if (deep->is_unordered_link())
-		throw RuntimeException(TRACE_INFO,
-			"Not implemented! TODO XXX FIXME");
-
-	// Ordered links are compared side-by-side
-	for (size_t i=0; i<sz; i++)
+#if 0
+	// Loop over the rest, doing a side-by-side compare.
+	for (uint i=0; i<sz; i++)
 	{
 		if (not value_is_type(dpo[i], vlo[i])) return false;
 	}
+	const HandleSeq& vlo = HandleCast(val)->getOutgoingSet();
+	const HandleSeq& dpo = deep->getOutgoingSet();
+#endif
 
 	// If we are here, all checks must hav passed.
 	return true;

--- a/opencog/atoms/core/TypeUtils.cc
+++ b/opencog/atoms/core/TypeUtils.cc
@@ -106,7 +106,7 @@ bool value_is_type(const Handle& spec, const ValuePtr& val)
 				"Not implemented! TODO XXX FIXME");
 
 		// Fall-thru and do link compares, below. Setup first.
-		sz = spec->get_arity();
+		sz = deep->get_arity();
 		off = 0;
 	}
 	else
@@ -130,7 +130,7 @@ bool value_is_type(const Handle& spec, const ValuePtr& val)
 			return false;
 
 		// Fall-thru and do link compares, below. Setup first.
-		sz = spec->get_arity() - 1;
+		sz = deep->get_arity() - 1;
 		off = 1;
 	}
 


### PR DESCRIPTION
The LinkSignatureLink enables the specification of signatures for data streams that have LinkValues in them. This occurs when a data stream has a complex structure, and is not just  a list of Atoms. The goal is to be able to filter and process the pipeline contents in real-time, as it arrives from sensory info sources.

Demo and unit tests in next pull request. The current Filtering code needs to be updated to work with Values (currently, only Atoms can be filtered).

For y'all who might be reading this: consider a stream of Atoms with variable TV's on them. A typical filtering task might be to accept only those that have a TV of more than 0.5, and discard the rest.