### PR TITLE
Deal with exceptions associated with invalid utf8 strings

### DIFF
--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -196,6 +196,7 @@ private:
 	static SCM ss_is_closed(SCM);
 
 	// Misc utilities
+	static SCM convert_to_utf8(void *, SCM, SCM);
 	static std::string to_string(SCM);
 	static std::string protom_to_string(SCM);
 	static std::string protom_to_server_string(SCM);

--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -171,8 +171,6 @@ SCM SchemeSmob::convert_to_utf8 (void *data, SCM tag, SCM throw_args)
 			break;
 
 		// Unicode Private Use Area, U+E000 - U+F8FF
-#define START_AT_E000 1
-#ifdef START_AT_E000
 		// Use the range U+E000 to U+E0FF
 		out.push_back(0xee);
 		unsigned char c = inbuf[i];
@@ -180,7 +178,11 @@ SCM SchemeSmob::convert_to_utf8 (void *data, SCM tag, SCM throw_args)
 		else if (c < 0x80) { out.push_back(0x81); out.push_back(0x40 + c); }
 		else if (c < 0xc0) { out.push_back(0x82); out.push_back(c); }
 		else { out.push_back(0x83); out.push_back(c - 0x40); }
-#else
+
+		// Note that Microsoft NTFS uses U+F000 plus ASCII codepoint for
+		// encoding invalid chars in NTFS filenames. So using this would
+		// lead to collisions and unexpected behavior.
+#if 0
 		// Use the range U+F800 to U+F8FF
 		out.push_back(0xef);
 		unsigned char c = inbuf[i];

--- a/opencog/guile/SchemeSmobNew.cc
+++ b/opencog/guile/SchemeSmobNew.cc
@@ -318,15 +318,16 @@ std::string SchemeSmob::verify_string (SCM sname, const char *subrname,
 	if (not scm_is_string(sname))
 		scm_wrong_type_arg_msg(subrname, pos, sname, msg);
 
-	char * cname = scm_to_utf8_string(sname);
+	char* cname = scm_to_utf8_string(sname);
 
+#define MASK(x) (x & 0xff)
 	// Search for unicode U+E000 to undo guile brain damage. Pitty.
 	// Life sucks. See notes on ss_name() for gory details.
 	size_t i=0;
 	while (cname[i])
 	{
-		if (0xee != cname[i]) i++;
-		else if (0x80 <= cname[i+1] and 0x80 <= cname[i+2]) break;
+		if (0xee != MASK(cname[i])) i++;
+		else if (0x80 <= MASK(cname[i+1]) and 0x80 <= MASK(cname[i+2])) break;
 	}
 
 	std::string name;
@@ -344,11 +345,11 @@ std::string SchemeSmob::verify_string (SCM sname, const char *subrname,
 	while (cname[i])
 	{
 		// Decode exactly one byte in the range U+E000 to U+E0FF
-		if (0xee == cname[i] and
-		    0x80 <= cname[i+1] and cname[i+1] < 0x84 and
-		    0x80 <= cname[i+2] and cname[i+2] < 0xd0)
+		if (0xee == MASK(cname[i]) and
+		    0x80 <= MASK(cname[i+1]) and MASK(cname[i+1]) < 0x84 and
+		    0x80 <= MASK(cname[i+2]) and MASK(cname[i+2]) < 0xd0)
 		{
-			unsigned char c = 0x40 * (cname[i+1] - 0x80) + (cname[i+2] - 0x80);
+			unsigned char c = 0x40 * (MASK(cname[i+1]) - 0x80) + (MASK(cname[i+2]) - 0x80);
 			name.push_back(c);
 			i += 3;
 		}

--- a/opencog/guile/SchemeSmobNew.cc
+++ b/opencog/guile/SchemeSmobNew.cc
@@ -346,7 +346,7 @@ std::string SchemeSmob::verify_string (SCM sname, const char *subrname,
 		// Decode exactly one byte in the range U+E000 to U+E0FF
 		if (0xee == cname[i] and
 		    0x80 <= cname[i+1] and cname[i+1] < 0x84 and
-		    0x80 <= cname[i+2] and cname[i+2] < 0x84)
+		    0x80 <= cname[i+2] and cname[i+2] < 0xd0)
 		{
 			unsigned char c = 0x40 * (cname[i+1] - 0x80) + (cname[i+2] - 0x80);
 			name.push_back(c);

--- a/opencog/guile/SchemeSmobPrint.cc
+++ b/opencog/guile/SchemeSmobPrint.cc
@@ -133,7 +133,15 @@ int SchemeSmob::print_misc(SCM node, SCM port, scm_print_state * ps)
 
 	// Deal with a regression in guile-2.1.x See bug report
 	// https://debbugs.gnu.org/cgi/bugreport.cgi?bug=25397
-	scm_display (scm_from_utf8_string (str.c_str()), port);
+	// Basically, scm_puts() stopped working, AND guile made
+	// a huge design flaw in string handling. What a cock-up.
+	// See nots on SchemeSmob::convert_to_utf8() for details.
+
+	SCM scmstr = scm_c_catch(SCM_BOOL_T,
+		(scm_t_catch_body) scm_from_utf8_string, (void *) str.c_str(),
+		SchemeSmob::convert_to_utf8, (void *) str.c_str(), NULL, NULL);
+
+	scm_display (scmstr, port);
 #else
 	scm_puts (str.c_str(), port);
 #endif // HAVE_GUILE_2_2

--- a/tests/scm/CMakeLists.txt
+++ b/tests/scm/CMakeLists.txt
@@ -24,6 +24,7 @@ ADD_CXXTEST(SCMPrimitiveUTest)
 ADD_CXXTEST(MultiAtomSpaceUTest)
 ADD_CXXTEST(MultiThreadUTest)
 ADD_CXXTEST(SCMUtilsUTest)
+ADD_CXXTEST(SCMUtf8StringUTest)
 ADD_CXXTEST(SCMExecutionOutputUTest)
 
 ADD_GUILE_TEST(SCMOpencogTestRunnerPass scm-opencog-test-runner-pass.scm)

--- a/tests/scm/SCMUtf8StringUTest.cxxtest
+++ b/tests/scm/SCMUtf8StringUTest.cxxtest
@@ -1,0 +1,98 @@
+/*
+ * tests/scm/SCMUtf8StringUTest.cxxtest
+ *
+ * Copyright (C) 2009, 2011, 2014, 2025 Linas Vepstas <linasvepstas@gmail.com>
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/atomspace/AtomSpace.h>
+#include <opencog/guile/SchemeEval.h>
+#include <opencog/util/Logger.h>
+
+#include "../query/test-types.h"
+
+using namespace opencog;
+
+class SCMUtf8StringUTest :  public CxxTest::TestSuite
+{
+	private:
+		AtomSpacePtr as;
+		SchemeEval* evaluator;
+
+	public:
+
+		SCMUtf8StringUTest(void)
+		{
+			logger().set_level(Logger::DEBUG);
+			logger().set_print_to_stdout_flag(true);
+#include "../query/test-types.cc"
+		}
+
+		~SCMUtf8StringUTest()
+		{
+			// erase the log file if no assertions failed
+			if (!CxxTest::TestTracker::tracker().suiteFailed())
+				std::remove(logger().get_filename().c_str());
+		}
+
+		void setUp(void);
+		void tearDown(void);
+
+		void test_utf8(void);
+};
+
+/*
+ * This function sets up an implication link, and some data.
+ */
+#define an as->add_node
+#define al as->add_link
+void SCMUtf8StringUTest::setUp(void)
+{
+	as = createAtomSpace();
+	evaluator = new SchemeEval(as);
+	evaluator->eval("(add-to-load-path \"" PROJECT_SOURCE_DIR "\")");
+	evaluator->eval("(add-to-load-path \"../../..\")");
+}
+
+void SCMUtf8StringUTest::tearDown(void)
+{
+	delete evaluator;
+	evaluator = NULL;
+}
+
+#define CHKERR \
+	TSM_ASSERT("Caught scm error during eval", \
+		(false == evaluator->eval_error()));
+/*
+ * Test UTF8 String handling.
+ */
+
+void SCMUtf8StringUTest::test_utf8(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	// Test cog-inc-count! ---------------------------------
+	Handle counter = evaluator->eval_h("counter");
+	CHKERR;
+
+	TSM_ASSERT("Failed to find atom", Handle::UNDEFINED != counter);
+	TSM_ASSERT_EQUALS("Wrong atom type", CONCEPT_NODE, counter->get_type());
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+

--- a/tests/scm/SCMUtf8StringUTest.cxxtest
+++ b/tests/scm/SCMUtf8StringUTest.cxxtest
@@ -86,12 +86,22 @@ void SCMUtf8StringUTest::test_utf8(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	// Test cog-inc-count! ---------------------------------
-	Handle counter = evaluator->eval_h("counter");
-	CHKERR;
+	// Some microsoft-1252 codepage crap.
+	std::string name = "Bl";
+	name.push_back(0xc4);
+	name += "mchen";
+	Handle n1 = an(CONCEPT_NODE, std::string(name));
 
-	TSM_ASSERT("Failed to find atom", Handle::UNDEFINED != counter);
-	TSM_ASSERT_EQUALS("Wrong atom type", CONCEPT_NODE, counter->get_type());
+	// Should not crash
+	evaluator->eval("(cog-prt-atomspace)");
+	CHKERR;
+	Handle h = evaluator->eval_h("(car (cog-get-atoms 'Concept))");
+	CHKERR;
+	std::string n1str = h->get_name();
+	printf("duude %s\n", n1str.c_str());
+
+	// TSM_ASSERT("Failed to find atom", Handle::UNDEFINED != counter);
+	// TSM_ASSERT_EQUALS("Wrong atom type", CONCEPT_NODE, counter->get_type());
 
 	logger().debug("END TEST: %s", __FUNCTION__);
 }

--- a/tests/scm/SCMUtf8StringUTest.cxxtest
+++ b/tests/scm/SCMUtf8StringUTest.cxxtest
@@ -87,21 +87,37 @@ void SCMUtf8StringUTest::test_utf8(void)
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
 	// Some microsoft-1252 codepage crap.
-	std::string name = "Bl";
-	name.push_back(0xc4);
-	name += "mchen";
-	Handle n1 = an(CONCEPT_NODE, std::string(name));
+	std::string name1 = "Bl";
+	name1.push_back(0xc4);
+	name1 += "mchen";
+	Handle n1 = an(CONCEPT_NODE, std::string(name1));
 
 	// Should not crash
 	evaluator->eval("(cog-prt-atomspace)");
 	CHKERR;
-	Handle h = evaluator->eval_h("(car (cog-get-atoms 'Concept))");
+	Handle cnh = evaluator->eval_h("(car (cog-get-atoms 'Concept))");
 	CHKERR;
-	std::string n1str = h->get_name();
-	printf("duude %s\n", n1str.c_str());
+	std::string n1str = cnh->get_name();
+	TSM_ASSERT("String miscompare", n1str != name1);
 
-	// TSM_ASSERT("Failed to find atom", Handle::UNDEFINED != counter);
-	// TSM_ASSERT_EQUALS("Wrong atom type", CONCEPT_NODE, counter->get_type());
+	// Also should not crash
+	std::string utf = evaluator->eval("(cog-name (car (cog-get-atoms 'Concept)))");
+	CHKERR;
+	printf("duuude its %s\n", utf.c_str());
+
+	evaluator->eval("(define foon (cog-name (car (cog-get-atoms 'Concept))))");
+	CHKERR;
+
+	// Test string copy
+	Handle pnh = evaluator->eval_h("(Predicate foon)");
+	CHKERR;
+	std::string p1str = pnh->get_name();
+	TSM_ASSERT("String miscompare", p1str != name1);
+
+	Handle pnh2 = evaluator->eval_h("(car (cog-get-atoms 'Predicate))");
+	CHKERR;
+	std::string p2str = pnh2->get_name();
+	TSM_ASSERT("String miscompare", p2str != name1);
 
 	logger().debug("END TEST: %s", __FUNCTION__);
 }

--- a/tests/scm/SCMUtf8StringUTest.cxxtest
+++ b/tests/scm/SCMUtf8StringUTest.cxxtest
@@ -54,7 +54,9 @@ class SCMUtf8StringUTest :  public CxxTest::TestSuite
 		void tearDown(void);
 
 		void check_conv(std::string);
-		void test_utf8(void);
+		void test_blumchen(void);
+		void test_elakelaiset(void);
+		void test_wutang(void);
 };
 
 /*
@@ -134,7 +136,7 @@ void SCMUtf8StringUTest::check_conv(std::string name1)
 	TSM_ASSERT("String miscompare", 0 == name1.compare(p2str));
 }
 
-void SCMUtf8StringUTest::test_utf8(void)
+void SCMUtf8StringUTest::test_blumchen(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
@@ -148,3 +150,32 @@ void SCMUtf8StringUTest::test_utf8(void)
 	logger().debug("END TEST: %s", __FUNCTION__);
 }
 
+void SCMUtf8StringUTest::test_elakelaiset(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	// Some microsoft-1252 codepage crap.
+	std::string name1 = "el";
+	name1.push_back(0xb4);
+	name1 += "kel";
+	name1.push_back(0xb4);
+	name1 += "iset";
+
+	check_conv(name1);
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}
+
+void SCMUtf8StringUTest::test_wutang(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	// Some microsoft-1252 codepage crap.
+	std::string name1 = "Die Meistersinger von N";
+	name1.push_back(0xfc);
+	name1 += "rnberg";
+
+	check_conv(name1);
+
+	logger().debug("END TEST: %s", __FUNCTION__);
+}

--- a/tests/scm/SCMUtf8StringUTest.cxxtest
+++ b/tests/scm/SCMUtf8StringUTest.cxxtest
@@ -53,6 +53,7 @@ class SCMUtf8StringUTest :  public CxxTest::TestSuite
 		void setUp(void);
 		void tearDown(void);
 
+		void check_conv(std::string);
 		void test_utf8(void);
 };
 
@@ -85,17 +86,11 @@ void SCMUtf8StringUTest::tearDown(void)
 static void prtstr(std::string s)
 {
 	for (size_t i=0; i<s.length(); i++)
-		printf("It is %d %x %c\n", i, s[i], s[i]);
+		printf("It is %lu %x %c\n", i, s[i], s[i]);
 }
 
-void SCMUtf8StringUTest::test_utf8(void)
+void SCMUtf8StringUTest::check_conv(std::string name1)
 {
-	logger().debug("BEGIN TEST: %s", __FUNCTION__);
-
-	// Some microsoft-1252 codepage crap.
-	std::string name1 = "Bl";
-	name1.push_back(0xc4);
-	name1 += "mchen";
 	Handle n1 = an(CONCEPT_NODE, std::string(name1));
 
 	// Should not crash
@@ -127,6 +122,8 @@ void SCMUtf8StringUTest::test_utf8(void)
 	Handle pnh = evaluator->eval_h("(Predicate foon)");
 	CHKERR;
 	std::string p1str = pnh->get_name();
+	printf("Pred name %s\n", p1str.c_str());
+	prtstr(p1str);
 	TSM_ASSERT("String miscompare", p1str == name1);
 	TSM_ASSERT("String miscompare", 0 == name1.compare(p1str));
 
@@ -135,6 +132,18 @@ void SCMUtf8StringUTest::test_utf8(void)
 	std::string p2str = pnh2->get_name();
 	TSM_ASSERT("String miscompare", p2str == name1);
 	TSM_ASSERT("String miscompare", 0 == name1.compare(p2str));
+}
+
+void SCMUtf8StringUTest::test_utf8(void)
+{
+	logger().debug("BEGIN TEST: %s", __FUNCTION__);
+
+	// Some microsoft-1252 codepage crap.
+	std::string name1 = "Bl";
+	name1.push_back(0xc4);
+	name1 += "mchen";
+
+	check_conv(name1);
 
 	logger().debug("END TEST: %s", __FUNCTION__);
 }

--- a/tests/scm/SCMUtf8StringUTest.cxxtest
+++ b/tests/scm/SCMUtf8StringUTest.cxxtest
@@ -82,6 +82,12 @@ void SCMUtf8StringUTest::tearDown(void)
  * Test UTF8 String handling.
  */
 
+static void prtstr(std::string s)
+{
+	for (size_t i=0; i<s.length(); i++)
+		printf("It is %d %x %c\n", i, s[i], s[i]);
+}
+
 void SCMUtf8StringUTest::test_utf8(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
@@ -98,26 +104,37 @@ void SCMUtf8StringUTest::test_utf8(void)
 	Handle cnh = evaluator->eval_h("(car (cog-get-atoms 'Concept))");
 	CHKERR;
 	std::string n1str = cnh->get_name();
-	TSM_ASSERT("String miscompare", n1str != name1);
+	printf("got %s vs %s\n", n1str.c_str(), name1.c_str());
+	TSM_ASSERT("String miscompare", name1 == n1str);
+	TSM_ASSERT("String miscompare", 0 == name1.compare(n1str));
 
 	// Also should not crash
 	std::string utf = evaluator->eval("(cog-name (car (cog-get-atoms 'Concept)))");
 	CHKERR;
-	printf("duuude its %s\n", utf.c_str());
+	printf("Got the name %s\n", utf.c_str());
+	prtstr(utf);
 
 	evaluator->eval("(define foon (cog-name (car (cog-get-atoms 'Concept))))");
 	CHKERR;
+
+	std::string utf2 = evaluator->eval("foon");
+	CHKERR;
+	printf("Still Got the name %s\n", utf2.c_str());
+	prtstr(utf2);
+	TSM_ASSERT("String miscompare", utf == utf2);
 
 	// Test string copy
 	Handle pnh = evaluator->eval_h("(Predicate foon)");
 	CHKERR;
 	std::string p1str = pnh->get_name();
-	TSM_ASSERT("String miscompare", p1str != name1);
+	TSM_ASSERT("String miscompare", p1str == name1);
+	TSM_ASSERT("String miscompare", 0 == name1.compare(p1str));
 
 	Handle pnh2 = evaluator->eval_h("(car (cog-get-atoms 'Predicate))");
 	CHKERR;
 	std::string p2str = pnh2->get_name();
-	TSM_ASSERT("String miscompare", p2str != name1);
+	TSM_ASSERT("String miscompare", p2str == name1);
+	TSM_ASSERT("String miscompare", 0 == name1.compare(p2str));
 
 	logger().debug("END TEST: %s", __FUNCTION__);
 }


### PR DESCRIPTION
Seems there's no industry standard for this stuff, and so we're back to the roll-your-own solutions.

This is a waste of time and effort, but there's no other way forward. so bite the bullet.