### PR TITLE
Eliminate old crufty Python bindlink API

### DIFF
--- a/opencog/cython/CMakeLists.txt
+++ b/opencog/cython/CMakeLists.txt
@@ -25,9 +25,6 @@ INCLUDE_DIRECTORIES(
 FILE(MAKE_DIRECTORY opencog)
 FILE(COPY opencog/__init__.py DESTINATION opencog)
 
-# Legacy bindlink
-FILE(COPY opencog/bindlink.py DESTINATION opencog)
-
 ADD_LIBRARY(PythonEval
 	PythonEval.cc
 )

--- a/opencog/cython/opencog/CMakeLists.txt
+++ b/opencog/cython/opencog/CMakeLists.txt
@@ -57,7 +57,7 @@ list(APPEND ADDITIONAL_MAKE_CLEAN_FILES "atomspace_api.h")
 
 # opencog.atomspace Python bindings
 ADD_LIBRARY(atomspace_cython
-	BindlinkStub.cc
+	ExecuteStub.cc
 	atomspace.cpp
 )
 

--- a/opencog/cython/opencog/CMakeLists.txt
+++ b/opencog/cython/opencog/CMakeLists.txt
@@ -167,20 +167,13 @@ SET_TARGET_PROPERTIES(exec_cython PROPERTIES
 	PREFIX ""
 	OUTPUT_NAME execute)
 
-### install the modules ###
+### Install the modules ###
 INSTALL(TARGETS
 	atomspace_cython
 	exec_cython
 	logger_cython
 	type_constructors
 	utilities_cython
-	DESTINATION "${PYTHON_DEST}")
-
-# install the legacy bindlink module
-INSTALL(FILES
-	"bindlink.py"
-	"exec.py"
-	"scheme_wrapper.py"
 	DESTINATION "${PYTHON_DEST}")
 
 IF (HAVE_GUILE)

--- a/opencog/cython/opencog/ExecuteStub.cc
+++ b/opencog/cython/opencog/ExecuteStub.cc
@@ -4,7 +4,7 @@
 #include <opencog/atoms/execution/Instantiator.h>
 #include <opencog/atoms/value/Value.h>
 
-#include "BindlinkStub.h"
+#include "ExecuteStub.h"
 
 using namespace opencog;
 

--- a/opencog/cython/opencog/ExecuteStub.h
+++ b/opencog/cython/opencog/ExecuteStub.h
@@ -1,5 +1,5 @@
 /*
- * opencog/cython/BindlinkStub.h
+ * opencog/cython/opencog/ExecuteStub.h
  *
  * Copyright (C) 2011 by The OpenCog Foundation
  * All Rights Reserved
@@ -20,8 +20,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef _OPENCOG_BINDLINKSTUB_H
-#define _OPENCOG_BINDLINKSTUB_H
+#ifndef _OPENCOG_EXECUTESTUB_H
+#define _OPENCOG_EXECUTESTUB_H
 
 
 namespace opencog {
@@ -31,4 +31,4 @@ ValuePtr do_execute(AtomSpace*, Handle);
 } // namespace opencog
 
 
-#endif // _OPENCOG_BINDLINKSTUB_H
+#endif // _OPENCOG_EXECUTESTUB_H

--- a/opencog/cython/opencog/atomspace_details.pyx
+++ b/opencog/cython/opencog/atomspace_details.pyx
@@ -39,7 +39,7 @@ cdef vector[cHandle] atom_list_to_vector(list lst):
     return handle_vector
 
 
-cdef extern from "opencog/cython/opencog/BindlinkStub.h" namespace "opencog":
+cdef extern from "opencog/cython/opencog/ExecuteStub.h" namespace "opencog":
     cdef cValuePtr c_do_execute_atom "do_execute"(cAtomSpace*, cHandle) except +
 
 

--- a/opencog/cython/opencog/bindlink.py
+++ b/opencog/cython/opencog/bindlink.py
@@ -1,5 +1,0 @@
-import warnings
-
-from opencog.execute import *
-
-warnings.warn('opencog.bindlink has been renamed to opencog.execute, update your imports.', DeprecationWarning)

--- a/opencog/cython/opencog/exec.py
+++ b/opencog/cython/opencog/exec.py
@@ -1,5 +1,0 @@
-import warnings
-
-from opencog.execute import *
-
-warnings.warn('opencog.exec has been renamed to opencog.execute, update your imports.', DeprecationWarning)

--- a/opencog/cython/opencog/scheme_wrapper.py
+++ b/opencog/cython/opencog/scheme_wrapper.py
@@ -1,5 +1,0 @@
-import warnings
-
-from opencog.scheme import *
-
-warnings.warn('opencog.scheme_wrapper has been renamed to opencog.scheme, update your imports.', DeprecationWarning)


### PR DESCRIPTION
It's been marked deprecated since time immemorial. So just remove it.