### PR TITLE
Remove set_truthvalue() method from AtomSpace API

### DIFF
--- a/examples/c++-guile/ExampleSCM.cc
+++ b/examples/c++-guile/ExampleSCM.cc
@@ -22,10 +22,10 @@ Handle ss_print(const Handle& h)
 	return h;
 }
 
-TruthValuePtr ss_printmore(const Handle& h)
+ValuePtr ss_printmore(const Handle& h)
 {
 	printf("This is the atom: %s\n", h->to_string().c_str());
-	return h->getTruthValue();
+	return h->getValue(truth_key());
 }
 
 // ========================================================

--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -73,36 +73,12 @@ Atom::~Atom()
 }
 
 // ==============================================================
+// Singleton key for backwards compat with TruthValues
 
 const Handle& truth_key(void)
 {
 	static Handle tk(createNode(PREDICATE_NODE, "*-TruthValueKey-*"));
 	return tk;
-}
-
-void Atom::setTruthValue(const TruthValuePtr& newTV)
-{
-    if (nullptr == newTV) return;
-
-    // Another setter could be changing this, even as we are.
-    // So make a copy, first.
-    TruthValuePtr oldTV(getTruthValue());
-
-    // If both old and new are e.g. DEFAULT_TV, then do nothing.
-    if (oldTV.get() == newTV.get()) return;
-
-    // ... and we still need to make sure that only one thread is
-    // writing this at a time. std:shared_ptr is NOT thread-safe against
-    // multiple writers: see "Example 5" in
-    // http://www.boost.org/doc/libs/1_53_0/libs/smart_ptr/shared_ptr.htm#ThreadSafety
-    setValue (truth_key(), ValueCast(newTV));
-}
-
-TruthValuePtr Atom::getTruthValue() const
-{
-    ValuePtr pap(getValue(truth_key()));
-    if (nullptr == pap) return TruthValue::DEFAULT_TV();
-    return TruthValueCast(pap);
 }
 
 // ==============================================================

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -578,14 +578,6 @@ public:
     void clearValues();
 
     // ---------------------------------------------------
-    // Old TruthValue API. Deprcated; should be removed.
-    /** Returns the TruthValue object of the atom. */
-    TruthValuePtr getTruthValue() const;
-
-    //! Sets the TruthValue object of the atom.
-    void setTruthValue(const TruthValuePtr&);
-
-    // ---------------------------------------------------
     //! Return true if the incoming set is empty.
     bool isIncomingSetEmpty(const AtomSpace* = nullptr) const;
 

--- a/opencog/atoms/base/Link.cc
+++ b/opencog/atoms/base/Link.cc
@@ -74,7 +74,6 @@ std::string Link::to_short_string(const std::string& indent) const
         KVP_SHARED_LOCK;
         auto pr = _values.find(truth_key());
         if (_values.end() != pr and
-            *(pr->second) != *TruthValue::DEFAULT_TV() and
             SIMPLE_TRUTH_VALUE == pr->second->get_type())
         {
             answer += ' ' + pr->second->to_string();

--- a/opencog/atoms/base/Node.cc
+++ b/opencog/atoms/base/Node.cc
@@ -122,7 +122,6 @@ std::string Node::to_short_string(const std::string& indent) const
         KVP_SHARED_LOCK;
         auto pr = _values.find(truth_key());
         if (_values.end() != pr and
-            *(pr->second) != *TruthValue::DEFAULT_TV() and
             SIMPLE_TRUTH_VALUE == pr->second->get_type())
         {
             answer += ' ' + pr->second->to_string();

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -651,6 +651,10 @@ static bool crispy_maybe(AtomSpace* as,
 	{
 		TruthValuePtr tv(EvaluationLink::do_eval_scratch(as,
 		                 evelnk, scratch, silent));
+		// tv_eval_scratch nelow circa line 814 used to return
+		// (stv 1 0) for DEFAULT_TV. Not it returns nullptr.
+		// Since get_mean was 1.0, we return true for this case.
+		if (nullptr == tv) return true;
 		if (0.5 < tv->get_mean()) return true;
 		return false;
 	}

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -807,9 +807,7 @@ static TruthValuePtr tv_eval_scratch(AtomSpace* as,
 				tvp = scratch->add_atom(evelnk)->getValue(truth_key());
 			else
 				tvp = evelnk->getValue(truth_key());
-			if (tvp)
-				return TruthValueCast(tvp);
-			return TruthValue::DEFAULT_TV(); // what if we just return nullptr ??
+			return TruthValueCast(tvp);
 		}
 
 		HandleSeq args;

--- a/opencog/atoms/truthvalue/TruthValue.cc
+++ b/opencog/atoms/truthvalue/TruthValue.cc
@@ -35,24 +35,15 @@
 
 namespace opencog {
 
-const strength_t MAX_TRUTH  = 1.0;
-
 std::string TruthValue::to_short_string(const std::string& indent) const
 {
 	return to_string(indent);
 }
 
-TruthValuePtr TruthValue::DEFAULT_TV()
-{
-	// True, but no confidence.
-	static TruthValuePtr instance(std::make_shared<SimpleTruthValue>(MAX_TRUTH, 0.0));
-	return instance;
-}
-
 TruthValuePtr TruthValue::TRUE_TV()
 {
 	// True, with maximum confidence.
-	static TruthValuePtr instance(std::make_shared<SimpleTruthValue>(MAX_TRUTH, 1.0));
+	static TruthValuePtr instance(std::make_shared<SimpleTruthValue>(1.0, 1.0));
 	return instance;
 }
 

--- a/opencog/atoms/truthvalue/TruthValue.h
+++ b/opencog/atoms/truthvalue/TruthValue.h
@@ -81,19 +81,12 @@ public:
 	virtual std::string to_short_string(const std::string&) const;
 
 	// Special TVs
-
 	/**
 	 * The shared reference to a special TRUE (Simple) TruthValue
 	 * object with MAX_TRUTH mean and MAX_TV_CONFIDENCE count. That is,
 	 * its true with absolute confidence.
 	 */
 	static TruthValuePtr TRUE_TV();
-	/**
-	 * The shared reference to a special default (Simple) TruthValue
-	 * object with MAX_TRUTH mean and 0 count.  That is, its true,
-	 * but with no confidence.
-	 */
-	static TruthValuePtr DEFAULT_TV();
 	/**
 	 * The shared reference to a special FALSE (Simple) TruthValue
 	 * object with 0 mean and MAX_TV_CONFIDENCE count. That is, its

--- a/opencog/atomspace/AtomSpace.cc
+++ b/opencog/atomspace/AtomSpace.cc
@@ -488,13 +488,6 @@ Handle AtomSpace::set_value(const Handle& h,
 	COWBOY_CODE(SETV);
 }
 
-// Copy-on-write for setting truth values.
-Handle AtomSpace::set_truthvalue(const Handle& h, const TruthValuePtr& tvp)
-{
-   #define SET_TV(atm) atm->setTruthValue(tvp);
-	COWBOY_CODE(SET_TV);
-}
-
 // The increment is atomic i.e. thread-safe.
 Handle AtomSpace::increment_count(const Handle& h, const Handle& key,
                                   const std::vector<double>& count)

--- a/opencog/atomspace/AtomSpace.h
+++ b/opencog/atomspace/AtomSpace.h
@@ -405,7 +405,6 @@ public:
      * If the atom is copied, then the copy is returned.
      */
     Handle set_value(const Handle&, const Handle& key, const ValuePtr& value);
-    Handle set_truthvalue(const Handle&, const TruthValuePtr&);
 
     /**
      * Increment the count on a CountTruthValue, or increment the count

--- a/opencog/cython/opencog/atom.pyx
+++ b/opencog/cython/opencog/atom.pyx
@@ -45,15 +45,16 @@ cdef class Atom(Value):
                 self._name = ""
         return self._name
 
+    # XXX TODO REMOVE THESE SOON
     @property
     def tv(self):
         cdef cAtom* atom_ptr = self.handle.atom_ptr()
         cdef tv_ptr tvp
         if atom_ptr == NULL:   # avoid null-pointer deref
             raise RuntimeError("Null Atom!")
-        tvp = atom_ptr.getTruthValue()
+        tvp = tv_cast(atom_ptr.getValue(truth_key()))
         if (not tvp.get()):
-            raise AttributeError('cAtom returned NULL TruthValue pointer')
+            return createTruthValue(1.0, 0.0)
         return createTruthValue(tvp.get().get_mean(), tvp.get().get_confidence())
 
     @tv.setter
@@ -65,7 +66,7 @@ cdef class Atom(Value):
         cdef cAtom* atom_ptr = self.handle.atom_ptr()
         if atom_ptr == NULL:   # avoid null-pointer deref
             raise RuntimeError("Null Atom!")
-        atom_ptr.setTruthValue(deref((<TruthValue>truth_value)._tvptr()))
+        atom_ptr.setValue(truth_key(), (<TruthValue>truth_value)._vptr())
 
     def id_string(self):
         return self.get_c_handle().get().id_to_string().decode('UTF-8')

--- a/opencog/cython/opencog/atomspace.pxd
+++ b/opencog/cython/opencog/atomspace.pxd
@@ -116,8 +116,6 @@ cdef extern from "opencog/atoms/base/Atom.h" namespace "opencog":
     cdef cppclass cAtom "opencog::Atom" (cValue):
         cAtom()
 
-        tv_ptr getTruthValue()
-        void setTruthValue(tv_ptr tvp)
         void setValue(const cHandle& key, const cValuePtr& value)
         cValuePtr getValue(const cHandle& key) const
         cpp_set[cHandle] getKeys()

--- a/opencog/cython/opencog/atomspace.pxd
+++ b/opencog/cython/opencog/atomspace.pxd
@@ -104,6 +104,7 @@ cdef class TruthValue(Value):
     cdef strength_t _mean(self)
     cdef confidence_t _confidence(self)
     cdef cTruthValue* _ptr(self)
+    cdef cValuePtr _vptr(self)
     cdef tv_ptr* _tvptr(self)
 
 # ContentHash
@@ -146,6 +147,7 @@ cdef extern from "opencog/atoms/base/Atom.h" namespace "opencog":
 
 
     cdef cHandle handle_cast "HandleCast" (cValuePtr) except +
+    cdef cHandle truth_key()
 
 # Handle
 cdef extern from "opencog/atoms/base/Handle.h" namespace "opencog":
@@ -197,7 +199,6 @@ cdef extern from "opencog/atomspace/AtomSpace.h" namespace "opencog":
         cHandle xget_handle(Type t, vector[cHandle])
 
         cHandle set_value(cHandle h, cHandle key, cValuePtr value)
-        cHandle set_truthvalue(cHandle h, tv_ptr tvn)
         cHandle get_atom(cHandle & h)
         bint is_valid_handle(cHandle h)
         int get_size()

--- a/opencog/cython/opencog/atomspace.pxd
+++ b/opencog/cython/opencog/atomspace.pxd
@@ -81,7 +81,6 @@ cdef extern from "opencog/atoms/truthvalue/TruthValue.h" namespace "opencog":
         double get_mean()
         double get_confidence()
         @staticmethod
-        tv_ptr DEFAULT_TV()
         bint operator==(cTruthValue h)
         bint operator!=(cTruthValue h)
 

--- a/opencog/cython/opencog/atomspace.pxd
+++ b/opencog/cython/opencog/atomspace.pxd
@@ -74,15 +74,12 @@ cdef class Value:
 
 
 # TruthValue
-ctypedef double confidence_t
-ctypedef double strength_t
-
 cdef extern from "opencog/atoms/truthvalue/TruthValue.h" namespace "opencog":
     ctypedef shared_ptr[cTruthValue] tv_ptr "opencog::TruthValuePtr"
 
     cdef cppclass cTruthValue "const opencog::TruthValue"(cValue):
-        strength_t get_mean()
-        confidence_t get_confidence()
+        double get_mean()
+        double get_confidence()
         @staticmethod
         tv_ptr DEFAULT_TV()
         bint operator==(cTruthValue h)
@@ -94,15 +91,15 @@ cdef extern from "opencog/atoms/truthvalue/TruthValue.h" namespace "opencog":
 cdef extern from "opencog/atoms/truthvalue/SimpleTruthValue.h" namespace "opencog":
     cdef cppclass cSimpleTruthValue "opencog::SimpleTruthValue"(cTruthValue):
         cSimpleTruthValue(double, double)
-        strength_t get_mean()
-        confidence_t get_confidence()
+        double get_mean()
+        double get_confidence()
         string to_string()
         bint operator==(cTruthValue h)
         bint operator!=(cTruthValue h)
 
 cdef class TruthValue(Value):
-    cdef strength_t _mean(self)
-    cdef confidence_t _confidence(self)
+    cdef double _mean(self)
+    cdef double _confidence(self)
     cdef cTruthValue* _ptr(self)
     cdef cValuePtr _vptr(self)
     cdef tv_ptr* _tvptr(self)

--- a/opencog/cython/opencog/atomspace_details.pyx
+++ b/opencog/cython/opencog/atomspace_details.pyx
@@ -184,13 +184,6 @@ cdef class AtomSpace(Value):
         self.atomspace.set_value(deref(atom.handle), deref(key.handle),
                                  value.get_c_value_ptr())
 
-    def set_truthvalue(self, Atom atom, TruthValue tv):
-        """ Set the truth value on atom
-        """
-        if self.atomspace == NULL:
-            raise RuntimeError("Null AtomSpace!")
-        self.atomspace.set_value(deref(atom.handle), truth_key(), tv._vptr())
-
     # Methods to make the atomspace act more like a standard Python container
     def __contains__(self, atom):
         """ Custom checker to see if object is in AtomSpace """

--- a/opencog/cython/opencog/atomspace_details.pyx
+++ b/opencog/cython/opencog/atomspace_details.pyx
@@ -189,7 +189,7 @@ cdef class AtomSpace(Value):
         """
         if self.atomspace == NULL:
             raise RuntimeError("Null AtomSpace!")
-        self.atomspace.set_truthvalue(deref(atom.handle), deref(tv._tvptr()))
+        self.atomspace.set_value(deref(atom.handle), truth_key(), tv._vptr())
 
     # Methods to make the atomspace act more like a standard Python container
     def __contains__(self, atom):

--- a/opencog/cython/opencog/execute.pyx
+++ b/opencog/cython/opencog/execute.pyx
@@ -1,6 +1,6 @@
 from opencog.atomspace cimport Atom, AtomSpace
 from opencog.atomspace cimport cAtomSpace, cTruthValue
-from opencog.atomspace cimport tv_ptr, strength_t, confidence_t
+from opencog.atomspace cimport tv_ptr
 from opencog.atomspace cimport create_python_value_from_c_value
 
 from cython.operator cimport dereference as deref
@@ -17,6 +17,6 @@ def evaluate_atom(AtomSpace atomspace, Atom atom):
         atomspace.atomspace, deref(atom.handle)
     )
     cdef cTruthValue* result_tv = result_tv_ptr.get()
-    cdef strength_t strength = deref(result_tv).get_mean()
-    cdef confidence_t confidence = deref(result_tv).get_confidence()
+    cdef double strength = deref(result_tv).get_mean()
+    cdef double confidence = deref(result_tv).get_confidence()
     return TruthValue(strength, confidence)

--- a/opencog/cython/opencog/truth_value.pyx
+++ b/opencog/cython/opencog/truth_value.pyx
@@ -43,5 +43,8 @@ cdef class TruthValue(Value):
     cdef cTruthValue* _ptr(self):
         return <cTruthValue*>(self.get_c_value_ptr().get())
 
+    cdef cValuePtr _vptr(self):
+        return <cValuePtr>(self.get_c_value_ptr())
+
     cdef tv_ptr* _tvptr(self):
         return <tv_ptr*>&((<PtrHolder>self.ptr_holder).shared_ptr)

--- a/opencog/cython/opencog/truth_value.pyx
+++ b/opencog/cython/opencog/truth_value.pyx
@@ -18,7 +18,7 @@ cdef class TruthValue(Value):
     # exported in opencog.atomspace. To keep it work before proper fix
     # TruthValue constructor is modified to accept both old parameters
     # (strength and confidence) and new ptr_holder parameter.
-    # def __init__(self, strength_t strength=1.0, confidence_t confidence=1.0, PtrHolder ptr_holder=None):
+    # def __init__(self, double strength=1.0, double confidence=1.0, PtrHolder ptr_holder=None):
     #     cdef tv_ptr c_ptr
     #     if ptr_holder is not None:
     #         super().__init__(ptr_holder)
@@ -34,10 +34,10 @@ cdef class TruthValue(Value):
     def confidence(self):
         return self._confidence()
 
-    cdef strength_t _mean(self):
+    cdef double _mean(self):
         return self._ptr().get_mean()
 
-    cdef confidence_t _confidence(self):
+    cdef double _confidence(self):
         return self._ptr().get_confidence()
 
     cdef cTruthValue* _ptr(self):

--- a/opencog/cython/opencog/type_constructors.pyx
+++ b/opencog/cython/opencog/type_constructors.pyx
@@ -6,8 +6,6 @@
 #
 # This imports all the python wrappers for atom creation.
 #
-from opencog.atomspace cimport strength_t, confidence_t
-
 import warnings
 
 from opencog.atomspace import (createBoolValue,
@@ -57,7 +55,7 @@ def StringValue(arg):
 def UnisetValue(arg=None):
     return createUnisetValue(arg)
 
-def TruthValue(strength_t strength=1.0, confidence_t confidence=1.0):
+def TruthValue(double strength=1.0, double confidence=1.0):
     return createTruthValue(strength, confidence)
 
 # Argh. Need to hand-craft a pyx file for these. XXX FIXME

--- a/opencog/guile/SchemeSmobNew.cc
+++ b/opencog/guile/SchemeSmobNew.cc
@@ -96,15 +96,7 @@ SCM SchemeSmob::protom_to_scm (const ValuePtr& pa)
 ValuePtr SchemeSmob::scm_to_protom (SCM sh)
 {
 	if (not SCM_SMOB_PREDICATE(SchemeSmob::cog_misc_tag, sh))
-#ifdef RAINY_DAY_PROJECT
-	{
-		if (scm_is_false(sh))
-			return ValueCast(TruthValue::FALSE_TV());
-		return ValueCast(TruthValue::TRUE_TV());
-	}
-#else
 		return nullptr;
-#endif
 
 	scm_t_bits misctype = SCM_SMOB_FLAGS(sh);
 	if (COG_PROTOM != misctype) // Should this be a wrong-type-arg?

--- a/opencog/guile/SchemeSmobNew.cc
+++ b/opencog/guile/SchemeSmobNew.cc
@@ -480,7 +480,7 @@ SCM SchemeSmob::ss_new_node (SCM stype, SCM sname, SCM kv_pairs)
 
 		// Look for "stv" and so on.
 		const TruthValuePtr tv(get_tv_from_list(kv_pairs));
-		if (tv) h = asp->set_truthvalue(h, tv);
+		if (tv) h = asp->set_value(h, truth_key(), tv);
 
 		// Are there any keys?
 		// Expecting an association list of key-value pairs, e.g.
@@ -531,7 +531,7 @@ SCM SchemeSmob::ss_node (SCM stype, SCM sname, SCM kv_pairs)
 
 	// If there was a truth value, change it.
 	const TruthValuePtr tv(get_tv_from_list(kv_pairs));
-	if (tv) h = asp->set_truthvalue(h, tv);
+	if (tv) h = asp->set_value(h, truth_key(), tv);
 
 	scm_remember_upto_here_1(kv_pairs);
 	return handle_to_scm (h);
@@ -737,7 +737,7 @@ SCM SchemeSmob::ss_new_link (SCM stype, SCM satom_list)
 
 		// Look for "stv" and so on.
 		const TruthValuePtr tv(get_tv_from_list(satom_list));
-		if (tv) h = atomspace->set_truthvalue(h, tv);
+		if (tv) h = atomspace->set_value(h, truth_key(), tv);
 
 		// Are there any keys?
 		// Expecting an association list of key-value pairs, e.g.
@@ -786,7 +786,7 @@ SCM SchemeSmob::ss_link (SCM stype, SCM satom_list)
 
 	// If there was a truth value, change it.
 	const TruthValuePtr tv(get_tv_from_list(satom_list));
-	if (tv) h = atomspace->set_truthvalue(h, tv);
+	if (tv) h = atomspace->set_value(h, truth_key(), tv);
 
 	scm_remember_upto_here_1(satom_list);
 	return handle_to_scm (h);

--- a/opencog/query/TermMatchMixin.cc
+++ b/opencog/query/TermMatchMixin.cc
@@ -561,7 +561,7 @@ bool TermMatchMixin::eval_term(const Handle& virt,
 	    _nameserver.isA(vty, FUNCTION_LINK))
 	{
 		gvirt = _as->add_atom(gvirt);
-		TruthValuePtr tvp = gvirt->getTruthValue();
+		ValuePtr tvp = gvirt->getValue(truth_key());
 
 		// Avoid null-pointer dereference if user specified a bogus evaluation.
 		// i.e. an evaluation that failed to return a TV.
@@ -573,7 +573,7 @@ bool TermMatchMixin::eval_term(const Handle& virt,
 		DO_LOG({LAZY_LOG_FINE << "Eval_term evaluation yielded tv="
 		                      << tvp->to_string() << std::endl;})
 
-		return crisp_truth_from_tv(tvp);
+		return crisp_truth_from_tv(TruthValueCast(tvp));
 	}
 
 	_temp_aspace->clear();
@@ -724,10 +724,10 @@ bool TermMatchMixin::eval_sentence(const Handle& top,
 	const auto& g = gnds.find(top);
 	if (gnds.end() != g)
 	{
-		TruthValuePtr tvp(g->second->getTruthValue());
+		ValuePtr tvp(g->second->getValue(truth_key()));
 		DO_LOG({LAZY_LOG_FINE << "Non-logical atom has tv="
 		              << tvp->to_string() << std::endl;})
-		return crisp_truth_from_tv(tvp);
+		return crisp_truth_from_tv(TruthValueCast(tvp));
 	}
 
 	// If it's not grounded, then perhaps its executable.

--- a/opencog/scm/opencog/base/tv.scm
+++ b/opencog/scm/opencog/base/tv.scm
@@ -63,7 +63,7 @@
        guile> (cog-tv? y)
        #f
 "
-	(cog-subtype? 'TruthValue (cog-type EXP))
+	(if EXP (cog-subtype? 'TruthValue (cog-type EXP)) #f)
 )
 
 (define-public (cog-ctv? EXP)
@@ -72,7 +72,7 @@
     Return #t if EXP is a CountTruthValue, else return #f.
     Equivalent to (equal? 'CountTruthValue (cog-type EXP))
 "
-	(equal? 'CountTruthValue (cog-type EXP))
+	(if EXP (equal? 'CountTruthValue (cog-type EXP)) #f)
 )
 
 ; ===================================================================
@@ -85,7 +85,7 @@
 
     See also: cog-mean
 "
-	(cog-value-ref TV 0)
+	(if TV (cog-value-ref TV 0) #f)
 )
 
 (define-public (cog-tv-confidence TV)
@@ -96,7 +96,7 @@
 
     See also: cog-confidence
 "
-	(cog-value-ref TV 1)
+	(if TV (cog-value-ref TV 1) #f)
 )
 
 (define-public (cog-tv-count TV)

--- a/opencog/scm/opencog/base/tv.scm
+++ b/opencog/scm/opencog/base/tv.scm
@@ -119,7 +119,8 @@
 (define-public (cog-tv ATOM)
 "
  cog-tv ATOM
-    Return the truth-value of ATOM.
+    Return the truth-value of ATOM. If there is no truth value,
+    set on this ATOM, #f is returned.
 
     Example:
        ; Define a node
@@ -133,8 +134,7 @@
     See also: cog-set-tv!
 "
 	(define tvkey (Predicate "*-TruthValueKey-*"))
-	(define tv (cog-value ATOM tvkey))
-	(if tv tv (stv 1 0))
+	(cog-value ATOM tvkey)
 )
 
 ; ===================================================================

--- a/tests/atoms/flow/FormulaUTest.cxxtest
+++ b/tests/atoms/flow/FormulaUTest.cxxtest
@@ -184,7 +184,7 @@ void FormulaUTest::test_putlink()
 	Handle hset = _eval.eval_h("(cog-execute! put-link)");
 	Handle hevo = hset->getOutgoingAtom(0);
 
-	TruthValuePtr tvp = hevo->getTruthValue();
+	TruthValuePtr tvp = TruthValueCast(hevo->getValue(truth_key()));
 	printf("Putter result=%s\n", tvp->to_string().c_str());
 	TS_ASSERT_EQUALS(tvp->get_type(), SIMPLE_TRUTH_VALUE);
 	FloatValuePtr fvp = FloatValueCast(ValueCast(tvp));

--- a/tests/atoms/flow/FormulaUTest.cxxtest
+++ b/tests/atoms/flow/FormulaUTest.cxxtest
@@ -104,16 +104,12 @@ void FormulaUTest::test_evaluation()
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
 	TruthValuePtr tvp = _eval.eval_tv("(cog-tv my-ev-link)");
-	printf("Get before-ev-stv=%s\n", tvp->to_string().c_str());
-	TS_ASSERT_EQUALS(tvp->get_type(), SIMPLE_TRUTH_VALUE);
-	FloatValuePtr fvp = FloatValueCast(ValueCast(tvp));
-	TS_ASSERT_LESS_THAN(fabs(fvp->value()[0] - 1.0), MAXERR);
-	TS_ASSERT_LESS_THAN(fabs(fvp->value()[1] - 0.0), MAXERR);
+	TS_ASSERT(tvp == nullptr);
 
 	tvp = _eval.eval_tv("(cog-evaluate! my-ev-link)");
 	printf("Get eval-tv=%s\n", tvp->to_string().c_str());
 	TS_ASSERT_EQUALS(tvp->get_type(), SIMPLE_TRUTH_VALUE);
-	fvp = FloatValueCast(ValueCast(tvp));
+	FloatValuePtr fvp = FloatValueCast(ValueCast(tvp));
 	TS_ASSERT_LESS_THAN(fabs(fvp->value()[0] - 0.75), MAXERR);
 	TS_ASSERT_LESS_THAN(fabs(fvp->value()[1] - 0.628), MAXERR);
 
@@ -132,16 +128,12 @@ void FormulaUTest::test_evalform()
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
 	TruthValuePtr tvp = _eval.eval_tv("(cog-tv eval-formula)");
-	printf("Get before-ev-form=%s\n", tvp->to_string().c_str());
-	TS_ASSERT_EQUALS(tvp->get_type(), SIMPLE_TRUTH_VALUE);
-	FloatValuePtr fvp = FloatValueCast(ValueCast(tvp));
-	TS_ASSERT_LESS_THAN(fabs(fvp->value()[0] - 1.0), MAXERR);
-	TS_ASSERT_LESS_THAN(fabs(fvp->value()[1] - 0.0), MAXERR);
+	TS_ASSERT(tvp == nullptr);
 
 	tvp = _eval.eval_tv("(cog-evaluate! eval-formula)");
 	printf("Get eval-formula=%s\n", tvp->to_string().c_str());
 	TS_ASSERT_EQUALS(tvp->get_type(), SIMPLE_TRUTH_VALUE);
-	fvp = FloatValueCast(ValueCast(tvp));
+	FloatValuePtr fvp = FloatValueCast(ValueCast(tvp));
 	TS_ASSERT_LESS_THAN(fabs(fvp->value()[0] - 0.52), MAXERR);
 	TS_ASSERT_LESS_THAN(fabs(fvp->value()[1] - 0.9), MAXERR);
 
@@ -154,11 +146,7 @@ void FormulaUTest::test_evalform()
 
 	// ------------------
 	tvp = _eval.eval_tv("(cog-tv eval-lambda)");
-	printf("Get before-ev-lambda=%s\n", tvp->to_string().c_str());
-	TS_ASSERT_EQUALS(tvp->get_type(), SIMPLE_TRUTH_VALUE);
-	fvp = FloatValueCast(ValueCast(tvp));
-	TS_ASSERT_LESS_THAN(fabs(fvp->value()[0] - 1.0), MAXERR);
-	TS_ASSERT_LESS_THAN(fabs(fvp->value()[1] - 0.0), MAXERR);
+	TS_ASSERT(tvp == nullptr);
 
 	tvp = _eval.eval_tv("(cog-evaluate! eval-lambda)");
 	printf("Get eval-lambda=%s\n", tvp->to_string().c_str());
@@ -238,11 +226,7 @@ void FormulaUTest::test_define()
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
 	TruthValuePtr tvp = _eval.eval_tv("(cog-tv red-form)");
-	printf("Get before red-form=%s\n", tvp->to_string().c_str());
-	TS_ASSERT_EQUALS(tvp->get_type(), SIMPLE_TRUTH_VALUE);
-	FloatValuePtr fvp = FloatValueCast(ValueCast(tvp));
-	TS_ASSERT_LESS_THAN(fabs(fvp->value()[0] - 1.0), MAXERR);
-	TS_ASSERT_LESS_THAN(fabs(fvp->value()[1] - 0.0), MAXERR);
+	TS_ASSERT(tvp == nullptr);
 
 	// --------------
 	_eval.eval("(cog-set-value! atom-a tvkey (SimpleTruthValue 0.3 0.5))");
@@ -251,7 +235,7 @@ void FormulaUTest::test_define()
 	tvp = _eval.eval_tv("(cog-evaluate! red-form)");
 	printf("New red-form=%s\n", tvp->to_string().c_str());
 	TS_ASSERT_EQUALS(tvp->get_type(), SIMPLE_TRUTH_VALUE);
-	fvp = FloatValueCast(ValueCast(tvp));
+	FloatValuePtr fvp = FloatValueCast(ValueCast(tvp));
 	TS_ASSERT_LESS_THAN(fabs(fvp->value()[0] - 0.88), MAXERR);
 	TS_ASSERT_LESS_THAN(fabs(fvp->value()[1] - 0.25), MAXERR);
 

--- a/tests/atomspace/AtomSpaceUTest.cxxtest
+++ b/tests/atomspace/AtomSpaceUTest.cxxtest
@@ -55,7 +55,7 @@ using namespace std;
 Handle addRealAtom(AtomSpace& as, Handle atom,
                    TruthValuePtr tvn = TruthValuePtr())
 {
-    TruthValuePtr newTV = tvn ? tvn: atom->getTruthValue();
+    TruthValuePtr newTV = tvn ? tvn: TruthValueCast(atom->getValue(truth_key()));
     // Check if the given Atom reference is of an atom
     // that was not inserted yet.  If so, adds the atom. Otherwise, just sets
     // result to the correct/valid handle.
@@ -67,7 +67,7 @@ Handle addRealAtom(AtomSpace& as, Handle atom,
         if (result == Handle::UNDEFINED) {
             result = as.add_node(node->get_type(),
                                  std::move(std::string(node->get_name())));
-            result->setTruthValue(newTV);
+            result->setValue(truth_key(), newTV);
             return result;
         }
     } else {
@@ -76,11 +76,11 @@ Handle addRealAtom(AtomSpace& as, Handle atom,
         if (result == Handle::UNDEFINED) {
             result = as.add_link(link->get_type(),
                                  std::move(HandleSeq(link->getOutgoingSet())));
-            result->setTruthValue(newTV);
+            result->setValue(truth_key(), newTV);
             return result;
         }
     }
-    result->setTruthValue(newTV);
+    result->setValue(truth_key(), newTV);
     return result;
 }
 
@@ -96,24 +96,24 @@ HandleSeq createSimpleGraph(AtomSpace* atomSpace, const char* baseName)
     TruthValuePtr tv3 = createSimpleTruthValue(0.5, 0.99);
     buf[baseNameLength] = '1';
     Handle h1 = atomSpace->add_node(CONCEPT_NODE, buf);
-    h1->setTruthValue(tv1);
+    h1->setValue(truth_key(), tv1);
     buf[baseNameLength] = '2';
     Handle h2 = atomSpace->add_node(CONCEPT_NODE, buf);
-    h2->setTruthValue(tv2);
+    h2->setValue(truth_key(), tv2);
     buf[baseNameLength] = '3';
     Handle h3 = atomSpace->add_node(CONCEPT_NODE, buf);
-    h3->setTruthValue(tv3);
+    h3->setValue(truth_key(), tv3);
 
     HandleSeq outgoing1;
     outgoing1.push_back(h2);
     outgoing1.push_back(h3);
     Handle l1 = atomSpace->add_link(LIST_LINK, std::move(outgoing1));
-    l1->setTruthValue(tv1);
+    l1->setValue(truth_key(), tv1);
     HandleSeq outgoing2;
     outgoing2.push_back(h1);
     outgoing2.push_back(l1);
     Handle l2 = atomSpace->add_link(EVALUATION_LINK, std::move(outgoing2));
-    l2->setTruthValue(tv2);
+    l2->setValue(truth_key(), tv2);
 
     HandleSeq testAtoms;
     testAtoms.push_back(h1);
@@ -284,7 +284,7 @@ public:
 
     struct mean : public HandlePredicate {
         virtual bool test(const Handle& h) const {
-            return h->getTruthValue()->get_mean() > 0.8;
+            return TruthValueCast(h->getValue(truth_key()))->get_mean() > 0.8;
         }
     };
 
@@ -310,7 +310,7 @@ public:
         Handle h[NUM_NODES];
         for (int i = 0; i < NUM_NODES; i++) {
             h[i] = atomSpace->add_node(CONCEPT_NODE, nodeNames[i]);
-            h[i]->setTruthValue(createSimpleTruthValue(0.001, 0.99));
+            h[i]->setValue(truth_key(), createSimpleTruthValue(0.001, 0.99));
         }
         logger().debug("Nodes created");
 
@@ -321,7 +321,7 @@ public:
             temp[0] = h[i];
             temp[1] = h[4];
             FU[i] = atomSpace->add_link(SUBSET_LINK, std::move(temp));
-            FU[i]->setTruthValue(createSimpleTruthValue(ForceUser[i], 0.99));
+            FU[i]->setValue(truth_key(), createSimpleTruthValue(ForceUser[i], 0.99));
         }
         logger().debug("ForceUser links created");
 
@@ -333,32 +333,32 @@ public:
             out[i].push_back(h[5]);
             H[i] = atomSpace->add_link(INHERITANCE_LINK,
                                        std::move(HandleSeq(out[i])));
-            H[i]->setTruthValue(createSimpleTruthValue(Human[i], 0.99));
+            H[i]->setValue(truth_key(), createSimpleTruthValue(Human[i], 0.99));
         }
         logger().debug("Human links created");
 
         // Check TVS
         for (int i = 0; i < NUM_NODES; i++) {
-            TruthValuePtr tv = h[i]->getTruthValue();
+            TruthValuePtr tv = TruthValueCast(h[i]->getValue(truth_key()));
             logger().debug("h: tv mean = %f, atomSpace->getMean(h[i]) = %f",
-                 tv->get_mean(), h[i]->getTruthValue()->get_mean());
+                 tv->get_mean(), TruthValueCast(h[i]->getValue(truth_key()))->get_mean());
             TS_ASSERT(fabs(tv->get_mean() - 0.001) < FLOAT_ACCEPTABLE_ERROR);
             logger().debug("h: confidence = %f, diff = %f, error = %f", tv->get_confidence(), fabs(tv->get_confidence() - 0.99), FLOAT_ACCEPTABLE_ERROR);
             TS_ASSERT(fabs(tv->get_confidence() - 0.99) < FLOAT_ACCEPTABLE_ERROR);
             if (i < NUM_FORCEUSER_LINKS) {
-                TruthValuePtr tv = FU[i]->getTruthValue();
+                TruthValuePtr tv = TruthValueCast(FU[i]->getValue(truth_key()));
                 logger().debug("h: tv mean = %f, atomSpace->getMean(h[i]) = %f",
-                  tv->get_mean(), h[i]->getTruthValue()->get_mean());
+                  tv->get_mean(), TruthValueCast(h[i]->getValue(truth_key()))->get_mean());
                 logger().debug("FU: tv mean = %f, atomSpace->getMean(FU[i]) = %f\n",
-                 tv->get_mean(), FU[i]->getTruthValue()->get_mean());
+                 tv->get_mean(), TruthValueCast(FU[i]->getValue(truth_key()))->get_mean());
                 TS_ASSERT(fabs(tv->get_mean() - ForceUser[i]) < FLOAT_ACCEPTABLE_ERROR);
                 logger().debug("FU: confidence = %f, diff = %f, error = %f", tv->get_confidence(), fabs(tv->get_confidence() - 0.99), FLOAT_ACCEPTABLE_ERROR);
                 TS_ASSERT(fabs(tv->get_confidence() - 0.99) < FLOAT_ACCEPTABLE_ERROR);
             }
             if (i < NUM_HUMAN_LINKS) {
-                TruthValuePtr tv = H[i]->getTruthValue();
+                TruthValuePtr tv = TruthValueCast(H[i]->getValue(truth_key()));
                 logger().debug("h: tv mean = %f, atomSpace->getMean(h[i]) = %f",
-                     tv->get_mean(), h[i]->getTruthValue()->get_mean());
+                     tv->get_mean(), TruthValueCast(h[i]->getValue(truth_key()))->get_mean());
                 TS_ASSERT(fabs(tv->get_mean() - Human[i]) < FLOAT_ACCEPTABLE_ERROR);
                 logger().debug("H: confidence = %f, diff = %f, error = %f", tv->get_confidence(), fabs(tv->get_confidence() - 0.99), FLOAT_ACCEPTABLE_ERROR);
                 TS_ASSERT(fabs(tv->get_confidence() - 0.99) < FLOAT_ACCEPTABLE_ERROR);
@@ -503,34 +503,34 @@ public:
         TruthValuePtr tv2 = createSimpleTruthValue(0.001, 0.00001);
         TruthValuePtr tv3 = createSimpleTruthValue(0.5, 0.99);
         Handle h1 = atomSpace->add_node(PREDICATE_NODE, "barkingAt");
-        h1->setTruthValue(tv1);
+        h1->setValue(truth_key(), tv1);
         Handle h2 = atomSpace->add_node(CONCEPT_NODE, "dog1");
-        h2->setTruthValue(tv2);
+        h2->setValue(truth_key(), tv2);
         Handle h3 = atomSpace->add_node(CONCEPT_NODE, "tree");
-        h3->setTruthValue(tv3);
+        h3->setValue(truth_key(), tv3);
 
         tv1 = createSimpleTruthValue(0.002, 0.00002);
         tv2 = createSimpleTruthValue(0.1, 0.0);
         tv3 = createSimpleTruthValue(0.6, 0.90);
-        h1->setTruthValue(tv1);
-        h2->setTruthValue(tv2);
-        h3->setTruthValue(tv3);
+        h1->setValue(truth_key(), tv1);
+        h2->setValue(truth_key(), tv2);
+        h3->setValue(truth_key(), tv3);
         Handle h1_ = atomSpace->add_node(PREDICATE_NODE, "barkingAt");
         Handle h2_ = atomSpace->add_node(CONCEPT_NODE, "dog1");
         Handle h3_ = atomSpace->add_node(CONCEPT_NODE, "tree");
 
         TS_ASSERT(h1 == h1_);
-        TruthValuePtr h1tv = h1->getTruthValue();
+        TruthValuePtr h1tv = TruthValueCast(h1->getValue(truth_key()));
         logger().debug("h1tv = %s", h1tv->to_string().c_str());
         logger().debug("tv1 = %s", tv1->to_string().c_str());
         TS_ASSERT(fabs(h1tv->get_mean() - tv1->get_mean()) < FLOAT_ACCEPTABLE_ERROR);
         TS_ASSERT(fabs(h1tv->get_count() - tv1->get_count()) < FLOAT_ACCEPTABLE_ERROR);
         TS_ASSERT(h2 == h2_);
-        TruthValuePtr h2tv = h2->getTruthValue();
+        TruthValuePtr h2tv = TruthValueCast(h2->getValue(truth_key()));
         TS_ASSERT(fabs(h2tv->get_mean() - tv2->get_mean()) < FLOAT_ACCEPTABLE_ERROR);
         TS_ASSERT(fabs(h2tv->get_count() - tv2->get_count()) < FLOAT_ACCEPTABLE_ERROR);
         TS_ASSERT(h3 == h3_);
-        TruthValuePtr h3tv = h3->getTruthValue();
+        TruthValuePtr h3tv = TruthValueCast(h3->getValue(truth_key()));
         TS_ASSERT(fabs(h3tv->get_mean() - tv3->get_mean()) < FLOAT_ACCEPTABLE_ERROR);
         TS_ASSERT(fabs(h3tv->get_count() - tv3->get_count()) < FLOAT_ACCEPTABLE_ERROR);
 
@@ -556,11 +556,11 @@ public:
     {
         logger().info("Begin testAddLink()");
         Handle h1 = atomSpace->add_node(PREDICATE_NODE, "barkingAt");
-        h1->setTruthValue(createSimpleTruthValue(0.001, 0.00001));
+        h1->setValue(truth_key(), createSimpleTruthValue(0.001, 0.00001));
         Handle h2 = atomSpace->add_node(CONCEPT_NODE, "dog1");
-        h2->setTruthValue(createSimpleTruthValue(0.001, 0.00001));
+        h2->setValue(truth_key(), createSimpleTruthValue(0.001, 0.00001));
         Handle h3 = atomSpace->add_node(CONCEPT_NODE, "tree");
-        h3->setTruthValue(createSimpleTruthValue(0.5, 0.99));
+        h3->setValue(truth_key(), createSimpleTruthValue(0.5, 0.99));
         TruthValuePtr tv1 = createSimpleTruthValue(0.001, 0.00001);
         TruthValuePtr tv2 = createSimpleTruthValue(0.001, 0.00001);
         HandleSeq outgoing1;
@@ -568,31 +568,31 @@ public:
         outgoing1.push_back(h3);
         Handle l1 = atomSpace->add_link(LIST_LINK,
                                         std::move(HandleSeq(outgoing1)));
-        l1->setTruthValue(tv1);
+        l1->setValue(truth_key(), tv1);
         HandleSeq outgoing2;
         outgoing2.push_back(h1);
         outgoing2.push_back(l1);
         Handle l2 = atomSpace->add_link(EVALUATION_LINK,
                                         std::move(HandleSeq(outgoing2)));
-        l2->setTruthValue(tv2);
+        l2->setValue(truth_key(), tv2);
 
         tv1 = createSimpleTruthValue(0.002, 0.00002);
-        l1->setTruthValue(tv1);
+        l1->setValue(truth_key(), tv1);
         Handle l1_ = atomSpace->add_link(LIST_LINK,
                                          std::move(HandleSeq(outgoing1)));
         tv2 = createSimpleTruthValue(0.1, 0.0);
-        l2->setTruthValue(tv2);
+        l2->setValue(truth_key(), tv2);
         Handle l2_ = atomSpace->add_link(EVALUATION_LINK,
                                          std::move(HandleSeq(outgoing2)));
 
         TS_ASSERT(l1 == l1_);
-        TruthValuePtr l1tv = l1->getTruthValue();
+        TruthValuePtr l1tv = TruthValueCast(l1->getValue(truth_key()));
         logger().debug("l1tv = %s", l1tv->to_string().c_str());
         logger().debug("tv1 = %s", tv1->to_string().c_str());
         TS_ASSERT(fabs(l1tv->get_mean() - tv1->get_mean()) < FLOAT_ACCEPTABLE_ERROR);
         TS_ASSERT(fabs(l1tv->get_count() - tv1->get_count()) < FLOAT_ACCEPTABLE_ERROR);
         TS_ASSERT(l2 ==  l2_);
-        TruthValuePtr l2tv = l2->getTruthValue();
+        TruthValuePtr l2tv = TruthValueCast(l2->getValue(truth_key()));
         TS_ASSERT(fabs(l2tv->get_mean() - tv2->get_mean()) < FLOAT_ACCEPTABLE_ERROR);
         TS_ASSERT(fabs(l2tv->get_count() - tv2->get_count()) < FLOAT_ACCEPTABLE_ERROR);
 
@@ -608,10 +608,10 @@ public:
         logger().info("Begin testTVUpdate");
 
         Handle h1 = createNode(CONCEPT_NODE, "dog1");
-        h1->setTruthValue(createSimpleTruthValue(0.001, 0.00001));
+        h1->setValue(truth_key(), createSimpleTruthValue(0.001, 0.00001));
         Handle ash1 = atomSpace->add_atom(h1);
         TruthValuePtr tv1 = createSimpleTruthValue(0.001, 0.00001);
-        TruthValuePtr htv = ash1->getTruthValue();
+        TruthValuePtr htv = TruthValueCast(ash1->getValue(truth_key()));
         logger().debug("ash1 = %s", ash1->to_string().c_str());
         logger().debug("htv = %s", htv->to_string().c_str());
         logger().debug("tv1 = %s", tv1->to_string().c_str());
@@ -620,26 +620,26 @@ public:
         TS_ASSERT(fabs(htv->get_count() - tv1->get_count()) < FLOAT_ACCEPTABLE_ERROR);
 
         Handle h2 = createNode(CONCEPT_NODE, "dog1");
-        h2->setTruthValue(createSimpleTruthValue(0.02, 0.002));
+        h2->setValue(truth_key(), createSimpleTruthValue(0.02, 0.002));
         Handle ash2 = atomSpace->add_atom(h2);
         TruthValuePtr tv2 = createSimpleTruthValue(0.02, 0.002);
         logger().debug("ash2 = %s", ash2->to_string().c_str());
 
         TS_ASSERT(ash1 == ash2);
-        htv = ash1->getTruthValue();
+        htv = TruthValueCast(ash1->getValue(truth_key()));
         logger().debug("htv = %s", htv->to_string().c_str());
         logger().debug("tv2 = %s", tv2->to_string().c_str());
         TS_ASSERT(fabs(htv->get_mean() - tv2->get_mean()) < FLOAT_ACCEPTABLE_ERROR);
         TS_ASSERT(fabs(htv->get_count() - tv2->get_count()) < FLOAT_ACCEPTABLE_ERROR);
 
         Handle h3 = createNode(CONCEPT_NODE, "dog1");
-        h3->setTruthValue(createSimpleTruthValue(0.3, 0.03));
+        h3->setValue(truth_key(), createSimpleTruthValue(0.3, 0.03));
         Handle ash3 = atomSpace->add_atom(h3);
         TruthValuePtr tv3 = createSimpleTruthValue(0.3, 0.03);
         logger().debug("ash3 = %s", ash3->to_string().c_str());
 
         TS_ASSERT(ash1 == ash3);
-        htv = ash1->getTruthValue();
+        htv = TruthValueCast(ash1->getValue(truth_key()));
         logger().debug("htv = %s", htv->to_string().c_str());
         logger().debug("tv3 = %s", tv3->to_string().c_str());
         TS_ASSERT(fabs(htv->get_mean() - tv3->get_mean()) < FLOAT_ACCEPTABLE_ERROR);
@@ -662,11 +662,11 @@ public:
     void testGetHandleSetByName()
     {
         Handle h1 = atomSpace->add_node(PREDICATE_NODE, "dog1");
-        h1->setTruthValue(createSimpleTruthValue(0.001, 0.00001));
+        h1->setValue(truth_key(), createSimpleTruthValue(0.001, 0.00001));
         Handle h2 = atomSpace->add_node(CONCEPT_NODE, "dog1");
-        h2->setTruthValue(createSimpleTruthValue(0.001, 0.00001));
+        h2->setValue(truth_key(), createSimpleTruthValue(0.001, 0.00001));
         Handle h3 = atomSpace->add_node(NODE, "dog1");
-        h3->setTruthValue(createSimpleTruthValue(0.5, 0.99));
+        h3->setValue(truth_key(), createSimpleTruthValue(0.5, 0.99));
 
         HandleSeq namedAtoms;
         atomSpace->get_handles_by_type(namedAtoms, NODE, true);

--- a/tests/atomspace/COWSpaceUTest.cxxtest
+++ b/tests/atomspace/COWSpaceUTest.cxxtest
@@ -78,24 +78,24 @@ public:
 		TruthValuePtr tv3(createSimpleTruthValue(0.3, 0.3));
 		Handle h2o = ovly->set_value(h2, truth_key(), tv3);
 		TS_ASSERT(h2 != h2o);
-		TS_ASSERT(h2o->getTruthValue() == tv3);
-		TS_ASSERT(h2->getTruthValue() == tv2);
+		TS_ASSERT(h2o->getValue(truth_key()) == tv3);
+		TS_ASSERT(h2->getValue(truth_key()) == tv2);
 
 		Handle h2b = base->add_node(CONCEPT_NODE, "Grade A2");
 		TS_ASSERT(h2 == h2b);
-		TS_ASSERT(h2b->getTruthValue() == tv2);
+		TS_ASSERT(h2b->getValue(truth_key()) == tv2);
 
 		// Setting truth value a second time in overlay should NOT COW
 		TruthValuePtr tv4(createSimpleTruthValue(0.4, 0.4));
 		Handle h2v = ovly->set_value(h2, truth_key(), tv4);
 		TS_ASSERT(h2 != h2v);
 		TS_ASSERT(h2o == h2v);
-		TS_ASSERT(h2o->getTruthValue() == tv4);
-		TS_ASSERT(h2->getTruthValue() == tv2);
+		TS_ASSERT(h2o->getValue(truth_key()) == tv4);
+		TS_ASSERT(h2->getValue(truth_key()) == tv2);
 
 		Handle h2c = base->add_node(CONCEPT_NODE, "Grade A2");
 		TS_ASSERT(h2 == h2c);
-		TS_ASSERT(h2c->getTruthValue() == tv2);
+		TS_ASSERT(h2c->getValue(truth_key()) == tv2);
 
 		logger().debug("END TEST: %s", __FUNCTION__);
 	}
@@ -124,37 +124,37 @@ public:
 		// Setting truth value in overlay should trigger COW
 		Handle h2o = ovly->set_value(h2, truth_key(), tv3);
 		TS_ASSERT(h2 != h2o);
-		TS_ASSERT(h2o->getTruthValue() == tv3);
-		TS_ASSERT(h2->getTruthValue() == tv2);
+		TS_ASSERT(h2o->getValue(truth_key()) == tv3);
+		TS_ASSERT(h2->getValue(truth_key()) == tv2);
 
 		// No problem touching the base space.
 		Handle h2b = base->add_node(CONCEPT_NODE, "Grade A2");
 		TS_ASSERT(h2 == h2b);
-		TS_ASSERT(h2b->getTruthValue() == tv2);
+		TS_ASSERT(h2b->getValue(truth_key()) == tv2);
 
 		// No problem altering the base space.
 		Handle h4b = base->set_value(h2, truth_key(), tv4);
 		TS_ASSERT(h2 == h4b);
-		TS_ASSERT(h4b->getTruthValue() == tv4);
+		TS_ASSERT(h4b->getValue(truth_key()) == tv4);
 
 		// The TV in the overlay should not have been affected,
 		// when the TV in the base was changed.
 		Handle h2u = ovly->add_node(CONCEPT_NODE, "Grade A2");
 		TS_ASSERT(h2 != h2u);
 		TS_ASSERT(h2o == h2u);
-		TS_ASSERT(h2u->getTruthValue() == tv3);
+		TS_ASSERT(h2u->getValue(truth_key()) == tv3);
 
 		// Setting truth value a second time in overlay should NOT COW
 		Handle h2v = ovly->set_value(h2, truth_key(), tv5);
 		TS_ASSERT(h2 != h2v);
 		TS_ASSERT(h2o == h2v);
-		TS_ASSERT(h2o->getTruthValue() == tv5);
-		TS_ASSERT(h2->getTruthValue() == tv4);
+		TS_ASSERT(h2o->getValue(truth_key()) == tv5);
+		TS_ASSERT(h2->getValue(truth_key()) == tv4);
 
 		// Base should be OK.
 		Handle h2c = base->add_node(CONCEPT_NODE, "Grade A2");
 		TS_ASSERT(h2 == h2c);
-		TS_ASSERT(h2c->getTruthValue() == tv4);
+		TS_ASSERT(h2c->getValue(truth_key()) == tv4);
 
 		logger().debug("END TEST: %s", __FUNCTION__);
 	}

--- a/tests/atomspace/COWSpaceUTest.cxxtest
+++ b/tests/atomspace/COWSpaceUTest.cxxtest
@@ -61,11 +61,11 @@ public:
 
 		// Create two atoms in the base atomspace
 		Handle h1 = base->add_node(CONCEPT_NODE, "A1 beef");
-		Handle h1t = base->set_truthvalue(h1, tv1);
+		Handle h1t = base->set_value(h1, truth_key(), tv1);
 		TS_ASSERT(h1 == h1t);
 
 		Handle h2 = base->add_node(CONCEPT_NODE, "Grade A2");
-		Handle h2t = base->set_truthvalue(h2, tv2);
+		Handle h2t = base->set_value(h2, truth_key(), tv2);
 		TS_ASSERT(h2 == h2t);
 
 		// Setting base to read-only should prevent insertion
@@ -76,7 +76,7 @@ public:
 
 		// Setting truth value in overlay should trigger COW
 		TruthValuePtr tv3(createSimpleTruthValue(0.3, 0.3));
-		Handle h2o = ovly->set_truthvalue(h2, tv3);
+		Handle h2o = ovly->set_value(h2, truth_key(), tv3);
 		TS_ASSERT(h2 != h2o);
 		TS_ASSERT(h2o->getTruthValue() == tv3);
 		TS_ASSERT(h2->getTruthValue() == tv2);
@@ -87,7 +87,7 @@ public:
 
 		// Setting truth value a second time in overlay should NOT COW
 		TruthValuePtr tv4(createSimpleTruthValue(0.4, 0.4));
-		Handle h2v = ovly->set_truthvalue(h2, tv4);
+		Handle h2v = ovly->set_value(h2, truth_key(), tv4);
 		TS_ASSERT(h2 != h2v);
 		TS_ASSERT(h2o == h2v);
 		TS_ASSERT(h2o->getTruthValue() == tv4);
@@ -114,15 +114,15 @@ public:
 
 		// Create two atoms in the base atomspace
 		Handle h1 = base->add_node(CONCEPT_NODE, "A1 beef");
-		Handle h1t = base->set_truthvalue(h1, tv1);
+		Handle h1t = base->set_value(h1, truth_key(), tv1);
 		TS_ASSERT(h1 == h1t);
 
 		Handle h2 = base->add_node(CONCEPT_NODE, "Grade A2");
-		Handle h2t = base->set_truthvalue(h2, tv2);
+		Handle h2t = base->set_value(h2, truth_key(), tv2);
 		TS_ASSERT(h2 == h2t);
 
 		// Setting truth value in overlay should trigger COW
-		Handle h2o = ovly->set_truthvalue(h2, tv3);
+		Handle h2o = ovly->set_value(h2, truth_key(), tv3);
 		TS_ASSERT(h2 != h2o);
 		TS_ASSERT(h2o->getTruthValue() == tv3);
 		TS_ASSERT(h2->getTruthValue() == tv2);
@@ -133,7 +133,7 @@ public:
 		TS_ASSERT(h2b->getTruthValue() == tv2);
 
 		// No problem altering the base space.
-		Handle h4b = base->set_truthvalue(h2, tv4);
+		Handle h4b = base->set_value(h2, truth_key(), tv4);
 		TS_ASSERT(h2 == h4b);
 		TS_ASSERT(h4b->getTruthValue() == tv4);
 
@@ -145,7 +145,7 @@ public:
 		TS_ASSERT(h2u->getTruthValue() == tv3);
 
 		// Setting truth value a second time in overlay should NOT COW
-		Handle h2v = ovly->set_truthvalue(h2, tv5);
+		Handle h2v = ovly->set_value(h2, truth_key(), tv5);
 		TS_ASSERT(h2 != h2v);
 		TS_ASSERT(h2o == h2v);
 		TS_ASSERT(h2o->getTruthValue() == tv5);

--- a/tests/atomspace/MultiSpaceUTest.cxxtest
+++ b/tests/atomspace/MultiSpaceUTest.cxxtest
@@ -72,11 +72,11 @@ public:
 
 		// Create three atoms in three different atomspaces
 		Handle h1 = as1.add_node(CONCEPT_NODE, "1");
-		h1->setTruthValue(tv1);
+		h1->setValue(truth_key(), tv1);
 		Handle h2 = as2.add_node(NUMBER_NODE, "2");
-		h2->setTruthValue(tv2);
+		h2->setValue(truth_key(), tv2);
 		Handle h3 = as3.add_node(VARIABLE_NODE, "3");
-		h3->setTruthValue(tv3);
+		h3->setValue(truth_key(), tv3);
 
 		// Fetch three atoms in three different atomspaces
 		Handle hn1 = as1.add_node(CONCEPT_NODE, "1");
@@ -95,9 +95,9 @@ public:
 
 		// The truth value *pointers* should be identical, as they
 		// should point to the same exact truth value instance.
-		TS_ASSERT(hn1->getTruthValue() == h1->getTruthValue());
-		TS_ASSERT(hn2->getTruthValue() == h2->getTruthValue());
-		TS_ASSERT(hn3->getTruthValue() == h3->getTruthValue());
+		TS_ASSERT(hn1->getValue(truth_key()) == h1->getValue(truth_key()));
+		TS_ASSERT(hn2->getValue(truth_key()) == h2->getValue(truth_key()));
+		TS_ASSERT(hn3->getValue(truth_key()) == h3->getValue(truth_key()));
 	}
 
 	// Test multiple independent atomspaces.  Make sure they do not
@@ -111,25 +111,25 @@ public:
 
 		// Create three nodes
 		Handle n1(createNode(CONCEPT_NODE, "uni-1"));
-		n1->setTruthValue(tv1);
+		n1->setValue(truth_key(), tv1);
 		Handle n2(createNode(NUMBER_NODE, "2.2222"));
-		n2->setTruthValue(tv2);
+		n2->setValue(truth_key(), tv2);
 		Handle n3(createNode(VARIABLE_NODE, "uni-3"));
-		n3->setTruthValue(tv3);
+		n3->setValue(truth_key(), tv3);
 
 		// Create three links holding these three
 		TruthValuePtr tv(createSimpleTruthValue(0.33, 1.0/3.0));
 
 		// Create three copies of this link in three atomspaces
 		Handle h1 = as1.add_link(LIST_LINK, n1, n2, n3);
-		h1->setTruthValue(tv);
+		h1->setValue(truth_key(), tv);
 		Handle h2 = as2.add_atom(h1);
 		Handle h3 = as3.add_atom(h2);
 
 		// The truth values themselves should be equal, as values.
-		TS_ASSERT(*h1->getTruthValue() == *tv);
-		TS_ASSERT(*h2->getTruthValue() == *tv);
-		TS_ASSERT(*h3->getTruthValue() == *tv);
+		TS_ASSERT(*h1->getValue(truth_key()) == *tv);
+		TS_ASSERT(*h2->getValue(truth_key()) == *tv);
+		TS_ASSERT(*h3->getValue(truth_key()) == *tv);
 
 		// Fetch three atoms in three different atomspaces
 		Handle h1n1 = as1.get_node(CONCEPT_NODE, "uni-1");
@@ -159,17 +159,17 @@ public:
 		TS_ASSERT(h2n3 != h3n3);
 
 		// The truth values themselves should be equal, as values.
-		TS_ASSERT(*h1n1->getTruthValue() == *tv1);
-		TS_ASSERT(*h2n1->getTruthValue() == *tv1);
-		TS_ASSERT(*h3n1->getTruthValue() == *tv1);
+		TS_ASSERT(*h1n1->getValue(truth_key()) == *tv1);
+		TS_ASSERT(*h2n1->getValue(truth_key()) == *tv1);
+		TS_ASSERT(*h3n1->getValue(truth_key()) == *tv1);
 
-		TS_ASSERT(*h1n2->getTruthValue() == *tv2);
-		TS_ASSERT(*h2n2->getTruthValue() == *tv2);
-		TS_ASSERT(*h3n2->getTruthValue() == *tv2);
+		TS_ASSERT(*h1n2->getValue(truth_key()) == *tv2);
+		TS_ASSERT(*h2n2->getValue(truth_key()) == *tv2);
+		TS_ASSERT(*h3n2->getValue(truth_key()) == *tv2);
 
-		TS_ASSERT(*h1n3->getTruthValue() == *tv3);
-		TS_ASSERT(*h2n3->getTruthValue() == *tv3);
-		TS_ASSERT(*h3n3->getTruthValue() == *tv3);
+		TS_ASSERT(*h1n3->getValue(truth_key()) == *tv3);
+		TS_ASSERT(*h2n3->getValue(truth_key()) == *tv3);
+		TS_ASSERT(*h3n3->getValue(truth_key()) == *tv3);
 	}
 
 	// Test copying back and forth.
@@ -329,22 +329,22 @@ public:
 
 		// Create three nodes in the base atomspace
 		Handle hnd1 = nas1->add_node(CONCEPT_NODE, "nest-1");
-		hnd1->setTruthValue(tv1);
+		hnd1->setValue(truth_key(), tv1);
 		Handle hnd2 = nas1->add_node(NUMBER_NODE, "2.34");
-		hnd2->setTruthValue(tv2);
+		hnd2->setValue(truth_key(), tv2);
 		Handle hnd3 = nas1->add_node(VARIABLE_NODE, "nest-3");
-		hnd3->setTruthValue(tv3);
+		hnd3->setValue(truth_key(), tv3);
 
 		// Create three links holding these three
 		TruthValuePtr tv(createSimpleTruthValue(0.33, 1.0/3.0));
 
 		// Create a link in the middle atomspace
 		Handle h2 = nas2->add_link(LIST_LINK, hnd1, hnd2, hnd3);
-		h2->setTruthValue(tv);
+		h2->setValue(truth_key(), tv);
 
 		// Try to create a link in the grandchild atomspace
 		Handle h3 = nas3->add_link(LIST_LINK, hnd1, hnd2, hnd3);
-		h3->setTruthValue(tv);
+		h3->setValue(truth_key(), tv);
 
 		// The middle and grand-child links should be one and the same.
 		TS_ASSERT(h2 == h3);
@@ -378,17 +378,17 @@ public:
 
 		// The truth value *pointers* should be identical, of course,
 		// since they are the very same atoms.
-		TS_ASSERT(hnd1->getTruthValue() == h1n1->getTruthValue());
-		TS_ASSERT(hnd2->getTruthValue() == h1n2->getTruthValue());
-		TS_ASSERT(hnd3->getTruthValue() == h1n3->getTruthValue());
+		TS_ASSERT(hnd1->getValue(truth_key()) == h1n1->getValue(truth_key()));
+		TS_ASSERT(hnd2->getValue(truth_key()) == h1n2->getValue(truth_key()));
+		TS_ASSERT(hnd3->getValue(truth_key()) == h1n3->getValue(truth_key()));
 
-		TS_ASSERT(hnd1->getTruthValue() == h2n1->getTruthValue());
-		TS_ASSERT(hnd2->getTruthValue() == h2n2->getTruthValue());
-		TS_ASSERT(hnd3->getTruthValue() == h2n3->getTruthValue());
+		TS_ASSERT(hnd1->getValue(truth_key()) == h2n1->getValue(truth_key()));
+		TS_ASSERT(hnd2->getValue(truth_key()) == h2n2->getValue(truth_key()));
+		TS_ASSERT(hnd3->getValue(truth_key()) == h2n3->getValue(truth_key()));
 
-		TS_ASSERT(hnd1->getTruthValue() == h3n1->getTruthValue());
-		TS_ASSERT(hnd2->getTruthValue() == h3n2->getTruthValue());
-		TS_ASSERT(hnd3->getTruthValue() == h3n3->getTruthValue());
+		TS_ASSERT(hnd1->getValue(truth_key()) == h3n1->getValue(truth_key()));
+		TS_ASSERT(hnd2->getValue(truth_key()) == h3n2->getValue(truth_key()));
+		TS_ASSERT(hnd3->getValue(truth_key()) == h3n3->getValue(truth_key()));
 	}
 
 	// This tests bug report #9

--- a/tests/query/BindTVUTest.cxxtest
+++ b/tests/query/BindTVUTest.cxxtest
@@ -84,7 +84,7 @@ void BindTVUTest::test_single_bindlink(void)
 	logger().debug() << "answers = " << oc_to_string(answers);
 
 	Handle answer = answers->getOutgoingAtom(0);
-	TruthValuePtr stv = answer->getTruthValue(); 
+	TruthValuePtr stv = TruthValueCast(answer->getValue(truth_key()));
 	float strength = stv->get_mean();
 	float confidence = stv->get_confidence();
 	float expected = 0.55;

--- a/tests/query/EvalLinkDefaultTVUTest.cxxtest
+++ b/tests/query/EvalLinkDefaultTVUTest.cxxtest
@@ -71,12 +71,7 @@ public:
 		Handle answer = answers->getOutgoingAtom(0);
 		int num_results = answers->getOutgoingSet().size();
 		TS_ASSERT_EQUALS(num_results, 1);
-		TruthValuePtr stv = answer->getTruthValue();
-		float strength = stv->get_mean();
-		float confidence = stv->get_confidence();
-		float expected_strength = 1;
-		float expected_confidence = 0;
-		TS_ASSERT_EQUALS(strength, expected_strength);
-		TS_ASSERT_EQUALS(confidence, expected_confidence);
+		ValuePtr stv = answer->getValue(truth_key());
+		TS_ASSERT_EQUALS(nullptr, stv);
 	}
 };

--- a/tests/query/ExecutionOutputUTest.cxxtest
+++ b/tests/query/ExecutionOutputUTest.cxxtest
@@ -144,7 +144,7 @@ void ExecutionOutputUTest::test_exec(void)
 			an(CONCEPT_NODE, "be"),
 			hcapital = an(CONCEPT_NODE, "capital")
 		)
-	)->setTruthValue(TruthValue::TRUE_TV());
+	)->setValue(truth_key(), TruthValue::TRUE_TV());
 
 	Handle hprep;
 	al(EVALUATION_LINK,
@@ -153,7 +153,7 @@ void ExecutionOutputUTest::test_exec(void)
 			an(CONCEPT_NODE, "capital"),
 			an(CONCEPT_NODE, "Spain")
 		)
-	)->setTruthValue(TruthValue::TRUE_TV());
+	)->setValue(truth_key(), TruthValue::TRUE_TV());
 
 	const char * str =
 	"(define (make-verb-prep verb prep) \n"

--- a/tests/query/GetLinkUTest.cxxtest
+++ b/tests/query/GetLinkUTest.cxxtest
@@ -278,7 +278,7 @@ void GetLinkUTest::test_not_equal(void)
 
 	Handle P = an(PREDICATE_NODE, "P");
 	Handle Q = an(PREDICATE_NODE, "Q");
-	Q->setTruthValue(SimpleTruthValue::TRUE_TV());
+	Q->setValue(truth_key(), SimpleTruthValue::TRUE_TV());
 
 	Handle Qvar = an(VARIABLE_NODE, "$Q");
 	Handle vardecl = al(VARIABLE_LIST,

--- a/tests/query/no-exception.scm
+++ b/tests/query/no-exception.scm
@@ -68,12 +68,20 @@
 ) ; [67][45]
 )
 
+(define (get-mean ATOM)
+	(define tv (cog-tv ATOM))
+	(if tv (cog-tv-mean tv) 1))
+
+(define (get-confidence ATOM)
+	(define tv (cog-tv ATOM))
+	(if tv (cog-tv-confidence tv) 0))
+
 ;; Schema returning undefined handle
 (define (crisp-modus-ponens-formula A AB B)
-    (let (  (sA (cog-mean A))
-            (cA (cog-confidence A))
-            (sAB (cog-mean AB))
-            (cAB (cog-confidence AB)))
+    (let (  (sA (get-mean A))
+            (cA (get-confidence A))
+            (sAB (get-mean AB))
+            (cAB (get-confidence AB)))
         (if (and (>= sA 0.5) (>= cA 0.5) (>= sAB 0.5) (>= cAB 0.5))
             (cog-set-tv! B (stv 1 1)))))
 

--- a/tests/scm/BasicSCMUTest.cxxtest
+++ b/tests/scm/BasicSCMUTest.cxxtest
@@ -645,12 +645,6 @@ void BasicSCMUTest::check_parse_link(const char * tipo, Type type,
 	eval->clear_pending();
 	TSM_ASSERT("Failed to create parse link", !eval_err);
 
-	HandleSeq links;
-	as->get_handles_by_type(links, type, true);
-	//printf("Number of links found: %d\n",links.size());
-	for (const Handle& h: links)
-		check_tv(h, 1.0, 0.0); // DEFAULT_TV is true with no confidence
-
 	Type t1 = nameserver().getType(nodename1);
 	Handle h1 = as->xget_handle(t1, value1);
 	TSM_ASSERT("Failed to find handle", h1 != nullptr);

--- a/tests/scm/BasicSCMUTest.cxxtest
+++ b/tests/scm/BasicSCMUTest.cxxtest
@@ -158,7 +158,7 @@ void BasicSCMUTest::test_utf8(void)
 
 void BasicSCMUTest::check_tv(const Handle& h, double mean, double conf)
 {
-	TruthValuePtr tv = h->getTruthValue();
+	TruthValuePtr tv = TruthValueCast(h->getValue(truth_key()));
 	double m = tv->get_mean();
 	double c = tv->get_confidence();
 
@@ -345,7 +345,7 @@ void BasicSCMUTest::check_truth_value(const TruthValuePtr& tv)
 	TSM_ASSERT("Failed to get the handle", h != Handle::UNDEFINED);
 	TSM_ASSERT("Failed to get the correct handle", h == hadd);
 	// hack to avoid floating error
-	bool tv_eq = tv->to_string() == h->getTruthValue()->to_string();
+	bool tv_eq = tv->to_string() == h->getValue(truth_key())->to_string();
 	TSM_ASSERT("TVs are different", tv_eq);
 
 	// Check the fast-path API, too

--- a/tests/scm/MultiAtomSpaceUTest.cxxtest
+++ b/tests/scm/MultiAtomSpaceUTest.cxxtest
@@ -236,7 +236,7 @@ void MultiAtomSpace::test_load(void)
 	CHKEV(ev1);
 	ev1->eval("(test-incr-cnt)");
 	CHKEV(ev1);
-	TruthValuePtr tv1 = counter1->getTruthValue();
+	TruthValuePtr tv1 = TruthValueCast(counter1->getValue(truth_key()));
 
 	TSM_ASSERT_EQUALS("Wrong truth value type", COUNT_TRUTH_VALUE, tv1->get_type());
 	TSM_ASSERT_EQUALS("wrong count found", 4, (int)(tv1->get_count()));
@@ -255,7 +255,7 @@ void MultiAtomSpace::test_load(void)
 	ev2->eval("(test-incr-cnt)");
 	CHKEV(ev2);
 
-	TruthValuePtr tv2 = counter2->getTruthValue();
+	TruthValuePtr tv2 = TruthValueCast(counter2->getValue(truth_key()));
 
 	TSM_ASSERT_EQUALS("Wrong truth value type", COUNT_TRUTH_VALUE, tv2->get_type());
 	TSM_ASSERT_EQUALS("wrong count found", 1, (int)(tv2->get_count()));
@@ -271,7 +271,7 @@ void MultiAtomSpace::test_load(void)
 
 	TSM_ASSERT("Atoms should be same", counter1 == counter3);
 
-	TruthValuePtr tv3 = counter3->getTruthValue();
+	TruthValuePtr tv3 = TruthValueCast(counter3->getValue(truth_key()));
 
 	TSM_ASSERT_EQUALS("Wrong truth value type", COUNT_TRUTH_VALUE, tv3->get_type());
 	TSM_ASSERT_EQUALS("wrong count found", 4, (int)(tv3->get_count()));

--- a/tests/scm/MultiAtomSpaceUTest.cxxtest
+++ b/tests/scm/MultiAtomSpaceUTest.cxxtest
@@ -483,7 +483,8 @@ void MultiAtomSpace::test_readonly_scm(void)
 
 	// Verify that the TV never changed.
 	TruthValuePtr tvp = evaluator->eval_tv("(cog-tv (Concept \"A\"))");
-	TS_ASSERT (*tvp == *TruthValue::DEFAULT_TV());
+	TS_ASSERT(tvp->get_mean() == 1.0);
+	TS_ASSERT(tvp->get_confidence() == 0.0);
 
 	logger().debug("END TEST: %s", __FUNCTION__);	
 }

--- a/tests/scm/MultiAtomSpaceUTest.cxxtest
+++ b/tests/scm/MultiAtomSpaceUTest.cxxtest
@@ -483,8 +483,7 @@ void MultiAtomSpace::test_readonly_scm(void)
 
 	// Verify that the TV never changed.
 	TruthValuePtr tvp = evaluator->eval_tv("(cog-tv (Concept \"A\"))");
-	TS_ASSERT(tvp->get_mean() == 1.0);
-	TS_ASSERT(tvp->get_confidence() == 0.0);
+	TS_ASSERT(tvp == nullptr);
 
 	logger().debug("END TEST: %s", __FUNCTION__);	
 }

--- a/tests/scm/SCMUtilsUTest.cxxtest
+++ b/tests/scm/SCMUtilsUTest.cxxtest
@@ -104,7 +104,7 @@ void SCMUtilsUTest::test_utils(void)
 	CHKERR;
 	evaluator->eval("(test-incr-cnt)");
 	CHKERR;
-	TruthValuePtr tv = counter->getTruthValue();
+	TruthValuePtr tv = TruthValueCast(counter->getValue(truth_key()));
 
 	TSM_ASSERT_EQUALS("Wrong truth value type", COUNT_TRUTH_VALUE, tv->get_type());
 	TSM_ASSERT_EQUALS("wrong count found", 3, (int)(tv->get_count()));


### PR DESCRIPTION
A distinct method is not needed; the general API is sufficient to provide this ability.