### PR TITLE
Remove stale TruthValue inferfaces from the Python API

### DIFF
--- a/cmake/OpenCogGenPythonTypes.cmake
+++ b/cmake/OpenCogGenPythonTypes.cmake
@@ -58,26 +58,26 @@ MACRO(OPENCOG_PYTHON_WRITE_DEFS PYTHON_FILE)
 
 		IF (ISNODE STREQUAL "NODE")
 			FILE(APPEND "${PYTHON_FILE}"
-				"def ${TYPE_NAME}(node_name, tv=None):\n"
-				"    return add_node(types.${TYPE_NAME}, node_name, tv)\n"
+				"def ${TYPE_NAME}(node_name):\n"
+				"    return add_node(types.${TYPE_NAME}, node_name)\n"
 			)
 			IF (NOT SHORT_NAME STREQUAL "")
 				FILE(APPEND "${PYTHON_FILE}"
-					"def ${SHORT_NAME}(node_name, tv=None):\n"
-					"    return add_node(types.${TYPE_NAME}, node_name, tv)\n"
+					"def ${SHORT_NAME}(node_name):\n"
+					"    return add_node(types.${TYPE_NAME}, node_name)\n"
 				)
 			ENDIF (NOT SHORT_NAME STREQUAL "")
 		ENDIF (ISNODE STREQUAL "NODE")
 
 		IF (ISLINK STREQUAL "LINK")
 			FILE(APPEND "${PYTHON_FILE}"
-				"def ${TYPE_NAME}(*args, tv=None):\n"
-				"    return add_link(types.${TYPE_NAME}, args, tv=tv)\n"
+				"def ${TYPE_NAME}(*args):\n"
+				"    return add_link(types.${TYPE_NAME}, args)\n"
 			)
 			IF (NOT SHORT_NAME STREQUAL "")
 				FILE(APPEND "${PYTHON_FILE}"
-					"def ${SHORT_NAME}(*args, tv=None):\n"
-					"    return add_link(types.${TYPE_NAME}, args, tv=tv)\n"
+					"def ${SHORT_NAME}(*args):\n"
+					"    return add_link(types.${TYPE_NAME}, args)\n"
 				)
 			ENDIF (NOT SHORT_NAME STREQUAL "")
 		ENDIF (ISLINK STREQUAL "LINK")

--- a/opencog/cython/opencog/atom.pyx
+++ b/opencog/cython/opencog/atom.pyx
@@ -45,29 +45,6 @@ cdef class Atom(Value):
                 self._name = ""
         return self._name
 
-    # XXX TODO REMOVE THESE SOON
-    @property
-    def tv(self):
-        cdef cAtom* atom_ptr = self.handle.atom_ptr()
-        cdef tv_ptr tvp
-        if atom_ptr == NULL:   # avoid null-pointer deref
-            raise RuntimeError("Null Atom!")
-        tvp = tv_cast(atom_ptr.getValue(truth_key()))
-        if (not tvp.get()):
-            return createTruthValue(1.0, 0.0)
-        return createTruthValue(tvp.get().get_mean(), tvp.get().get_confidence())
-
-    @tv.setter
-    def tv(self, truth_value):
-        try:
-            assert isinstance(truth_value, TruthValue)
-        except AssertionError:
-            raise TypeError("atom.tv property needs a TruthValue object")
-        cdef cAtom* atom_ptr = self.handle.atom_ptr()
-        if atom_ptr == NULL:   # avoid null-pointer deref
-            raise RuntimeError("Null Atom!")
-        atom_ptr.setValue(truth_key(), (<TruthValue>truth_value)._vptr())
-
     def id_string(self):
         return self.get_c_handle().get().id_to_string().decode('UTF-8')
 
@@ -135,10 +112,6 @@ cdef class Atom(Value):
             raise RuntimeError("Null Atom!")
         handle_vector = atom_ptr.getIncomingSetByType(type)
         return convert_handle_seq_to_python_list(handle_vector)
-
-    def truth_value(self, mean, conf):
-        self.tv = createTruthValue(mean, conf)
-        return self
 
     def is_executable(self):
         cdef cAtom* atom_ptr = self.handle.atom_ptr()

--- a/opencog/cython/opencog/atom.pyx
+++ b/opencog/cython/opencog/atom.pyx
@@ -58,7 +58,7 @@ cdef class Atom(Value):
         cdef cValuePtr value = self.get_c_handle().get().getValue(
             deref((<Atom>key).handle))
         if value.get() == NULL:
-            raise RuntimeError("Null Atom!")
+            return None
         return create_python_value_from_c_value(value)
 
     def get_keys(self):

--- a/opencog/cython/opencog/atomspace.pxd
+++ b/opencog/cython/opencog/atomspace.pxd
@@ -184,10 +184,7 @@ cdef extern from "opencog/atomspace/AtomSpace.h" namespace "opencog":
         cHandle add_atom(cHandle handle) except +
 
         cHandle xadd_node(Type t, string s) except +
-        cHandle add_node(Type t, string s, tv_ptr tvn) except +
-
         cHandle xadd_link(Type t, vector[cHandle]) except +
-        cHandle add_link(Type t, vector[cHandle], tv_ptr tvn) except +
 
         cHandle xget_handle(Type t, string s)
         cHandle xget_handle(Type t, vector[cHandle])

--- a/opencog/cython/opencog/atomspace.pxd
+++ b/opencog/cython/opencog/atomspace.pxd
@@ -100,8 +100,6 @@ cdef class TruthValue(Value):
     cdef double _mean(self)
     cdef double _confidence(self)
     cdef cTruthValue* _ptr(self)
-    cdef cValuePtr _vptr(self)
-    cdef tv_ptr* _tvptr(self)
 
 # ContentHash
 

--- a/opencog/cython/opencog/atomspace_details.pyx
+++ b/opencog/cython/opencog/atomspace_details.pyx
@@ -6,6 +6,9 @@ from cython.operator cimport dereference as deref, preincrement as inc
 
 # from atomspace cimport *
 
+# tvkey holds a pointer to (PredicateNode "*-TruthValueKey-*") which
+# is the key under which all TruthValues are stored.
+tvkey = create_python_value_from_c_value(<cValuePtr>(truth_key()))
 
 # @todo use the guide here to separate out into a hierarchy
 # http://wiki.cython.org/PackageHierarchy

--- a/opencog/cython/opencog/atomspace_details.pyx
+++ b/opencog/cython/opencog/atomspace_details.pyx
@@ -87,14 +87,14 @@ cdef class AtomSpace(Value):
         elif op == 3: # !=
             return not is_equal
 
-    def add(self, Type t, name=None, out=None, TruthValue tv=None):
+    def add(self, Type t, name=None, out=None):
         """ add method that determines exact method to call from type """
         if is_a(t, types.Node):
             assert out is None, "Nodes can't have outgoing sets"
-            atom = self.add_node(t, name, tv)
+            atom = self.add_node(t, name)
         else:
             assert name is None, "Links can't have names"
-            atom = self.add_link(t, out, tv)
+            atom = self.add_link(t, out)
         return atom
 
     def add_atom(self, Atom atom):
@@ -103,9 +103,8 @@ cdef class AtomSpace(Value):
             return None
         return create_python_value_from_c_value(<cValuePtr&>(result, result.get()))
 
-    def add_node(self, Type t, atom_name, TruthValue tv=None):
+    def add_node(self, Type t, atom_name):
         """ Add Node to AtomSpace
-        @todo support [0.5,0.5] format for TruthValue.
         @todo support type name for type.
         @returns the newly created Atom
         """
@@ -118,14 +117,10 @@ cdef class AtomSpace(Value):
         cdef cHandle result = self.atomspace.xadd_node(t, name)
 
         if result == result.UNDEFINED: return None
-        atom = Atom.createAtom(result);
-        if tv :
-            atom.tv = tv
-        return atom
+        return Atom.createAtom(result);
 
-    def add_link(self, Type t, outgoing, TruthValue tv=None):
+    def add_link(self, Type t, outgoing):
         """ Add Link to AtomSpace
-        @todo support [0.5,0.5] format for TruthValue.
         @todo support type name for type.
         @returns handle referencing the newly created Atom
         """
@@ -136,10 +131,7 @@ cdef class AtomSpace(Value):
         cdef cHandle result
         result = self.atomspace.xadd_link(t, handle_vector)
         if result == result.UNDEFINED: return None
-        atom = Atom.createAtom(result);
-        if tv :
-            atom.tv = tv
-        return atom
+        return Atom.createAtom(result);
 
     def is_valid(self, atom):
         """ Check whether the passed handle refers to an actual atom

--- a/opencog/cython/opencog/truth_value.pyx
+++ b/opencog/cython/opencog/truth_value.pyx
@@ -9,15 +9,15 @@ def createTruthValue(strength = 1.0, confidence = 1.0):
 
 cdef class TruthValue(Value):
     """ The truth value represents the strength and confidence of
-        a relationship or term. In OpenCog there are a number of TruthValue
-        types, but as these involve additional complexity we focus primarily on
-        the SimpleTruthValue type which allows strength and confidence
+        a relationship or term.
     """
     # Type constructors for all atoms and values are exported via
-    # opencog.type_constructors module. Except TruthValue which is historically
-    # exported in opencog.atomspace. To keep it work before proper fix
-    # TruthValue constructor is modified to accept both old parameters
-    # (strength and confidence) and new ptr_holder parameter.
+    # opencog.type_constructors module. Except TruthValue which is
+    # historically exported in opencog.atomspace. To keep it working
+    # before a proper fix, the TruthValue constructor is modified to
+    # accept both the old parameters (strength and confidence) and
+    # the new ptr_holder parameter.
+    #
     # def __init__(self, double strength=1.0, double confidence=1.0, PtrHolder ptr_holder=None):
     #     cdef tv_ptr c_ptr
     #     if ptr_holder is not None:

--- a/opencog/cython/opencog/truth_value.pyx
+++ b/opencog/cython/opencog/truth_value.pyx
@@ -42,9 +42,3 @@ cdef class TruthValue(Value):
 
     cdef cTruthValue* _ptr(self):
         return <cTruthValue*>(self.get_c_value_ptr().get())
-
-    cdef cValuePtr _vptr(self):
-        return <cValuePtr>(self.get_c_value_ptr())
-
-    cdef tv_ptr* _tvptr(self):
-        return <tv_ptr*>&((<PtrHolder>self.ptr_holder).shared_ptr)

--- a/opencog/cython/opencog/utilities.pxd
+++ b/opencog/cython/opencog/utilities.pxd
@@ -2,17 +2,14 @@ from libcpp.vector cimport vector
 from libcpp.string cimport string
 from libcpp.memory cimport shared_ptr
 from libcpp.set cimport set as cpp_set
-from opencog.atomspace cimport cAtomSpace, Type, tv_ptr, cHandle, cValuePtr
+from opencog.atomspace cimport cAtomSpace, Type, cHandle, cValuePtr
 
 
 cdef extern from "opencog/cython/opencog/Utilities.h" namespace "opencog":
     cdef void c_initialize_python "opencog::initialize_python" ()
     cdef void c_finalize_python "opencog::finalize_python" ()
     cHandle c_add_node "opencog::add_node" (Type t, const string s) except +
-    # cHandle c_add_node "opencog::add_node" (Type t, string s, tv_ptr tvn) except +
     cHandle c_add_link "opencog::add_link" (Type t, const vector[cHandle]) except +
-    # cHandle c_add_link "opencog::add_link" (Type t, vector[cHandle], tv_ptr tvn) except +
-
 
 cdef extern from "opencog/cython/executioncontext/Context.h" namespace "opencog":
     cValuePtr get_context_atomspace();

--- a/opencog/cython/opencog/utilities.pyx
+++ b/opencog/cython/opencog/utilities.pyx
@@ -19,7 +19,8 @@ def initialize_opencog(AtomSpace atomspace=None):
     Set default atomspace(deprecated feature) and
     create python evaluator singleton object.
 
-    Calling this function should not be needed. Use set_default_atomspace to set default atomspace.
+    Calling this function should not be needed.
+    Use set_default_atomspace to set default atomspace.
     Python evaluator will be created on first evaluation.
     """
     if atomspace is not None:
@@ -58,7 +59,7 @@ def tmp_atomspace():
         set_default_atomspace(parent_atomspace)
 
 
-def add_link(Type t, outgoing, TruthValue tv=None):
+def add_link(Type t, outgoing):
 
     # Unwrap double-wrapped lists. The type constructors create these.
     if 1 == len(outgoing) and isinstance(outgoing[0], list):
@@ -75,13 +76,10 @@ def add_link(Type t, outgoing, TruthValue tv=None):
     cdef cHandle result
     result = c_add_link(t, handle_vector)
     if result == result.UNDEFINED: return None
-    atom = create_python_value_from_c_value(<cValuePtr&>(result, result.get()))
-    if tv is not None:
-        atom.tv = tv
-    return atom
+    return create_python_value_from_c_value(<cValuePtr&>(result, result.get()))
 
 
-def add_node(Type t, atom_name, TruthValue tv=None):
+def add_node(Type t, atom_name):
     """
     Add Node to the atomspace from the current context
     """
@@ -109,11 +107,7 @@ def add_node(Type t, atom_name, TruthValue tv=None):
     cdef cHandle result = c_add_node(t, name)
 
     if result == result.UNDEFINED: return None
-    atom = create_python_value_from_c_value(<cValuePtr&>(result, result.get()))
-    if tv is not None:
-        atom.tv = tv
-    return atom
-
+    return create_python_value_from_c_value(<cValuePtr&>(result, result.get()))
 
 def set_default_atomspace(AtomSpace atomspace):
     """
@@ -141,18 +135,3 @@ def get_default_atomspace():
 
 def pop_default_atomspace():
     return AtomSpace_factoid(pop_context_atomspace())
-
-
-def is_closed(Atom atom):
-    """
-    Return True iff the atom is closed, that is does not contain free variables.
-    """
-    return c_is_closed(atom.get_c_handle())
-
-
-def get_free_variables(Atom atom):
-    """
-    Return the list of free variables in a given atom.
-    """
-    cdef cpp_set[cHandle] variables = c_get_free_variables(atom.get_c_handle())
-    return [create_python_value_from_c_value(<cValuePtr&>(h, h.get())) for h in variables]

--- a/opencog/cython/opencog/value.pyx
+++ b/opencog/cython/opencog/value.pyx
@@ -89,8 +89,9 @@ cdef class Value:
 
     def __richcmp__(self, other, op):
         if not isinstance(other, Value):
-            raise TypeError('Value cannot be compared with {}'
-                            .format(type(other)))
+            # raise TypeError('Value cannot be compared with {}'
+            #                 .format(type(other)))
+            return False
         cdef cValue* self_ptr = (<Value>self).get_c_value_ptr().get()
         cdef cValue* other_ptr = (<Value>other).get_c_value_ptr().get()
         if op == Py_EQ:

--- a/tests/cython/atomspace/test_atom.py
+++ b/tests/cython/atomspace/test_atom.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest import TestCase
 
-from opencog.atomspace import Atom
+from opencog.atomspace import Atom, tvkey
 
 from opencog.atomspace import types, is_a, get_type, get_type_name, create_child_atomspace
 
@@ -33,7 +33,7 @@ class AtomTest(TestCase):
         self.assertEqual(0, len(keys))
 
         tv = TruthValue(0.7, 0.7)
-        atom.tv = tv
+        atom.set_value(tvkey, tv)
         keys = atom.get_keys()
         self.assertEqual(1, len(keys))
         # Since the type or name of the TruthValue key may change, check that

--- a/tests/cython/atomspace/test_atomspace.py
+++ b/tests/cython/atomspace/test_atomspace.py
@@ -76,8 +76,9 @@ class AtomSpaceTest(TestCase):
         self.assertTrue(l2 == l1)
 
         n3 = Node("test3")
-        l3 = Link(n1, n3).set_value(tvkey, TruthValue(0.5, 0.8))
+        l3 = Link(n1, n3)
         self.assertTrue(l3 is not None)
+        l3.set_value(tvkey, TruthValue(0.5, 0.8))
 
         # Should fail when adding an intentionally bad type
         caught = False
@@ -231,7 +232,7 @@ class AtomTest(TestCase):
     def test_creation(self):
         a = Node("test1")
         self.assertEqual(a.name, "test1")
-        self.assertEqual(a.get_value(tvkey), null)
+        self.assertEqual(a.get_value(tvkey), None)
 
     def test_w_truthvalue(self):
         a = Node("test2")

--- a/tests/cython/atomspace/test_atomspace.py
+++ b/tests/cython/atomspace/test_atomspace.py
@@ -66,10 +66,6 @@ class AtomSpaceTest(TestCase):
         a3 = Node("test_w_tv").truth_value(0.5, 0.8)
         self.assertEqual(self.space.size(), 3)
 
-        # Test alternative way of adding with a truthvalue
-        a4 = Node("test_w_tv_alt", tv=TruthValue(0.5, 0.8))
-        self.assertEqual(self.space.size(), 4)
-
     def test_add_link(self):
         n1 = Node("test1")
         n2 = Node("test2")
@@ -82,10 +78,6 @@ class AtomSpaceTest(TestCase):
         n3 = Node("test3")
         l3 = Link(n1, n3).truth_value(0.5, 0.8)
         self.assertTrue(l3 is not None)
-
-        n4 = Node("test4")
-        l4 = Link(n1, n4, tv=TruthValue(0.5, 0.8))
-        self.assertTrue(l4 is not None)
 
         # Should fail when adding an intentionally bad type
         caught = False

--- a/tests/cython/atomspace/test_atomspace.py
+++ b/tests/cython/atomspace/test_atomspace.py
@@ -63,7 +63,7 @@ class AtomSpaceTest(TestCase):
         self.assertEqual(caught, True)
 
         # Test adding with a truthvalue
-        a3 = Node("test_w_tv").truth_value(0.5, 0.8)
+        a3 = Node("test_w_tv").set_value(tvkey, TruthValue(0.5, 0.8))
         self.assertEqual(self.space.size(), 3)
 
     def test_add_link(self):
@@ -76,7 +76,7 @@ class AtomSpaceTest(TestCase):
         self.assertTrue(l2 == l1)
 
         n3 = Node("test3")
-        l3 = Link(n1, n3).truth_value(0.5, 0.8)
+        l3 = Link(n1, n3).set_value(tvkey, TruthValue(0.5, 0.8))
         self.assertTrue(l3 is not None)
 
         # Should fail when adding an intentionally bad type
@@ -108,9 +108,9 @@ class AtomSpaceTest(TestCase):
 
         # check truth_value function of atom
         atom = Node("atom with tv")
-        default_tv = atom.tv
-        atom.truth_value(0.75, 0.9)
-        new_tv = atom.tv
+        default_tv = atom.get_value(tvkey)
+        atom.set_value(tvkey, TruthValue(0.75, 0.9))
+        new_tv = atom.get_value(tvkey)
         self.assertFalse(new_tv == default_tv)
         self.assertEqual(new_tv.mean, 0.75)
         self.assertAlmostEqual(new_tv.confidence, 0.9, places=4)
@@ -231,17 +231,13 @@ class AtomTest(TestCase):
     def test_creation(self):
         a = Node("test1")
         self.assertEqual(a.name, "test1")
-        self.assertEqual(a.tv, TruthValue(1.0, 0.0)) # default is true, no confidence
+        self.assertEqual(a.get_value(tvkey), null)
 
     def test_w_truthvalue(self):
         a = Node("test2")
         tv = TruthValue(0.5, 100)
         a.set_value(tvkey, tv)
-        self.assertEqual(a.tv, tv)
-
-        # test set tv
-        a.tv = TruthValue(0.1, 10)
-        self.assertEqual(a.tv, TruthValue(0.1, 10))
+        self.assertEqual(a.get_value(tvkey), tv)
 
     def test_out(self):
         # test get out
@@ -302,7 +298,7 @@ class AtomTest(TestCase):
         a1.set_value(tvkey, tv)
 
         a2 = Node("test2")
-        a2.tv = TruthValue(0.1, 0.3)
+        a2.set_value(tvkey, TruthValue(0.1, 0.3))
 
         l = Link(a1, a2)
 

--- a/tests/cython/atomspace/test_atomspace.py
+++ b/tests/cython/atomspace/test_atomspace.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 import opencog.atomspace
-from opencog.atomspace import Atom
+from opencog.atomspace import Atom, tvkey
 from opencog.atomspace import types, is_a, get_type, get_type_name, create_child_atomspace
 
 from opencog.type_constructors import *
@@ -234,8 +234,9 @@ class AtomTest(TestCase):
         self.assertEqual(a.tv, TruthValue(1.0, 0.0)) # default is true, no confidence
 
     def test_w_truthvalue(self):
+        a = Node("test2")
         tv = TruthValue(0.5, 100)
-        a = Node("test2", tv)
+        a.set_value(tvkey, tv)
         self.assertEqual(a.tv, tv)
 
         # test set tv
@@ -248,8 +249,9 @@ class AtomTest(TestCase):
 
         self.assertEqual(a1.out, [])
 
+        a2 = Node("test3")
         tv = TruthValue(0.5, 100)
-        a2 = Node("test3", tv)
+        a2.set_value(tvkey, tv)
 
         l = Link(a1, a2)
         self.assertEqual(l.out, [a1, a2])
@@ -262,8 +264,9 @@ class AtomTest(TestCase):
 
         self.assertEqual(a1.arity, 0)
 
+        a2 = Node("test3")
         tv = TruthValue(0.5, 100)
-        a2 = Node("test3", tv)
+        a2.set_value(tvkey, tv)
 
         l = Link(a1, a2)
         self.assertEqual(l.arity, 2)
@@ -294,8 +297,9 @@ class AtomTest(TestCase):
 
     def test_strings(self):
         # set up a link and atoms
+        a1 = Node("test1")
         tv = TruthValue(0.5, 0.8)
-        a1 = Node("test1", tv)
+        a1.set_value(tvkey, tv)
 
         a2 = Node("test2")
         a2.tv = TruthValue(0.1, 0.3)

--- a/tests/cython/atomspace/test_exception.py
+++ b/tests/cython/atomspace/test_exception.py
@@ -50,7 +50,7 @@ class TestExceptions(unittest.TestCase):
             evaluate_atom(self.space, eval_link)
             self.assertFalse("call should fail")
         except RuntimeError as e:
-                   # Use `nosetests3 --nocapture` to see this print...
+            # Use `nosetests3 --nocapture` to see this print...
             print(f"The exception message is {str(e)}")
             self.assertTrue("not found in module" in str(e))
 

--- a/tests/cython/atomspace/test_nameserver.py
+++ b/tests/cython/atomspace/test_nameserver.py
@@ -10,11 +10,11 @@ with type_decl_context(__name__):
     decl_type(types.Node, 'SomeNode')
     decl_type(types.Link, 'SomeLink')
 
-def SomeNode(name, tv=None):
-    return add_node(types.SomeNode, name, tv)
+def SomeNode(name):
+    return add_node(types.SomeNode, name)
 
-def SomeLink(*args, tv=None):
-    return add_link(types.SomeLink, args, tv)
+def SomeLink(*args):
+    return add_link(types.SomeLink, args)
 
 class NameserverTest(unittest.TestCase):
 

--- a/tests/cython/bindlink/test_functions.py
+++ b/tests/cython/bindlink/test_functions.py
@@ -70,4 +70,7 @@ def func_one(v):
 
 
 def func_two(v):
-    return ListLink(ConceptNode("barleycorn"), v).get_value(tvkey)
+    tv = ListLink(ConceptNode("barleycorn"), v).get_value(tvkey)
+    if (tv is None):
+        return TruthValue(1, 0)
+    return tv

--- a/tests/cython/bindlink/test_functions.py
+++ b/tests/cython/bindlink/test_functions.py
@@ -1,7 +1,7 @@
 #
 # Test Functions
 
-from opencog.atomspace import types, Atom
+from opencog.atomspace import types, Atom, tvkey
 from opencog.type_constructors import *
 
 
@@ -65,9 +65,9 @@ func_one_result = TruthValue (0,1) # false
 def func_one(v):
     thing = ConceptNode("barleycorn")
     thang = ListLink(thing, v)
-    thang.tv = func_one_result
-    return thang.tv
+    thang.set_value(tvkey, func_one_result)
+    return func_one_result
 
 
 def func_two(v):
-    return ListLink(ConceptNode("barleycorn"), v).tv
+    return ListLink(ConceptNode("barleycorn"), v).get_value(tvkey)

--- a/tests/cython/guile/test_pattern.py
+++ b/tests/cython/guile/test_pattern.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from opencog.atomspace import AtomSpace, Atom
+from opencog.atomspace import AtomSpace, Atom, tvkey
 from opencog.type_constructors import TruthValue
 from opencog.atomspace import types, is_a, get_type, get_type_name
 from opencog.scheme import scheme_eval, scheme_eval_h
@@ -47,8 +47,8 @@ class SchemeTest(TestCase):
         print("Added atom\n")
         # Make sure the truth value is what's in the SCM file.
         expected = TruthValue(0.5, 0.5)
-        self.assertEqual(a1.tv, expected)
-        print(f"Got={str(a1.tv)} expected={str(expected)}")
+        self.assertEqual(a1.get_value(tvkey), expected)
+        print(f"Got={str(a1.get_value(tvkey))} expected={str(expected)}")
 
     # Create lots of large, random strings, try to trick guile gc
     # into running, while in the python context. We want to make
@@ -85,7 +85,7 @@ class SchemeTest(TestCase):
 
         # Make sure the truth value is what's in the SCM file.
         expected = TruthValue(0.5, 0.5)
-        self.assertEqual(a1.tv, expected)
+        self.assertEqual(a1.get_value(tvkey), expected)
 
         # Actually, the atoms overall should compare.
         self.assertEqual(a1, basic)

--- a/tests/cython/utilities/test_utilities.py
+++ b/tests/cython/utilities/test_utilities.py
@@ -7,7 +7,7 @@ from unittest import TestCase
 
 from opencog.type_constructors import *
 from opencog.atomspace import AtomSpace
-from opencog.utilities import set_default_atomspace, finalize_opencog, is_closed, get_free_variables
+from opencog.utilities import set_default_atomspace, finalize_opencog
 
 __author__ = 'Curtis Faith'
 
@@ -30,18 +30,3 @@ class UtilitiesTest(TestCase):
     def test_initialize_finalize(self):
         set_default_atomspace(self.atomspace)
         finalize_opencog()
-
-    def test_is_closed(self):
-        A = self.atomspace.add_node(types.ConceptNode, 'A')
-        B = self.atomspace.add_node(types.ConceptNode, 'B')
-        X = self.atomspace.add_node(types.VariableNode, '$X')
-        AB = self.atomspace.add_link(types.InheritanceLink, [A, B])
-        AX = self.atomspace.add_link(types.InheritanceLink, [A, X])
-        self.assertTrue(is_closed(AB))
-        self.assertFalse(is_closed(AX))
-
-    def test_get_free_variables(self):
-        A = self.atomspace.add_node(types.ConceptNode, 'A')
-        X = self.atomspace.add_node(types.VariableNode, '$X')
-        AX = self.atomspace.add_link(types.InheritanceLink, [A, X])
-        self.assertEqual(get_free_variables(AX), [X])

--- a/tests/scm/scm-python-arity.scm
+++ b/tests/scm/scm-python-arity.scm
@@ -14,7 +14,7 @@
 
 ; Define a python func returning a TV
 (python-eval "
-from opencog.atomspace import AtomSpace, types
+from opencog.atomspace import AtomSpace, types, tvkey
 from opencog.type_constructors import TruthValue
 
 
@@ -22,7 +22,7 @@ from opencog.type_constructors import TruthValue
 def foo(atom_a, atom_b) :
     atomspace = atom_a.atomspace
     TV = TruthValue(0.2, 0.69)
-    atomspace.add_node(types.ConceptNode, 'Apple', TV)
+    atomspace.add_node(types.ConceptNode, 'Apple').set_value(tvkey, TV)
     atomspace.add_link(types.InheritanceLink, [atom_a, atom_b])
     return TruthValue(0.42, 0.24)
 ")

--- a/tests/scm/scm-python-shared-atomspace.scm
+++ b/tests/scm/scm-python-shared-atomspace.scm
@@ -16,15 +16,16 @@
 
 ; Define a python func returning a TV
 (python-eval "
-from opencog.atomspace import AtomSpace, types
+from opencog.atomspace import AtomSpace, types, tvkey
 from opencog.type_constructors import get_default_atomspace, TruthValue
 
 
 # Twiddle some atoms in the atomspace
 def foo(atom_a, atom_b):
     atomspace = get_default_atomspace()
+    apple = atomspace.add_node(types.ConceptNode, 'Apple')
     TV = TruthValue(0.2, 0.69)
-    atomspace.add_node(types.ConceptNode, 'Apple', TV)
+    apple.set_value(tvkey, TV)
     atomspace.add_link(types.InheritanceLink, [atom_a, atom_b])
     return TruthValue(0.42, 0.24)
 ")


### PR DESCRIPTION
TruthValues still work as always. The out-of-date API for them, however encourages misunderstanding/misuse. Just get rid of it.