### PR TITLE
fine-grained AtomSpace locks

### DIFF
--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -594,6 +594,12 @@ void AtomSpace::get_handles_by_type(HandleSeq& hseq,
                                     bool parent,
                                     const AtomSpace* cas) const
 {
+    // This should never happen!
+    if (type < ATOM)
+        throw RuntimeException(TRACE_INFO,
+             "There will never be handles of type %d %s!",
+             type, nameserver().getTypeName(type).c_str());
+
     if (nullptr == cas) cas = this;
 
     // If this is a copy-on-write space, then deduplicate the Atoms,

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -594,11 +594,11 @@ void AtomSpace::get_handles_by_type(HandleSeq& hseq,
                                     bool parent,
                                     const AtomSpace* cas) const
 {
-    // This should never happen!
-    if (type < ATOM)
-        throw RuntimeException(TRACE_INFO,
-             "There will never be handles of type %d %s!",
-             type, nameserver().getTypeName(type).c_str());
+    // Its a user error to ask for the handles of any type
+    // that is not an Atom. We could throw an error and irritate
+    // the user, or we could just silently ignore a plausible
+    // request. Lets just silently ignore.
+    if (type < ATOM) return;
 
     if (nullptr == cas) cas = this;
 

--- a/opencog/atomspace/AtomTable.cc
+++ b/opencog/atomspace/AtomTable.cc
@@ -598,7 +598,7 @@ void AtomSpace::get_handles_by_type(HandleSeq& hseq,
     // that is not an Atom. We could throw an error and irritate
     // the user, or we could just silently ignore a plausible
     // request. Lets just silently ignore.
-    if (type < ATOM) return;
+    if (not subclass and type < ATOM) return;
 
     if (nullptr == cas) cas = this;
 
@@ -677,6 +677,8 @@ void AtomSpace::shadow_by_type(UnorderedHandleSet& hset,
                                bool parent,
                                const AtomSpace* cas) const
 {
+    if (not subclass and type < ATOM) return;
+
     // See the vector version of this code for documentation.
     if (STATE_LINK == type)
     {
@@ -718,6 +720,8 @@ void AtomSpace::get_handles_by_type(UnorderedHandleSet& hset,
                                     bool parent,
                                     const AtomSpace* cas) const
 {
+    if (not subclass and type < ATOM) return;
+
     // If this is a copy-on-write space, then deduplicate the Atoms,
     // returning the shallowest version of each Atom.
     if (_copy_on_write)
@@ -748,6 +752,8 @@ void AtomSpace::get_root_set_by_type(HandleSeq& hseq,
                                      bool parent,
                                      const AtomSpace* cas) const
 {
+    if (not subclass and type < ATOM) return;
+
     // cut-n-paste of above.
     if (nullptr == cas) cas = this;
 
@@ -810,3 +816,5 @@ void AtomSpace::get_atoms_in_frame(HandleSeq& hseq) const
 {
     typeIndex.get_handles_by_type(hseq, ATOM, true);
 }
+
+// ======================= END OF FILE =================

--- a/opencog/atomspace/TypeIndex.cc
+++ b/opencog/atomspace/TypeIndex.cc
@@ -29,6 +29,7 @@ TypeIndex::TypeIndex(void) :
 	_nameserver(nameserver()),
 	_idx(VEC_SIZE)
 {
+	_offset_to_atom = ATOM;
 	resize();
 }
 

--- a/opencog/atomspace/TypeIndex.cc
+++ b/opencog/atomspace/TypeIndex.cc
@@ -25,25 +25,29 @@
 using namespace opencog;
 
 TypeIndex::TypeIndex(void) :
-	_num_types(TYPE_RESERVE_SIZE),
+	_reserved(TYPE_RESERVE_SIZE),
 	_nameserver(nameserver()),
 	_idx(VEC_SIZE)
 {
+	_num_types = nameserver().getNumberOfClasses();
 	_offset_to_atom = ATOM;
 	resize();
 }
 
 void TypeIndex::resize(void)
 {
-	size_t newsz = nameserver().getNumberOfClasses();
-	if (_num_types <= newsz)
+	int newsz = nameserver().getNumberOfClasses();
+	if (newsz < _reserved + _offset_to_atom) return;
+
+	// If we are here, we need to resize. Get the BFL.
+
 		throw RuntimeException(TRACE_INFO,
 			"Ran out of space for new types!");
 }
 
 void TypeIndex::clear(void)
 {
-	std::vector<AtomSet> dead(VEC_SIZE);
+	std::vector<AtomSet> dead(_reserved);
 	{
 		// std::shared_lock<std::shared_mutex> lck(_idxmtx);
 		dead.swap(_idx);

--- a/opencog/atomspace/TypeIndex.cc
+++ b/opencog/atomspace/TypeIndex.cc
@@ -25,7 +25,7 @@
 using namespace opencog;
 
 TypeIndex::TypeIndex(void) :
-	_num_types(MAX_SUPPORTED_TYPES),
+	_num_types(TYPE_RESERVE_SIZE),
 	_nameserver(nameserver()),
 	_idx(VEC_SIZE)
 {

--- a/opencog/atomspace/TypeIndex.cc
+++ b/opencog/atomspace/TypeIndex.cc
@@ -27,7 +27,7 @@ using namespace opencog;
 TypeIndex::TypeIndex(void) :
 	_num_types(MAX_SUPPORTED_TYPES),
 	_nameserver(nameserver()),
-	_idx(POOL_SIZE * _num_types + 1)
+	_idx(VEC_SIZE)
 {
 	resize();
 }
@@ -42,7 +42,7 @@ void TypeIndex::resize(void)
 
 void TypeIndex::clear(void)
 {
-	std::vector<AtomSet> dead;
+	std::vector<AtomSet> dead(VEC_SIZE);
 	{
 		// std::shared_lock<std::shared_mutex> lck(_idxmtx);
 		dead.swap(_idx);

--- a/opencog/atomspace/TypeIndex.cc
+++ b/opencog/atomspace/TypeIndex.cc
@@ -83,8 +83,8 @@ void TypeIndex::get_handles_by_type(HandleSeq& hseq,
 	// allocations and copies whenever the allocated size is exceeded.
 	hseq.reserve(initial_size + size_of_append);
 
-	TYPE_INDEX_SHARED_LOCK;
 	const AtomSet& s(_idx.at(type));
+	TYPE_INDEX_SHARED_LOCK(s);
 	for (const Handle& h : s)
 		hseq.push_back(h);
 
@@ -106,8 +106,8 @@ void TypeIndex::get_handles_by_type(UnorderedHandleSet& hset,
                                     Type type,
                                     bool subclass) const
 {
-	TYPE_INDEX_SHARED_LOCK;
 	const AtomSet& s(_idx.at(type));
+	TYPE_INDEX_SHARED_LOCK(s);
 	hset.insert(s.begin(), s.end());
 
 	// Not subclassing? We are done!
@@ -140,12 +140,14 @@ void TypeIndex::get_rootset_by_type(HandleSeq& hseq,
 	// allocations and copies whenever the allocated size is exceeded.
 	hseq.reserve(initial_size + size_of_append);
 
-	TYPE_INDEX_SHARED_LOCK;
 	const AtomSet& s(_idx.at(type));
-	for (const Handle& h : s)
 	{
-		if (h->isIncomingSetEmpty(cas))
-			hseq.push_back(h);
+		TYPE_INDEX_SHARED_LOCK(s);
+		for (const Handle& h : s)
+		{
+			if (h->isIncomingSetEmpty(cas))
+				hseq.push_back(h);
+		}
 	}
 
 	// Not subclassing? We are done!
@@ -156,6 +158,7 @@ void TypeIndex::get_rootset_by_type(HandleSeq& hseq,
 		if (not _nameserver.isA(t, type)) continue;
 
 		const AtomSet& s(_idx.at(t));
+		TYPE_INDEX_SHARED_LOCK(s);
 		for (const Handle& h : s)
 			if (h->isIncomingSetEmpty(cas))
 				hseq.push_back(h);

--- a/opencog/atomspace/TypeIndex.cc
+++ b/opencog/atomspace/TypeIndex.cc
@@ -125,7 +125,7 @@ void TypeIndex::get_handles_by_type(HandleSeq& hseq,
 	// Not subclassing? We are done!
 	if (not subclass) return;
 
-	Type tstar = max(type+1, _offset_to_atom);
+	Type tstar = std::max(type+1, _offset_to_atom);
 	for (Type t = tstar; t<_num_types; t++)
 	{
 		if (not _nameserver.isA(t, type)) continue;
@@ -162,7 +162,7 @@ void TypeIndex::get_handles_by_type(UnorderedHandleSet& hset,
 	// Not subclassing? We are done!
 	if (not subclass) return;
 
-	Type tstar = max(type+1, _offset_to_atom);
+	Type tstar = std::max(type+1, _offset_to_atom);
 	for (Type t = tstar; t<_num_types; t++)
 	{
 		if (not _nameserver.isA(t, type)) continue;
@@ -215,7 +215,7 @@ void TypeIndex::get_rootset_by_type(HandleSeq& hseq,
 	// Not subclassing? We are done!
 	if (not subclass) return;
 
-	Type tstar = max(type+1, _offset_to_atom);
+	Type tstar = std::max(type+1, _offset_to_atom);
 	for (Type t = tstar; t<_num_types; t++)
 	{
 		if (not _nameserver.isA(t, type)) continue;

--- a/opencog/atomspace/TypeIndex.cc
+++ b/opencog/atomspace/TypeIndex.cc
@@ -36,15 +36,15 @@ TypeIndex::TypeIndex(void) :
 
 #define GET_BFL(vec) \
 	for (int ibu = 0; ibu < (int) vec.size(); ibu++) { \
-		const AtomSet& s(vec[ibu]); \
+		AtomSet& s(vec[ibu]); \
 		s._mtx.lock(); }
 
 #define DROP_BFL(vec) \
 	for (int ibu = 0; ibu < (int) vec.size(); ibu++) { \
-		const AtomSet& s(vec[ibu]); \
+		AtomSet& s(vec[ibu]); \
 		s._mtx.unlock(); }
 
-void TypeIndex::resize(void)
+void TypeIndex::resize(void) const
 {
 	int newsz = nameserver().getNumberOfClasses();
 	if (newsz < _reserved + _offset_to_atom) return;
@@ -57,6 +57,7 @@ void TypeIndex::resize(void)
 	std::vector<AtomSet> newvec(_reserved * POOL_SIZE);
 	GET_BFL(_idx)
 	newvec.swap(_idx);
+	_num_types = newsz;
 	DROP_BFL(newvec)
 }
 
@@ -96,6 +97,8 @@ void TypeIndex::get_handles_by_type(HandleSeq& hseq,
                                     Type type,
                                     bool subclass) const
 {
+	if (not subclass and type < _offset_to_atom) return;
+
 	// Get the initial size of the handles vector.
 	size_t initial_size = hseq.size();
 
@@ -107,19 +110,23 @@ void TypeIndex::get_handles_by_type(HandleSeq& hseq,
 	// allocations and copies whenever the allocated size is exceeded.
 	hseq.reserve(initial_size + size_of_append);
 
-	int start = get_bucket_start(type);
-	for (int ibu = start; ibu < start + POOL_SIZE; ibu++)
+	if (type >= _offset_to_atom)
 	{
-		const AtomSet& s(_idx[ibu]);
-		TYPE_INDEX_SHARED_LOCK(s);
-		for (const Handle& h : s)
-			hseq.push_back(h);
+		int start = get_bucket_start(type);
+		for (int ibu = start; ibu < start + POOL_SIZE; ibu++)
+		{
+			const AtomSet& s(_idx[ibu]);
+			TYPE_INDEX_SHARED_LOCK(s);
+			for (const Handle& h : s)
+				hseq.push_back(h);
+		}
 	}
 
 	// Not subclassing? We are done!
 	if (not subclass) return;
 
-	for (Type t = type+1; t<_num_types; t++)
+	Type tstar = max(type+1, _offset_to_atom);
+	for (Type t = tstar; t<_num_types; t++)
 	{
 		if (not _nameserver.isA(t, type)) continue;
 
@@ -139,18 +146,24 @@ void TypeIndex::get_handles_by_type(UnorderedHandleSet& hset,
                                     Type type,
                                     bool subclass) const
 {
-	int start = get_bucket_start(type);
-	for (int ibu = start; ibu < start + POOL_SIZE; ibu++)
+	if (not subclass and type < _offset_to_atom) return;
+
+	if (type >= _offset_to_atom)
 	{
-		const AtomSet& s(_idx[ibu]);
-		TYPE_INDEX_SHARED_LOCK(s);
-		hset.insert(s.begin(), s.end());
+		int start = get_bucket_start(type);
+		for (int ibu = start; ibu < start + POOL_SIZE; ibu++)
+		{
+			const AtomSet& s(_idx[ibu]);
+			TYPE_INDEX_SHARED_LOCK(s);
+			hset.insert(s.begin(), s.end());
+		}
 	}
 
 	// Not subclassing? We are done!
 	if (not subclass) return;
 
-	for (Type t = type+1; t<_num_types; t++)
+	Type tstar = max(type+1, _offset_to_atom);
+	for (Type t = tstar; t<_num_types; t++)
 	{
 		if (not _nameserver.isA(t, type)) continue;
 
@@ -171,6 +184,8 @@ void TypeIndex::get_rootset_by_type(HandleSeq& hseq,
                                     bool subclass,
                                     const AtomSpace* cas) const
 {
+	if (not subclass and type < _offset_to_atom) return;
+
 	// Get the initial size of the handles vector.
 	size_t initial_size = hseq.size();
 
@@ -182,22 +197,26 @@ void TypeIndex::get_rootset_by_type(HandleSeq& hseq,
 	// allocations and copies whenever the allocated size is exceeded.
 	hseq.reserve(initial_size + size_of_append);
 
-	int start = get_bucket_start(type);
-	for (int ibu = start; ibu < start + POOL_SIZE; ibu++)
+	if (type >= _offset_to_atom)
 	{
-		const AtomSet& s(_idx[ibu]);
-		TYPE_INDEX_SHARED_LOCK(s);
-		for (const Handle& h : s)
+		int start = get_bucket_start(type);
+		for (int ibu = start; ibu < start + POOL_SIZE; ibu++)
 		{
-			if (h->isIncomingSetEmpty(cas))
-				hseq.push_back(h);
+			const AtomSet& s(_idx[ibu]);
+			TYPE_INDEX_SHARED_LOCK(s);
+			for (const Handle& h : s)
+			{
+				if (h->isIncomingSetEmpty(cas))
+					hseq.push_back(h);
+			}
 		}
 	}
 
 	// Not subclassing? We are done!
 	if (not subclass) return;
 
-	for (Type t = type+1; t<_num_types; t++)
+	Type tstar = max(type+1, _offset_to_atom);
+	for (Type t = tstar; t<_num_types; t++)
 	{
 		if (not _nameserver.isA(t, type)) continue;
 

--- a/opencog/atomspace/TypeIndex.cc
+++ b/opencog/atomspace/TypeIndex.cc
@@ -50,7 +50,6 @@ void TypeIndex::clear(void)
 		// Clear the AtomSpace before releasing the lock.
 		for (auto& s : dead)
 		{
-			TYPE_INDEX_UNIQUE_LOCK(s);
 			for (auto& h : s)
 				h->_atom_space = nullptr;
 		}
@@ -65,7 +64,6 @@ void TypeIndex::clear(void)
 	// that would result in lock inversion.
 	for (auto& s : dead)
 	{
-		TYPE_INDEX_UNIQUE_LOCK(s);
 		for (auto& h : s)
 			h->remove();
 		s.clear();

--- a/opencog/atomspace/TypeIndex.cc
+++ b/opencog/atomspace/TypeIndex.cc
@@ -90,7 +90,7 @@ void TypeIndex::get_handles_by_type(HandleSeq& hseq,
 	int start = get_bucket_start(type);
 	for (int ibu = start; ibu < start + POOL_SIZE; ibu++)
 	{
-		const AtomSet& s(_idx.at(ibu));
+		const AtomSet& s(_idx[ibu]);
 		TYPE_INDEX_SHARED_LOCK(s);
 		for (const Handle& h : s)
 			hseq.push_back(h);
@@ -106,7 +106,7 @@ void TypeIndex::get_handles_by_type(HandleSeq& hseq,
 		int start = get_bucket_start(t);
 		for (int ibu = start; ibu < start + POOL_SIZE; ibu++)
 		{
-			const AtomSet& s(_idx.at(ibu));
+			const AtomSet& s(_idx[ibu]);
 			TYPE_INDEX_SHARED_LOCK(s);
 			for (const Handle& h : s)
 				hseq.push_back(h);
@@ -122,7 +122,7 @@ void TypeIndex::get_handles_by_type(UnorderedHandleSet& hset,
 	int start = get_bucket_start(type);
 	for (int ibu = start; ibu < start + POOL_SIZE; ibu++)
 	{
-		const AtomSet& s(_idx.at(ibu));
+		const AtomSet& s(_idx[ibu]);
 		TYPE_INDEX_SHARED_LOCK(s);
 		hset.insert(s.begin(), s.end());
 	}
@@ -137,7 +137,7 @@ void TypeIndex::get_handles_by_type(UnorderedHandleSet& hset,
 		int start = get_bucket_start(t);
 		for (int ibu = start; ibu < start + POOL_SIZE; ibu++)
 		{
-			const AtomSet& s(_idx.at(ibu));
+			const AtomSet& s(_idx[ibu]);
 			TYPE_INDEX_SHARED_LOCK(s);
 			hset.insert(s.begin(), s.end());
 		}
@@ -165,7 +165,7 @@ void TypeIndex::get_rootset_by_type(HandleSeq& hseq,
 	int start = get_bucket_start(type);
 	for (int ibu = start; ibu < start + POOL_SIZE; ibu++)
 	{
-		const AtomSet& s(_idx.at(ibu));
+		const AtomSet& s(_idx[ibu]);
 		TYPE_INDEX_SHARED_LOCK(s);
 		for (const Handle& h : s)
 		{
@@ -184,7 +184,7 @@ void TypeIndex::get_rootset_by_type(HandleSeq& hseq,
 		int start = get_bucket_start(t);
 		for (int ibu = start; ibu < start + POOL_SIZE; ibu++)
 		{
-			const AtomSet& s(_idx.at(ibu));
+			const AtomSet& s(_idx[ibu]);
 			TYPE_INDEX_SHARED_LOCK(s);
 			for (const Handle& h : s)
 				if (h->isIncomingSetEmpty(cas))

--- a/opencog/atomspace/TypeIndex.h
+++ b/opencog/atomspace/TypeIndex.h
@@ -87,15 +87,15 @@ class TypeIndex
 		NameServer& _nameserver;
 		std::vector<AtomSet> _idx;
 
-		static constexpr int POOL_SIZE = 1;
-		static constexpr int POOL_MASK = POOL_SIZE-1;
+		static constexpr int MAX_SUPPORTED_TYPES = 1024;
+		static constexpr int POOL_SIZE = 8;
 		int get_bucket_start(Type t) const
 		{
 			return POOL_SIZE * t;
 		}
 		int get_bucket(const Handle& h) const
 		{
-			return h->get_type();
+			return POOL_SIZE * h->get_type() + h->get_hash() % POOL_SIZE;
 		}
 		AtomSet& get_atom_set(const Handle& h)
 		{

--- a/opencog/atomspace/TypeIndex.h
+++ b/opencog/atomspace/TypeIndex.h
@@ -83,7 +83,8 @@ struct AtomSet :
 class TypeIndex
 {
 	private:
-		size_t _num_types;
+		int _num_types;
+		int _offset_to_atom;
 		NameServer& _nameserver;
 		std::vector<AtomSet> _idx;
 
@@ -92,12 +93,12 @@ class TypeIndex
 		static constexpr int VEC_SIZE = TYPE_RESERVE_SIZE * POOL_SIZE;
 		int get_bucket_start(Type t) const
 		{
-			return POOL_SIZE * t;
+			return POOL_SIZE * (t - _offset_to_atom);
 		}
 		int get_bucket(const Handle& h) const
 		{
 			int ibu = h->get_hash() % POOL_SIZE;
-			ibu += POOL_SIZE * h->get_type();
+			ibu += POOL_SIZE * (h->get_type() - _offset_to_atom);
 			return ibu;
 		}
 		AtomSet& get_atom_set(const Handle& h)

--- a/opencog/atomspace/TypeIndex.h
+++ b/opencog/atomspace/TypeIndex.h
@@ -84,6 +84,7 @@ class TypeIndex
 {
 	private:
 		int _num_types;
+		int _reserved;
 		int _offset_to_atom;
 		NameServer& _nameserver;
 		std::vector<AtomSet> _idx;

--- a/opencog/atomspace/TypeIndex.h
+++ b/opencog/atomspace/TypeIndex.h
@@ -51,18 +51,20 @@ namespace opencog
 //    sometimes reports the same result twice. Why? I dunno. This
 //    one failure is enough to say "not recommended." I don't need
 //    to be chasing obscure bugs.
+#if HAVE_FOLLY_XXX
+	typedef folly::F14ValueSet<Handle> AtomHanSet;
+#else
+	typedef std::unordered_set<Handle> AtomHanSet;
+#endif
 
 // The AtomSet is just a set, plus a lock on that set.
-struct AtomSet :
-#if HAVE_FOLLY_XXX
-	public folly::F14ValueSet<Handle>
-#else
-	public std::unordered_set<Handle>
-#endif
+struct AtomSet : AtomHanSet
 {
 	mutable std::shared_mutex _mtx;
 	AtomSet() = default;
-	AtomSet(AtomSet&& other) noexcept {}
+	AtomSet(AtomSet&& other) noexcept :
+		AtomHanSet(std::move(other))
+	{}
 };
 
 #define TYPE_INDEX_SHARED_LOCK(s) std::shared_lock<std::shared_mutex> lck(s._mtx);

--- a/opencog/atomspace/TypeIndex.h
+++ b/opencog/atomspace/TypeIndex.h
@@ -52,6 +52,7 @@ namespace opencog
 //    one failure is enough to say "not recommended." I don't need
 //    to be chasing obscure bugs.
 
+// The AtomSet is just a set, plus a lock on that set.
 struct AtomSet :
 #if HAVE_FOLLY_XXX
 	public folly::F14ValueSet<Handle>
@@ -60,7 +61,8 @@ struct AtomSet :
 #endif
 {
 	mutable std::shared_mutex _mtx;
-
+	AtomSet() = default;
+	AtomSet(AtomSet&& other) noexcept {}
 };
 
 #define TYPE_INDEX_SHARED_LOCK(s) std::shared_lock<std::shared_mutex> lck(s._mtx);

--- a/opencog/atomspace/TypeIndex.h
+++ b/opencog/atomspace/TypeIndex.h
@@ -89,13 +89,16 @@ class TypeIndex
 
 		static constexpr int MAX_SUPPORTED_TYPES = 1024;
 		static constexpr int POOL_SIZE = 8;
+		static constexpr int VEC_SIZE = MAX_SUPPORTED_TYPES * POOL_SIZE;
 		int get_bucket_start(Type t) const
 		{
 			return POOL_SIZE * t;
 		}
 		int get_bucket(const Handle& h) const
 		{
-			return POOL_SIZE * h->get_type() + h->get_hash() % POOL_SIZE;
+			int ibu = h->get_hash() % POOL_SIZE;
+			ibu += POOL_SIZE * h->get_type();
+			return ibu;
 		}
 		AtomSet& get_atom_set(const Handle& h)
 		{

--- a/opencog/atomspace/TypeIndex.h
+++ b/opencog/atomspace/TypeIndex.h
@@ -87,9 +87,9 @@ class TypeIndex
 		NameServer& _nameserver;
 		std::vector<AtomSet> _idx;
 
-		static constexpr int MAX_SUPPORTED_TYPES = 1024;
+		static constexpr int TYPE_RESERVE_SIZE = 1024;
 		static constexpr int POOL_SIZE = 8;
-		static constexpr int VEC_SIZE = MAX_SUPPORTED_TYPES * POOL_SIZE;
+		static constexpr int VEC_SIZE = TYPE_RESERVE_SIZE * POOL_SIZE;
 		int get_bucket_start(Type t) const
 		{
 			return POOL_SIZE * t;
@@ -172,7 +172,8 @@ class TypeIndex
 			size_t result = size(type);
 			if (not subclass) return result;
 
-			for (Type t = ATOM; t<_num_types; t++)
+			// All subclassed types have a larger type.
+			for (Type t = type+1; t<_num_types; t++)
 			{
 				if (t != type and _nameserver.isA(t, type))
 					result += size(t);

--- a/opencog/atomspace/TypeIndex.h
+++ b/opencog/atomspace/TypeIndex.h
@@ -86,6 +86,15 @@ class TypeIndex
 		size_t _num_types;
 		NameServer& _nameserver;
 		std::vector<AtomSet> _idx;
+
+		AtomSet& get_atom_set(const Handle& h)
+		{
+			return _idx.at(h->get_type());
+		}
+		const AtomSet& get_atom_set_const(const Handle& h) const
+		{
+			return _idx.at(h->get_type());
+		}
 	public:
 		TypeIndex(void);
 		void resize(void);
@@ -94,7 +103,7 @@ class TypeIndex
 		// Else, return nullptr
 		Handle insertAtom(const Handle& h)
 		{
-			AtomSet& s(_idx.at(h->get_type()));
+			AtomSet& s(get_atom_set(h));
 			TYPE_INDEX_UNIQUE_LOCK(s);
 			auto iter = s.find(h);
 			if (s.end() != iter) return *iter;
@@ -104,14 +113,14 @@ class TypeIndex
 
 		bool removeAtom(const Handle& h)
 		{
-			AtomSet& s(_idx.at(h->get_type()));
+			AtomSet& s(get_atom_set(h));
 			TYPE_INDEX_UNIQUE_LOCK(s);
 			return 1 == s.erase(h);
 		}
 
 		Handle findAtom(const Handle& h) const
 		{
-			const AtomSet& s(_idx.at(h->get_type()));
+			const AtomSet& s(get_atom_set_const(h));
 			TYPE_INDEX_SHARED_LOCK(s);
 			auto iter = s.find(h);
 			if (s.end() == iter) return Handle::UNDEFINED;

--- a/opencog/atomspace/TypeIndex.h
+++ b/opencog/atomspace/TypeIndex.h
@@ -102,11 +102,11 @@ class TypeIndex
 		}
 		AtomSet& get_atom_set(const Handle& h)
 		{
-			return _idx.at(get_bucket(h));
+			return _idx[get_bucket(h)];
 		}
 		const AtomSet& get_atom_set_const(const Handle& h) const
 		{
-			return _idx.at(get_bucket(h));
+			return _idx[get_bucket(h)];
 		}
 	public:
 		TypeIndex(void);
@@ -147,7 +147,7 @@ class TypeIndex
 			int start = get_bucket_start(t);
 			for (int ibu = start; ibu < start + POOL_SIZE; ibu++)
 			{
-				const AtomSet& s(_idx.at(ibu));
+				const AtomSet& s(_idx[ibu]);
 				TYPE_INDEX_SHARED_LOCK(s);
 				cnt += s.size();
 			}

--- a/opencog/atomspace/TypeIndex.h
+++ b/opencog/atomspace/TypeIndex.h
@@ -83,9 +83,9 @@ struct AtomSet :
 class TypeIndex
 {
 	private:
-		std::vector<AtomSet> _idx;
 		size_t _num_types;
 		NameServer& _nameserver;
+		std::vector<AtomSet> _idx;
 	public:
 		TypeIndex(void);
 		void resize(void);

--- a/opencog/cython/opencog/atomspace_details.pyx
+++ b/opencog/cython/opencog/atomspace_details.pyx
@@ -209,7 +209,7 @@ cdef class AtomSpace(Value):
         """ Support iterating across all atoms in the atomspace """
         if self.atomspace == NULL:
             raise RuntimeError("Null AtomSpace!")
-        return iter(self.get_atoms_by_type(0))
+        return iter(self.get_atoms_by_type(types.Atom))
 
     def size(self):
         """ Return the number of atoms in the AtomSpace """

--- a/opencog/scm/opencog/base/core-docs.scm
+++ b/opencog/scm/opencog/base/core-docs.scm
@@ -1052,7 +1052,8 @@
         guile> (cog-get-types)
 
     See also:
-        cog-get-subtypes TYPE -- Return list of subtypes of TYPE.
+        cog-get-subtypes TYPE -- Return list of immediate subtypes of TYPE.
+        cog-get-all-subtypes TYPE -- Return list of all subtypes of TYPE.
 ")
 
 (set-procedure-property! cog-type->int 'documentation
@@ -1076,6 +1077,10 @@
     Example:
         guile> (cog-get-subtypes 'Atom)
         (Link Node)
+
+    See also:
+        cog-get-all-subtypes TYPE -- Return list of all subtypes of TYPE.
+        cog-get-types -- Return list of all types.
 ")
 
 (set-procedure-property! cog-subtype? 'documentation

--- a/opencog/scm/opencog/base/utilities.scm
+++ b/opencog/scm/opencog/base/utilities.scm
@@ -289,7 +289,7 @@
 
 	(for-each
 		(lambda (ty) (cog-map-type prt-atom ty ATOMSPACE))
-		(cog-get-types))
+		(cog-get-all-subtypes 'Atom))
 )
 
 ; -----------------------------------------------------------------------


### PR DESCRIPTION
Use fine-grained locks for managing AtomSpace insertion/deletion. This should allow more threads to run in parallel.