### PR TITLE
Use generic type declarations for all Values

### DIFF
--- a/opencog/atoms/value/BoolValue.h
+++ b/opencog/atoms/value/BoolValue.h
@@ -85,6 +85,7 @@ public:
 };
 
 VALUE_PTR_DECL(BoolValue);
+CREATE_VALUE_DECL(BoolValue);
 
 // Boolean operation functions that work directly with BoolValuePtr
 ValuePtr bool_and(bool f, const BoolValuePtr& fvp);

--- a/opencog/atoms/value/BoolValue.h
+++ b/opencog/atoms/value/BoolValue.h
@@ -42,9 +42,6 @@ namespace opencog
  * Boolean-and, boolean-or, and boolean-not operate on 64-bit chunks
  * for improved performance.
  */
-class BoolValue;
-typedef std::shared_ptr<const BoolValue> BoolValuePtr;
-
 class BoolValue
 	: public Value
 {
@@ -87,18 +84,7 @@ public:
 	}
 };
 
-static inline BoolValuePtr BoolValueCast(const ValuePtr& a)
-	{ return std::dynamic_pointer_cast<const BoolValue>(a); }
-
-static inline const ValuePtr ValueCast(const BoolValuePtr& fv)
-{
-	return std::shared_ptr<Value>(fv, (Value*) fv.get());
-}
-
-template<typename ... Type>
-static inline std::shared_ptr<BoolValue> createBoolValue(Type&&... args) {
-	return std::make_shared<BoolValue>(std::forward<Type>(args)...);
-}
+VALUE_PTR_DECL(BoolValue);
 
 // Boolean operation functions that work directly with BoolValuePtr
 ValuePtr bool_and(bool f, const BoolValuePtr& fvp);

--- a/opencog/atoms/value/ContainerValue.h
+++ b/opencog/atoms/value/ContainerValue.h
@@ -72,9 +72,7 @@ public:
 	virtual bool operator==(const Value&) const;
 };
 
-typedef std::shared_ptr<ContainerValue> ContainerValuePtr;
-static inline ContainerValuePtr ContainerValueCast(ValuePtr& a)
-	{ return std::dynamic_pointer_cast<ContainerValue>(a); }
+VALUE_PTR_DECL(ContainerValue);
 
 /** @}*/
 } // namespace opencog

--- a/opencog/atoms/value/FloatValue.h
+++ b/opencog/atoms/value/FloatValue.h
@@ -73,19 +73,8 @@ public:
 	virtual bool operator==(const Value&) const;
 };
 
-typedef std::shared_ptr<const FloatValue> FloatValuePtr;
-static inline FloatValuePtr FloatValueCast(const ValuePtr& a)
-	{ return std::dynamic_pointer_cast<const FloatValue>(a); }
-
-static inline const ValuePtr ValueCast(const FloatValuePtr& fv)
-{
-	return std::shared_ptr<Value>(fv, (Value*) fv.get());
-}
-
-template<typename ... Type>
-static inline std::shared_ptr<FloatValue> createFloatValue(Type&&... args) {
-	return std::make_shared<FloatValue>(std::forward<Type>(args)...);
-}
+VALUE_PTR_DECL(FloatValue);
+CREATE_VALUE_DECL(FloatValue);
 
 // Scalar multiplication and addition
 std::vector<double> plus(double, const std::vector<double>&);

--- a/opencog/atoms/value/FormulaStream.h
+++ b/opencog/atoms/value/FormulaStream.h
@@ -63,16 +63,8 @@ public:
 	virtual bool operator==(const Value&) const;
 };
 
-typedef std::shared_ptr<FormulaStream> FormulaStreamPtr;
-static inline FormulaStreamPtr FormulaStreamCast(ValuePtr& a)
-	{ return std::dynamic_pointer_cast<FormulaStream>(a); }
-
-template<typename ... Type>
-static inline std::shared_ptr<FormulaStream> createFormulaStream(Type&&... args)
-{
-	return std::make_shared<FormulaStream>(std::forward<Type>(args)...);
-}
-
+VALUE_PTR_DECL(FormulaStream);
+CREATE_VALUE_DECL(FormulaStream);
 
 /** @}*/
 } // namespace opencog

--- a/opencog/atoms/value/FutureStream.h
+++ b/opencog/atoms/value/FutureStream.h
@@ -62,16 +62,8 @@ public:
 	virtual bool operator==(const Value&) const;
 };
 
-typedef std::shared_ptr<FutureStream> FutureStreamPtr;
-static inline FutureStreamPtr FutureStreamCast(ValuePtr& a)
-	{ return std::dynamic_pointer_cast<FutureStream>(a); }
-
-template<typename ... Type>
-static inline std::shared_ptr<FutureStream> createFutureStream(Type&&... args)
-{
-	return std::make_shared<FutureStream>(std::forward<Type>(args)...);
-}
-
+VALUE_PTR_DECL(FutureStream);
+CREATE_VALUE_DECL(FutureStream);
 
 /** @}*/
 } // namespace opencog

--- a/opencog/atoms/value/LinkStreamValue.h
+++ b/opencog/atoms/value/LinkStreamValue.h
@@ -50,10 +50,7 @@ public:
 	virtual bool operator==(const Value&) const;
 };
 
-typedef std::shared_ptr<LinkStreamValue> LinkStreamValuePtr;
-static inline LinkStreamValuePtr LinkStreamValueCast(ValuePtr& a)
-	{ return std::dynamic_pointer_cast<LinkStreamValue>(a); }
-
+VALUE_PTR_DECL(LinkStreamValue);
 
 /** @}*/
 } // namespace opencog

--- a/opencog/atoms/value/LinkValue.h
+++ b/opencog/atoms/value/LinkValue.h
@@ -108,16 +108,8 @@ public:
 	virtual bool operator==(const Value&) const;
 };
 
-typedef std::shared_ptr<LinkValue> LinkValuePtr;
-static inline LinkValuePtr LinkValueCast(const ValuePtr& a)
-	{ return std::dynamic_pointer_cast<LinkValue>(a); }
-static inline const ValuePtr ValueCast(const LinkValuePtr& lv)
-	{ return std::shared_ptr<Value>(lv, (Value*) lv.get()); }
-
-template<typename ... Type>
-static inline std::shared_ptr<LinkValue> createLinkValue(Type&&... args) {
-	return std::make_shared<LinkValue>(std::forward<Type>(args)...);
-}
+VALUE_PTR_DECL(LinkValue);
+CREATE_VALUE_DECL(LinkValue);
 
 /** @}*/
 } // namespace opencog

--- a/opencog/atoms/value/QueueValue.h
+++ b/opencog/atoms/value/QueueValue.h
@@ -63,14 +63,8 @@ public:
 	virtual bool operator==(const Value&) const;
 };
 
-typedef std::shared_ptr<QueueValue> QueueValuePtr;
-static inline QueueValuePtr QueueValueCast(ValuePtr& a)
-	{ return std::dynamic_pointer_cast<QueueValue>(a); }
-
-template<typename ... Type>
-static inline std::shared_ptr<QueueValue> createQueueValue(Type&&... args) {
-   return std::make_shared<QueueValue>(std::forward<Type>(args)...);
-}
+VALUE_PTR_DECL(QueueValue);
+CREATE_VALUE_DECL(QueueValue);
 
 /** @}*/
 } // namespace opencog

--- a/opencog/atoms/value/RandomStream.h
+++ b/opencog/atoms/value/RandomStream.h
@@ -53,15 +53,8 @@ public:
 	virtual std::string to_string(const std::string& indent = "") const;
 };
 
-typedef std::shared_ptr<RandomStream> RandomStreamPtr;
-static inline RandomStreamPtr RandomStreamCast(ValuePtr& a)
-	{ return std::dynamic_pointer_cast<RandomStream>(a); }
-
-template<typename ... Type>
-static inline std::shared_ptr<RandomStream> createRandomStream(Type&&... args) {
-	return std::make_shared<RandomStream>(std::forward<Type>(args)...);
-}
-
+VALUE_PTR_DECL(RandomStream);
+CREATE_VALUE_DECL(RandomStream);
 
 /** @}*/
 } // namespace opencog

--- a/opencog/atoms/value/StreamValue.h
+++ b/opencog/atoms/value/StreamValue.h
@@ -60,9 +60,7 @@ public:
 	virtual bool operator==(const Value&) const;
 };
 
-typedef std::shared_ptr<StreamValue> StreamValuePtr;
-static inline StreamValuePtr StreamValueCast(ValuePtr& a)
-	{ return std::dynamic_pointer_cast<StreamValue>(a); }
+VALUE_PTR_DECL(StreamValue);
 
 /** @}*/
 } // namespace opencog

--- a/opencog/atoms/value/StringValue.h
+++ b/opencog/atoms/value/StringValue.h
@@ -67,17 +67,8 @@ public:
 	virtual bool operator==(const Value&) const;
 };
 
-typedef std::shared_ptr<const StringValue> StringValuePtr;
-static inline StringValuePtr StringValueCast(const ValuePtr& a)
-	{ return std::dynamic_pointer_cast<const StringValue>(a); }
-static inline const ValuePtr ValueCast(const StringValuePtr& sv)
-	{ return std::shared_ptr<Value>(sv, (Value*) sv.get()); }
-
-template<typename ... Type>
-static inline std::shared_ptr<StringValue> createStringValue(Type&&... args) {
-	return std::make_shared<StringValue>(std::forward<Type>(args)...);
-}
-
+VALUE_PTR_DECL(StringValue);
+CREATE_VALUE_DECL(StringValue);
 
 /** @}*/
 } // namespace opencog

--- a/opencog/atoms/value/UnisetValue.h
+++ b/opencog/atoms/value/UnisetValue.h
@@ -65,14 +65,8 @@ public:
 	virtual bool operator==(const Value&) const;
 };
 
-typedef std::shared_ptr<UnisetValue> UnisetValuePtr;
-static inline UnisetValuePtr UnisetValueCast(ValuePtr& a)
-	{ return std::dynamic_pointer_cast<UnisetValue>(a); }
-
-template<typename ... Type>
-static inline std::shared_ptr<UnisetValue> createUnisetValue(Type&&... args) {
-   return std::make_shared<UnisetValue>(std::forward<Type>(args)...);
-}
+VALUE_PTR_DECL(UnisetValue);
+CREATE_VALUE_DECL(UnisetValue);
 
 /** @}*/
 } // namespace opencog

--- a/opencog/atoms/value/Value.h
+++ b/opencog/atoms/value/Value.h
@@ -176,10 +176,12 @@ createValue(Args&&... args) {
 
 #define VALUE_PTR_DECL(CNAME) \
 	typedef std::shared_ptr<CNAME> CNAME##Ptr; \
-	static inline CNAME##Ptr CNAME##Cast(ValuePtr& a) \
+	static inline CNAME##Ptr CNAME##Cast(const ValuePtr& a) \
 		{ return std::dynamic_pointer_cast<CNAME>(a); } \
 	static inline const ValuePtr ValueCast(const CNAME##Ptr& fv) \
-		{ return std::shared_ptr<Value>(fv, (Value*) fv.get()); } \
+		{ return std::shared_ptr<Value>(fv, (Value*) fv.get()); }
+
+#define CREATE_VALUE_DECL(CNAME) \
 	template<typename ... Type> \
 	static inline std::shared_ptr<CNAME> create##CNAME(Type&&... args) \
 		{ return std::make_shared<CNAME>(std::forward<Type>(args)...); }

--- a/opencog/atoms/value/Value.h
+++ b/opencog/atoms/value/Value.h
@@ -174,6 +174,16 @@ createValue(Args&&... args) {
 	return std::make_shared<T>(std::forward<Args>(args)...);
 }
 
+#define VALUE_PTR_DECL(CNAME) \
+	typedef std::shared_ptr<CNAME> CNAME##Ptr; \
+	static inline CNAME##Ptr CNAME##Cast(ValuePtr& a) \
+		{ return std::dynamic_pointer_cast<CNAME>(a); } \
+	static inline const ValuePtr ValueCast(const CNAME##Ptr& fv) \
+		{ return std::shared_ptr<Value>(fv, (Value*) fv.get()); } \
+	template<typename ... Type> \
+	static inline std::shared_ptr<CNAME> create##CNAME(Type&&... args) \
+		{ return std::make_shared<CNAME>(std::forward<Type>(args)...); }
+
 /** @}*/
 } // namespace opencog
 


### PR DESCRIPTION
This eliminates some cut-n-paste of common type declaration code.