### PR TITLE
Remove hidden boost dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -805,7 +805,7 @@ jobs:
           command: cd build && make -j2 tests
       - run:
           name: Run tests
-          command: cd build && make -j2 test ARGS=-j2
+          command: cd build && make -j2 check ARGS=-j2
       - run:
           name: Install OpenCog
           command: cd build && make -j2 install && ldconfig

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -797,24 +797,22 @@ jobs:
       - run:
           name: CMake Configure
           command: mkdir build && cd build && cmake ..
-#
-# Stub out until the latest link-grammar is available.
-#      - run:
-#          name: Build
-#          command: cd build && make -j2
-#      - run:
-#          name: Build tests
-#          command: cd build && make -j2 tests
-#      - run:
-#          name: Run tests
-#          command: cd build && make -j2 test ARGS=-j2
-#      - run:
-#          name: Install OpenCog
-#          command: cd build && make -j2 install && ldconfig
-#      - run:
-#          name: Print test log
-#          command: cat build/tests/Testing/Temporary/LastTest.log
-#          when: always
+      - run:
+          name: Build
+          command: cd build && make -j2
+      - run:
+          name: Build tests
+          command: cd build && make -j2 tests
+      - run:
+          name: Run tests
+          command: cd build && make -j2 test ARGS=-j2
+      - run:
+          name: Install OpenCog
+          command: cd build && make -j2 install && ldconfig
+      - run:
+          name: Print test log
+          command: cat build/tests/Testing/Temporary/LastTest.log
+          when: always
       - persist_to_workspace:
           root: /ws/
           paths:

--- a/opencog/atoms/base/ClassServer.cc
+++ b/opencog/atoms/base/ClassServer.cc
@@ -29,6 +29,7 @@
 
 #include "ClassServer.h"
 
+#include <cassert>
 #include <exception>
 
 #include <opencog/atoms/atom_types/types.h>

--- a/opencog/atoms/base/Handle.cc
+++ b/opencog/atoms/base/Handle.cc
@@ -344,34 +344,6 @@ std::string oc_to_string(const HandlePairSeq& hps, const std::string& indent)
 	return ss.str();
 }
 
-std::string oc_to_string(const HandleCounter& hc, const std::string& indent)
-{
-	std::stringstream ss;
-	ss << indent << "size = " << hc.size();
-	size_t i = 0;
-	for (const auto& el : hc) {
-		ss << std::endl << indent << "atom[" << i << "]:" << std::endl
-		   << oc_to_string(el.first, indent + OC_TO_STRING_INDENT)
-		   << indent << "num[" << i << "]:" << el.second << std::endl;
-		i++;
-	}
-	return ss.str();
-}
-
-std::string oc_to_string(const HandleUCounter& huc, const std::string& indent)
-{
-	std::stringstream ss;
-	ss << indent << "size = " << huc.size();
-	size_t i = 0;
-	for (const auto& el : huc) {
-		ss << std::endl << indent << "atom[" << i << "]:" << std::endl
-		   << oc_to_string(el.first, indent + OC_TO_STRING_INDENT)
-		   << indent << "num[" << i << "]:" << el.second << std::endl;
-		i++;
-	}
-	return ss.str();
-}
-
 std::string oc_to_string(Type type, const std::string& indent)
 {
 	std::stringstream ss;

--- a/opencog/atoms/base/Handle.h
+++ b/opencog/atoms/base/Handle.h
@@ -40,7 +40,6 @@
 #include <vector>
 
 #include <opencog/util/empty_string.h>
-#include <opencog/util/Counter.h>
 #include <opencog/atoms/atom_types/types.h>
 
 /** \addtogroup grp_atomspace
@@ -218,12 +217,6 @@ typedef std::set<HandleMap> HandleMapSet;
 //! a sequence of handle pairs
 typedef std::vector<HandlePair> HandlePairSeq;
 
-//! a map from handle to double
-typedef Counter<Handle, double> HandleCounter;
-
-//! a map from handle to unsigned
-typedef Counter<Handle, unsigned> HandleUCounter;
-
 // A map of variables to their groundings.  Everyone working with
 // groundings uses this type; changing the type here allows easy
 // comparisons of performance for these two mapping styles.
@@ -347,10 +340,6 @@ std::string oc_to_string(const HandleMapSeqSeq& hmss,
 std::string oc_to_string(const HandleMapSet& hms,
                          const std::string& indent=empty_string);
 std::string oc_to_string(const HandlePairSeq& hps,
-                         const std::string& indent=empty_string);
-std::string oc_to_string(const HandleCounter& hc,
-                         const std::string& indent=empty_string);
-std::string oc_to_string(const HandleUCounter& huc,
                          const std::string& indent=empty_string);
 std::string oc_to_string(Type type,
                          const std::string& indent=empty_string);


### PR DESCRIPTION
HandleCoounter appears to be unused anywhere. It pulled in cogutil/Counter.h which pulls in boost/operators.h which causes build problems on some systems.  So just get rid of it.