### PR TITLE
Bugfix filter execution

### DIFF
--- a/opencog/atoms/core/FreeVariables.cc
+++ b/opencog/atoms/core/FreeVariables.cc
@@ -459,16 +459,18 @@ void FreeVariables::erase(const Handle& var)
 
 Handle FreeVariables::substitute_nocheck(const Handle& term,
                                          const HandleSeq& args,
-                                         bool silent) const
+                                         bool silent,
+                                         bool do_exec) const
 {
-	return substitute_scoped(term, args, index);
+	return substitute_scoped(term, args, index, do_exec);
 }
 
 Handle FreeVariables::substitute_nocheck(const Handle& term,
                                          const HandleMap& vm,
-                                         bool silent) const
+                                         bool silent,
+                                         bool do_exec) const
 {
-	return substitute_scoped(term, make_sequence(vm), index);
+	return substitute_scoped(term, make_sequence(vm), index, do_exec);
 }
 
 bool FreeVariables::operator<(const FreeVariables& other) const

--- a/opencog/atoms/core/FreeVariables.h
+++ b/opencog/atoms/core/FreeVariables.h
@@ -131,12 +131,14 @@ struct FreeVariables : Replacement
 	/// almost-pure because it does honour the semantics of QuoteLink.
 	Handle substitute_nocheck(const Handle&,
 	                          const HandleSeq&,
-	                          bool silent=false) const;
+	                          bool silent=false,
+	                          bool do_exec=false) const;
 
 	/// Like the above, but takes a mapping from variables to arguments.
 	Handle substitute_nocheck(const Handle&,
 	                          const HandleMap&,
-	                          bool silent=false) const;
+	                          bool silent=false,
+	                          bool do_exec=false) const;
 
 	/// Comparison operator. Used to enable containers holding
 	/// this class.

--- a/opencog/atoms/core/Replacement.cc
+++ b/opencog/atoms/core/Replacement.cc
@@ -62,6 +62,7 @@ Handle Replacement::replace_nocheck(const Handle& term,
 Handle Replacement::substitute_scoped(Handle term,
                                       const HandleSeq& args,
                                       const IndexMap& index_map,
+                                      bool do_exec,
                                       Quotation quotation)
 {
 	bool unquoted = quotation.is_unquoted();
@@ -125,7 +126,7 @@ Handle Replacement::substitute_scoped(Handle term,
 		// that wraps them up.  See FilterLinkUTest for examples.
 		if (GLOB_NODE == h->get_type())
 		{
-			Handle glst(substitute_scoped(h, args, *index_map_ptr, quotation));
+			Handle glst(substitute_scoped(h, args, *index_map_ptr, do_exec, quotation));
 			changed = true;
 
 			// Also unwrap any ListLinks that were inserted by
@@ -138,8 +139,30 @@ Handle Replacement::substitute_scoped(Handle term,
 		}
 		else
 		{
-			Handle sub(substitute_scoped(h, args, *index_map_ptr, quotation));
-			if (sub != h) changed = true;
+			Handle sub(substitute_scoped(h, args, *index_map_ptr, do_exec, quotation));
+			if (sub != h)
+			{
+				changed = true;
+
+				// End of the line for streaming data. If the arguments
+				// that were being plugged in were executable streams,
+				// but they're being placed into something that is not
+				// executable, then run those streams, terminating them.
+				// The final result is then just a plain-old ordinary
+				// non-executable Atom, and nothing more.
+				if (do_exec and
+				    not term->is_executable() and
+				    sub->is_executable())
+				{
+					ValuePtr evp = sub->execute();
+					if (evp->is_atom())
+						sub = HandleCast(evp);
+					else
+						throw InvalidParamterException(TRACE_INFO,
+							"Wanted Atom as result of execution, got %s!"
+							evp->to_string().c_str());
+				}
+			}
 			oset.emplace_back(sub);
 		}
 	}

--- a/opencog/atoms/core/Replacement.cc
+++ b/opencog/atoms/core/Replacement.cc
@@ -33,7 +33,8 @@ namespace opencog {
 /* ================================================================= */
 
 Handle Replacement::replace_nocheck(const Handle& term,
-                                    const HandleMap& vm)
+                                    const HandleMap& vm,
+                                    bool do_exec)
 {
 	HandleSeq to_insert;
 	IndexMap insert_index;
@@ -44,7 +45,7 @@ Handle Replacement::replace_nocheck(const Handle& term,
 		insert_index.insert({pr.first, idx});
 		idx++;
 	}
-	return substitute_scoped(term, to_insert, insert_index);
+	return substitute_scoped(term, to_insert, insert_index, do_exec);
 }
 
 /* ================================================================= */
@@ -158,8 +159,8 @@ Handle Replacement::substitute_scoped(Handle term,
 					if (evp->is_atom())
 						sub = HandleCast(evp);
 					else
-						throw InvalidParamterException(TRACE_INFO,
-							"Wanted Atom as result of execution, got %s!"
+						throw InvalidParamException(TRACE_INFO,
+							"Wanted Atom as result of execution, got %s!",
 							evp->to_string().c_str());
 				}
 			}

--- a/opencog/atoms/core/Replacement.h
+++ b/opencog/atoms/core/Replacement.h
@@ -70,7 +70,7 @@ struct Replacement
 protected:
 	static Handle substitute_scoped(Handle, const HandleSeq&,
 	                                const IndexMap&,
-	                                bool do_exec = false,
+	                                bool do_exec,
 	                                Quotation quotation=Quotation());
 	static bool must_alpha_convert(const Handle& scope, const HandleSeq& args);
 	static bool must_alpha_hide(const Handle& scope, const IndexMap& index_map);

--- a/opencog/atoms/core/Replacement.h
+++ b/opencog/atoms/core/Replacement.h
@@ -61,6 +61,7 @@ struct Replacement
 protected:
 	static Handle substitute_scoped(Handle, const HandleSeq&,
 	                                const IndexMap&,
+	                                bool do_exec = false,
 	                                Quotation quotation=Quotation());
 	static bool must_alpha_convert(const Handle& scope, const HandleSeq& args);
 	static bool must_alpha_hide(const Handle& scope, const IndexMap& index_map);

--- a/opencog/atoms/core/Replacement.h
+++ b/opencog/atoms/core/Replacement.h
@@ -45,6 +45,14 @@ namespace opencog
 /// but performs type-checking before doing so. (It just calls this
 /// class to do the actual work, if type-checks pass.)
 ///
+/// If the `do_exec` flag is set, and the grounding Atom is executable,
+/// while the wrapping Link is not, then the groudning Atom is executed,
+/// with the resulting Atom used for the substitution. This allows
+/// streams to be terminated in ordinary non-executable Links. Doing
+/// execution this way seems to be a bit cleaner and more precise than
+/// what `class Instantiator` does: it just executes everything it finds
+/// rather indiscriminantly, which is perhaps (??) not a good idea.
+///
 /// See also `class Instantiator`, which does a similar replacement,
 /// except that it also executes any executable links that it encounters
 /// along the way, and places the results into an AtomSpace.
@@ -56,7 +64,8 @@ struct Replacement
 	/// any atoms that occur in the map by their mapped value.
 	/// It has the name "nocheck" because no type-checking is
 	/// performed before replacement.
-	static Handle replace_nocheck(const Handle&, const HandleMap&);
+	static Handle replace_nocheck(const Handle&, const HandleMap&,
+	                              bool do_exec = false);
 
 protected:
 	static Handle substitute_scoped(Handle, const HandleSeq&,

--- a/opencog/atoms/flow/FilterLink.cc
+++ b/opencog/atoms/flow/FilterLink.cc
@@ -545,7 +545,7 @@ ValuePtr FilterLink::rewrite_one(const ValuePtr& vterm,
 	// beta-reduction; we've already done that, during matching.
 	for (const Handle& impl : _rewrite)
 	{
-		ValuePtr red(_mvars->substitute_nocheck(impl, valseq));
+		ValuePtr red(_mvars->substitute_nocheck(impl, valseq, false, true));
 		if (red->is_atom() and HandleCast(red)->is_executable())
 		{
 			ValuePtr v(HandleCast(red)->execute(scratch, silent));

--- a/opencog/atoms/flow/ValueOfLink.cc
+++ b/opencog/atoms/flow/ValueOfLink.cc
@@ -132,8 +132,17 @@ ValuePtr ValueOfLink::execute(AtomSpace* as, bool silent)
 		{
 			return createFloatValue(NumberNodeCast(_outgoing[0])->value());
 		}
+
+		// Well, we could also be wrapping a unary ValueShim.
+		// I think this only happens when there's a bug somewhere
+		// else, but ... well, its not totally preposterous, so
+		// go ahead and handle it.
+		if (VALUE_SHIM_LINK == _outgoing[0]->get_type())
+		{
+			return _outgoing[0]->execute(as, silent);
+		}
 		throw InvalidParamException(TRACE_INFO,
-			"Expecting an Atom and a key");
+			"Expecting an Atom and a key; got %s", to_string().c_str());
 	}
 
 	return do_execute(as, silent);

--- a/tests/atoms/flow/string-of-test.scm
+++ b/tests/atoms/flow/string-of-test.scm
@@ -45,5 +45,31 @@
 	(equal? string-from-node (StringValue "do-da")))
 
 ; -----------
+
+(cog-set-value! (Anchor "anch") (Predicate "flokey")
+	(StringValue "scoobey"))
+
+(define filter-string
+	(Filter
+		(Rule
+			(Variable "$strv")
+			(Variable "$strv")
+			(Edge (Predicate "foobar")
+				(List
+					(StringOf (Type 'Concept)
+						(ValueOf (Variable "$strv"))))))
+		(ValueOf (Anchor "anch") (Predicate "flokey"))))
+
+(define flow-string
+	(cog-execute! filter-string))
+
+(format #t "Flow string got ~A\n" flow-string)
+
+(test-assert "flow-string"
+	(equal? flow-string
+		(Edge (Predicate "foobar")
+			(List (Concept "scoobey")))))
+
+; -----------
 (test-end tname)
 (opencog-test-end)


### PR DESCRIPTION
This fixes an old design flaw: execution of links should have been a bottom-up process instead of top-down. The top-down approach has caused a lot of confusion over the years, and a lot of crazy-making brain-damage. For some reason, doing it bottom-up was never considered before. So this is an all-new idea.  Current gut instinct is that this is what should have been done all along, but ... who knows. Time will tell.