### PR TITLE
Store query results directly with the query pattern

### DIFF
--- a/opencog/atoms/pattern/MeetLink.cc
+++ b/opencog/atoms/pattern/MeetLink.cc
@@ -51,9 +51,16 @@ QueueValuePtr MeetLink::do_execute(AtomSpace* as, bool silent)
 {
 	if (nullptr == as) as = _atom_space;
 
+	// Where shall we place results? Why, right here!
+	ValuePtr vp(getValue(get_handle()));
+	QueueValuePtr qvp(QueueValueCast(vp));
+	if (nullptr == qvp)
+		throw RuntimeException(TRACE_INFO,
+			"Expecting QueueValue for results!");
+
 	try
 	{
-		SatisfyingSet sater(as);
+		SatisfyingSet sater(as, qvp);
 		sater.satisfy(PatternLinkCast(get_handle()));
 		return sater.get_result_queue();
 	}

--- a/opencog/atoms/pattern/MeetLink.cc
+++ b/opencog/atoms/pattern/MeetLink.cc
@@ -53,10 +53,14 @@ QueueValuePtr MeetLink::do_execute(AtomSpace* as, bool silent)
 
 	// Where shall we place results? Why, right here!
 	ValuePtr vp(getValue(get_handle()));
+	if (nullptr == vp)
+		throw RuntimeException(TRACE_INFO,
+			"Expecting location for results!");
 	QueueValuePtr qvp(QueueValueCast(vp));
 	if (nullptr == qvp)
 		throw RuntimeException(TRACE_INFO,
-			"Expecting QueueValue for results!");
+			"Expecting QueueValue for results, got %s",
+			vp->to_string().c_str());
 
 	try
 	{

--- a/opencog/atoms/pattern/MeetLink.cc
+++ b/opencog/atoms/pattern/MeetLink.cc
@@ -62,7 +62,7 @@ QueueValuePtr MeetLink::do_execute(AtomSpace* as, bool silent)
 	{
 		SatisfyingSet sater(as, qvp);
 		sater.satisfy(PatternLinkCast(get_handle()));
-		return sater.get_result_queue();
+		return qvp;
 	}
 	catch(const StandardException& ex)
 	{

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -29,6 +29,8 @@
 #include <opencog/atoms/core/FindUtils.h>
 #include <opencog/atoms/core/FreeLink.h>
 #include <opencog/atoms/core/NumberNode.h>
+#include <opencog/atoms/value/QueueValue.h>
+#include <opencog/atomspace/AtomSpace.h>
 
 #include "BindLink.h"
 #include "DualLink.h"
@@ -221,6 +223,10 @@ void PatternLink::init(void)
 	// I'm not convinced its a valid use of Quoting. It seems
 	// like a bug. But whatever. System crashes if the body is
 	// not set.
+	// The root cause is that Nil used PatternLink instead of
+	// RuleLink in URE, which made his code run slow and introduced
+	// crazy-making into the patterns. We should ditch this, given
+	// that teh URE is dead meat anyway.
 	if (nullptr == _body) return;
 
 	if (2 < _outgoing.size() or
@@ -237,6 +243,19 @@ void PatternLink::init(void)
 	debug_log("PatternLink::init()");
 	// logger().fine("Pattern: %s", to_long_string("").c_str());
 #endif
+}
+
+/* ================================================================= */
+
+void PatternLink::setAtomSpace(AtomSpace* as)
+{
+	RuleLink::setAtomSpace(as);
+
+	// All patterns will record results into queues. We attach
+	// queues now. User can over-ride later, if desired.
+	QueueValuePtr qvp = createQueueValue();
+	const Handle& self(get_handle());
+	as->set_value(self, self, qvp);
 }
 
 /* ================================================================= */

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -251,6 +251,9 @@ void PatternLink::setAtomSpace(AtomSpace* as)
 {
 	RuleLink::setAtomSpace(as);
 
+	// Can be called with null pointer during destruction.
+	if (nullptr == as) return;
+
 	// All patterns will record results into queues. We attach
 	// queues now. User can over-ride later, if desired.
 	// Start queue in closed state, otherwise it will hang

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -253,7 +253,10 @@ void PatternLink::setAtomSpace(AtomSpace* as)
 
 	// All patterns will record results into queues. We attach
 	// queues now. User can over-ride later, if desired.
+	// Start queue in closed state, otherwise it will hang
+	// in update() when printing.
 	QueueValuePtr qvp = createQueueValue();
+	qvp->close();
 	const Handle& self(get_handle());
 	as->set_value(self, self, qvp);
 }

--- a/opencog/atoms/pattern/PatternLink.h
+++ b/opencog/atoms/pattern/PatternLink.h
@@ -152,6 +152,8 @@ protected:
 	void disjointed_init(void);
 	void setup_components(void);
 
+	virtual void setAtomSpace(AtomSpace *);
+
 protected:
 	// utility debug print
 	static void prt(const Handle& h)

--- a/opencog/atoms/pattern/QueryLink.cc
+++ b/opencog/atoms/pattern/QueryLink.cc
@@ -116,7 +116,7 @@ QueueValuePtr QueryLink::do_execute(AtomSpace* as, bool silent)
 	 * get naive users into trouble, but there are legit uses, not just
 	 * in the URE, for doing disconnected searches.
 	 */
-	bool do_conn_check=false;
+	bool do_conn_check = false;
 	if (do_conn_check and 0 == _virtual.size() and 1 < _components.size())
 		throw InvalidParamException(TRACE_INFO,
 		                            "QueryLink consists of multiple "

--- a/opencog/atoms/pattern/QueryLink.cc
+++ b/opencog/atoms/pattern/QueryLink.cc
@@ -148,10 +148,9 @@ QueueValuePtr QueryLink::do_execute(AtomSpace* as, bool silent)
 	}
 
 	// If we got a non-empty answer, just return it.
-	QueueValuePtr qv(impl.get_result_queue());
-	OC_ASSERT(qv->is_closed(), "Unexpected queue state!");
-	if (0 < qv->concurrent_queue<ValuePtr>::size())
-		return qv;
+	OC_ASSERT(qvp->is_closed(), "Unexpected queue state!");
+	if (0 < qvp->concurrent_queue<ValuePtr>::size())
+		return qvp;
 
 	// If we are here, then there were zero matches.
 	//
@@ -172,14 +171,14 @@ QueueValuePtr QueryLink::do_execute(AtomSpace* as, bool silent)
 	if (0 == pat.pmandatory.size() and 0 < pat.absents.size()
 	    and not intu->optionals_present())
 	{
-		qv->open();
+		qvp->open();
 		for (const Handle& himp: impl.implicand)
-			qv->push(std::move(impl.inst.execute(himp, true)));
-		qv->close();
-		return qv;
+			qvp->push(std::move(impl.inst.execute(himp, true)));
+		qvp->close();
+		return qvp;
 	}
 
-	return qv;
+	return qvp;
 }
 
 ValuePtr QueryLink::execute(AtomSpace* as, bool silent)

--- a/opencog/atoms/pattern/QueryLink.cc
+++ b/opencog/atoms/pattern/QueryLink.cc
@@ -122,7 +122,14 @@ QueueValuePtr QueryLink::do_execute(AtomSpace* as, bool silent)
 		                            "QueryLink consists of multiple "
 		                            "disconnected components!");
 
-	Implicator impl(as);
+	// Where shall we place results? Why, right here!
+	ValuePtr vp(getValue(get_handle()));
+	QueueValuePtr qvp(QueueValueCast(vp));
+	if (nullptr == qvp)
+		throw RuntimeException(TRACE_INFO,
+			"Expecting QueueValue for results!");
+
+	Implicator impl(as, qvp);
 	impl.implicand = this->get_implicand();
 
 	try

--- a/opencog/atoms/value/QueueValue.cc
+++ b/opencog/atoms/value/QueueValue.cc
@@ -88,6 +88,25 @@ void QueueValue::update() const
 
 // ==============================================================
 
+void QueueValue::clear()
+{
+	// Reset contents
+	_value.clear();
+
+	// Do nothing; we don't want to clobber the _value
+	if (is_closed())
+	{
+		wait_and_take_all();
+		return;
+	}
+
+	close();
+	wait_and_take_all();
+	open();
+}
+
+// ==============================================================
+
 bool QueueValue::operator==(const Value& other) const
 {
 	// Derived classes use this, so use get_type()

--- a/opencog/atoms/value/QueueValue.h
+++ b/opencog/atoms/value/QueueValue.h
@@ -50,6 +50,7 @@ public:
 	QueueValue(void) : LinkStreamValue(QUEUE_VALUE) {}
 	QueueValue(const ValueSeq&);
 	virtual ~QueueValue() {}
+	virtual void clear();
 	virtual bool operator==(const Value&) const;
 };
 

--- a/opencog/query/Implicator.h
+++ b/opencog/query/Implicator.h
@@ -38,9 +38,9 @@ class Implicator:
 	public SatisfyMixin
 {
 	public:
-		Implicator(AtomSpace* asp) :
+		Implicator(AtomSpace* asp, QueueValuePtr& qvp) :
 			InitiateSearchMixin(asp),
-			RewriteMixin(asp),
+			RewriteMixin(asp, qvp),
 			TermMatchMixin(asp) {}
 
 			virtual void set_pattern(const Variables& vars,

--- a/opencog/query/RewriteMixin.cc
+++ b/opencog/query/RewriteMixin.cc
@@ -151,8 +151,10 @@ void RewriteMixin::insert_result(ValuePtr v)
 
 bool RewriteMixin::start_search(void)
 {
-	if (_result_queue->is_closed())
-		_result_queue->open();
+	if (not _result_queue->is_closed())
+		_result_queue->close();
+	_result_queue->wait_and_take_all();
+	_result_queue->open();
 	return false;
 }
 

--- a/opencog/query/RewriteMixin.cc
+++ b/opencog/query/RewriteMixin.cc
@@ -151,10 +151,9 @@ void RewriteMixin::insert_result(ValuePtr v)
 
 bool RewriteMixin::start_search(void)
 {
-	if (not _result_queue->is_closed())
-		_result_queue->close();
-	_result_queue->wait_and_take_all();
-	_result_queue->open();
+	_result_queue->clear();
+	if (_result_queue->is_closed())
+		_result_queue->open();
 	return false;
 }
 

--- a/opencog/query/RewriteMixin.cc
+++ b/opencog/query/RewriteMixin.cc
@@ -151,9 +151,11 @@ void RewriteMixin::insert_result(ValuePtr v)
 
 bool RewriteMixin::start_search(void)
 {
-	_result_queue->clear();
 	if (_result_queue->is_closed())
+	{
+		_result_queue->clear();
 		_result_queue->open();
+	}
 	return false;
 }
 

--- a/opencog/query/RewriteMixin.cc
+++ b/opencog/query/RewriteMixin.cc
@@ -28,8 +28,9 @@
 
 using namespace opencog;
 
-RewriteMixin::RewriteMixin(AtomSpace* as)
-	: _as(as), _num_results(0), inst(as), max_results(SIZE_MAX)
+RewriteMixin::RewriteMixin(AtomSpace* as, QueueValuePtr& qvp)
+	: _as(as), _result_queue(qvp),
+	_num_results(0), inst(as), max_results(SIZE_MAX)
 {
 }
 
@@ -150,10 +151,8 @@ void RewriteMixin::insert_result(ValuePtr v)
 
 bool RewriteMixin::start_search(void)
 {
-	// *Every* search gets a brand new, fresh queue!
-	// This allows users to hang on to the old queue, holding
-	// previous results, if they need to.
-	_result_queue = createQueueValue();
+	if (_result_queue->is_closed())
+		_result_queue->open();
 	return false;
 }
 

--- a/opencog/query/RewriteMixin.h
+++ b/opencog/query/RewriteMixin.h
@@ -68,7 +68,7 @@ class RewriteMixin :
 		std::map<GroundingMap, size_t> _group_sizes;
 
 	public:
-		RewriteMixin(AtomSpace*);
+		RewriteMixin(AtomSpace*, QueueValuePtr&);
 		Instantiator inst;
 		HandleSeq implicand;
 		size_t max_results;

--- a/opencog/query/RewriteMixin.h
+++ b/opencog/query/RewriteMixin.h
@@ -81,9 +81,6 @@ class RewriteMixin :
 
 		virtual bool start_search(void);
 		virtual bool search_finished(bool);
-
-		virtual QueueValuePtr get_result_queue()
-		{ return _result_queue; }
 };
 
 }; // namespace opencog

--- a/opencog/query/Satisfier.cc
+++ b/opencog/query/Satisfier.cc
@@ -207,8 +207,10 @@ bool SatisfyingSet::propose_grouping(const GroundingMap &var_soln,
 
 bool SatisfyingSet::start_search(void)
 {
-	if (_result_queue->is_closed())
-		_result_queue->open();
+	if (not _result_queue->is_closed())
+		_result_queue->close();
+	_result_queue->wait_and_take_all();
+	_result_queue->open();
 	return false;
 }
 

--- a/opencog/query/Satisfier.cc
+++ b/opencog/query/Satisfier.cc
@@ -207,9 +207,11 @@ bool SatisfyingSet::propose_grouping(const GroundingMap &var_soln,
 
 bool SatisfyingSet::start_search(void)
 {
-	_result_queue->clear();
 	if (_result_queue->is_closed())
+	{
+		_result_queue->clear();
 		_result_queue->open();
+	}
 	return false;
 }
 

--- a/opencog/query/Satisfier.cc
+++ b/opencog/query/Satisfier.cc
@@ -207,10 +207,9 @@ bool SatisfyingSet::propose_grouping(const GroundingMap &var_soln,
 
 bool SatisfyingSet::start_search(void)
 {
-	if (not _result_queue->is_closed())
-		_result_queue->close();
-	_result_queue->wait_and_take_all();
-	_result_queue->open();
+	_result_queue->clear();
+	if (_result_queue->is_closed())
+		_result_queue->open();
 	return false;
 }
 

--- a/opencog/query/Satisfier.cc
+++ b/opencog/query/Satisfier.cc
@@ -207,10 +207,8 @@ bool SatisfyingSet::propose_grouping(const GroundingMap &var_soln,
 
 bool SatisfyingSet::start_search(void)
 {
-	// *Every* search gets a brand new, fresh queue!
-	// This allows users to hang on to the old queue, holding
-	// previous results, if they need to.
-	_result_queue = createQueueValue();
+	if (_result_queue->is_closed())
+		_result_queue->open();
 	return false;
 }
 

--- a/opencog/query/Satisfier.h
+++ b/opencog/query/Satisfier.h
@@ -107,9 +107,10 @@ class SatisfyingSet :
 		std::map<GroundingMap, ValueSet> _groups;
 
 	public:
-		SatisfyingSet(AtomSpace* as) :
+		SatisfyingSet(AtomSpace* as, const QueueValuePtr& qvp) :
 			ContinuationMixin(as),
-			_as(as), _num_results(0), max_results(SIZE_MAX) {}
+			_as(as), _result_queue(qvp),
+			_num_results(0), max_results(SIZE_MAX) {}
 
 		size_t max_results;
 

--- a/opencog/query/Satisfier.h
+++ b/opencog/query/Satisfier.h
@@ -134,9 +134,6 @@ class SatisfyingSet :
 
 		virtual bool start_search(void);
 		virtual bool search_finished(bool);
-
-		virtual QueueValuePtr get_result_queue()
-		{ return _result_queue; }
 };
 
 }; // namespace opencog

--- a/tests/atoms/parallel/ThreadedUTest.cxxtest
+++ b/tests/atoms/parallel/ThreadedUTest.cxxtest
@@ -121,8 +121,10 @@ void ThreadedUTest::test_many(void)
 	{
 		HandleSeq hs = LinkValueCast(v)->to_handle_seq();
 		TS_ASSERT_EQUALS(1, hs.size());
-		if (flower == hs[0]) nflowers++;
-		if (rock == hs[0]) nrocks++;
+		TS_ASSERT_EQUALS(LIST_LINK, hs[0]->get_type());
+		TS_ASSERT_EQUALS(2, hs[0]->size());
+		if (flower == hs[0]->getOutgoingAtom(1)) nflowers++;
+		if (rock == hs[0]->getOutgoingAtom(1)) nrocks++;
 	}
 
 	printf("Got %zu flowers and %zu rocks\n", nflowers, nrocks);

--- a/tests/atoms/parallel/threaded.scm
+++ b/tests/atoms/parallel/threaded.scm
@@ -23,22 +23,29 @@
 
 ; (cog-execute! pexec)
 
-; one-hundred things to do in two threads.
+; One-hundred things to do in two threads.
+; This is set up so that each Query differs from all the others.
+; This avoids issues when the same Query/Meet is run in parallel:
+; both instances place results on the same result queue; if one
+; instance closes the queue while the other is still adding to it,
+; an exception gets thrown and everything goes haywire.
 (define pmany
 	(ExecuteThreaded
 		(Number 2)
 		(Set
 			(map
 				(lambda (n)
-					(Meet
+					(Query
 						(TypedVariable (Variable "X") (Type 'Concept))
-						(Inheritance (Variable "X") (Concept "mineral"))))
+						(Inheritance (Variable "X") (Concept "mineral"))
+						(List (Number n) (Variable "X"))))
 				(iota 50))
 			(map
 				(lambda (n)
-					(Meet
+					(Query
 						(TypedVariable (Variable "X") (Type 'Concept))
-						(Inheritance (Variable "X") (Concept "plant"))))
+						(Inheritance (Variable "X") (Concept "plant"))
+						(List (Number n) (Variable "X"))))
 				(iota 50))
 	)))
 

--- a/tests/query/AbsentUTest.cxxtest
+++ b/tests/query/AbsentUTest.cxxtest
@@ -94,7 +94,7 @@ void AbsentUTest::test_single(void)
 	// Verify the initial state, room should be empty
 	Handle state = eval->eval_h("(show-room-state)");
 	printf("Expecting: %s\n", empty->to_string().c_str());
-	printf("Got: %s\n", state->to_string().c_str());
+	printf("Got: %s\n\n", state->to_string().c_str());
 	TS_ASSERT_EQUALS(state, empty);
 
 	// Make the golem come alive
@@ -104,7 +104,7 @@ void AbsentUTest::test_single(void)
 
 	state = eval->eval_h("(show-room-state)");
 	printf("Expecting: %s\n", full->to_string().c_str());
-	printf("Got: %s\n", state->to_string().c_str());
+	printf("Got: %s\n\n", state->to_string().c_str());
 	TS_ASSERT_EQUALS(state, full);
 
 	// Kill the golem
@@ -121,6 +121,8 @@ void AbsentUTest::test_single(void)
 	eval->eval_h("(cog-execute! is-invisible)");
 
 	state = eval->eval_h("(show-room-state)");
+	printf("Expecting: %s\n", full->to_string().c_str());
+	printf("Got: %s\n\n", state->to_string().c_str());
 	TS_ASSERT_EQUALS(state, full);
 
 	eval->eval_h("(cog-execute! destroy)");

--- a/tests/query/ExecutionOutputUTest.cxxtest
+++ b/tests/query/ExecutionOutputUTest.cxxtest
@@ -247,29 +247,32 @@ void ExecutionOutputUTest::test_varsub(void)
 	BindLinkPtr predicament(BindLinkCast(pred));
 
 	// Now perform the search.
-	Implicator simpl(as.get());
+	QueueValuePtr qvp(createQueueValue());
+	qvp->close();
+	Implicator simpl(as.get(), qvp);
 	simpl.implicand = situation->get_implicand();
 	simpl.satisfy(situation);
 
 	// The result_list contains a list of the grounded expressions.
-	simpl.get_result_queue()->open();
+	qvp->open();
 
 	// If it's empty, it will hang ...
 	TSM_ASSERT_EQUALS("no results returned",
-		false, simpl.get_result_queue()->is_empty());
+		false, qvp->is_empty());
 
-	Handle res = HandleCast(simpl.get_result_queue()->value_pop());
+	Handle res = HandleCast(qvp->value_pop());
 	printf("res is %s\n", res->to_short_string().c_str());
 	TSM_ASSERT_EQUALS("incorrect resolution", res, resolution);
 
 	// Now perform the search.
-	Implicator pimpl(as.get());
+	qvp->close();
+	Implicator pimpl(as.get(), qvp);
 	pimpl.implicand = predicament->get_implicand();
 	pimpl.satisfy(predicament);
 
 	// The result_list contains a list of the grounded expressions.
-	pimpl.get_result_queue()->open();
-	Handle del = HandleCast(pimpl.get_result_queue()->value_pop());
+	qvp->open();
+	Handle del = HandleCast(qvp->value_pop());
 	printf("del is %s\n", del->to_short_string().c_str());
 	TSM_ASSERT_EQUALS("incorrect delivarance", del, deliverance);
 

--- a/tests/query/imply.h
+++ b/tests/query/imply.h
@@ -28,7 +28,9 @@ static inline Handle imply(AtomSpace* as, Handle hclauses, Handle himplicand)
 	BindLinkPtr bl(createBindLink(std::move(oset)));
 
 	// Now perform the search.
-	Implicator impl(as);
+	QueueValuePtr qvp(createQueueValue());
+	qvp->close();
+	Implicator impl(as, qvp);
 	impl.implicand.push_back(himplicand);
 
 	impl.satisfy(bl);
@@ -36,9 +38,8 @@ static inline Handle imply(AtomSpace* as, Handle hclauses, Handle himplicand)
 	// The result_set contains a list of the grounded expressions.
 	// Turn it into a true list, and return it.
 	HandleSeq hlist;
-	QueueValuePtr qv(impl.get_result_queue());
-	OC_ASSERT(qv->is_closed(), "Unexpected queue state!");
-	std::queue<ValuePtr> vals(qv->wait_and_take_all());
+	OC_ASSERT(qvp->is_closed(), "Unexpected queue state!");
+	std::queue<ValuePtr> vals(qvp->wait_and_take_all());
 	while (not vals.empty())
 	{
 		hlist.push_back(HandleCast(vals.front()));


### PR DESCRIPTION
This is an interesting change, and I don't know why I didn't do this a decade ago. The results of a query can be stored with the query itself. This provides a cache for the query.

This is interesting, because it allows *any* query to be used as a matrix (or tensor) for computing similarity measures (of any kind .. cosine or minmax or MI or whatever.) the margials live with the query itself, instead of being stored somewhere else, outside of the atomspace.

That means three things: first, less code and less complexity.  Second, the results can be shipped around to network or storage, just like any other atoms. Third, one now instantly gets a pure Atomese API for tensors of arbitrary shape. Any pattern whatsoever defines a de facto space on which dot-products or whatever can be computed.

This is so ... painfully obvious, I'm amazed I didn't see this much earlier. Where was my head at?

The next pull request will add some basic marginals (needed to get the full effect for the general case.)