### PR TITLE
Provide wrappers for the local incoming set.

### DIFF
--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -414,7 +414,7 @@ private:
 protected:
     bool have_inset_map(void) const { return true; }
     InSetMap& get_inset_map(void) { return _local_incoming_set._iset; }
-    const InSetMap& get_inset_map_const(void) { return _local_incoming_set._iset; }
+    const InSetMap& get_inset_map_const(void) const { return _local_incoming_set._iset; }
 
     void keep_incoming_set();
     void drop_incoming_set();

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -379,6 +379,7 @@ protected:
     Atom& operator=(Atom&& other) // move assignment operator
         { return *this; }
 
+private:
     // The incoming set is not tracked by the garbage collector;
     // this is required, in order to avoid cyclic references.
     // That is, we use weak pointers here, not strong ones.
@@ -408,7 +409,13 @@ protected:
         // std::map<Type, WincomingSet> _iset;
         InSetMap _iset;
     };
-    InSet _incoming_set;
+    InSet _local_incoming_set;
+
+protected:
+    bool have_inset_map(void) const { return true; }
+    InSetMap& get_inset_map(void) { return _local_incoming_set._iset; }
+    const InSetMap& get_inset_map_const(void) { return _local_incoming_set._iset; }
+
     void keep_incoming_set();
     void drop_incoming_set();
 

--- a/opencog/atomspace/Frame.cc
+++ b/opencog/atomspace/Frame.cc
@@ -84,9 +84,10 @@ void Frame::scrub_incoming_set(void)
 	// Iterate over all frame types
 	std::vector<Type> framet;
 	nameserver().getChildrenRecursive(FRAME, back_inserter(framet));
+	InSetMap& iset = get_inset_map();
 	for (Type t : framet)
 	{
-		auto bucket = _incoming_set._iset.find(t);
+		auto bucket = iset.find(t);
 		for (auto bi = bucket->second.begin(); bi != bucket->second.end();)
 		{
 			if (0 == bi->use_count())


### PR DESCRIPTION
Goal is to make an anticipate move of the incoming set to the AtomSpace simpler.
