### PR TITLE
Change BoolValue to use packed 64-bit format.

### DIFF
--- a/opencog/atoms/reduct/BoolOpLink.cc
+++ b/opencog/atoms/reduct/BoolOpLink.cc
@@ -46,34 +46,34 @@ ValuePtr BoolOpLink::execute(AtomSpace* as, bool silent)
 		throw InvalidParamException(TRACE_INFO, "Expecting a BoolBalue");
 
 	BoolValuePtr bvp = BoolValueCast(vp);
-	std::vector<bool> bv = bvp->value();
 
 	if (BOOL_NOT_LINK == get_type())
 	{
 		if (1 != sz)
 			throw InvalidParamException(TRACE_INFO, "BoolNotLink expects one argument");
-		bv = bool_not(bv);
-		return createBoolValue(bv);
+		return bool_not(bvp);
 	}
 
 	if (BOOL_AND_LINK == get_type())
 	{
+		ValuePtr result = vp;
 		for (size_t i=1; i<sz; i++)
 		{
 			BoolValuePtr av = BoolValueCast(_outgoing[i]->execute(as, silent));
-			bv = bool_and(av->value(), bv);
+			result = bool_and(BoolValueCast(result), av);
 		}
-		return createBoolValue(bv);
+		return result;
 	}
 
 	if (BOOL_OR_LINK == get_type())
 	{
+		ValuePtr result = vp;
 		for (size_t i=1; i<sz; i++)
 		{
 			BoolValuePtr av = BoolValueCast(_outgoing[i]->execute(as, silent));
-			bv = bool_or(av->value(), bv);
+			result = bool_or(BoolValueCast(result), av);
 		}
-		return createBoolValue(bv);
+		return result;
 	}
 	throw InvalidParamException(TRACE_INFO, "Unexpected BoolOpLink");
 }

--- a/opencog/atoms/value/BoolValue.cc
+++ b/opencog/atoms/value/BoolValue.cc
@@ -120,11 +120,10 @@ BoolValue::BoolValue(unsigned long mask)
 	}
 }
 
-const std::vector<bool>& BoolValue::value() const
+std::vector<bool> BoolValue::value() const
 {
 	update();
-	_value_cache = unpack_vector();
-	return _value_cache;
+	return unpack_vector();
 }
 
 std::string BoolValue::to_string(const std::string& indent) const

--- a/opencog/atoms/value/BoolValue.h
+++ b/opencog/atoms/value/BoolValue.h
@@ -51,7 +51,6 @@ class BoolValue
 protected:
 	mutable std::vector<uint64_t> _packed_bits;
 	mutable size_t _bit_count;
-	mutable std::vector<bool> _value_cache;  // Cache for Python bindings compatibility
 
 	virtual void update() const {}
 
@@ -85,7 +84,7 @@ public:
 
 	virtual ~BoolValue() {}
 
-	const std::vector<bool>& value() const;  // Returns cached value for Python bindings
+	std::vector<bool> value() const;  // Returns cached value for Python bindings
 	size_t size() const { return _bit_count; }
 	ValuePtr value_at_index(size_t) const;
 

--- a/opencog/atoms/value/BoolValue.h
+++ b/opencog/atoms/value/BoolValue.h
@@ -37,46 +37,74 @@ namespace opencog
 /**
  * BoolValues hold an ordered vector of bools.
  *
- * This provides a reference interface for bools. It is NOT fast
- * or optimized for heavy-duty hypervector processing. Most ops,
- * such as boolean-and, boolean-or are implemented as bitwise-loops,
- * when 64-bit ops would be much more efficient.
- *
- * XXX FIXME Convert the implementation to std::vector<uint64_t>
+ * This provides a reference interface for bools. Internally, bits
+ * are packed into uint64_t values for efficient boolean operations.
+ * Boolean-and, boolean-or, and boolean-not operate on 64-bit chunks
+ * for improved performance.
  */
+class BoolValue;
+typedef std::shared_ptr<const BoolValue> BoolValuePtr;
+
 class BoolValue
 	: public Value
 {
 protected:
-	mutable std::vector<bool> _value;
+	mutable std::vector<uint64_t> _packed_bits;
+	mutable size_t _bit_count;
+	mutable std::vector<bool> _value_cache;  // Cache for Python bindings compatibility
 
 	virtual void update() const {}
 
-	BoolValue(Type t) : Value(t) {}
+	BoolValue(Type t) : Value(t), _bit_count(0) {}
+
+	void set_bit(size_t index, bool value) const;
+	bool get_bit(size_t index) const;
+	void pack_vector(const std::vector<bool>& v);
+	std::vector<bool> unpack_vector() const;
 
 public:
-	BoolValue(bool v) : Value(BOOL_VALUE) { _value.push_back(v); }
-	BoolValue(const std::vector<bool>& v)
-		: Value(BOOL_VALUE), _value(v) {}
+	// Helper methods for bit manipulation
+	static constexpr size_t BITS_PER_WORD = 64;
+
+	static size_t word_index(size_t bit_index) {
+		return bit_index / BITS_PER_WORD;
+	}
+
+	static size_t bit_offset(size_t bit_index) {
+		return bit_index % BITS_PER_WORD;
+	}
+
+	static size_t words_needed(size_t bit_count) {
+		return (bit_count + BITS_PER_WORD - 1) / BITS_PER_WORD;
+	}
+
+	BoolValue(bool v);
+	BoolValue(const std::vector<bool>& v);
 	BoolValue(unsigned long);
-	BoolValue(Type t, const std::vector<bool>& v) : Value(t), _value(v) {}
+	BoolValue(Type t, const std::vector<bool>& v);
 
 	virtual ~BoolValue() {}
 
-	const std::vector<bool>& value() const { update(); return _value; }
-	size_t size() const { return _value.size(); }
+	const std::vector<bool>& value() const;  // Returns cached value for Python bindings
+	size_t size() const { return _bit_count; }
 	ValuePtr value_at_index(size_t) const;
 
 	/** Returns a string representation of the value. */
-	virtual std::string to_string(const std::string& indent = "") const
-	{ return to_string(indent, _type); }
+	virtual std::string to_string(const std::string& indent = "") const;
 	std::string to_string(const std::string& indent, Type) const;
 
 	/** Returns true if two values are equal. */
 	virtual bool operator==(const Value&) const;
+
+	// Public methods to get packed data (for bool operations)
+	const std::vector<uint64_t>& get_packed_bits() const { return _packed_bits; }
+	size_t get_bit_count() const { return _bit_count; }
+	void set_packed_data(std::vector<uint64_t>&& bits, size_t count) {
+		_packed_bits = std::move(bits);
+		_bit_count = count;
+	}
 };
 
-typedef std::shared_ptr<const BoolValue> BoolValuePtr;
 static inline BoolValuePtr BoolValueCast(const ValuePtr& a)
 	{ return std::dynamic_pointer_cast<const BoolValue>(a); }
 
@@ -90,45 +118,14 @@ static inline std::shared_ptr<BoolValue> createBoolValue(Type&&... args) {
 	return std::make_shared<BoolValue>(std::forward<Type>(args)...);
 }
 
-// Scalar boolean ops
-std::vector<bool> bool_and(bool, const std::vector<bool>&);
-std::vector<bool> bool_or(bool, const std::vector<bool>&);
-std::vector<bool> bool_not(const std::vector<bool>&);
+// Boolean operation functions that work directly with BoolValuePtr
+ValuePtr bool_and(bool f, const BoolValuePtr& fvp);
+ValuePtr bool_or(bool f, const BoolValuePtr& fvp);
+ValuePtr bool_not(const BoolValuePtr& fvp);
 
-inline
-ValuePtr bool_and(bool f, const BoolValuePtr& fvp) {
-	return createBoolValue(bool_and(f, fvp->value()));
-}
-inline
-ValuePtr bool_or(bool f, const BoolValuePtr& fvp) {
-	return createBoolValue(bool_or(f, fvp->value()));
-}
-inline
-ValuePtr bool_not(const BoolValuePtr& fvp) {
-	return createBoolValue(bool_not(fvp->value()));
-}
-
-std::vector<bool> bool_and(const std::vector<bool>&, const std::vector<bool>&);
-std::vector<bool> bool_or(const std::vector<bool>&, const std::vector<bool>&);
-
-/// Vector boolean ops. When operating on an object bool_op and itself,
-/// take a sample first; this is needed to correctly handle streaming
-/// values, as they issue new values every time they are called. Failing
-/// to sample results in violations...
-inline
-ValuePtr bool_and(const BoolValuePtr& fvpa, const BoolValuePtr& fvpb) {
-	if (fvpa != fvpb)
-		return createBoolValue(bool_and(fvpa->value(), fvpb->value()));
-	auto sample = fvpa->value();
-	return createBoolValue(bool_and(sample, fvpb->value()));
-}
-inline
-ValuePtr bool_or(const BoolValuePtr& fvpa, const BoolValuePtr& fvpb) {
-	if (fvpa != fvpb)
-		return createBoolValue(bool_or(fvpa->value(), fvpb->value()));
-	auto sample = fvpa->value();
-	return createBoolValue(bool_or(sample, fvpb->value()));
-}
+// Vector boolean operations
+ValuePtr bool_and(const BoolValuePtr& fvpa, const BoolValuePtr& fvpb);
+ValuePtr bool_or(const BoolValuePtr& fvpa, const BoolValuePtr& fvpb);
 
 /** @}*/
 } // namespace opencog

--- a/opencog/cython/opencog/bool_value.pyx
+++ b/opencog/cython/opencog/bool_value.pyx
@@ -11,7 +11,7 @@ cdef class BoolValue(Value):
 
     def to_list(self):
         return BoolValue.vector_of_bool_to_list(
-            &((<cBoolValue*>self.get_c_value_ptr().get()).value()))
+            (<cBoolValue*>self.get_c_value_ptr().get()).value())
 
     @staticmethod
     cdef vector[bool] list_of_bool_to_vector(list python_list):
@@ -22,7 +22,7 @@ cdef class BoolValue(Value):
         return cpp_vector
 
     @staticmethod
-    cdef list vector_of_bool_to_list(const vector[bool]* cpp_vector):
+    cdef list vector_of_bool_to_list(vector[bool] cpp_vector):
         list = []
         it = cpp_vector.const_begin()
         while it != cpp_vector.const_end():


### PR DESCRIPTION
The original code used std::vector<bool> but a recent problem suggests switching to packed 64-bit ints.  The main issue is that gcc-14.2.0 in Debian Trixie prints some undecipherable warning/error during compilation. From what I can tell, `std::vector<bool>` might just be broken in this compiler. :-(

The change seems worthwhile, anyway, as it should improve the performance of the bitops. The good news is that there are very few users just right now.