### PR TITLE
Fix  crash in filter when matching top-level globs

### DIFF
--- a/opencog/atoms/flow/FilterLink.cc
+++ b/opencog/atoms/flow/FilterLink.cc
@@ -139,6 +139,7 @@ bool FilterLink::glob_compare(const HandleSeq& tlo, const VECT& glo,
 	// The vector to match has to be at least as long as the template.
 	if (gsz < tsz) return false;
 
+	_recursive_glob = true;
 	// If we are here, there is a glob node in the pattern.  A glob can
 	// match one or more atoms in a row. Thus, we have a more
 	// complicated search ...
@@ -334,6 +335,12 @@ bool FilterLink::extract(const Handle& termpat,
 		// Check the type of the value.
 		if (not _mvars->is_type(termpat, vgnd)) return false;
 
+		// If we are deep in doing glob compares, then all that was
+		// needed is the result of the the type compare. However,
+		// if this is a top-level glob that is wrapping everything,
+		// then we need to record it (immediately below).
+		if (_recursive_glob) return true;
+
 		// Globs are always wrapped, no matter what, by a List or
 		// a LinkValue, because for the general case, the arity
 		// is unknown (even though its exactly one, here.)
@@ -460,6 +467,7 @@ ValuePtr FilterLink::rewrite_one(const ValuePtr& vterm,
 	// See if the term passes pattern matching. If it does, the
 	// side effect is that we get a grounding map as output.
 	ValueMap valmap;
+	_recursive_glob = false;
 	if (not extract(_pattern->get_body(), vterm, valmap, scratch, silent))
 		return Handle::UNDEFINED;
 

--- a/opencog/atoms/flow/FilterLink.cc
+++ b/opencog/atoms/flow/FilterLink.cc
@@ -330,9 +330,7 @@ bool FilterLink::extract(const Handle& termpat,
 	{
 		// Check the type of the value.
 		if (not _mvars->is_type(termpat, vgnd)) return false;
-
-		// Not the right place to record a grounding...
-		// valmap.emplace(std::make_pair(termpat, vgnd));
+		valmap.emplace(std::make_pair(termpat, vgnd));
 		return true;
 	}
 

--- a/opencog/atoms/flow/FilterLink.cc
+++ b/opencog/atoms/flow/FilterLink.cc
@@ -136,6 +136,9 @@ bool FilterLink::glob_compare(const HandleSeq& tlo, const VECT& glo,
 {
 	size_t gsz = glo.size();
 
+	// The vector to match has to be at least as long as the template.
+	if (gsz < tsz) return false;
+
 	// If we are here, there is a glob node in the pattern.  A glob can
 	// match one or more atoms in a row. Thus, we have a more
 	// complicated search ...
@@ -331,7 +334,9 @@ bool FilterLink::extract(const Handle& termpat,
 		// Check the type of the value.
 		if (not _mvars->is_type(termpat, vgnd)) return false;
 
-		// Globs are always wrapped, no matter what, by a List
+		// Globs are always wrapped, no matter what, by a List or
+		// a LinkValue, because for the general case, the arity
+		// is unknown (even though its exactly one, here.)
 		if (vgnd->is_atom())
 			valmap.emplace(std::make_pair(termpat,
 			               createLink(LIST_LINK, HandleCast(vgnd))));

--- a/opencog/atoms/flow/FilterLink.cc
+++ b/opencog/atoms/flow/FilterLink.cc
@@ -330,7 +330,13 @@ bool FilterLink::extract(const Handle& termpat,
 	{
 		// Check the type of the value.
 		if (not _mvars->is_type(termpat, vgnd)) return false;
-		valmap.emplace(std::make_pair(termpat, vgnd));
+
+		// Globs are always wrapped, no matter what, by a List
+		if (vgnd->is_atom())
+			valmap.emplace(std::make_pair(termpat,
+			               createLink(LIST_LINK, HandleCast(vgnd))));
+		else
+			valmap.emplace(std::make_pair(termpat, createLinkValue(vgnd)));
 		return true;
 	}
 

--- a/opencog/atoms/flow/FilterLink.h
+++ b/opencog/atoms/flow/FilterLink.h
@@ -69,6 +69,7 @@ protected:
 	                  ValueMap&, AtomSpace*, bool, Quotation,
 	                  ValuePtr (*)(const VECT&&),
 	                  size_t, size_t) const;
+	mutable bool _recursive_glob;
 public:
 	FilterLink(const HandleSeq&&, Type=FILTER_LINK);
 	FilterLink(const Handle& pattern, const Handle& term);

--- a/tests/atoms/flow/CMakeLists.txt
+++ b/tests/atoms/flow/CMakeLists.txt
@@ -25,5 +25,6 @@ TARGET_LINK_LIBRARIES(DynamicUTest execution smob)
 ADD_CXXTEST(FilterLinkUTest)
 TARGET_LINK_LIBRARIES(FilterLinkUTest execution smob)
 
+ADD_GUILE_TEST(FilterGlobTest filter-glob-test.scm)
 ADD_GUILE_TEST(FilterValueTest filter-value-test.scm)
 ADD_GUILE_TEST(FilterFloatTest filter-float-test.scm)

--- a/tests/atoms/flow/filter-glob-test.scm
+++ b/tests/atoms/flow/filter-glob-test.scm
@@ -1,0 +1,58 @@
+;
+; filter-glob-test.scm -- Simple tests of top-level globs.
+;
+(use-modules (opencog) (opencog exec))
+(use-modules (opencog test-runner))
+
+(opencog-test-runner)
+(define tname "filter-glob-test")
+(test-begin tname)
+
+; -----------
+(define glob-all (Filter (Glob "$x") (Concept "va")))
+(define e-glob-all (cog-execute! glob-all))
+
+(test-assert "glob of everything"
+	(equal? e-glob-all (List (Concept "va"))))
+
+; -----------
+(define glob-rule
+	(Filter
+		(Rule (Glob "$x")(Glob "$x")(Glob "$x"))
+		(Concept "vb")))
+(define e-glob-rule (cog-execute! glob-rule))
+
+(test-assert "glob of everything"
+	(equal? e-glob-rule (List (Concept "vb"))))
+
+; -----------
+(define glob-of
+   (Filter
+      (Rule (Glob "$x")(Glob "$x")(Glob "$x"))
+		(ValueOf (Concept "a") (Predicate "b"))))
+
+(cog-set-value! (Concept "a") (Predicate "b") (Concept "vc"))
+
+(define e-glob-of (cog-execute! glob-of))
+(test-assert "glob of value of"
+	(equal? e-glob-of (List (Concept "vc"))))
+
+(cog-set-value! (Concept "a") (Predicate "b")
+	(StringValue "a" "b" "c"))
+
+(define e-glob-svof (cog-execute! glob-of))
+(test-assert "glob of string"
+	(equal? e-glob-svof (LinkValue (StringValue "a" "b" "c"))))
+
+(cog-set-value! (Concept "a") (Predicate "b")
+	(LinkValue (StringValue "d" "e" "f")))
+
+(define e-glob-lsvof (cog-execute! glob-of))
+(test-assert "glob of linkstring"
+	(equal? e-glob-lsvof (LinkValue (LinkValue (StringValue "d" "e" "f")))))
+
+; -----------
+
+(test-end tname)
+
+(opencog-test-end)


### PR DESCRIPTION
Earlier commits were almost correct, but had unexpected side effects.