### PR TITLE
Cut loose from the obsolete opencog git repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -681,80 +681,6 @@ jobs:
             - attention
             - ccache
 
-  opencog:
-    docker:
-      - image: $CIRCLE_PROJECT_USERNAME/opencog-deps
-        user: root
-        environment:
-          CCACHE_DIR: /ws/ccache
-    working_directory: /ws/opencog
-    steps:
-      - attach_workspace:
-          at: /ws/
-      - restore_cache:
-          name: Restore GHC Cache
-          keys:
-            - ghc-{{checksum "/ws/atomspace/opencog/haskell/stack.yaml"}}-{{ arch }}
-      - restore_cache:
-          name: Restore Haskell Deps Cache
-          keys:
-            - haskelldeps-{{checksum "/ws/atomspace/opencog/haskell/stack.yaml"}}-{{checksum "/ws/atomspace/opencog/haskell/opencog-atomspace.cabal"}}-{{ arch }}
-      - run:
-          name: Install CogUtil
-          command: cd /ws/cogutil/build && make -j2 install && ldconfig
-      - run:
-          name: Install AtomSpace
-          command: cd /ws/atomspace/build && make -j2 install && ldconfig
-      - run:
-          name: Install AtomSpaceStorage
-          command: cd /ws/atomspace-storage/build && make -j2 install && ldconfig
-      - run:
-          name: Install Unify
-          command: cd /ws/unify/build && make -j2 install && ldconfig
-      - run:
-          name: Install URE
-          command: cd /ws/ure/build && make -j2 install && ldconfig
-      - run:
-          name: Install CogServer
-          command: cd /ws/cogserver/build && make install && ldconfig
-      - run:
-          name: Install Attention
-          command: cd /ws/attention/build && make install && ldconfig
-      - run:
-          name: Install Link Grammar Atomese
-          command: |
-            git clone --depth 1 https://github.com/$CIRCLE_PROJECT_USERNAME/lg-atomese /ws/lg-atomese
-            mkdir -p /ws/lg-atomese/build
-            cd /ws/lg-atomese/build && cmake .. && make -j2 && make -j2 install
-            ldconfig
-      - run:
-          name: Checkout OpenCog
-          command: git clone --depth 1 https://github.com/$CIRCLE_PROJECT_USERNAME/opencog .
-      - run:
-          name: CMake Configure
-          command: mkdir build && cd build && cmake ..
-      - run:
-          name: Build
-          command: cd build && make -j2
-      - run:
-          name: Build tests
-          command: cd build && make -j2 tests
-      - run:
-          name: Run tests
-          command: cd build && make -j2 check ARGS=-j2
-      - run:
-          name: Install OpenCog
-          command: cd build && make -j2 install && ldconfig
-      - run:
-          name: Print test log
-          command: cat build/tests/Testing/Temporary/LastTest.log
-          when: always
-      - persist_to_workspace:
-          root: /ws/
-          paths:
-            - opencog
-            - ccache
-
   package: #Place holder
     docker:
       - image: $CIRCLE_PROJECT_USERNAME/opencog-deps
@@ -825,15 +751,15 @@ workflows:
           requires:
             - atomspace
             - cogserver
-      - opencog:
-          requires:
-            - atomspace
-            - attention
-            - cogserver
-            - ure
       - package:
           requires:
-            - opencog
+            - atomspace
+            - atomspace-cog
+            - atomspace-rocks
+            - atomspace-storage
+            - cogserver
+            - matrix
+            - unify
           filters:
             branches:
               only: master

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -638,7 +638,6 @@ public:
     // Deprecated calls, do not use these in new code!
     // Some day, these will be removed.
     // The two getIncoming calls are only used in cython/opencog/atom.pyx
-    // The foreach_incoming call is used extensively in old OpenCog.
 
     //! Deprecated! Do not use in new code!
     //! Place incoming set into STL container of Handles.
@@ -683,24 +682,6 @@ public:
             WEAKLY_DO(h, w, { *result = h; result ++; })
         return result;
     }
-
-    //! Deprecated! Do not use in new code!
-    //! Invoke the callback on each atom in the incoming set of
-    //! handle h, until one of them returns true, in which case
-    //! iteration stops, and true is returned. Otherwise the
-    //! callback is called on all incomings and false is returned.
-    template<class T>
-    inline bool foreach_incoming(bool (T::*cb)(const Handle&), T *data) const
-    {
-        // We make a copy of the set, so that we don't call the
-        // callback with locks held.
-        IncomingSet vh(getIncomingSet());
-
-        for (const Handle& lp : vh)
-            if ((data->*cb)(lp)) return true;
-        return false;
-    }
-
 };
 
 #define ATOM_PTR_DECL(CNAME)                                \


### PR DESCRIPTION
I want to clean up old code. This is a blocker to doing that. The old opencog git repo is dead. There is nothing there worth saving.