### PR TITLE
Provide thread-safe set

### DIFF
--- a/opencog/atoms/atom_types/atom_types.script
+++ b/opencog/atoms/atom_types/atom_types.script
@@ -61,7 +61,8 @@ CONTAINER_VALUE <- LINK_STREAM_VALUE
 QUEUE_VALUE <- CONTAINER_VALUE
 
 // A thread-safe set of Values (uniset; deduplicates multiple entries.)
-SET_VALUE <- CONTAINER_VALUE
+// Note that 'SET_VALUE' already taken by SET_VALUE_LINK
+UNISET_VALUE <- CONTAINER_VALUE
 
 // A stream of Values, computed by a function held in the AtomSpace.
 // Just like FormulaStream, but for vectors of Values.

--- a/opencog/atoms/atom_types/atom_types.script
+++ b/opencog/atoms/atom_types/atom_types.script
@@ -54,8 +54,14 @@ FORMULA_STREAM <- STREAM_VALUE,LIST_VALUE
 // A base class for time-varying Value sequences.
 LINK_STREAM_VALUE <- LINK_VALUE
 
+// A base class for thread-safe concurrent containers.
+CONTAINER_VALUE <- LINK_STREAM_VALUE
+
 // A thread-safe FIFO queue of Value sequences.
-QUEUE_VALUE <- LINK_STREAM_VALUE
+QUEUE_VALUE <- CONTAINER_VALUE
+
+// A thread-safe set of Values (uniset; deduplicates multiple entries.)
+SET_VALUE <- CONTAINER_VALUE
 
 // A stream of Values, computed by a function held in the AtomSpace.
 // Just like FormulaStream, but for vectors of Values.

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -230,11 +230,11 @@ static ValuePtr exec_or_eval(AtomSpace* as,
 	Handle sterm(scratch->add_atom(term));
 	ValuePtr vp(inst.execute(sterm, silent));
 
-	// If the return value is a QueueValue, we assume that this
+	// If the return value is a ContainerValue, we assume that this
 	// is the result of executing a MeetLink or QueryLink.
 	// In this case, unwrap it, to get the "actual value".
 	// This feels slightly hacky, but will do for just right now.
-	if (QUEUE_VALUE == vp->get_type())
+	if (vp->is_type(CONTAINER_VALUE))
 	{
 		HandleSeq hs(LinkValueCast(vp)->to_handle_seq());
 		if (1 == hs.size())

--- a/opencog/atoms/join/JoinLink.cc
+++ b/opencog/atoms/join/JoinLink.cc
@@ -722,7 +722,7 @@ QueueValuePtr JoinLink::do_execute(AtomSpace* as,
 	// copying things into it. Whatever. Fix this.
 	QueueValuePtr qvp(createQueueValue());
 	for (const Handle& h : hs)
-		qvp->push(as->add_atom(h));
+		qvp->add(as->add_atom(h));
 
 	qvp->close();
 	return qvp;

--- a/opencog/atoms/parallel/ExecuteThreadedLink.cc
+++ b/opencog/atoms/parallel/ExecuteThreadedLink.cc
@@ -105,7 +105,7 @@ static void thread_exec(AtomSpace* as, bool silent,
 			ValuePtr pap(inst.execute(h));
 			if (pap and pap->is_atom())
 				pap = as->add_atom(HandleCast(pap));
-			qvp->push(std::move(pap));
+			qvp->add(std::move(pap));
 		}
 		catch (const std::exception& ex)
 		{

--- a/opencog/atoms/pattern/BindLink.cc
+++ b/opencog/atoms/pattern/BindLink.cc
@@ -65,9 +65,9 @@ BindLink::BindLink(const HandleSeq&& hseq, Type t)
 /** Wrap query results in a SetLink, place them in the AtomSpace. */
 ValuePtr BindLink::execute(AtomSpace* as, bool silent)
 {
-	QueueValuePtr qv(do_execute(as, silent));
-	OC_ASSERT(qv->is_closed(), "Unexpected queue state!");
-	HandleSeq rslt(qv->to_handle_seq());
+	ContainerValuePtr cv(do_execute(as, silent));
+	OC_ASSERT(cv->is_closed(), "Unexpected queue state!");
+	HandleSeq rslt(cv->to_handle_seq());
 
 	// The result_set contains a list of the grounded expressions.
 	// (The order of the list has no significance, so it's really a set.)

--- a/opencog/atoms/pattern/GetLink.cc
+++ b/opencog/atoms/pattern/GetLink.cc
@@ -22,6 +22,7 @@
 #include <opencog/util/oc_assert.h>
 #include <opencog/atoms/atom_types/NameServer.h>
 #include <opencog/atoms/core/UnorderedLink.h>
+#include <opencog/atoms/value/ContainerValue.h>
 #include <opencog/query/Satisfier.h>
 
 #include "GetLink.h"
@@ -49,9 +50,9 @@ GetLink::GetLink(const HandleSeq&& hseq, Type t)
 
 ValuePtr GetLink::execute(AtomSpace* as, bool silent)
 {
-	QueueValuePtr qv(MeetLink::do_execute(as, silent));
-	OC_ASSERT(qv->is_closed(), "Unexpected queue state!");
-	HandleSet hs(qv->to_handle_set());
+	ContainerValuePtr cv(MeetLink::do_execute(as, silent));
+	OC_ASSERT(cv->is_closed(), "Unexpected queue state!");
+	HandleSet hs(cv->to_handle_set());
 
 	// Create the satisfying set, and cache it.
 	Handle satset(createUnorderedLink(std::move(hs), SET_LINK));

--- a/opencog/atoms/pattern/MeetLink.cc
+++ b/opencog/atoms/pattern/MeetLink.cc
@@ -47,7 +47,7 @@ MeetLink::MeetLink(const HandleSeq&& hseq, Type t)
 
 /* ================================================================= */
 
-QueueValuePtr MeetLink::do_execute(AtomSpace* as, bool silent)
+ContainerValuePtr MeetLink::do_execute(AtomSpace* as, bool silent)
 {
 	if (nullptr == as) as = _atom_space;
 
@@ -56,17 +56,17 @@ QueueValuePtr MeetLink::do_execute(AtomSpace* as, bool silent)
 	if (nullptr == vp)
 		throw RuntimeException(TRACE_INFO,
 			"Expecting location for results!");
-	QueueValuePtr qvp(QueueValueCast(vp));
-	if (nullptr == qvp)
+	ContainerValuePtr cvp(ContainerValueCast(vp));
+	if (nullptr == cvp)
 		throw RuntimeException(TRACE_INFO,
-			"Expecting QueueValue for results, got %s",
+			"Expecting ContainerValue for results, got %s",
 			vp->to_string().c_str());
 
 	try
 	{
-		SatisfyingSet sater(as, qvp);
+		SatisfyingSet sater(as, cvp);
 		sater.satisfy(PatternLinkCast(get_handle()));
-		return qvp;
+		return cvp;
 	}
 	catch(const StandardException& ex)
 	{

--- a/opencog/atoms/pattern/MeetLink.h
+++ b/opencog/atoms/pattern/MeetLink.h
@@ -23,6 +23,7 @@
 #define _OPENCOG_MEET_LINK_H
 
 #include <opencog/atoms/pattern/PatternLink.h>
+#include <opencog/atoms/value/ContainerValue.h>
 
 namespace opencog
 {
@@ -33,7 +34,7 @@ class MeetLink : public PatternLink
 {
 protected:
 	void init(void);
-	virtual QueueValuePtr do_execute(AtomSpace*, bool silent);
+	virtual ContainerValuePtr do_execute(AtomSpace*, bool silent);
 
 public:
 	MeetLink(const HandleSeq&&, Type=MEET_LINK);

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -29,7 +29,7 @@
 #include <opencog/atoms/core/FindUtils.h>
 #include <opencog/atoms/core/FreeLink.h>
 #include <opencog/atoms/core/NumberNode.h>
-#include <opencog/atoms/value/QueueValue.h>
+#include <opencog/atoms/value/SetValue.h>
 #include <opencog/atomspace/AtomSpace.h>
 
 #include "BindLink.h"
@@ -251,14 +251,15 @@ void PatternLink::setAtomSpace(AtomSpace* as)
 {
 	RuleLink::setAtomSpace(as);
 
-	// All patterns will record results into queues. We attach
-	// queues now. User can over-ride later, if desired.
-	// Start queue in closed state, otherwise it will hang
-	// in update() when printing.
-	QueueValuePtr qvp = createQueueValue();
-	qvp->close();
+	// All patterns will record results into thread-safe queues or to
+	// thread-safe deduplicated sets. Use a set by default. User can
+	// over-ride later, as desired.
+	// Start in closed state, otherwise it will hang in update()
+	// when printing.
+	SetValuePtr svp = createSetValue();
+	svp->close();
 	const Handle& self(get_handle());
-	as->set_value(self, self, qvp);
+	as->set_value(self, self, svp);
 }
 
 /* ================================================================= */

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -29,7 +29,7 @@
 #include <opencog/atoms/core/FindUtils.h>
 #include <opencog/atoms/core/FreeLink.h>
 #include <opencog/atoms/core/NumberNode.h>
-#include <opencog/atoms/value/SetValue.h>
+#include <opencog/atoms/value/UnisetValue.h>
 #include <opencog/atomspace/AtomSpace.h>
 
 #include "BindLink.h"
@@ -259,7 +259,7 @@ void PatternLink::setAtomSpace(AtomSpace* as)
 	// over-ride later, as desired.
 	// Start in closed state, otherwise it will hang in update()
 	// when printing.
-	SetValuePtr svp = createSetValue();
+	UnisetValuePtr svp = createUnisetValue();
 	svp->close();
 
 	const Handle& self(get_handle());

--- a/opencog/atoms/pattern/QueryLink.cc
+++ b/opencog/atoms/pattern/QueryLink.cc
@@ -103,7 +103,7 @@ QueryLink::QueryLink(const HandleSeq&& hseq, Type t)
  * atoms that could be a ground are found in the atomspace, then they
  * will be reported.
  */
-QueueValuePtr QueryLink::do_execute(AtomSpace* as, bool silent)
+ContainerValuePtr QueryLink::do_execute(AtomSpace* as, bool silent)
 {
 	if (nullptr == as) as = _atom_space;
 
@@ -124,12 +124,12 @@ QueueValuePtr QueryLink::do_execute(AtomSpace* as, bool silent)
 
 	// Where shall we place results? Why, right here!
 	ValuePtr vp(getValue(get_handle()));
-	QueueValuePtr qvp(QueueValueCast(vp));
-	if (nullptr == qvp)
+	ContainerValuePtr cvp(ContainerValueCast(vp));
+	if (nullptr == cvp)
 		throw RuntimeException(TRACE_INFO,
 			"Expecting QueueValue for results!");
 
-	Implicator impl(as, qvp);
+	Implicator impl(as, cvp);
 	impl.implicand = this->get_implicand();
 
 	try
@@ -148,9 +148,9 @@ QueueValuePtr QueryLink::do_execute(AtomSpace* as, bool silent)
 	}
 
 	// If we got a non-empty answer, just return it.
-	OC_ASSERT(qvp->is_closed(), "Unexpected queue state!");
-	if (0 < qvp->size())
-		return qvp;
+	OC_ASSERT(cvp->is_closed(), "Unexpected queue state!");
+	if (0 < cvp->size())
+		return cvp;
 
 	// If we are here, then there were zero matches.
 	//
@@ -171,14 +171,14 @@ QueueValuePtr QueryLink::do_execute(AtomSpace* as, bool silent)
 	if (0 == pat.pmandatory.size() and 0 < pat.absents.size()
 	    and not intu->optionals_present())
 	{
-		qvp->open();
+		cvp->open();
 		for (const Handle& himp: impl.implicand)
-			qvp->add(std::move(impl.inst.execute(himp, true)));
-		qvp->close();
-		return qvp;
+			cvp->add(std::move(impl.inst.execute(himp, true)));
+		cvp->close();
+		return cvp;
 	}
 
-	return qvp;
+	return cvp;
 }
 
 ValuePtr QueryLink::execute(AtomSpace* as, bool silent)

--- a/opencog/atoms/pattern/QueryLink.cc
+++ b/opencog/atoms/pattern/QueryLink.cc
@@ -149,7 +149,7 @@ QueueValuePtr QueryLink::do_execute(AtomSpace* as, bool silent)
 
 	// If we got a non-empty answer, just return it.
 	OC_ASSERT(qvp->is_closed(), "Unexpected queue state!");
-	if (0 < qvp->concurrent_queue<ValuePtr>::size())
+	if (0 < qvp->size())
 		return qvp;
 
 	// If we are here, then there were zero matches.
@@ -173,7 +173,7 @@ QueueValuePtr QueryLink::do_execute(AtomSpace* as, bool silent)
 	{
 		qvp->open();
 		for (const Handle& himp: impl.implicand)
-			qvp->push(std::move(impl.inst.execute(himp, true)));
+			qvp->add(std::move(impl.inst.execute(himp, true)));
 		qvp->close();
 		return qvp;
 	}

--- a/opencog/atoms/pattern/QueryLink.h
+++ b/opencog/atoms/pattern/QueryLink.h
@@ -23,7 +23,7 @@
 #define _OPENCOG_QUERY_LINK_H
 
 #include <opencog/atoms/pattern/PatternLink.h>
-#include <opencog/atoms/value/QueueValue.h>
+#include <opencog/atoms/value/ContainerValue.h>
 
 namespace opencog
 {
@@ -35,7 +35,7 @@ class QueryLink : public PatternLink
 protected:
 	void init(void);
 
-	virtual QueueValuePtr do_execute(AtomSpace*, bool silent);
+	virtual ContainerValuePtr do_execute(AtomSpace*, bool silent);
 
 public:
 	QueryLink(const HandleSeq&&, Type=QUERY_LINK);

--- a/opencog/atoms/value/CMakeLists.txt
+++ b/opencog/atoms/value/CMakeLists.txt
@@ -3,6 +3,7 @@ INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR})
 ADD_LIBRARY (value
 	Value.cc
 	BoolValue.cc
+	ContainerValue.cc
 	FloatValue.cc
 	FormulaStream.cc
 	FutureStream.cc
@@ -30,6 +31,7 @@ INSTALL (TARGETS value EXPORT AtomSpaceTargets
 
 INSTALL (FILES
 	BoolValue.h
+	ContainerValue.h
 	FloatValue.h
 	FormulaStream.h
 	FutureStream.h

--- a/opencog/atoms/value/CMakeLists.txt
+++ b/opencog/atoms/value/CMakeLists.txt
@@ -11,6 +11,7 @@ ADD_LIBRARY (value
 	LinkValue.cc
 	QueueValue.cc
 	RandomStream.cc
+	SetValue.cc
 	StreamValue.cc
 	StringValue.cc
 	ValueFactory.cc
@@ -39,6 +40,7 @@ INSTALL (FILES
 	LinkValue.h
 	QueueValue.h
 	RandomStream.h
+	SetValue.h
 	StreamValue.h
 	StringValue.h
 	Value.h

--- a/opencog/atoms/value/CMakeLists.txt
+++ b/opencog/atoms/value/CMakeLists.txt
@@ -11,9 +11,9 @@ ADD_LIBRARY (value
 	LinkValue.cc
 	QueueValue.cc
 	RandomStream.cc
-	SetValue.cc
 	StreamValue.cc
 	StringValue.cc
+	UnisetValue.cc
 	ValueFactory.cc
 	VoidValue.cc
 )
@@ -40,9 +40,9 @@ INSTALL (FILES
 	LinkValue.h
 	QueueValue.h
 	RandomStream.h
-	SetValue.h
 	StreamValue.h
 	StringValue.h
+	UnisetValue.h
 	Value.h
 	ValueFactory.h
 	VoidValue.h

--- a/opencog/atoms/value/ContainerValue.cc
+++ b/opencog/atoms/value/ContainerValue.cc
@@ -1,0 +1,42 @@
+/*
+ * opencog/atoms/value/ContainerValue.cc
+ *
+ * Copyright (C) 2020, 2025 Linas Vepstas
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/atoms/value/ContainerValue.h>
+
+using namespace opencog;
+
+// ==============================================================
+
+bool ContainerValue::operator==(const Value& other) const
+{
+	// Derived classes use this, so use get_type()
+	if (get_type() != other.get_type()) return false;
+
+	if (this == &other) return true;
+
+	if (not is_closed()) return false;
+	if (not ((const ContainerValue*) &other)->is_closed()) return false;
+
+	return LinkValue::operator==(other);
+}
+
+// ==============================================================

--- a/opencog/atoms/value/ContainerValue.h
+++ b/opencog/atoms/value/ContainerValue.h
@@ -1,7 +1,7 @@
 /*
  * opencog/atoms/value/ContainerValue.h
  *
- * Copyright (C) 2020 Linas Vepstas
+ * Copyright (C) 2020, 2025 Linas Vepstas
  * All Rights Reserved
  *
  * This program is free software; you can redistribute it and/or modify
@@ -56,19 +56,17 @@ class ContainerValue
 {
 protected:
 	ContainerValue(Type t) : LinkStreamValue(t) {}
-	virtual void update() const;
 
 public:
 	ContainerValue(void) : LinkStreamValue(CONTAINER_VALUE) {}
-	ContainerValue(const ValueSeq&);
 	virtual ~ContainerValue() {}
 	virtual void open(void) = 0;
 	virtual void close(void) = 0;
-	virtual bool is_open(void) = 0;
+	virtual bool is_closed(void) const = 0;
 
 	virtual void add(const ValuePtr&) = 0;
 	virtual ValuePtr remove(void) = 0;
-	virtual size_t size(void) = 0;
+	virtual size_t size(void) const = 0;
 
 	virtual void clear(void) = 0;
 	virtual bool operator==(const Value&) const;

--- a/opencog/atoms/value/ContainerValue.h
+++ b/opencog/atoms/value/ContainerValue.h
@@ -65,8 +65,8 @@ public:
 	virtual bool is_closed(void) const = 0;
 
 	virtual void add(const ValuePtr&) = 0;
+	virtual void add(ValuePtr&&) = 0;
 	virtual ValuePtr remove(void) = 0;
-	virtual size_t size(void) const = 0;
 
 	virtual void clear(void) = 0;
 	virtual bool operator==(const Value&) const;

--- a/opencog/atoms/value/ContainerValue.h
+++ b/opencog/atoms/value/ContainerValue.h
@@ -1,0 +1,84 @@
+/*
+ * opencog/atoms/value/ContainerValue.h
+ *
+ * Copyright (C) 2020 Linas Vepstas
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef _OPENCOG_CONTAINER_VALUE_H
+#define _OPENCOG_CONTAINER_VALUE_H
+
+#include <opencog/atoms/value/LinkStreamValue.h>
+#include <opencog/atoms/atom_types/atom_types.h>
+
+namespace opencog
+{
+
+/** \addtogroup grp_atomspace
+ *  @{
+ */
+
+/**
+ * ContainerValues provide a thread-safe containers for Values. They
+ * provide a producer-consumer API, where the produced values are to
+ * added to the container (possibly from multiple threads) and are
+ * removed by consumers (possibly in other threads.)
+ *
+ * It provides a uniform API for all such containers, i.e. both queues
+ * and sets, for code that wants to handle either type (e.g. for
+ * queries.) The add() method will append to the end of a queue,
+ * or, for sets, insert into the set, while remove() will remove from
+ * the head of a queue, or, for sets, remove in whatever order the set
+ * pool provides (using std::less by default.)
+ *
+ * Semantics include open() and close(). The close() method allows the
+ * producer to tell consumers that it's done adding things. i.e. its
+ * an end-of-stream indicator. (XXX Maybe this should be moved to the
+ * LinkStreamValue base class ??)
+ */
+class ContainerValue
+	: public LinkStreamValue
+{
+protected:
+	ContainerValue(Type t) : LinkStreamValue(t) {}
+	virtual void update() const;
+
+public:
+	ContainerValue(void) : LinkStreamValue(CONTAINER_VALUE) {}
+	ContainerValue(const ValueSeq&);
+	virtual ~ContainerValue() {}
+	virtual void open(void) = 0;
+	virtual void close(void) = 0;
+	virtual bool is_open(void) = 0;
+
+	virtual void add(const ValuePtr&) = 0;
+	virtual ValuePtr remove(void) = 0;
+	virtual size_t size(void) = 0;
+
+	virtual void clear(void) = 0;
+	virtual bool operator==(const Value&) const;
+};
+
+typedef std::shared_ptr<ContainerValue> ContainerValuePtr;
+static inline ContainerValuePtr ContainerValueCast(ValuePtr& a)
+	{ return std::dynamic_pointer_cast<ContainerValue>(a); }
+
+/** @}*/
+} // namespace opencog
+
+#endif // _OPENCOG_CONTAINER_VALUE_H

--- a/opencog/atoms/value/QueueValue.cc
+++ b/opencog/atoms/value/QueueValue.cc
@@ -88,6 +88,45 @@ void QueueValue::update() const
 
 // ==============================================================
 
+void QueueValue::open()
+{
+	const_cast<QueueValue*>(this) -> open();
+}
+
+void QueueValue::close()
+{
+	const_cast<QueueValue*>(this) -> close();
+}
+
+bool QueueValue::is_closed() const
+{
+	return const_cast<QueueValue*>(this) -> is_closed();
+}
+
+// ==============================================================
+
+void QueueValue::add(const ValuePtr& vp)
+{
+	push(vp);
+}
+
+void QueueValue::add(ValuePtr&& vp)
+{
+	push(vp);
+}
+
+ValuePtr QueueValue::remove(void)
+{
+	return value_pop();
+}
+
+size_t QueueValue::size(void) const
+{
+	return const_cast<QueueValue*>(this) -> size();
+}
+
+// ==============================================================
+
 void QueueValue::clear()
 {
 	// Reset contents

--- a/opencog/atoms/value/QueueValue.cc
+++ b/opencog/atoms/value/QueueValue.cc
@@ -90,11 +90,13 @@ void QueueValue::update() const
 
 void QueueValue::open()
 {
+	if (not is_closed()) return;
 	const_cast<QueueValue*>(this) -> open();
 }
 
 void QueueValue::close()
 {
+	if (is_closed()) return;
 	const_cast<QueueValue*>(this) -> close();
 }
 

--- a/opencog/atoms/value/QueueValue.cc
+++ b/opencog/atoms/value/QueueValue.cc
@@ -126,6 +126,11 @@ ValuePtr QueueValue::remove(void)
 
 size_t QueueValue::size(void) const
 {
+	if (is_closed())
+	{
+		if (0 != conq::size()) update();
+		return _value.size();
+	}
 	return conq::size();
 }
 

--- a/opencog/atoms/value/QueueValue.cc
+++ b/opencog/atoms/value/QueueValue.cc
@@ -28,7 +28,7 @@ using namespace opencog;
 // ==============================================================
 
 QueueValue::QueueValue(const ValueSeq& vseq)
-	: LinkStreamValue(QUEUE_VALUE)
+	: ContainerValue(QUEUE_VALUE)
 {
 	for (const ValuePtr& v: vseq)
 		push(v); // concurrent_queue<ValutePtr>::push(v);

--- a/opencog/atoms/value/QueueValue.h
+++ b/opencog/atoms/value/QueueValue.h
@@ -24,7 +24,7 @@
 #define _OPENCOG_QUEUE_VALUE_H
 
 #include <opencog/util/concurrent_queue.h>
-#include <opencog/atoms/value/LinkStreamValue.h>
+#include <opencog/atoms/value/ContainerValue.h>
 #include <opencog/atoms/atom_types/atom_types.h>
 
 namespace opencog
@@ -40,17 +40,26 @@ namespace opencog
  * values are to be handled in sequential order, in a different thread.
  */
 class QueueValue
-	: public LinkStreamValue, public concurrent_queue<ValuePtr>
+	: public ContainerValue, protected concurrent_queue<ValuePtr>
 {
 protected:
-	QueueValue(Type t) : LinkStreamValue(t) {}
+	QueueValue(Type t) : ContainerValue(t) {}
 	virtual void update() const;
 
 public:
-	QueueValue(void) : LinkStreamValue(QUEUE_VALUE) {}
+	QueueValue(void) : ContainerValue(QUEUE_VALUE) {}
 	QueueValue(const ValueSeq&);
 	virtual ~QueueValue() {}
-	virtual void clear();
+	virtual void open(void);
+	virtual void close(void);
+	virtual bool is_closed(void) const;
+
+	virtual void add(const ValuePtr&);
+	virtual void add(ValuePtr&&);
+	virtual ValuePtr remove(void);
+	virtual size_t size(void) const;
+	virtual void clear(void);
+
 	virtual bool operator==(const Value&) const;
 };
 

--- a/opencog/atoms/value/SetValue.cc
+++ b/opencog/atoms/value/SetValue.cc
@@ -1,0 +1,166 @@
+/*
+ * opencog/atoms/value/SetValue.cc
+ *
+ * Copyright (C) 2020 Linas Vepstas
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/atoms/value/SetValue.h>
+#include <opencog/atoms/value/ValueFactory.h>
+
+using namespace opencog;
+
+// ==============================================================
+
+SetValue::SetValue(const ValueSeq& vseq)
+	: ContainerValue(SET_VALUE)
+{
+	for (const ValuePtr& v: vseq)
+		push(v); // concurrent_queue<ValutePtr>::push(v);
+
+	// Since this constructor placed stuff on the queue,
+	// we also close it, to indicate we are "done" placing
+	// things on the queue. If some user needs to add more,
+	// then they need to re-open.
+	close();
+}
+
+// ==============================================================
+
+// This will clear the return value, and then block until the
+// writer closes the queue. Only then does this return. Upon
+// return, all of the values that the writer ever wrote are
+// in the list of values.
+//
+// Basically, the reader should open the queue, the writer should
+// produce a bunch of values, and, when done, close the queue. The
+// reader can then hoover them all up by calling LinkValue::value()
+//
+// Alternately, more clever users can work with the concurrent queue
+// API directly; they do not need to go through this API.
+void SetValue::update() const
+{
+	// Do nothing; we don't want to clobber the _value
+	if (is_closed() and 0 == concurrent_queue<ValuePtr>::size()) return;
+
+	// Reset, to start with.
+	_value.clear();
+
+	// Loop forever, as long as the queue is open.
+	try
+	{
+		while (true)
+		{
+			ValuePtr val;
+			const_cast<SetValue*>(this) -> pop(val);
+			_value.emplace_back(val);
+		}
+	}
+	catch (typename concurrent_queue<ValuePtr>::Canceled& e)
+	{}
+
+	// If we are here, the queue closed up. Reopen it
+	// just long enough to drain any remaining values.
+	const_cast<SetValue*>(this) -> cancel_reset();
+	while (not is_empty())
+	{
+		ValuePtr val;
+		const_cast<SetValue*>(this) -> pop(val);
+		_value.emplace_back(val);
+	}
+	const_cast<SetValue*>(this) -> cancel();
+}
+
+// ==============================================================
+
+void SetValue::open()
+{
+	const_cast<SetValue*>(this) -> open();
+}
+
+void SetValue::close()
+{
+	const_cast<SetValue*>(this) -> close();
+}
+
+bool SetValue::is_closed() const
+{
+	return const_cast<SetValue*>(this) -> is_closed();
+}
+
+// ==============================================================
+
+void SetValue::add(const ValuePtr& vp)
+{
+	push(vp);
+}
+
+void SetValue::add(ValuePtr&& vp)
+{
+	push(vp);
+}
+
+ValuePtr SetValue::remove(void)
+{
+	return value_pop();
+}
+
+size_t SetValue::size(void) const
+{
+	return const_cast<SetValue*>(this) -> size();
+}
+
+// ==============================================================
+
+void SetValue::clear()
+{
+	// Reset contents
+	_value.clear();
+
+	// Do nothing; we don't want to clobber the _value
+	if (is_closed())
+	{
+		wait_and_take_all();
+		return;
+	}
+
+	close();
+	wait_and_take_all();
+	open();
+}
+
+// ==============================================================
+
+bool SetValue::operator==(const Value& other) const
+{
+	// Derived classes use this, so use get_type()
+	if (get_type() != other.get_type()) return false;
+
+	if (this == &other) return true;
+
+	if (not is_closed()) return false;
+	if (not ((const SetValue*) &other)->is_closed()) return false;
+
+	return LinkValue::operator==(other);
+}
+
+// ==============================================================
+
+// Adds factory when library is loaded.
+DEFINE_VALUE_FACTORY(SET_VALUE,
+                     createSetValue, std::vector<ValuePtr>)

--- a/opencog/atoms/value/SetValue.h
+++ b/opencog/atoms/value/SetValue.h
@@ -1,0 +1,80 @@
+/*
+ * opencog/atoms/value/SetValue.h
+ *
+ * Copyright (C) 2020 Linas Vepstas
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef _OPENCOG_SET_VALUE_H
+#define _OPENCOG_SET_VALUE_H
+
+#include <opencog/util/concurrent_set.h>
+#include <opencog/atoms/value/ContainerValue.h>
+#include <opencog/atoms/atom_types/atom_types.h>
+
+namespace opencog
+{
+
+/** \addtogroup grp_atomspace
+ *  @{
+ */
+
+/**
+ * SetValues provide a thread-safe uniset of Values. They are
+ * meant to be used for producer-consumer APIs, where the produced
+ * values are added, possibly in different threads from which they
+ * are removed.  This is a uniset, in that elements are deduplicated
+ * so that the set contains only one copy of a given element.
+ */
+class SetValue
+	: public ContainerValue, protected concurrent_set<ValuePtr>
+{
+protected:
+	SetValue(Type t) : ContainerValue(t) {}
+	virtual void update() const;
+
+public:
+	SetValue(void) : ContainerValue(SET_VALUE) {}
+	SetValue(const ValueSeq&);
+	virtual ~SetValue() {}
+	virtual void open(void);
+	virtual void close(void);
+	virtual bool is_closed(void) const;
+
+	virtual void add(const ValuePtr&);
+	virtual void add(ValuePtr&&);
+	virtual ValuePtr remove(void);
+	virtual size_t size(void) const;
+	virtual void clear(void);
+
+	virtual bool operator==(const Value&) const;
+};
+
+typedef std::shared_ptr<SetValue> SetValuePtr;
+static inline SetValuePtr SetValueCast(ValuePtr& a)
+	{ return std::dynamic_pointer_cast<SetValue>(a); }
+
+template<typename ... Type>
+static inline std::shared_ptr<SetValue> createSetValue(Type&&... args) {
+   return std::make_shared<SetValue>(std::forward<Type>(args)...);
+}
+
+/** @}*/
+} // namespace opencog
+
+#endif // _OPENCOG_SET_VALUE_H

--- a/opencog/atoms/value/UnisetValue.cc
+++ b/opencog/atoms/value/UnisetValue.cc
@@ -126,6 +126,11 @@ ValuePtr UnisetValue::remove(void)
 
 size_t UnisetValue::size(void) const
 {
+	if (is_closed())
+	{
+		if (0 != conset::size()) update();
+		return _value.size();
+	}
 	return conset::size();
 }
 

--- a/opencog/atoms/value/UnisetValue.cc
+++ b/opencog/atoms/value/UnisetValue.cc
@@ -1,5 +1,5 @@
 /*
- * opencog/atoms/value/SetValue.cc
+ * opencog/atoms/value/UnisetValue.cc
  *
  * Copyright (C) 2020 Linas Vepstas
  * All Rights Reserved
@@ -20,7 +20,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/atoms/value/SetValue.h>
+#include <opencog/atoms/value/UnisetValue.h>
 #include <opencog/atoms/value/ValueFactory.h>
 
 using namespace opencog;
@@ -29,8 +29,8 @@ typedef concurrent_set<ValuePtr> conset;
 
 // ==============================================================
 
-SetValue::SetValue(const ValueSeq& vseq)
-	: ContainerValue(SET_VALUE)
+UnisetValue::UnisetValue(const ValueSeq& vseq)
+	: ContainerValue(UNISET_VALUE)
 {
 	for (const ValuePtr& v: vseq)
 		conset::insert(v);
@@ -55,7 +55,7 @@ SetValue::SetValue(const ValueSeq& vseq)
 //
 // Alternately, more clever users can work with the concurrent queue
 // API directly; they do not need to go through this API.
-void SetValue::update() const
+void UnisetValue::update() const
 {
 	// Do nothing; we don't want to clobber the _value
 	if (is_closed() and 0 == conset::size()) return;
@@ -69,7 +69,7 @@ void SetValue::update() const
 		while (true)
 		{
 			ValuePtr val;
-			const_cast<SetValue*>(this) -> get(val);
+			const_cast<UnisetValue*>(this) -> get(val);
 			_value.emplace_back(val);
 		}
 	}
@@ -78,60 +78,60 @@ void SetValue::update() const
 
 	// If we are here, the queue closed up. Reopen it
 	// just long enough to drain any remaining values.
-	const_cast<SetValue*>(this) -> cancel_reset();
+	const_cast<UnisetValue*>(this) -> cancel_reset();
 	while (not is_empty())
 	{
 		ValuePtr val;
-		const_cast<SetValue*>(this) -> get(val);
+		const_cast<UnisetValue*>(this) -> get(val);
 		_value.emplace_back(val);
 	}
-	const_cast<SetValue*>(this) -> cancel();
+	const_cast<UnisetValue*>(this) -> cancel();
 }
 
 // ==============================================================
 
-void SetValue::open()
+void UnisetValue::open()
 {
 	if (not is_closed()) return;
 	conset::open();
 }
 
-void SetValue::close()
+void UnisetValue::close()
 {
 	if (is_closed()) return;
 	conset::close();
 }
 
-bool SetValue::is_closed() const
+bool UnisetValue::is_closed() const
 {
 	return conset::is_closed();
 }
 
 // ==============================================================
 
-void SetValue::add(const ValuePtr& vp)
+void UnisetValue::add(const ValuePtr& vp)
 {
 	conset::insert(vp);
 }
 
-void SetValue::add(ValuePtr&& vp)
+void UnisetValue::add(ValuePtr&& vp)
 {
 	conset::insert(vp);
 }
 
-ValuePtr SetValue::remove(void)
+ValuePtr UnisetValue::remove(void)
 {
 	return conset::value_get();
 }
 
-size_t SetValue::size(void) const
+size_t UnisetValue::size(void) const
 {
 	return conset::size();
 }
 
 // ==============================================================
 
-void SetValue::clear()
+void UnisetValue::clear()
 {
 	// Reset contents
 	_value.clear();
@@ -150,7 +150,7 @@ void SetValue::clear()
 
 // ==============================================================
 
-bool SetValue::operator==(const Value& other) const
+bool UnisetValue::operator==(const Value& other) const
 {
 	// Derived classes use this, so use get_type()
 	if (get_type() != other.get_type()) return false;
@@ -158,7 +158,7 @@ bool SetValue::operator==(const Value& other) const
 	if (this == &other) return true;
 
 	if (not is_closed()) return false;
-	if (not ((const SetValue*) &other)->is_closed()) return false;
+	if (not ((const UnisetValue*) &other)->is_closed()) return false;
 
 	return LinkValue::operator==(other);
 }
@@ -166,5 +166,5 @@ bool SetValue::operator==(const Value& other) const
 // ==============================================================
 
 // Adds factory when library is loaded.
-DEFINE_VALUE_FACTORY(SET_VALUE,
-                     createSetValue, std::vector<ValuePtr>)
+DEFINE_VALUE_FACTORY(UNISET_VALUE,
+                     createUnisetValue, std::vector<ValuePtr>)

--- a/opencog/atoms/value/UnisetValue.h
+++ b/opencog/atoms/value/UnisetValue.h
@@ -1,5 +1,5 @@
 /*
- * opencog/atoms/value/SetValue.h
+ * opencog/atoms/value/UnisetValue.h
  *
  * Copyright (C) 2020 Linas Vepstas
  * All Rights Reserved
@@ -20,8 +20,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef _OPENCOG_SET_VALUE_H
-#define _OPENCOG_SET_VALUE_H
+#ifndef _OPENCOG_UNISET_VALUE_H
+#define _OPENCOG_UNISET_VALUE_H
 
 #include <opencog/util/concurrent_set.h>
 #include <opencog/atoms/value/ContainerValue.h>
@@ -35,23 +35,23 @@ namespace opencog
  */
 
 /**
- * SetValues provide a thread-safe uniset of Values. They are
+ * UnisetValues provide a thread-safe uniset of Values. They are
  * meant to be used for producer-consumer APIs, where the produced
  * values are added, possibly in different threads from which they
  * are removed.  This is a uniset, in that elements are deduplicated
  * so that the set contains only one copy of a given element.
  */
-class SetValue
+class UnisetValue
 	: public ContainerValue, protected concurrent_set<ValuePtr>
 {
 protected:
-	SetValue(Type t) : ContainerValue(t) {}
+	UnisetValue(Type t) : ContainerValue(t) {}
 	virtual void update() const;
 
 public:
-	SetValue(void) : ContainerValue(SET_VALUE) {}
-	SetValue(const ValueSeq&);
-	virtual ~SetValue() {}
+	UnisetValue(void) : ContainerValue(UNISET_VALUE) {}
+	UnisetValue(const ValueSeq&);
+	virtual ~UnisetValue() {}
 	virtual void open(void);
 	virtual void close(void);
 	virtual bool is_closed(void) const;
@@ -65,16 +65,16 @@ public:
 	virtual bool operator==(const Value&) const;
 };
 
-typedef std::shared_ptr<SetValue> SetValuePtr;
-static inline SetValuePtr SetValueCast(ValuePtr& a)
-	{ return std::dynamic_pointer_cast<SetValue>(a); }
+typedef std::shared_ptr<UnisetValue> UnisetValuePtr;
+static inline UnisetValuePtr UnisetValueCast(ValuePtr& a)
+	{ return std::dynamic_pointer_cast<UnisetValue>(a); }
 
 template<typename ... Type>
-static inline std::shared_ptr<SetValue> createSetValue(Type&&... args) {
-   return std::make_shared<SetValue>(std::forward<Type>(args)...);
+static inline std::shared_ptr<UnisetValue> createUnisetValue(Type&&... args) {
+   return std::make_shared<UnisetValue>(std::forward<Type>(args)...);
 }
 
 /** @}*/
 } // namespace opencog
 
-#endif // _OPENCOG_SET_VALUE_H
+#endif // _OPENCOG_UNISET_VALUE_H

--- a/opencog/query/Implicator.h
+++ b/opencog/query/Implicator.h
@@ -38,9 +38,9 @@ class Implicator:
 	public SatisfyMixin
 {
 	public:
-		Implicator(AtomSpace* asp, QueueValuePtr& qvp) :
+		Implicator(AtomSpace* asp, ContainerValuePtr& cvp) :
 			InitiateSearchMixin(asp),
-			RewriteMixin(asp, qvp),
+			RewriteMixin(asp, cvp),
 			TermMatchMixin(asp) {}
 
 			virtual void set_pattern(const Variables& vars,

--- a/opencog/query/RewriteMixin.cc
+++ b/opencog/query/RewriteMixin.cc
@@ -146,7 +146,7 @@ void RewriteMixin::insert_result(ValuePtr v)
 	if (_result_set.end() != _result_set.find(v)) return;
 
 	_result_set.insert(v);
-	_result_queue->push(std::move(v));
+	_result_queue->add(std::move(v));
 }
 
 bool RewriteMixin::start_search(void)
@@ -171,7 +171,7 @@ bool RewriteMixin::search_finished(bool done)
 		// size_t gsz = gset.second.size();
 		size_t gsz = _group_sizes[gset.first];
 		if (gmin <= gsz and gsz <= gmax)
-			_result_queue->push(createLinkValue(gset.second));
+			_result_queue->add(std::move(createLinkValue(gset.second)));
 	}
 
 	_result_queue->close();

--- a/opencog/query/RewriteMixin.cc
+++ b/opencog/query/RewriteMixin.cc
@@ -28,7 +28,7 @@
 
 using namespace opencog;
 
-RewriteMixin::RewriteMixin(AtomSpace* as, QueueValuePtr& qvp)
+RewriteMixin::RewriteMixin(AtomSpace* as, ContainerValuePtr& qvp)
 	: _as(as), _result_queue(qvp),
 	_num_results(0), inst(as), max_results(SIZE_MAX)
 {

--- a/opencog/query/RewriteMixin.h
+++ b/opencog/query/RewriteMixin.h
@@ -29,7 +29,7 @@
 #include <opencog/atomspace/AtomSpace.h>
 
 #include <opencog/atoms/execution/Instantiator.h>
-#include <opencog/atoms/value/QueueValue.h>
+#include <opencog/atoms/value/ContainerValue.h>
 #include <opencog/query/PatternMatchCallback.h>
 
 
@@ -60,7 +60,7 @@ class RewriteMixin :
 
 		DECLARE_PE_MUTEX;
 		ValueSet _result_set;
-		QueueValuePtr _result_queue;
+		ContainerValuePtr _result_queue;
 		void insert_result(ValuePtr);
 
 		size_t _num_results;
@@ -68,7 +68,7 @@ class RewriteMixin :
 		std::map<GroundingMap, size_t> _group_sizes;
 
 	public:
-		RewriteMixin(AtomSpace*, QueueValuePtr&);
+		RewriteMixin(AtomSpace*, ContainerValuePtr&);
 		Instantiator inst;
 		HandleSeq implicand;
 		size_t max_results;

--- a/opencog/query/Satisfier.cc
+++ b/opencog/query/Satisfier.cc
@@ -176,7 +176,7 @@ bool SatisfyingSet::propose_grounding(const GroundingMap &var_soln,
 	if (_num_results >= max_results)
 		return true;
 
-	_result_queue->push(wrap_result(var_soln));
+	_result_queue->add(std::move(wrap_result(var_soln)));
 
 	// If we found as many as we want, then stop looking for more.
 	return (_num_results >= max_results);
@@ -226,7 +226,7 @@ bool SatisfyingSet::search_finished(bool done)
 	{
 		size_t gsz = gset.second.size();
 		if (gmin <= gsz and gsz <= gmax)
-			_result_queue->push(createLinkValue(gset.second));
+			_result_queue->add(std::move(createLinkValue(gset.second)));
 	}
 
 	_result_queue->close();

--- a/opencog/query/Satisfier.h
+++ b/opencog/query/Satisfier.h
@@ -26,7 +26,7 @@
 
 #include <vector>
 
-#include <opencog/atoms/value/QueueValue.h>
+#include <opencog/atoms/value/ContainerValue.h>
 #include <opencog/atomspace/AtomSpace.h>
 
 #include <opencog/query/ContinuationMixin.h>
@@ -46,7 +46,7 @@ namespace opencog {
 class Satisfier :
 	public ContinuationMixin
 {
-	public: // Arghhh. OpenPsi accesses these directly...
+	protected:
 		Handle _pattern_body;
 		bool _have_variables;
 
@@ -100,16 +100,16 @@ class SatisfyingSet :
 		AtomSpace* _as;
 		DECLARE_PE_MUTEX;
 		HandleSeq _varseq;
-		QueueValuePtr _result_queue;
+		ContainerValuePtr _result_queue;
 
 		ValuePtr wrap_result(const GroundingMap &var_soln);
 		size_t _num_results;
 		std::map<GroundingMap, ValueSet> _groups;
 
 	public:
-		SatisfyingSet(AtomSpace* as, const QueueValuePtr& qvp) :
+		SatisfyingSet(AtomSpace* as, const ContainerValuePtr& cvp) :
 			ContinuationMixin(as),
-			_as(as), _result_queue(qvp),
+			_as(as), _result_queue(cvp),
 			_num_results(0), max_results(SIZE_MAX) {}
 
 		size_t max_results;

--- a/tests/query/EvaluationUTest.cxxtest
+++ b/tests/query/EvaluationUTest.cxxtest
@@ -307,7 +307,7 @@ void EvaluationUTest::test_lambda(void)
 {
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
-	eval->eval("(load-from-path \"tests/query/eval-lambda\")");
+	eval->eval("(load-from-path \"tests/query/eval-lambda.scm\")");
 
 	TruthValuePtr tvp = eval->eval_tv("(cog-evaluate! is-red-light)");
 	printf ("Red light TV: %s\n", tvp->to_string().c_str());

--- a/tests/query/ExecutionOutputUTest.cxxtest
+++ b/tests/query/ExecutionOutputUTest.cxxtest
@@ -248,8 +248,9 @@ void ExecutionOutputUTest::test_varsub(void)
 
 	// Now perform the search.
 	QueueValuePtr qvp(createQueueValue());
+	ContainerValuePtr cvp(qvp);
 	qvp->close();
-	Implicator simpl(as.get(), qvp);
+	Implicator simpl(as.get(), cvp);
 	simpl.implicand = situation->get_implicand();
 	simpl.satisfy(situation);
 
@@ -257,22 +258,21 @@ void ExecutionOutputUTest::test_varsub(void)
 	qvp->open();
 
 	// If it's empty, it will hang ...
-	TSM_ASSERT_EQUALS("no results returned",
-		false, qvp->is_empty());
+	TSM_ASSERT("no results returned", 0 != qvp->size());
 
-	Handle res = HandleCast(qvp->value_pop());
+	Handle res = HandleCast(qvp->remove());
 	printf("res is %s\n", res->to_short_string().c_str());
 	TSM_ASSERT_EQUALS("incorrect resolution", res, resolution);
 
 	// Now perform the search.
 	qvp->close();
-	Implicator pimpl(as.get(), qvp);
+	Implicator pimpl(as.get(), cvp);
 	pimpl.implicand = predicament->get_implicand();
 	pimpl.satisfy(predicament);
 
 	// The result_list contains a list of the grounded expressions.
 	qvp->open();
-	Handle del = HandleCast(qvp->value_pop());
+	Handle del = HandleCast(qvp->remove());
 	printf("del is %s\n", del->to_short_string().c_str());
 	TSM_ASSERT_EQUALS("incorrect delivarance", del, deliverance);
 

--- a/tests/query/imply.h
+++ b/tests/query/imply.h
@@ -2,6 +2,7 @@
 #include <opencog/util/oc_assert.h>
 #include <opencog/atoms/core/FindUtils.h>
 #include <opencog/atoms/pattern/BindLink.h>
+#include <opencog/atoms/value/QueueValue.h>
 #include <opencog/atomspace/AtomSpace.h>
 #include <opencog/query/Implicator.h>
 
@@ -29,22 +30,17 @@ static inline Handle imply(AtomSpace* as, Handle hclauses, Handle himplicand)
 
 	// Now perform the search.
 	QueueValuePtr qvp(createQueueValue());
+	ContainerValuePtr cvp(qvp);
 	qvp->close();
-	Implicator impl(as, qvp);
+	Implicator impl(as, cvp);
 	impl.implicand.push_back(himplicand);
 
 	impl.satisfy(bl);
 
 	// The result_set contains a list of the grounded expressions.
 	// Turn it into a true list, and return it.
-	HandleSeq hlist;
 	OC_ASSERT(qvp->is_closed(), "Unexpected queue state!");
-	std::queue<ValuePtr> vals(qvp->wait_and_take_all());
-	while (not vals.empty())
-	{
-		hlist.push_back(HandleCast(vals.front()));
-		vals.pop();
-	}
+	HandleSeq hlist(qvp->to_handle_seq());
 	Handle gl = as->add_link(LIST_LINK, std::move(hlist));
 	return gl;
 }

--- a/tests/query/meet-link-value-test.scm
+++ b/tests/query/meet-link-value-test.scm
@@ -36,8 +36,8 @@
 
 (define qvalue (cog-execute! flow-pairs))
 
-(test-assert "Return value is a queue value"
-	(equal? (cog-type qvalue) 'QueueValue))
+(test-assert "Return value is a container value"
+	(cog-subtype? 'ContainerValue (cog-type qvalue)))
 
 (test-assert "Size of queue is ten"
 	(equal? 10 (length (cog-value->list qvalue))))


### PR DESCRIPTION
Most query results can be placed in a set, not a queue. So ... use a set.

This set is thread-safe, and also deduplicates entries. 