### PR TITLE
bugfix evaluations are done outside of atomspace.

### DIFF
--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -227,7 +227,8 @@ static ValuePtr exec_or_eval(AtomSpace* as,
 	}
 
 	Instantiator inst(as);
-	ValuePtr vp(inst.execute(term, silent));
+	Handle sterm(scratch->add_atom(term));
+	ValuePtr vp(inst.execute(sterm, silent));
 
 	// If the return value is a QueueValue, we assume that this
 	// is the result of executing a MeetLink or QueryLink.


### PR DESCRIPTION
This is some ancient bug. Probably responsible for assorted crazy-making in years past.