### PR TITLE
Allow type conversion when specifying collections.

### DIFF
--- a/tests/atoms/flow/collection-of-test.scm
+++ b/tests/atoms/flow/collection-of-test.scm
@@ -35,23 +35,30 @@
 ; Same as above, but do type conversion.
 
 (define get-qry-edge
-	(Type 'EdgeLink)
-	(Get
-		(TypedVariable (Variable "X") (Type 'Concept))
-		(Evaluation (Predicate "foo") (Variable "X"))))
-
-(define set-qry-edge
-	(Type 'EdgeLink)
 	(CollectionOf
+		(Type 'EdgeLink)
+		(Get
+			(TypedVariable (Variable "X") (Type 'Concept))
+			(Evaluation (Predicate "foo") (Variable "X")))))
+
+(define meet-qry-edge
+	(CollectionOf
+		(Type 'EdgeLink)
 		(Meet
 			(TypedVariable (Variable "X") (Type 'Concept))
 			(Evaluation (Predicate "foo") (Variable "X")))))
 
-(test-assert "get edge"
-	(equal? (cog-execute! get-qry-edge) (Edge (Concept "bar"))))
+(define qry-edge (cog-execute! get-qry-edge))
+(format #t "Get edge is ~A" qry-edge)
 
-(test-assert "collection edcge"
-	(equal? (cog-execute! set-qry0edge) (Edge (Concept "bar"))))
+(define meet-edge (cog-execute! meet-qry-edge))
+(format #t "Meet edge is ~A" meet-edge)
+
+(test-assert "get edge"
+	(equal? qry-edge (Edge (Concept "bar"))))
+
+(test-assert "meet edge"
+	(equal? meet-edge (Edge (Concept "bar"))))
 
 (test-end tname)
 

--- a/tests/atoms/flow/collection-of-test.scm
+++ b/tests/atoms/flow/collection-of-test.scm
@@ -11,6 +11,9 @@
 
 (Evaluation (Predicate "foo") (Concept "bar"))
 
+; -------------------------------------------------------------
+; Base function: convert to set.
+
 (define get-qry
 	(Get
 		(TypedVariable (Variable "X") (Type 'Concept))
@@ -27,6 +30,28 @@
 
 (test-assert "collection set"
 	(equal? (cog-execute! set-qry) (Set (Concept "bar"))))
+
+; -------------------------------------------------------------
+; Same as above, but do type conversion.
+
+(define get-qry-edge
+	(Type 'EdgeLink)
+	(Get
+		(TypedVariable (Variable "X") (Type 'Concept))
+		(Evaluation (Predicate "foo") (Variable "X"))))
+
+(define set-qry-edge
+	(Type 'EdgeLink)
+	(CollectionOf
+		(Meet
+			(TypedVariable (Variable "X") (Type 'Concept))
+			(Evaluation (Predicate "foo") (Variable "X")))))
+
+(test-assert "get edge"
+	(equal? (cog-execute! get-qry-edge) (Edge (Concept "bar"))))
+
+(test-assert "collection edcge"
+	(equal? (cog-execute! set-qry0edge) (Edge (Concept "bar"))))
 
 (test-end tname)
 


### PR DESCRIPTION
Make CollectionOfLink work more like StringOfLink, so that an optional type conversion can be  performed, when rewriting links.