### PR TITLE
Fixing compilation errors in MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,14 @@ SET(SEMANTIC_VERSION ${CMAKE_MATCH_1})
 INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR} ${CMAKE_BINARY_DIR}
 	${COGUTIL_INCLUDE_DIR})
 
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+	message(STATUS "Configuring for macOS...")
+    
+    # Add macOS-specific include and library paths
+    include_directories(/opt/homebrew/include)
+    link_directories(/opt/homebrew/lib)
+endif()
+
 # Macros that define how atom types get declared.
 INCLUDE("${CMAKE_SOURCE_DIR}/cmake/OpenCogAtomTypes.cmake")
 

--- a/opencog/atoms/columnvec/FloatColumn.cc
+++ b/opencog/atoms/columnvec/FloatColumn.cc
@@ -68,7 +68,7 @@ ValuePtr FloatColumn::do_handle_loop(AtomSpace* as, bool silent,
 		else
 			throw RuntimeException(TRACE_INFO,
 				"Expecting numeric value, got %s\n",
-				vp->to_string());
+				vp->to_string().c_str());
 	}
 
 	return createFloatValue(std::move(dvec));
@@ -94,7 +94,7 @@ ValuePtr FloatColumn::do_execute(AtomSpace* as, bool silent)
 			if (not vpe->is_type(LINK_VALUE))
 				throw RuntimeException(TRACE_INFO,
 					"Expecting LinkValue, got %s\n",
-					vpe->to_string());
+					vpe->to_string().c_str());
 
 			// If we are here, we've got a LinkValue.
 			// Inside of loop is cut-n-paste of that below.
@@ -123,7 +123,7 @@ ValuePtr FloatColumn::do_execute(AtomSpace* as, bool silent)
 				else
 					throw RuntimeException(TRACE_INFO,
 						"Expecting numeric value, got %s\n",
-						vp->to_string());
+						vp->to_string().c_str());
 			}
 			return createFloatValue(std::move(dvec));
 		}

--- a/opencog/atoms/flow/IncrementValueLink.cc
+++ b/opencog/atoms/flow/IncrementValueLink.cc
@@ -86,7 +86,7 @@ ValuePtr IncrementValueLink::execute(AtomSpace* as, bool silent)
 
 	throw RuntimeException(TRACE_INFO,
 		"Expecting numeric value, got %s\n",
-		vp->to_string());
+		vp->to_string().c_str());
 }
 
 DEFINE_LINK_FACTORY(IncrementValueLink, INCREMENT_VALUE_LINK)


### PR DESCRIPTION
Fixing errors of type 
`
/Users/nitinissacjoy/workspace/ml/atomspace/opencog/atoms/columnvec/FloatColumn.cc:71:5: error: cannot pass object of non-trivial type 'std::string' (aka 'basic_string<char>') through variadic constructor; call will abort at runtime [-Wnon-pod-varargs]
   71 |                                 vp->to_string());
      |                                 ^
/Users/nitinissacjoy/workspace/ml/atomspace/opencog/atoms/columnvec/FloatColumn.cc:97:6: error: cannot pass object of non-trivial type 'std::string' (aka 'basic_string<char>') through variadic constructor; call will abort at runtime [-Wnon-pod-varargs]
   97 |                                         vpe->to_string());
      |                                         ^
/Users/nitinissacjoy/workspace/ml/atomspace/opencog/atoms/columnvec/FloatColumn.cc:126:7: error: cannot pass object of non-trivial type 'std::string' (aka 'basic_string<char>') through variadic constructor; call will abort at runtime [-Wnon-pod-varargs]
  126 |                                                 vp->to_string());
      |                     
`



Also issues where files from /opt/homebrew/include are not being included

