### PR TITLE
Move TruthValues out of the core implementation

### DIFF
--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -105,36 +105,6 @@ TruthValuePtr Atom::getTruthValue() const
     return TruthValueCast(pap);
 }
 
-TruthValuePtr Atom::incrementCountTV(double cnt)
-{
-	double mean = 1.0;
-	double conf = 0.0;
-
-	// Lock so that count updates are atomic!
-	KVP_UNIQUE_LOCK;
-
-	auto pr = _values.find(truth_key());
-	if (_values.end() != pr)
-	{
-		const TruthValuePtr& tvp = TruthValueCast(pr->second);
-		// tvp might be nullptr, if someone set the TV to something
-		// that is not a truth value. This can happen if the truth
-		// predicate is used directly with setValue().
-		if (tvp)
-		{
-			if (COUNT_TRUTH_VALUE == tvp->get_type())
-				cnt += tvp->get_count();
-			mean = tvp->get_mean();
-			conf = tvp->get_confidence();
-		}
-	}
-
-	TruthValuePtr newTV = createCountTruthValue(mean, conf, cnt);
-
-	_values[truth_key()] = ValueCast(newTV);
-	return newTV;
-}
-
 // ==============================================================
 /// Setting values associated with this atom.
 /// If the value is a null pointer, then the key is removed.

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -585,10 +585,6 @@ public:
     //! Sets the TruthValue object of the atom.
     void setTruthValue(const TruthValuePtr&);
 
-    /// Increment the CountTruthValue atomically.
-    /// Return the new TruthValue
-    TruthValuePtr incrementCountTV(double);
-
     // ---------------------------------------------------
     //! Return true if the incoming set is empty.
     bool isIncomingSetEmpty(const AtomSpace* = nullptr) const;

--- a/opencog/atoms/truthvalue/TruthValue.cc
+++ b/opencog/atoms/truthvalue/TruthValue.cc
@@ -63,13 +63,6 @@ TruthValuePtr TruthValue::FALSE_TV()
 	return instance;
 }
 
-TruthValuePtr TruthValue::TRIVIAL_TV()
-{
-	// False, with no confidence.
-	static TruthValuePtr instance(std::make_shared<SimpleTruthValue>(0.0, 0.0));
-	return instance;
-}
-
 bool TruthValue::isDefaultTV() const
 {
 	static TruthValuePtr dtv(DEFAULT_TV());

--- a/opencog/atoms/truthvalue/TruthValue.cc
+++ b/opencog/atoms/truthvalue/TruthValue.cc
@@ -83,55 +83,6 @@ bool TruthValue::isDefaultTV() const
 	return false;
 }
 
-/**
- * Return true if the TV value is one of the pre-defined TV values.
- */
-bool TruthValue::isDefinedTV() const
-{
-	TruthValuePtr dtv = DEFAULT_TV();
-	if (dtv.get() == this) return true;
-	if (get_type() == dtv->get_type() and
-	    get_mean() == dtv->get_mean() and
-	    get_confidence() == dtv->get_confidence())
-	{
-		return true;
-	}
-
-	dtv = TRUE_TV();
-	if (dtv.get() == this) return true;
-
-	dtv = FALSE_TV();
-	if (dtv.get() == this) return true;
-
-	dtv = TRIVIAL_TV();
-	if (dtv.get() == this) return true;
-
-	dtv = TRUE_TV();
-	if (get_type() == dtv->get_type() and
-	    get_mean() == dtv->get_mean() and
-	    get_confidence() == dtv->get_confidence())
-	{
-		return true;
-	}
-
-	dtv = FALSE_TV();
-	if (get_type() == dtv->get_type() and
-	    get_mean() == dtv->get_mean() and
-	    get_confidence() == dtv->get_confidence())
-	{
-		return true;
-	}
-
-	dtv = TRIVIAL_TV();
-	if (get_type() == dtv->get_type() and
-	    get_mean() == dtv->get_mean() and
-	    get_confidence() == dtv->get_confidence())
-	{
-		return true;
-	}
-	return false;
-}
-
 bool TruthValue::nearly_equal(double a, double b)
 {
 	if (a == b) return true;

--- a/opencog/atoms/truthvalue/TruthValue.h
+++ b/opencog/atoms/truthvalue/TruthValue.h
@@ -100,12 +100,6 @@ public:
 	 * false with absolute confidence.
 	 */
 	static TruthValuePtr FALSE_TV();
-	/**
-	 * The shared reference to a special TRIVIAL (Simple) TruthValue
-	 * object with 0 mean and 0 count. That is, its false, but with
-	 * no confidence.
-	 */
-	static TruthValuePtr TRIVIAL_TV();
 
 	virtual strength_t get_mean()  const = 0;
 	virtual confidence_t get_confidence()  const = 0;

--- a/opencog/atoms/truthvalue/TruthValue.h
+++ b/opencog/atoms/truthvalue/TruthValue.h
@@ -116,7 +116,6 @@ public:
 	 * operator!= only compares pointers.
 	 */
 	virtual bool isDefaultTV() const;
-	virtual bool isDefinedTV() const;
 };
 
 static inline TruthValuePtr TruthValueCast(const ValuePtr& pa)

--- a/opencog/atomspace/AtomSpace.cc
+++ b/opencog/atomspace/AtomSpace.cc
@@ -495,14 +495,6 @@ Handle AtomSpace::set_truthvalue(const Handle& h, const TruthValuePtr& tvp)
 	COWBOY_CODE(SET_TV);
 }
 
-// Copy-on-write for incrementing truth values.
-// The increment is atomic i.e. thread-safe.
-Handle AtomSpace::increment_countTV(const Handle& h, double cnt)
-{
-	#define INC_TV(atm) atm->incrementCountTV(cnt);
-	COWBOY_CODE(INC_TV);
-}
-
 // The increment is atomic i.e. thread-safe.
 Handle AtomSpace::increment_count(const Handle& h, const Handle& key,
                                   const std::vector<double>& count)

--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -417,7 +417,6 @@ public:
      */
     Handle increment_count(const Handle&, const Handle&, const std::vector<double>&);
     Handle increment_count(const Handle&, const Handle&, size_t, double);
-    Handle increment_countTV(const Handle&, double = 1.0);
 
     /**
      * Find an equivalent Atom that is exactly the same as the arg.

--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -347,7 +347,6 @@ void SchemeSmob::register_procs()
 
 	// Value property setters on atoms
 	register_proc("cog-set-tv!",           2, 0, 0, C(ss_set_tv));
-	register_proc("cog-inc-count!",        2, 0, 0, C(ss_inc_count));
 	register_proc("cog-inc-value!",        4, 0, 0, C(ss_inc_value));
 	register_proc("cog-update-value!",     3, 0, 0, C(ss_update_value));
 

--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -346,7 +346,6 @@ void SchemeSmob::register_procs()
 	register_proc("cog-set-value-ref!",    4, 0, 0, C(ss_set_value_ref));
 
 	// Value property setters on atoms
-	register_proc("cog-set-tv!",           2, 0, 0, C(ss_set_tv));
 	register_proc("cog-inc-value!",        4, 0, 0, C(ss_inc_value));
 	register_proc("cog-update-value!",     3, 0, 0, C(ss_update_value));
 

--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -365,7 +365,6 @@ void SchemeSmob::register_procs()
 	register_proc("cog-keys->alist",       1, 0, 0, C(ss_keys_alist));
 	register_proc("cog-value",             2, 0, 0, C(ss_value));
 	register_proc("cog-value-type",        2, 0, 0, C(ss_value_type));
-	register_proc("cog-tv",                1, 0, 0, C(ss_tv));
 	register_proc("cog-atomspace",         0, 1, 0, C(ss_as));
 	register_proc("cog-as",                0, 1, 0, C(ss_as));
 

--- a/opencog/guile/SchemeSmob.cc
+++ b/opencog/guile/SchemeSmob.cc
@@ -371,11 +371,6 @@ void SchemeSmob::register_procs()
 	register_proc("cog-atomspace",         0, 1, 0, C(ss_as));
 	register_proc("cog-as",                0, 1, 0, C(ss_as));
 
-	// Truth-values
-	register_proc("cog-tv-mean",           1, 0, 0, C(ss_tv_get_mean));
-	register_proc("cog-tv-confidence",     1, 0, 0, C(ss_tv_get_confidence));
-	register_proc("cog-tv-count",          1, 0, 0, C(ss_tv_get_count));
-
 	// Atom Spaces
 	register_proc("cog-new-atomspace",     0, 0, 1, C(ss_new_as));
 	register_proc("cog-add-atomspace",     1, 0, 0, C(ss_add_as));

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -141,7 +141,6 @@ private:
 	static SCM from_type(const ValuePtr&);
 	static SCM ss_type(SCM);
 	static SCM ss_arity(SCM);
-	static SCM ss_tv(SCM);
 	static SCM ss_keys(SCM);
 	static SCM ss_keys_alist(SCM);
 	static SCM ss_value(SCM, SCM);
@@ -161,11 +160,6 @@ private:
 	static SCM ss_get_subtypes(SCM);
 	static SCM ss_subtype_p(SCM, SCM);
 	static SCM ss_count(SCM, SCM);
-
-	// Truth values
-	static SCM ss_tv_get_mean(SCM);
-	static SCM ss_tv_get_confidence(SCM);
-	static SCM ss_tv_get_count(SCM);
 
 	// Atom Spaces
 	static SCM ss_new_as(SCM);

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -132,7 +132,6 @@ private:
 	static SCM set_value(const Handle&, const Handle&,
 	                     const ValuePtr&, SCM, const char*);
 	static SCM ss_set_values(SCM, SCM);
-	static SCM ss_inc_count(SCM, SCM);
 	static SCM ss_inc_value(SCM, SCM, SCM, SCM);
 	static SCM ss_update_value(SCM, SCM, SCM);
 	static SCM ss_set_value_ref(SCM, SCM, SCM, SCM);

--- a/opencog/guile/SchemeSmob.h
+++ b/opencog/guile/SchemeSmob.h
@@ -127,7 +127,6 @@ private:
 	static SCM value_ref(const ValuePtr&, size_t);
 
 	// Property setters on atoms
-	static SCM ss_set_tv(SCM, SCM);
 	static SCM ss_set_value(SCM, SCM, SCM);
 	static SCM set_value(const Handle&, const Handle&,
 	                     const ValuePtr&, SCM, const char*);

--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -255,17 +255,7 @@ SCM SchemeSmob::ss_arity (SCM svalue)
 }
 
 /* ============================================================== */
-/* Truth value setters/getters */
-
-SCM SchemeSmob::ss_tv (SCM satom)
-{
-	Handle h = verify_handle(satom, "cog-tv");
-	return protom_to_scm(ValueCast(h->getTruthValue()));
-}
-
-/* ============================================================== */
 /// Atomic increment the count of some generic FloatValue.
-/// Just like ss_inc_count but generic.
 /// key == key for value
 /// cnt == how much to increment
 /// ref == list-ref, which location to increment.

--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -283,20 +283,6 @@ SCM SchemeSmob::ss_set_tv (SCM satom, SCM stv)
 	}
 }
 
-/// Atomic increment the count, keeping mean and confidence as-is.
-/// Converts existing truth value to a CountTruthValue.
-SCM SchemeSmob::ss_inc_count (SCM satom, SCM scnt)
-{
-	Handle h = verify_handle(satom, "cog-inc-count!");
-	double cnt = verify_real(scnt, "cog-inc-count!", 2);
-
-	const AtomSpacePtr& asp = ss_get_env_as("cog-inc-count!");
-	Handle ha(asp->increment_countTV(h, cnt));
-	if (ha == h)
-		return satom;
-	return handle_to_scm(ha);
-}
-
 /* ============================================================== */
 /// Atomic increment the count of some generic FloatValue.
 /// Just like ss_inc_count but generic.

--- a/opencog/guile/SchemeSmobAtom.cc
+++ b/opencog/guile/SchemeSmobAtom.cc
@@ -263,26 +263,6 @@ SCM SchemeSmob::ss_tv (SCM satom)
 	return protom_to_scm(ValueCast(h->getTruthValue()));
 }
 
-SCM SchemeSmob::ss_set_tv (SCM satom, SCM stv)
-{
-	Handle h = verify_handle(satom, "cog-set-tv!");
-	TruthValuePtr tv = verify_tv(stv, "cog-set-tv!", 2);
-	scm_remember_upto_here_1(stv);
-
-	const AtomSpacePtr& asp = ss_get_env_as("cog-set-tv!");
-	try
-	{
-		Handle newh = asp->set_truthvalue(h, tv);
-
-		if (h == newh) return satom;
-		return handle_to_scm(newh);
-	}
-	catch (const std::exception& ex)
-	{
-		throw_exception(ex, "cog-set-tv!", satom);
-	}
-}
-
 /* ============================================================== */
 /// Atomic increment the count of some generic FloatValue.
 /// Just like ss_inc_count but generic.

--- a/opencog/guile/SchemeSmobTV.cc
+++ b/opencog/guile/SchemeSmobTV.cc
@@ -76,34 +76,4 @@ TruthValuePtr SchemeSmob::verify_tv(SCM stv, const char *subrname, int pos)
 	return tv;
 }
 
-/**
- * Return the truth value mean.
- * This is meant to be the fastest-possible of getting the mean.
- */
-SCM SchemeSmob::ss_tv_get_mean(SCM s)
-{
-	TruthValuePtr tv = verify_tv(s, "cog-tv-mean");
-	return scm_from_double(tv->get_mean());
-}
-
-/**
- * Return the truth value confidence
- * This is meant to be the fastest-possible of getting the confidence.
- */
-SCM SchemeSmob::ss_tv_get_confidence(SCM s)
-{
-	TruthValuePtr tv = verify_tv(s, "cog-tv-confidence");
-	return scm_from_double(tv->get_confidence());
-}
-
-/**
- * Return the truth value count
- * This is meant to be the fastest-possible of getting the count.
- */
-SCM SchemeSmob::ss_tv_get_count(SCM s)
-{
-	TruthValuePtr tv = verify_tv(s, "cog-tv-count");
-	return scm_from_double(tv->get_count());
-}
-
 /* ===================== END OF FILE ============================ */

--- a/opencog/scm/opencog.scm
+++ b/opencog/scm/opencog.scm
@@ -52,7 +52,6 @@ cog-extract-recursive!
 cog-get-subtypes
 cog-get-types
 cog-handle
-cog-inc-count!
 cog-incoming-by-type
 cog-incoming-set
 cog-incoming-size
@@ -78,15 +77,10 @@ cog-outgoing-by-type
 cog-outgoing-set
 cog-set-atomspace!
 cog-set-server-mode!
-cog-set-tv!
 cog-set-value!
 cog-set-value-ref!
 cog-set-values!
 cog-subtype?
-cog-tv
-cog-tv-confidence
-cog-tv-count
-cog-tv-mean
 cog-type
 cog-type->int
 cog-update-value!

--- a/opencog/scm/opencog/base/core-docs.scm
+++ b/opencog/scm/opencog/base/core-docs.scm
@@ -647,22 +647,6 @@
     See also: cog-set-tv!
 ")
 
-(set-procedure-property! cog-set-tv! 'documentation
-"
- cog-set-tv! ATOM TV
-    Set the truth-value of ATOM to TV.
-
-    Example:
-       ; Define a node
-       guile> (define x (Concept \"def\"))
-       guile> (cog-tv x)
-       (stv 1 0)
-       guile> (cog-set-tv! x (SimpleTruthValue 0.9 0.8))
-       (ConceptNode \"def\" (stv 0.9 0.8))
-       guile> (cog-tv x)
-       (stv 0.9 0.8)
-")
-
 ; ===================================================================
 
 (set-procedure-property! cog-new-value 'documentation

--- a/opencog/scm/opencog/base/core-docs.scm
+++ b/opencog/scm/opencog/base/core-docs.scm
@@ -630,25 +630,6 @@
 
 ; ===================================================================
 
-(set-procedure-property! cog-tv 'documentation
-"
- cog-tv ATOM
-    Return the truth-value of ATOM.
-
-    Example:
-       ; Define a node
-       guile> (define x
-                 (Concept \"abc\" (SimpleTruthValue 0.2 0.5)))
-       guile> (cog-tv x)
-       (stv 0.2 0.5)
-       guile> (cog-tv? (cog-tv x))
-       #t
-
-    See also: cog-set-tv!
-")
-
-; ===================================================================
-
 (set-procedure-property! cog-new-value 'documentation
 "
  cog-new-value TYPE ARGS

--- a/opencog/scm/opencog/base/core-docs.scm
+++ b/opencog/scm/opencog/base/core-docs.scm
@@ -598,29 +598,6 @@
        #t
 ")
 
-(set-procedure-property! cog-inc-count! 'documentation
-"
-  cog-inc-count! ATOM CNT -- Increment count truth value on ATOM by CNT.
-
-  Atomically increment the count on a CountTruthValue by CNT. The mean
-  and confidence values are left untouched.  CNT may be any floating
-  point number (positive or negative).
-
-  If the current truth value on the ATOM is not a CountTruthValue,
-  then the truth value is replaced by a CountTruthValue, with the
-  count set to CNT.
-
-  The increment is atomic; that is, it is safe against racing threads.
-
-  Example usage:
-     (cog-inc-count! (Concept \"Answer\") 42.0)
-
-  See also:
-      cog-count -- Fetch the current count.
-      cog-inc-value! -- Increment an arbitrary FloatValue.
-      cog-update-value! -- A generic atomic read-modify-write.
-")
-
 (set-procedure-property! cog-inc-value! 'documentation
 "
   cog-inc-value! ATOM KEY CNT REF -- Increment value on ATOM by CNT.

--- a/opencog/scm/opencog/base/core-docs.scm
+++ b/opencog/scm/opencog/base/core-docs.scm
@@ -686,35 +686,7 @@
        (stv 0.9 0.8)
 ")
 
-(set-procedure-property! cog-tv-mean 'documentation
-"
- cog-tv-mean TV
-    Return the `mean` of the TruthValue TV. This is a single
-    floating point-number.
-
-    See also: cog-mean
-")
-
-(set-procedure-property! cog-tv-confidence 'documentation
-"
- cog-tv-confidence TV
-    Return the `confidence` of the TruthValue TV. This is a single
-    floating point-number.
-
-    See also: cog-confidence
-")
-
-(set-procedure-property! cog-tv-count 'documentation
-"
- cog-tv-count TV
-    Return the `count` of the TruthValue TV. This is a single
-    floating point-number.
-
-    See also: cog-count
-")
-
 ; ===================================================================
-;
 
 (set-procedure-property! cog-new-value 'documentation
 "

--- a/opencog/scm/opencog/base/tv.scm
+++ b/opencog/scm/opencog/base/tv.scm
@@ -115,3 +115,33 @@
 )
 
 ; ===================================================================
+
+(define-public (cog-inc-count! ATOM CNT)
+"
+  cog-inc-count! ATOM CNT -- Increment count truth value on ATOM by CNT.
+
+  Atomically increment the count on a CountTruthValue by CNT. The mean
+  and confidence values are left untouched.  CNT may be any floating
+  point number (positive or negative).
+
+  If the current truth value on the ATOM is not a CountTruthValue,
+  then the truth value is replaced by a CountTruthValue, with the
+  count set to CNT.
+
+  The increment is atomic; that is, it is safe against racing threads.
+
+  Example usage:
+     (cog-inc-count! (Concept \"Answer\") 42.0)
+
+  See also:
+      cog-count -- Fetch the current count.
+      cog-inc-value! -- Increment an arbitrary FloatValue.
+      cog-update-value! -- A generic atomic read-modify-write.
+"
+	(define tvkey (Predicate "*-TruthValueKey-*"))
+	(catch #t
+		(lambda () (cog-inc-value! ATOM tvkey CNT 2))
+		(lambda (key . args) (cog-set-value! ATOM tvkey (ctv 1 0 CNT))))
+)
+
+; ===================================================================

--- a/opencog/scm/opencog/base/tv.scm
+++ b/opencog/scm/opencog/base/tv.scm
@@ -76,3 +76,42 @@
 )
 
 ; ===================================================================
+
+(define-public (cog-tv-mean TV)
+"
+ cog-tv-mean TV
+    Return the `mean` of the TruthValue TV. This is a single
+    floating point-number.
+
+    See also: cog-mean
+"
+	(cog-value-ref TV 0)
+)
+
+(define-public (cog-tv-confidence TV)
+"
+ cog-tv-confidence TV
+    Return the `confidence` of the TruthValue TV. This is a single
+    floating point-number.
+
+    See also: cog-confidence
+"
+	(cog-value-ref TV 1)
+)
+
+(define-public (cog-tv-count TV)
+"
+ cog-tv-count TV
+    Return the `count` of the TruthValue TV. This is a single
+    floating point-number.
+
+    See also: cog-count
+"
+	(define DEFAULT_K 800.0)
+	(if (cog-ctv? TV)
+		(cog-value-ref TV 2)
+		(let ((conf (cog-tv-confidence TV)))
+			(/ (* DEFAULT_K conf) (- 1.00000001 conf))))
+)
+
+; ===================================================================

--- a/opencog/scm/opencog/base/tv.scm
+++ b/opencog/scm/opencog/base/tv.scm
@@ -188,3 +188,36 @@
 )
 
 ; ===================================================================
+
+(define-public (cog-mean ATOM)
+"
+ cog-mean ATOM
+    Return the `mean` of the TruthValue on ATOM. This is a single
+    floating point-number.
+
+    See also: cog-confidence, cog-count, cog-tv
+"
+	(cog-tv-mean (cog-tv ATOM)))
+
+
+(define-public (cog-confidence ATOM)
+"
+ cog-confidence ATOM
+    Return the `confidence` of the TruthValue on ATOM. This is a single
+    floating point-number.
+
+    See also: cog-mean, cog-count, cog-tv
+"
+	(cog-tv-confidence (cog-tv ATOM)))
+
+(define-public (cog-count ATOM)
+"
+ cog-count ATOM
+    Return the `count` of the TruthValue on ATOM. This is a single
+    floating point-number.
+
+    See also: cog-mean, cog-confidence, cog-tv, cog-inc-count!
+"
+	(cog-tv-count (cog-tv ATOM)))
+
+; ===================================================================

--- a/opencog/scm/opencog/base/tv.scm
+++ b/opencog/scm/opencog/base/tv.scm
@@ -133,7 +133,8 @@
     See also: cog-set-tv!
 "
 	(define tvkey (Predicate "*-TruthValueKey-*"))
-	(cog-value ATOM tvkey)
+	(define tv (cog-value ATOM tvkey))
+	(if tv tv (stv 1 0))
 )
 
 ; ===================================================================

--- a/opencog/scm/opencog/base/tv.scm
+++ b/opencog/scm/opencog/base/tv.scm
@@ -116,6 +116,28 @@
 
 ; ===================================================================
 
+(define-public (cog-tv ATOM)
+"
+ cog-tv ATOM
+    Return the truth-value of ATOM.
+
+    Example:
+       ; Define a node
+       guile> (define x
+                 (Concept \"abc\" (SimpleTruthValue 0.2 0.5)))
+       guile> (cog-tv x)
+       (stv 0.2 0.5)
+       guile> (cog-tv? (cog-tv x))
+       #t
+
+    See also: cog-set-tv!
+"
+	(define tvkey (Predicate "*-TruthValueKey-*"))
+	(cog-value ATOM tvkey)
+)
+
+; ===================================================================
+
 (define-public (cog-set-tv! ATOM TV)
 "
  cog-set-tv! ATOM TV

--- a/opencog/scm/opencog/base/tv.scm
+++ b/opencog/scm/opencog/base/tv.scm
@@ -116,6 +116,27 @@
 
 ; ===================================================================
 
+(define-public (cog-set-tv! ATOM TV)
+"
+ cog-set-tv! ATOM TV
+    Set the truth-value of ATOM to TV.
+
+    Example:
+       ; Define a node
+       guile> (define x (Concept \"def\"))
+       guile> (cog-tv x)
+       (stv 1 0)
+       guile> (cog-set-tv! x (SimpleTruthValue 0.9 0.8))
+       (ConceptNode \"def\" (stv 0.9 0.8))
+       guile> (cog-tv x)
+       (stv 0.9 0.8)
+"
+	(define tvkey (Predicate "*-TruthValueKey-*"))
+	(cog-set-value! ATOM tvkey TV)
+)
+
+; ===================================================================
+
 (define-public (cog-inc-count! ATOM CNT)
 "
   cog-inc-count! ATOM CNT -- Increment count truth value on ATOM by CNT.

--- a/opencog/scm/opencog/base/utilities.scm
+++ b/opencog/scm/opencog/base/utilities.scm
@@ -1195,35 +1195,3 @@
     (delete-duplicates (append subtypes (apply append rec-subtypes)))))
 
 ; ---------------------------------------------------------------------
-
-(define-public (cog-mean ATOM)
-"
- cog-mean ATOM
-    Return the `mean` of the TruthValue on ATOM. This is a single
-    floating point-number.
-
-    See also: cog-confidence, cog-count, cog-tv
-"
-	(cog-tv-mean (cog-tv ATOM)))
-
-(define-public (cog-confidence ATOM)
-"
- cog-confidence ATOM
-    Return the `confidence` of the TruthValue on ATOM. This is a single
-    floating point-number.
-
-    See also: cog-mean, cog-count, cog-tv
-"
-	(cog-tv-confidence (cog-tv ATOM)))
-
-(define-public (cog-count ATOM)
-"
- cog-count ATOM
-    Return the `count` of the TruthValue on ATOM. This is a single
-    floating point-number.
-
-    See also: cog-mean, cog-confidence, cog-tv, cog-inc-count!
-"
-	(cog-tv-count (cog-tv ATOM)))
-
-; ---------------------------------------------------------------------

--- a/tests/atoms/flow/SetTVUTest.cxxtest
+++ b/tests/atoms/flow/SetTVUTest.cxxtest
@@ -59,15 +59,20 @@ void SetTVUTest::test_copy()
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
 	TruthValuePtr tvp = _eval.eval_tv("(cog-tv (Concept \"bar\"))");
-	TS_ASSERT_EQUALS(tvp, TruthValue::DEFAULT_TV());
+	TruthValuePtr result = TruthValue::DEFAULT_TV();
+
+	printf("expect: %s\n", tvp->to_string().c_str());
+	printf("result: %s\n", result->to_string().c_str());
+	TS_ASSERT(*tvp == *result);
 
 	tvp = _eval.eval_tv("(cog-tv (Concept \"foo\"))");
 
-	TruthValuePtr result = _eval.eval_tv("(cog-execute! copy-tv)");
+	result = _eval.eval_tv("(cog-execute! copy-tv)");
 	printf("expect: %s\n", tvp->to_string().c_str());
 	printf("result: %s\n", result->to_string().c_str());
 
 	TS_ASSERT_EQUALS(tvp, result);
+	// TS_ASSERT(*tvp == *result);
 
 	result = _eval.eval_tv("(cog-tv (Concept \"bar\"))");
 	printf("expect: %s\n", tvp->to_string().c_str());

--- a/tests/atomspace/deep-space-test.scm
+++ b/tests/atomspace/deep-space-test.scm
@@ -80,8 +80,9 @@
 		(test-equal "count-tv" cnt
 			(inexact->exact (cog-tv-count (cog-tv (cog-node 'Concept "hello")))))
 
-		; Each atomspace should contain just one atom.
-		(test-equal "atomspace-size" 1 (count-all))
+		; Each atomspace should contain just two atoms.
+		; One, plus (Predicate "*-TruthValueKey-*")
+		(test-equal "atomspace-size" 2 (count-all))
 		(set! cnt (+ 1 cnt)))
 	space-list)
 
@@ -104,7 +105,8 @@
 		(test-equal "membership" space
 			(cog-atomspace (cog-node 'Concept "hello")))
 
-		(test-equal "atomspace-size" 2 (count-all))
+		; Two atoms, plus (Predicate "*-TruthValueKey-*")
+		(test-equal "atomspace-size" 3 (count-all))
 	)
 	space-list)
 
@@ -203,8 +205,9 @@
 		(test-equal "count-tv" cnt
 			(inexact->exact (cog-tv-count (cog-tv (Concept "hello")))))
 
-		; Each atomspace should contain just three atoms.
-		(test-equal "atomspace-size" 3 (count-all))
+		; Each atomspace should contain just four atoms.
+		; Three, plus (Predicate "*-TruthValueKey-*")
+		(test-equal "atomspace-size" 4 (count-all))
 
 		(test-equal "incoming-size" 1 (cog-incoming-size (Concept "foo")))
 		(test-equal "incoming-size" 1 (cog-incoming-size (Concept "hello")))

--- a/tests/scm/MultiAtomSpaceUTest.cxxtest
+++ b/tests/scm/MultiAtomSpaceUTest.cxxtest
@@ -474,6 +474,7 @@ void MultiAtomSpace::test_readonly_scm(void)
 	logger().debug("BEGIN TEST: %s", __FUNCTION__);
 
 	evaluator->eval("(define A (Concept \"A\"))");
+	evaluator->eval("(cog-tv A)");
 	evaluator->eval("(cog-atomspace-ro!)");
 	evaluator->eval("(define tv (stv 0.1 0.1))");
 
@@ -482,7 +483,7 @@ void MultiAtomSpace::test_readonly_scm(void)
 
 	// Verify that the TV never changed.
 	TruthValuePtr tvp = evaluator->eval_tv("(cog-tv (Concept \"A\"))");
-	TS_ASSERT (TruthValue::DEFAULT_TV() == tvp);
+	TS_ASSERT (*tvp == *TruthValue::DEFAULT_TV());
 
 	logger().debug("END TEST: %s", __FUNCTION__);	
 }

--- a/tests/scm/SCMExecutionOutputUTest.cxxtest
+++ b/tests/scm/SCMExecutionOutputUTest.cxxtest
@@ -297,8 +297,9 @@ void SCMExecutionOutputUTest::test_recursive(void)
 	CHKEV(eval);
 
 	// Now, the atomspace has three atoms (Inheritance julian king)
+	// Plus also (Predicate "*-TruthValueKey-*")
 	size = as->get_size();
-	TS_ASSERT_EQUALS(size, 3);
+	TS_ASSERT_EQUALS(size, 4);
 
 	// Start out with Anneliese a newborn princess.
 	eval->eval(
@@ -306,7 +307,7 @@ void SCMExecutionOutputUTest::test_recursive(void)
 	);
 	CHKEV(eval);
 	size = as->get_size();
-	TS_ASSERT_EQUALS(size, 4);
+	TS_ASSERT_EQUALS(size, 5);
 
 	eval->eval(
 		"(exe-royalize anne)"
@@ -317,8 +318,9 @@ void SCMExecutionOutputUTest::test_recursive(void)
 	// 3:  (Inheritance julian king)
 	// 3:  (Inheritance anne queen)
 	// 3:  (ExecutionLink (GroundedSchemaNode) (ListLink anne))
+	// Plus also (Predicate "*-TruthValueKey-*")
 	size = as->get_size();
-	TS_ASSERT_EQUALS(size, 9);
+	TS_ASSERT_EQUALS(size, 10);
 
 	size = as->get_size();
 


### PR DESCRIPTION
This is the first part of several patch sequences that remove TruthValues from the core C++ implementation.  Wrappers are provided to maintain backwards compatibility. The basic observation is that TruthValues have been superseded by the more generic FloatValues, and maintenance becomes easier by removing teh general cruft that came with TruthValues.  