### PR TITLE
Remove cog-mean cog-confidence cog-count from API

### DIFF
--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -370,9 +370,6 @@ void SchemeSmob::register_procs()
 	register_proc("cog-tv",                1, 0, 0, C(ss_tv));
 	register_proc("cog-atomspace",         0, 1, 0, C(ss_as));
 	register_proc("cog-as",                0, 1, 0, C(ss_as));
-	register_proc("cog-mean",              1, 0, 0, C(ss_get_mean));
-	register_proc("cog-confidence",        1, 0, 0, C(ss_get_confidence));
-	register_proc("cog-count",             1, 0, 0, C(ss_get_count));
 
 	// Truth-values
 	register_proc("cog-tv-mean",           1, 0, 0, C(ss_tv_get_mean));

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -144,9 +144,6 @@ private:
 	static SCM ss_type(SCM);
 	static SCM ss_arity(SCM);
 	static SCM ss_tv(SCM);
-	static SCM ss_get_mean(SCM);
-	static SCM ss_get_confidence(SCM);
-	static SCM ss_get_count(SCM);
 	static SCM ss_keys(SCM);
 	static SCM ss_keys_alist(SCM);
 	static SCM ss_value(SCM, SCM);

--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -263,36 +263,6 @@ SCM SchemeSmob::ss_tv (SCM satom)
 	return protom_to_scm(ValueCast(h->getTruthValue()));
 }
 
-/**
- * Return the truth value mean on the atom.
- * This is meant to be the fastest possible way of accessing the mean.
- */
-SCM SchemeSmob::ss_get_mean(SCM satom)
-{
-	Handle h = verify_handle(satom, "cog-mean");
-	return scm_from_double(h->getTruthValue()->get_mean());
-}
-
-/**
- * Return the truth value confidence on the atom.
- * This is meant to be the fastest possible way of accessing the confidence.
- */
-SCM SchemeSmob::ss_get_confidence(SCM satom)
-{
-	Handle h = verify_handle(satom, "cog-confidence");
-	return scm_from_double(h->getTruthValue()->get_confidence());
-}
-
-/**
- * Return the truth value count on the atom.
- * This is meant to be the fastest possible way of accessing the count.
- */
-SCM SchemeSmob::ss_get_count(SCM satom)
-{
-	Handle h = verify_handle(satom, "cog-count");
-	return scm_from_double(h->getTruthValue()->get_count());
-}
-
 SCM SchemeSmob::ss_set_tv (SCM satom, SCM stv)
 {
 	Handle h = verify_handle(satom, "cog-set-tv!");

--- a/opencog/scm/opencog.scm
+++ b/opencog/scm/opencog.scm
@@ -45,8 +45,6 @@ cog-atomspace-readonly?
 cog-atomspace-ro!
 cog-atomspace-rw!
 cog-atomspace-uuid
-cog-confidence
-cog-count
 cog-count-atoms
 cog-equal?
 cog-extract!
@@ -65,7 +63,6 @@ cog-keys->alist
 cog-link
 cog-link?
 cog-map-type
-cog-mean
 cog-name
 cog-new-ast
 cog-new-atom

--- a/opencog/scm/opencog/base/core-docs.scm
+++ b/opencog/scm/opencog/base/core-docs.scm
@@ -651,33 +651,6 @@
       cog-set-value-ref! - Set one location in a vector.
 ")
 
-(set-procedure-property! cog-mean 'documentation
-"
- cog-mean ATOM
-    Return the `mean` of the TruthValue on ATOM. This is a single
-    floating point-number.
-
-    See also: cog-confidence, cog-count, cog-tv
-")
-
-(set-procedure-property! cog-confidence 'documentation
-"
- cog-confidence ATOM
-    Return the `confidence` of the TruthValue on ATOM. This is a single
-    floating point-number.
-
-    See also: cog-mean, cog-count, cog-tv
-")
-
-(set-procedure-property! cog-count 'documentation
-"
- cog-count ATOM
-    Return the `count` of the TruthValue on ATOM. This is a single
-    floating point-number.
-
-    See also: cog-mean, cog-confidence, cog-tv, cog-inc-count!
-")
-
 ; ===================================================================
 
 (set-procedure-property! cog-tv 'documentation

--- a/opencog/scm/opencog/base/utilities.scm
+++ b/opencog/scm/opencog/base/utilities.scm
@@ -1195,3 +1195,35 @@
     (delete-duplicates (append subtypes (apply append rec-subtypes)))))
 
 ; ---------------------------------------------------------------------
+
+(define-public (cog-mean ATOM)
+"
+ cog-mean ATOM
+    Return the `mean` of the TruthValue on ATOM. This is a single
+    floating point-number.
+
+    See also: cog-confidence, cog-count, cog-tv
+"
+	(cog-tv-mean (cog-tv ATOM)))
+
+(define-public (cog-confidence ATOM)
+"
+ cog-confidence ATOM
+    Return the `confidence` of the TruthValue on ATOM. This is a single
+    floating point-number.
+
+    See also: cog-mean, cog-count, cog-tv
+"
+	(cog-tv-confidence (cog-tv ATOM)))
+
+(define-public (cog-count ATOM)
+"
+ cog-count ATOM
+    Return the `count` of the TruthValue on ATOM. This is a single
+    floating point-number.
+
+    See also: cog-mean, cog-confidence, cog-tv, cog-inc-count!
+"
+	(cog-tv-count (cog-tv ATOM)))
+
+; ---------------------------------------------------------------------


### PR DESCRIPTION
These were originally provided as "performance" entry points. But this is not how the API should be used, so these are being removed.

The overall goal is to slim down the guile API, in general.