### PR TITLE
Add marginals to *all* patterns

### DIFF
--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -296,6 +296,18 @@ void PatternLink::setAtomSpace(AtomSpace* as)
 		as->set_value(self, tyvar.first, svp);
 		as->set_value(self, HandleCast(tyvar.second), svp);
 	}
+
+	// Some variables are untyped. Grab those, too.
+	for (const Handle& untyvar : _variables.varseq)
+	{
+		// Skip, if its typed already.
+		// if (_variables._typemap.contains(untyvar)) continue;
+		if (_variables._typemap.end() != _variables._typemap.find(untyvar))
+			continue;
+		UnisetValuePtr svp(createUnisetValue());
+		svp->close();
+		as->set_value(self, untyvar, svp);
+	}
 }
 
 /* ================================================================= */

--- a/opencog/atoms/pattern/PatternLink.cc
+++ b/opencog/atoms/pattern/PatternLink.cc
@@ -259,11 +259,43 @@ void PatternLink::setAtomSpace(AtomSpace* as)
 	// over-ride later, as desired.
 	// Start in closed state, otherwise it will hang in update()
 	// when printing.
-	UnisetValuePtr svp = createUnisetValue();
+	UnisetValuePtr svp(createUnisetValue());
 	svp->close();
 
 	const Handle& self(get_handle());
 	as->set_value(self, self, svp);
+
+	// If there are multiple rewrites given, then create a distinct
+	// set for each. Otherwise, one is enough.
+	if (_implicand.size() == 1)
+	{
+		as->set_value(self, _implicand[0], svp);
+	}
+	else
+	{
+		for (const Handle& hi : _implicand)
+		{
+			UnisetValuePtr svp(createUnisetValue());
+			svp->close();
+			as->set_value(self, hi, svp);
+		}
+	}
+
+	// Marginals will likewise be sets. There will be one marginal for
+	// each variable, associated with the variable declaration. The
+	// marginals will contain all groundings seen for that particular
+	// variable. For ease of use, we'll put exactly the same marginal
+	// in *two* places: the raw variable name, and the type declaration
+	// for that variable. Some users will find one easier to use than
+	// the other, and it costs nothing in performance/efficiency to
+	// provide both.
+	for (const auto& tyvar : _variables._typemap)
+	{
+		UnisetValuePtr svp(createUnisetValue());
+		svp->close();
+		as->set_value(self, tyvar.first, svp);
+		as->set_value(self, HandleCast(tyvar.second), svp);
+	}
 }
 
 /* ================================================================= */

--- a/opencog/atoms/pattern/QueryLink.cc
+++ b/opencog/atoms/pattern/QueryLink.cc
@@ -130,7 +130,6 @@ ContainerValuePtr QueryLink::do_execute(AtomSpace* as, bool silent)
 			"Expecting QueueValue for results!");
 
 	Implicator impl(as, cvp);
-	impl.implicand = this->get_implicand();
 
 	try
 	{
@@ -171,9 +170,10 @@ ContainerValuePtr QueryLink::do_execute(AtomSpace* as, bool silent)
 	if (0 == pat.pmandatory.size() and 0 < pat.absents.size()
 	    and not intu->optionals_present())
 	{
+		Instantiator inst(as);
 		cvp->open();
-		for (const Handle& himp: impl.implicand)
-			cvp->add(std::move(impl.inst.execute(himp, true)));
+		for (const Handle& himp: get_implicand())
+			cvp->add(std::move(inst.execute(himp, true)));
 		cvp->close();
 		return cvp;
 	}

--- a/opencog/query/Implicator.h
+++ b/opencog/query/Implicator.h
@@ -48,7 +48,7 @@ class Implicator:
 			{
 				InitiateSearchMixin::set_pattern(vars, pat);
 				TermMatchMixin::set_pattern(vars, pat);
-				RewriteMixin::setup_marginals();
+				RewriteMixin::set_pattern(vars, pat);
 			}
 
 			virtual bool satisfy(const PatternLinkPtr& plp)

--- a/opencog/query/Implicator.h
+++ b/opencog/query/Implicator.h
@@ -48,6 +48,13 @@ class Implicator:
 			{
 				InitiateSearchMixin::set_pattern(vars, pat);
 				TermMatchMixin::set_pattern(vars, pat);
+				RewriteMixin::setup_marginals();
+			}
+
+			virtual bool satisfy(const PatternLinkPtr& plp)
+			{
+				RewriteMixin::set_plp(plp);
+				return SatisfyMixin::satisfy(plp);
 			}
 };
 

--- a/opencog/query/RewriteMixin.cc
+++ b/opencog/query/RewriteMixin.cc
@@ -34,7 +34,7 @@ RewriteMixin::RewriteMixin(AtomSpace* as, ContainerValuePtr& qvp)
 {
 }
 
-void RewriteMixin::setup_marginals(void)
+void RewriteMixin::setup_marginals(const HandleSeq& varseq)
 {
 }
 
@@ -70,15 +70,15 @@ bool RewriteMixin::propose_grounding(const GroundingMap &var_soln,
 	// See issue #950 and pull req #962. XXX FIXME later.
 	// Tested by BuggyBindLinkUTest and NoExceptionUTest.
 	try {
-		if (1 == implicand.size())
+		if (1 == _implicand.size())
 		{
-			ValuePtr v(inst.instantiate(implicand[0], var_soln, true));
+			ValuePtr v(inst.instantiate(_implicand[0], var_soln, true));
 			insert_result(v);
 		}
 		else
 		{
 			ValueSeq vs;
-			for (const Handle& himp: implicand)
+			for (const Handle& himp: _implicand)
 			{
 				ValuePtr v(inst.instantiate(himp, var_soln, true));
 				vs.emplace_back(v);
@@ -119,7 +119,7 @@ bool RewriteMixin::propose_grouping(const GroundingMap &var_soln,
 	_group_sizes[grouping] ++;
 
 	try {
-		for (const Handle& himp: implicand)
+		for (const Handle& himp: _implicand)
 		{
 			ValuePtr v(inst.instantiate(himp, var_soln, true));
 

--- a/opencog/query/RewriteMixin.cc
+++ b/opencog/query/RewriteMixin.cc
@@ -36,6 +36,25 @@ RewriteMixin::RewriteMixin(AtomSpace* as, ContainerValuePtr& qvp)
 
 void RewriteMixin::setup_marginals(const HandleSeq& varseq)
 {
+	// Grab the places where we'll record the marginals.
+	for (const Handle& var: varseq)
+	{
+		ValuePtr vp(_plp->getValue(var));
+		ContainerValuePtr cvp(ContainerValueCast(vp));
+		if (nullptr == cvp) continue;
+		cvp->open();
+		_var_marginals.insert({var, cvp});
+	}
+
+	// Record the implicands, too
+	for (const Handle& himp: _implicand)
+	{
+		ValuePtr vp(_plp->getValue(himp));
+		ContainerValuePtr cvp(ContainerValueCast(vp));
+		if (nullptr == cvp) continue;
+		cvp->open();
+		_implicand_grnds.insert({himp, cvp});
+	}
 }
 
 /**

--- a/opencog/query/RewriteMixin.cc
+++ b/opencog/query/RewriteMixin.cc
@@ -34,10 +34,10 @@ RewriteMixin::RewriteMixin(AtomSpace* as, ContainerValuePtr& qvp)
 {
 }
 
-void RewriteMixin::setup_marginals(const HandleSeq& varseq)
+void RewriteMixin::setup_marginals(void)
 {
 	// Grab the places where we'll record the marginals.
-	for (const Handle& var: varseq)
+	for (const Handle& var: _varseq)
 	{
 		ValuePtr vp(_plp->getValue(var));
 		ContainerValuePtr cvp(ContainerValueCast(vp));
@@ -65,6 +65,11 @@ void RewriteMixin::setup_marginals(const HandleSeq& varseq)
 	}
 }
 
+void RewriteMixin::record_marginals(const GroundingMap& var_soln)
+{
+	//for (const Handle& hv : _varseq)
+}
+
 /**
  * This callback takes the reported grounding, runs it through the
  * instantiator, to create the implicand, and then records the result
@@ -75,8 +80,8 @@ void RewriteMixin::setup_marginals(const HandleSeq& varseq)
  * to continue hunting for more, we return `false` here. We want to
  * find all possible groundings.)
  */
-bool RewriteMixin::propose_grounding(const GroundingMap &var_soln,
-                                     const GroundingMap &term_soln)
+bool RewriteMixin::propose_grounding(const GroundingMap& var_soln,
+                                     const GroundingMap& term_soln)
 {
 	LOCK_PE_MUTEX;
 	// PatternMatchEngine::print_solution(var_soln, term_soln);
@@ -87,6 +92,9 @@ bool RewriteMixin::propose_grounding(const GroundingMap &var_soln,
 
 	_num_results ++;
 
+	// Record marginals for variables.
+	record_marginals(var_soln);
+
 	// Catch and ignore SilentExceptions. This arises when
 	// running with the URE, which creates ill-formed links
 	// (due to rules producing nothing). Ideally this should
@@ -96,6 +104,7 @@ bool RewriteMixin::propose_grounding(const GroundingMap &var_soln,
 	// meanwhile this try-catch is used.
 	// See issue #950 and pull req #962. XXX FIXME later.
 	// Tested by BuggyBindLinkUTest and NoExceptionUTest.
+	// Well, given that URE is dead meat, maybe we can remove this?
 	try {
 		if (1 == _implicand.size())
 		{

--- a/opencog/query/RewriteMixin.cc
+++ b/opencog/query/RewriteMixin.cc
@@ -122,10 +122,14 @@ bool RewriteMixin::propose_grounding(const GroundingMap& var_soln,
 		if (1 == _implicand.size())
 		{
 			ValuePtr v(inst.instantiate(_implicand[0], var_soln, true));
-			auto it = _implicand_grnds.find(_implicand[0]);
-			if (_implicand_grnds.end() != it)
-				(*it).second->add(v);
-			insert_result(v);
+			// AbsentLinks can result in nullptr v's
+			if (nullptr != v)
+			{
+				auto it = _implicand_grnds.find(_implicand[0]);
+				if (_implicand_grnds.end() != it)
+					(*it).second->add(v);
+				insert_result(v);
+			}
 		}
 		else
 		{
@@ -133,10 +137,13 @@ bool RewriteMixin::propose_grounding(const GroundingMap& var_soln,
 			for (const Handle& himp: _implicand)
 			{
 				ValuePtr v(inst.instantiate(himp, var_soln, true));
-				auto it = _implicand_grnds.find(himp);
-				if (_implicand_grnds.end() != it)
-					(*it).second->add(v);
-				vs.emplace_back(v);
+				if (nullptr != v)
+				{
+					auto it = _implicand_grnds.find(himp);
+					if (_implicand_grnds.end() != it)
+						(*it).second->add(v);
+					vs.emplace_back(v);
+				}
 			}
 			insert_result(createLinkValue(vs));
 		}
@@ -196,7 +203,6 @@ bool RewriteMixin::propose_grouping(const GroundingMap &var_soln,
 
 void RewriteMixin::insert_result(ValuePtr v)
 {
-	if (nullptr == v) return;
 	if (_result_set.end() != _result_set.find(v)) return;
 
 	// Insert atom into the atomspace immediately. This avoids having

--- a/opencog/query/RewriteMixin.cc
+++ b/opencog/query/RewriteMixin.cc
@@ -42,7 +42,11 @@ void RewriteMixin::setup_marginals(const HandleSeq& varseq)
 		ValuePtr vp(_plp->getValue(var));
 		ContainerValuePtr cvp(ContainerValueCast(vp));
 		if (nullptr == cvp) continue;
-		cvp->open();
+		if (cvp->is_closed())
+		{
+			cvp->clear();
+			cvp->open();
+		}
 		_var_marginals.insert({var, cvp});
 	}
 
@@ -52,7 +56,11 @@ void RewriteMixin::setup_marginals(const HandleSeq& varseq)
 		ValuePtr vp(_plp->getValue(himp));
 		ContainerValuePtr cvp(ContainerValueCast(vp));
 		if (nullptr == cvp) continue;
-		cvp->open();
+		if (cvp->is_closed())
+		{
+			cvp->clear();
+			cvp->open();
+		}
 		_implicand_grnds.insert({himp, cvp});
 	}
 }

--- a/opencog/query/RewriteMixin.cc
+++ b/opencog/query/RewriteMixin.cc
@@ -122,6 +122,9 @@ bool RewriteMixin::propose_grounding(const GroundingMap& var_soln,
 		if (1 == _implicand.size())
 		{
 			ValuePtr v(inst.instantiate(_implicand[0], var_soln, true));
+			auto it = _implicand_grnds.find(_implicand[0]);
+			if (_implicand_grnds.end() != it)
+				(*it).second->add(v);
 			insert_result(v);
 		}
 		else
@@ -130,6 +133,9 @@ bool RewriteMixin::propose_grounding(const GroundingMap& var_soln,
 			for (const Handle& himp: _implicand)
 			{
 				ValuePtr v(inst.instantiate(himp, var_soln, true));
+				auto it = _implicand_grnds.find(himp);
+				if (_implicand_grnds.end() != it)
+					(*it).second->add(v);
 				vs.emplace_back(v);
 			}
 			insert_result(createLinkValue(vs));
@@ -148,6 +154,9 @@ bool RewriteMixin::propose_grounding(const GroundingMap& var_soln,
 /// to dribble in. Perhaps the engine search could be modified in some
 /// clever way to find groupings in a single batch; but for now, I don't
 /// see how this could be done.
+/// XXX FIXME now I see how it can be done. The groupings should
+/// be converted to marginals, and handled the same way. So this
+/// needs a rewrite. Good thing that almost no one uses this ...
 bool RewriteMixin::propose_grouping(const GroundingMap &var_soln,
                                     const GroundingMap &term_soln,
                                     const GroundingMap &grouping)

--- a/opencog/query/RewriteMixin.cc
+++ b/opencog/query/RewriteMixin.cc
@@ -34,6 +34,10 @@ RewriteMixin::RewriteMixin(AtomSpace* as, ContainerValuePtr& qvp)
 {
 }
 
+void RewriteMixin::setup_marginals(void)
+{
+}
+
 /**
  * This callback takes the reported grounding, runs it through the
  * instantiator, to create the implicand, and then records the result

--- a/opencog/query/RewriteMixin.h
+++ b/opencog/query/RewriteMixin.h
@@ -64,20 +64,30 @@ class RewriteMixin :
 		void insert_result(ValuePtr);
 
 		PatternLinkPtr _plp;
+		HandleSeq _implicand;
 		std::map<Handle, ContainerValuePtr> _var_marginals;
 		std::map<Handle, ContainerValuePtr> _implicand_grnds;
-		void setup_marginals(void);
-		void set_plp(const PatternLinkPtr& plp) { _plp = plp; }
+		void setup_marginals(const HandleSeq&);
+		void set_plp(const PatternLinkPtr& plp)
+		{
+			_plp = plp;
+			_implicand = _plp->get_implicand();
+		}
 
 		size_t _num_results;
 		std::map<GroundingMap, ValueSet> _groups;
 		std::map<GroundingMap, size_t> _group_sizes;
 
+		Instantiator inst;
 	public:
 		RewriteMixin(AtomSpace*, ContainerValuePtr&);
-		Instantiator inst;
-		HandleSeq implicand;
 		size_t max_results;
+
+		virtual void set_pattern(const Variables& vars,
+		                         const Pattern& pat)
+		{
+			setup_marginals(vars.varseq);
+		}
 
 		virtual bool propose_grounding(const GroundingMap &var_soln,
 		                               const GroundingMap &term_soln);

--- a/opencog/query/RewriteMixin.h
+++ b/opencog/query/RewriteMixin.h
@@ -63,6 +63,12 @@ class RewriteMixin :
 		ContainerValuePtr _result_queue;
 		void insert_result(ValuePtr);
 
+		PatternLinkPtr _plp;
+		std::map<Handle, ContainerValuePtr> _var_marginals;
+		std::map<Handle, ContainerValuePtr> _implicand_grnds;
+		void setup_marginals(void);
+		void set_plp(const PatternLinkPtr& plp) { _plp = plp; }
+
 		size_t _num_results;
 		std::map<GroundingMap, ValueSet> _groups;
 		std::map<GroundingMap, size_t> _group_sizes;

--- a/opencog/query/RewriteMixin.h
+++ b/opencog/query/RewriteMixin.h
@@ -64,15 +64,17 @@ class RewriteMixin :
 		void insert_result(ValuePtr);
 
 		PatternLinkPtr _plp;
+		HandleSeq _varseq;
 		HandleSeq _implicand;
 		std::map<Handle, ContainerValuePtr> _var_marginals;
 		std::map<Handle, ContainerValuePtr> _implicand_grnds;
-		void setup_marginals(const HandleSeq&);
+		void setup_marginals(void);
 		void set_plp(const PatternLinkPtr& plp)
 		{
 			_plp = plp;
 			_implicand = _plp->get_implicand();
 		}
+		void record_marginals(const GroundingMap&);
 
 		size_t _num_results;
 		std::map<GroundingMap, ValueSet> _groups;
@@ -86,7 +88,8 @@ class RewriteMixin :
 		virtual void set_pattern(const Variables& vars,
 		                         const Pattern& pat)
 		{
-			setup_marginals(vars.varseq);
+			_varseq = vars.varseq;
+			setup_marginals();
 		}
 
 		virtual bool propose_grounding(const GroundingMap &var_soln,

--- a/opencog/query/Satisfier.cc
+++ b/opencog/query/Satisfier.cc
@@ -126,17 +126,17 @@ bool Satisfier::search_finished(bool done)
 
 // ===========================================================
 
-bool SatisfyingSet::satisfy(const PatternLinkPtr& plp)
+void SatisfyingSet::setup_marginals(void)
 {
 	// Grab the places where we'll record the marginals.
 	for (const Handle& var: _varseq)
 	{
-		ValuePtr vp(plp->getValue(var));
+		ValuePtr vp(_plp->getValue(var));
 		ContainerValuePtr cvp(ContainerValueCast(vp));
 		if (nullptr == cvp) continue;
+		cvp->open();
 		_var_marginals.insert({var, cvp});
 	}
-	return ContinuationMixin::satisfy(plp);
 }
 
 ValuePtr SatisfyingSet::wrap_result(const GroundingMap &var_soln)
@@ -245,6 +245,10 @@ bool SatisfyingSet::search_finished(bool done)
 		if (gmin <= gsz and gsz <= gmax)
 			_result_queue->add(std::move(createLinkValue(gset.second)));
 	}
+
+	// Close all queues
+	for (auto& mgs : _var_marginals)
+		mgs.second->close();
 
 	_result_queue->close();
 	return done;

--- a/opencog/query/Satisfier.cc
+++ b/opencog/query/Satisfier.cc
@@ -126,6 +126,11 @@ bool Satisfier::search_finished(bool done)
 
 // ===========================================================
 
+bool SatisfyingSet::satisfy(const PatternLinkPtr& plp)
+{
+	return ContinuationMixin::satisfy(plp);
+}
+
 ValuePtr SatisfyingSet::wrap_result(const GroundingMap &var_soln)
 {
 	_num_results ++;

--- a/opencog/query/Satisfier.cc
+++ b/opencog/query/Satisfier.cc
@@ -134,7 +134,11 @@ void SatisfyingSet::setup_marginals(void)
 		ValuePtr vp(_plp->getValue(var));
 		ContainerValuePtr cvp(ContainerValueCast(vp));
 		if (nullptr == cvp) continue;
-		cvp->open();
+		if (cvp->is_closed())
+		{
+			cvp->clear();
+			cvp->open();
+		}
 		_var_marginals.insert({var, cvp});
 	}
 }

--- a/opencog/query/Satisfier.cc
+++ b/opencog/query/Satisfier.cc
@@ -172,7 +172,11 @@ ValuePtr SatisfyingSet::wrap_result(const GroundingMap &var_soln)
 		// have a grounding; this will cause std::map::at to throw.
 		try
 		{
-			vargnds.push_back(var_soln.at(hv));
+			ValuePtr gvp(var_soln.at(hv));
+			auto it = _var_marginals.find(hv);
+			if (_var_marginals.end() != it)
+				(*it).second->add(gvp);
+			vargnds.push_back(gvp);
 		}
 		catch (...)
 		{

--- a/opencog/query/Satisfier.cc
+++ b/opencog/query/Satisfier.cc
@@ -128,6 +128,13 @@ bool Satisfier::search_finished(bool done)
 
 bool SatisfyingSet::satisfy(const PatternLinkPtr& plp)
 {
+	for (const Handle& var: _varseq)
+	{
+		ValuePtr vp(plp->getValue(var));
+		ContainerValuePtr cvp(ContainerValueCast(vp));
+		if (nullptr == cvp) continue;
+		_var_marginals.insert({var, cvp});
+	}
 	return ContinuationMixin::satisfy(plp);
 }
 

--- a/opencog/query/Satisfier.cc
+++ b/opencog/query/Satisfier.cc
@@ -143,7 +143,7 @@ void SatisfyingSet::setup_marginals(void)
 	}
 }
 
-ValuePtr SatisfyingSet::wrap_result(const GroundingMap &var_soln)
+ValuePtr SatisfyingSet::wrap_result(const GroundingMap& var_soln)
 {
 	_num_results ++;
 
@@ -191,8 +191,8 @@ ValuePtr SatisfyingSet::wrap_result(const GroundingMap &var_soln)
 }
 
 // MeetLink and GetLink groundings go through here.
-bool SatisfyingSet::propose_grounding(const GroundingMap &var_soln,
-                                      const GroundingMap &term_soln)
+bool SatisfyingSet::propose_grounding(const GroundingMap& var_soln,
+                                      const GroundingMap& term_soln)
 {
 	LOCK_PE_MUTEX;
 	// PatternMatchEngine::log_solution(var_soln, term_soln);

--- a/opencog/query/Satisfier.cc
+++ b/opencog/query/Satisfier.cc
@@ -128,6 +128,7 @@ bool Satisfier::search_finished(bool done)
 
 bool SatisfyingSet::satisfy(const PatternLinkPtr& plp)
 {
+	// Grab the places where we'll record the marginals.
 	for (const Handle& var: _varseq)
 	{
 		ValuePtr vp(plp->getValue(var));
@@ -147,7 +148,11 @@ ValuePtr SatisfyingSet::wrap_result(const GroundingMap &var_soln)
 		// std::map::at() can throw. Rethrow for easier deubugging.
 		try
 		{
-			return var_soln.at(_varseq[0]);
+			ValuePtr gvp(var_soln.at(_varseq[0]));
+			auto it = _var_marginals.find(_varseq[0]);
+			if (_var_marginals.end() != it)
+				(*it).second->add(gvp);
+			return gvp;
 		}
 		catch (...)
 		{

--- a/opencog/query/Satisfier.h
+++ b/opencog/query/Satisfier.h
@@ -102,7 +102,6 @@ class SatisfyingSet :
 		HandleSeq _varseq;
 		ContainerValuePtr _result_queue;
 		std::map<Handle, ContainerValuePtr> _var_marginals;
-		std::map<Handle, ContainerValuePtr> _implicant_results;
 
 		ValuePtr wrap_result(const GroundingMap &var_soln);
 		size_t _num_results;

--- a/opencog/query/Satisfier.h
+++ b/opencog/query/Satisfier.h
@@ -101,6 +101,8 @@ class SatisfyingSet :
 		DECLARE_PE_MUTEX;
 		HandleSeq _varseq;
 		ContainerValuePtr _result_queue;
+		std::map<Handle, ContainerValuePtr> _var_marginals;
+		std::map<Handle, ContainerValuePtr> _implicant_results;
 
 		ValuePtr wrap_result(const GroundingMap &var_soln);
 		size_t _num_results;
@@ -120,6 +122,8 @@ class SatisfyingSet :
 			_varseq = vars.varseq;
 			ContinuationMixin::set_pattern(vars, pat);
 		}
+
+		virtual bool satisfy(const PatternLinkPtr&);
 
 		// Return true if a satisfactory grounding has been
 		// found. Note that in case where you want all possible

--- a/opencog/query/Satisfier.h
+++ b/opencog/query/Satisfier.h
@@ -99,9 +99,11 @@ class SatisfyingSet :
 	protected:
 		AtomSpace* _as;
 		DECLARE_PE_MUTEX;
+		PatternLinkPtr _plp;
 		HandleSeq _varseq;
 		ContainerValuePtr _result_queue;
 		std::map<Handle, ContainerValuePtr> _var_marginals;
+		void setup_marginals(void);
 
 		ValuePtr wrap_result(const GroundingMap &var_soln);
 		size_t _num_results;
@@ -120,9 +122,13 @@ class SatisfyingSet :
 		{
 			_varseq = vars.varseq;
 			ContinuationMixin::set_pattern(vars, pat);
+			setup_marginals();
 		}
 
-		virtual bool satisfy(const PatternLinkPtr&);
+		virtual bool satisfy(const PatternLinkPtr& plp) {
+			_plp = plp;
+			return ContinuationMixin::satisfy(plp);
+		}
 
 		// Return true if a satisfactory grounding has been
 		// found. Note that in case where you want all possible

--- a/tests/query/CMakeLists.txt
+++ b/tests/query/CMakeLists.txt
@@ -118,6 +118,7 @@ ADD_GUILE_TEST(QuoteStartTest quote-start-test.scm)
 ADD_GUILE_TEST(RecursiveTest recursive-test.scm)
 ADD_GUILE_TEST(SignatureTest signature-test.scm)
 ADD_GUILE_TEST(UnifyTest unify-test.scm)
+ADD_GUILE_TEST(MarginalsTest marginals-test.scm)
 
 # -------------------------------------------------------------
 # Special unit-test chem atom types.

--- a/tests/query/ExecutionOutputUTest.cxxtest
+++ b/tests/query/ExecutionOutputUTest.cxxtest
@@ -251,7 +251,6 @@ void ExecutionOutputUTest::test_varsub(void)
 	ContainerValuePtr cvp(qvp);
 	qvp->close();
 	Implicator simpl(as.get(), cvp);
-	simpl.implicand = situation->get_implicand();
 	simpl.satisfy(situation);
 
 	// The result_list contains a list of the grounded expressions.
@@ -267,7 +266,6 @@ void ExecutionOutputUTest::test_varsub(void)
 	// Now perform the search.
 	qvp->close();
 	Implicator pimpl(as.get(), cvp);
-	pimpl.implicand = predicament->get_implicand();
 	pimpl.satisfy(predicament);
 
 	// The result_list contains a list of the grounded expressions.

--- a/tests/query/imply.h
+++ b/tests/query/imply.h
@@ -33,8 +33,6 @@ static inline Handle imply(AtomSpace* as, Handle hclauses, Handle himplicand)
 	ContainerValuePtr cvp(qvp);
 	qvp->close();
 	Implicator impl(as, cvp);
-	impl.implicand.push_back(himplicand);
-
 	impl.satisfy(bl);
 
 	// The result_set contains a list of the grounded expressions.

--- a/tests/query/marginals-test.scm
+++ b/tests/query/marginals-test.scm
@@ -34,6 +34,8 @@
 
 (format #t "Query results ~A\n" (cog-value q q))
 (format #t "Query vars ~A\n" (cog-value q (Variable "$x")))
+(format #t "Query implicands ~A\n"
+	(cog-value q (Link (Item "fumble") (Variable "$x"))))
 
 (define m2 (Meet
 	(Present

--- a/tests/query/marginals-test.scm
+++ b/tests/query/marginals-test.scm
@@ -95,15 +95,47 @@
 	(Present
 		(Edge (Predicate "foo") (List (Variable "$x")(Item "right"))))))
 
+(cog-execute! m2)
+
+(test-assert "m2 keynum" (equal? 2 (length (cog-keys m2))))
+(test-assert "m2 grnds" (equal? 3 (length (cog-value->list
+	(cog-value m2 m2 )))))
+(test-assert "m2 vars" (equal? 3 (length (cog-value->list
+	(cog-value m2 (Variable "$x"))))))
+
+; ----------------------------------------------------------
+
 (define m3 (Meet
 	(TypedVariable (Variable "$x") (Type "Item"))
 	(Present
 		(Edge (Predicate "foo") (List (Variable "$x")(Item "right"))))))
 
+(cog-execute! m3)
+(test-assert "m3 keynum" (equal? 3 (length (cog-keys m3))))
+(test-assert "m3 grnds" (equal? 3 (length (cog-value->list
+	(cog-value m3 m3 )))))
+(test-assert "m3 vars" (equal? 3 (length (cog-value->list
+	(cog-value m3 (Variable "$x"))))))
+(test-assert "m3 typed vars" (equal? 3 (length (cog-value->list
+	(cog-value m3 (TypedVariable (Variable "$x") (Type "Item")))))))
+
+; ----------------------------------------------------------
+
 (define m4 (Meet
 	(VariableList (TypedVariable (Variable "$x") (Type "Item")))
 	(Present
 		(Edge (Predicate "foo") (List (Variable "$x")(Item "right"))))))
+
+(cog-execute! m4)
+(test-assert "m4 keynum" (equal? 3 (length (cog-keys m4))))
+(test-assert "m4 grnds" (equal? 3 (length (cog-value->list
+	(cog-value m4 m4 )))))
+(test-assert "m4 vars" (equal? 3 (length (cog-value->list
+	(cog-value m4 (Variable "$x"))))))
+(test-assert "m4 typed vars" (equal? 3 (length (cog-value->list
+	(cog-value m4 (TypedVariable (Variable "$x") (Type "Item")))))))
+
+; ----------------------------------------------------------
 
 (define m5 (Meet
 	(VariableList
@@ -121,6 +153,18 @@
 (format #t "M5 right vars ~A\n" (cog-value m5 (Variable "$ro")))
 (format #t "M5 typed right vars ~A\n"
 	(cog-value m5 (TypedVariable (Variable "$ro") (Type "Item"))))
+
+(test-assert "m5 keynum" (equal? 4 (length (cog-keys m5))))
+(test-assert "m5 grnds" (equal? 5 (length (cog-value->list
+	(cog-value m5 m5 )))))
+(test-assert "m5 vars" (equal? 5 (length (cog-value->list
+	(cog-value m5 (Variable "$loo"))))))
+(test-assert "m5 right vars" (equal? 2 (length (cog-value->list
+	(cog-value m5 (Variable "$ro"))))))
+(test-assert "m5 typed right vars" (equal? 2 (length (cog-value->list
+	(cog-value m5 (TypedVariable (Variable "$ro") (Type "Item")))))))
+
+; ----------------------------------------------------------
 
 (test-end tname)
 (opencog-test-end)

--- a/tests/query/marginals-test.scm
+++ b/tests/query/marginals-test.scm
@@ -1,6 +1,13 @@
+;
+; marginals-test.scm
+;
+; Unit test for storing results and marginals with the query itself.
+; This is the future replacement for the old matrix API. Much cleaner.
+
 
 (use-modules (opencog) (opencog exec))
 
+; Data to prime the pump.
 (Edge (Predicate "foo") (List (Item "left") (Item "right")))
 (Edge (Predicate "foo") (List (Item "lefter") (Item "right")))
 (Edge (Predicate "foo") (List (Item "leftest") (Item "right")))

--- a/tests/query/marginals-test.scm
+++ b/tests/query/marginals-test.scm
@@ -3,9 +3,13 @@
 ;
 ; Unit test for storing results and marginals with the query itself.
 ; This is the future replacement for the old matrix API. Much cleaner.
-
-
+;
 (use-modules (opencog) (opencog exec))
+(use-modules (opencog test-runner))
+
+(opencog-test-runner)
+(define tname "marginals-test")
+(test-begin tname)
 
 ; Data to prime the pump.
 (Edge (Predicate "foo") (List (Item "left") (Item "right")))
@@ -23,6 +27,14 @@
 (format #t "Meet grnd ~A\n" (cog-value m m))
 (format #t "Meet vars ~A\n" (cog-value m (Variable "$x")))
 
+(test-assert "meet keynum" (equal? 2 (length (cog-keys m))))
+(test-assert "meet grnds" (equal? 3 (length (cog-value->list
+	(cog-value m m )))))
+(test-assert "meet vars" (equal? 3 (length (cog-value->list
+	(cog-value m (Variable "$x"))))))
+
+; ----------------------------------------------------------
+
 (define q (Query
 	(Variable "$x")
 	(Present
@@ -36,6 +48,14 @@
 (format #t "Query vars ~A\n" (cog-value q (Variable "$x")))
 (format #t "Query implicand ~A\n"
 	(cog-value q (Link (Item "fumble") (Variable "$x"))))
+
+(test-assert "query keynum" (equal? 3 (length (cog-keys q))))
+(test-assert "query grnds" (equal? 3 (length (cog-value->list
+	(cog-value q q)))))
+(test-assert "query vars" (equal? 3 (length (cog-value->list
+	(cog-value q (Variable "$x"))))))
+
+; ----------------------------------------------------------
 
 (define q2 (Query
 	(Variable "$x")
@@ -56,6 +76,20 @@
 	(cog-value q2 (Link (Concept "bramble") (Variable "$x"))))
 (format #t "Query implicand three ~A\n"
 	(cog-value q2 (Link (Item "borat") (Variable "$x") (Item "culture"))))
+
+(test-assert "q2 keynum" (equal? 5 (length (cog-keys q2))))
+(test-assert "q2 grnds" (equal? 3 (length (cog-value->list
+	(cog-value q2 q2)))))
+(test-assert "q2 vars" (equal? 3 (length (cog-value->list
+	(cog-value q2 (Variable "$x"))))))
+(test-assert "q2 impl one" (equal? 3 (length (cog-value->list
+	(cog-value q2 (Link (Item "fumble") (Variable "$x")))))))
+(test-assert "q2 impl two" (equal? 3 (length (cog-value->list
+	(cog-value q2 (Link (Concept "bramble") (Variable "$x")))))))
+(test-assert "q2 impl three" (equal? 3 (length (cog-value->list
+	(cog-value q2 (Link (Item "borat") (Variable "$x") (Item "culture")))))))
+
+; ----------------------------------------------------------
 
 (define m2 (Meet
 	(Present
@@ -88,3 +122,5 @@
 (format #t "M5 typed right vars ~A\n"
 	(cog-value m5 (TypedVariable (Variable "$ro") (Type "Item"))))
 
+(test-end tname)
+(opencog-test-end)

--- a/tests/query/marginals-test.scm
+++ b/tests/query/marginals-test.scm
@@ -34,8 +34,28 @@
 
 (format #t "Query results ~A\n" (cog-value q q))
 (format #t "Query vars ~A\n" (cog-value q (Variable "$x")))
-(format #t "Query implicands ~A\n"
+(format #t "Query implicand ~A\n"
 	(cog-value q (Link (Item "fumble") (Variable "$x"))))
+
+(define q2 (Query
+	(Variable "$x")
+	(Present
+		(Edge (Predicate "foo") (List (Variable "$x")(Item "right"))))
+	(Link (Item "fumble") (Variable "$x"))
+	(Link (Concept "bramble") (Variable "$x"))
+	(Link (Item "borat") (Variable "$x") (Item "culture"))))
+
+(format #t "Query keys ~A\n" (cog-keys q2))
+(cog-execute! q2)
+
+(format #t "Query results ~A\n" (cog-value q2 q2))
+(format #t "Query vars ~A\n" (cog-value q2 (Variable "$x")))
+(format #t "Query implicand one ~A\n"
+	(cog-value q2 (Link (Item "fumble") (Variable "$x"))))
+(format #t "Query implicand two ~A\n"
+	(cog-value q2 (Link (Concept "bramble") (Variable "$x"))))
+(format #t "Query implicand three ~A\n"
+	(cog-value q2 (Link (Item "borat") (Variable "$x") (Item "culture"))))
 
 (define m2 (Meet
 	(Present

--- a/tests/query/marginals-test.scm
+++ b/tests/query/marginals-test.scm
@@ -1,0 +1,61 @@
+
+(use-modules (opencog) (opencog exec))
+
+(Edge (Predicate "foo") (List (Item "left") (Item "right")))
+(Edge (Predicate "foo") (List (Item "lefter") (Item "right")))
+(Edge (Predicate "foo") (List (Item "leftest") (Item "right")))
+(Edge (Predicate "foo") (List (Item "lefty") (Item "loosey")))
+
+(define m (Meet
+	(Variable "$x")
+	(Present
+		(Edge (Predicate "foo") (List (Variable "$x")(Item "right"))))))
+
+(format #t "Meet keys ~A\n" (cog-keys m))
+(cog-execute! m)
+(format #t "Meet grnd ~A\n" (cog-value m m))
+(format #t "Meet vars ~A\n" (cog-value m (Variable "$x")))
+
+(define q (Query
+	(Variable "$x")
+	(Present
+		(Edge (Predicate "foo") (List (Variable "$x")(Item "right"))))
+	(Link (Item "fumble") (Variable "$x"))))
+
+(format #t "Query keys ~A\n" (cog-keys q))
+(cog-execute! q)
+
+(format #t "Query results ~A\n" (cog-value q q))
+(format #t "Query vars ~A\n" (cog-value q (Variable "$x")))
+
+(define m2 (Meet
+	(Present
+		(Edge (Predicate "foo") (List (Variable "$x")(Item "right"))))))
+
+(define m3 (Meet
+	(TypedVariable (Variable "$x") (Type "Item"))
+	(Present
+		(Edge (Predicate "foo") (List (Variable "$x")(Item "right"))))))
+
+(define m4 (Meet
+	(VariableList (TypedVariable (Variable "$x") (Type "Item")))
+	(Present
+		(Edge (Predicate "foo") (List (Variable "$x")(Item "right"))))))
+
+(define m5 (Meet
+	(VariableList
+		(Variable "$loo")
+		(TypedVariable (Variable "$ro") (Type "Item")))
+	(Present
+		(Edge (Predicate "foo")
+			(List (Variable "$loo")(Variable "$ro"))))))
+
+(format #t "Meet5 keys ~A\n" (cog-keys m5))
+(cog-execute! m5)
+
+(format #t "M5 results ~A\n" (cog-value m5 m5))
+(format #t "M5 left vars ~A\n" (cog-value m5 (Variable "$loo")))
+(format #t "M5 right vars ~A\n" (cog-value m5 (Variable "$ro")))
+(format #t "M5 typed right vars ~A\n"
+	(cog-value m5 (TypedVariable (Variable "$ro") (Type "Item"))))
+


### PR DESCRIPTION
This wraps up part one. The intended use is that these marginals can be used to compute any kind of similarity measure for any kind of sparse pattern tensors.  viz. same idea as the sparse vector embeddings in the old matrix code, except this time clean and self-contained.