### PR TITLE
Add postgres to the circle-ci test chain

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -669,6 +669,9 @@ workflows:
   build-test-package:
     jobs:
       - atomspace
+      - atomspace-pgres:
+          requires:
+            - atomspace
       - atomspace-rocks:
           requires:
             - atomspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,51 @@ jobs:
             - atomspace
             - ccache
 
+  atomspace-pgres:
+    docker:
+      - image: $CIRCLE_PROJECT_USERNAME/opencog-deps
+        user: root
+        environment:
+          CCACHE_DIR: /ws/ccache
+    working_directory: /ws/atomspace-pgres
+    steps:
+      - attach_workspace:
+          at: /ws/
+      - run:
+          name: Install CogUtil
+          command: cd /ws/cogutil/build && make -j2 install && ldconfig
+      - run:
+          name: Install AtomSpace
+          command: cd /ws/atomspace/build && make -j2 install && ldconfig
+      - run:
+          name: Checkout AtomSpacePgres
+          command: git clone --depth 1 https://github.com/$CIRCLE_PROJECT_USERNAME/atomspace-pgres .
+      - run:
+          name: CMake Configure
+          command: mkdir build && cd build && cmake ..
+      - run:
+          name: Build
+          command: cd build && make -j2
+      - run:
+          name: Build tests
+          command: cd build && make -j2 tests
+      - run:
+          name: Run tests
+          command: cd build && make check
+      - run:
+          name: Install AtomSpacePgres
+          command: cd build && make -j2 install && ldconfig
+      - run:
+          name: Print test log
+          command: cat build/tests/Testing/Temporary/LastTest.log
+          when: always
+      - persist_to_workspace:
+          root: /ws/
+          paths:
+            - atomspace-pgres
+            # See https://github.com/opencog/cogutil/commit/da53c4079c3972904857a365a7761ac5923e4e92
+            # - ccache
+
   atomspace-rocks:
     docker:
       - image: $CIRCLE_PROJECT_USERNAME/opencog-deps


### PR DESCRIPTION
Now that postgres is removed, add it back into the unit test chain for circle-ci