### PR TITLE
Atomese for working with Keys

### DIFF
--- a/opencog/atoms/atom_types/atom_types.script
+++ b/opencog/atoms/atom_types/atom_types.script
@@ -1068,6 +1068,16 @@ TYPE_OF_LINK <- VALUE_OF_LINK
 // Grab an IncomingSet of an Atom, and return it as a LinkValue.
 INCOMING_OF_LINK <- VALUE_OF_LINK
 
+// Return all of the keys that are in use on the given Atom.
+// All of these are placed into a LinkValue, and returned as that.
+KEYS_OF_LINK <- VALUE_OF_LINK
+
+// Return crisp true/false, whether this Atom is used anywhere
+// as a key. We do not track, at this time, where it is used as
+// a key; this would eat up a lot of RAM and we don't want to do
+// that, if we can avoid it.
+IS_KEY_LINK <- VIRTUAL_LINK
+
 // Convert between Link/LinkValue types. If no type is specified,
 // then convert to SetLink. Primarily intended to convert a LinkValue
 // to a SetLink, but can go other ways. The argument is presumed to

--- a/opencog/atoms/base/Atom.cc
+++ b/opencog/atoms/base/Atom.cc
@@ -86,6 +86,9 @@ const Handle& truth_key(void)
 /// If the value is a null pointer, then the key is removed.
 void Atom::setValue(const Handle& key, const ValuePtr& value)
 {
+	// We want to know if the key is .. being used as a key.
+	key->markIsKey();
+
 	// This is rather irritating, but we fake it for the
 	// PredicateNode "*-TruthValueKey-*" because if we don't
 	// then load-from-file and load-from-network breaks.
@@ -347,6 +350,11 @@ bool Atom::setPresent(void)
 {
     uint8_t old_flags = _flags.fetch_and(~ABSENT_FLAG);
     return old_flags & ABSENT_FLAG;
+}
+
+void Atom::markIsKey(void)
+{
+    _flags.fetch_or(IS_KEY_FLAG);
 }
 
 // ==============================================================

--- a/opencog/atoms/base/Atom.h
+++ b/opencog/atoms/base/Atom.h
@@ -334,7 +334,8 @@ protected:
         ABSENT_FLAG     = 0x01,  // 0000 0001
         MARKED_FLAG     = 0x02,  // 0000 0010
         CHECKED_FLAG    = 0x04,  // 0000 0100
-        USE_ISET_FLAG   = 0x08   // 0000 1000
+        USE_ISET_FLAG   = 0x08,  // 0000 1000
+        IS_KEY_FLAG     = 0x10   // 0001 0000
     };
     mutable std::atomic<uint8_t> _flags;
 
@@ -459,6 +460,9 @@ private:
     bool setAbsent();
     bool setPresent();
 
+    /** Indicate this Atom is used as a key */
+    void markIsKey();
+
     void getLocalInc(const AtomSpace*, HandleSet&, Type) const;
     void getCoveredInc(const AtomSpace*, HandleSet&, Type) const;
 
@@ -557,6 +561,9 @@ public:
     /// Atomically increment a generic FloatValue.
     ValuePtr incrementCount(const Handle& key, const std::vector<double>&);
     ValuePtr incrementCount(const Handle& key, size_t idx, double);
+
+    /// Return true if this Atom is used as a key, somewhere, anywhere.
+    bool isKey() const { return _flags.load() & IS_KEY_FLAG; }
 
     /// Get the set of all keys in use for this Atom.
     HandleSet getKeys() const;

--- a/opencog/atoms/execution/EvaluationLink.cc
+++ b/opencog/atoms/execution/EvaluationLink.cc
@@ -261,6 +261,17 @@ static ValuePtr exec_or_eval(AtomSpace* as,
 	return vp;
 }
 
+/// Return true, if any Atom in the outgoing set is being used as
+/// a key somewhere. Usually, the outgoing set will be just one Atom,
+/// but we are prepared for anything, here.
+static bool is_key(const Handle& h)
+{
+	for (const Handle& ho : h->getOutgoingSet())
+		if (ho->isKey()) return true;
+
+	return false;
+}
+
 /// Check for syntactic equality. Specifically, when comparing
 /// atoms, the handles MUST be the same handle.
 /// If there are two or more elements, they must ALL be equal.
@@ -610,6 +621,7 @@ static bool crispy_maybe(AtomSpace* as,
 	if (MEMBER_LINK == t) return member(scratch, evelnk, silent);
 	if (SUBSET_LINK == t) return subset(scratch, evelnk, silent);
 	if (EXCLUSIVE_LINK == t) return exclusive(scratch, evelnk, silent);
+	if (IS_KEY_LINK == t) return is_key(evelnk);
 
 	// -------------------------
 	if (nameserver().isA(t, CRISP_OUTPUT_LINK) and

--- a/opencog/atoms/flow/CMakeLists.txt
+++ b/opencog/atoms/flow/CMakeLists.txt
@@ -8,6 +8,7 @@ ADD_LIBRARY (atomflow
 	FilterLink.cc
 	IncomingOfLink.cc
 	IncrementValueLink.cc
+	KeysOfLink.cc
 	LinkSignatureLink.cc
 	NumberOfLink.cc
 	PromiseLink.cc
@@ -40,6 +41,7 @@ INSTALL (FILES
 	FilterLink.h
 	IncomingOfLink.h
 	IncrementValueLink.h
+	KeysOfLink.h
 	LinkSignatureLink.h
 	NumberOfLink.h
 	PromiseLink.h

--- a/opencog/atoms/flow/KeysOfLink.cc
+++ b/opencog/atoms/flow/KeysOfLink.cc
@@ -1,0 +1,71 @@
+/*
+ * KeysOfLink.cc
+ *
+ * Copyright (C) 2025 BrainyBlaze Dynamics, Inc.
+ *
+ * Author: Linas Vepstas <linasvepstas@gmail.com>  January 2009
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the
+ * exceptions at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/atoms/value/LinkValue.h>
+
+#include "KeysOfLink.h"
+
+using namespace opencog;
+
+KeysOfLink::KeysOfLink(const HandleSeq&& oset, Type t)
+	: FunctionLink(std::move(oset), t)
+{
+	if (not nameserver().isA(t, KEYS_OF_LINK))
+	{
+		const std::string& tname = nameserver().getTypeName(t);
+		throw InvalidParamException(TRACE_INFO,
+			"Expecting a KeysOfLink, got %s", tname.c_str());
+	}
+}
+
+// ---------------------------------------------------------------
+
+/// Return a LinkValue containing all keys from all atoms in the outgoing set.
+ValuePtr KeysOfLink::execute(AtomSpace* as, bool silent)
+{
+	// Collect all keys from all atoms in the outgoing set
+	HandleSet all_keys;
+
+	for (const Handle& h : _outgoing)
+	{
+		// If the given Atom is executable, then execute it.
+		Handle atom(h);
+		if (atom->is_executable())
+		{
+			atom = HandleCast(atom->execute(as, silent));
+			if (nullptr == atom) continue;
+		}
+
+		// Get the keys for this atom and merge them into the master set
+		HandleSet keys = atom->getKeys();
+		all_keys.insert(keys.begin(), keys.end());
+	}
+
+	// Convert the set to a sequence and return as LinkValue
+	HandleSeq key_seq(all_keys.begin(), all_keys.end());
+	return createLinkValue(std::move(key_seq));
+}
+
+DEFINE_LINK_FACTORY(KeysOfLink, KEYS_OF_LINK)
+
+/* ===================== END OF FILE ===================== */

--- a/opencog/atoms/flow/KeysOfLink.h
+++ b/opencog/atoms/flow/KeysOfLink.h
@@ -1,0 +1,68 @@
+/*
+ * opencog/atoms/flow/KeysOfLink.h
+ *
+ * Copyright (C) 2025 BrainyBlaze Dynamics, Inc.
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef _OPENCOG_KEYS_OF_LINK_H
+#define _OPENCOG_KEYS_OF_LINK_H
+
+#include <opencog/atoms/core/FunctionLink.h>
+
+namespace opencog
+{
+/** \addtogroup grp_atomspace
+ *  @{
+ */
+
+/// The KeysOfLink returns a LinkValue holding all of the keys
+/// that are in use on the atoms in the outgoing set.
+///
+/// For example,
+///
+///     KeysOfLink
+///         Concept "foo"
+///         Concept "bar"
+///
+/// will return
+///
+///     (LinkValue (Predicate "key1") (Predicate "key2") ...)
+///
+/// containing all keys from both atoms, merged into one set.
+///
+class KeysOfLink : public FunctionLink
+{
+public:
+	KeysOfLink(const HandleSeq&&, Type = KEYS_OF_LINK);
+	KeysOfLink(const KeysOfLink&) = delete;
+	KeysOfLink& operator=(const KeysOfLink&) = delete;
+
+	// Return a pointer to LinkValue holding all the keys.
+	virtual ValuePtr execute(AtomSpace*, bool);
+
+	static Handle factory(const Handle&);
+};
+
+LINK_PTR_DECL(KeysOfLink)
+#define createKeysOfLink CREATE_DECL(KeysOfLink)
+
+/** @}*/
+}
+
+#endif // _OPENCOG_KEYS_OF_LINK_H

--- a/opencog/atoms/value/LinkValue.h
+++ b/opencog/atoms/value/LinkValue.h
@@ -69,28 +69,22 @@ public:
 		: Value(t), _value(std::move(vlist)) {}
 
 	LinkValue(Type t, const ValueSet& vset)
-		: Value(t)
-	{ for (const ValuePtr& v: vset) _value.emplace_back(v); }
+		: Value(t), _value(vset.begin(), vset.end()) {}
 
 	LinkValue(Type t, const HandleSeq& hseq)
-		: Value(t)
-	{ for (const Handle& h: hseq) _value.emplace_back(h); }
+		: Value(t), _value(hseq.begin(), hseq.end()) {}
 
 	LinkValue(Type t, const HandleSet& hset)
-		: Value(t)
-	{ for (const Handle& h: hset) _value.emplace_back(h); }
+		: Value(t), _value(hset.begin(), hset.end()) {}
 
 	LinkValue(const ValueSet& vset)
-		: Value(LINK_VALUE)
-	{ for (const ValuePtr& v: vset) _value.emplace_back(v); }
+		: Value(LINK_VALUE), _value(vset.begin(), vset.end()) {}
 
 	LinkValue(const HandleSeq& hseq)
-		: Value(LINK_VALUE)
-	{ for (const Handle& h: hseq) _value.emplace_back(h); }
+		: Value(LINK_VALUE), _value(hseq.begin(), hseq.end()) {}
 
 	LinkValue(const HandleSet& hset)
-		: Value(LINK_VALUE)
-	{ for (const Handle& h: hset) _value.emplace_back(h); }
+		: Value(LINK_VALUE), _value(hset.begin(), hset.end()) {}
 
 	virtual ~LinkValue() {}
 

--- a/tests/atoms/flow/CMakeLists.txt
+++ b/tests/atoms/flow/CMakeLists.txt
@@ -10,6 +10,7 @@ ADD_CXXTEST(StreamValueOfUTest)
 IF (HAVE_GUILE)
 	ADD_GUILE_TEST(CollectionOfTest collection-of-test.scm)
 	ADD_GUILE_TEST(IncomingOfTest incoming-of-test.scm)
+	ADD_GUILE_TEST(KeysOfTest keys-of-test.scm)
 
 	LINK_LIBRARIES(execution smob)
 	ADD_CXXTEST(FormulaUTest)

--- a/tests/atoms/flow/keys-of-test.scm
+++ b/tests/atoms/flow/keys-of-test.scm
@@ -1,0 +1,58 @@
+;
+; keys-of-test.scm -- Verify that KeysOfLink works.
+;
+
+(use-modules (opencog) (opencog exec))
+(use-modules (opencog test-runner))
+
+(opencog-test-runner)
+(define tname "keys-of-test")
+(test-begin tname)
+
+; Create an atom and attach some values with different keys
+(define test-atom (Concept "test-atom"))
+
+(define key1 (Predicate "key-one"))
+(define key2 (Predicate "key-two"))
+(define key3 (Predicate "key-three"))
+
+; Attach values using different keys
+(cog-set-value! test-atom key1 (FloatValue 1.0 2.0 3.0))
+(cog-set-value! test-atom key2 (StringValue "hello" "world"))
+(cog-set-value! test-atom key3 (FloatValue 42.0))
+
+; Test KeysOfLink with single atom
+(define keys-result (cog-execute! (KeysOf test-atom)))
+
+; We expect 3 keys
+(test-assert "keys-count"
+	(equal? (cog-arity keys-result) 3))
+
+; Verify the keys are present in the result
+; Convert to a set for easier comparison
+(define keys-set (cog-execute! (CollectionOf (KeysOf test-atom))))
+(test-assert "keys-content"
+	(equal? keys-set (Set key1 key2 key3)))
+
+; Test KeysOfLink with multiple atoms
+(define test-atom2 (Concept "test-atom-2"))
+(define key4 (Predicate "key-four"))
+
+(cog-set-value! test-atom2 key2 (FloatValue 100.0))
+(cog-set-value! test-atom2 key4 (StringValue "foo"))
+
+; Get keys from both atoms
+(define all-keys (cog-execute! (KeysOf test-atom test-atom2)))
+
+; We expect 4 unique keys (key1, key2, key3, key4)
+; Note: key2 appears on both atoms but should only appear once
+(test-assert "multi-keys-count"
+	(equal? (cog-arity all-keys) 4))
+
+(define all-keys-set (cog-execute! (CollectionOf (KeysOf test-atom test-atom2))))
+(test-assert "multi-keys-content"
+	(equal? all-keys-set (Set key1 key2 key3 key4)))
+
+(test-end tname)
+
+(opencog-test-end)


### PR DESCRIPTION
Add two Atomese that return keys, and indicate if an Atom is being used as a key. Useful for amanging keys by using queries.